### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 7)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -131,7 +131,7 @@ public class AIUtils {
   }
 
   static List<Unit> interleaveCarriersAndPlanes(final List<Unit> units, final int planesThatDontNeedToLand) {
-    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.UnitCanLandOnCarrier))) {
+    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
       return units;
     }
     // Clone the current list

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -1018,7 +1018,7 @@ class ProCombatMoveAI {
         // Add destroyer if territory has subs and a destroyer has been already added
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
         if (Match.anyMatch(defendingUnits, Matches.UnitIsSub)
-            && Match.noneMatch(attackMap.get(t).getUnits(), Matches.UnitIsDestroyer)) {
+            && Match.noneMatch(attackMap.get(t).getUnits(), Matches.unitIsDestroyer())) {
           attackMap.get(t).addUnit(unit);
           it.remove();
           break;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -636,7 +636,7 @@ class ProNonCombatMoveAI {
       // Set non-air units in territories
       for (final Iterator<Unit> it = sortedUnitMoveOptions.keySet().iterator(); it.hasNext();) {
         final Unit unit = it.next();
-        if (Matches.UnitCanLandOnCarrier.match(unit)) {
+        if (Matches.unitCanLandOnCarrier().match(unit)) {
           continue;
         }
         Territory maxWinTerritory = null;
@@ -992,7 +992,7 @@ class ProNonCombatMoveAI {
       moveMap.get(t).addUnits(moveMap.get(t).getTempUnits());
       moveMap.get(t).putAllAmphibAttackMap(moveMap.get(t).getTempAmphibAttackMap());
       for (final Unit u : moveMap.get(t).getTempUnits()) {
-        if (Matches.UnitIsTransport.match(u)) {
+        if (Matches.unitIsTransport().match(u)) {
           transportMoveMap.remove(u);
           for (final Iterator<ProTransport> it = transportMapList.iterator(); it.hasNext();) {
             if (it.next().getTransport().equals(u)) {
@@ -1383,7 +1383,7 @@ class ProNonCombatMoveAI {
       // Move air units to defend transports
       for (final Iterator<Unit> it = currentUnitMoveMap.keySet().iterator(); it.hasNext();) {
         final Unit u = it.next();
-        if (Matches.UnitCanLandOnCarrier.match(u)) {
+        if (Matches.unitCanLandOnCarrier().match(u)) {
           for (final Territory t : currentUnitMoveMap.get(u)) {
             if (t.isWater() && moveMap.get(t).isCanHold() && !moveMap.get(t).getAllDefenders().isEmpty()
                 && Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
@@ -1555,7 +1555,7 @@ class ProNonCombatMoveAI {
       moveMap.get(t).addUnits(moveMap.get(t).getTempUnits());
       moveMap.get(t).putAllAmphibAttackMap(moveMap.get(t).getTempAmphibAttackMap());
       for (final Unit u : moveMap.get(t).getTempUnits()) {
-        if (Matches.UnitIsTransport.match(u)) {
+        if (Matches.unitIsTransport().match(u)) {
           transportMoveMap.remove(u);
           for (final Iterator<ProTransport> it = transportMapList.iterator(); it.hasNext();) {
             if (it.next().getTransport().equals(u)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -548,7 +548,7 @@ class ProPurchaseAI {
       // Determine if need destroyer
       boolean needDestroyer = false;
       if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
-          && Match.noneMatch(ownedLocalUnits, Matches.UnitIsDestroyer)) {
+          && Match.noneMatch(ownedLocalUnits, Matches.unitIsDestroyer())) {
         needDestroyer = true;
       }
 
@@ -1067,7 +1067,7 @@ class ProPurchaseAI {
       final List<Unit> units = new ArrayList<>(placeTerritory.getDefendingUnits());
       units.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
       final List<Unit> myUnits = Match.getMatches(units, Matches.unitIsOwnedBy(player));
-      final int numMyTransports = Match.countMatches(myUnits, Matches.UnitIsTransport);
+      final int numMyTransports = Match.countMatches(myUnits, Matches.unitIsTransport());
       final int numSeaDefenders = Match.countMatches(units, Matches.unitIsNotTransport());
 
       // Determine needed defense strength
@@ -1147,7 +1147,7 @@ class ProPurchaseAI {
 
         // Determine if need destroyer
         if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
-            && Match.noneMatch(t.getUnits().getMatches(Matches.unitIsOwnedBy(player)), Matches.UnitIsDestroyer)) {
+            && Match.noneMatch(t.getUnits().getMatches(Matches.unitIsOwnedBy(player)), Matches.unitIsDestroyer())) {
           needDestroyer = true;
         }
         ProLogger.trace(t + ", needDestroyer=" + needDestroyer + ", checking defense since has enemy attackers: "
@@ -1160,7 +1160,7 @@ class ProPurchaseAI {
         boolean hasOnlyRetreatingSubs =
             Properties.getSubRetreatBeforeBattle(data)
                 && !initialDefendingUnits.isEmpty() && Match.allMatch(initialDefendingUnits, Matches.UnitIsSub)
-                && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
+                && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsDestroyer());
         for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
 
           // Check remaining production
@@ -1226,7 +1226,7 @@ class ProPurchaseAI {
             hasOnlyRetreatingSubs =
                 Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
                     && Match.allMatch(defendingUnits, Matches.UnitIsSub)
-                    && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
+                    && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsDestroyer());
           }
         }
 
@@ -1296,7 +1296,7 @@ class ProPurchaseAI {
 
       // Check if destroyer is needed
       final int numEnemySubs = Match.countMatches(enemyUnitsInSeaTerritories, Matches.UnitIsSub);
-      final int numMyDestroyers = Match.countMatches(myUnitsInSeaTerritories, Matches.UnitIsDestroyer);
+      final int numMyDestroyers = Match.countMatches(myUnitsInSeaTerritories, Matches.unitIsDestroyer());
       if (numEnemySubs > 2 * numMyDestroyers) {
         needDestroyer = true;
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -111,14 +111,14 @@ final class ProTechAI {
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanMove());
       final Match<Unit> enemyTransport = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitIsSea, Matches.UnitIsTransport, Matches.unitCanMove());
+          Matches.UnitIsSea, Matches.unitIsTransport(), Matches.unitCanMove());
       final Match<Unit> enemyShip = Match.allOf(
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitIsSea,
           Matches.unitCanMove());
       final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.unitCanMove());
-      final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.unitCanMove());
+      final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.unitIsTransport(), Matches.unitCanMove());
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       // should change this to read production frontier and tech
@@ -366,7 +366,7 @@ final class ProTechAI {
     final HashSet<Integer> ignore = new HashSet<>();
     ignore.add(1);
     final Match<Unit> blitzUnit =
-        Match.allOf(Matches.unitIsOwnedBy(enemyPlayer), Matches.UnitCanBlitz, Matches.unitCanMove());
+        Match.allOf(Matches.unitIsOwnedBy(enemyPlayer), Matches.unitCanBlitz(), Matches.unitCanMove());
     final Match<Territory> validBlitzRoute = Match.allOf(
         Matches.territoryHasNoEnemyUnits(enemyPlayer, data),
         Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data));
@@ -501,7 +501,7 @@ final class ProTechAI {
     for (final Unit u : unitDistance.keySet()) {
       if (lz != null && Matches.unitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
-      } else if (ac != null && Matches.UnitCanLandOnCarrier.match(u)
+      } else if (ac != null && Matches.unitCanLandOnCarrier().match(u)
           && Matches.unitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
       }
@@ -535,7 +535,7 @@ final class ProTechAI {
       return null;
     }
     final Match<Unit> sub = Match.allOf(Matches.UnitIsSub.invert());
-    final Match<Unit> transport = Match.allOf(Matches.UnitIsTransport.invert(), Matches.UnitIsLand.invert());
+    final Match<Unit> transport = Match.allOf(Matches.unitIsTransport().invert(), Matches.UnitIsLand.invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.UnitIsInfrastructure.invert(),
         Matches.alliedUnit(player, data).invert());
@@ -689,7 +689,7 @@ final class ProTechAI {
         infantry.add(x);
       } else if (Matches.unitIsArtillery().match(x)) {
         artillery.add(x);
-      } else if (Matches.UnitCanBlitz.match(x)) {
+      } else if (Matches.unitCanBlitz().match(x)) {
         armor.add(x);
       } else {
         others.add(x);

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -284,7 +284,7 @@ public class ProTerritoryManager {
     final Set<Unit> movedTransports = new HashSet<>();
     for (final ProTerritory patd : attackOptions.getTerritoryMap().values()) {
       movedTransports.addAll(patd.getAmphibAttackMap().keySet());
-      movedTransports.addAll(Match.getMatches(patd.getUnits(), Matches.UnitIsTransport));
+      movedTransports.addAll(Match.getMatches(patd.getUnits(), Matches.unitIsTransport()));
     }
     return movedTransports.size() >= attackOptions.getTransportList().size();
   }
@@ -628,7 +628,7 @@ public class ProTerritoryManager {
           }
 
           // Populate appropriate unit move options map
-          if (Matches.UnitIsTransport.match(mySeaUnit)) {
+          if (Matches.unitIsTransport().match(mySeaUnit)) {
             if (transportMoveMap.containsKey(mySeaUnit)) {
               transportMoveMap.get(mySeaUnit).add(potentialTerritory);
             } else {
@@ -790,7 +790,7 @@ public class ProTerritoryManager {
         possibleMoveTerritories.add(myUnitTerritory);
         final Set<Territory> potentialTerritories =
             new HashSet<>(Match.getMatches(possibleMoveTerritories, moveToTerritoryMatch));
-        if (!isCombatMove && Matches.UnitCanLandOnCarrier.match(myAirUnit)) {
+        if (!isCombatMove && Matches.unitCanLandOnCarrier().match(myAirUnit)) {
           potentialTerritories
               .addAll(Match.getMatches(possibleMoveTerritories, Matches.territoryIsInList(possibleCarrierTerritories)));
         }
@@ -820,7 +820,7 @@ public class ProTerritoryManager {
             final List<Territory> landingTerritories = Match.getMatches(possibleLandingTerritories,
                 ProMatches.territoryCanLandAirUnits(player, data, isCombatMove, enemyTerritories, alliedTerritories));
             List<Territory> carrierTerritories = new ArrayList<>();
-            if (Matches.UnitCanLandOnCarrier.match(myAirUnit)) {
+            if (Matches.unitCanLandOnCarrier().match(myAirUnit)) {
               carrierTerritories =
                   Match.getMatches(possibleLandingTerritories, Matches.territoryIsInList(possibleCarrierTerritories));
             }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -95,7 +95,7 @@ public class ProMatches {
           Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
               Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
               Matches.territoryIsInList(enemyTerritories).invert());
-      if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
+      if (isCombatMove && Matches.unitCanBlitz().match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
         final Match<Territory> alliedWithNoEnemiesMatch = Match.allOf(
             Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
         final Match<Territory> alliedOrBlitzableMatch =
@@ -112,7 +112,7 @@ public class ProMatches {
       final List<Territory> blockedTerritories, final List<Territory> clearedTerritories) {
     Match<Territory> alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
         Matches.territoryIsInList(clearedTerritories));
-    if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
+    if (isCombatMove && Matches.unitCanBlitz().match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
       alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
           Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
     }
@@ -386,7 +386,7 @@ public class ProMatches {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsTransport());
       return match.match(u);
     });
   }
@@ -489,7 +489,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedTransport(final PlayerID player) {
-    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsTransport());
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -99,7 +99,7 @@ public class ProOddsCalculator {
       return new ProBattleResult(100, 0.1, true, attackingUnits, new ArrayList<>(), 0);
     } else if (Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
         && Match.allMatch(defendingUnits, Matches.UnitIsSub)
-        && Match.noneMatch(attackingUnits, Matches.UnitIsDestroyer)) {
+        && Match.noneMatch(attackingUnits, Matches.unitIsDestroyer())) {
       return new ProBattleResult();
     }
     return null;

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -232,7 +232,7 @@ public class ProTransportUtils {
 
   public static List<Unit> interleaveUnitsCarriersAndPlanes(final List<Unit> units,
       final int planesThatDontNeedToLand) {
-    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.UnitCanLandOnCarrier))) {
+    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
       return units;
     }
 

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -200,7 +200,7 @@ public class WeakAI extends AbstractAI {
         route.add(neighbor);
         moveUnits.add(units);
         moveRoutes.add(route);
-        transportsToLoad.add(neighbor.getUnits().getMatches(Matches.UnitIsTransport));
+        transportsToLoad.add(neighbor.getUnits().getMatches(Matches.unitIsTransport()));
       }
     }
   }
@@ -711,7 +711,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countTransports(final GameData data, final PlayerID player) {
-    final Match<Unit> ownedTransport = Match.allOf(Matches.UnitIsTransport, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedTransport = Match.allOf(Matches.unitIsTransport(), Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedTransport);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -496,7 +496,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
       return null;
     }
-    final Match<Unit> ownedFighters = Match.allOf(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedFighters = Match.allOf(Matches.unitCanLandOnCarrier(), Matches.unitIsOwnedBy(player));
     if (!producer.getUnits().anyMatch(ownedFighters)) {
       return null;
     }
@@ -887,7 +887,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
           && Match.anyMatch(allProducedUnits, Matches.UnitIsCarrier))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
               && Match.anyMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
-        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier())));
       }
     }
     if (Match.anyMatch(units, Matches.unitIsConstruction())) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -61,7 +61,7 @@ public class AirMovementValidator {
     final Territory routeStart = route.getStart();
     // we cannot forget to account for allied air at our location already
     final Match<Unit> airAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final HashSet<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(routeEnd.getUnits().getUnits(), airAlliedNotOwned));
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(units, airAlliedNotOwned));
@@ -162,7 +162,7 @@ public class AirMovementValidator {
     final Match<Unit> carrierAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
-    // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+    // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLHTRCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     // final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
@@ -199,9 +199,9 @@ public class AirMovementValidator {
       final Collection<Unit> airNotToConsider, final PlayerID player, final Route route, final GameData data) {
     final Match<Unit> ownedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
     final Match<Unit> ownedAirMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedAirMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     final Territory routeEnd = route.getEnd();
@@ -617,7 +617,7 @@ public class AirMovementValidator {
     }
     if (territory.isWater()) {
       // if they cant all land on carriers
-      if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.UnitCanLandOnCarrier)) {
+      if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.unitCanLandOnCarrier())) {
         return false;
       }
       // when doing the calculation, make sure to include the units
@@ -637,7 +637,7 @@ public class AirMovementValidator {
   private static Collection<Unit> getAirThatMustLandOnCarriers(final GameData data, final Collection<Unit> ownedAir,
       final Route route, final MoveValidationResult result) {
     final Collection<Unit> airThatMustLandOnCarriers = new ArrayList<>();
-    final Match<Unit> canLandOnCarriers = Matches.UnitCanLandOnCarrier;
+    final Match<Unit> canLandOnCarriers = Matches.unitCanLandOnCarrier();
     for (final Unit unit : ownedAir) {
       if (!canFindLand(data, unit, route)) {
         if (canLandOnCarriers.match(unit)) {
@@ -679,7 +679,7 @@ public class AirMovementValidator {
         if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
-              .getMatches(Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));
+              .getMatches(Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier()));
           for (final Unit airUnit : airCargo) {
             final TripleAUnit taUnit = (TripleAUnit) airUnit;
             if (taUnit.getTransportedBy() != null && taUnit.getTransportedBy().equals(unit)) {
@@ -709,7 +709,7 @@ public class AirMovementValidator {
   }
 
   private static int carrierCost(final Unit unit) {
-    if (Matches.UnitCanLandOnCarrier.match(unit)) {
+    if (Matches.unitCanLandOnCarrier().match(unit)) {
       return UnitAttachment.get(unit.getType()).getCarrierCost();
     }
     return 0;

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -388,7 +388,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final IDelegateBridge bridge) {
     if (TechTracker.hasParatroopers(player)) {
       final Collection<Unit> airTransports =
-          Match.getMatches(battleSite.getUnits().getUnits(), Matches.UnitIsAirTransport);
+          Match.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAirTransport());
       final Collection<Unit> paratroops =
           Match.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAirTransportable());
       if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
@@ -867,7 +867,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           // refactored.
           final MustFightBattle mfb = (MustFightBattle) battle;
           final Collection<Territory> neighborsLand = data.getMap().getNeighbors(to, Matches.TerritoryIsLand);
-          if (Match.anyMatch(attackingUnits, Matches.UnitIsTransport)) {
+          if (Match.anyMatch(attackingUnits, Matches.unitIsTransport())) {
             // first, we have to reset the "transportedBy" setting for all the land units that were offloaded
             final CompositeChange change1 = new CompositeChange();
             mfb.reLoadTransports(attackingUnits, change1);
@@ -879,7 +879,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                 new HashMap<>();
             final Map<Unit, Collection<Unit>> dependenciesForMfb =
                 TransportTracker.transporting(attackingUnits, attackingUnits);
-            for (final Unit transport : Match.getMatches(attackingUnits, Matches.UnitIsTransport)) {
+            for (final Unit transport : Match.getMatches(attackingUnits, Matches.unitIsTransport())) {
               // however, the map we add to the newly created battle, cannot hold any units that are NOT in this
               // territory.
               // BUT it must still hold all transports
@@ -891,11 +891,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             for (final Territory t : neighborsLand) {
               // All other maps, must hold only the transported units that in their territory
               final Collection<Unit> allNeighborUnits =
-                  new ArrayList<>(Match.getMatches(attackingUnits, Matches.UnitIsTransport));
+                  new ArrayList<>(Match.getMatches(attackingUnits, Matches.unitIsTransport()));
               allNeighborUnits.addAll(t.getUnits().getMatches(Matches.unitIsLandAndOwnedBy(m_player)));
               final Map<Unit, Collection<Unit>> dependenciesForNeighbors =
-                  TransportTracker.transporting(Match.getMatches(allNeighborUnits, Matches.UnitIsTransport),
-                      Match.getMatches(allNeighborUnits, Matches.UnitIsTransport.invert()));
+                  TransportTracker.transporting(Match.getMatches(allNeighborUnits, Matches.unitIsTransport()),
+                      Match.getMatches(allNeighborUnits, Matches.unitIsTransport().invert()));
               dependencies.put(t, dependenciesForNeighbors);
             }
             mfb.addDependentUnits(dependencies.get(to));
@@ -1515,7 +1515,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     availableLand.removeAll(canNotLand);
     whereCanLand.addAll(availableLand);
     // now for carrier-air-landing validation
-    if (!strandedAir.isEmpty() && Match.allMatch(strandedAir, Matches.UnitCanLandOnCarrier)) {
+    if (!strandedAir.isEmpty() && Match.allMatch(strandedAir, Matches.unitCanLandOnCarrier())) {
       final HashSet<Territory> availableWater = new HashSet<>();
       availableWater.addAll(Match.getMatches(possibleTerrs,
           Match.allOf(
@@ -1531,7 +1531,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .carrierCapacity(t.getUnits().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)), t);
         if (!t.equals(currentTerr)) {
           carrierCapacity -= AirMovementValidator.carrierCost(t.getUnits().getMatches(
-              Match.allOf(Matches.UnitCanLandOnCarrier, Matches.alliedUnit(alliedPlayer, data))));
+              Match.allOf(Matches.unitCanLandOnCarrier(), Matches.alliedUnit(alliedPlayer, data))));
         } else {
           carrierCapacity -= carrierCostForCurrentTerr;
         }

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -678,7 +678,7 @@ public class BattleTracker implements Serializable {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id);
       } else if (ta.getCapital() != null) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, id);
-      } else if (m_blitzed.contains(territory) && Match.anyMatch(arrivedUnits, Matches.UnitCanBlitz)) {
+      } else if (m_blitzed.contains(territory) && Match.anyMatch(arrivedUnits, Matches.unitCanBlitz())) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_BLITZ, id);
       } else {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_LAND, id);

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -89,7 +89,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -75,7 +75,7 @@ class EditValidator {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
@@ -91,7 +91,7 @@ class EditValidator {
           }
         }
         if (Match.anyMatch(units, Matches.UnitIsAir)) {
-          if (Match.anyMatch(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
+          if (Match.anyMatch(units, Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier().invert()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -99,7 +99,7 @@ public class Fire implements IExecutable {
     final int hitCount = m_dice.getHits();
     AbstractBattle.getDisplay(bridge).notifyDice(m_dice, m_stepName);
     final int countTransports =
-        Match.countMatches(m_attackableUnits, Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea));
+        Match.countMatches(m_attackableUnits, Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea));
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
       final Collection<Unit> nonTransports = Match.getMatches(m_attackableUnits,

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -127,7 +127,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
         continue;
       }
       // map transports, try to fill
-      final Collection<Unit> transports = Match.getMatches(units, Matches.UnitIsTransport);
+      final Collection<Unit> transports = Match.getMatches(units, Matches.unitIsTransport());
       final Collection<Unit> land = Match.getMatches(units, Matches.UnitIsLand);
       for (final Unit toLoad : land) {
         final UnitAttachment ua = UnitAttachment.get(toLoad.getType());

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -135,26 +135,32 @@ public final class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsDestroyer =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
+  public static Match<Unit> unitIsDestroyer() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
+  }
 
   public static Match<UnitType> unitTypeIsDestroyer() {
     return Match.of(type -> UnitAttachment.get(type).getIsDestroyer());
   }
 
-  public static final Match<Unit> UnitIsTransport = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return (ua.getTransportCapacity() != -1 && ua.getIsSea());
-  });
+  /**
+   * Returns a match indicating the specified unit can transport other units by sea.
+   */
+  public static Match<Unit> unitIsTransport() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return ua.getTransportCapacity() != -1 && ua.getIsSea();
+    });
+  }
 
   public static Match<Unit> unitIsNotTransport() {
-    return UnitIsTransport.invert();
+    return unitIsTransport().invert();
   }
 
   static Match<Unit> unitIsTransportAndNotDestroyer() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return !Matches.UnitIsDestroyer.match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
+      return !Matches.unitIsDestroyer().match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
     });
   }
 
@@ -457,8 +463,9 @@ public final class Matches {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBombard(id));
   }
 
-  public static final Match<Unit> UnitCanBlitz =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner()));
+  public static Match<Unit> unitCanBlitz() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner()));
+  }
 
   static Match<Unit> unitIsLandTransport() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsLandTransport());
@@ -486,8 +493,9 @@ public final class Matches {
     return Match.of(type -> !UnitAttachment.get(type).getIsAir());
   }
 
-  public static final Match<Unit> UnitCanLandOnCarrier =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCost() != -1);
+  public static Match<Unit> unitCanLandOnCarrier() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCost() != -1);
+  }
 
   public static final Match<Unit> UnitIsCarrier =
       Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1);
@@ -727,15 +735,20 @@ public final class Matches {
     return unitIsAirTransportable().invert();
   }
 
-  public static final Match<Unit> UnitIsAirTransport = Match.of(obj -> {
-    final TechAttachment ta = TechAttachment.get(obj.getOwner());
-    if (ta == null || !ta.getParatroopers()) {
-      return false;
-    }
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getIsAirTransport();
-  });
+  /**
+   * Returns a match indicating the specified unit can transport other units by air.
+   */
+  public static Match<Unit> unitIsAirTransport() {
+    return Match.of(obj -> {
+      final TechAttachment ta = TechAttachment.get(obj.getOwner());
+      if (ta == null || !ta.getParatroopers()) {
+        return false;
+      }
+      final UnitType type = obj.getUnitType();
+      final UnitAttachment ua = UnitAttachment.get(type);
+      return ua.getIsAirTransport();
+    });
+  }
 
   public static Match<Unit> unitIsArtillery() {
     return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getArtillery());
@@ -1561,7 +1574,7 @@ public final class Matches {
       }
       // paratrooper on an air transport
       if (forceLoadParatroopersIfPossible) {
-        final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+        final Collection<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
         final Collection<Unit> paratroops = Match.getMatches(units, Matches.unitIsAirTransportable());
         if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
           if (TransportUtils.mapTransportsToLoad(paratroops, airTransports)

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -326,7 +326,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
         Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
-            Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft());
+            Matches.unitCanLandOnCarrier(), Matches.unitHasMovementLeft());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> ownedFighters = t.getUnits().getMatches(ownedFightersMatch);

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -149,7 +149,7 @@ public class MovePerformer implements Serializable {
         // territory. This means they
         // are still dependent during the middle steps of the route.
         final Collection<Unit> dependentOnSomethingTilTheEndOfRoute = new ArrayList<>();
-        final Collection<Unit> airTransports = Match.getMatches(arrived, Matches.UnitIsAirTransport);
+        final Collection<Unit> airTransports = Match.getMatches(arrived, Matches.unitIsAirTransport());
         final Collection<Unit> paratroops = Match.getMatches(arrived, Matches.unitIsAirTransportable());
         if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
           final Map<Unit, Unit> transportingAir =
@@ -344,7 +344,7 @@ public class MovePerformer implements Serializable {
     }
     if (routeEnd != null && Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
         && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnits()
-            .anyMatch(Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
+            .anyMatch(Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
@@ -365,7 +365,7 @@ public class MovePerformer implements Serializable {
     }
     final GameData data = m_bridge.getData();
     final Match<Unit> paratroopNAirTransports = Match.anyOf(
-        Matches.UnitIsAirTransport,
+        Matches.unitIsAirTransport(),
         Matches.unitIsAirTransportable());
     final boolean paratroopsLanding = Match.anyMatch(arrived, paratroopNAirTransports)
         && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
@@ -386,7 +386,7 @@ public class MovePerformer implements Serializable {
     // If paratroops moved normally (within their normal movement) remove their dependency to the airTransports
     // So they can all continue to move normally
     if (!paratroopsLanding && !dependentAirTransportableUnits.isEmpty()) {
-      final Collection<Unit> airTransports = Match.getMatches(arrived, Matches.UnitIsAirTransport);
+      final Collection<Unit> airTransports = Match.getMatches(arrived, Matches.unitIsAirTransport());
       airTransports.addAll(dependentAirTransportableUnits.keySet());
       MovePanel.clearDependents(airTransports);
     }
@@ -433,7 +433,7 @@ public class MovePerformer implements Serializable {
         }
         final Unit transportedBy = ((TripleAUnit) unit).getTransportedBy();
         // we will unload our paratroopers after they land in battle (after aa guns fire)
-        if (paratroopsLanding && transportedBy != null && Matches.UnitIsAirTransport.match(transportedBy)
+        if (paratroopsLanding && transportedBy != null && Matches.unitIsAirTransport().match(transportedBy)
             && GameStepPropertiesHelper.isCombatMove(data)
             && Matches.territoryHasNonSubmergedEnemyUnits(m_player, data).match(route.getEnd())) {
           continue;

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -283,7 +283,9 @@ public class MoveValidator {
           && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
-      for (final Unit u : Match.getMatches(units, Match.allOf(Matches.UnitCanBlitz.invert(), Matches.unitIsNotAir()))) {
+      for (final Unit u : Match.getMatches(units, Match.allOf(
+          Matches.unitCanBlitz().invert(),
+          Matches.unitIsNotAir()))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
@@ -332,7 +334,7 @@ public class MoveValidator {
           return result.setErrorReturnResult("Cannot blitz on that route");
         }
       } else if (allEnemyBlitzable && !(route.getStart().isWater() || route.getEnd().isWater())) {
-        final Match<Unit> blitzingUnit = Match.anyOf(Matches.UnitCanBlitz, Matches.UnitIsAir);
+        final Match<Unit> blitzingUnit = Match.anyOf(Matches.unitCanBlitz(), Matches.UnitIsAir);
         final Match<Unit> nonBlitzing = blitzingUnit.invert();
         final Collection<Unit> nonBlitzingUnits = Match.getMatches(units, nonBlitzing);
         // remove any units that gain blitz due to certain abilities
@@ -607,7 +609,7 @@ public class MoveValidator {
             // simple: if it movement group contains an air-transport, then assume we are doing paratroopers. else,
             // assume we are doing
             // mechanized
-            if (Match.anyMatch(units, Matches.UnitIsAirTransport)) {
+            if (Match.anyMatch(units, Matches.unitIsAirTransport())) {
               for (final Unit airTransport : dependencies.keySet()) {
                 if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
                   unitOk = true;
@@ -813,7 +815,7 @@ public class MoveValidator {
   }
 
   private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
-    final Match<Unit> enemyDestroyer = Match.allOf(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
+    final Match<Unit> enemyDestroyer = Match.allOf(Matches.unitIsDestroyer(), Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
       if (current.getUnits().anyMatch(enemyDestroyer)) {
         return true;
@@ -847,9 +849,9 @@ public class MoveValidator {
     // See if we even need to go to the trouble of checking for AirTransported units
     final boolean checkForAlreadyTransported = !route.getStart().isWater() && route.hasWater();
     if (checkForAlreadyTransported) {
-      // TODO Leaving UnitIsTransport for potential use with amphib transports (hovercraft, ducks, etc...)
+      // TODO Leaving unitIsTransport() for potential use with amphib transports (hovercraft, ducks, etc...)
       final List<Unit> transports =
-          Match.getMatches(units, Match.anyOf(Matches.UnitIsTransport, Matches.UnitIsAirTransport));
+          Match.getMatches(units, Match.anyOf(Matches.unitIsTransport(), Matches.unitIsAirTransport()));
       final List<Unit> transportable =
           Match.getMatches(units, Match.anyOf(Matches.unitCanBeTransported(), Matches.unitIsAirTransportable()));
       // Check if there are transports in the group to be checked
@@ -1164,7 +1166,7 @@ public class MoveValidator {
   static boolean allLandUnitsAreBeingParatroopered(final Collection<Unit> units) {
     // some units that can't be paratrooped
     if (units.isEmpty()
-        || !Match.allMatch(units, Match.anyOf(Matches.unitIsAirTransportable(), Matches.UnitIsAirTransport,
+        || !Match.allMatch(units, Match.anyOf(Matches.unitIsAirTransportable(), Matches.unitIsAirTransport(),
             Matches.UnitIsAir))) {
       return false;
     }
@@ -1175,7 +1177,7 @@ public class MoveValidator {
     if (paratroopsRequiringTransport.isEmpty()) {
       return false;
     }
-    final List<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+    final List<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
     final List<Unit> allParatroops =
         TransportUtils.findUnitsToLoadOnAirTransports(paratroopsRequiringTransport, airTransports);
     if (!allParatroops.containsAll(paratroopsRequiringTransport)) {
@@ -1214,7 +1216,7 @@ public class MoveValidator {
       return result;
     }
     if (Match.noneMatch(units, Matches.unitIsAirTransportable())
-        || Match.noneMatch(units, Matches.UnitIsAirTransport)) {
+        || Match.noneMatch(units, Matches.unitIsAirTransport())) {
       return result;
     }
     if (nonCombat && !isAirTransportableCanMoveDuringNonCombat(data)) {
@@ -1228,7 +1230,7 @@ public class MoveValidator {
       if (paratroopsRequiringTransport.isEmpty()) {
         return result;
       }
-      final List<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+      final List<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
       // TODO kev change below to mapAirTransports (or modify mapTransports to handle air cargo)
       // Map<Unit, Unit> airTransportsAndParatroops = MoveDelegate.mapTransports(route, paratroopsRequiringTransport,
       // airTransports);
@@ -1362,7 +1364,7 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> transportsMustMoveWith(final Collection<Unit> units) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     // map transports
-    final Collection<Unit> transports = Match.getMatches(units, Matches.UnitIsTransport);
+    final Collection<Unit> transports = Match.getMatches(units, Matches.unitIsTransport());
     final Iterator<Unit> iter = transports.iterator();
     while (iter.hasNext()) {
       final Unit transport = iter.next();
@@ -1375,7 +1377,7 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
-    final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+    final Collection<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
     // Then check those that have already had their transportedBy set
     for (final Unit airTransport : airTransports) {
       if (!mustMoveWith.containsKey(airTransport)) {
@@ -1403,7 +1405,7 @@ public class MoveValidator {
     final Match<Unit> friendlyNotOwnedAir = Match.allOf(
         Matches.alliedUnit(player, data),
         Matches.unitIsOwnedBy(player).invert(),
-        Matches.UnitCanLandOnCarrier);
+        Matches.unitCanLandOnCarrier());
     final Collection<Unit> alliedAir = Match.getMatches(startUnits, friendlyNotOwnedAir);
     if (alliedAir.isEmpty()) {
       return Collections.emptyMap();

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -234,7 +234,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // need to double
     // check)
     if (TechAttachment.isAirTransportable(m_attacker)) {
-      final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+      final Collection<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
       final Collection<Unit> paratroops = Match.getMatches(units, Matches.unitIsAirTransportable());
       if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
         // Load capable bombers by default>
@@ -515,7 +515,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       if (!m_battleSite.isWater() && TechAttachment.isAirTransportable(m_attacker)) {
         final Collection<Unit> bombers =
-            Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.UnitIsAirTransport);
+            Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.unitIsAirTransport());
         if (!bombers.isEmpty()) {
           final Collection<Unit> dependents = getDependentUnits(bombers);
           if (!dependents.isEmpty()) {
@@ -526,19 +526,19 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
-      if (!Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)
+      if (!Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer())
           && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
         steps.add(m_attacker.getName() + SUBS_SUBMERGE);
       }
-      if (!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)
+      if (!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer())
           && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
         steps.add(m_defender.getName() + SUBS_SUBMERGE);
       }
     }
     // See if there any unescorted trns
     if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsTransport)
-          || Match.anyMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsTransport())
+          || Match.anyMatch(m_defendingUnits, Matches.unitIsTransport())) {
         steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
@@ -583,7 +583,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
-      // if(!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.allMatch(m_attackingUnits,
+      // if(!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && Match.allMatch(m_attackingUnits,
       // Matches.UnitIsAir))
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
@@ -593,7 +593,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_battleSite.isWater() && isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
-      // if(!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.anyMatch(m_attackingUnits,
+      // if(!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_attackingUnits,
       // Matches.UnitIsAir) &&
       // Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
@@ -621,7 +621,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      // if(!Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer) && Match.anyMatch(m_defendingUnits,
+      // if(!Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_defendingUnits,
       // Matches.UnitIsAir) &&
       // Match.anyMatch(m_attackingUnits, Matches.UnitIsSub))
       if (Match.anyMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
@@ -848,7 +848,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           } else {
             // Get all allied transports in the territory
             final Match<Unit> matchAllied = Match.allOf(
-                Matches.UnitIsTransport,
+                Matches.unitIsTransport(),
                 Matches.unitIsNotCombatTransport(),
                 Matches.isUnitAllied(m_attacker, m_data));
             final List<Unit> alliedTransports = Match.getMatches(m_battleSite.getUnits().getUnits(), matchAllied);
@@ -1139,7 +1139,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private ReturnFire returnFireAgainstAttackingSubs() {
-    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer);
+    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer());
     final boolean defendingSubsSneakAttack = defendingSubsSneakAttack2();
     final ReturnFire returnFireAgainstAttackingSubs;
     if (!attackingSubsSneakAttack) {
@@ -1159,7 +1159,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
      * calculate here, this holds for the fight round, but can't be computed later
      * since destroyers may die
      */
-    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer);
+    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer());
     final boolean defendingSubsSneakAttack = defendingSubsSneakAttack2();
     final ReturnFire returnFireAgainstDefendingSubs;
     if (!defendingSubsSneakAttack) {
@@ -1173,7 +1173,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean defendingSubsSneakAttack2() {
-    return !Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && defendingSubsSneakAttack3();
+    return !Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && defendingSubsSneakAttack3();
   }
 
   private boolean defendingSubsSneakAttack3() {
@@ -1276,10 +1276,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAttackerRetreatSubs() {
-    if (Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer())) {
       return false;
     }
-    if (Match.anyMatch(m_defendingWaitingToDie, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_defendingWaitingToDie, Matches.unitIsDestroyer())) {
       return false;
     }
     return canAttackerRetreat() || canSubsSubmerge();
@@ -1324,10 +1324,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canDefenderRetreatSubs() {
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer())) {
       return false;
     }
-    if (Match.anyMatch(m_attackingWaitingToDie, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_attackingWaitingToDie, Matches.unitIsDestroyer())) {
       return false;
     }
     return getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.UnitIsSub)).size() != 0
@@ -1544,7 +1544,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   // Retreat landed units from allied territory when their transport retreats
   private Change retreatFromNonCombat(Collection<Unit> units, final Territory retreatTo) {
     final CompositeChange change = new CompositeChange();
-    units = Match.getMatches(units, Matches.UnitIsTransport);
+    units = Match.getMatches(units, Matches.unitIsTransport());
     final Collection<Unit> retreated = getTransportDependents(units);
     if (!retreated.isEmpty()) {
       Territory retreatedFrom = null;
@@ -1735,7 +1735,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // Get all allied transports in the territory
     final Match<Unit> matchAllied = Match.allOf(
-        Matches.UnitIsTransport,
+        Matches.unitIsTransport(),
         Matches.unitIsNotCombatTransport(),
         Matches.isUnitAllied(player, m_data),
         Matches.UnitIsSea);
@@ -1880,7 +1880,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
     return !(m_battleSite.isWater() && Match.anyMatch(firedAt, Matches.UnitIsSub)
-        && Match.noneMatch(firing, Matches.UnitIsDestroyer));
+        && Match.noneMatch(firing, Matches.unitIsDestroyer()));
   }
 
   private void defendAirOnNonSubs() {
@@ -2037,7 +2037,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
     // anything.
-    if (isAirAttackSubRestricted() && !Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)
+    if (isAirAttackSubRestricted() && !Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer())
         && Match.anyMatch(attackedDefenders, Matches.UnitIsSub)) {
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsSub));
     }
@@ -2068,7 +2068,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
     // anything.
-    if (isAirAttackSubRestricted() && !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)
+    if (isAirAttackSubRestricted() && !Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer())
         && Match.anyMatch(attackedAttackers, Matches.UnitIsSub)) {
       attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.UnitIsSub));
     }
@@ -2322,7 +2322,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
     // remove any allied air units that are stuck on damaged carriers (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Match.allOf(Matches.unitIsBeingTransported(),
-        Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
+        Matches.UnitIsAir, Matches.unitCanLandOnCarrier())));
     // remove any units that were in air combat (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Matches.unitWasInAirBattle()));
     return unitList;
@@ -2351,7 +2351,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void landParatroops(final IDelegateBridge bridge) {
     if (TechAttachment.isAirTransportable(m_attacker)) {
       final Collection<Unit> airTransports =
-          Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.UnitIsAirTransport);
+          Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.unitIsAirTransport());
       if (!airTransports.isEmpty()) {
         final Collection<Unit> dependents = getDependentUnits(airTransports);
         if (!dependents.isEmpty()) {
@@ -2437,7 +2437,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   // Remove landed units from allied territory when their transport sinks
   private void removeFromNonCombatLandings(final Collection<Unit> units, final IDelegateBridge bridge) {
-    for (final Unit transport : Match.getMatches(units, Matches.UnitIsTransport)) {
+    for (final Unit transport : Match.getMatches(units, Matches.unitIsTransport())) {
       final Collection<Unit> lost = getTransportDependents(Collections.singleton(transport));
       if (lost.isEmpty()) {
         continue;
@@ -2528,7 +2528,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       m_battleResultDescription = BattleRecord.BattleResultDescription.WON_WITHOUT_CONQUERING;
     }
     // Clear the transported_by for successfully offloaded units
-    final Collection<Unit> transports = Match.getMatches(m_attackingUnits, Matches.UnitIsTransport);
+    final Collection<Unit> transports = Match.getMatches(m_attackingUnits, Matches.unitIsTransport());
     if (!transports.isEmpty()) {
       final CompositeChange change = new CompositeChange();
       final Collection<Unit> dependents = getTransportDependents(transports);
@@ -2607,7 +2607,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     carrierCost +=
         AirMovementValidator.carrierCost(Match.getMatches(getDependentUnits(m_defendingUnits), alliedDefendingAir));
     for (final Unit currentUnit : new ArrayList<>(defendingAir)) {
-      if (!Matches.UnitCanLandOnCarrier.match(currentUnit)) {
+      if (!Matches.unitCanLandOnCarrier().match(currentUnit)) {
         defendingAir.remove(currentUnit);
         continue;
       }
@@ -2628,7 +2628,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.UnitIsCarrier);
     if (!carriers.isEmpty() && !Properties.getAlliedAirIndependent(data)) {
       final Match<Unit> alliedFighters = Match.allOf(Matches.isUnitAllied(attacker, data),
-          Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+          Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
       final Collection<Unit> alliedAirInTerr = Match.getMatches(attackingUnits, alliedFighters);
       for (final Unit fighter : alliedAirInTerr) {
         final TripleAUnit taUnit = (TripleAUnit) fighter;

--- a/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -60,11 +60,11 @@ public class UnitBattleComparator implements Comparator<Unit> {
       return 0;
     }
     final boolean airOrCarrierOrTransport1 = Matches.UnitIsAir.match(u1) || Matches.UnitIsCarrier.match(u1)
-        || (!transporting1 && Matches.UnitIsTransport.match(u1));
+        || (!transporting1 && Matches.unitIsTransport().match(u1));
     final boolean airOrCarrierOrTransport2 = Matches.UnitIsAir.match(u2) || Matches.UnitIsCarrier.match(u2)
-        || (!transporting2 && Matches.UnitIsTransport.match(u2));
-    final boolean subDestroyer1 = Matches.UnitIsSub.match(u1) || Matches.UnitIsDestroyer.match(u1);
-    final boolean subDestroyer2 = Matches.UnitIsSub.match(u2) || Matches.UnitIsDestroyer.match(u2);
+        || (!transporting2 && Matches.unitIsTransport().match(u2));
+    final boolean subDestroyer1 = Matches.UnitIsSub.match(u1) || Matches.unitIsDestroyer().match(u1);
+    final boolean subDestroyer2 = Matches.UnitIsSub.match(u2) || Matches.unitIsDestroyer().match(u2);
     final boolean multiHpCanRepair1 = m_multiHitpointCanRepair.contains(u1.getType());
     final boolean multiHpCanRepair2 = m_multiHitpointCanRepair.contains(u2.getType());
     if (!m_ignorePrimaryPower) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -595,7 +595,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       if (submerge) {
         // submerge if all air vs subs
         final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.UnitIsSub);
-        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
+        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.unitIsDestroyer().invert());
         final List<Unit> ourUnits = getOurUnits();
         final List<Unit> enemyUnits = getEnemyUnits();
         if (ourUnits == null || enemyUnits == null) {

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -94,7 +94,7 @@ public class MovePanel extends AbstractMovePanel {
   // Same as above! Delete this crap after refactoring.
   public static void clearDependents(final Collection<Unit> units) {
     for (final Unit unit : units) {
-      if (Matches.UnitIsAirTransport.match(unit)) {
+      if (Matches.unitIsAirTransport().match(unit)) {
         dependentUnits.remove(unit);
       }
     }
@@ -204,7 +204,7 @@ public class MovePanel extends AbstractMovePanel {
 
     // Match criteria to ensure that chosen transports will match selected units
     final Match<Collection<Unit>> transportsToUnloadMatch = Match.of(units -> {
-      final List<Unit> sortedTransports = Match.getMatches(units, Matches.UnitIsTransport);
+      final List<Unit> sortedTransports = Match.getMatches(units, Matches.unitIsTransport());
       final Collection<Unit> availableUnits = new ArrayList<>(unitsToUnload);
 
       // track the changing capacities of the transports as we assign units
@@ -268,7 +268,7 @@ public class MovePanel extends AbstractMovePanel {
     if (option != JOptionPane.OK_OPTION) {
       return Collections.emptyList();
     }
-    final Collection<Unit> chosenTransports = Match.getMatches(chooser.getSelected(), Matches.UnitIsTransport);
+    final Collection<Unit> chosenTransports = Match.getMatches(chooser.getSelected(), Matches.unitIsTransport());
     final List<Unit> allUnitsInSelectedTransports = new ArrayList<>();
     for (final Unit transport : chosenTransports) {
       final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
@@ -451,7 +451,7 @@ public class MovePanel extends AbstractMovePanel {
     Collection<Unit> transportsToLoad = Collections.emptyList();
     if (MoveValidator.isLoad(units, dependentUnits, route, getData(), getCurrentPlayer())) {
       transportsToLoad = route.getEnd().getUnits().getMatches(
-          Match.allOf(Matches.UnitIsTransport, Matches.alliedUnit(getCurrentPlayer(), getData())));
+          Match.allOf(Matches.unitIsTransport(), Matches.alliedUnit(getCurrentPlayer(), getData())));
     }
     List<Unit> best = new ArrayList<>(units);
     // if the player selects a land unit and other units
@@ -571,7 +571,7 @@ public class MovePanel extends AbstractMovePanel {
       minTransportCost = Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
     }
     final Match<Unit> candidateTransportsMatch = Match.allOf(
-        Matches.UnitIsTransport,
+        Matches.unitIsTransport(),
         Matches.alliedUnit(unitOwner, getGameData()));
     final List<Unit> candidateTransports = Match.getMatches(endOwnedUnits, candidateTransportsMatch);
 
@@ -687,7 +687,7 @@ public class MovePanel extends AbstractMovePanel {
 
     // the match criteria to ensure that chosen transports will match selected units
     final Match<Collection<Unit>> transportsToLoadMatch = Match.of(units -> {
-      final Collection<Unit> transports = Match.getMatches(units, Matches.UnitIsTransport);
+      final Collection<Unit> transports = Match.getMatches(units, Matches.unitIsTransport());
       // prevent too many transports from being selected
       return (transports.size() <= Math.min(unitsToLoad.size(), candidateTransports.size()));
     });
@@ -843,7 +843,7 @@ public class MovePanel extends AbstractMovePanel {
         // Load Bombers with paratroops
         if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
             && TechAttachment.isAirTransportable(getCurrentPlayer())
-            && Match.anyMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved()))) {
+            && Match.anyMatch(selectedUnits, Match.allOf(Matches.unitIsAirTransport(), Matches.unitHasNotMoved()))) {
           final PlayerID player = getCurrentPlayer();
           // TODO Transporting allied units
           // Get the potential units to load
@@ -859,7 +859,7 @@ public class MovePanel extends AbstractMovePanel {
           }
           // Get the potential air transports to load
           final Match.CompositeBuilder<Unit> candidateAirTransportsMatchBuilder = Match.newCompositeBuilder(
-              Matches.UnitIsAirTransport,
+              Matches.unitIsAirTransport(),
               Matches.unitIsOwnedBy(player),
               Matches.unitHasNotMoved(),
               Matches.transportIsNotTransporting());
@@ -891,7 +891,7 @@ public class MovePanel extends AbstractMovePanel {
       final Set<Unit> defaultSelections = new HashSet<>();
       // prevent too many bombers from being selected
       final Match<Collection<Unit>> transportsToLoadMatch = Match.of(units -> {
-        final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+        final Collection<Unit> airTransports = Match.getMatches(units, Matches.unitIsAirTransport());
         return (airTransports.size() <= candidateAirTransports.size());
       });
       // Allow player to select which to load.
@@ -1092,7 +1092,7 @@ public class MovePanel extends AbstractMovePanel {
       }
       Collection<Unit> transports = null;
       final Match.CompositeBuilder<Unit> paratroopNBombersBuilder = Match.newCompositeBuilder(
-          Matches.UnitIsAirTransport,
+          Matches.unitIsAirTransport(),
           Matches.unitIsAirTransportable());
       final boolean paratroopsLanding = Match.anyMatch(units, paratroopNBombersBuilder.all());
       if (route.isLoad() && Match.anyMatch(units, Matches.UnitIsLand)) {

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -136,7 +136,9 @@ public class PlacePanel extends AbstractMovePanel {
             || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
           units = Match.getMatches(units, Matches.UnitIsSea);
         } else {
-          final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(Matches.UnitIsSea, Matches.UnitCanLandOnCarrier);
+          final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(
+              Matches.UnitIsSea,
+              Matches.unitCanLandOnCarrier());
           units = Match.getMatches(units, unitIsSeaOrCanLandOnCarrier);
         }
       } else {

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -145,7 +145,7 @@ public class TransportUtils {
   public static List<Unit> findUnitsToLoadOnAirTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> airTransports = Match.getMatches(transports, Matches.UnitIsAirTransport);
+    final Collection<Unit> airTransports = Match.getMatches(transports, Matches.unitIsAirTransport());
     final List<Unit> canBeTransported = sortByTransportCostDescending(units);
 
     // Define the max of all units that could be loaded

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -65,7 +65,7 @@ public class UnitSeperator {
     }
     for (final Unit current : units) {
       int unitMovement = -1;
-      if (categorizeMovement || (categorizeTrnMovement && Matches.UnitIsTransport.match(current))) {
+      if (categorizeMovement || (categorizeTrnMovement && Matches.unitIsTransport().match(current))) {
         unitMovement = TripleAUnit.get(current).getMovementLeft();
       }
       int unitTransportCost = -1;

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -216,7 +216,7 @@ public class RevisedTest {
     r.setStart(russia);
     r.add(novo);
     r.add(sinkiang);
-    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.UnitCanBlitz), r));
+    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.unitCanBlitz()), r));
     moveDelegate.undoMove(0);
     assertTrue(battle.getBattleTracker().wasConquered(sinkiang));
     // now move the planes into the territory
@@ -283,7 +283,7 @@ public class RevisedTest {
     // try to load them on the british players turn
     final Territory sz2 = territory("2 Sea Zone", gameData);
     final String error = moveDelegate(gameData).move(uk.getUnits().getMatches(Matches.unitIsOwnedBy(americans)),
-        new Route(uk, sz2), sz2.getUnits().getMatches(Matches.UnitIsTransport));
+        new Route(uk, sz2), sz2.getUnits().getMatches(Matches.unitIsTransport()));
     // should not be able to load on british turn, only on american turn
     assertFalse(error == null);
   }
@@ -399,7 +399,7 @@ public class RevisedTest {
     final Route sz14To13 = new Route();
     sz14To13.setStart(sz14);
     sz14To13.add(sz13);
-    final List<Unit> transports = sz14.getUnits().getMatches(Matches.UnitIsTransport);
+    final List<Unit> transports = sz14.getUnits().getMatches(Matches.unitIsTransport());
     assertEquals(1, transports.size());
     final String error = moveDelegate.move(transports, sz14To13);
     assertNull(error, error);
@@ -422,7 +422,7 @@ public class RevisedTest {
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     final String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // make sure the transport was loaded
@@ -455,7 +455,7 @@ public class RevisedTest {
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     // load the transport
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
@@ -501,7 +501,7 @@ public class RevisedTest {
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     // load the transports
     // in two moves
     String error = moveDelegate.move(infantry.subList(0, 1), eeToSz5, Collections.singletonList(transport));
@@ -541,7 +541,7 @@ public class RevisedTest {
     final List<Unit> infantry = eastEurope.getUnits()
         .getMatches(Match.allOf(Matches.unitIsOfType(infantryType), Matches.unitIsOwnedBy(japanese)));
     assertEquals(1, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // try to unload
@@ -570,7 +570,7 @@ public class RevisedTest {
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // unload one infantry to Norway
@@ -623,7 +623,7 @@ public class RevisedTest {
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // unload one infantry to Norway
@@ -1307,7 +1307,7 @@ public class RevisedTest {
     removeFrom(cauc, cauc.getUnits().getMatches(Matches.unitIsNotAa()));
     // blitz
     final Territory wr = territory("West Russia", gameData);
-    move(wr.getUnits().getMatches(Matches.UnitCanBlitz), new Route(wr, cauc));
+    move(wr.getUnits().getMatches(Matches.unitCanBlitz()), new Route(wr, cauc));
     final Set<Territory> fire = new RocketsFireHelper().getTerritoriesWithRockets(gameData, germans(gameData));
     // germany, WE, SE, but not caucusus
     assertEquals(fire.size(), 3);
@@ -1378,17 +1378,18 @@ public class RevisedTest {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // load two transports, 1 tank each
-    load(germany.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(germany, sz5));
-    load(germany.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(germany, sz5));
-    load(germany.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
     // attack sz 6
-    move(sz5.getUnits().getMatches(Match.anyOf(Matches.UnitCanBlitz, Matches.UnitIsTransport)), new Route(sz5, sz6));
+    move(sz5.getUnits().getMatches(Match.anyOf(Matches.unitCanBlitz(), Matches.unitIsTransport())),
+        new Route(sz5, sz6));
     // unload transports, 1 each to a different country
     // this move is illegal now
-    assertMoveError(sz6.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(sz6, norway));
+    assertMoveError(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, norway));
     // this move is illegal now
-    assertMoveError(sz6.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(sz6, we));
-    move(sz6.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(sz6, uk));
+    assertMoveError(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, we));
+    move(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, uk));
     // fight the battle
     moveDelegate(gameData).end();
     final MustFightBattle battle =
@@ -1397,8 +1398,8 @@ public class RevisedTest {
     bridge.setRandomSource(new ScriptedRandomSource(0));
     battle.fight(bridge);
     // the armour should have died
-    assertEquals(0, norway.getUnits().countMatches(Matches.UnitCanBlitz));
-    assertEquals(2, we.getUnits().countMatches(Matches.UnitCanBlitz));
+    assertEquals(0, norway.getUnits().countMatches(Matches.unitCanBlitz()));
+    assertEquals(2, we.getUnits().countMatches(Matches.unitCanBlitz()));
     assertEquals(0, uk.getUnits().countMatches(Matches.unitIsOwnedBy(germans)));
   }
 
@@ -1433,7 +1434,7 @@ public class RevisedTest {
 
   @Test
   public void testTransportIsTransport() {
-    assertTrue(Matches.UnitIsTransport.match(transport(gameData).create(british(gameData))));
-    assertFalse(Matches.UnitIsTransport.match(infantry(gameData).create(british(gameData))));
+    assertTrue(Matches.unitIsTransport().match(transport(gameData).create(british(gameData))));
+    assertFalse(Matches.unitIsTransport().match(infantry(gameData).create(british(gameData))));
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -320,7 +320,7 @@ public class WW2V3Year41Test {
     final Territory sz13 = territory("13 Sea Zone", gameData);
     final Route sz9ToSz13 = new Route(sz9, territory("12 Sea Zone", gameData), sz13);
     // move the transport to attack, this is suicide but valid
-    move(sz9.getUnits().getMatches(Matches.UnitIsTransport), sz9ToSz13);
+    move(sz9.getUnits().getMatches(Matches.unitIsTransport()), sz9ToSz13);
     // load the transport
     load(gibraltar.getUnits().getUnits(), new Route(gibraltar, sz13));
     moveDelegate.end();
@@ -346,7 +346,7 @@ public class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Route sz9ToSz7 = new Route(sz9, territory("8 Sea Zone", gameData), sz7);
     // move the transport to attack, this is suicide but valid
-    final List<Unit> transports = sz9.getUnits().getMatches(Matches.UnitIsTransport);
+    final List<Unit> transports = sz9.getUnits().getMatches(Matches.unitIsTransport());
     move(transports, sz9ToSz7);
     // load the transport
     load(uk.getUnits().getMatches(Matches.unitIsInfantry()), new Route(uk, sz7));
@@ -403,7 +403,7 @@ public class WW2V3Year41Test {
     // attack from bulgraia
     move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
     // add a blitz attack
-    move(poland.getUnits().getMatches(Matches.UnitCanBlitz), new Route(poland, eastPoland, ukraine));
+    move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
     // that territory was just conquered
     final MustFightBattle battle =
@@ -428,7 +428,7 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     // add a blitz attack
     String errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.UnitCanBlitz), new Route(poland, eastPoland, ukraine));
+        moveDelegate.move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
     assertError(errorResults);
     /*
      * Now try with an AA
@@ -444,7 +444,7 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     // add a blitz attack
     errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.UnitCanBlitz), new Route(poland, eastPoland, ukraine));
+        moveDelegate.move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
     assertError(errorResults);
   }
 
@@ -481,7 +481,7 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     // load the trn
     errorResults = moveDelegate.move(finland.getUnits().getMatches(Matches.unitIsAaForAnything()),
-        new Route(finland, sz5), sz5.getUnits().getMatches(Matches.UnitIsTransport));
+        new Route(finland, sz5), sz5.getUnits().getMatches(Matches.unitIsTransport()));
     assertValid(errorResults);
     // unload the trn
     errorResults = moveDelegate.move(sz5.getUnits().getMatches(Matches.unitIsAaForAnything()), new Route(sz5, germany));
@@ -532,14 +532,14 @@ public class WW2V3Year41Test {
     final int preCountIntBelorussia = belorussia.getUnits().size();
     // Get units
     final Collection<Unit> moveUnits = poland.getUnits().getUnits(infantryType, 3);
-    moveUnits.addAll(poland.getUnits().getMatches(Matches.UnitCanBlitz));
+    moveUnits.addAll(poland.getUnits().getMatches(Matches.unitCanBlitz()));
     // add a INVALID blitz attack
     final String errorResults = moveDelegate.move(moveUnits, new Route(poland, eastPoland, belorussia));
     assertError(errorResults);
     // Fix the number of units
     moveUnits.clear();
     moveUnits.addAll(poland.getUnits().getUnits(infantryType, 2));
-    moveUnits.addAll(poland.getUnits().getMatches(Matches.UnitCanBlitz));
+    moveUnits.addAll(poland.getUnits().getMatches(Matches.unitCanBlitz()));
     // add a VALID blitz attack
     final String validResults = moveDelegate.move(moveUnits, new Route(poland, eastPoland, belorussia));
     assertValid(validResults);
@@ -1046,7 +1046,7 @@ public class WW2V3Year41Test {
     // TechAttachment.get(italians).setDestroyerBombard("true");
     UnitAttachment.get(destroyer(gameData)).setCanBombard("true");
     // Set the bombard strength for the DDs
-    final Collection<Unit> dds = Match.getMatches(sz15.getUnits().getUnits(), Matches.UnitIsDestroyer);
+    final Collection<Unit> dds = Match.getMatches(sz15.getUnits().getUnits(), Matches.unitIsDestroyer());
     final Iterator<Unit> ddIter = dds.iterator();
     while (ddIter.hasNext()) {
       final Unit unit = ddIter.next();
@@ -1166,7 +1166,7 @@ public class WW2V3Year41Test {
     final Route r = new Route(france, germany, poland);
     final List<Unit> toMove = new ArrayList<>();
     // 1 armour and 1 infantry
-    toMove.addAll(france.getUnits().getMatches(Matches.UnitCanBlitz));
+    toMove.addAll(france.getUnits().getMatches(Matches.unitCanBlitz()));
     toMove.add(france.getUnits().getMatches(Matches.unitIsInfantry()).get(0));
     move(toMove, r);
   }
@@ -1213,7 +1213,7 @@ public class WW2V3Year41Test {
     final Territory karelia = territory("Karelia S.S.R.", gameData);
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
-    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.UnitCanBlitz);
+    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
     toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
@@ -1230,7 +1230,7 @@ public class WW2V3Year41Test {
     final Territory karelia = territory("Karelia S.S.R.", gameData);
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
-    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.UnitCanBlitz);
+    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
     toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
@@ -1253,7 +1253,7 @@ public class WW2V3Year41Test {
     List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
+    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
     // move to nwe, this is a valid move, and it not a partroop move
     move(bomberAndParatroop, new Route(germany, nwe));
   }
@@ -1274,7 +1274,7 @@ public class WW2V3Year41Test {
     final List<Unit> paratrooper = nwe.getUnits().getMatches(Matches.unitIsAirTransportable());
     move(paratrooper, new Route(nwe, germany));
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
+    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
     // move the units to east poland
     final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
     assertError(error);
@@ -1294,7 +1294,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     // Move the bomber first
-    final List<Unit> bomber = germany.getUnits().getMatches(Matches.UnitIsAirTransport);
+    final List<Unit> bomber = germany.getUnits().getMatches(Matches.unitIsAirTransport());
     move(bomber, new Route(germany, poland));
     // Pick up a paratrooper
     final List<Unit> bomberAndParatroop = new ArrayList<>(bomber);
@@ -1318,7 +1318,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     final List<Unit> bomberAndParatroop = new ArrayList<>();
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
+    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
     // add 2 infantry
     bomberAndParatroop.addAll(germany.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 2));
     // move the units to east poland
@@ -1344,9 +1344,9 @@ public class WW2V3Year41Test {
     List<Unit> paratroopers = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratroopers = paratroopers.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratroopers);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
+    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
     final Route route = new Route(germany, poland, eastPoland);
-    final List<Unit> airTransports = germany.getUnits().getMatches(Matches.UnitIsAirTransport);
+    final List<Unit> airTransports = germany.getUnits().getMatches(Matches.unitIsAirTransport());
     for (final Unit airTransport : airTransports) {
       for (final Unit unit : paratroopers) {
         final Change change = TransportTracker.loadTransportChange((TripleAUnit) airTransport, unit);
@@ -1381,10 +1381,10 @@ public class WW2V3Year41Test {
     List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
-    final List<Unit> tanks = poland.getUnits().getMatches(Matches.UnitCanBlitz);
+    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
+    final List<Unit> tanks = poland.getUnits().getMatches(Matches.unitCanBlitz());
     move(tanks, new Route(poland, eastPoland, beloRussia));
-    final List<Unit> airTransports = Match.getMatches(bomberAndParatroop, Matches.UnitIsAirTransport);
+    final List<Unit> airTransports = Match.getMatches(bomberAndParatroop, Matches.unitIsAirTransport());
     for (final Unit airTransport : airTransports) {
       for (final Unit unit : paratrooper) {
         final Change change = TransportTracker.loadTransportChange((TripleAUnit) airTransport, unit);
@@ -1633,7 +1633,7 @@ public class WW2V3Year41Test {
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // blitz in two steps
-    final Collection<Unit> armour = egypt.getUnits().getMatches(Matches.UnitCanBlitz);
+    final Collection<Unit> armour = egypt.getUnits().getMatches(Matches.unitCanBlitz());
     move(armour, new Route(egypt, libya));
     assertEquals(libya.getOwner(), british(gameData));
     move(armour, new Route(libya, morrocco));

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -57,7 +57,7 @@ public class WW2V3Year42Test {
     final Route sz13To12 = new Route();
     sz13To12.setStart(sz13);
     sz13To12.add(sz12);
-    final List<Unit> transports = sz13.getUnits().getMatches(Matches.UnitIsTransport);
+    final List<Unit> transports = sz13.getUnits().getMatches(Matches.unitIsTransport());
     assertEquals(1, transports.size());
     final String error = moveDelegate.move(transports, sz13To12);
     assertEquals(error, null);
@@ -156,7 +156,7 @@ public class WW2V3Year42Test {
     // attack with a german sub
     move(sz7.getUnits().getUnits(), new Route(sz7, sz6, sz5));
     // move the transport away
-    move(sz5.getUnits().getMatches(Matches.UnitIsTransport), new Route(sz5, sz6));
+    move(sz5.getUnits().getMatches(Matches.unitIsTransport()), new Route(sz5, sz6));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.