### PR TITLE
Remove unused method parameters

### DIFF
--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -156,7 +156,7 @@ public class UnitType extends NamedAttachable {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getImage(ut, player, data, false, false);
+              final Optional<Image> unitImage = imageFactory.getImage(ut, player, false, false);
               if (unitImage.isPresent()) {
                 if (!rVal.contains(ut)) {
                   rVal.add(ut);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -56,7 +56,7 @@ final class ProTechAI {
       tokensToBuy = 1;
     }
     if (techTokensQuantity > 0 || tokensToBuy > 0) {
-      final List<TechnologyFrontier> cats = TechAdvance.getPlayerTechCategories(data, player);
+      final List<TechnologyFrontier> cats = TechAdvance.getPlayerTechCategories(player);
       // retaining 65% chance of choosing land advances using basic ww2v3 model.
       if (data.getTechnologyFrontier().isEmpty()) {
         if (Math.random() > 0.35) {

--- a/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -39,9 +39,9 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     super(name, attachable, gameData);
   }
 
-  public static CompositeChange triggerSetUsedForThisRound(final PlayerID player, final IDelegateBridge bridge) {
+  public static CompositeChange triggerSetUsedForThisRound(final PlayerID player) {
     final CompositeChange change = new CompositeChange();
-    for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, bridge.getData(), null)) {
+    for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
       if (ta.getUsedThisRound()) {
         final int currentUses = ta.getUses();
         if (currentUses > 0) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -135,8 +135,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * @return set of trigger attachments (If you use null for the match condition, you will get all triggers for this
    *         player)
    */
-  public static Set<TriggerAttachment> getTriggers(final PlayerID player, final GameData data,
-      final Match<TriggerAttachment> cond) {
+  static Set<TriggerAttachment> getTriggers(final PlayerID player, final Match<TriggerAttachment> cond) {
     final Set<TriggerAttachment> trigs = new HashSet<>();
     final Map<String, IAttachment> map = player.getAttachments();
     final Iterator<String> iter = map.keySet().iterator();
@@ -159,7 +158,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void collectAndFireTriggers(final HashSet<PlayerID> players,
       final Match<TriggerAttachment> triggerMatch, final IDelegateBridge bridge, final String beforeOrAfter,
       final String stepName) {
-    final HashSet<TriggerAttachment> toFirePossible = collectForAllTriggersMatching(players, triggerMatch, bridge);
+    final HashSet<TriggerAttachment> toFirePossible = collectForAllTriggersMatching(players, triggerMatch);
     if (toFirePossible.isEmpty()) {
       return;
     }
@@ -174,11 +173,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   public static HashSet<TriggerAttachment> collectForAllTriggersMatching(final HashSet<PlayerID> players,
-      final Match<TriggerAttachment> triggerMatch, final IDelegateBridge bridge) {
-    final GameData data = bridge.getData();
+      final Match<TriggerAttachment> triggerMatch) {
     final HashSet<TriggerAttachment> toFirePossible = new HashSet<>();
     for (final PlayerID player : players) {
-      toFirePossible.addAll(TriggerAttachment.getTriggers(player, data, triggerMatch));
+      toFirePossible.addAll(TriggerAttachment.getTriggers(player, triggerMatch));
     }
     return toFirePossible;
   }
@@ -295,7 +293,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     TriggerAttachment trigger = null;
     for (final PlayerID player : getData().getPlayerList().getPlayers()) {
-      for (final TriggerAttachment ta : getTriggers(player, getData(), null)) {
+      for (final TriggerAttachment ta : getTriggers(player, null)) {
         if (ta.getName().equals(s[0])) {
           trigger = ta;
           break;
@@ -2452,7 +2450,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         // numberOfTimes:useUses:testUses:testConditions:testChance
         TriggerAttachment toFire = null;
         for (final PlayerID player : data.getPlayerList().getPlayers()) {
-          for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, data, null)) {
+          for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
             if (ta.getName().equals(tuple.getFirst())) {
               toFire = ta;
               break;

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -73,7 +73,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     }
     TriggerAttachment trigger = null;
     for (final PlayerID player : getData().getPlayerList().getPlayers()) {
-      for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, getData(), null)) {
+      for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
         if (ta.getName().equals(s[0])) {
           trigger = ta;
           break;
@@ -124,7 +124,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
       // numberOfTimes:useUses:testUses:testConditions:testChance
       TriggerAttachment toFire = null;
       for (final PlayerID player : data.getPlayerList().getPlayers()) {
-        for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, data, null)) {
+        for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
           if (ta.getName().equals(tuple.getFirst())) {
             toFire = ta;
             break;
@@ -172,7 +172,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
    * @return gets the valid actions for this player.
    */
   public static Collection<UserActionAttachment> getValidActions(final PlayerID player,
-      final HashMap<ICondition, Boolean> testedConditions, final GameData data) {
+      final HashMap<ICondition, Boolean> testedConditions) {
     return Match.getMatches(getUserActionAttachments(player), Match.allOf(
         Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions)));
   }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -525,7 +525,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   protected String isValidPlacement(final Collection<Unit> units, final Territory at, final PlayerID player) {
     // do we hold enough units
-    String error = playerHasEnoughUnits(units, at, player);
+    String error = playerHasEnoughUnits(units, player);
     if (error != null) {
       return error;
     }
@@ -550,7 +550,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   /**
    * Make sure the player has enough in hand to place the units.
    */
-  String playerHasEnoughUnits(final Collection<Unit> units, final Territory at, final PlayerID player) {
+  private static String playerHasEnoughUnits(final Collection<Unit> units, final PlayerID player) {
     // make sure the player has enough units in hand to place
     if (!player.getUnits().getUnits().containsAll(units)) {
       return "Not enough units";

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -638,9 +638,8 @@ public class AirBattle extends AbstractBattle {
     return Match.of(u -> UnitAttachment.get(u.getType()).getAirAttack(u.getOwner()) > 0);
   }
 
-  static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {
-    final Match<Unit> canIntercept = Matches.unitCanAirBattle();
-    return canIntercept;
+  static Match<Unit> attackingGroundSeaBattleEscorts() {
+    return Matches.unitCanAirBattle();
   }
 
   private static Match<Unit> defendingGroundSeaBattleInterceptors(final PlayerID attacker, final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -307,8 +307,7 @@ public class BattleTracker implements Serializable {
       // create both an air battle and a normal battle
       if (!airBattleCompleted && Properties.getBattlesMayBePreceededByAirBattles(data)
           && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(route.getEnd(), id, data, bombing)) {
-        addAirBattle(route, Match.getMatches(units, AirBattle.attackingGroundSeaBattleEscorts(id, data)), id, data,
-            false);
+        addAirBattle(route, Match.getMatches(units, AirBattle.attackingGroundSeaBattleEscorts()), id, data, false);
       }
       final Change change = addMustFightBattleChange(route, units, id, data);
       bridge.addChange(change);

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -301,7 +301,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     if (null != (result = checkEditMode())) {
       return result;
     }
-    if (null != (result = EditValidator.validateChangePoliticalRelationships(getData(), relationshipChanges))) {
+    if (null != (result = EditValidator.validateChangePoliticalRelationships(relationshipChanges))) {
       return result;
     }
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(getData());

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -272,7 +272,7 @@ class EditValidator {
     return result;
   }
 
-  static String validateChangePoliticalRelationships(final GameData data,
+  static String validateChangePoliticalRelationships(
       final Collection<Triple<PlayerID, PlayerID, RelationshipType>> relationshipChanges) {
     final String result = null;
     if (relationshipChanges == null || relationshipChanges.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -112,7 +112,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
                   TriggerAttachment.activateTriggerMatch(), TriggerAttachment.victoryMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(data.getPlayerList().getPlayers()), endRoundDelegateTriggerMatch, m_bridge);
+          new HashSet<>(data.getPlayerList().getPlayers()), endRoundDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =
@@ -183,7 +183,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     if (Properties.getTriggers(data)) {
       final CompositeChange change = new CompositeChange();
       for (final PlayerID player : data.getPlayerList().getPlayers()) {
-        change.add(AbstractTriggerAttachment.triggerSetUsedForThisRound(player, m_bridge));
+        change.add(AbstractTriggerAttachment.triggerSetUsedForThisRound(player));
       }
       if (!change.isEmpty()) {
         m_bridge.getHistoryWriter().startEvent("Setting uses for triggers used this round.");

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -221,7 +221,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
           Match.anyOf(TriggerAttachment.resourceMatch()));
       toFirePossible.addAll(TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(player)), endTurnDelegateTriggerMatch, bridge));
+          new HashSet<>(Collections.singleton(player)), endTurnDelegateTriggerMatch));
       allConditionsNeeded.addAll(
           AbstractConditionsAttachment.getAllConditionsRecursive(new HashSet<>(toFirePossible), null));
     }

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -91,13 +91,13 @@ public class InitializationDelegate extends BaseTripleADelegate {
     initAiStartingBonusIncome(bridge);
     initDeleteAssetsOfDisabledPlayers(bridge);
     initTransportedLandUnits(bridge);
-    resetUnitState(bridge);
+    resetUnitState();
   }
 
   /**
    * The initTransportedLandUnits has some side effects, and we need to reset unit state to get rid of them.
    */
-  private void resetUnitState(final IDelegateBridge bridge) {
+  private void resetUnitState() {
     final Change change = MoveDelegate.getResetUnitStateChange(getData());
     if (!change.isEmpty()) {
       m_bridge.getHistoryWriter().startEvent("Cleaning up unit state.");

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -92,7 +92,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           moveCombatDelegateBeforeBonusTriggerMatch, moveCombatDelegateAfterBonusTriggerMatch);
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAllTriggerMatch, m_bridge);
+            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAllTriggerMatch);
         if (!toFirePossible.isEmpty()) {
 
           // collect conditions and test them for ALL triggers, both those that we will fire before and those we will
@@ -100,7 +100,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           testedConditions = TriggerAttachment.collectTestsForAllTriggers(toFirePossible, m_bridge);
           final HashSet<TriggerAttachment> toFireBeforeBonus =
               TriggerAttachment.collectForAllTriggersMatching(new HashSet<>(Collections.singleton(m_player)),
-                  moveCombatDelegateBeforeBonusTriggerMatch, m_bridge);
+                  moveCombatDelegateBeforeBonusTriggerMatch);
           if (!toFireBeforeBonus.isEmpty()) {
 
             // get all triggers that are satisfied based on the tested conditions.
@@ -144,7 +144,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // placing triggered units at beginning of combat move, but after bonuses and repairing, etc, have been done.
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final HashSet<TriggerAttachment> toFireAfterBonus = TriggerAttachment.collectForAllTriggersMatching(
-            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAfterBonusTriggerMatch, m_bridge);
+            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAfterBonusTriggerMatch);
         if (!toFireAfterBonus.isEmpty()) {
 
           // get all triggers that are satisfied based on the tested conditions.
@@ -457,7 +457,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final CompositeChange clearAlliedAir = new CompositeChange();
     for (final Unit carrier : damagedCarriers) {
       final CompositeChange change = MustFightBattle.clearTransportedByForAlliedAirOnCarrier(
-          Collections.singleton(carrier), fullyRepaired.get(carrier), carrier.getOwner(), data);
+          Collections.singleton(carrier), carrier.getOwner(), data);
       if (!change.isEmpty()) {
         clearAlliedAir.add(change);
       }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -362,7 +362,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     updateOffensiveAAUnits();
     updateDefendingAAUnits();
     // list the steps
-    m_stepStrings = determineStepStrings(true, bridge);
+    m_stepStrings = determineStepStrings(true);
     final ITripleADisplay display = getDisplay(bridge);
     display.showBattle(m_battleID, m_battleSite, getBattleTitle(),
         removeNonCombatants(m_attackingUnits, true, false, false, false),
@@ -484,7 +484,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_attackingUnits.removeAll(Match.getMatches(m_attackingUnits, airNotInTerritory));
   }
 
-  List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
+  List<String> determineStepStrings(final boolean showFirstRun) {
     final List<String> steps = new ArrayList<>();
     if (canFireOffensiveAA()) {
       for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
@@ -972,7 +972,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           // determine any AA
           updateOffensiveAAUnits();
           updateDefendingAAUnits();
-          m_stepStrings = determineStepStrings(false, bridge);
+          m_stepStrings = determineStepStrings(false);
           final ITripleADisplay display = getDisplay(bridge);
           display.listBattleSteps(m_battleID, m_stepStrings);
           // continue fighting
@@ -2622,7 +2622,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   static CompositeChange clearTransportedByForAlliedAirOnCarrier(final Collection<Unit> attackingUnits,
-      final Territory battleSite, final PlayerID attacker, final GameData data) {
+      final PlayerID attacker, final GameData data) {
     final CompositeChange change = new CompositeChange();
     // Clear the transported_by for successfully won battles where there was an allied air unit held as cargo by an
     // carrier unit
@@ -2669,12 +2669,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
     // Must clear transportedby for allied air on carriers for both attacking units and retreating units
     final CompositeChange clearAlliedAir =
-        clearTransportedByForAlliedAirOnCarrier(m_attackingUnits, m_battleSite, m_attacker, m_data);
+        clearTransportedByForAlliedAirOnCarrier(m_attackingUnits, m_attacker, m_data);
     if (!clearAlliedAir.isEmpty()) {
       bridge.addChange(clearAlliedAir);
     }
     final CompositeChange clearAlliedAirRetreated =
-        clearTransportedByForAlliedAirOnCarrier(m_attackingUnitsRetreated, m_battleSite, m_attacker, m_data);
+        clearTransportedByForAlliedAirOnCarrier(m_attackingUnitsRetreated, m_attacker, m_data);
     if (!clearAlliedAirRetreated.isEmpty()) {
       bridge.addChange(clearAlliedAirRetreated);
     }

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -63,7 +63,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
           Match.anyOf(TriggerAttachment.relationshipChangeMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(m_player)), politicsDelegateTriggerMatch, m_bridge);
+          new HashSet<>(Collections.singleton(m_player)), politicsDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -70,7 +70,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
                 TriggerAttachment.prodFrontierEditMatch(), TriggerAttachment.purchaseMatch()));
         // get all possible triggers based on this match.
         final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-            new HashSet<>(Collections.singleton(m_player)), purchaseDelegateTriggerMatch, m_bridge);
+            new HashSet<>(Collections.singleton(m_player)), purchaseDelegateTriggerMatch);
         if (!toFirePossible.isEmpty()) {
           // get all conditions possibly needed by these triggers, and then test them.
           final HashMap<ICondition, Boolean> testedConditions =

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -130,7 +130,7 @@ public class RocketsFireHelper {
 
   Set<Territory> getTerritoriesWithRockets(final GameData data, final PlayerID player) {
     final Set<Territory> territories = new HashSet<>();
-    final Match<Unit> ownedRockets = rocketMatch(player, data);
+    final Match<Unit> ownedRockets = rocketMatch(player);
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(data);
     for (final Territory current : data.getMap()) {
       if (tracker.wasConquered(current)) {
@@ -143,7 +143,7 @@ public class RocketsFireHelper {
     return territories;
   }
 
-  Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
+  private static Match<Unit> rocketMatch(final PlayerID player) {
     return Match.allOf(Matches.unitIsRocket(), Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
         Matches.unitIsBeingTransported().invert(), Matches.unitIsSubmerged().invert(), Matches.unitHasNotMoved());
   }
@@ -195,7 +195,7 @@ public class RocketsFireHelper {
     if (attackFrom == null) {
       rockets = null;
     } else {
-      rockets = new ArrayList<>(Match.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player, data)));
+      rockets = new ArrayList<>(Match.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player)));
     }
     final int numberOfAttacks = (rockets == null ? 1
         : Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -64,7 +64,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
               TriggerAttachment.supportMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(m_player)), techActivationDelegateTriggerMatch, m_bridge);
+          new HashSet<>(Collections.singleton(m_player)), techActivationDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -248,7 +248,7 @@ public abstract class TechAdvance extends NamedAttachable {
   /**
    * Returns all possible tech categories for this player.
    */
-  public static List<TechnologyFrontier> getPlayerTechCategories(final GameData data, final PlayerID player) {
+  public static List<TechnologyFrontier> getPlayerTechCategories(final PlayerID player) {
     if (player != null) {
       return player.getTechnologyFrontierList().getFrontiers();
     }

--- a/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -42,11 +42,10 @@ public class TechTracker implements Serializable {
    * successfully researched
    * already.
    */
-  public static Collection<TechnologyFrontier> getFullyResearchedPlayerTechCategories(final GameData data,
-      final PlayerID id) {
+  public static Collection<TechnologyFrontier> getFullyResearchedPlayerTechCategories(final PlayerID id) {
     final Collection<TechnologyFrontier> rVal = new ArrayList<>();
     final TechAttachment attachment = TechAttachment.get(id);
-    for (final TechnologyFrontier tf : TechAdvance.getPlayerTechCategories(data, id)) {
+    for (final TechnologyFrontier tf : TechAdvance.getPlayerTechCategories(id)) {
       boolean has = true;
       for (final TechAdvance t : tf.getTechs()) {
         has = t.hasTech(attachment);

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -83,7 +83,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
           Match.anyOf(TriggerAttachment.techAvailableMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(m_player)), technologyDelegateTriggerMatch, m_bridge);
+          new HashSet<>(Collections.singleton(m_player)), technologyDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -76,7 +76,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     } finally {
       data.releaseReadLock();
     }
-    return UserActionAttachment.getValidActions(m_player, testedConditions, data);
+    return UserActionAttachment.getValidActions(m_player, testedConditions);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import javax.swing.ImageIcon;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.ui.Util;
@@ -83,7 +82,7 @@ public class ResourceImageFactory {
   /**
    * Return a icon image.
    */
-  public ImageIcon getIcon(final Resource type, final GameData data, final boolean large) {
+  public ImageIcon getIcon(final Resource type, final boolean large) {
     final String fullName = type.getName() + (large ? "_large" : "");
     if (m_icons.containsKey(fullName)) {
       return m_icons.get(fullName);

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 import javax.swing.ImageIcon;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
@@ -108,8 +107,7 @@ public class UnitImageFactory {
   /**
    * Return the appropriate unit image.
    */
-  public Optional<Image> getImage(final UnitType type, final PlayerID player, final GameData data,
-      final boolean damaged,
+  public Optional<Image> getImage(final UnitType type, final PlayerID player, final boolean damaged,
       final boolean disabled) {
     final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
@@ -159,10 +157,9 @@ public class UnitImageFactory {
     return Optional.ofNullable(image);
   }
 
-  public Optional<Image> getHighlightImage(final UnitType type, final PlayerID player, final GameData data,
-      final boolean damaged,
+  public Optional<Image> getHighlightImage(final UnitType type, final PlayerID player, final boolean damaged,
       final boolean disabled) {
-    final Optional<Image> baseImage = getImage(type, player, data, damaged, disabled);
+    final Optional<Image> baseImage = getImage(type, player, damaged, disabled);
     if (!baseImage.isPresent()) {
       return Optional.empty();
     }
@@ -184,8 +181,7 @@ public class UnitImageFactory {
   /**
    * Return a icon image for a unit.
    */
-  public Optional<ImageIcon> getIcon(final UnitType type, final PlayerID player, final GameData data,
-      final boolean damaged,
+  public Optional<ImageIcon> getIcon(final UnitType type, final PlayerID player, final boolean damaged,
       final boolean disabled) {
     final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -905,7 +905,7 @@ class OddsCalculatorPanel extends JPanel {
       }
       for (final UnitCategory category : categories) {
         if (predicate.match(category.getType())) {
-          final UnitPanel upanel = new UnitPanel(data, context, category, costs);
+          final UnitPanel upanel = new UnitPanel(context, category, costs);
           upanel.addChangeListener(listenerUnitPanel);
           add(upanel);
         }
@@ -976,8 +976,7 @@ class OddsCalculatorPanel extends JPanel {
     private final List<WidgetChangedListener> listeners = new CopyOnWriteArrayList<>();
     private final ScrollableTextFieldListener listenerTextField = field -> notifyListeners();
 
-    UnitPanel(final GameData data, final IUIContext context, final UnitCategory category,
-        final IntegerMap<UnitType> costs) {
+    UnitPanel(final IUIContext context, final UnitCategory category, final IntegerMap<UnitType> costs) {
       this.category = category;
       this.context = context;
       textField = new ScrollableTextField(0, 512);
@@ -992,7 +991,7 @@ class OddsCalculatorPanel extends JPanel {
 
 
       final Optional<Image> img =
-          this.context.getUnitImageFactory().getImage(category.getType(), category.getOwner(), data,
+          this.context.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
               category.hasDamageOrBombingUnitDamage(), category.getDisabled());
 
       final JLabel label = img.isPresent() ? new JLabel(new ImageIcon(img.get())) : new JLabel();
@@ -1192,7 +1191,7 @@ class OddsCalculatorPanel extends JPanel {
           final String toolTipText = "<html>" + category.getType().getName() + ":  "
               + category.getType().getTooltip(category.getOwner()) + "</html>";
           final Optional<Image> img =
-              context.getUnitImageFactory().getImage(category.getType(), category.getOwner(), data,
+              context.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
                   category.hasDamageOrBombingUnitDamage(), category.getDisabled());
           if (img.isPresent()) {
             final JButton button = new JButton(new ImageIcon(img.get()));

--- a/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -133,7 +133,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       final UnitCategory category = iter.next();
       final Optional<ImageIcon> icon =
           movePanel.getMap().getUiContext().getUnitImageFactory().getIcon(category.getType(),
-              category.getOwner(), gameData, category.hasDamageOrBombingUnitDamage(), category.getDisabled());
+              category.getOwner(), category.hasDamageOrBombingUnitDamage(), category.getDisabled());
       if (icon.isPresent()) {
         final JLabel label = new JLabel("x" + category.getUnits().size() + " ", icon.get(), SwingConstants.LEFT);
         unitsBox.add(label);

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -517,7 +517,7 @@ public class BattleDisplay extends JPanel {
         public void actionPerformed(final ActionEvent e) {
           final String messageText = message + " " + btnText + ".";
           if (chooser == null || chooserScrollPane == null) {
-            chooser = new UnitChooser(selectFrom, defaultCasualties, dependents, gameData, allowMultipleHitsPerUnit,
+            chooser = new UnitChooser(selectFrom, defaultCasualties, dependents, allowMultipleHitsPerUnit,
                 mapPanel.getUiContext());
             chooser.setTitle(messageText);
             if (isEditMode) {
@@ -832,7 +832,7 @@ public class BattleDisplay extends JPanel {
         }
         for (int i = 0; i <= gameData.getDiceSides(); i++) {
           if (shift[i] > 0) {
-            columns.get(i).add(new TableData(category.getOwner(), shift[i], category.getType(), gameData,
+            columns.get(i).add(new TableData(category.getOwner(), shift[i], category.getType(),
                 category.hasDamageOrBombingUnitDamage(), category.getDisabled(), uiContext));
           }
         }
@@ -881,10 +881,10 @@ public class BattleDisplay extends JPanel {
 
     private TableData() {}
 
-    TableData(final PlayerID player, final int count, final UnitType type, final GameData data, final boolean damaged,
+    TableData(final PlayerID player, final int count, final UnitType type, final boolean damaged,
         final boolean disabled, final IUIContext uiContext) {
       this.count = count;
-      icon = uiContext.getUnitImageFactory().getIcon(type, player, data, damaged, disabled);
+      icon = uiContext.getUnitImageFactory().getIcon(type, player, damaged, disabled);
     }
 
     void updateStamp(final JLabel stamp) {
@@ -959,7 +959,7 @@ public class BattleDisplay extends JPanel {
         final JPanel panel = new JPanel();
         // TODO Kev determine if we need to identify if the unit is hit/disabled
         final Optional<ImageIcon> unitImage =
-            uiContext.getUnitImageFactory().getIcon(category.getType(), category.getOwner(), data,
+            uiContext.getUnitImageFactory().getIcon(category.getType(), category.getOwner(),
                 damaged && category.hasDamageOrBombingUnitDamage(), disabled && category.getDisabled());
         final JLabel unit = unitImage.isPresent() ? new JLabel(unitImage.get()) : new JLabel();
         panel.add(unit);

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -386,7 +386,7 @@ public class BattlePanel extends ActionPanel {
       final PlayerID hit, final CasualtyList defaultCasualties, final boolean allowMultipleHitsPerUnit) {
     final Task<CasualtyDetails> task = () -> {
       final boolean isEditMode = (dice == null);
-      final UnitChooser chooser = new UnitChooser(selectFrom, defaultCasualties, dependents, getData(),
+      final UnitChooser chooser = new UnitChooser(selectFrom, defaultCasualties, dependents,
           allowMultipleHitsPerUnit, getMap().getUiContext());
       chooser.setTitle(message);
       if (isEditMode) {
@@ -425,7 +425,7 @@ public class BattlePanel extends ActionPanel {
     return battleDisplay.getRetreat(message, possible, submerge);
   }
 
-  public void gotoStep(final GUID battleId, final String step) {
+  public void gotoStep(final String step) {
     SwingUtilities.invokeLater(() -> {
       if (battleDisplay != null) {
         battleDisplay.setStep(step);
@@ -433,7 +433,7 @@ public class BattlePanel extends ActionPanel {
     });
   }
 
-  public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {
+  public void bombingResults(final List<Die> dice, final int cost) {
     SwingUtilities.invokeLater(() -> {
       if (battleDisplay != null) {
         battleDisplay.bombingResults(dice, cost);

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -154,7 +154,7 @@ class EditPanel extends ActionPanel {
         if (mustChoose) {
           final String chooserText = "Remove units from " + selectedTerritory + ":";
           final UnitChooser chooser = new UnitChooser(allUnits, selectedUnits, mustMoveWithDetails.getMustMoveWith(),
-              true, false, getData(), /* allowTwoHit= */false, getMap().getUiContext());
+              true, false, /* allowTwoHit= */false, getMap().getUiContext());
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, chooserText,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
           if (option != JOptionPane.OK_OPTION) {
@@ -709,7 +709,7 @@ class EditPanel extends ActionPanel {
             return;
           }
           final String text = "Remove from " + t.getName();
-          final UnitChooser chooser = new UnitChooser(unitsToMove, selectedUnits, null, false, false, getData(),
+          final UnitChooser chooser = new UnitChooser(unitsToMove, selectedUnits, null, false, false,
               false, getMap().getUiContext());
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);

--- a/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -41,8 +41,7 @@ public class EditProductionPanel extends ProductionPanel {
   }
 
   @Override
-  protected void initRules(final PlayerID player, final GameData data,
-      final IntegerMap<ProductionRule> initialPurchase) {
+  protected void initRules(final PlayerID player, final IntegerMap<ProductionRule> initialPurchase) {
     this.data.acquireReadLock();
     try {
       id = player;
@@ -88,7 +87,7 @@ public class EditProductionPanel extends ProductionPanel {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getImage(ut, player, data, false, false);
+              final Optional<Image> unitImage = imageFactory.getImage(ut, player, false, false);
               if (unitImage.isPresent()) {
                 unitsAllowed.add(ut);
                 final IntegerMap<NamedAttachable> result = new IntegerMap<>();

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -231,8 +231,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   private void recreateTiles(final GameData data, final IUIContext uiContext) {
-    this.tileManager.createTiles(new Rectangle(this.uiContext.getMapData().getMapDimensions()), data,
-        this.uiContext.getMapData());
+    this.tileManager.createTiles(new Rectangle(this.uiContext.getMapData().getMapDimensions()));
     this.tileManager.resetTiles(data, uiContext.getMapData());
   }
 
@@ -243,7 +242,7 @@ public class MapPanel extends ImageScrollerLargeView {
   // Beagle Code used to chnage map skin
   void changeImage(final Dimension newDimensions) {
     model.setMaxBounds((int) newDimensions.getWidth(), (int) newDimensions.getHeight());
-    tileManager.createTiles(new Rectangle(newDimensions), gameData, uiContext.getMapData());
+    tileManager.createTiles(new Rectangle(newDimensions));
     tileManager.resetTiles(gameData, uiContext.getMapData());
   }
 
@@ -420,7 +419,7 @@ public class MapPanel extends ImageScrollerLargeView {
 
   public void updateCountries(final Collection<Territory> countries) {
     tileManager.updateTerritories(countries, gameData, uiContext.getMapData());
-    smallMapImageManager.update(gameData, uiContext.getMapData());
+    smallMapImageManager.update(uiContext.getMapData());
     SwingUtilities.invokeLater(() -> {
       smallView.repaint();
       repaint();
@@ -601,7 +600,7 @@ public class MapPanel extends ImageScrollerLargeView {
           }
 
           final Optional<Image> image = uiContext.getUnitImageFactory().getHighlightImage(category.getType(),
-              category.getOwner(), gameData, category.hasDamageOrBombingUnitDamage(), category.getDisabled());
+              category.getOwner(), category.hasDamageOrBombingUnitDamage(), category.getDisabled());
           if (image.isPresent()) {
             final AffineTransform t = new AffineTransform();
             t.translate(normalizeX(r.getX() - getXOffset()) * scale, normalizeY(r.getY() - getYOffset()) * scale);
@@ -743,7 +742,7 @@ public class MapPanel extends ImageScrollerLargeView {
     for (final Territory territory : gameData.getMap().getTerritories()) {
       smallMapImageManager.updateTerritoryOwner(territory, gameData, uiContext.getMapData());
     }
-    smallMapImageManager.update(gameData, uiContext.getMapData());
+    smallMapImageManager.update(uiContext.getMapData());
   }
 
   void changeSmallMapOffscreenMap() {

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -260,7 +260,7 @@ public class MovePanel extends AbstractMovePanel {
     // Choosing what transports to unload
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
         mustMoveWithDetails.getMustMoveWith(), /* categorizeMovement */true, /* categorizeTransportCost */false,
-        getGameData(), /* allowTwoHit */false, getMap().getUiContext(), transportsToUnloadMatch);
+        /* allowTwoHit */false, getMap().getUiContext(), transportsToUnloadMatch);
     chooser.setTitle("What transports do you want to unload");
     final int option =
         JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What transports do you want to unload",
@@ -693,7 +693,7 @@ public class MovePanel extends AbstractMovePanel {
     });
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
         endMustMoveWith.getMustMoveWith(), /* categorizeMovement */true, /* categorizeTransportCost */false,
-        getGameData(), /* allowTwoHit */false, getMap().getUiContext(), transportsToLoadMatch);
+        /* allowTwoHit */false, getMap().getUiContext(), transportsToLoadMatch);
     chooser.setTitle("What transports do you want to load");
     final int option =
         JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What transports do you want to load",
@@ -773,12 +773,12 @@ public class MovePanel extends AbstractMovePanel {
               .getMatches(unitsToMove, Matches.unitIsOwnedBy(getUnitOwner(unitsToMove))).containsAll(unitsToMove)) {
             // use matcher to prevent units of different owners being chosen
             chooser = new UnitChooser(unitsToMove, selectedUnits, /* mustMoveWith */null,
-                /* categorizeMovement */false, /* categorizeTransportCost */false, getData(), /* allowTwoHit */false,
+                /* categorizeMovement */false, /* categorizeTransportCost */false, /* allowTwoHit */false,
                 getMap().getUiContext(), ownerMatch);
           } else {
             chooser =
                 new UnitChooser(unitsToMove, selectedUnits, /* mustMoveWith */null, /* categorizeMovement */false,
-                    /* categorizeTransportCost */false, getData(), /* allowTwoHit */false, getMap().getUiContext());
+                    /* categorizeTransportCost */false, /* allowTwoHit */false, getMap().getUiContext());
           }
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -896,7 +896,7 @@ public class MovePanel extends AbstractMovePanel {
       });
       // Allow player to select which to load.
       final UnitChooser chooser = new UnitChooser(candidateAirTransports, defaultSelections, dependentUnits,
-          /* categorizeMovement */true, /* categorizeTransportCost */false, getGameData(), /* allowTwoHit */false,
+          /* categorizeMovement */true, /* categorizeTransportCost */false, /* allowTwoHit */false,
           getMap().getUiContext(), transportsToLoadMatch);
       chooser.setTitle("Select air transports to load");
       final int option =
@@ -1197,7 +1197,7 @@ public class MovePanel extends AbstractMovePanel {
       sortUnitsToMove(candidateUnits, route);
       final UnitChooser chooser =
           new UnitChooser(candidateUnits, defaultSelections, mustMoveWithDetails.getMustMoveWith(), true, false,
-              getGameData(), false, getMap().getUiContext(), matchCriteria);
+              false, getMap().getUiContext(), matchCriteria);
       final String text = "Select units to move from " + getFirstSelectedTerritory() + ".";
       final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
           JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -1325,7 +1325,7 @@ public class MovePanel extends AbstractMovePanel {
       final String action) {
     // Allow player to select which to load.
     final UnitChooser chooser = new UnitChooser(unitsToLoad, defaultSelections, dependentUnits,
-        /* categorizeMovement */false, /* categorizeTransportCost */true, getGameData(), /* allowTwoHit */false,
+        /* categorizeMovement */false, /* categorizeTransportCost */true, /* allowTwoHit */false,
         getMap().getUiContext(), unitsToLoadMatch);
     chooser.setTitle(title);
     final int option =

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -182,7 +182,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       currentAction = selectUnitsAction;
       setWidgetActivation();
       final UnitChooser unitChooser = new UnitChooser(unitChoices, Collections.emptyMap(),
-          getData(), false, getMap().getUiContext());
+          false, getMap().getUiContext());
       unitChooser.setMaxAndShowMaxButton(unitsPerPick);
       if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
           JOptionPane.OK_CANCEL_OPTION, new CountDownLatchHandler(true))) {

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -84,8 +84,7 @@ public class PlacePanel extends AbstractMovePanel {
       if (units.isEmpty()) {
         return;
       }
-      final UnitChooser chooser =
-          new UnitChooser(units, Collections.emptyMap(), getData(), false, getMap().getUiContext());
+      final UnitChooser chooser = new UnitChooser(units, Collections.emptyMap(), false, getMap().getUiContext());
       final String messageText = "Place units in " + territory.getName();
       if (maxUnits[0] >= 0) {
         chooser.setMaxAndShowMaxButton(maxUnits[0]);
@@ -163,7 +162,7 @@ public class PlacePanel extends AbstractMovePanel {
 
   private void updateUnits() {
     final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(getCurrentPlayer().getUnits().getUnits());
-    unitsToPlace.setUnitsFromCategories(unitCategories, getData());
+    unitsToPlace.setUnitsFromCategories(unitCategories);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -92,7 +92,7 @@ public class ProductionPanel extends JPanel {
 
     this.bid = bid;
     this.data = data;
-    this.initRules(id, data, initialPurchase);
+    this.initRules(id, initialPurchase);
     this.initLayout();
     this.calculateLimits();
     dialog.pack();
@@ -109,10 +109,7 @@ public class ProductionPanel extends JPanel {
     return rules;
   }
 
-
-  // made this protected so can be extended by edit production panel
-  protected void initRules(final PlayerID player, final GameData data,
-      final IntegerMap<ProductionRule> initialPurchase) {
+  protected void initRules(final PlayerID player, final IntegerMap<ProductionRule> initialPurchase) {
     this.data.acquireReadLock();
     try {
       id = player;
@@ -244,7 +241,7 @@ public class ProductionPanel extends JPanel {
         final NamedAttachable resourceOrUnit = iter.next();
         if (resourceOrUnit instanceof UnitType) {
           final UnitType type = (UnitType) resourceOrUnit;
-          icon = uiContext.getUnitImageFactory().getIcon(type, id, data, false, false);
+          icon = uiContext.getUnitImageFactory().getIcon(type, id, false, false);
           final UnitAttachment attach = UnitAttachment.get(type);
           final int attack = attach.getAttack(id);
           final int movement = attach.getMovement(id);
@@ -261,7 +258,7 @@ public class ProductionPanel extends JPanel {
           }
         } else if (resourceOrUnit instanceof Resource) {
           final Resource resource = (Resource) resourceOrUnit;
-          icon = Optional.of(uiContext.getResourceImageFactory().getIcon(resource, data, true));
+          icon = Optional.of(uiContext.getResourceImageFactory().getIcon(resource, true));
           info.setText("resource");
           tooltip.append(resource.getName()).append(": resource");
           name.setText(resource.getName());

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -243,7 +243,7 @@ public class ProductionRepairPanel extends JPanel {
       }
       repairResults = rule.getResults().getInt(type);
       final TripleAUnit taUnit = (TripleAUnit) repairUnit;
-      final Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(type, id, data,
+      final Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(type, id,
           Matches.unitHasTakenSomeBombingUnitDamage().match(repairUnit), Matches.unitIsDisabled().match(repairUnit));
       final String text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "</html>";
 

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -74,13 +74,12 @@ public class PurchasePanel extends ActionPanel {
 
       add(Box.createVerticalStrut(4));
 
-      purhcasedUnits.setUnitsFromProductionRuleMap(new IntegerMap<>(), id, getData());
+      purhcasedUnits.setUnitsFromProductionRuleMap(new IntegerMap<>(), id);
       add(purhcasedUnits);
 
       getData().acquireReadLock();
       try {
-        purchasedPreviousRoundsUnits.setUnitsFromCategories(UnitSeperator.categorize(id.getUnits().getUnits()),
-            getData());
+        purchasedPreviousRoundsUnits.setUnitsFromCategories(UnitSeperator.categorize(id.getUnits().getUnits()));
         add(Box.createVerticalStrut(4));
         if (!id.getUnits().isEmpty()) {
           add(purchasedPreviousRoundsLabel);
@@ -122,7 +121,7 @@ public class PurchasePanel extends ActionPanel {
         purchase = ProductionPanel.getProduction(player, (JFrame) getTopLevelAncestor(), data, bid, purchase,
             getMap().getUiContext());
       }
-      purhcasedUnits.setUnitsFromProductionRuleMap(purchase, player, data);
+      purhcasedUnits.setUnitsFromProductionRuleMap(purchase, player);
       if (purchase.totalValues() == 0) {
         purchasedLabel.setText("");
         buyButton.setText(BUY);

--- a/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -43,16 +43,14 @@ public class SimpleUnitPanel extends JPanel {
    *        a HashMap in the form ProductionRule -> number of units
    *        assumes that each production rule has 1 result, which is simple the number of units.
    */
-  public void setUnitsFromProductionRuleMap(final IntegerMap<ProductionRule> units, final PlayerID player,
-      final GameData data) {
+  void setUnitsFromProductionRuleMap(final IntegerMap<ProductionRule> units, final PlayerID player) {
     removeAll();
     final TreeSet<ProductionRule> productionRules = new TreeSet<>(productionRuleComparator);
     productionRules.addAll(units.keySet());
     for (final ProductionRule productionRule : productionRules) {
       final int quantity = units.getInt(productionRule);
       for (final NamedAttachable resourceOrUnit : productionRule.getResults().keySet()) {
-        addUnits(player, data, quantity * productionRule.getResults().getInt(resourceOrUnit), resourceOrUnit, false,
-            false);
+        addUnits(player, quantity * productionRule.getResults().getInt(resourceOrUnit), resourceOrUnit, false, false);
       }
     }
   }
@@ -75,7 +73,7 @@ public class SimpleUnitPanel extends JPanel {
         if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           // check to see if the repair rule matches the damaged unit
           if (unit.getType().equals((repairRule.getResults().keySet().iterator().next()))) {
-            addUnits(player, data, quantity, unit.getType(), Matches.unitHasTakenSomeBombingUnitDamage().match(unit),
+            addUnits(player, quantity, unit.getType(), Matches.unitHasTakenSomeBombingUnitDamage().match(unit),
                 Matches.unitIsDisabled().match(unit));
           }
         }
@@ -87,26 +85,26 @@ public class SimpleUnitPanel extends JPanel {
    * @param categories
    *        a collection of UnitCategories.
    */
-  public void setUnitsFromCategories(final Collection<UnitCategory> categories, final GameData data) {
+  public void setUnitsFromCategories(final Collection<UnitCategory> categories) {
     removeAll();
     for (final UnitCategory category : categories) {
-      addUnits(category.getOwner(), data, category.getUnits().size(), category.getType(),
+      addUnits(category.getOwner(), category.getUnits().size(), category.getType(),
           category.hasDamageOrBombingUnitDamage(), category.getDisabled());
     }
   }
 
-  private void addUnits(final PlayerID player, final GameData data, final int quantity, final NamedAttachable unit,
+  private void addUnits(final PlayerID player, final int quantity, final NamedAttachable unit,
       final boolean damaged, final boolean disabled) {
     final JLabel label = new JLabel();
     label.setText(" x " + quantity);
     if (unit instanceof UnitType) {
       final Optional<ImageIcon> icon =
-          uiContext.getUnitImageFactory().getIcon((UnitType) unit, player, data, damaged, disabled);
+          uiContext.getUnitImageFactory().getIcon((UnitType) unit, player, damaged, disabled);
       if (icon.isPresent()) {
         label.setIcon(icon.get());
       }
     } else if (unit instanceof Resource) {
-      label.setIcon(uiContext.getResourceImageFactory().getIcon((Resource) unit, data, true));
+      label.setIcon(uiContext.getResourceImageFactory().getIcon((Resource) unit, true));
     }
     add(label);
   }

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -94,9 +94,8 @@ public class TechPanel extends ActionPanel {
 
   private List<TechnologyFrontier> getAvailableCategories() {
     final Collection<TechnologyFrontier> currentAdvances =
-        TechTracker.getFullyResearchedPlayerTechCategories(getData(), getCurrentPlayer());
-    final Collection<TechnologyFrontier> allAdvances =
-        TechAdvance.getPlayerTechCategories(getData(), getCurrentPlayer());
+        TechTracker.getFullyResearchedPlayerTechCategories(getCurrentPlayer());
+    final Collection<TechnologyFrontier> allAdvances = TechAdvance.getPlayerTechCategories(getCurrentPlayer());
     return Util.difference(allAdvances, currentAdvances);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -93,14 +93,13 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       gameData.releaseReadLock();
     }
     add(new JLabel("Units: " + unitsInTerritory.size()));
-    final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, uiContext, gameData));
+    final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, uiContext));
     scroll.setBorder(BorderFactory.createEmptyBorder());
     add(scroll);
     refresh();
   }
 
-  private static JPanel unitsInTerritoryPanel(final Collection<Unit> unitsInTerritory, final IUIContext uiContext,
-      final GameData data) {
+  private static JPanel unitsInTerritoryPanel(final Collection<Unit> unitsInTerritory, final IUIContext uiContext) {
     final JPanel panel = new JPanel();
     panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -116,7 +115,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       }
       // TODO Kev determine if we need to identify if the unit is hit/disabled
       final Optional<ImageIcon> unitIcon =
-          uiContext.getUnitImageFactory().getIcon(item.getType(), item.getOwner(), data,
+          uiContext.getUnitImageFactory().getIcon(item.getType(), item.getOwner(),
               item.hasDamageOrBombingUnitDamage(), item.getDisabled());
       if (unitIcon.isPresent()) {
         // overlay flag onto upper-right of icon

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1149,7 +1149,7 @@ public class TripleAFrame extends MainGameFrame {
           final Collection<Unit> possible = possibleScramblers.get(from).getSecond();
           final int maxAllowed =
               Math.min(BattleDelegate.getMaxScrambleCount(possibleScramblers.get(from).getFirst()), possible.size());
-          final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
+          final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
           chooser.setMaxAndShowMaxButton(maxAllowed);
           choosers.add(Tuple.of(from, chooser));
           panelChooser.add(chooser);
@@ -1234,7 +1234,7 @@ public class TripleAFrame extends MainGameFrame {
         panelChooser.add(whereFrom);
         panelChooser.add(new JLabel(" "));
         final int maxAllowed = possible.size();
-        final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
+        final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
         chooser.setMaxAndShowMaxButton(maxAllowed);
         panelChooser.add(chooser);
         final JScrollPane chooserScrollPane = new JScrollPane(panelChooser);
@@ -1944,7 +1944,7 @@ public class TripleAFrame extends MainGameFrame {
     final AtomicReference<JScrollPane> panelRef = new AtomicReference<>();
     final AtomicReference<UnitChooser> chooserRef = new AtomicReference<>();
     SwingAction.invokeAndWait(() -> {
-      final UnitChooser chooser = new UnitChooser(fighters, Collections.emptyMap(), data, false, uiContext);
+      final UnitChooser chooser = new UnitChooser(fighters, Collections.emptyMap(), false, uiContext);
       final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
       final int availHeight = screenResolution.height - 120;
       final int availWidth = screenResolution.width - 40;

--- a/src/main/java/games/strategy/triplea/ui/UIContext.java
+++ b/src/main/java/games/strategy/triplea/ui/UIContext.java
@@ -137,7 +137,7 @@ public class UIContext extends AbstractUIContext {
   @Override
   public JLabel createUnitImageJLabel(final UnitType type, final PlayerID player, final GameData data,
       final UnitDamage damaged, final UnitEnable disabled) {
-    final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, data, damaged == UnitDamage.DAMAGED,
+    final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, damaged == UnitDamage.DAMAGED,
         disabled == UnitEnable.DISABLED);
     if (image.isPresent()) {
       return new JLabel(image.get());

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -20,7 +20,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.dataObjects.CasualtyList;
 import games.strategy.triplea.util.UnitCategory;
@@ -38,37 +37,33 @@ final class UnitChooser extends JPanel {
   private JTextArea title;
   private int total = -1;
   private final JLabel leftToSelect = new JLabel();
-  private final GameData data;
   private boolean allowMultipleHits = false;
   private JButton autoSelectButton;
   private JButton selectNoneButton;
   private final IUIContext uiContext;
   private final Match<Collection<Unit>> match;
 
-  UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent, final GameData data,
+  UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent,
       final boolean allowTwoHit, final IUIContext uiContext) {
-    this(units, Collections.emptyList(), dependent, data, allowTwoHit, uiContext);
+    this(units, Collections.emptyList(), dependent, allowTwoHit, uiContext);
   }
 
-  UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
-      final Map<Unit, Collection<Unit>> dependent, final GameData data, final boolean allowTwoHit,
-      final IUIContext uiContext) {
-    this(units, defaultSelections, dependent, false, false, data, allowTwoHit, uiContext);
+  private UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
+      final Map<Unit, Collection<Unit>> dependent, final boolean allowTwoHit, final IUIContext uiContext) {
+    this(units, defaultSelections, dependent, false, false, allowTwoHit, uiContext);
   }
 
-  private UnitChooser(final Map<Unit, Collection<Unit>> dependent, final GameData data, final boolean allowMultipleHits,
+  private UnitChooser(final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits,
       final IUIContext uiContext, final Match<Collection<Unit>> match) {
     dependents = dependent;
-    this.data = data;
     this.allowMultipleHits = allowMultipleHits;
     this.uiContext = uiContext;
     this.match = match;
   }
 
   UnitChooser(final Collection<Unit> units, final CasualtyList defaultSelections,
-      final Map<Unit, Collection<Unit>> dependent, final GameData data, final boolean allowMultipleHits,
-      final IUIContext uiContext) {
-    this(dependent, data, allowMultipleHits, uiContext, null);
+      final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits, final IUIContext uiContext) {
+    this(dependent, allowMultipleHits, uiContext, null);
     final List<Unit> combinedList = defaultSelections.getDamaged();
     // TODO: this adds it to the default selections list, is this intended?
     combinedList.addAll(defaultSelections.getKilled());
@@ -78,18 +73,17 @@ final class UnitChooser extends JPanel {
 
   UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
-      final boolean categorizeTransportCost, final GameData data, final boolean allowMultipleHits,
-      final IUIContext uiContext) {
-    this(dependent, data, allowMultipleHits, uiContext, null);
+      final boolean categorizeTransportCost, final boolean allowMultipleHits, final IUIContext uiContext) {
+    this(dependent, allowMultipleHits, uiContext, null);
     createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
     layoutEntries();
   }
 
   UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
-      final boolean categorizeTransportCost, final GameData data, final boolean allowMultipleHits,
+      final boolean categorizeTransportCost, final boolean allowMultipleHits,
       final IUIContext uiContext, final Match<Collection<Unit>> match) {
-    this(dependent, data, allowMultipleHits, uiContext, match);
+    this(dependent, allowMultipleHits, uiContext, match);
     createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
     layoutEntries();
   }
@@ -190,7 +184,7 @@ final class UnitChooser extends JPanel {
   }
 
   private void addCategory(final UnitCategory category, final int defaultValue) {
-    final ChooserEntry entry = new ChooserEntry(category, total, textFieldListener, data, allowMultipleHits,
+    final ChooserEntry entry = new ChooserEntry(category, total, textFieldListener, allowMultipleHits,
         defaultValue, uiContext);
     entries.add(entry);
   }
@@ -328,7 +322,6 @@ final class UnitChooser extends JPanel {
   private static final class ChooserEntry {
     private final UnitCategory category;
     private final ScrollableTextFieldListener hitTextFieldListener;
-    private final GameData gameData;
     private final boolean hasMultipleHits;
     private final List<Integer> defaultHits;
     private final List<ScrollableTextField> hitTexts;
@@ -338,9 +331,8 @@ final class UnitChooser extends JPanel {
     private final IUIContext uiContext;
 
     ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,
-        final GameData data, final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
+        final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
       hitTextFieldListener = listener;
-      gameData = data;
       this.category = category;
       this.leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
       hasMultipleHits =
@@ -478,7 +470,7 @@ final class UnitChooser extends JPanel {
       public void paint(final Graphics g) {
         super.paint(g);
         final Optional<Image> image =
-            uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(), gameData,
+            uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
                 forceDamaged || category.hasDamageOrBombingUnitDamage(), category.getDisabled());
         if (image.isPresent()) {
           g.drawImage(image.get(), 0, 0, this);
@@ -490,7 +482,7 @@ final class UnitChooser extends JPanel {
           final UnitOwner holder = iter.next();
           final int x = uiContext.getUnitImageFactory().getUnitImageWidth() * index;
           final Optional<Image> unitImg =
-              uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), gameData, false, false);
+              uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), false, false);
           if (unitImg.isPresent()) {
             g.drawImage(unitImg.get(), x, 0, this);
           }

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -70,7 +70,7 @@ public class TripleADisplay implements ITripleADisplay {
 
   @Override
   public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {
-    ui.getBattlePanel().bombingResults(battleId, dice, cost);
+    ui.getBattlePanel().bombingResults(dice, cost);
   }
 
   @Override
@@ -98,7 +98,7 @@ public class TripleADisplay implements ITripleADisplay {
 
   @Override
   public void gotoBattleStep(final GUID battleId, final String step) {
-    ui.getBattlePanel().gotoStep(battleId, step);
+    ui.getBattlePanel().gotoStep(step);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -99,7 +99,7 @@ public class HistoryDetailsPanel extends JPanel implements IHistoryDetailsPanel 
   private void renderUnits(final GridBagConstraints mainConstraints, final Collection<Unit> units) {
     final Collection<UnitCategory> unitsCategories = UnitSeperator.categorize(units);
     final SimpleUnitPanel unitsPanel = new SimpleUnitPanel(mapPanel.getUiContext());
-    unitsPanel.setUnitsFromCategories(unitsCategories, data);
+    unitsPanel.setUnitsFromCategories(unitsCategories);
     add(unitsPanel, mainConstraints);
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -39,7 +39,7 @@ public class SmallMapImageManager {
     this.offscreen = Util.copyImage(offscreen);
   }
 
-  public void update(final GameData data, final MapData mapData) {
+  public void update(final MapData mapData) {
     final Stopwatch stopwatch = new Stopwatch(logger, Level.FINEST, "Small map updating took");
     final Graphics onScreenGraphics = view.getOffScreenImage().getGraphics();
     onScreenGraphics.drawImage(offscreen, 0, 0, null);

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -158,7 +158,7 @@ public class TileManager {
     }
   }
 
-  public void createTiles(final Rectangle bounds, final GameData data, final MapData mapData) {
+  public void createTiles(final Rectangle bounds) {
     acquireLock();
     try {
       // create our tiles

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -91,7 +91,7 @@ public class UnitsDrawer implements IDrawable {
     }
     final PlayerID owner = data.getPlayerList().getPlayerID(playerName);
     final Optional<Image> img =
-        uiContext.getUnitImageFactory().getImage(type, owner, data, damaged > 0 || bombingUnitDamage > 0, disabled);
+        uiContext.getUnitImageFactory().getImage(type, owner, damaged > 0 || bombingUnitDamage > 0, disabled);
 
     if (!img.isPresent()) {
       ClientLogger

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -29,13 +29,6 @@ public class UnitSeperator {
         sort);
   }
 
-  public static Set<UnitCategory> categorize(final boolean sort, final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
-      final boolean categorizeTransportCost, final boolean categorizeTerritories) {
-    return categorize(units, dependent, categorizeMovement, categorizeTransportCost, /* ctgzTrnMovement */false,
-        sort);
-  }
-
   /**
    * Break the units into discrete categories.
    * Do this based on unit owner, and optionally dependent units and movement
@@ -111,11 +104,5 @@ public class UnitSeperator {
       final boolean categorizeMovement, final boolean categorizeTransportCost) {
     // sort by default
     return categorize(units, dependent, categorizeMovement, categorizeTransportCost, true);
-  }
-
-  public static Set<UnitCategory> categorize(final Map<Unit, Collection<Unit>> dependent, final Collection<Unit> units,
-      final boolean categorizeMovement, final boolean categorizeTransportCost, final boolean categorizeTerritories) {
-    // sort by default
-    return categorize(true, units, dependent, categorizeMovement, categorizeTransportCost, categorizeTerritories);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -958,7 +958,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
         attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW).toString(), steps.toString());
   }
@@ -980,7 +980,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
         attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW).toString(), steps.toString());
   }
@@ -1002,7 +1002,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
             attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, REMOVE_CASUALTIES,
@@ -1040,7 +1040,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
      * Every sub, regardless of whether it is on the attacking or defending side, fires in the Opening Fire step of
@@ -1097,7 +1097,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
      * Every sub, regardless of whether it is on the attacking or defending side, fires in the Opening Fire step of
@@ -1157,7 +1157,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES,
         REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
@@ -1196,7 +1196,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
      * Every sub, regardless of whether it is on the attacking or defending side, fires in the Opening Fire step of
@@ -1257,7 +1257,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
         attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE,

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -830,7 +830,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + SUBS_FIRE,
             defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE, attacker + SELECT_SUB_CASUALTIES,
@@ -865,7 +865,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(defender + SUBS_SUBMERGE, defender + SUBS_FIRE, attacker + SELECT_SUB_CASUALTIES,
             REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + FIRE,
@@ -901,7 +901,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES,
             REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES, defender + SUBS_FIRE,
@@ -938,7 +938,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
-    final List<String> steps = battle.determineStepStrings(true, bridge);
+    final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, attacker + FIRE,
             defender + SELECT_CASUALTIES, defender + SUBS_FIRE, attacker + SELECT_SUB_CASUALTIES, defender + FIRE,


### PR DESCRIPTION
This PR removes unused parameters from several methods.  In some cases, removing a method parameter causes a parameter in the caller to become unused.  I just kept pulling the thread until I reached the end.

Where possible, I reduced the visibility of modified methods and/or made them `static`.

None of the modified methods are invoked via RMI, and thus these changes shouldn't cause any compatibility issues.