### PR TITLE
Add requiresUnitsToMove Option to UnitAttachment XML

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1829,6 +1829,9 @@ public final class Matches {
     });
   }
 
+  /**
+   * Checks if requiresUnits criteria allows placement in territory based on units there at the start of turn.
+   */
   public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnitsInList(
       final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return Match.of(unitWhichRequiresUnits -> {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1068,16 +1068,14 @@ public final class Matches {
   }
 
   /**
-   * Does NOT check for Canals, Blitzing, Loading units on transports, TerritoryEffects that disallow units, Stacking
-   * Limits, Unit movement
-   * left, Fuel available, etc.<br>
+   * Does NOT check for: Canals, Blitzing, Loading units on transports, TerritoryEffects that disallow units, Stacking
+   * Limits, Unit movement left, Fuel available, etc.
    * <br>
-   * Does check for: Impassable, ImpassableNeutrals, ImpassableToAirNeutrals, RestrictedTerritories, Land units moving
-   * on water, Sea units
-   * moving on land,
-   * and territories that are disallowed due to a relationship attachment (canMoveLandUnitsOverOwnedLand,
-   * canMoveAirUnitsOverOwnedLand,
-   * canLandAirUnitsOnOwnedLand, canMoveIntoDuringCombatMove, etc).
+   * <br>
+   * Does check for: Impassable, ImpassableNeutrals, ImpassableToAirNeutrals, RestrictedTerritories, requiresUnitToMove,
+   * Land units moving on water, Sea units moving on land, and territories that are disallowed due to a relationship
+   * attachment (canMoveLandUnitsOverOwnedLand, canMoveAirUnitsOverOwnedLand, canLandAirUnitsOnOwnedLand,
+   * canMoveIntoDuringCombatMove, etc).
    */
   public static Match<Territory> territoryIsPassableAndNotRestrictedAndOkByRelationships(
       final PlayerID playerWhoOwnsAllTheUnitsMoving, final GameData data, final boolean isCombatMovePhase,
@@ -1865,6 +1863,38 @@ public final class Matches {
         }
       }
       return canBuild;
+    });
+  }
+
+  /**
+   * Check if unit meets requiredUnitsToMove criteria and can move into territory.
+   */
+  public static Match<Unit> unitHasRequiredUnitsToMove(final Territory t) {
+    return Match.of(unit -> {
+
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (ua == null || ua.getRequiresUnitsToMove() == null || ua.getRequiresUnitsToMove().isEmpty()) {
+        return true;
+      }
+
+      final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
+          Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsNotDisabled());
+      final List<Unit> units = Match.getMatches(t.getUnits().getUnits(), unitIsOwnedByAndNotDisabled);
+
+      for (final String[] array : ua.getRequiresUnitsToMove()) {
+        boolean haveAll = true;
+        for (final UnitType ut : ua.getListedUnits(array)) {
+          if (Match.noneMatch(units, Matches.unitIsOfType(ut))) {
+            haveAll = false;
+            break;
+          }
+        }
+        if (haveAll) {
+          return true;
+        }
+      }
+
+      return false;
     });
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -655,7 +655,15 @@ public class MoveValidator {
         return result.setErrorReturnResult("Territory Effects disallow some units into "
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
+      // Check requiresUnitsToMove conditions
+      for (final Territory t : route.getSteps()) {
+        if (!Match.allMatch(units, Matches.unitHasRequiredUnitsToMove(t))) {
+          return result.setErrorReturnResult(
+              t.getName() + " doesn't have the required units to allow moving the selected units into it");
+        }
+      }
     } // !isEditMode
+
     // make sure that no non sea non transportable no carriable units end at sea
     if (route.getEnd() != null && route.getEnd().isWater()) {
       for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
@@ -739,7 +747,7 @@ public class MoveValidator {
   static Map<Unit, Collection<Unit>> getDependents(final Collection<Unit> units) {
     // just worry about transports
     final Map<Unit, Collection<Unit>> dependents = new HashMap<>();
-    for (Unit unit : units) {
+    for (final Unit unit : units) {
       dependents.put(unit, TransportTracker.transporting(unit));
     }
     return dependents;
@@ -899,7 +907,7 @@ public class MoveValidator {
       throw new IllegalArgumentException("no units");
     }
     int max = 0;
-    for (Unit unit : units) {
+    for (final Unit unit : units) {
       final int left = TripleAUnit.get(unit).getMovementLeft();
       max = Math.max(left, max);
     }
@@ -911,7 +919,7 @@ public class MoveValidator {
       throw new IllegalArgumentException("no units");
     }
     int least = Integer.MAX_VALUE;
-    for (Unit unit : units) {
+    for (final Unit unit : units) {
       final int left = TripleAUnit.get(unit).getMovementLeft();
       least = Math.min(left, least);
     }
@@ -1064,7 +1072,7 @@ public class MoveValidator {
     }
     if (route.getEnd().isWater() && route.getStart().isWater()) {
       // make sure units and transports stick together
-      for (Unit unit : units) {
+      for (final Unit unit : units) {
         final UnitAttachment ua = UnitAttachment.get(unit.getType());
         // make sure transports dont leave their units behind
         if (ua.getTransportCapacity() != -1) {
@@ -1113,7 +1121,7 @@ public class MoveValidator {
           result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
         } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
           Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
-          for (Unit transportToLoad : transportsToLoad) {
+          for (final Unit transportToLoad : transportsToLoad) {
             final TripleAUnit trn = (TripleAUnit) transportToLoad;
             if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(trn, route.getEnd())) {
               final UnitAttachment ua = UnitAttachment.get(unit.getType());

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -222,6 +222,20 @@ public class GameDataTestUtil {
   }
 
   /**
+   * Returns a germanTrain UnitType object for the specified GameData object.
+   */
+  public static UnitType germanTrain(final GameData data) {
+    return unitType("germanTrain", data);
+  }
+
+  /**
+   * Returns a germanRail UnitType object for the specified GameData object.
+   */
+  public static UnitType germanRail(final GameData data) {
+    return unitType("germanRail", data);
+  }
+
+  /**
    * Returns a factory_upgrade UnitType object for the specified GameData object.
    */
   public static UnitType factoryUpgrade(final GameData data) {

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -1,27 +1,40 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
+import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.Match;
 
 public class MoveValidatorTest extends DelegateTest {
+
+  private GameData gameData;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
+    gameData = TestMapGameData.TWW.getGameData();
   }
 
   @Test
@@ -117,4 +130,32 @@ public class MoveValidatorTest extends DelegateTest {
     units.addAll(infantry.create(2, british));
     assertTrue(Match.anyMatch(units, Matches.UnitIsLand));
   }
+
+  @Test
+  public void testValidateMoveForRequiresUnitsToMove() {
+
+    // Move regular units
+    final PlayerID germans = GameDataTestUtil.germany(gameData);
+    final Territory berlin = territory("Berlin", gameData);
+    final Territory easternGermany = territory("Eastern Germany", gameData);
+    final Route r = new Route(berlin, easternGermany);
+    List<Unit> toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
+    MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, gameData);
+    assertTrue(results.isMoveValid());
+
+    // Add germanTrain to units which fails since it requires germainRail
+    addTo(berlin, GameDataTestUtil.germanTrain(gameData).create(1, germans));
+    toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
+    results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, gameData);
+    assertFalse(results.isMoveValid());
+
+    // Add germanRail to destination so move succeeds
+    addTo(easternGermany, GameDataTestUtil.germanRail(gameData).create(1, germans));
+    results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, gameData);
+    assertTrue(results.isMoveValid());
+  }
+
 }

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -28,13 +28,13 @@ import games.strategy.util.Match;
 
 public class MoveValidatorTest extends DelegateTest {
 
-  private GameData gameData;
+  private GameData twwGameData;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    gameData = TestMapGameData.TWW.getGameData();
+    twwGameData = TestMapGameData.TWW.getGameData();
   }
 
   @Test
@@ -135,26 +135,26 @@ public class MoveValidatorTest extends DelegateTest {
   public void testValidateMoveForRequiresUnitsToMove() {
 
     // Move regular units
-    final PlayerID germans = GameDataTestUtil.germany(gameData);
-    final Territory berlin = territory("Berlin", gameData);
-    final Territory easternGermany = territory("Eastern Germany", gameData);
+    final PlayerID germans = GameDataTestUtil.germany(twwGameData);
+    final Territory berlin = territory("Berlin", twwGameData);
+    final Territory easternGermany = territory("Eastern Germany", twwGameData);
     final Route r = new Route(berlin, easternGermany);
     List<Unit> toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
     MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
-        new HashMap<>(), false, null, gameData);
+        new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add germanTrain to units which fails since it requires germainRail
-    addTo(berlin, GameDataTestUtil.germanTrain(gameData).create(1, germans));
+    addTo(berlin, GameDataTestUtil.germanTrain(twwGameData).create(1, germans));
     toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
-        new HashMap<>(), false, null, gameData);
+        new HashMap<>(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to destination so move succeeds
-    addTo(easternGermany, GameDataTestUtil.germanRail(gameData).create(1, germans));
+    addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
-        new HashMap<>(), false, null, gameData);
+        new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -28,13 +28,10 @@ import games.strategy.util.Match;
 
 public class MoveValidatorTest extends DelegateTest {
 
-  private GameData twwGameData;
-
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    twwGameData = TestMapGameData.TWW.getGameData();
   }
 
   @Test
@@ -132,7 +129,9 @@ public class MoveValidatorTest extends DelegateTest {
   }
 
   @Test
-  public void testValidateMoveForRequiresUnitsToMove() {
+  public void testValidateMoveForRequiresUnitsToMove() throws Exception {
+
+    final GameData twwGameData = TestMapGameData.TWW.getGameData();
 
     // Move regular units
     final PlayerID germans = GameDataTestUtil.germany(twwGameData);

--- a/src/test/resources/Total_World_War_Dec1941.xml
+++ b/src/test/resources/Total_World_War_Dec1941.xml
@@ -1891,6 +1891,8 @@
     <alliance player="Brazil" alliance="Neutral"/>
   </playerList>
   <unitList>
+    <unit name="germanTrain"/>
+    <unit name="germanRail"/>
     <unit name="germanInfantry"/>
     <unit name="germanAlpineInfantry"/>
     <unit name="germanCombatEngineer"/>
@@ -7676,6 +7678,32 @@
       <option name="whenCapturedChangesInto" value="any:India:true:Material:1"/>
     </attachment>
     <!-- German Units -->
+    <attachment name="unitAttachment" attachTo="germanTrain" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="movement" value="5"/>
+      <option name="attack" value="0"/>
+      <option name="defense" value="0"/>
+      <option name="transportCost" value="2"/>
+      <option name="canBeGivenByTerritoryTo" value="Germany"/>
+      <option name="requiresUnits" value="germanFactory"/>
+      <option name="canInvadeOnlyFrom" value="none"/>
+      <option name="requiresUnitsToMove" value="germanRail"/>
+    </attachment>
+    <attachment name="unitAttachment" attachTo="germanRail" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="isInfrastructure" value="true"/>
+      <option name="canBeDamaged" value="true"/>
+      <option name="maxDamage" value="12"/>
+      <option name="maxOperationalDamage" value="8"/>
+      <option name="movement" value="0"/>
+      <option name="attack" value="0"/>
+      <option name="defense" value="0"/>
+      <option name="isConstruction" value="true"/>
+      <option name="constructionType" value="fProduction"/>
+      <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+      <option name="maxConstructionsPerTypePerTerr" value="1"/>
+      <option name="canDieFromReachingMaxDamage" value="true"/>
+      <option name="consumesUnits" value="1:Material"/>
+      <option name="requiresUnits" value="germanCombatEngineer"/>
+    </attachment>
     <attachment name="unitAttachment" attachTo="germanInfantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
       <option name="movement" value="1"/>
       <option name="attack" value="2"/>


### PR DESCRIPTION
**Addresses:** https://forums.triplea-game.org/topic/303/unitattachment-which-allows-requires-another-unit-to-move

**Use case:** Have a way to create trains and rails for moving units.

**Functional Changes**
- Added new UnitAttachment option "requiresUnitsToMove" which functions similarly to "requiresUnits" except units are required for movement instead of placement
- Should be no changes to existing maps that don't use this new option

**XML Example**
```
<attachment name="unitAttachment" attachTo="germanTrain" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
<option name="requiresUnitsToMove" value="germanRail"/>
</attachment>
```

**Variations**
1 choice, 1 unit:
```
<option name="requiresUnitsToMove" value="germanRail"/>
```

1 choice, multiple units (AND):
```
<option name="requiresUnitsToMove" value="germanRail:germanRailAdvanced"/>
```

multiple choices (OR), 1 unit:
```
<option name="requiresUnitsToMove" value="germanRail"/>
<option name="requiresUnitsToMove" value="russianRail"/>
```

multiple choices (OR), multiple units (AND):
```
<option name="requiresUnitsToMove" value="germanRail:germanRailAdvanced"/>
<option name="requiresUnitsToMove" value="russianRail:russianRailAdvanced"/>
```