### PR TITLE
Refactor gradle build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport
+script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport --parallel
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
-- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release --parallel
 - ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport --parallel
+script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
-- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release --parallel
+- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release
 - ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -52,23 +52,13 @@ sourceSets {
     }
 }
 
-compileJava {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:all"
-}
-compileTestJava {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:all"
-}
-compileIntegTestJava {
-    options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:all"
-}
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) {
     options.incremental = true
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:all"
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -42,11 +42,25 @@ def getEngineVersion() {
 
 version = getEngineVersion()
 
+sourceSets {
+    integTest {
+        java.srcDir 'src/integ_test/java'
+        resources.srcDir 'src/integ_test/resources'
+
+        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
+        runtimeClasspath = output + compileClasspath
+    }
+}
+
 compileJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:all"
 }
 compileTestJava {
+    options.encoding = 'UTF-8'
+    options.compilerArgs << "-Xlint:all"
+}
+compileIntegTestJava {
     options.encoding = 'UTF-8'
     options.compilerArgs << "-Xlint:all"
 }
@@ -65,16 +79,6 @@ jar {
 
 repositories {
     jcenter()
-}
-
-sourceSets {
-    integTest {
-        java.srcDir 'src/integ_test/java'
-        resources.srcDir 'src/integ_test/resources'
-
-        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
-        runtimeClasspath = output + compileClasspath
-    }
 }
 
 dependencies {


### PR DESCRIPTION
The `--parallel` flag makes run gradle rasks in parallel if possible (the one task does not depend on the other)

This improves the travis execution time slightly (about 1-2 minutes), but not as much as I hoped for...
It might be possible to improve execution even more, by implementing the tasks individually using parallel file access etc., but this is out-of-scope for this PR.

(The gradle file was refactored a little bit)