### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 8)

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -161,7 +161,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
       if (t.getOwner().equals(this)) {
         ownsLand = true;
       }
-      if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
+      if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this), Matches.unitCanProduceUnits()))) {
         hasFactory = true;
       }
       if (ownsLand && hasFactory) {

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -369,7 +369,7 @@ public class TripleAUnit extends Unit {
         // can use "production" or "unitProduction"
         return territoryUnitProduction * 2;
       } else {
-        if (Matches.UnitCanProduceUnits.match(u)) {
+        if (Matches.unitCanProduceUnits().match(u)) {
           if (ua.getCanProduceXUnits() < 0) {
             // can use "production" or "unitProduction"
             return territoryUnitProduction * ua.getMaxDamage();
@@ -431,7 +431,7 @@ public class TripleAUnit extends Unit {
     if (u == null) {
       return 0;
     }
-    if (!Matches.UnitCanProduceUnits.match(u)) {
+    if (!Matches.unitCanProduceUnits().match(u)) {
       return 0;
     }
     int productionCapacity = 0;

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -131,7 +131,7 @@ public class AIUtils {
   }
 
   static List<Unit> interleaveCarriersAndPlanes(final List<Unit> units, final int planesThatDontNeedToLand) {
-    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
+    if (!(Match.anyMatch(units, Matches.unitIsCarrier()) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
       return units;
     }
     // Clone the current list
@@ -157,7 +157,7 @@ public class AIUtils {
         // If this is the first carrier seek
         if (seekedCarrier == null) {
           final int seekedCarrierIndex = getIndexOfLastUnitMatching(result,
-              Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             // No carriers left
             break;
@@ -186,7 +186,7 @@ public class AIUtils {
             filledCarriers.add(seekedCarrier);
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;
@@ -224,7 +224,7 @@ public class AIUtils {
             }
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -312,8 +312,8 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       final List<Territory> notOwned = Match.getMatches(territoryChoices, Matches.isTerritoryOwnedBy(me).invert());
       if (notOwned.isEmpty()) {
         // only owned territories left
-        final boolean nonFactoryUnitsLeft = Match.anyMatch(unitChoices, Matches.UnitCanProduceUnits.invert());
-        final Match<Unit> ownedFactories = Match.allOf(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
+        final boolean nonFactoryUnitsLeft = Match.anyMatch(unitChoices, Matches.unitCanProduceUnits().invert());
+        final Match<Unit> ownedFactories = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsOwnedBy(me));
         final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(territoryChoices);
@@ -340,7 +340,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           }
         } else {
           final int maxTerritoriesToPopulate = Math.min(territoryChoices.size(),
-              Math.max(4, Match.countMatches(unitChoices, Matches.UnitCanProduceUnits)));
+              Math.max(4, Match.countMatches(unitChoices, Matches.unitCanProduceUnits())));
           test.addAll(territoriesWithFactories);
           if (!test.isEmpty()) {
             if (test.size() < maxTerritoriesToPopulate) {
@@ -403,7 +403,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
     final Set<Unit> unitsToPlace = new HashSet<>();
     if (unitChoices != null && !unitChoices.isEmpty() && unitsPerPick > 0) {
       Collections.shuffle(unitChoices);
-      final List<Unit> nonFactory = Match.getMatches(unitChoices, Matches.UnitCanProduceUnits.invert());
+      final List<Unit> nonFactory = Match.getMatches(unitChoices, Matches.unitCanProduceUnits().invert());
       if (nonFactory.isEmpty()) {
         for (int i = 0; i < unitsPerPick && !unitChoices.isEmpty(); i++) {
           unitsToPlace.add(unitChoices.get(0));

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -1017,7 +1017,7 @@ class ProCombatMoveAI {
 
         // Add destroyer if territory has subs and a destroyer has been already added
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
-        if (Match.anyMatch(defendingUnits, Matches.UnitIsSub)
+        if (Match.anyMatch(defendingUnits, Matches.unitIsSub())
             && Match.noneMatch(attackMap.get(t).getUnits(), Matches.unitIsDestroyer())) {
           attackMap.get(t).addUnit(unit);
           it.remove();
@@ -1382,7 +1382,7 @@ class ProCombatMoveAI {
       final Set<Territory> canBombardTerritories = new HashSet<>();
       for (final ProTerritory patd : prioritizedTerritories) {
         final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
-        final boolean hasDefenders = Match.anyMatch(defendingUnits, Matches.UnitIsInfrastructure.invert());
+        final boolean hasDefenders = Match.anyMatch(defendingUnits, Matches.unitIsInfrastructure().invert());
         if (bombardMap.get(u).contains(patd.getTerritory()) && !patd.getTransportTerritoryMap().isEmpty()
             && hasDefenders && !TransportTracker.isTransporting(u)) {
           canBombardTerritories.add(patd.getTerritory());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -150,7 +150,7 @@ class ProNonCombatMoveAI {
 
     // Log a warning if any units not assigned to a territory (skip infrastructure for now)
     for (final Unit u : territoryManager.getDefendOptions().getUnitMoveMap().keySet()) {
-      if (Matches.UnitIsInfrastructure.invert().match(u)) {
+      if (Matches.unitIsInfrastructure().invert().match(u)) {
         ProLogger.warn(player + ": " + unitTerritoryMap.get(u) + " has unmoved unit: " + u + " with options: "
             + territoryManager.getDefendOptions().getUnitMoveMap().get(u));
       }
@@ -612,7 +612,7 @@ class ProNonCombatMoveAI {
       for (final Iterator<Unit> it = sortedUnitMoveOptions.keySet().iterator(); it.hasNext();) {
         final Unit unit = it.next();
         final boolean isAirUnit = UnitAttachment.get(unit.getType()).getIsAir();
-        if (isAirUnit || Matches.UnitIsCarrier.match(unit)) {
+        if (isAirUnit || Matches.unitIsCarrier().match(unit)) {
           continue; // skip air and carrier units
         }
         final TreeMap<Double, Territory> estimatesMap = new TreeMap<>();
@@ -667,7 +667,7 @@ class ProNonCombatMoveAI {
           it.remove();
 
           // If carrier has dependent allied fighters then move them too
-          if (Matches.UnitIsCarrier.match(unit)) {
+          if (Matches.unitIsCarrier().match(unit)) {
             final Territory unitTerritory = unitTerritoryMap.get(unit);
             final Map<Unit, Collection<Unit>> carrierMustMoveWith =
                 MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
@@ -1365,7 +1365,7 @@ class ProNonCombatMoveAI {
                 it.remove();
 
                 // If carrier has dependent allied fighters then move them too
-                if (Matches.UnitIsCarrier.match(u)) {
+                if (Matches.unitIsCarrier().match(u)) {
                   final Territory unitTerritory = unitTerritoryMap.get(u);
                   final Map<Unit, Collection<Unit>> carrierMustMoveWith = MoveValidator
                       .carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
@@ -1442,7 +1442,7 @@ class ProNonCombatMoveAI {
             it.remove();
 
             // If carrier has dependent allied fighters then move them too
-            if (Matches.UnitIsCarrier.match(u)) {
+            if (Matches.unitIsCarrier().match(u)) {
               final Territory unitTerritory = unitTerritoryMap.get(u);
               final Map<Unit, Collection<Unit>> carrierMustMoveWith =
                   MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
@@ -1480,7 +1480,7 @@ class ProNonCombatMoveAI {
               it.remove();
 
               // If carrier has dependent allied fighters then move them too
-              if (Matches.UnitIsCarrier.match(u)) {
+              if (Matches.unitIsCarrier().match(u)) {
                 final Territory unitTerritory = unitTerritoryMap.get(u);
                 final Map<Unit, Collection<Unit>> carrierMustMoveWith =
                     MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
@@ -1861,7 +1861,7 @@ class ProNonCombatMoveAI {
         final Unit u = it.next();
 
         // Only check factory units
-        if (Matches.UnitCanProduceUnits.match(u)) {
+        if (Matches.unitCanProduceUnits().match(u)) {
           Territory maxValueTerritory = null;
           double maxValue = 0;
           for (final Territory t : infraUnitMoveMap.get(u)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -74,7 +74,7 @@ class ProPurchaseAI {
     this.data = data;
     this.player = player;
     final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player),
-        Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+        Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     final List<Territory> rfactories = Match.getMatches(data.getMap().getTerritories(),
         ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
     if (player.getRepairFrontier() != null
@@ -547,7 +547,7 @@ class ProPurchaseAI {
 
       // Determine if need destroyer
       boolean needDestroyer = false;
-      if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
+      if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsSub())
           && Match.noneMatch(ownedLocalUnits, Matches.unitIsDestroyer())) {
         needDestroyer = true;
       }
@@ -1146,7 +1146,7 @@ class ProPurchaseAI {
       if (enemyAttackOptions.getMax(t) != null) {
 
         // Determine if need destroyer
-        if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
+        if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsSub())
             && Match.noneMatch(t.getUnits().getMatches(Matches.unitIsOwnedBy(player)), Matches.unitIsDestroyer())) {
           needDestroyer = true;
         }
@@ -1159,7 +1159,7 @@ class ProPurchaseAI {
             initialDefendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
         boolean hasOnlyRetreatingSubs =
             Properties.getSubRetreatBeforeBattle(data)
-                && !initialDefendingUnits.isEmpty() && Match.allMatch(initialDefendingUnits, Matches.UnitIsSub)
+                && !initialDefendingUnits.isEmpty() && Match.allMatch(initialDefendingUnits, Matches.unitIsSub())
                 && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsDestroyer());
         for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
 
@@ -1225,7 +1225,7 @@ class ProPurchaseAI {
                 defendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
                 Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
-                    && Match.allMatch(defendingUnits, Matches.UnitIsSub)
+                    && Match.allMatch(defendingUnits, Matches.unitIsSub())
                     && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsDestroyer());
           }
         }
@@ -1295,7 +1295,7 @@ class ProPurchaseAI {
       }
 
       // Check if destroyer is needed
-      final int numEnemySubs = Match.countMatches(enemyUnitsInSeaTerritories, Matches.UnitIsSub);
+      final int numEnemySubs = Match.countMatches(enemyUnitsInSeaTerritories, Matches.unitIsSub());
       final int numMyDestroyers = Match.countMatches(myUnitsInSeaTerritories, Matches.unitIsDestroyer());
       if (numEnemySubs > 2 * numMyDestroyers) {
         needDestroyer = true;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -463,7 +463,7 @@ final class ProTechAI {
     Territory ac = null;
     final Match<Unit> enemyPlane = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.unitCanMove());
     final Match<Unit> enemyCarrier =
-        Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.unitCanMove());
+        Match.allOf(Matches.unitIsCarrier(), Matches.unitIsOwnedBy(player), Matches.unitCanMove());
     q.add(start);
     Territory current = null;
     distance.put(start, 0);
@@ -534,10 +534,10 @@ final class ProTechAI {
     if (start == null || destination == null || !start.isWater() || !destination.isWater()) {
       return null;
     }
-    final Match<Unit> sub = Match.allOf(Matches.UnitIsSub.invert());
+    final Match<Unit> sub = Match.allOf(Matches.unitIsSub().invert());
     final Match<Unit> transport = Match.allOf(Matches.unitIsTransport().invert(), Matches.UnitIsLand.invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
-        Matches.UnitIsInfrastructure.invert(),
+        Matches.unitIsInfrastructure().invert(),
         Matches.alliedUnit(player, data).invert());
     if (Properties.getIgnoreTransportInMovement(data)) {
       unitCondBuilder.add(transport);

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -750,7 +750,7 @@ public class ProTerritoryManager {
       findNavalMoveOptions(player, myUnitTerritories, new HashMap<>(), unitMoveMap2, new HashMap<>(),
           Matches.TerritoryIsWater, enemyTerritories, false, true);
       for (final Unit u : unitMoveMap2.keySet()) {
-        if (Matches.UnitIsCarrier.match(u)) {
+        if (Matches.unitIsCarrier().match(u)) {
           possibleCarrierTerritories.addAll(unitMoveMap2.get(u));
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
@@ -66,8 +66,8 @@ public class ProSimulateTurnUtils {
         // Make updates to data
         final List<Unit> attackersToRemove = new ArrayList<>(attackers);
         attackersToRemove.removeAll(remainingUnits);
-        final List<Unit> defendersToRemove = Match.getMatches(defenders, Matches.UnitIsInfrastructure.invert());
-        final List<Unit> infrastructureToChangeOwner = Match.getMatches(defenders, Matches.UnitIsInfrastructure);
+        final List<Unit> defendersToRemove = Match.getMatches(defenders, Matches.unitIsInfrastructure().invert());
+        final List<Unit> infrastructureToChangeOwner = Match.getMatches(defenders, Matches.unitIsInfrastructure());
         ProLogger.debug("attackersToRemove=" + attackersToRemove);
         ProLogger.debug("defendersToRemove=" + defendersToRemove);
         ProLogger.debug("infrastructureToChangeOwner=" + infrastructureToChangeOwner);
@@ -175,7 +175,7 @@ public class ProSimulateTurnUtils {
         }
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);
         delegateBridge.addChange(takeOverFriendlyTerritories);
-        final Collection<Unit> units = Match.getMatches(item.getUnits().getUnits(), Matches.UnitIsInfrastructure);
+        final Collection<Unit> units = Match.getMatches(item.getUnits().getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, t);
           delegateBridge.addChange(takeOverNonComUnits);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -55,7 +55,7 @@ public class ProBattleUtils {
     Collections.reverse(sortedUnitsList);
     final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
         defendingUnits, false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
-    final List<Unit> defendersWithHitPoints = Match.getMatches(defendingUnits, Matches.UnitIsInfrastructure.invert());
+    final List<Unit> defendersWithHitPoints = Match.getMatches(defendingUnits, Matches.unitIsInfrastructure().invert());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
     return ((attackPower / data.getDiceSides()) >= totalDefenderHitPoints);
   }
@@ -66,7 +66,7 @@ public class ProBattleUtils {
     if (attackingUnits.size() == 0) {
       return 0;
     }
-    final List<Unit> actualDefenders = Match.getMatches(defendingUnits, Matches.UnitIsInfrastructure.invert());
+    final List<Unit> actualDefenders = Match.getMatches(defendingUnits, Matches.unitIsInfrastructure().invert());
     if (actualDefenders.size() == 0) {
       return 100;
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -164,7 +164,7 @@ public class ProMatches {
 
   private static Match<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> {
-      final Match<Unit> subOnly = Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsSub,
+      final Match<Unit> subOnly = Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsSub(),
           Matches.enemyUnit(player, data).invert());
       return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
           || Matches.territoryHasNoEnemyUnits(player, data).match(t);
@@ -195,7 +195,7 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
-    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
@@ -225,20 +225,20 @@ public class ProMatches {
   }
 
   private static Match<Territory> territoryHasNonMobileInfraFactory() {
-    final Match<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits,
-        Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft().invert());
+    final Match<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(),
+        Matches.unitIsInfrastructure(), Matches.unitHasMovementLeft().invert());
     return Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLand(final PlayerID player) {
     final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitIsOwnedBy(player),
-        Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+        Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryOwnedBy(player),
         Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
-    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryAllied(player, data),
         Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
@@ -403,7 +403,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
     return Match.allOf(unitCanBeMovedAndIsOwned(player),
-        Matches.unitCanNotMoveDuringCombatMove(), Matches.UnitIsInfrastructure);
+        Matches.unitCanNotMoveDuringCombatMove(), Matches.unitIsInfrastructure());
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
@@ -420,12 +420,12 @@ public class ProMatches {
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
       final Territory t) {
     return Match.allOf(unitCantBeMovedAndIsAlliedDefender(player, data, t),
-        Matches.UnitIsNotInfrastructure);
+        Matches.unitIsNotInfrastructure());
   }
 
   public static Match<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
-        Matches.UnitIsNotInfrastructure);
+        Matches.unitIsNotInfrastructure());
   }
 
   public static Match<Unit> unitIsAlliedNotOwned(final PlayerID player, final GameData data) {
@@ -449,7 +449,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsNotInfrastructure());
   }
 
   public static Match<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -65,7 +65,7 @@ public class ProMoveUtils {
         moveUnits.add(unitList);
 
         // If carrier has dependent allied fighters then move them too
-        if (Matches.UnitIsCarrier.match(u)) {
+        if (Matches.unitIsCarrier().match(u)) {
           final Map<Unit, Collection<Unit>> carrierMustMoveWith =
               MoveValidator.carrierMustMoveWith(startTerritory.getUnits().getUnits(), startTerritory, data, player);
           if (carrierMustMoveWith.containsKey(u)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -88,7 +88,7 @@ public class ProOddsCalculator {
       final List<Unit> defendingUnits) {
     final GameData data = ProData.getData();
 
-    final boolean hasNoDefenders = Match.noneMatch(defendingUnits, Matches.UnitIsNotInfrastructure);
+    final boolean hasNoDefenders = Match.noneMatch(defendingUnits, Matches.unitIsNotInfrastructure());
     final boolean isLandAndCanOnlyBeAttackedByAir =
         !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.UnitIsAir);
     if (attackingUnits.size() == 0) {
@@ -98,7 +98,7 @@ public class ProOddsCalculator {
     } else if (hasNoDefenders) {
       return new ProBattleResult(100, 0.1, true, attackingUnits, new ArrayList<>(), 0);
     } else if (Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
-        && Match.allMatch(defendingUnits, Matches.UnitIsSub)
+        && Match.allMatch(defendingUnits, Matches.unitIsSub())
         && Match.noneMatch(attackingUnits, Matches.unitIsDestroyer())) {
       return new ProBattleResult();
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -285,7 +285,7 @@ public class ProPurchaseUtils {
 
   private static PlayerID getOriginalFactoryOwner(final Territory territory, final PlayerID player) {
 
-    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.UnitCanProduceUnits);
+    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.unitCanProduceUnits());
     if (factoryUnits.size() == 0) {
       throw new IllegalStateException("No factory in territory:" + territory);
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -232,7 +232,7 @@ public class ProTransportUtils {
 
   public static List<Unit> interleaveUnitsCarriersAndPlanes(final List<Unit> units,
       final int planesThatDontNeedToLand) {
-    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
+    if (!(Match.anyMatch(units, Matches.unitIsCarrier()) && Match.anyMatch(units, Matches.unitCanLandOnCarrier()))) {
       return units;
     }
 
@@ -258,7 +258,7 @@ public class ProTransportUtils {
         // If this is the first carrier seek and not last unit
         if (seekedCarrier == null && i > 0) {
           final int seekedCarrierIndex = AIUtils.getIndexOfLastUnitMatching(result,
-              Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             break; // No carriers left
           }
@@ -288,7 +288,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }
@@ -331,7 +331,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.unitIsCarrier(), Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -168,7 +168,7 @@ public class WeakAI extends AbstractAI {
     if (capitol == null || !capitol.getOwner().equals(player)) {
       return;
     }
-    List<Unit> unitsToLoad = capitol.getUnits().getMatches(Matches.UnitIsInfrastructure.invert());
+    List<Unit> unitsToLoad = capitol.getUnits().getMatches(Matches.unitIsInfrastructure().invert());
     unitsToLoad = Match.getMatches(unitsToLoad, Matches.unitIsOwnedBy(getPlayerID()));
     for (final Territory neighbor : data.getMap().getNeighbors(capitol)) {
       if (!neighbor.isWater()) {
@@ -450,7 +450,7 @@ public class WeakAI extends AbstractAI {
           Matches.unitIsNotAa(),
           // we can never move factories
           Matches.unitCanMove(),
-          Matches.UnitIsNotInfrastructure,
+          Matches.unitIsNotInfrastructure(),
           Matches.UnitIsLand);
       final Match<Territory> moveThrough =
           Match.allOf(Matches.territoryIsImpassable().invert(),
@@ -574,8 +574,8 @@ public class WeakAI extends AbstractAI {
       if (!ta1.isCapital() && ta2.isCapital()) {
         return 1;
       }
-      final boolean factoryInT1 = o1.getUnits().anyMatch(Matches.UnitCanProduceUnits);
-      final boolean factoryInT2 = o2.getUnits().anyMatch(Matches.UnitCanProduceUnits);
+      final boolean factoryInT1 = o1.getUnits().anyMatch(Matches.unitCanProduceUnits());
+      final boolean factoryInT2 = o2.getUnits().anyMatch(Matches.unitCanProduceUnits());
       // next take territories which can produce
       if (factoryInT1 && !factoryInT2) {
         return -1;
@@ -583,8 +583,8 @@ public class WeakAI extends AbstractAI {
       if (!factoryInT1 && factoryInT2) {
         return 1;
       }
-      final boolean infrastructureInT1 = o1.getUnits().anyMatch(Matches.UnitIsInfrastructure);
-      final boolean infrastructureInT2 = o2.getUnits().anyMatch(Matches.UnitIsInfrastructure);
+      final boolean infrastructureInT1 = o1.getUnits().anyMatch(Matches.unitIsInfrastructure());
+      final boolean infrastructureInT2 = o2.getUnits().anyMatch(Matches.unitIsInfrastructure());
       // next take territories with infrastructure
       if (infrastructureInT1 && !infrastructureInT2) {
         return -1;
@@ -612,7 +612,7 @@ public class WeakAI extends AbstractAI {
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
             final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
-                Matches.UnitIsNotInfrastructure, Matches.unitCanMove(), Matches.unitIsNotAa(),
+                Matches.unitIsNotInfrastructure(), Matches.unitCanMove(), Matches.unitIsNotAa(),
                 Matches.unitCanNotMoveDuringCombatMove().invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
               moveRoutes.add(data.getMap().getRoute(attackFrom, enemy));
@@ -645,7 +645,7 @@ public class WeakAI extends AbstractAI {
             Match.of(o -> !unitsAlreadyMoved.contains(o)),
             Matches.unitIsNotAa(),
             Matches.unitCanMove(),
-            Matches.UnitIsNotInfrastructure,
+            Matches.unitIsNotInfrastructure(),
             Matches.unitCanNotMoveDuringCombatMove().invert(),
             Matches.unitIsNotSea());
         final Set<Territory> dontMoveFrom = new HashSet<>();
@@ -792,7 +792,7 @@ public class WeakAI extends AbstractAI {
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
     List<RepairRule> rrules = Collections.emptyList();
-    final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
+    final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanProduceUnits());
     final List<Territory> rfactories =
         Match.getMatches(Utils.findUnitTerr(data, ourFactories), Matches.isTerritoryOwnedBy(player));
     // figure out if anything needs to be repaired
@@ -1010,7 +1010,7 @@ public class WeakAI extends AbstractAI {
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {
-      if (t != capitol && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
+      if (t != capitol && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1529,7 +1529,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       change.add(ChangeFactory.markNoMovementChange(unit));
     }
     // place units
-    final Collection<Unit> factoryAndInfrastructure = Match.getMatches(units, Matches.UnitIsInfrastructure);
+    final Collection<Unit> factoryAndInfrastructure = Match.getMatches(units, Matches.unitIsInfrastructure());
     change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, player));
     final String transcriptText = MyFormatter.attachmentNameToText(t.getName()) + ": " + player.getName() + " has "
         + MyFormatter.unitsToTextNoOwner(units) + " placed in " + terr.getName();

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -268,7 +268,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
 
     // play a sound
-    if (Match.anyMatch(units, Matches.UnitIsInfrastructure)) {
+    if (Match.anyMatch(units, Matches.unitIsInfrastructure())) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, m_player);
     } else if (Match.anyMatch(units, Matches.UnitIsSea)) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, m_player);
@@ -296,7 +296,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!didIt) {
       throw new IllegalStateException("Something wrong with consuming/upgrading units");
     }
-    final Collection<Unit> factoryAndInfrastructure = Match.getMatches(placeableUnits, Matches.UnitIsInfrastructure);
+    final Collection<Unit> factoryAndInfrastructure = Match.getMatches(placeableUnits, Matches.unitIsInfrastructure());
     if (!factoryAndInfrastructure.isEmpty()) {
       change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, player));
     }
@@ -479,7 +479,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!canMoveExistingFightersToNewCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData())) {
       return null;
     }
-    if (Match.noneMatch(units, Matches.UnitIsCarrier)) {
+    if (Match.noneMatch(units, Matches.unitIsCarrier())) {
       return null;
     }
     // do we have any spare carrier capacity
@@ -493,7 +493,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!Matches.TerritoryIsLand.match(producer)) {
       return null;
     }
-    if (!producer.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
+    if (!producer.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
       return null;
     }
     final Match<Unit> ownedFighters = Match.allOf(Matches.unitCanLandOnCarrier(), Matches.unitIsOwnedBy(player));
@@ -503,7 +503,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (wasConquered(producer)) {
       return null;
     }
-    if (Match.anyMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)) {
+    if (Match.anyMatch(getAlreadyProduced(producer), Matches.unitCanProduceUnits())) {
       return null;
     }
     final List<Unit> fighters = producer.getUnits().getMatches(ownedFighters);
@@ -673,8 +673,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return "No more Constructions Allowed in " + producer.getName();
     }
     // check we havent just put a factory there (should we be checking producer?)
-    if (Match.anyMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)
-        || Match.anyMatch(getAlreadyProduced(to), Matches.UnitCanProduceUnits)) {
+    if (Match.anyMatch(getAlreadyProduced(producer), Matches.unitCanProduceUnits())
+        || Match.anyMatch(getAlreadyProduced(to), Matches.unitCanProduceUnits())) {
       return "Factory in " + producer.getName() + " cant produce until 1 turn after it is created";
     }
     return "No Factory in " + producer.getName();
@@ -884,9 +884,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (!water) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction())));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
-          && Match.anyMatch(allProducedUnits, Matches.UnitIsCarrier))
+          && Match.anyMatch(allProducedUnits, Matches.unitIsCarrier()))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
-              && Match.anyMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
+              && Match.anyMatch(to.getUnits().getUnits(), Matches.unitIsCarrier()))) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier())));
       }
     }
@@ -1570,7 +1570,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    * will be thrown. return value may be null.
    */
   protected PlayerID getOriginalFactoryOwner(final Territory territory) {
-    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.UnitCanProduceUnits);
+    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.unitCanProduceUnits());
     if (factoryUnits.size() == 0) {
       throw new IllegalStateException("No factory in territory:" + territory);
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -68,7 +68,7 @@ public class AirMovementValidator {
     // now we must see if we also need to account for units (allied cargo) that are moving with our carriers, if we have
     // selected any
     // carriers
-    final Collection<Unit> movingCarriersAtStartLocationBeingMoved = Match.getMatches(units, Matches.UnitIsCarrier);
+    final Collection<Unit> movingCarriersAtStartLocationBeingMoved = Match.getMatches(units, Matches.unitIsCarrier());
     if (!movingCarriersAtStartLocationBeingMoved.isEmpty()) {
       final Map<Unit, Collection<Unit>> carrierToAlliedCargo =
           MoveValidator.carrierMustMoveWith(units, routeStart, data, player);
@@ -86,7 +86,8 @@ public class AirMovementValidator {
     // now we should see if the carriers we are moving with, plus the carriers already there, can handle all our air
     // units (we check ending
     // territories first, separately, because it is special [it includes units in our selection])
-    final Collection<Unit> carriersAtEnd = Match.getMatches(getFriendly(routeEnd, player, data), Matches.UnitIsCarrier);
+    final Collection<Unit> carriersAtEnd =
+        Match.getMatches(getFriendly(routeEnd, player, data), Matches.unitIsCarrier());
     carriersAtEnd.addAll(movingCarriersAtStartLocationBeingMoved);
     // to keep track of all carriers, and their fighters, that have moved, so that we do not move them again.
     final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters = new HashMap<>();
@@ -160,13 +161,13 @@ public class AirMovementValidator {
       final PlayerID player, final GameData data) {
     final IntegerMap<Territory> startingSpace = new IntegerMap<>();
     final Match<Unit> carrierAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
+        Matches.isUnitAllied(player, data), Matches.unitIsCarrier());
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
     // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLHTRCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     // final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
-    final List<Unit> carriersInProductionQueue = player.getUnits().getMatches(Matches.UnitIsCarrier);
+    final List<Unit> carriersInProductionQueue = player.getUnits().getMatches(Matches.unitIsCarrier());
     for (final Territory t : landingSpots) {
       if (landAirOnNewCarriers && !carriersInProductionQueue.isEmpty()) {
         if (Matches.TerritoryIsWater.match(t)
@@ -197,13 +198,13 @@ public class AirMovementValidator {
       final List<Territory> landingSpots, final Collection<Territory> potentialCarrierOrigins,
       final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters, final Collection<Unit> airThatMustLandOnCarriers,
       final Collection<Unit> airNotToConsider, final PlayerID player, final Route route, final GameData data) {
-    final Match<Unit> ownedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
+    final Match<Unit> ownedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsCarrier());
     final Match<Unit> ownedAirMatch =
         Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedAirMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
+        Matches.isUnitAllied(player, data), Matches.unitIsCarrier());
     final Territory routeEnd = route.getEnd();
     final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
     final IntegerMap<Territory> landingSpotsWithCarrierCapacity =
@@ -463,7 +464,7 @@ public class AirMovementValidator {
 
   private static int maxMovementLeftForAllOwnedCarriers(final PlayerID player, final GameData data) {
     int max = 0;
-    final Match<Unit> ownedCarrier = Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedCarrier = Match.allOf(Matches.unitIsCarrier(), Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       for (final Unit carrier : t.getUnits().getMatches(ownedCarrier)) {
         max = Math.max(max, ((TripleAUnit) carrier).getMovementLeft());
@@ -672,7 +673,7 @@ public class AirMovementValidator {
    * restrictions.
    */
   public static int carrierCapacity(final Unit unit, final Territory territoryUnitsAreCurrentlyIn) {
-    if (Matches.UnitIsCarrier.match(unit)) {
+    if (Matches.unitIsCarrier().match(unit)) {
       // here we check to see if the unit can no longer carry units
       if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLANDONCARRIER).match(unit)) {
         // and we must check to make sure we let any allied air that are cargo stay here

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -422,7 +422,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final boolean ignoreTransports = isIgnoreTransportInMovement(data);
     final boolean ignoreSubs = isIgnoreSubInMovement(data);
     final Match<Unit> seaTransports = Match.allOf(Matches.unitIsTransportButNotCombatTransport(), Matches.UnitIsSea);
-    final Match<Unit> seaTranportsOrSubs = Match.anyOf(seaTransports, Matches.UnitIsSub);
+    final Match<Unit> seaTranportsOrSubs = Match.anyOf(seaTransports, Matches.unitIsSub());
     // we want to match all sea zones with our units and enemy units
     final Match<Territory> anyTerritoryWithOwnAndEnemy = Match.allOf(
         Matches.territoryHasUnitsOwnedBy(player), Matches.territoryHasEnemyUnits(player, data));
@@ -455,7 +455,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         // we need to remove any units which are participating in bombing raids
         attackingUnits.removeAll(bombingBattle.getAttackingUnits());
       }
-      if (Match.allMatch(attackingUnits, Matches.UnitIsInfrastructure)) {
+      if (Match.allMatch(attackingUnits, Matches.unitIsInfrastructure())) {
         continue;
       }
       IBattle battle = battleTracker.getPendingBattle(territory, false, BattleType.NORMAL);
@@ -463,7 +463,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         // we must land any paratroopers here, but only if there is not going to be a battle (cus battles land them
         // separately, after aa
         // fires)
-        if (Match.allMatch(enemyUnits, Matches.UnitIsInfrastructure)) {
+        if (Match.allMatch(enemyUnits, Matches.unitIsInfrastructure())) {
           landParatroopers(player, territory, bridge);
         }
         bridge.getHistoryWriter().startEvent(player.getName() + " creates battle in territory " + territory.getName());
@@ -534,7 +534,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
           // if only enemy subs... attack them?
-          if (ignoreSubs && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsSub)) {
+          if (ignoreSubs && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.unitIsSub())) {
             if (!remotePlayer.selectAttackSubs(territory)) {
               final BattleResults results = new BattleResults(battle, WhoWon.NOTFINISHED, data);
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleID(), null, 0, 0,
@@ -607,7 +607,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       for (final PlayerID p : enemyPlayers) {
         final Match<Unit> canPreventCapture = Match.allOf(Matches.unitIsEnemyOf(data, p),
-            Matches.unitIsNotAir(), Matches.UnitIsNotInfrastructure);
+            Matches.unitIsNotAir(), Matches.unitIsNotInfrastructure());
         enemyUnitsOfAbandonedToUnits.addAll(territory.getUnits().getMatches(canPreventCapture));
       }
       // only look at bombing battles, because otherwise the normal attack will determine the ownership of the territory
@@ -1090,7 +1090,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // Get those that are neighbors
       final Collection<Territory> areSeaNeighbors = Match.getMatches(neighbors, neighboringSeaZonesWithAlliedUnits);
       // Set up match criteria for allied carriers
-      final Match<Unit> alliedCarrier = Match.allOf(Matches.UnitIsCarrier, Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedCarrier = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(defender, data));
       // Set up match criteria for allied planes
       final Match<Unit> alliedPlane = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(defender, data));
       // See if neighboring carriers have any capacity available

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -510,7 +510,7 @@ public class BattleTracker implements Serializable {
       // TODO check if istrn and NOT isDD
       // If subs are restricted from controlling sea zones, subtract them
       if (Properties.getSubControlSeaZoneRestricted(data)) {
-        totalMatches -= Match.countMatches(arrivedUnits, Matches.UnitIsSub);
+        totalMatches -= Match.countMatches(arrivedUnits, Matches.unitIsSub());
       }
       if (totalMatches == 0) {
         return;
@@ -720,7 +720,7 @@ public class BattleTracker implements Serializable {
         if (changeTracker != null) {
           changeTracker.addChange(takeOverFriendlyTerritories);
         }
-        final Collection<Unit> units = Match.getMatches(item.getUnits().getUnits(), Matches.UnitIsInfrastructure);
+        final Collection<Unit> units = Match.getMatches(item.getUnits().getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, territory);
           bridge.addChange(takeOverNonComUnits);
@@ -772,7 +772,7 @@ public class BattleTracker implements Serializable {
     }
     // destroy any disabled units owned by the enemy that are NOT infrastructure or factories
     final Match<Unit> enemyToBeDestroyed = Match.allOf(Matches.enemyUnit(id, data),
-        Matches.unitIsDisabled(), Matches.UnitIsInfrastructure.invert());
+        Matches.unitIsDisabled(), Matches.unitIsInfrastructure().invert());
     final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
     if (!destroyed.isEmpty()) {
       final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
@@ -783,7 +783,7 @@ public class BattleTracker implements Serializable {
       }
     }
     // take over non combatants
-    final Match<Unit> enemyNonCom = Match.allOf(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
+    final Match<Unit> enemyNonCom = Match.allOf(Matches.enemyUnit(id, data), Matches.unitIsInfrastructure());
     final Match<Unit> willBeCaptured = Match.anyOf(enemyNonCom,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
     final Collection<Unit> nonCom = territory.getUnits().getMatches(willBeCaptured);
@@ -867,7 +867,7 @@ public class BattleTracker implements Serializable {
     }
     // if just an enemy factory &/or AA then no battle
     final Collection<Unit> enemyUnits = Match.getMatches(site.getUnits().getUnits(), Matches.enemyUnit(id, data));
-    if (route.getEnd() != null && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsInfrastructure)) {
+    if (route.getEnd() != null && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.unitIsInfrastructure())) {
       return ChangeFactory.EMPTY_CHANGE;
     }
     IBattle battle = getPendingBattle(site, false, BattleType.NORMAL);

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -144,12 +144,12 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         + player.getName(), territory);
     if (!data.getRelationshipTracker().isAtWar(territory.getOwner(), player)) {
       // change ownership of friendly factories
-      final Collection<Unit> units = territory.getUnits().getMatches(Matches.UnitIsInfrastructure);
+      final Collection<Unit> units = territory.getUnits().getMatches(Matches.unitIsInfrastructure());
       for (final Unit unit : units) {
         m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
-      final Match<Unit> enemyNonCom = Match.allOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data));
+      final Match<Unit> enemyNonCom = Match.allOf(Matches.unitIsInfrastructure(), Matches.enemyUnit(player, data));
       final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
       // mark no movement for enemy units
       m_bridge.addChange(ChangeFactory.markNoMovementChange(units));

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -95,7 +95,7 @@ class EditValidator {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
-          final Match<Unit> friendlyCarriers = Match.allOf(Matches.UnitIsCarrier, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyCarriers = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
           final Match<Unit> friendlyAirUnits = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -57,7 +57,7 @@ public class Fire implements IExecutable {
      * to:
      * m_attackableUnits = attackableUnits;
      */
-    m_attackableUnits = Match.getMatches(attackableUnits, Matches.UnitIsNotInfrastructure);
+    m_attackableUnits = Match.getMatches(attackableUnits, Matches.unitIsNotInfrastructure());
     m_canReturnFire = canReturnFire;
     m_firingUnits = firingUnits;
     m_stepName = stepName;

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -336,7 +336,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
         if (territoryAttachment.getOriginalOwner() == null && current.getOwner() != null) {
           changes.add(OriginalOwnerTracker.addOriginalOwnerChange(current, current.getOwner()));
         }
-        final Collection<Unit> factoryAndInfrastructure = current.getUnits().getMatches(Matches.UnitIsInfrastructure);
+        final Collection<Unit> factoryAndInfrastructure = current.getUnits().getMatches(Matches.unitIsInfrastructure());
         changes.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, current.getOwner()));
       } else if (!current.isWater()) {
         final TerritoryAttachment territoryAttachment = TerritoryAttachment.get(current);

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -322,7 +322,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       final PlayerID player) {
     final GameData data = bridge.getData();
     final Match<Unit> crippledAlliedCarriersMatch = Match.allOf(Matches.isUnitAllied(player, data),
-        Matches.unitIsOwnedBy(player).invert(), Matches.UnitIsCarrier,
+        Matches.unitIsOwnedBy(player).invert(), Matches.unitIsCarrier(),
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
         Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
@@ -584,7 +584,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     boolean hasProducedCarriers = false;
     for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, m_player)) {
-      if (p.getUnits().anyMatch(Matches.UnitIsCarrier)) {
+      if (p.getUnits().anyMatch(Matches.unitIsCarrier())) {
         hasProducedCarriers = true;
         break;
       }
@@ -598,7 +598,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // Check if player still has units to place
       if (!player.equals(m_player)) {
         util.removeAirThatCantLand(player,
-            ((player.getUnits().anyMatch(Matches.UnitIsCarrier) || hasProducedCarriers) && lhtrCarrierProd));
+            ((player.getUnits().anyMatch(Matches.unitIsCarrier()) || hasProducedCarriers) && lhtrCarrierProd));
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -348,7 +348,7 @@ public class MovePerformer implements Serializable {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
-      for (final Unit unit : Match.getMatches(units, Match.allOf(Matches.UnitIsSub, Matches.UnitIsAir.invert()))) {
+      for (final Unit unit : Match.getMatches(units, Match.allOf(Matches.unitIsSub(), Matches.UnitIsAir.invert()))) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -428,7 +428,7 @@ public class MoveValidator {
       }
     }
     // Subs can't travel under DDs
-    if (isSubmersibleSubsAllowed(data) && !units.isEmpty() && Match.allMatch(units, Matches.UnitIsSub)) {
+    if (isSubmersibleSubsAllowed(data) && !units.isEmpty() && Match.allMatch(units, Matches.unitIsSub())) {
       // this is ok unless there are destroyer on the path
       if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
@@ -441,7 +441,7 @@ public class MoveValidator {
             Matches.unitIsSubmerged());
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
             && !(!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir) && end.isWater())) {
-          if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSub)
+          if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSub())
               || !Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
 
             return result.setErrorReturnResult("Cannot advance to battle in non combat");
@@ -525,7 +525,7 @@ public class MoveValidator {
     // subs may possibly carry units...
     if (isSubmersibleSubsAllowed(data)) {
       final Collection<Unit> matches = Match.getMatches(units, Matches.unitIsBeingTransported().invert());
-      if (!matches.isEmpty() && Match.allMatch(matches, Matches.UnitIsSub)) {
+      if (!matches.isEmpty() && Match.allMatch(matches, Matches.unitIsSub())) {
         // this is ok unless there are destroyer on the path
         if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
           return result.setErrorReturnResult("Cannot move submarines under destroyers");
@@ -762,8 +762,10 @@ public class MoveValidator {
    * AA and factory dont count as enemy.
    */
   static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
-    final Match<Unit> alliedOrNonCombat =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(), Matches.unitIsSubmerged());
+    final Match<Unit> alliedOrNonCombat = Match.anyOf(
+        Matches.unitIsInfrastructure(),
+        Matches.enemyUnit(player, data).invert(),
+        Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     for (final Territory current : route.getMiddleSteps()) {
       if (!current.getUnits().allMatch(alliedOrNonCombat)) {
@@ -780,13 +782,13 @@ public class MoveValidator {
   static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player, final GameData data,
       final boolean ignoreRouteEnd) {
     final Match<Unit> subOnly =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
+        Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsSub(), Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOnly =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.unitIsTransportButNotCombatTransport(),
+        Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsTransportButNotCombatTransport(),
             Matches.UnitIsLand, Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOrSubOnly =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.unitIsTransportButNotCombatTransport(),
-            Matches.UnitIsLand, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
+        Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsTransportButNotCombatTransport(),
+            Matches.UnitIsLand, Matches.unitIsSub(), Matches.enemyUnit(player, data).invert());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
     boolean validMove = false;
@@ -989,7 +991,7 @@ public class MoveValidator {
               || Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
-      final Match<Unit> enemySubmarineMatch = Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
+      final Match<Unit> enemySubmarineMatch = Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.unitIsSub());
       final Match<Unit> ownedSeaNonTransportMatch =
           Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
               Matches.unitIsNotTransportButCouldBeCombatTransport());
@@ -1420,7 +1422,7 @@ public class MoveValidator {
     }
     // remove air that can be carried by allied
     final Match<Unit> friendlyNotOwnedCarrier = Match.allOf(
-        Matches.UnitIsCarrier,
+        Matches.unitIsCarrier(),
         Matches.alliedUnit(player, data),
         Matches.unitIsOwnedBy(player).invert());
     final Collection<Unit> alliedCarrier = Match.getMatches(startUnits, friendlyNotOwnedCarrier);
@@ -1436,7 +1438,7 @@ public class MoveValidator {
     final Map<Unit, Collection<Unit>> mapping = new HashMap<>();
     // get air that must be carried by our carriers
     final Collection<Unit> ownedCarrier =
-        Match.getMatches(units, Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player)));
+        Match.getMatches(units, Match.allOf(Matches.unitIsCarrier(), Matches.unitIsOwnedBy(player)));
     final Iterator<Unit> ownedCarrierIter = ownedCarrier.iterator();
     while (ownedCarrierIter.hasNext()) {
       final Unit carrier = ownedCarrierIter.next();

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -343,7 +343,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // it is possible that no attacking units are present, if so end now
     // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns, and
     // infrastructure.
-    if (Match.getMatches(m_attackingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
+    if (Match.getMatches(m_attackingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
       endBattle(bridge);
       defenderWins(bridge);
       return;
@@ -351,7 +351,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // it is possible that no defending units exist
     // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns, and
     // infrastructure.
-    if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
+    if (Match.getMatches(m_defendingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
       endBattle(bridge);
       attackerWins(bridge);
       return;
@@ -381,9 +381,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // play a sound
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)
           || Match.anyMatch(m_defendingUnits, Matches.UnitIsSea)) {
-        if ((!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsSub))
-            || (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)
-                && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))) {
+        if ((!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsSub()))
+            || (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())
+                && Match.anyMatch(m_defendingUnits, Matches.unitIsSub()))) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_SUBS, m_attacker);
         } else {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_NORMAL, m_attacker);
@@ -527,11 +527,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
       if (!Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer())
-          && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+          && Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
         steps.add(m_attacker.getName() + SUBS_SUBMERGE);
       }
       if (!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer())
-          && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
         steps.add(m_defender.getName() + SUBS_SUBMERGE);
       }
     }
@@ -544,7 +544,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // if attacker has no sneak attack subs, then defendering sneak attack subs fire first and remove casualties
     final boolean defenderSubsFireFirst = defenderSubsFireFirst();
-    if (defenderSubsFireFirst && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (defenderSubsFireFirst && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
       steps.add(m_defender.getName() + SUBS_FIRE);
       steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
@@ -554,7 +554,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // attacker subs sneak attack
     // Attacking subs have no sneak attack if Destroyers are present
     if (m_battleSite.isWater()) {
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
         steps.add(m_attacker.getName() + SUBS_FIRE);
         steps.add(m_defender.getName() + SELECT_SUB_CASUALTIES);
       }
@@ -570,7 +570,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean defendingSubsFireWithAllDefendersAlways = !defendingSubsSneakAttack3();
     if (m_battleSite.isWater()) {
       if (!defendingSubsFireWithAllDefendersAlways && !defendingSubsFireWithAllDefenders && !defenderSubsFireFirst
-          && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
         steps.add(m_defender.getName() + SUBS_FIRE);
         steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
       }
@@ -595,7 +595,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units.addAll(m_attackingUnits);
       // if(!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_attackingUnits,
       // Matches.UnitIsAir) &&
-      // Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))
+      // Match.anyMatch(m_defendingUnits, Matches.unitIsSub()))
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(AIR_ATTACK_NON_SUBS);
       }
@@ -610,7 +610,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      if (Match.anyMatch(units, Matches.UnitIsSub) && !defenderSubsFireFirst
+      if (Match.anyMatch(units, Matches.unitIsSub()) && !defenderSubsFireFirst
           && (defendingSubsFireWithAllDefenders || defendingSubsFireWithAllDefendersAlways)) {
         steps.add(m_defender.getName() + SUBS_FIRE);
         steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
@@ -623,7 +623,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units.addAll(m_defendingWaitingToDie);
       // if(!Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_defendingUnits,
       // Matches.UnitIsAir) &&
-      // Match.anyMatch(m_attackingUnits, Matches.UnitIsSub))
+      // Match.anyMatch(m_attackingUnits, Matches.unitIsSub()))
       if (Match.anyMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
         steps.add(AIR_DEFEND_NON_SUBS);
       }
@@ -638,21 +638,21 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_battleSite.isWater()) {
       if (canSubsSubmerge()) {
         if (!isSubRetreatBeforeBattle()) {
-          if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
             steps.add(m_attacker.getName() + SUBS_SUBMERGE);
           }
-          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
             steps.add(m_defender.getName() + SUBS_SUBMERGE);
           }
         }
       } else {
         if (canAttackerRetreatSubs()) {
-          if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
             steps.add(m_attacker.getName() + SUBS_WITHDRAW);
           }
         }
         if (canDefenderRetreatSubs()) {
-          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
             steps.add(m_defender.getName() + SUBS_WITHDRAW);
           }
         }
@@ -841,7 +841,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
         // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns,
         // and infrastructure.
-        if (Match.getMatches(m_attackingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
+        if (Match.getMatches(m_attackingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
           if (!isTransportCasualtiesRestricted()) {
             endBattle(bridge);
             defenderWins(bridge);
@@ -869,7 +869,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           }
           // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns,
           // and infrastructure.
-        } else if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
+        } else if (Match.getMatches(m_defendingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
           if (isTransportCasualtiesRestricted()) {
             // If there are undefended attacking transports, determine if they automatically die
             checkUndefendedTransports(bridge, m_defender);
@@ -1216,7 +1216,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // or if we are moving out of a territory containing enemy units, we cannot retreat back there
     final Match.CompositeBuilder<Unit> enemyUnitsThatPreventRetreatBuilder = Match.newCompositeBuilder(
         Matches.enemyUnit(m_attacker, m_data),
-        Matches.UnitIsNotInfrastructure,
+        Matches.unitIsNotInfrastructure(),
         Matches.unitIsBeingTransported().invert(),
         Matches.unitIsSubmerged().invert());
     if (Properties.getIgnoreSubInMovement(m_data)) {
@@ -1330,7 +1330,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (Match.anyMatch(m_attackingWaitingToDie, Matches.unitIsDestroyer())) {
       return false;
     }
-    return getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.UnitIsSub)).size() != 0
+    return getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.unitIsSub()))
+        .size() != 0
         || canSubsSubmerge();
   }
 
@@ -1338,7 +1339,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAttackerRetreatSubs()) {
       return;
     }
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
       queryRetreat(false, RetreatType.SUBS, bridge, getAttackerRetreatTerritories());
     }
   }
@@ -1347,9 +1348,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canDefenderRetreatSubs()) {
       return;
     }
-    if (!m_isOver && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (!m_isOver && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
       queryRetreat(true, RetreatType.SUBS, bridge,
-          getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.UnitIsSub)));
+          getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.unitIsSub())));
     }
   }
 
@@ -1397,7 +1398,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units.addAll(m_battleSite.getUnits().getMatches(Matches.unitIsOwnedBy(m_attacker)));
     }
     if (subs) {
-      units = Match.getMatches(units, Matches.UnitIsSub);
+      units = Match.getMatches(units, Matches.unitIsSub());
     } else if (planes) {
       units = Match.getMatches(units, Matches.UnitIsAir);
     } else if (partialAmphib) {
@@ -1791,12 +1792,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       hasUnitsThatCanRollLeft = Match.anyMatch(m_attackingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_attackingUnits,
-          Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.allOf(notSubmergedAndType, Matches.unitIsNotInfrastructure()));
     } else {
       hasUnitsThatCanRollLeft = Match.anyMatch(m_defendingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_defendingUnits,
-          Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.allOf(notSubmergedAndType, Matches.unitIsNotInfrastructure()));
     }
     final boolean enemy = !attacker;
     final boolean enemyHasUnitsThatCanRollLeft;
@@ -1818,16 +1819,16 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
     if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
-        && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
+        && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
       // Get all defending subs (including allies) in the territory.
-      final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
+      final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.unitIsSub());
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
     } else if (!m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
-        && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
+        && Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
       // Get all attacking subs in the territory
-      final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);
+      final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.unitIsSub());
       // submerge attacking subs
       submergeUnits(attackingSubs, false, bridge);
     }
@@ -1879,7 +1880,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
-    return !(m_battleSite.isWater() && Match.anyMatch(firedAt, Matches.UnitIsSub)
+    return !(m_battleSite.isWater() && Match.anyMatch(firedAt, Matches.unitIsSub())
         && Match.noneMatch(firing, Matches.unitIsDestroyer()));
   }
 
@@ -1932,7 +1933,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void attackSubs(final ReturnFire returnFire) {
-    final Collection<Unit> firing = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);
+    final Collection<Unit> firing = Match.getMatches(m_attackingUnits, Matches.unitIsSub());
     if (firing.isEmpty()) {
       return;
     }
@@ -1952,7 +1953,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     Collection<Unit> firing = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
     firing.addAll(m_defendingUnits);
     firing.addAll(m_defendingWaitingToDie);
-    firing = Match.getMatches(firing, Matches.UnitIsSub);
+    firing = Match.getMatches(firing, Matches.unitIsSub());
     if (firing.isEmpty()) {
       return;
     }
@@ -1982,9 +1983,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else if (returnFire == ReturnFire.SUBS) {
       // move to waiting to die
       if (defender) {
-        m_defendingWaitingToDie.addAll(Match.getMatches(killed, Matches.UnitIsSub));
+        m_defendingWaitingToDie.addAll(Match.getMatches(killed, Matches.unitIsSub()));
       } else {
-        m_attackingWaitingToDie.addAll(Match.getMatches(killed, Matches.UnitIsSub));
+        m_attackingWaitingToDie.addAll(Match.getMatches(killed, Matches.unitIsSub()));
       }
       remove(Match.getMatches(killed, Matches.unitIsNotSub()), bridge, m_battleSite, defender);
     } else if (returnFire == ReturnFire.NONE) {
@@ -2038,10 +2039,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // attack subs with
     // anything.
     if (isAirAttackSubRestricted() && !Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer())
-        && Match.anyMatch(attackedDefenders, Matches.UnitIsSub)) {
-      attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsSub));
+        && Match.anyMatch(attackedDefenders, Matches.unitIsSub())) {
+      attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.unitIsSub()));
     }
-    if (!suicideAttackers.isEmpty() && Match.allMatch(suicideAttackers, Matches.UnitIsSub)) {
+    if (!suicideAttackers.isEmpty() && Match.allMatch(suicideAttackers, Matches.unitIsSub())) {
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsAir));
     }
     if (suicideAttackers.size() == 0 || attackedDefenders.size() == 0) {
@@ -2061,7 +2062,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // TODO: add a global toggle for returning fire (Veqryn)
-    final Match<Unit> attackableUnits = Match.allOf(Matches.UnitIsNotInfrastructure,
+    final Match<Unit> attackableUnits = Match.allOf(Matches.unitIsNotInfrastructure(),
         Matches.unitIsSuicide().invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideDefenders = Match.getMatches(m_defendingUnits, Matches.unitIsSuicide());
     final Collection<Unit> attackedAttackers = Match.getMatches(m_attackingUnits, attackableUnits);
@@ -2069,10 +2070,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // attack subs with
     // anything.
     if (isAirAttackSubRestricted() && !Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer())
-        && Match.anyMatch(attackedAttackers, Matches.UnitIsSub)) {
-      attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.UnitIsSub));
+        && Match.anyMatch(attackedAttackers, Matches.unitIsSub())) {
+      attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.unitIsSub()));
     }
-    if (!suicideDefenders.isEmpty() && Match.allMatch(suicideDefenders, Matches.UnitIsSub)) {
+    if (!suicideDefenders.isEmpty() && Match.allMatch(suicideDefenders, Matches.unitIsSub())) {
       suicideDefenders.removeAll(Match.getMatches(suicideDefenders, Matches.UnitIsAir));
     }
     if (suicideDefenders.size() == 0 || attackedAttackers.size() == 0) {
@@ -2463,8 +2464,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_whoWon = WhoWon.DEFENDER;
     getDisplay(bridge).battleEnd(m_battleID, m_defender.getName() + " win");
     if (Properties.getAbandonedTerritoriesMayBeTakenOverImmediately(m_data)) {
-      if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
-        final List<Unit> allyOfAttackerUnits = m_battleSite.getUnits().getMatches(Matches.UnitIsNotInfrastructure);
+      if (Match.getMatches(m_defendingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
+        final List<Unit> allyOfAttackerUnits = m_battleSite.getUnits().getMatches(Matches.unitIsNotInfrastructure());
         if (!allyOfAttackerUnits.isEmpty()) {
           final PlayerID abandonedToPlayer = AbstractBattle.findPlayerWithMostUnits(allyOfAttackerUnits);
           bridge.getHistoryWriter()
@@ -2625,7 +2626,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final CompositeChange change = new CompositeChange();
     // Clear the transported_by for successfully won battles where there was an allied air unit held as cargo by an
     // carrier unit
-    final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.UnitIsCarrier);
+    final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.unitIsCarrier());
     if (!carriers.isEmpty() && !Properties.getAlliedAirIndependent(data)) {
       final Match<Unit> alliedFighters = Match.allOf(Matches.isUnitAllied(attacker, data),
           Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -113,7 +113,8 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         picked = allPickableTerritories.get(pos % allPickableTerritories.size());
         final CompositeChange change = new CompositeChange();
         change.add(ChangeFactory.changeOwner(picked, m_currentPickingPlayer));
-        final Collection<Unit> factoryAndInfrastructure = Match.getMatches(unitsToPlace, Matches.UnitIsInfrastructure);
+        final Collection<Unit> factoryAndInfrastructure =
+            Match.getMatches(unitsToPlace, Matches.unitIsInfrastructure());
         if (!factoryAndInfrastructure.isEmpty()) {
           change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, m_currentPickingPlayer));
         }
@@ -143,7 +144,8 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         }
         final CompositeChange change = new CompositeChange();
         change.add(ChangeFactory.changeOwner(picked, m_currentPickingPlayer));
-        final Collection<Unit> factoryAndInfrastructure = Match.getMatches(unitsToPlace, Matches.UnitIsInfrastructure);
+        final Collection<Unit> factoryAndInfrastructure =
+            Match.getMatches(unitsToPlace, Matches.unitIsInfrastructure());
         if (!factoryAndInfrastructure.isEmpty()) {
           change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, m_currentPickingPlayer));
         }
@@ -189,7 +191,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         }
       }
       final CompositeChange change = new CompositeChange();
-      final Collection<Unit> factoryAndInfrastructure = Match.getMatches(unitsToPlace, Matches.UnitIsInfrastructure);
+      final Collection<Unit> factoryAndInfrastructure = Match.getMatches(unitsToPlace, Matches.unitIsInfrastructure());
       if (!factoryAndInfrastructure.isEmpty()) {
         change.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, m_currentPickingPlayer));
       }

--- a/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -59,12 +59,12 @@ public class UnitBattleComparator implements Comparator<Unit> {
       }
       return 0;
     }
-    final boolean airOrCarrierOrTransport1 = Matches.UnitIsAir.match(u1) || Matches.UnitIsCarrier.match(u1)
+    final boolean airOrCarrierOrTransport1 = Matches.UnitIsAir.match(u1) || Matches.unitIsCarrier().match(u1)
         || (!transporting1 && Matches.unitIsTransport().match(u1));
-    final boolean airOrCarrierOrTransport2 = Matches.UnitIsAir.match(u2) || Matches.UnitIsCarrier.match(u2)
+    final boolean airOrCarrierOrTransport2 = Matches.UnitIsAir.match(u2) || Matches.unitIsCarrier().match(u2)
         || (!transporting2 && Matches.unitIsTransport().match(u2));
-    final boolean subDestroyer1 = Matches.UnitIsSub.match(u1) || Matches.unitIsDestroyer().match(u1);
-    final boolean subDestroyer2 = Matches.UnitIsSub.match(u2) || Matches.unitIsDestroyer().match(u2);
+    final boolean subDestroyer1 = Matches.unitIsSub().match(u1) || Matches.unitIsDestroyer().match(u1);
+    final boolean subDestroyer2 = Matches.unitIsSub().match(u2) || Matches.unitIsDestroyer().match(u2);
     final boolean multiHpCanRepair1 = m_multiHitpointCanRepair.contains(u1.getType());
     final boolean multiHpCanRepair2 = m_multiHitpointCanRepair.contains(u2.getType());
     if (!m_ignorePrimaryPower) {

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -26,7 +26,7 @@ public class UnitsThatCantFightUtil {
     for (final Territory current : m_data.getMap()) {
       // get all owned non-combat units
       final Match.CompositeBuilder<Unit> ownedUnitsMatchBuilder = Match.newCompositeBuilder(
-          Matches.UnitIsInfrastructure.invert());
+          Matches.unitIsInfrastructure().invert());
       if (current.isWater()) {
         ownedUnitsMatchBuilder.add(Matches.UnitIsLand.invert());
       }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/BattleResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/BattleResults.java
@@ -61,11 +61,11 @@ public class BattleResults extends GameDataComponent {
   }
 
   public int getAttackingCombatUnitsLeft() {
-    return Match.countMatches(m_remainingAttackingUnits, Matches.UnitIsNotInfrastructure);
+    return Match.countMatches(m_remainingAttackingUnits, Matches.unitIsNotInfrastructure());
   }
 
   public int getDefendingCombatUnitsLeft() {
-    return Match.countMatches(m_remainingDefendingUnits, Matches.UnitIsNotInfrastructure);
+    return Match.countMatches(m_remainingDefendingUnits, Matches.unitIsNotInfrastructure());
   }
 
   public int getBattleRoundsFought() {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -594,7 +594,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       }
       if (submerge) {
         // submerge if all air vs subs
-        final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.UnitIsSub);
+        final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.unitIsSub());
         final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.unitIsDestroyer().invert());
         final List<Unit> ourUnits = getOurUnits();
         final List<Unit> enemyUnits = getEnemyUnits();

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -802,7 +802,7 @@ public class TripleAFrame extends MainGameFrame {
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     int carrierCount = 0;
     for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, id)) {
-      carrierCount += p.getUnits().getMatches(Matches.UnitIsCarrier).size();
+      carrierCount += p.getUnits().getMatches(Matches.unitIsCarrier()).size();
     }
     final boolean canProduceCarriersUnderFighter = lhtrProd && carrierCount != 0;
     if (canProduceCarriersUnderFighter && carrierCount > 0) {

--- a/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
@@ -20,7 +20,7 @@ public class PlaceDelegate extends AbstractPlaceDelegate {
   @Override
   protected int getProduction(final Territory territory) {
     final Collection<Unit> allUnits = territory.getUnits().getUnits();
-    final int factoryCount = Match.countMatches(allUnits, Matches.UnitCanProduceUnits);
+    final int factoryCount = Match.countMatches(allUnits, Matches.unitCanProduceUnits());
     return 5 * factoryCount;
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -812,7 +812,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(northAtlantic);
     Collection<Unit> units = new ArrayList<>();
     units.addAll(Match.getMatches(gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits().getUnits(),
-        Matches.UnitIsCarrier));
+        Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
@@ -822,7 +822,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(blackSea);
     units = new ArrayList<>();
     units.addAll(Match.getMatches(
-        gameData.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.UnitIsCarrier));
+        gameData.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -725,7 +725,7 @@ public class RevisedTest {
     sz45To50.setStart(sz45);
     sz45To50.add(sz50);
     final List<Unit> japSub =
-        sz45.getUnits().getMatches(Match.allOf(Matches.UnitIsSub, Matches.unitIsOwnedBy(japanese)));
+        sz45.getUnits().getMatches(Match.allOf(Matches.unitIsSub(), Matches.unitIsOwnedBy(japanese)));
     error = moveDelegate.move(japSub, sz45To50);
     // make sure no error
     assertNull(error);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1407,7 +1407,7 @@ public class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Territory sz5 = territory("5 Sea Zone", gameData);
     // remove the sub
-    removeFrom(sz5, sz5.getUnits().getMatches(Matches.UnitIsSub));
+    removeFrom(sz5, sz5.getUnits().getMatches(Matches.unitIsSub()));
 
     when(dummyPlayer.retreatQuery(any(), anyBoolean(), any(),
         any(), any())).thenAnswer(new Answer<Territory>() {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.