### PR TITLE
Serialization proxy: Extract superclasses for GameDataComponent proxy tests

### DIFF
--- a/src/test/java/games/strategy/engine/data/TestEqualityComparatorCollectionBuilder.java
+++ b/src/test/java/games/strategy/engine/data/TestEqualityComparatorCollectionBuilder.java
@@ -43,6 +43,20 @@ public final class TestEqualityComparatorCollectionBuilder {
     return this;
   }
 
+  /**
+   * Adds the specified collection of equality comparators to the collection under construction.
+   *
+   * @param equalityComparators The collection of equality comparators to add.
+   *
+   * @return A reference to this builder.
+   */
+  public TestEqualityComparatorCollectionBuilder addAll(final Collection<EqualityComparator> equalityComparators) {
+    checkNotNull(equalityComparators);
+
+    this.equalityComparators.addAll(equalityComparators);
+    return this;
+  }
+
   public Collection<EqualityComparator> build() {
     return new ArrayList<>(equalityComparators);
   }

--- a/src/test/java/games/strategy/internal/persistence/serializable/AaRadarAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/AaRadarAdvanceProxyAsProxyTest.java
@@ -1,35 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.AARadarAdvance;
 
-public final class AaRadarAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<AARadarAdvance> {
+public final class AaRadarAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<AARadarAdvance> {
   public AaRadarAdvanceProxyAsProxyTest() {
-    super(AARadarAdvance.class);
-  }
-
-  @Override
-  protected AARadarAdvance newGameDataComponent(final GameData gameData) {
-    final AARadarAdvance aaRadarAdvance = new AARadarAdvance(gameData);
-    initializeAttachable(aaRadarAdvance);
-    return aaRadarAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.AA_RADAR_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(AaRadarAdvanceProxy.FACTORY);
+    super(
+        AARadarAdvance.class,
+        AARadarAdvance::new,
+        EngineDataEqualityComparators.AA_RADAR_ADVANCE,
+        AaRadarAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/AaRadarAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/AaRadarAdvanceProxyAsProxyTest.java
@@ -1,44 +1,35 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.AARadarAdvance;
 
-public final class AaRadarAdvanceProxyAsProxyTest extends AbstractProxyTestCase<AARadarAdvance> {
+public final class AaRadarAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<AARadarAdvance> {
   public AaRadarAdvanceProxyAsProxyTest() {
     super(AARadarAdvance.class);
   }
 
   @Override
-  protected Collection<AARadarAdvance> createPrincipals() {
-    return Arrays.asList(newAaRadarAdvance());
-  }
-
-  private static AARadarAdvance newAaRadarAdvance() {
-    final AARadarAdvance aaRadarAdvance = new AARadarAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(aaRadarAdvance);
+  protected AARadarAdvance newGameDataComponent(final GameData gameData) {
+    final AARadarAdvance aaRadarAdvance = new AARadarAdvance(gameData);
+    initializeAttachable(aaRadarAdvance);
     return aaRadarAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.AA_RADAR_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.AA_RADAR_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(AaRadarAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(AaRadarAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/AbstractGameDataComponentProxyTestCase.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/AbstractGameDataComponentProxyTestCase.java
@@ -1,0 +1,85 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameDataComponent;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+
+/**
+ * A fixture for testing the basic aspects of {@link GameDataComponent} proxy classes.
+ *
+ * @param <T> The type of the game data component to be proxied.
+ */
+public abstract class AbstractGameDataComponentProxyTestCase<T extends GameDataComponent>
+    extends AbstractProxyTestCase<T> {
+  protected AbstractGameDataComponentProxyTestCase(final Class<T> principalType) {
+    super(principalType);
+  }
+
+  @Override
+  protected final Collection<T> createPrincipals() {
+    return Arrays.asList(newGameDataComponent(TestGameDataFactory.newValidGameData()));
+  }
+
+  /**
+   * Creates an instance of the game data component whose capability to be persisted via a proxy will be tested.
+   *
+   * @param gameData The game data that owns the component.
+   *
+   * @return The game data component to be tested.
+   */
+  protected abstract T newGameDataComponent(GameData gameData);
+
+  @Override
+  protected final Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .addAll(getAdditionalEqualityComparators())
+        .build();
+  }
+
+  /**
+   * Gets the collection of additional equality comparators required to compare two instances of the game data component
+   * type for equality. Any equality comparators required to compare two instances of {@link GameData} do not need to be
+   * included.
+   *
+   * <p>
+   * This implementation returns an empty collection. Subclasses may override and are not required to call the
+   * superclass implementation.
+   * </p>
+   *
+   * @return The collection of additional equality comparators required to compare two instances of the game data
+   *         component type for equality.
+   */
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected final Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .addAll(getAdditionalProxyFactories())
+        .build();
+  }
+
+  /**
+   * Gets the collection of additional proxy factories required for the game data component to be persisted. Any proxy
+   * factories required to persist an instance of {@link GameData} do not need to be included.
+   *
+   * <p>
+   * This implementation returns an empty collection. Subclasses may override and are not required to call the
+   * superclass implementation.
+   * </p>
+   *
+   * @return The collection of additional proxy factories required for the game data component to be persisted.
+   */
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Collections.emptyList();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/AbstractTechAdvanceProxyTestCase.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/AbstractTechAdvanceProxyTestCase.java
@@ -1,0 +1,58 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Function;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.triplea.delegate.TechAdvance;
+
+/**
+ * A fixture for testing the basic aspects of {@link TechAdvance} proxy classes.
+ *
+ * @param <T> The type of the technology advance to be proxied.
+ */
+public abstract class AbstractTechAdvanceProxyTestCase<T extends TechAdvance>
+    extends AbstractGameDataComponentProxyTestCase<T> {
+  private final EqualityComparator equalityComparator;
+  private final Function<GameData, T> newTechAdvance;
+  private final ProxyFactory proxyFactory;
+
+  protected AbstractTechAdvanceProxyTestCase(
+      final Class<T> principalType,
+      final Function<GameData, T> newTechAdvance,
+      final EqualityComparator equalityComparator,
+      final ProxyFactory proxyFactory) {
+    super(principalType);
+
+    checkNotNull(newTechAdvance);
+    checkNotNull(equalityComparator);
+    checkNotNull(proxyFactory);
+
+    this.equalityComparator = equalityComparator;
+    this.newTechAdvance = newTechAdvance;
+    this.proxyFactory = proxyFactory;
+  }
+
+  @Override
+  protected final T newGameDataComponent(final GameData gameData) {
+    final T techAdvance = newTechAdvance.apply(gameData);
+    initializeAttachable(techAdvance);
+    return techAdvance;
+  }
+
+  @Override
+  protected final Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Collections.singletonList(equalityComparator);
+  }
+
+  @Override
+  protected final Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Collections.singletonList(proxyFactory);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/DestroyerBombardTechAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/DestroyerBombardTechAdvanceProxyAsProxyTest.java
@@ -1,36 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.DestroyerBombardTechAdvance;
 
 public final class DestroyerBombardTechAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<DestroyerBombardTechAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<DestroyerBombardTechAdvance> {
   public DestroyerBombardTechAdvanceProxyAsProxyTest() {
-    super(DestroyerBombardTechAdvance.class);
-  }
-
-  @Override
-  protected DestroyerBombardTechAdvance newGameDataComponent(final GameData gameData) {
-    final DestroyerBombardTechAdvance destroyerBombardTechAdvance = new DestroyerBombardTechAdvance(gameData);
-    initializeAttachable(destroyerBombardTechAdvance);
-    return destroyerBombardTechAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.DESTROYER_BOMBARD_TECH_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(DestroyerBombardTechAdvanceProxy.FACTORY);
+    super(
+        DestroyerBombardTechAdvance.class,
+        DestroyerBombardTechAdvance::new,
+        EngineDataEqualityComparators.DESTROYER_BOMBARD_TECH_ADVANCE,
+        DestroyerBombardTechAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/DestroyerBombardTechAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/DestroyerBombardTechAdvanceProxyAsProxyTest.java
@@ -1,46 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.DestroyerBombardTechAdvance;
 
 public final class DestroyerBombardTechAdvanceProxyAsProxyTest
-    extends AbstractProxyTestCase<DestroyerBombardTechAdvance> {
+    extends AbstractGameDataComponentProxyTestCase<DestroyerBombardTechAdvance> {
   public DestroyerBombardTechAdvanceProxyAsProxyTest() {
     super(DestroyerBombardTechAdvance.class);
   }
 
   @Override
-  protected Collection<DestroyerBombardTechAdvance> createPrincipals() {
-    return Arrays.asList(newDestroyerBombardTechAdvance());
-  }
-
-  private static DestroyerBombardTechAdvance newDestroyerBombardTechAdvance() {
-    final DestroyerBombardTechAdvance destroyerBombardTechAdvance =
-        new DestroyerBombardTechAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(destroyerBombardTechAdvance);
+  protected DestroyerBombardTechAdvance newGameDataComponent(final GameData gameData) {
+    final DestroyerBombardTechAdvance destroyerBombardTechAdvance = new DestroyerBombardTechAdvance(gameData);
+    initializeAttachable(destroyerBombardTechAdvance);
     return destroyerBombardTechAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.DESTROYER_BOMBARD_TECH_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.DESTROYER_BOMBARD_TECH_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(DestroyerBombardTechAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(DestroyerBombardTechAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/FakeTechAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/FakeTechAdvanceProxyAsProxyTest.java
@@ -1,33 +1,20 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.newFakeTechAdvance;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
+import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.triplea.delegate.FakeTechAdvance;
 
-public final class FakeTechAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<FakeTechAdvance> {
+public final class FakeTechAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<FakeTechAdvance> {
   public FakeTechAdvanceProxyAsProxyTest() {
-    super(FakeTechAdvance.class);
+    super(
+        FakeTechAdvance.class,
+        FakeTechAdvanceProxyAsProxyTest::newFakeTechAdvance,
+        EngineDataEqualityComparators.FAKE_TECH_ADVANCE,
+        FakeTechAdvanceProxy.FACTORY);
   }
 
-  @Override
-  protected FakeTechAdvance newGameDataComponent(final GameData gameData) {
-    return newFakeTechAdvance(gameData, "Tech Advance");
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.FAKE_TECH_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(FakeTechAdvanceProxy.FACTORY);
+  private static FakeTechAdvance newFakeTechAdvance(final GameData gameData) {
+    return TestGameDataComponentFactory.newFakeTechAdvance(gameData, "Tech Advance");
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/FakeTechAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/FakeTechAdvanceProxyAsProxyTest.java
@@ -1,39 +1,33 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newFakeTechAdvance;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.FakeTechAdvance;
 
-public final class FakeTechAdvanceProxyAsProxyTest extends AbstractProxyTestCase<FakeTechAdvance> {
+public final class FakeTechAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<FakeTechAdvance> {
   public FakeTechAdvanceProxyAsProxyTest() {
     super(FakeTechAdvance.class);
   }
 
   @Override
-  protected Collection<FakeTechAdvance> createPrincipals() {
-    return Arrays.asList(
-        TestGameDataComponentFactory.newFakeTechAdvance(TestGameDataFactory.newValidGameData(), "Tech Advance"));
+  protected FakeTechAdvance newGameDataComponent(final GameData gameData) {
+    return newFakeTechAdvance(gameData, "Tech Advance");
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.FAKE_TECH_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.FAKE_TECH_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(FakeTechAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(FakeTechAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/HeavyBomberAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/HeavyBomberAdvanceProxyAsProxyTest.java
@@ -1,36 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 
-public final class HeavyBomberAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<HeavyBomberAdvance> {
+public final class HeavyBomberAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<HeavyBomberAdvance> {
   public HeavyBomberAdvanceProxyAsProxyTest() {
-    super(HeavyBomberAdvance.class);
-  }
-
-  @Override
-  protected HeavyBomberAdvance newGameDataComponent(final GameData gameData) {
-    final HeavyBomberAdvance heavyBomberAdvance = new HeavyBomberAdvance(gameData);
-    initializeAttachable(heavyBomberAdvance);
-    return heavyBomberAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.HEAVY_BOMBER_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(HeavyBomberAdvanceProxy.FACTORY);
+    super(
+        HeavyBomberAdvance.class,
+        HeavyBomberAdvance::new,
+        EngineDataEqualityComparators.HEAVY_BOMBER_ADVANCE,
+        HeavyBomberAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/HeavyBomberAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/HeavyBomberAdvanceProxyAsProxyTest.java
@@ -1,44 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 
-public final class HeavyBomberAdvanceProxyAsProxyTest extends AbstractProxyTestCase<HeavyBomberAdvance> {
+public final class HeavyBomberAdvanceProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<HeavyBomberAdvance> {
   public HeavyBomberAdvanceProxyAsProxyTest() {
     super(HeavyBomberAdvance.class);
   }
 
   @Override
-  protected Collection<HeavyBomberAdvance> createPrincipals() {
-    return Arrays.asList(newHeavyBomberAdvance());
-  }
-
-  private static HeavyBomberAdvance newHeavyBomberAdvance() {
-    final HeavyBomberAdvance heavyBomberAdvance = new HeavyBomberAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(heavyBomberAdvance);
+  protected HeavyBomberAdvance newGameDataComponent(final GameData gameData) {
+    final HeavyBomberAdvance heavyBomberAdvance = new HeavyBomberAdvance(gameData);
+    initializeAttachable(heavyBomberAdvance);
     return heavyBomberAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.HEAVY_BOMBER_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.HEAVY_BOMBER_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(HeavyBomberAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(HeavyBomberAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ImprovedArtillerySupportAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ImprovedArtillerySupportAdvanceProxyAsProxyTest.java
@@ -1,46 +1,37 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 
 public final class ImprovedArtillerySupportAdvanceProxyAsProxyTest
-    extends AbstractProxyTestCase<ImprovedArtillerySupportAdvance> {
+    extends AbstractGameDataComponentProxyTestCase<ImprovedArtillerySupportAdvance> {
   public ImprovedArtillerySupportAdvanceProxyAsProxyTest() {
     super(ImprovedArtillerySupportAdvance.class);
   }
 
   @Override
-  protected Collection<ImprovedArtillerySupportAdvance> createPrincipals() {
-    return Arrays.asList(newImprovedArtillerySupportAdvance());
-  }
-
-  private static ImprovedArtillerySupportAdvance newImprovedArtillerySupportAdvance() {
+  protected ImprovedArtillerySupportAdvance newGameDataComponent(final GameData gameData) {
     final ImprovedArtillerySupportAdvance improvedArtillerySupportAdvance =
-        new ImprovedArtillerySupportAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(improvedArtillerySupportAdvance);
+        new ImprovedArtillerySupportAdvance(gameData);
+    initializeAttachable(improvedArtillerySupportAdvance);
     return improvedArtillerySupportAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.IMPROVED_ARTILLERY_SUPPORT_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.IMPROVED_ARTILLERY_SUPPORT_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(ImprovedArtillerySupportAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(ImprovedArtillerySupportAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ImprovedArtillerySupportAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ImprovedArtillerySupportAdvanceProxyAsProxyTest.java
@@ -1,37 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 
 public final class ImprovedArtillerySupportAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<ImprovedArtillerySupportAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<ImprovedArtillerySupportAdvance> {
   public ImprovedArtillerySupportAdvanceProxyAsProxyTest() {
-    super(ImprovedArtillerySupportAdvance.class);
-  }
-
-  @Override
-  protected ImprovedArtillerySupportAdvance newGameDataComponent(final GameData gameData) {
-    final ImprovedArtillerySupportAdvance improvedArtillerySupportAdvance =
-        new ImprovedArtillerySupportAdvance(gameData);
-    initializeAttachable(improvedArtillerySupportAdvance);
-    return improvedArtillerySupportAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.IMPROVED_ARTILLERY_SUPPORT_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(ImprovedArtillerySupportAdvanceProxy.FACTORY);
+    super(
+        ImprovedArtillerySupportAdvance.class,
+        ImprovedArtillerySupportAdvance::new,
+        EngineDataEqualityComparators.IMPROVED_ARTILLERY_SUPPORT_ADVANCE,
+        ImprovedArtillerySupportAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ImprovedShipyardsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ImprovedShipyardsAdvanceProxyAsProxyTest.java
@@ -1,36 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ImprovedShipyardsAdvance;
 
 public final class ImprovedShipyardsAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<ImprovedShipyardsAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<ImprovedShipyardsAdvance> {
   public ImprovedShipyardsAdvanceProxyAsProxyTest() {
-    super(ImprovedShipyardsAdvance.class);
-  }
-
-  @Override
-  protected ImprovedShipyardsAdvance newGameDataComponent(final GameData gameData) {
-    final ImprovedShipyardsAdvance improvedShipyardsAdvance = new ImprovedShipyardsAdvance(gameData);
-    initializeAttachable(improvedShipyardsAdvance);
-    return improvedShipyardsAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.IMPROVED_SHIPYARDS_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(ImprovedShipyardsAdvanceProxy.FACTORY);
+    super(
+        ImprovedShipyardsAdvance.class,
+        ImprovedShipyardsAdvance::new,
+        EngineDataEqualityComparators.IMPROVED_SHIPYARDS_ADVANCE,
+        ImprovedShipyardsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ImprovedShipyardsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ImprovedShipyardsAdvanceProxyAsProxyTest.java
@@ -1,45 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ImprovedShipyardsAdvance;
 
-public final class ImprovedShipyardsAdvanceProxyAsProxyTest extends AbstractProxyTestCase<ImprovedShipyardsAdvance> {
+public final class ImprovedShipyardsAdvanceProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<ImprovedShipyardsAdvance> {
   public ImprovedShipyardsAdvanceProxyAsProxyTest() {
     super(ImprovedShipyardsAdvance.class);
   }
 
   @Override
-  protected Collection<ImprovedShipyardsAdvance> createPrincipals() {
-    return Arrays.asList(newImprovedShipyardsAdvance());
-  }
-
-  private static ImprovedShipyardsAdvance newImprovedShipyardsAdvance() {
-    final ImprovedShipyardsAdvance improvedShipyardsAdvance =
-        new ImprovedShipyardsAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(improvedShipyardsAdvance);
+  protected ImprovedShipyardsAdvance newGameDataComponent(final GameData gameData) {
+    final ImprovedShipyardsAdvance improvedShipyardsAdvance = new ImprovedShipyardsAdvance(gameData);
+    initializeAttachable(improvedShipyardsAdvance);
     return improvedShipyardsAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.IMPROVED_SHIPYARDS_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.IMPROVED_SHIPYARDS_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(ImprovedShipyardsAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(ImprovedShipyardsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/IncreasedFactoryProductionAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/IncreasedFactoryProductionAdvanceProxyAsProxyTest.java
@@ -1,37 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.IncreasedFactoryProductionAdvance;
 
 public final class IncreasedFactoryProductionAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<IncreasedFactoryProductionAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<IncreasedFactoryProductionAdvance> {
   public IncreasedFactoryProductionAdvanceProxyAsProxyTest() {
-    super(IncreasedFactoryProductionAdvance.class);
-  }
-
-  @Override
-  protected IncreasedFactoryProductionAdvance newGameDataComponent(final GameData gameData) {
-    final IncreasedFactoryProductionAdvance increasedFactoryProductionAdvance =
-        new IncreasedFactoryProductionAdvance(gameData);
-    initializeAttachable(increasedFactoryProductionAdvance);
-    return increasedFactoryProductionAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.INCREASED_FACTORY_PRODUCTION_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(IncreasedFactoryProductionAdvanceProxy.FACTORY);
+    super(
+        IncreasedFactoryProductionAdvance.class,
+        IncreasedFactoryProductionAdvance::new,
+        EngineDataEqualityComparators.INCREASED_FACTORY_PRODUCTION_ADVANCE,
+        IncreasedFactoryProductionAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/IncreasedFactoryProductionAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/IncreasedFactoryProductionAdvanceProxyAsProxyTest.java
@@ -1,46 +1,37 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.IncreasedFactoryProductionAdvance;
 
 public final class IncreasedFactoryProductionAdvanceProxyAsProxyTest
-    extends AbstractProxyTestCase<IncreasedFactoryProductionAdvance> {
+    extends AbstractGameDataComponentProxyTestCase<IncreasedFactoryProductionAdvance> {
   public IncreasedFactoryProductionAdvanceProxyAsProxyTest() {
     super(IncreasedFactoryProductionAdvance.class);
   }
 
   @Override
-  protected Collection<IncreasedFactoryProductionAdvance> createPrincipals() {
-    return Arrays.asList(newIncreasedFactoryProductionAdvance());
-  }
-
-  private static IncreasedFactoryProductionAdvance newIncreasedFactoryProductionAdvance() {
+  protected IncreasedFactoryProductionAdvance newGameDataComponent(final GameData gameData) {
     final IncreasedFactoryProductionAdvance increasedFactoryProductionAdvance =
-        new IncreasedFactoryProductionAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(increasedFactoryProductionAdvance);
+        new IncreasedFactoryProductionAdvance(gameData);
+    initializeAttachable(increasedFactoryProductionAdvance);
     return increasedFactoryProductionAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.INCREASED_FACTORY_PRODUCTION_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.INCREASED_FACTORY_PRODUCTION_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IncreasedFactoryProductionAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(IncreasedFactoryProductionAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/IndustrialTechnologyAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/IndustrialTechnologyAdvanceProxyAsProxyTest.java
@@ -1,36 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.IndustrialTechnologyAdvance;
 
 public final class IndustrialTechnologyAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<IndustrialTechnologyAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<IndustrialTechnologyAdvance> {
   public IndustrialTechnologyAdvanceProxyAsProxyTest() {
-    super(IndustrialTechnologyAdvance.class);
-  }
-
-  @Override
-  protected IndustrialTechnologyAdvance newGameDataComponent(final GameData gameData) {
-    final IndustrialTechnologyAdvance industrialTechnologyAdvance = new IndustrialTechnologyAdvance(gameData);
-    initializeAttachable(industrialTechnologyAdvance);
-    return industrialTechnologyAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.INDUSTRIAL_TECHNOLOGY_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(IndustrialTechnologyAdvanceProxy.FACTORY);
+    super(
+        IndustrialTechnologyAdvance.class,
+        IndustrialTechnologyAdvance::new,
+        EngineDataEqualityComparators.INDUSTRIAL_TECHNOLOGY_ADVANCE,
+        IndustrialTechnologyAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/IndustrialTechnologyAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/IndustrialTechnologyAdvanceProxyAsProxyTest.java
@@ -1,46 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.IndustrialTechnologyAdvance;
 
 public final class IndustrialTechnologyAdvanceProxyAsProxyTest
-    extends AbstractProxyTestCase<IndustrialTechnologyAdvance> {
+    extends AbstractGameDataComponentProxyTestCase<IndustrialTechnologyAdvance> {
   public IndustrialTechnologyAdvanceProxyAsProxyTest() {
     super(IndustrialTechnologyAdvance.class);
   }
 
   @Override
-  protected Collection<IndustrialTechnologyAdvance> createPrincipals() {
-    return Arrays.asList(newIndustrialTechnologyAdvance());
-  }
-
-  private static IndustrialTechnologyAdvance newIndustrialTechnologyAdvance() {
-    final IndustrialTechnologyAdvance industrialTechnologyAdvance =
-        new IndustrialTechnologyAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(industrialTechnologyAdvance);
+  protected IndustrialTechnologyAdvance newGameDataComponent(final GameData gameData) {
+    final IndustrialTechnologyAdvance industrialTechnologyAdvance = new IndustrialTechnologyAdvance(gameData);
+    initializeAttachable(industrialTechnologyAdvance);
     return industrialTechnologyAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.INDUSTRIAL_TECHNOLOGY_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.INDUSTRIAL_TECHNOLOGY_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IndustrialTechnologyAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(IndustrialTechnologyAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/JetPowerAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/JetPowerAdvanceProxyAsProxyTest.java
@@ -1,44 +1,35 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.JetPowerAdvance;
 
-public final class JetPowerAdvanceProxyAsProxyTest extends AbstractProxyTestCase<JetPowerAdvance> {
+public final class JetPowerAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<JetPowerAdvance> {
   public JetPowerAdvanceProxyAsProxyTest() {
     super(JetPowerAdvance.class);
   }
 
   @Override
-  protected Collection<JetPowerAdvance> createPrincipals() {
-    return Arrays.asList(newJetPowerAdvance());
-  }
-
-  private static JetPowerAdvance newJetPowerAdvance() {
-    final JetPowerAdvance jetPowerAdvance = new JetPowerAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(jetPowerAdvance);
+  protected JetPowerAdvance newGameDataComponent(final GameData gameData) {
+    final JetPowerAdvance jetPowerAdvance = new JetPowerAdvance(gameData);
+    initializeAttachable(jetPowerAdvance);
     return jetPowerAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.JET_POWER_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.JET_POWER_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(JetPowerAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(JetPowerAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/JetPowerAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/JetPowerAdvanceProxyAsProxyTest.java
@@ -1,35 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.JetPowerAdvance;
 
-public final class JetPowerAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<JetPowerAdvance> {
+public final class JetPowerAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<JetPowerAdvance> {
   public JetPowerAdvanceProxyAsProxyTest() {
-    super(JetPowerAdvance.class);
-  }
-
-  @Override
-  protected JetPowerAdvance newGameDataComponent(final GameData gameData) {
-    final JetPowerAdvance jetPowerAdvance = new JetPowerAdvance(gameData);
-    initializeAttachable(jetPowerAdvance);
-    return jetPowerAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.JET_POWER_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(JetPowerAdvanceProxy.FACTORY);
+    super(
+        JetPowerAdvance.class,
+        JetPowerAdvance::new,
+        EngineDataEqualityComparators.JET_POWER_ADVANCE,
+        JetPowerAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/LongRangeAircraftAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/LongRangeAircraftAdvanceProxyAsProxyTest.java
@@ -1,45 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.LongRangeAircraftAdvance;
 
-public final class LongRangeAircraftAdvanceProxyAsProxyTest extends AbstractProxyTestCase<LongRangeAircraftAdvance> {
+public final class LongRangeAircraftAdvanceProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<LongRangeAircraftAdvance> {
   public LongRangeAircraftAdvanceProxyAsProxyTest() {
     super(LongRangeAircraftAdvance.class);
   }
 
   @Override
-  protected Collection<LongRangeAircraftAdvance> createPrincipals() {
-    return Arrays.asList(newLongRangeAircraftAdvance());
-  }
-
-  private static LongRangeAircraftAdvance newLongRangeAircraftAdvance() {
-    final LongRangeAircraftAdvance longRangeAircraftAdvance =
-        new LongRangeAircraftAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(longRangeAircraftAdvance);
+  protected LongRangeAircraftAdvance newGameDataComponent(final GameData gameData) {
+    final LongRangeAircraftAdvance longRangeAircraftAdvance = new LongRangeAircraftAdvance(gameData);
+    initializeAttachable(longRangeAircraftAdvance);
     return longRangeAircraftAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.LONG_RANGE_AIRCRAFT_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.LONG_RANGE_AIRCRAFT_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(LongRangeAircraftAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(LongRangeAircraftAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/LongRangeAircraftAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/LongRangeAircraftAdvanceProxyAsProxyTest.java
@@ -1,36 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.LongRangeAircraftAdvance;
 
 public final class LongRangeAircraftAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<LongRangeAircraftAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<LongRangeAircraftAdvance> {
   public LongRangeAircraftAdvanceProxyAsProxyTest() {
-    super(LongRangeAircraftAdvance.class);
-  }
-
-  @Override
-  protected LongRangeAircraftAdvance newGameDataComponent(final GameData gameData) {
-    final LongRangeAircraftAdvance longRangeAircraftAdvance = new LongRangeAircraftAdvance(gameData);
-    initializeAttachable(longRangeAircraftAdvance);
-    return longRangeAircraftAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.LONG_RANGE_AIRCRAFT_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(LongRangeAircraftAdvanceProxy.FACTORY);
+    super(
+        LongRangeAircraftAdvance.class,
+        LongRangeAircraftAdvance::new,
+        EngineDataEqualityComparators.LONG_RANGE_AIRCRAFT_ADVANCE,
+        LongRangeAircraftAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/MechanizedInfantryAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/MechanizedInfantryAdvanceProxyAsProxyTest.java
@@ -1,45 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.MechanizedInfantryAdvance;
 
-public final class MechanizedInfantryAdvanceProxyAsProxyTest extends AbstractProxyTestCase<MechanizedInfantryAdvance> {
+public final class MechanizedInfantryAdvanceProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<MechanizedInfantryAdvance> {
   public MechanizedInfantryAdvanceProxyAsProxyTest() {
     super(MechanizedInfantryAdvance.class);
   }
 
   @Override
-  protected Collection<MechanizedInfantryAdvance> createPrincipals() {
-    return Arrays.asList(newMechanizedInfantryAdvance());
-  }
-
-  private static MechanizedInfantryAdvance newMechanizedInfantryAdvance() {
-    final MechanizedInfantryAdvance mechanizedInfantryAdvance =
-        new MechanizedInfantryAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(mechanizedInfantryAdvance);
+  protected MechanizedInfantryAdvance newGameDataComponent(final GameData gameData) {
+    final MechanizedInfantryAdvance mechanizedInfantryAdvance = new MechanizedInfantryAdvance(gameData);
+    initializeAttachable(mechanizedInfantryAdvance);
     return mechanizedInfantryAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.MECHANIZED_INFANTRY_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.MECHANIZED_INFANTRY_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(MechanizedInfantryAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(MechanizedInfantryAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/MechanizedInfantryAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/MechanizedInfantryAdvanceProxyAsProxyTest.java
@@ -1,36 +1,15 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.MechanizedInfantryAdvance;
 
 public final class MechanizedInfantryAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<MechanizedInfantryAdvance> {
+    extends AbstractTechAdvanceProxyTestCase<MechanizedInfantryAdvance> {
   public MechanizedInfantryAdvanceProxyAsProxyTest() {
-    super(MechanizedInfantryAdvance.class);
-  }
-
-  @Override
-  protected MechanizedInfantryAdvance newGameDataComponent(final GameData gameData) {
-    final MechanizedInfantryAdvance mechanizedInfantryAdvance = new MechanizedInfantryAdvance(gameData);
-    initializeAttachable(mechanizedInfantryAdvance);
-    return mechanizedInfantryAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.MECHANIZED_INFANTRY_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(MechanizedInfantryAdvanceProxy.FACTORY);
+    super(
+        MechanizedInfantryAdvance.class,
+        MechanizedInfantryAdvance::new,
+        EngineDataEqualityComparators.MECHANIZED_INFANTRY_ADVANCE,
+        MechanizedInfantryAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ParatroopersAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ParatroopersAdvanceProxyAsProxyTest.java
@@ -1,44 +1,36 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ParatroopersAdvance;
 
-public final class ParatroopersAdvanceProxyAsProxyTest extends AbstractProxyTestCase<ParatroopersAdvance> {
+public final class ParatroopersAdvanceProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<ParatroopersAdvance> {
   public ParatroopersAdvanceProxyAsProxyTest() {
     super(ParatroopersAdvance.class);
   }
 
   @Override
-  protected Collection<ParatroopersAdvance> createPrincipals() {
-    return Arrays.asList(newParatroopersAdvance());
-  }
-
-  private static ParatroopersAdvance newParatroopersAdvance() {
-    final ParatroopersAdvance paratroopersAdvance = new ParatroopersAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(paratroopersAdvance);
+  protected ParatroopersAdvance newGameDataComponent(final GameData gameData) {
+    final ParatroopersAdvance paratroopersAdvance = new ParatroopersAdvance(gameData);
+    initializeAttachable(paratroopersAdvance);
     return paratroopersAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.PARATROOPERS_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.PARATROOPERS_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(ParatroopersAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(ParatroopersAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ParatroopersAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ParatroopersAdvanceProxyAsProxyTest.java
@@ -1,36 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.ParatroopersAdvance;
 
-public final class ParatroopersAdvanceProxyAsProxyTest
-    extends AbstractGameDataComponentProxyTestCase<ParatroopersAdvance> {
+public final class ParatroopersAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<ParatroopersAdvance> {
   public ParatroopersAdvanceProxyAsProxyTest() {
-    super(ParatroopersAdvance.class);
-  }
-
-  @Override
-  protected ParatroopersAdvance newGameDataComponent(final GameData gameData) {
-    final ParatroopersAdvance paratroopersAdvance = new ParatroopersAdvance(gameData);
-    initializeAttachable(paratroopersAdvance);
-    return paratroopersAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.PARATROOPERS_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(ParatroopersAdvanceProxy.FACTORY);
+    super(
+        ParatroopersAdvance.class,
+        ParatroopersAdvance::new,
+        EngineDataEqualityComparators.PARATROOPERS_ADVANCE,
+        ParatroopersAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
@@ -1,53 +1,45 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newProductionRule;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionFrontier;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.util.CoreEqualityComparators;
 
-public final class ProductionFrontierProxyAsProxyTest extends AbstractProxyTestCase<ProductionFrontier> {
+public final class ProductionFrontierProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<ProductionFrontier> {
   public ProductionFrontierProxyAsProxyTest() {
     super(ProductionFrontier.class);
   }
 
   @Override
-  protected Collection<ProductionFrontier> createPrincipals() {
-    return Arrays.asList(newProductionFrontier());
-  }
-
-  private static ProductionFrontier newProductionFrontier() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
+  protected ProductionFrontier newGameDataComponent(final GameData gameData) {
     return new ProductionFrontier("productionFrontier", gameData, Arrays.asList(
-        TestGameDataComponentFactory.newProductionRule(gameData, "productionRule1"),
-        TestGameDataComponentFactory.newProductionRule(gameData, "productionRule2")));
+        newProductionRule(gameData, "productionRule1"),
+        newProductionRule(gameData, "productionRule2")));
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(CoreEqualityComparators.INTEGER_MAP)
-        .add(EngineDataEqualityComparators.PRODUCTION_FRONTIER)
-        .add(EngineDataEqualityComparators.PRODUCTION_RULE)
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        CoreEqualityComparators.INTEGER_MAP,
+        EngineDataEqualityComparators.PRODUCTION_FRONTIER,
+        EngineDataEqualityComparators.PRODUCTION_RULE,
+        EngineDataEqualityComparators.RESOURCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IntegerMapProxy.FACTORY)
-        .add(ProductionFrontierProxy.FACTORY)
-        .add(ProductionRuleProxy.FACTORY)
-        .add(ResourceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        IntegerMapProxy.FACTORY,
+        ProductionFrontierProxy.FACTORY,
+        ProductionRuleProxy.FACTORY,
+        ResourceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
@@ -1,45 +1,40 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newProductionRule;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionRule;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.util.CoreEqualityComparators;
 
-public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<ProductionRule> {
+public final class ProductionRuleProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<ProductionRule> {
   public ProductionRuleProxyAsProxyTest() {
     super(ProductionRule.class);
   }
 
   @Override
-  protected Collection<ProductionRule> createPrincipals() {
-    return Arrays.asList(TestGameDataComponentFactory.newProductionRule(
-        TestGameDataFactory.newValidGameData(),
-        "productionRule"));
+  protected ProductionRule newGameDataComponent(final GameData gameData) {
+    return newProductionRule(gameData, "productionRule");
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(CoreEqualityComparators.INTEGER_MAP)
-        .add(EngineDataEqualityComparators.PRODUCTION_RULE)
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        CoreEqualityComparators.INTEGER_MAP,
+        EngineDataEqualityComparators.PRODUCTION_RULE,
+        EngineDataEqualityComparators.RESOURCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IntegerMapProxy.FACTORY)
-        .add(ProductionRuleProxy.FACTORY)
-        .add(ResourceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        IntegerMapProxy.FACTORY,
+        ProductionRuleProxy.FACTORY,
+        ResourceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/RepairFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RepairFrontierProxyAsProxyTest.java
@@ -1,53 +1,44 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newRepairRule;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.RepairFrontier;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.util.CoreEqualityComparators;
 
-public final class RepairFrontierProxyAsProxyTest extends AbstractProxyTestCase<RepairFrontier> {
+public final class RepairFrontierProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<RepairFrontier> {
   public RepairFrontierProxyAsProxyTest() {
     super(RepairFrontier.class);
   }
 
   @Override
-  protected Collection<RepairFrontier> createPrincipals() {
-    return Arrays.asList(newRepairFrontier());
-  }
-
-  private static RepairFrontier newRepairFrontier() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
+  protected RepairFrontier newGameDataComponent(final GameData gameData) {
     return new RepairFrontier("repairFrontier", gameData, Arrays.asList(
-        TestGameDataComponentFactory.newRepairRule(gameData, "repairRule1"),
-        TestGameDataComponentFactory.newRepairRule(gameData, "repairRule2")));
+        newRepairRule(gameData, "repairRule1"),
+        newRepairRule(gameData, "repairRule2")));
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(CoreEqualityComparators.INTEGER_MAP)
-        .add(EngineDataEqualityComparators.REPAIR_FRONTIER)
-        .add(EngineDataEqualityComparators.REPAIR_RULE)
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        CoreEqualityComparators.INTEGER_MAP,
+        EngineDataEqualityComparators.REPAIR_FRONTIER,
+        EngineDataEqualityComparators.REPAIR_RULE,
+        EngineDataEqualityComparators.RESOURCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IntegerMapProxy.FACTORY)
-        .add(RepairFrontierProxy.FACTORY)
-        .add(RepairRuleProxy.FACTORY)
-        .add(ResourceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        IntegerMapProxy.FACTORY,
+        RepairFrontierProxy.FACTORY,
+        RepairRuleProxy.FACTORY,
+        ResourceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/RepairRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RepairRuleProxyAsProxyTest.java
@@ -1,45 +1,40 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newRepairRule;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.RepairRule;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.util.CoreEqualityComparators;
 
-public final class RepairRuleProxyAsProxyTest extends AbstractProxyTestCase<RepairRule> {
+public final class RepairRuleProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<RepairRule> {
   public RepairRuleProxyAsProxyTest() {
     super(RepairRule.class);
   }
 
   @Override
-  protected Collection<RepairRule> createPrincipals() {
-    return Arrays.asList(TestGameDataComponentFactory.newRepairRule(
-        TestGameDataFactory.newValidGameData(),
-        "repairRule"));
+  protected RepairRule newGameDataComponent(final GameData gameData) {
+    return newRepairRule(gameData, "repairRule");
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(CoreEqualityComparators.INTEGER_MAP)
-        .add(EngineDataEqualityComparators.REPAIR_RULE)
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        CoreEqualityComparators.INTEGER_MAP,
+        EngineDataEqualityComparators.REPAIR_RULE,
+        EngineDataEqualityComparators.RESOURCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IntegerMapProxy.FACTORY)
-        .add(RepairRuleProxy.FACTORY)
-        .add(ResourceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        IntegerMapProxy.FACTORY,
+        RepairRuleProxy.FACTORY,
+        ResourceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
@@ -1,52 +1,44 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newResource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ResourceCollection;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.util.CoreEqualityComparators;
 
-public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestCase<ResourceCollection> {
+public final class ResourceCollectionProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<ResourceCollection> {
   public ResourceCollectionProxyAsProxyTest() {
     super(ResourceCollection.class);
   }
 
   @Override
-  protected Collection<ResourceCollection> createPrincipals() {
-    return Arrays.asList(newResourceCollection());
-  }
-
-  private static ResourceCollection newResourceCollection() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
+  protected ResourceCollection newGameDataComponent(final GameData gameData) {
     final ResourceCollection resourceCollection = new ResourceCollection(gameData);
-    resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource1"), 11);
-    resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource2"), 22);
+    resourceCollection.addResource(newResource(gameData, "resource1"), 11);
+    resourceCollection.addResource(newResource(gameData, "resource2"), 22);
     return resourceCollection;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(CoreEqualityComparators.INTEGER_MAP)
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .add(EngineDataEqualityComparators.RESOURCE_COLLECTION)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        CoreEqualityComparators.INTEGER_MAP,
+        EngineDataEqualityComparators.RESOURCE,
+        EngineDataEqualityComparators.RESOURCE_COLLECTION);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(IntegerMapProxy.FACTORY)
-        .add(ResourceProxy.FACTORY)
-        .add(ResourceCollectionProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        IntegerMapProxy.FACTORY,
+        ResourceProxy.FACTORY,
+        ResourceCollectionProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
@@ -1,38 +1,33 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newResource;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 
-public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resource> {
+public final class ResourceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<Resource> {
   public ResourceProxyAsProxyTest() {
     super(Resource.class);
   }
 
   @Override
-  protected Collection<Resource> createPrincipals() {
-    return Arrays.asList(TestGameDataComponentFactory.newResource(TestGameDataFactory.newValidGameData(), "resource"));
+  protected Resource newGameDataComponent(final GameData gameData) {
+    return newResource(gameData, "resource");
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.RESOURCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.RESOURCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(ResourceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(ResourceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/RocketsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RocketsAdvanceProxyAsProxyTest.java
@@ -1,35 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.RocketsAdvance;
 
-public final class RocketsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<RocketsAdvance> {
+public final class RocketsAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<RocketsAdvance> {
   public RocketsAdvanceProxyAsProxyTest() {
-    super(RocketsAdvance.class);
-  }
-
-  @Override
-  protected RocketsAdvance newGameDataComponent(final GameData gameData) {
-    final RocketsAdvance rocketsAdvance = new RocketsAdvance(gameData);
-    initializeAttachable(rocketsAdvance);
-    return rocketsAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.ROCKETS_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(RocketsAdvanceProxy.FACTORY);
+    super(
+        RocketsAdvance.class,
+        RocketsAdvance::new,
+        EngineDataEqualityComparators.ROCKETS_ADVANCE,
+        RocketsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/RocketsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RocketsAdvanceProxyAsProxyTest.java
@@ -1,44 +1,35 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.RocketsAdvance;
 
-public final class RocketsAdvanceProxyAsProxyTest extends AbstractProxyTestCase<RocketsAdvance> {
+public final class RocketsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<RocketsAdvance> {
   public RocketsAdvanceProxyAsProxyTest() {
     super(RocketsAdvance.class);
   }
 
   @Override
-  protected Collection<RocketsAdvance> createPrincipals() {
-    return Arrays.asList(newRocketsAdvance());
-  }
-
-  private static RocketsAdvance newRocketsAdvance() {
-    final RocketsAdvance rocketsAdvance = new RocketsAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(rocketsAdvance);
+  protected RocketsAdvance newGameDataComponent(final GameData gameData) {
+    final RocketsAdvance rocketsAdvance = new RocketsAdvance(gameData);
+    initializeAttachable(rocketsAdvance);
     return rocketsAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.ROCKETS_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.ROCKETS_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(RocketsAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(RocketsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/SuperSubsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/SuperSubsAdvanceProxyAsProxyTest.java
@@ -1,35 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.SuperSubsAdvance;
 
-public final class SuperSubsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<SuperSubsAdvance> {
+public final class SuperSubsAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<SuperSubsAdvance> {
   public SuperSubsAdvanceProxyAsProxyTest() {
-    super(SuperSubsAdvance.class);
-  }
-
-  @Override
-  protected SuperSubsAdvance newGameDataComponent(final GameData gameData) {
-    final SuperSubsAdvance superSubsAdvance = new SuperSubsAdvance(gameData);
-    initializeAttachable(superSubsAdvance);
-    return superSubsAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.SUPER_SUBS_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(SuperSubsAdvanceProxy.FACTORY);
+    super(
+        SuperSubsAdvance.class,
+        SuperSubsAdvance::new,
+        EngineDataEqualityComparators.SUPER_SUBS_ADVANCE,
+        SuperSubsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/SuperSubsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/SuperSubsAdvanceProxyAsProxyTest.java
@@ -1,44 +1,35 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.SuperSubsAdvance;
 
-public final class SuperSubsAdvanceProxyAsProxyTest extends AbstractProxyTestCase<SuperSubsAdvance> {
+public final class SuperSubsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<SuperSubsAdvance> {
   public SuperSubsAdvanceProxyAsProxyTest() {
     super(SuperSubsAdvance.class);
   }
 
   @Override
-  protected Collection<SuperSubsAdvance> createPrincipals() {
-    return Arrays.asList(newSuperSubsAdvance());
-  }
-
-  private static SuperSubsAdvance newSuperSubsAdvance() {
-    final SuperSubsAdvance superSubsAdvance = new SuperSubsAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(superSubsAdvance);
+  protected SuperSubsAdvance newGameDataComponent(final GameData gameData) {
+    final SuperSubsAdvance superSubsAdvance = new SuperSubsAdvance(gameData);
+    initializeAttachable(superSubsAdvance);
     return superSubsAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.SUPER_SUBS_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.SUPER_SUBS_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(SuperSubsAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(SuperSubsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/TechnologyFrontierListProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TechnologyFrontierListProxyAsProxyTest.java
@@ -1,53 +1,43 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newTechnologyFrontier;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TechnologyFrontierList;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 
-public final class TechnologyFrontierListProxyAsProxyTest extends AbstractProxyTestCase<TechnologyFrontierList> {
+public final class TechnologyFrontierListProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<TechnologyFrontierList> {
   public TechnologyFrontierListProxyAsProxyTest() {
     super(TechnologyFrontierList.class);
   }
 
   @Override
-  protected Collection<TechnologyFrontierList> createPrincipals() {
-    return Arrays.asList(newTechnologyFrontierList());
-  }
-
-  private static TechnologyFrontierList newTechnologyFrontierList() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
+  protected TechnologyFrontierList newGameDataComponent(final GameData gameData) {
     final TechnologyFrontierList technologyFrontierList = new TechnologyFrontierList(gameData);
-    technologyFrontierList
-        .addTechnologyFrontier(TestGameDataComponentFactory.newTechnologyFrontier(gameData, "technologyFrontier1"));
-    technologyFrontierList
-        .addTechnologyFrontier(TestGameDataComponentFactory.newTechnologyFrontier(gameData, "technologyFrontier2"));
+    technologyFrontierList.addTechnologyFrontier(newTechnologyFrontier(gameData, "technologyFrontier1"));
+    technologyFrontierList.addTechnologyFrontier(newTechnologyFrontier(gameData, "technologyFrontier2"));
     return technologyFrontierList;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.FAKE_TECH_ADVANCE)
-        .add(EngineDataEqualityComparators.TECHNOLOGY_FRONTIER)
-        .add(EngineDataEqualityComparators.TECHNOLOGY_FRONTIER_LIST)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        EngineDataEqualityComparators.FAKE_TECH_ADVANCE,
+        EngineDataEqualityComparators.TECHNOLOGY_FRONTIER,
+        EngineDataEqualityComparators.TECHNOLOGY_FRONTIER_LIST);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(FakeTechAdvanceProxy.FACTORY)
-        .add(TechnologyFrontierProxy.FACTORY)
-        .add(TechnologyFrontierListProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        FakeTechAdvanceProxy.FACTORY,
+        TechnologyFrontierProxy.FACTORY,
+        TechnologyFrontierListProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/TechnologyFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TechnologyFrontierProxyAsProxyTest.java
@@ -1,42 +1,38 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.newTechnologyFrontier;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TechnologyFrontier;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 
-public final class TechnologyFrontierProxyAsProxyTest extends AbstractProxyTestCase<TechnologyFrontier> {
+public final class TechnologyFrontierProxyAsProxyTest
+    extends AbstractGameDataComponentProxyTestCase<TechnologyFrontier> {
   public TechnologyFrontierProxyAsProxyTest() {
     super(TechnologyFrontier.class);
   }
 
   @Override
-  protected Collection<TechnologyFrontier> createPrincipals() {
-    return Arrays.asList(TestGameDataComponentFactory.newTechnologyFrontier(
-        TestGameDataFactory.newValidGameData(),
-        "technologyFrontier"));
+  protected TechnologyFrontier newGameDataComponent(final GameData gameData) {
+    return newTechnologyFrontier(gameData, "technologyFrontier");
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.FAKE_TECH_ADVANCE)
-        .add(EngineDataEqualityComparators.TECHNOLOGY_FRONTIER)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        EngineDataEqualityComparators.FAKE_TECH_ADVANCE,
+        EngineDataEqualityComparators.TECHNOLOGY_FRONTIER);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(FakeTechAdvanceProxy.FACTORY)
-        .add(TechnologyFrontierProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        FakeTechAdvanceProxy.FACTORY,
+        TechnologyFrontierProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/TestProxyFactoryCollectionBuilder.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TestProxyFactoryCollectionBuilder.java
@@ -33,6 +33,11 @@ final class TestProxyFactoryCollectionBuilder {
     return this;
   }
 
+  TestProxyFactoryCollectionBuilder addAll(final Collection<ProxyFactory> proxyFactories) {
+    this.proxyFactories.addAll(proxyFactories);
+    return this;
+  }
+
   Collection<ProxyFactory> build() {
     return new ArrayList<>(proxyFactories);
   }

--- a/src/test/java/games/strategy/internal/persistence/serializable/WarBondsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/WarBondsAdvanceProxyAsProxyTest.java
@@ -1,44 +1,35 @@
 package games.strategy.internal.persistence.serializable;
 
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
-import games.strategy.engine.data.TestGameDataComponentFactory;
-import games.strategy.engine.data.TestGameDataFactory;
-import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.engine.data.GameData;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.WarBondsAdvance;
 
-public final class WarBondsAdvanceProxyAsProxyTest extends AbstractProxyTestCase<WarBondsAdvance> {
+public final class WarBondsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<WarBondsAdvance> {
   public WarBondsAdvanceProxyAsProxyTest() {
     super(WarBondsAdvance.class);
   }
 
   @Override
-  protected Collection<WarBondsAdvance> createPrincipals() {
-    return Arrays.asList(newWarBondsAdvance());
-  }
-
-  private static WarBondsAdvance newWarBondsAdvance() {
-    final WarBondsAdvance warBondsAdvance = new WarBondsAdvance(TestGameDataFactory.newValidGameData());
-    TestGameDataComponentFactory.initializeAttachable(warBondsAdvance);
+  protected WarBondsAdvance newGameDataComponent(final GameData gameData) {
+    final WarBondsAdvance warBondsAdvance = new WarBondsAdvance(gameData);
+    initializeAttachable(warBondsAdvance);
     return warBondsAdvance;
   }
 
   @Override
-  protected Collection<EqualityComparator> getEqualityComparators() {
-    return TestEqualityComparatorCollectionBuilder.forGameData()
-        .add(EngineDataEqualityComparators.WAR_BONDS_ADVANCE)
-        .build();
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.WAR_BONDS_ADVANCE);
   }
 
   @Override
-  protected Collection<ProxyFactory> getProxyFactories() {
-    return TestProxyFactoryCollectionBuilder.forGameData()
-        .add(WarBondsAdvanceProxy.FACTORY)
-        .build();
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(WarBondsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/WarBondsAdvanceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/WarBondsAdvanceProxyAsProxyTest.java
@@ -1,35 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import games.strategy.engine.data.EngineDataEqualityComparators;
-import games.strategy.engine.data.GameData;
-import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.test.EqualityComparator;
 import games.strategy.triplea.delegate.WarBondsAdvance;
 
-public final class WarBondsAdvanceProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<WarBondsAdvance> {
+public final class WarBondsAdvanceProxyAsProxyTest extends AbstractTechAdvanceProxyTestCase<WarBondsAdvance> {
   public WarBondsAdvanceProxyAsProxyTest() {
-    super(WarBondsAdvance.class);
-  }
-
-  @Override
-  protected WarBondsAdvance newGameDataComponent(final GameData gameData) {
-    final WarBondsAdvance warBondsAdvance = new WarBondsAdvance(gameData);
-    initializeAttachable(warBondsAdvance);
-    return warBondsAdvance;
-  }
-
-  @Override
-  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
-    return Arrays.asList(EngineDataEqualityComparators.WAR_BONDS_ADVANCE);
-  }
-
-  @Override
-  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
-    return Arrays.asList(WarBondsAdvanceProxy.FACTORY);
+    super(
+        WarBondsAdvance.class,
+        WarBondsAdvance::new,
+        EngineDataEqualityComparators.WAR_BONDS_ADVANCE,
+        WarBondsAdvanceProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -17,6 +17,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import games.strategy.test.EqualityComparator;
@@ -28,12 +29,9 @@ import games.strategy.test.EqualityComparatorRegistry;
  * @param <T> The type of the principal to be proxied.
  */
 public abstract class AbstractProxyTestCase<T> {
-  private final EqualityComparatorRegistry equalityComparatorRegistry =
-      EqualityComparatorRegistry.newInstance(getEqualityComparators());
-
+  private EqualityComparatorRegistry equalityComparatorRegistry;
   private final Class<T> principalType;
-
-  private final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance(getProxyFactories());
+  private ProxyRegistry proxyRegistry;
 
   protected AbstractProxyTestCase(final Class<T> principalType) {
     checkNotNull(principalType);
@@ -101,8 +99,14 @@ public abstract class AbstractProxyTestCase<T> {
     }
   }
 
+  @Before
+  public final void setUp() {
+    equalityComparatorRegistry = EqualityComparatorRegistry.newInstance(getEqualityComparators());
+    proxyRegistry = ProxyRegistry.newInstance(getProxyFactories());
+  }
+
   @Test
-  public void shouldBeAbleToRoundTripPrincipal() throws Exception {
+  public final void shouldBeAbleToRoundTripPrincipal() throws Exception {
     final Collection<T> principals = createPrincipals();
     assertThat(principals, is(not(empty())));
     for (final T expected : principals) {


### PR DESCRIPTION
This PR extracts two superclasses to reduce the amount of boilerplate in `GameDataComponent` proxy tests.