### PR TITLE
Update Map Maker help document link (#2294)

### DIFF
--- a/src/main/java/games/strategy/net/OpenFileUtility.java
+++ b/src/main/java/games/strategy/net/OpenFileUtility.java
@@ -11,7 +11,8 @@ import games.strategy.ui.SwingComponents;
 /**
  * A wrapper class for opening Files & URLs using the Desktop API.
  */
-public class OpenFileUtility {
+public final class OpenFileUtility {
+  private OpenFileUtility() {}
 
   /**
    * Opens a specific file on the user's computer using the local computer's file associations.
@@ -28,11 +29,11 @@ public class OpenFileUtility {
    * @param file The file to be opened.
    * @param action What to do if the Desktop API is not supported.
    */
-  public static void openFile(final File file, Runnable action) {
+  public static void openFile(final File file, final Runnable action) {
     if (Desktop.isDesktopSupported()) {
       try {
         Desktop.getDesktop().open(file);
-      } catch (IOException e) {
+      } catch (final IOException e) {
         ClientLogger.logError("Could not open File " + file.getAbsolutePath(), e);
       }
     } else {
@@ -46,11 +47,11 @@ public class OpenFileUtility {
    * @param url A URL of a web page (ex: "http://www.google.com/").
    * @param action What to do if the Desktop API is not supported.
    */
-  public static void openUrl(final String url, Runnable action) {
+  public static void openUrl(final String url, final Runnable action) {
     if (Desktop.isDesktopSupported()) {
       try {
         Desktop.getDesktop().browse(URI.create(url));
-      } catch (IOException e) {
+      } catch (final IOException e) {
         ClientLogger.logError("Could not open URL " + url, e);
       }
     } else {
@@ -67,7 +68,7 @@ public class OpenFileUtility {
     openUrl(url, () -> logDesktopApiMessage(url));
   }
 
-  private static void logDesktopApiMessage(String path) {
+  private static void logDesktopApiMessage(final String path) {
     SwingComponents.showDialog("Desktop API not supported",
         "We're sorry, but it seems that your installed java version doesn't support the Desktop API required to open "
             + path);

--- a/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -22,7 +22,8 @@ public enum UrlConstants {
   LATEST_GAME_DOWNLOAD_WEBSITE("http://www.triplea-game.org/download"),
   TRIPLEA_WEBSITE("http://www.triplea-game.org/"),
   MAP_DOWNLOAD_LIST("https://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.yaml?raw=true"),
-  LOBBY_PROPS_FILE_URL("https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml?raw=true");
+  LOBBY_PROPS_FILE_URL("https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml?raw=true"),
+  MAP_MAKER_HELP("https://github.com/triplea-game/triplea/blob/master/docs/map_making/map_and_map_skin_making_overview.md");
 
   private final String urlString;
 

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -3,8 +3,6 @@ package tools.map.making;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.io.File;
@@ -28,10 +26,10 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.net.OpenFileUtility;
+import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.ui.SwingAction;
 import tools.image.AutoPlacementFinder;
@@ -185,18 +183,7 @@ public class MapCreator extends JFrame {
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Click button open up the readme file on how to make maps:"));
     final JButton helpButton = new JButton("Start Tutorial  /  Show Help Document");
-    helpButton.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        try {
-          OpenFileUtility.openFile(
-              new File(ClientFileSystemHelper.getRootFolder(),
-                  "doc" + File.separator + "map_and_map_skin_making_overview.html"));
-        } catch (final Exception e1) {
-          e1.printStackTrace();
-        }
-      }
-    });
+    helpButton.addActionListener(e -> OpenFileUtility.openUrl(UrlConstants.MAP_MAKER_HELP.toString()));
     panel1.add(helpButton);
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Click button to select where your map folder is:"));


### PR DESCRIPTION
This PR fixes the broken Map Maker help document link reported in #2294.

This link actually broke some time ago and changed quite a lot in the past year and a half:

* In 42164ea, the document was moved from the `doc/` folder in this repo to the assets repo.
* The `doc/` folder in the assets repo was removed in triplea-game/assets@c9f5bd1 when all the documentation was moved to the website.
* The website docs were subsequently deleted in triplea-game/triplea-game.github.io@6928cf3 when the documentation was moved back to this repo.

#### Functional changes

I updated the link to point to the current location of the Map Maker help document at https://github.com/triplea-game/triplea/blob/master/docs/map_making/map_and_map_skin_making_overview.md

#### Refactoring changes

While I was here, I ran Clean Up on `OpenFileUtility`.

#### Testing

I verified that clicking the **Start Tutorial / Show Help Document** button in Map Maker opens the above URL in the user's default browser.