### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 9)

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -377,7 +377,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the shortest land route between two territories or null if no route exists.
    */
   public Route getLandRoute(final Territory t1, final Territory t2) {
-    return getRoute(t1, t2, Matches.TerritoryIsLand);
+    return getRoute(t1, t2, Matches.territoryIsLand());
   }
 
   /**
@@ -388,7 +388,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the shortest water route between two territories or null if no route exists.
    */
   public Route getWaterRoute(final Territory t1, final Territory t2) {
-    return getRoute(t1, t2, Matches.TerritoryIsWater);
+    return getRoute(t1, t2, Matches.territoryIsWater());
   }
 
   public Route getRoute_IgnoreEnd(final Territory t1, final Territory t2, final Match<Territory> match) {
@@ -516,7 +516,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the land distance between two territories or -1 if they are not connected.
    */
   public int getLandDistance(final Territory t1, final Territory t2) {
-    return getDistance(t1, t2, Matches.TerritoryIsLand);
+    return getDistance(t1, t2, Matches.territoryIsLand());
   }
 
   /**
@@ -527,7 +527,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the water distance between two territories or -1 if they are not connected.
    */
   public int getWaterDistance(final Territory t1, final Territory t2) {
-    return getDistance(t1, t2, Matches.TerritoryIsWater);
+    return getDistance(t1, t2, Matches.territoryIsWater());
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -410,7 +410,7 @@ public class Route implements Serializable, Iterable<Territory> {
     if (getStart().isWater()) {
       return true;
     }
-    return Match.anyMatch(getSteps(), Matches.TerritoryIsWater);
+    return Match.anyMatch(getSteps(), Matches.territoryIsWater());
   }
 
   /**
@@ -420,7 +420,7 @@ public class Route implements Serializable, Iterable<Territory> {
     if (!getStart().isWater()) {
       return true;
     }
-    return getAllTerritories().isEmpty() || !Match.allMatch(getAllTerritories(), Matches.TerritoryIsWater);
+    return getAllTerritories().isEmpty() || !Match.allMatch(getAllTerritories(), Matches.territoryIsWater());
   }
 
   public int getLargestMovementCost(final Collection<Unit> units) {

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -406,7 +406,7 @@ public class TripleAUnit extends Unit {
     if (producer.isWater()) {
       factoryMatchBuilder.add(Matches.UnitIsLand.invert());
     } else {
-      factoryMatchBuilder.add(Matches.UnitIsSea.invert());
+      factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }
     final Collection<Unit> factories = Match.getMatches(units, factoryMatchBuilder.all());
     if (factories.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -326,7 +326,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           } else {
             if (capitals.isEmpty()) {
               capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
-                  Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
+                  Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.territoryIsLand())));
             }
             final List<Territory> doesNotHaveFactoryYet =
                 Match.getMatches(territoryChoices, Matches.territoryHasUnitsThatMatch(ownedFactories).invert());
@@ -357,7 +357,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           } else {
             if (capitals.isEmpty()) {
               capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
-                  Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
+                  Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.territoryIsLand())));
             }
             if (capitals.isEmpty()) {
               picked = territoryChoices.get(0);
@@ -388,7 +388,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         } else {
           if (capitals.isEmpty()) {
             capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
-                Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
+                Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.territoryIsLand())));
           }
           if (capitals.isEmpty()) {
             picked = territoryChoices.get(0);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -104,7 +104,8 @@ class ProCombatMoveAI {
     for (final ProTerritory patd : attackOptions) {
       clearedTerritories.add(patd.getTerritory());
       if (!patd.getAmphibAttackMap().isEmpty()) {
-        possibleTransportTerritories.addAll(data.getMap().getNeighbors(patd.getTerritory(), Matches.TerritoryIsWater));
+        possibleTransportTerritories
+            .addAll(data.getMap().getNeighbors(patd.getTerritory(), Matches.territoryIsWater()));
       }
     }
     territoryManager.populateEnemyAttackOptions(clearedTerritories, new ArrayList<>(possibleTransportTerritories));
@@ -1473,7 +1474,7 @@ class ProCombatMoveAI {
 
       // Find max remaining defenders
       final Set<Territory> territoriesAdjacentToCapital =
-          data.getMap().getNeighbors(myCapital, Matches.TerritoryIsLand);
+          data.getMap().getNeighbors(myCapital, Matches.territoryIsLand());
       final List<Unit> defenders = myCapital.getUnits().getMatches(Matches.isUnitAllied(player, data));
       defenders.addAll(placeUnits);
       for (final Territory t : territoriesAdjacentToCapital) {
@@ -1495,7 +1496,7 @@ class ProCombatMoveAI {
       if (result.isHasLandUnitRemaining()) {
         double maxUnitsNearCapitalPerValue = 0.0;
         Territory maxTerritory = null;
-        final Set<Territory> territoriesNearCapital = data.getMap().getNeighbors(myCapital, Matches.TerritoryIsLand);
+        final Set<Territory> territoriesNearCapital = data.getMap().getNeighbors(myCapital, Matches.territoryIsLand());
         territoriesNearCapital.add(myCapital);
         for (final Territory t : attackMap.keySet()) {
           int unitsNearCapital = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -448,7 +448,7 @@ class ProNonCombatMoveAI {
       // Determine neighbor value
       double neighborValue = 0;
       if (!t.isWater()) {
-        final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.TerritoryIsLand);
+        final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsLand());
         for (final Territory neighbor : landNeighbors) {
           double neighborProduction = TerritoryAttachment.getProduction(neighbor);
           if (Matches.isTerritoryAllied(player, data).match(neighbor)) {
@@ -1131,7 +1131,7 @@ class ProNonCombatMoveAI {
           Territory unloadToTerritory = null;
           int maxNumSeaNeighbors = 0;
           for (final Territory t : possibleUnloadTerritories) {
-            final int numSeaNeighbors = data.getMap().getNeighbors(t, Matches.TerritoryIsWater).size();
+            final int numSeaNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsWater()).size();
             final boolean isAdjacentToEnemy =
                 ProMatches.territoryIsOrAdjacentToEnemyNotNeutralLand(player, data).match(t);
             if (moveMap.get(t) != null && (moveMap.get(t).isCanHold() || !isAdjacentToEnemy)
@@ -1181,7 +1181,8 @@ class ProNonCombatMoveAI {
                   .match(t);
           final int distance = data.getMap().getDistance_IgnoreEndForCondition(currentTerritory, t,
               ProMatches.territoryCanMoveSeaUnits(player, data, true));
-          final boolean hasSeaNeighbor = Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater).match(t);
+          final boolean hasSeaNeighbor =
+              Matches.territoryHasNeighborMatching(data, Matches.territoryIsWater()).match(t);
           final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player).match(t);
           if (!t.isWater() && hasSeaNeighbor && distance > 0
               && !(distance == 1 && territoryHasTransportableUnits && !hasFactory)) {
@@ -1343,7 +1344,7 @@ class ProNonCombatMoveAI {
       // Move sea units to defend transports
       for (final Iterator<Unit> it = currentUnitMoveMap.keySet().iterator(); it.hasNext();) {
         final Unit u = it.next();
-        if (Matches.UnitIsSea.match(u)) {
+        if (Matches.unitIsSea().match(u)) {
           for (final Territory t : currentUnitMoveMap.get(u)) {
             if (moveMap.get(t).isCanHold() && !moveMap.get(t).getAllDefenders().isEmpty()
                 && Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
@@ -1417,7 +1418,7 @@ class ProNonCombatMoveAI {
       // Move sea units to best location or safest location
       for (final Iterator<Unit> it = currentUnitMoveMap.keySet().iterator(); it.hasNext();) {
         final Unit u = it.next();
-        if (Matches.UnitIsSea.match(u)) {
+        if (Matches.unitIsSea().match(u)) {
           Territory maxValueTerritory = null;
           double maxValue = 0;
           for (final Territory t : currentUnitMoveMap.get(u)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -234,7 +234,7 @@ class ProPurchaseAI {
     // Find all purchase/place territories
     final Map<Territory, ProPurchaseTerritory> purchaseTerritories = ProPurchaseUtils.findPurchaseTerritories(player);
     final Set<Territory> placeTerritories = new HashSet<>();
-    placeTerritories.addAll(Match.getMatches(data.getMap().getTerritoriesOwnedBy(player), Matches.TerritoryIsLand));
+    placeTerritories.addAll(Match.getMatches(data.getMap().getTerritoriesOwnedBy(player), Matches.territoryIsLand()));
     for (final Territory t : purchaseTerritories.keySet()) {
       for (final ProPlaceTerritory ppt : purchaseTerritories.get(t).getCanPlaceTerritories()) {
         placeTerritories.add(ppt.getTerritory());
@@ -961,7 +961,7 @@ class ProPurchaseAI {
     for (final Territory t : purchaseFactoryTerritories) {
       final int production = TerritoryAttachment.get(t).getProduction();
       final double value = territoryValueMap.get(t) * production + 0.1 * production;
-      final boolean isAdjacentToSea = Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater).match(t);
+      final boolean isAdjacentToSea = Matches.territoryHasNeighborMatching(data, Matches.territoryIsWater()).match(t);
       final Set<Territory> nearbyLandTerritories =
           data.getMap().getNeighbors(t, 9, ProMatches.territoryCanMoveLandUnits(player, data, false));
       final int numNearbyEnemyTerritories =
@@ -1256,12 +1256,12 @@ class ProPurchaseAI {
       final int alliedDistance = (enemyDistance + 1) / 2;
       final Set<Territory> nearbyTerritories =
           data.getMap().getNeighbors(t, enemyDistance, ProMatches.territoryCanMoveAirUnits(player, data, false));
-      final List<Territory> nearbyLandTerritories = Match.getMatches(nearbyTerritories, Matches.TerritoryIsLand);
+      final List<Territory> nearbyLandTerritories = Match.getMatches(nearbyTerritories, Matches.territoryIsLand());
       final Set<Territory> nearbyEnemySeaTerritories =
-          data.getMap().getNeighbors(t, enemyDistance, Matches.TerritoryIsWater);
+          data.getMap().getNeighbors(t, enemyDistance, Matches.territoryIsWater());
       nearbyEnemySeaTerritories.add(t);
       final Set<Territory> nearbyAlliedSeaTerritories =
-          data.getMap().getNeighbors(t, alliedDistance, Matches.TerritoryIsWater);
+          data.getMap().getNeighbors(t, alliedDistance, Matches.territoryIsWater());
       nearbyAlliedSeaTerritories.add(t);
       final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
       final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
@@ -1276,7 +1276,7 @@ class ProPurchaseAI {
         if (enemySeaUnits.isEmpty()) {
           continue;
         }
-        final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbySeaTerritory, Matches.TerritoryIsWater);
+        final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbySeaTerritory, Matches.territoryIsWater());
         if (route == null) {
           continue;
         }
@@ -1414,7 +1414,7 @@ class ProPurchaseAI {
         }
 
         // Determine whether transports, amphib units, or both are needed
-        final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.TerritoryIsLand);
+        final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsLand());
         for (final Territory neighbor : landNeighbors) {
           if (territoryValueMap.get(neighbor) <= 0.25) {
             final List<Unit> unitsInTerritory = new ArrayList<>(neighbor.getUnits().getUnits());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -98,7 +98,7 @@ final class ProTechAI {
     if (!onWater) {
       nonTransportsInAttack = true;
     }
-    final Set<Territory> waterTerr = data.getMap().getNeighbors(location, Matches.TerritoryIsWater);
+    final Set<Territory> waterTerr = data.getMap().getNeighbors(location, Matches.territoryIsWater());
     while (playerIter.hasNext()) {
       float seaStrength = 0.0F;
       float firstStrength = 0.0F;
@@ -111,14 +111,14 @@ final class ProTechAI {
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanMove());
       final Match<Unit> enemyTransport = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitIsSea, Matches.unitIsTransport(), Matches.unitCanMove());
+          Matches.unitIsSea(), Matches.unitIsTransport(), Matches.unitCanMove());
       final Match<Unit> enemyShip = Match.allOf(
           Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitIsSea,
+          Matches.unitIsSea(),
           Matches.unitCanMove());
       final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.unitCanMove());
-      final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.unitIsTransport(), Matches.unitCanMove());
+      final Match<Unit> transport = Match.allOf(Matches.unitIsSea(), Matches.unitIsTransport(), Matches.unitCanMove());
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       // should change this to read production frontier and tech
@@ -144,7 +144,7 @@ final class ProTechAI {
       final List<Territory> checked = new ArrayList<>();
       final List<Unit> enemyWaterUnits = new ArrayList<>();
       for (final Territory t : data.getMap().getNeighbors(location,
-          onWater ? Matches.TerritoryIsWater : Matches.TerritoryIsLand)) {
+          onWater ? Matches.territoryIsWater() : Matches.territoryIsLand())) {
         if (ignoreTerr != null && ignoreTerr.contains(t)) {
           continue;
         }
@@ -153,7 +153,7 @@ final class ProTechAI {
         firstStrength += strength(enemies, true, onWater, transportsFirst);
         checked.add(t);
       }
-      if (Matches.TerritoryIsLand.match(location)) {
+      if (Matches.territoryIsLand().match(location)) {
         blitzStrength = determineEnemyBlitzStrength(location, blitzTerrRoutes, null, data, enemyPlayer);
       } else { // get ships attack strength
         // old assumed fleets won't split up, new lets them. no biggie.
@@ -173,7 +173,7 @@ final class ProTechAI {
       final List<Unit> attackPlanes =
           findPlaneAttackersThatCanLand(location, maxFighterDistance, enemyPlayer, data, ignoreTerr, checked);
       final float airStrength = allairstrength(attackPlanes, true);
-      if (Matches.territoryHasWaterNeighbor(data).match(location) && Matches.TerritoryIsLand.match(location)) {
+      if (Matches.territoryHasWaterNeighbor(data).match(location) && Matches.territoryIsLand().match(location)) {
         for (final Territory t4 : data.getMap().getNeighbors(location, maxTransportDistance)) {
           if (!t4.isWater()) {
             continue;
@@ -547,7 +547,7 @@ final class ProTechAI {
     }
     final Match<Territory> routeCond = Match.allOf(
         Matches.territoryHasUnitsThatMatch(unitCondBuilder.all()).invert(),
-        Matches.TerritoryIsWater);
+        Matches.territoryIsWater());
     final Match<Territory> routeCondition;
     if (attacking) {
       routeCondition = Match.anyOf(Matches.territoryIs(destination), routeCond);
@@ -738,6 +738,6 @@ final class ProTechAI {
    * Assumes that water is passable to air units always.
    */
   private static Match<Territory> territoryIsImpassableToAirUnits() {
-    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsImpassable());
+    return Match.allOf(Matches.territoryIsLand(), Matches.territoryIsImpassable());
   }
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseTerritory.java
@@ -38,7 +38,7 @@ public class ProPurchaseTerritory {
     canPlaceTerritories.add(new ProPlaceTerritory(territory));
     if (!isBid) {
       if (ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data).match(territory)) {
-        for (final Territory t : data.getMap().getNeighbors(territory, Matches.TerritoryIsWater)) {
+        for (final Territory t : data.getMap().getNeighbors(territory, Matches.territoryIsWater())) {
           if (Properties.getWW2V2(data) || Properties.getUnitPlacementInEnemySeas(data)
               || !t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
             canPlaceTerritories.add(new ProPlaceTerritory(t));

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -311,7 +311,7 @@ public class ProTerritoryManager {
         Matches.unitIsAirBase(), Matches.unitIsNotDisabled(), Matches.unitIsBeingTransported().invert());
     final Match.CompositeBuilder<Territory> canScrambleBuilder = Match.newCompositeBuilder(
         Match.anyOf(
-            Matches.TerritoryIsWater,
+            Matches.territoryIsWater(),
             Matches.isTerritoryEnemy(player, data)),
         Matches.territoryHasUnitsThatMatch(Match.allOf(
             Matches.unitCanScramble(),
@@ -467,7 +467,7 @@ public class ProTerritoryManager {
       enemyAttackMaps.add(attackMap);
       findAttackOptions(enemyPlayer, enemyUnitTerritories, attackMap, unitAttackMap, transportAttackMap, bombardMap,
           transportMapList, enemyTerritories, new ArrayList<>(alliedTerritories), territoriesToCheck, true, true);
-      alliedTerritories.addAll(Match.getMatches(attackMap.keySet(), Matches.TerritoryIsLand));
+      alliedTerritories.addAll(Match.getMatches(attackMap.keySet(), Matches.territoryIsLand()));
       enemyTerritories.removeAll(alliedTerritories);
     }
     return new ProOtherMoveOptions(enemyAttackMaps, player, true);
@@ -748,7 +748,7 @@ public class ProTerritoryManager {
     if (isCheckingEnemyAttacks || !isCombatMove) {
       final Map<Unit, Set<Territory>> unitMoveMap2 = new HashMap<>();
       findNavalMoveOptions(player, myUnitTerritories, new HashMap<>(), unitMoveMap2, new HashMap<>(),
-          Matches.TerritoryIsWater, enemyTerritories, false, true);
+          Matches.territoryIsWater(), enemyTerritories, false, true);
       for (final Unit u : unitMoveMap2.keySet()) {
         if (Matches.unitIsCarrier().match(u)) {
           possibleCarrierTerritories.addAll(unitMoveMap2.get(u));

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -196,12 +196,12 @@ public class ProBattleUtils {
     final int enemyDistance = Math.max(3, (landDistance + 1));
     final int alliedDistance = (enemyDistance + 1) / 2;
     final Set<Territory> nearbyTerritories = data.getMap().getNeighbors(t, enemyDistance);
-    final List<Territory> nearbyLandTerritories = Match.getMatches(nearbyTerritories, Matches.TerritoryIsLand);
+    final List<Territory> nearbyLandTerritories = Match.getMatches(nearbyTerritories, Matches.territoryIsLand());
     final Set<Territory> nearbyEnemySeaTerritories =
-        data.getMap().getNeighbors(t, enemyDistance, Matches.TerritoryIsWater);
+        data.getMap().getNeighbors(t, enemyDistance, Matches.territoryIsWater());
     nearbyEnemySeaTerritories.add(t);
     final Set<Territory> nearbyAlliedSeaTerritories =
-        data.getMap().getNeighbors(t, alliedDistance, Matches.TerritoryIsWater);
+        data.getMap().getNeighbors(t, alliedDistance, Matches.territoryIsWater());
     nearbyAlliedSeaTerritories.add(t);
     final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
     final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
@@ -217,7 +217,7 @@ public class ProBattleUtils {
       if (enemySeaUnits.isEmpty()) {
         continue;
       }
-      final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbySeaTerritory, Matches.TerritoryIsWater);
+      final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbySeaTerritory, Matches.territoryIsWater());
       if (route == null) {
         continue;
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -78,7 +78,7 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.TerritoryIsLand,
+    return Match.allOf(Matches.territoryIsLand(),
         Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
@@ -196,7 +196,7 @@ public class ProMatches {
 
   public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
     final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
-    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+    return Match.allOf(Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
@@ -234,19 +234,19 @@ public class ProMatches {
     final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitIsOwnedBy(player),
         Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryOwnedBy(player),
-        Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+        Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
     final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryAllied(player, data),
-        Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+        Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(final PlayerID player,
       final GameData data) {
     return Match.allOf(territoryHasInfraFactoryAndIsOwnedLand(player),
-        Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater));
+        Matches.territoryHasNeighborMatching(data, Matches.territoryIsWater()));
   }
 
   public static Match<Territory> territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
@@ -289,7 +289,7 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    final Match<Territory> alliedLand = Match.allOf(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
+    final Match<Territory> alliedLand = Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
     return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
   }
 
@@ -314,7 +314,7 @@ public class ProMatches {
       final GameData data, final List<Territory> territoriesThatCantBeHeld) {
     final Match<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
     final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
-        Match.allOf(Matches.TerritoryIsLand,
+        Match.allOf(Matches.territoryIsLand(),
             Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
     return Match.allOf(territoryIsLandAndAdjacentToMyLandUnits,
         territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
@@ -325,7 +325,7 @@ public class ProMatches {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
+      final Match<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.territoryIsLand());
       return match.match(t);
     });
   }
@@ -335,7 +335,7 @@ public class ProMatches {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+      final Match<Territory> match = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
       return match.match(t);
     });
   }
@@ -376,7 +376,7 @@ public class ProMatches {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsSea());
       return match.match(u);
     });
   }
@@ -530,8 +530,8 @@ public class ProMatches {
           .match(unitWhichRequiresUnits)) {
         return true;
       }
-      if (t.isWater() && Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
-        for (final Territory neighbor : t.getData().getMap().getNeighbors(t, Matches.TerritoryIsLand)) {
+      if (t.isWater() && Matches.unitIsSea().match(unitWhichRequiresUnits)) {
+        for (final Territory neighbor : t.getData().getMap().getNeighbors(t, Matches.territoryIsLand())) {
           final Collection<Unit> unitsAtStartOfTurnInCurrent = neighbor.getUnits().getUnits();
           if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
               .match(unitWhichRequiresUnits)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -75,7 +75,7 @@ public class ProMoveUtils {
 
         // Determine route and add to move list
         Route route = null;
-        if (Match.anyMatch(unitList, Matches.UnitIsSea)) {
+        if (Match.anyMatch(unitList, Matches.unitIsSea())) {
 
           // Sea unit (including carriers with planes)
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -158,7 +158,7 @@ public class ProOddsCalculator {
     // Create battle result object
     final List<Territory> territoryList = new ArrayList<>();
     territoryList.add(t);
-    if (!territoryList.isEmpty() && Match.allMatch(territoryList, Matches.TerritoryIsLand)) {
+    if (!territoryList.isEmpty() && Match.allMatch(territoryList, Matches.territoryIsLand())) {
       return new ProBattleResult(winPercentage, tuvSwing,
           Match.anyMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -262,7 +262,7 @@ public class ProPurchaseUtils {
     if (territory.isWater()) {
       factoryMatchBuilder.add(Matches.UnitIsLand.invert());
     } else {
-      factoryMatchBuilder.add(Matches.UnitIsSea.invert());
+      factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }
     final Collection<Unit> factoryUnits = territory.getUnits().getMatches(factoryMatchBuilder.all());
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -86,7 +86,7 @@ public class ProTerritoryValueUtils {
     final GameData data = ProData.getData();
     for (final Territory t : data.getMap().getTerritories()) {
       if (!territoriesThatCantBeHeld.contains(t) && t.isWater()
-          && !data.getMap().getNeighbors(t, Matches.TerritoryIsWater).isEmpty()) {
+          && !data.getMap().getNeighbors(t, Matches.territoryIsWater()).isEmpty()) {
 
         // Determine sea value based on nearby convoy production
         double nearbySeaProductionValue = 0;
@@ -263,7 +263,7 @@ public class ProTerritoryValueUtils {
       final List<Territory> territoriesToAttack, final Map<Territory, Double> territoryValueMap) {
 
     final GameData data = ProData.getData();
-    if (territoriesThatCantBeHeld.contains(t) || data.getMap().getNeighbors(t, Matches.TerritoryIsWater).isEmpty()) {
+    if (territoriesThatCantBeHeld.contains(t) || data.getMap().getNeighbors(t, Matches.territoryIsWater()).isEmpty()) {
       return 0.0;
     }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -220,7 +220,7 @@ public class ProUtils {
     int minDistance = 10;
     for (final Territory enemyLandTerritory : enemyOrAdjacentLandTerritories) {
       final int distance =
-          data.getMap().getDistance_IgnoreEndForCondition(t, enemyLandTerritory, Matches.TerritoryIsWater);
+          data.getMap().getDistance_IgnoreEndForCondition(t, enemyLandTerritory, Matches.territoryIsWater());
       if (distance > 0 && distance < minDistance) {
         minDistance = distance;
       }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -49,7 +49,7 @@ class Utils {
   static float getStrengthOfPotentialAttackers(final Territory location, final GameData data) {
     float strength = 0;
     for (final Territory t : data.getMap().getNeighbors(location,
-        location.isWater() ? Matches.TerritoryIsWater : Matches.TerritoryIsLand)) {
+        location.isWater() ? Matches.territoryIsWater() : Matches.territoryIsLand())) {
       final List<Unit> enemies = t.getUnits().getMatches(Matches.enemyUnit(location.getOwner(), data));
       strength += AIUtils.strength(enemies, true, location.isWater());
     }
@@ -76,7 +76,7 @@ class Utils {
   static boolean hasLandRouteToEnemyOwnedCapitol(final Territory t, final PlayerID us, final GameData data) {
     for (final PlayerID player : Match.getMatches(data.getPlayerList().getPlayers(), Matches.isAtWar(us, data))) {
       for (final Territory capital : TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data)) {
-        if (data.getMap().getDistance(t, capital, Matches.TerritoryIsLand) != -1) {
+        if (data.getMap().getDistance(t, capital, Matches.territoryIsLand()) != -1) {
           return true;
         }
       }
@@ -90,7 +90,7 @@ class Utils {
     final Iterator<Territory> waterFactIter = water.iterator();
     while (waterFactIter.hasNext()) {
       final Territory waterFact = waterFactIter.next();
-      if (!Matches.TerritoryIsWater.match(waterFact)) {
+      if (!Matches.territoryIsWater().match(waterFact)) {
         waterFactIter.remove();
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -65,13 +65,13 @@ public class WeakAI extends AbstractAI {
       return !impassable && !o.isWater() && Utils.hasLandRouteToEnemyOwnedCapitol(o, player, data);
     });
     final Match<Territory> routeCond =
-        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.allOf(Matches.territoryIsWater(), Matches.territoryHasNoEnemyUnits(player, data));
     final Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
     if (withNoEnemy != null && withNoEnemy.numberOfSteps() > 0) {
       return withNoEnemy;
     }
     // this will fail if our capitol is not next to water, c'est la vie.
-    final Route route = Utils.findNearest(ourCapitol, endMatch, Matches.TerritoryIsWater, data);
+    final Route route = Utils.findNearest(ourCapitol, endMatch, Matches.territoryIsWater(), data);
     if (route != null && route.numberOfSteps() == 0) {
       return null;
     }
@@ -87,7 +87,7 @@ public class WeakAI extends AbstractAI {
     // find a land route to an enemy territory from our capitol
     final Route invasionRoute =
         Utils.findNearest(capitol, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
-            Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsNeutralButNotWater().invert()), data);
+            Match.allOf(Matches.territoryIsLand(), Matches.territoryIsNeutralButNotWater().invert()), data);
     return invasionRoute == null;
   }
 
@@ -335,7 +335,7 @@ public class WeakAI extends AbstractAI {
   private static Route getMaxSeaRoute(final GameData data, final Territory start, final Territory destination,
       final PlayerID player) {
     final Match<Territory> routeCond =
-        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasEnemyUnits(player, data).invert(),
+        Match.allOf(Matches.territoryIsWater(), Matches.territoryHasEnemyUnits(player, data).invert(),
             Matches.territoryHasNonAllowedCanal(player, null, data).invert());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null) {
@@ -369,7 +369,7 @@ public class WeakAI extends AbstractAI {
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
         int ourStrength = 0;
-        final Collection<Territory> attackFrom = data.getMap().getNeighbors(enemy, Matches.TerritoryIsWater);
+        final Collection<Territory> attackFrom = data.getMap().getNeighbors(enemy, Matches.territoryIsWater());
         for (final Territory owned : attackFrom) {
           // dont risk units we are carrying
           if (owned.getUnits().anyMatch(Matches.UnitIsLand)) {
@@ -400,10 +400,10 @@ public class WeakAI extends AbstractAI {
       return null;
     }
     final Match<Territory> routeCondition =
-        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.allOf(Matches.territoryIsWater(), Matches.territoryHasNoEnemyUnits(player, data));
     // should select all territories with loaded transports
     final Match<Territory> transportOnSea =
-        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasLandUnitsOwnedBy(player));
+        Match.allOf(Matches.territoryIsWater(), Matches.territoryHasLandUnitsOwnedBy(player));
     Route altRoute = null;
     final int length = Integer.MAX_VALUE;
     for (final Territory t : data.getMap()) {
@@ -413,7 +413,7 @@ public class WeakAI extends AbstractAI {
       final Match<Unit> ownedTransports =
           Match.allOf(Matches.unitCanTransport(), Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
       final Match<Territory> enemyTerritory =
-          Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
+          Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.territoryIsLand(),
               Matches.territoryIsNeutralButNotWater().invert(), Matches.territoryIsEmpty());
       final int trans = t.getUnits().countMatches(ownedTransports);
       if (trans > 0) {
@@ -454,7 +454,7 @@ public class WeakAI extends AbstractAI {
           Matches.UnitIsLand);
       final Match<Territory> moveThrough =
           Match.allOf(Matches.territoryIsImpassable().invert(),
-              Matches.territoryIsNeutralButNotWater().invert(), Matches.TerritoryIsLand);
+              Matches.territoryIsNeutralButNotWater().invert(), Matches.territoryIsLand());
       final List<Unit> units = t.getUnits().getMatches(moveOfType);
       if (units.size() == 0) {
         continue;
@@ -487,7 +487,7 @@ public class WeakAI extends AbstractAI {
         }
       } else { // if we cant move to a capitol, move towards the enemy
         final Match<Territory> routeCondition =
-            Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsImpassable().invert());
+            Match.allOf(Matches.territoryIsLand(), Matches.territoryIsImpassable().invert());
         Route newRoute = Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
         // move to any enemy territory
         if (newRoute == null) {
@@ -1026,14 +1026,14 @@ public class WeakAI extends AbstractAI {
     if (placementLeft == -1) {
       placementLeft = Integer.MAX_VALUE;
     }
-    final List<Unit> seaUnits = new ArrayList<>(player.getUnits().getMatches(Matches.UnitIsSea));
+    final List<Unit> seaUnits = new ArrayList<>(player.getUnits().getMatches(Matches.unitIsSea()));
     if (seaUnits.size() > 0) {
       final Route amphibRoute = getAmphibRoute(player, data);
       Territory seaPlaceAt = null;
       if (amphibRoute != null) {
         seaPlaceAt = amphibRoute.getAllTerritories().get(1);
       } else {
-        final Set<Territory> seaNeighbors = data.getMap().getNeighbors(placeAt, Matches.TerritoryIsWater);
+        final Set<Territory> seaNeighbors = data.getMap().getNeighbors(placeAt, Matches.territoryIsWater());
         if (!seaNeighbors.isEmpty()) {
           seaPlaceAt = seaNeighbors.iterator().next();
         }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -270,7 +270,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // play a sound
     if (Match.anyMatch(units, Matches.unitIsInfrastructure())) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, m_player);
-    } else if (Match.anyMatch(units, Matches.UnitIsSea)) {
+    } else if (Match.anyMatch(units, Matches.unitIsSea())) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, m_player);
     } else if (Match.anyMatch(units, Matches.UnitIsAir)) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_AIR, m_player);
@@ -490,7 +490,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (capacity <= 0) {
       return null;
     }
-    if (!Matches.TerritoryIsLand.match(producer)) {
+    if (!Matches.territoryIsLand().match(producer)) {
       return null;
     }
     if (!producer.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
@@ -622,9 +622,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getOwner().equals(player)) {
       // sea constructions require either owning the sea zone or owning a surrounding land territory
       if (producer.isWater()
-          && Match.anyMatch(testUnits, Match.allOf(Matches.UnitIsSea, Matches.unitIsConstruction()))) {
+          && Match.anyMatch(testUnits, Match.allOf(Matches.unitIsSea(), Matches.unitIsConstruction()))) {
         boolean ownedNeighbor = false;
-        for (final Territory current : getData().getMap().getNeighbors(to, Matches.TerritoryIsLand)) {
+        for (final Territory current : getData().getMap().getNeighbors(to, Matches.territoryIsLand())) {
           if (current.getOwner().equals(player) && (canProduceInConquered || !wasConquered(current))) {
             ownedNeighbor = true;
             break;
@@ -641,11 +641,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!canProduceInConquered && wasConquered(producer)) {
       return producer.getName() + " was conquered this turn and cannot produce till next turn";
     }
-    if (isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player) && Matches.TerritoryIsLand.match(to)
+    if (isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player) && Matches.territoryIsLand().match(to)
         && Matches.isTerritoryOwnedBy(player).match(to)) {
       return null;
     }
-    if (isPlayerAllowedToPlacementAnySeaZoneByOwnedLand(player) && Matches.TerritoryIsWater.match(to)
+    if (isPlayerAllowedToPlacementAnySeaZoneByOwnedLand(player) && Matches.territoryIsWater().match(to)
         && Matches.isTerritoryOwnedBy(player).match(producer)) {
       return null;
     }
@@ -710,7 +710,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (canProduce(to, to, unitsToPlace, player, simpleCheck) == null) {
       producers.add(to);
     }
-    for (final Territory current : getData().getMap().getNeighbors(to, Matches.TerritoryIsLand)) {
+    for (final Territory current : getData().getMap().getNeighbors(to, Matches.territoryIsLand())) {
       if (canProduce(current, to, unitsToPlace, player, simpleCheck) == null) {
         producers.add(current);
       }
@@ -869,7 +869,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     final Collection<Unit> units = new ArrayList<>(allUnits);
     // if water, remove land. if land, remove water.
-    units.removeAll(Match.getMatches(units, water ? Matches.UnitIsLand : Matches.UnitIsSea));
+    units.removeAll(Match.getMatches(units, water ? Matches.UnitIsLand : Matches.unitIsSea()));
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> allProducedUnits = unitsPlacedInTerritorySoFar(to);
@@ -879,7 +879,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
     // we add factories and constructions later
     if (water || wasFactoryThereAtStart || (!water && isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player))) {
-      final Match<Unit> seaOrLandMatch = water ? Matches.UnitIsSea : Matches.UnitIsLand;
+      final Match<Unit> seaOrLandMatch = water ? Matches.unitIsSea() : Matches.UnitIsLand;
       placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.unitIsNotConstruction())));
       if (!water) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction())));
@@ -1078,7 +1078,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (producer.isWater()) {
       factoryMatchBuilder.add(Matches.UnitIsLand.invert());
     } else {
-      factoryMatchBuilder.add(Matches.UnitIsSea.invert());
+      factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }
     final Collection<Unit> factoryUnits = producer.getUnits().getMatches(factoryMatchBuilder.all());
     // boolean placementRestrictedByFactory = isPlacementRestrictedByFactory();
@@ -1383,7 +1383,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         return true;
       }
       if (!doNotCountNeighbors) {
-        if (Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
+        if (Matches.unitIsSea().match(unitWhichRequiresUnits)) {
           for (final Territory current : getAllProducers(to, m_player,
               Collections.singletonList(unitWhichRequiresUnits), true)) {
             final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
@@ -1521,7 +1521,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     final Collection<Unit> unitsInTo = to.getUnits().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
-    if (Matches.TerritoryIsWater.match(to)) {
+    if (Matches.territoryIsWater().match(to)) {
       for (final Territory current : getAllProducers(to, m_player, null, true)) {
         unitsPlacedAlready.addAll(getAlreadyProduced(current));
       }
@@ -1560,7 +1560,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to.isWater()) {
       factoryMatchBuilder.add(Matches.UnitIsLand.invert());
     } else {
-      factoryMatchBuilder.add(Matches.UnitIsSea.invert());
+      factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }
     return Match.countMatches(unitsAtStartOfTurnInTo, factoryMatchBuilder.all()) > 0;
   }

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -170,7 +170,7 @@ public class AirMovementValidator {
     final List<Unit> carriersInProductionQueue = player.getUnits().getMatches(Matches.unitIsCarrier());
     for (final Territory t : landingSpots) {
       if (landAirOnNewCarriers && !carriersInProductionQueue.isEmpty()) {
-        if (Matches.TerritoryIsWater.match(t)
+        if (Matches.territoryIsWater().match(t)
             && Matches.territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnitsNeighbor(data, player).match(t)) {
           // TODO: Here we are assuming that this factory can produce all of the carriers. Actually it might not be able
           // to produce any

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -315,7 +315,7 @@ public class BattleTracker implements Serializable {
         changeTracker.addChange(change);
       }
       if (Match.anyMatch(units, Matches.UnitIsLand)
-          || Match.anyMatch(units, Matches.UnitIsSea)) {
+          || Match.anyMatch(units, Matches.unitIsSea())) {
         addEmptyBattle(route, units, id, bridge, changeTracker, unitsNotUnloadedTilEndOfRoute);
       }
     }
@@ -732,7 +732,7 @@ public class BattleTracker implements Serializable {
     // say they were in combat
     // if the territory being taken over is water, then do not say any land units were in combat
     // (they may want to unload from the transport and attack)
-    if (Matches.TerritoryIsWater.match(territory) && arrivedUnits != null) {
+    if (Matches.territoryIsWater().match(territory) && arrivedUnits != null) {
       arrivedUnits.removeAll(Match.getMatches(arrivedUnits, Matches.UnitIsLand));
     }
     markWasInCombat(arrivedUnits, bridge, changeTracker);

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -47,7 +47,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       }
     } else {
       // we can place on territories we own
-      if (Match.anyMatch(units, Matches.UnitIsSea)) {
+      if (Match.anyMatch(units, Matches.unitIsSea())) {
         return "Cant place sea units on land";
       } else if (to.getOwner() == null) {
         return "You dont own " + to.getName();

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -474,7 +474,7 @@ public class DiceRoll implements Externalizable {
             strength += ua.getIsMarine();
           }
         }
-        if (ua.getIsSea() && isAmphibiousBattle && Matches.TerritoryIsLand.match(location)) {
+        if (ua.getIsSea() && isAmphibiousBattle && Matches.territoryIsLand().match(location)) {
           // change the strength to be bombard, not attack/defense, because this is a
           strength = ua.getBombard();
           // bombarding naval unit

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -82,14 +82,14 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final GameData data = getData();
     Map<Unit, Unit> mapLoading = null;
     if (territory.isWater()) {
-      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSea())) {
         if (Match.anyMatch(units, Matches.UnitIsLand)) {
           // this should be exact same as the one in the EditValidator
           if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -51,7 +51,7 @@ class EditValidator {
 
   static String validateChangeTerritoryOwner(final GameData data, final Territory territory, final PlayerID player) {
     String result = null;
-    if (Matches.TerritoryIsWater.match(territory) && territory.getOwner().equals(PlayerID.NULL_PLAYERID)
+    if (Matches.territoryIsWater().match(territory) && territory.getOwner().equals(PlayerID.NULL_PLAYERID)
         && TerritoryAttachment.get(territory) == null) {
       return "Territory is water and has no attachment";
     }
@@ -69,13 +69,13 @@ class EditValidator {
     final PlayerID player = units.iterator().next().getOwner();
     // check land/water sanity
     if (territory.isWater()) {
-      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSea())) {
         if (Match.anyMatch(units, Matches.UnitIsLand)) {
           if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
@@ -111,10 +111,10 @@ class EditValidator {
     } else {
       /*
        * // Can't add to enemy territory
-       * if (Matches.isTerritoryEnemy(player, data).match(territory) && !Matches.TerritoryIsWater.match(territory))
+       * if (Matches.isTerritoryEnemy(player, data).match(territory) && !Matches.territoryIsWater().match(territory))
        * return "Can't add units to enemy territory";
        */
-      if (Match.anyMatch(units, Matches.UnitIsSea)) {
+      if (Match.anyMatch(units, Matches.unitIsSea())) {
         return "Can't add sea units to land";
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -87,10 +87,10 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           final IntegerMap<UnitType> createsUnitsMap = ua.getCreatesUnitsList();
           final Collection<UnitType> willBeCreated = createsUnitsMap.keySet();
           for (final UnitType ut : willBeCreated) {
-            if (UnitAttachment.get(ut).getIsSea() && Matches.TerritoryIsLand.match(t)) {
+            if (UnitAttachment.get(ut).getIsSea() && Matches.territoryIsLand().match(t)) {
               toAddSea.addAll(ut.create(createsUnitsMap.getInt(ut), player));
             } else if (!UnitAttachment.get(ut).getIsSea() && !UnitAttachment.get(ut).getIsAir()
-                && Matches.TerritoryIsWater.match(t)) {
+                && Matches.territoryIsWater().match(t)) {
               toAddLand.addAll(ut.create(createsUnitsMap.getInt(ut), player));
             } else {
               toAdd.addAll(ut.create(createsUnitsMap.getInt(ut), player));
@@ -106,7 +106,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           change.add(place);
         }
         if (!toAddSea.isEmpty()) {
-          final Match<Territory> myTerrs = Match.allOf(Matches.TerritoryIsWater);
+          final Match<Territory> myTerrs = Match.allOf(Matches.territoryIsWater());
           final Collection<Territory> waterNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (waterNeighbors != null && !waterNeighbors.isEmpty()) {
             final Territory tw = getRandomTerritory(waterNeighbors, bridge);
@@ -119,7 +119,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAddLand.isEmpty()) {
-          final Match<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+          final Match<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (landNeighbors != null && !landNeighbors.isEmpty()) {
             final Territory tl = getRandomTerritory(landNeighbors, bridge);

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -99,13 +99,13 @@ public class Fire implements IExecutable {
     final int hitCount = m_dice.getHits();
     AbstractBattle.getDisplay(bridge).notifyDice(m_dice, m_stepName);
     final int countTransports =
-        Match.countMatches(m_attackableUnits, Match.allOf(Matches.unitIsTransport(), Matches.UnitIsSea));
+        Match.countMatches(m_attackableUnits, Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea()));
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
       final Collection<Unit> nonTransports = Match.getMatches(m_attackableUnits,
           Match.anyOf(Matches.unitIsNotTransportButCouldBeCombatTransport(), Matches.unitIsNotSea()));
       final Collection<Unit> transportsOnly = Match.getMatches(m_attackableUnits,
-          Match.allOf(Matches.unitIsTransportButNotCombatTransport(), Matches.UnitIsSea));
+          Match.allOf(Matches.unitIsTransportButNotCombatTransport(), Matches.unitIsSea()));
       final int numPossibleHits = AbstractBattle.getMaxHits(nonTransports);
       // more hits than combat units
       if (hitCount > numPossibleHits) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -366,17 +366,17 @@ public class MoveDelegate extends AbstractMoveDelegate {
           final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
               Matches.unitCanGiveBonusMovementToThisUnit(u));
           givesBonusUnits.addAll(Match.getMatches(t.getUnits().getUnits(), givesBonusUnit));
-          if (Matches.UnitIsSea.match(u)) {
+          if (Matches.unitIsSea().match(u)) {
             final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.UnitIsLand);
             final List<Territory> neighbors =
-                new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsLand));
+                new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsLand()));
             for (final Territory current : neighbors) {
               givesBonusUnits.addAll(Match.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
             }
           } else if (Matches.UnitIsLand.match(u)) {
-            final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.UnitIsSea);
+            final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.unitIsSea());
             final List<Territory> neighbors =
-                new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsWater));
+                new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsWater()));
             for (final Territory current : neighbors) {
               givesBonusUnits.addAll(Match.getMatches(current.getUnits().getUnits(), givesBonusUnitSea));
             }
@@ -480,17 +480,17 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final Match<Unit> repairUnit = Match.allOf(Matches.alliedUnit(owner, data),
         Matches.unitCanRepairOthers(), Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
-    if (Matches.UnitIsSea.match(unitToBeRepaired)) {
+    if (Matches.unitIsSea().match(unitToBeRepaired)) {
       final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);
       final List<Territory> neighbors =
-          new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsLand));
+          new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.territoryIsLand()));
       for (final Territory current : neighbors) {
         repairUnitsForThisUnit.addAll(current.getUnits().getMatches(repairUnitLand));
       }
     } else if (Matches.UnitIsLand.match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.UnitIsSea);
+      final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.unitIsSea());
       final List<Territory> neighbors =
-          new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsWater));
+          new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.territoryIsWater()));
       for (final Territory current : neighbors) {
         repairUnitsForThisUnit.addAll(current.getUnits().getMatches(repairUnitSea));
       }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -379,8 +379,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       BattleCalculator.sortPreBattle(m_defendingUnits);
       // play a sound
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)
-          || Match.anyMatch(m_defendingUnits, Matches.UnitIsSea)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsSea())
+          || Match.anyMatch(m_defendingUnits, Matches.unitIsSea())) {
         if ((!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsSub()))
             || (Match.anyMatch(m_attackingUnits, Matches.unitIsSub())
                 && Match.anyMatch(m_defendingUnits, Matches.unitIsSub()))) {
@@ -1240,18 +1240,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Match<Territory> conqueuredOrEnemy = Match.anyOf(
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(m_attacker, m_data),
         Match.allOf(
-            // Matches.TerritoryIsLand,
-            Matches.TerritoryIsWater, Matches.territoryWasFoughOver(m_battleTracker)));
+            // Matches.territoryIsLand(),
+            Matches.territoryIsWater(), Matches.territoryWasFoughOver(m_battleTracker)));
     possible.removeAll(Match.getMatches(possible, conqueuredOrEnemy));
 
     // the battle site is in the attacking from
     // if sea units are fighting a submerged sub
     possible.remove(m_battleSite);
     if (Match.anyMatch(m_attackingUnits, Matches.UnitIsLand) && !m_battleSite.isWater()) {
-      possible = Match.getMatches(possible, Matches.TerritoryIsLand);
+      possible = Match.getMatches(possible, Matches.territoryIsLand());
     }
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)) {
-      possible = Match.getMatches(possible, Matches.TerritoryIsWater);
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsSea())) {
+      possible = Match.getMatches(possible, Matches.territoryIsWater());
     }
     return possible;
   }
@@ -1368,7 +1368,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return MoveValidator.validateCanal(r, unitsToRetreat, m_defender, m_data) == null;
     });
     final Match<Territory> match = Match.allOf(
-        Matches.TerritoryIsWater,
+        Matches.territoryIsWater(),
         Matches.territoryHasNoEnemyUnits(player, m_data),
         canalMatch);
     possible = Match.getMatches(possible, match);
@@ -1404,8 +1404,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else if (partialAmphib) {
       units = Match.getMatches(units, Matches.unitWasNotAmphibious());
     }
-    if (Match.anyMatch(units, Matches.UnitIsSea)) {
-      availableTerritories = Match.getMatches(availableTerritories, Matches.TerritoryIsWater);
+    if (Match.anyMatch(units, Matches.unitIsSea())) {
+      availableTerritories = Match.getMatches(availableTerritories, Matches.territoryIsWater());
     }
     if (canDefendingSubsSubmergeOrRetreat) {
       availableTerritories.add(m_battleSite);
@@ -1473,7 +1473,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         getDisplay(bridge).notifyRetreat(messageShort, messageShort, step, retreatingPlayer);
       } else if (partialAmphib) {
         if (!m_headless) {
-          if (Match.anyMatch(units, Matches.UnitIsSea)) {
+          if (Match.anyMatch(units, Matches.unitIsSea())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
           } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
@@ -1488,7 +1488,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         getDisplay(bridge).notifyRetreat(messageShort, messageShort, step, retreatingPlayer);
       } else {
         if (!m_headless) {
-          if (Match.anyMatch(units, Matches.UnitIsSea)) {
+          if (Match.anyMatch(units, Matches.unitIsSea())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
           } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
@@ -1739,7 +1739,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         Matches.unitIsTransport(),
         Matches.unitIsNotCombatTransport(),
         Matches.isUnitAllied(player, m_data),
-        Matches.UnitIsSea);
+        Matches.unitIsSea());
     final List<Unit> alliedTransports = Match.getMatches(m_battleSite.getUnits().getUnits(), matchAllied);
     // If no transports, just return
     if (alliedTransports.isEmpty()) {
@@ -1761,7 +1761,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> enemyUnits = Match.getMatches(m_battleSite.getUnits().getUnits(), enemyUnitsMatch);
       // If there are attackers set their movement to 0 and kill the transports
       if (enemyUnits.size() > 0) {
-        final Change change = ChangeFactory.markNoMovementChange(Match.getMatches(enemyUnits, Matches.UnitIsSea));
+        final Change change = ChangeFactory.markNoMovementChange(Match.getMatches(enemyUnits, Matches.unitIsSea()));
         bridge.addChange(change);
         final boolean defender = player.equals(m_defender);
         remove(alliedTransports, bridge, m_battleSite, defender);
@@ -1780,8 +1780,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     final Match.CompositeBuilder<Unit> notSubmergedAndTypeBuilder = Match.newCompositeBuilder(
         Matches.unitIsSubmerged().invert());
-    if (Matches.TerritoryIsLand.match(m_battleSite)) {
-      notSubmergedAndTypeBuilder.add(Matches.UnitIsSea.invert());
+    if (Matches.territoryIsLand().match(m_battleSite)) {
+      notSubmergedAndTypeBuilder.add(Matches.unitIsSea().invert());
     } else {
       notSubmergedAndTypeBuilder.add(Matches.UnitIsLand.invert());
     }
@@ -2550,7 +2550,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     }
     if (!m_headless) {
-      if (Matches.TerritoryIsWater.match(m_battleSite)) {
+      if (Matches.territoryIsWater().match(m_battleSite)) {
         if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR_SUCCESSFUL,
               m_attacker);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -224,7 +224,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   }
 
   public Match<Territory> getTerritoryPickableMatch() {
-    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsNotImpassable(),
+    return Match.allOf(Matches.territoryIsLand(), Matches.territoryIsNotImpassable(),
         Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.territoryIsEmpty());
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -251,9 +251,9 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return result.setErrorReturnResult("May Only Fly Over Territories Where Air May Move");
     }
     final boolean someLand = Match.anyMatch(airborne, Matches.UnitIsLand);
-    final boolean someSea = Match.anyMatch(airborne, Matches.UnitIsSea);
-    final boolean land = Matches.TerritoryIsLand.match(end);
-    final boolean sea = Matches.TerritoryIsWater.match(end);
+    final boolean someSea = Match.anyMatch(airborne, Matches.unitIsSea());
+    final boolean land = Matches.territoryIsLand().match(end);
+    final boolean sea = Matches.territoryIsWater().match(end);
     if (someLand && someSea) {
       return result.setErrorReturnResult("Cannot Mix Land and Sea Units");
     } else if (someLand) {
@@ -272,7 +272,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
           return result.setErrorReturnResult("Airborne May Only Attack Territories Already Under Assault");
         } else if (land && someLand && !Match.anyMatch(battle.getAttackingUnits(), Matches.UnitIsLand)) {
           return result.setErrorReturnResult("Battle Must Have Some Land Units Participating Already");
-        } else if (sea && someSea && !Match.anyMatch(battle.getAttackingUnits(), Matches.UnitIsSea)) {
+        } else if (sea && someSea && !Match.anyMatch(battle.getAttackingUnits(), Matches.unitIsSea())) {
           return result.setErrorReturnResult("Battle Must Have Some Sea Units Participating Already");
         }
       }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -594,7 +594,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       }
       if (submerge) {
         // submerge if all air vs subs
-        final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.unitIsSub());
+        final Match<Unit> seaSub = Match.allOf(Matches.unitIsSea(), Matches.unitIsSub());
         final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.unitIsDestroyer().invert());
         final List<Unit> ourUnits = getOurUnits();
         final List<Unit> enemyUnits = getEnemyUnits();

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -133,10 +133,10 @@ public class PlacePanel extends AbstractMovePanel {
       if (territory.isWater()) {
         if (!(canProduceFightersOnCarriers() || canProduceNewFightersOnOldCarriers()
             || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
-          units = Match.getMatches(units, Matches.UnitIsSea);
+          units = Match.getMatches(units, Matches.unitIsSea());
         } else {
           final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(
-              Matches.UnitIsSea,
+              Matches.unitIsSea(),
               Matches.unitCanLandOnCarrier());
           units = Match.getMatches(units, unitIsSeaOrCanLandOnCarrier);
         }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.