### PR TITLE
Simplify CountDownLatchHandler usage

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -54,7 +54,6 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.ProgressWindow;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
@@ -403,7 +402,7 @@ public class GameRunner {
           .isLessThan(latestEngineOut.getLatestVersionOut())) {
         SwingUtilities
             .invokeLater(() -> EventThreadJOptionPane.showMessageDialog(null, latestEngineOut.getOutOfDateComponent(),
-                "Please Update TripleA", JOptionPane.INFORMATION_MESSAGE, false, new CountDownLatchHandler()));
+                "Please Update TripleA", JOptionPane.INFORMATION_MESSAGE));
         return true;
       }
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -403,7 +403,7 @@ public class GameRunner {
           .isLessThan(latestEngineOut.getLatestVersionOut())) {
         SwingUtilities
             .invokeLater(() -> EventThreadJOptionPane.showMessageDialog(null, latestEngineOut.getOutOfDateComponent(),
-                "Please Update TripleA", JOptionPane.INFORMATION_MESSAGE, false, new CountDownLatchHandler(true)));
+                "Please Update TripleA", JOptionPane.INFORMATION_MESSAGE, false, new CountDownLatchHandler()));
         return true;
       }
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -75,6 +75,6 @@ public class ClientLogin implements IConnectionLogin {
   @Override
   public void notifyFailedLogin(final String message) {
     EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parentComponent), message,
-        new CountDownLatchHandler(true));
+        new CountDownLatchHandler());
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -11,7 +11,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.net.IConnectionLogin;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
 /**
@@ -74,7 +73,6 @@ public class ClientLogin implements IConnectionLogin {
 
   @Override
   public void notifyFailedLogin(final String message) {
-    EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parentComponent), message,
-        new CountDownLatchHandler());
+    EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parentComponent), message);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -145,7 +145,7 @@ public class ClientModel implements IMessengerErrorListener {
     final int port = props.getPort();
     if (port >= 65536 || port <= 0) {
       EventThreadJOptionPane.showMessageDialog(ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE,
-          new CountDownLatchHandler(true));
+          new CountDownLatchHandler());
       return false;
     }
     final String address = props.getHost();
@@ -158,7 +158,7 @@ public class ClientModel implements IMessengerErrorListener {
     } catch (final Exception ioe) {
       ioe.printStackTrace(System.out);
       EventThreadJOptionPane.showMessageDialog(ui, "Unable to connect:" + ioe.getMessage(), "Error",
-          JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
+          JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
       return false;
     }
     m_messenger.addErrorListener(this);
@@ -271,8 +271,7 @@ public class ClientModel implements IMessengerErrorListener {
     public void cannotJoinGame(final String reason) {
       SwingUtilities.invokeLater(() -> {
         m_typePanelModel.showSelectType();
-        EventThreadJOptionPane.showMessageDialog(m_ui, "Could not join game: " + reason,
-            new CountDownLatchHandler(true));
+        EventThreadJOptionPane.showMessageDialog(m_ui, "Could not join game: " + reason, new CountDownLatchHandler());
       });
     }
   };
@@ -413,7 +412,7 @@ public class ClientModel implements IMessengerErrorListener {
     // In case for example there are many game windows open, it may not be clear which game disconnected.
     GameRunner.getChat().sendMessage("*** Was Disconnected ***", false);
     EventThreadJOptionPane.showMessageDialog(m_ui, "Connection to game host lost.\nPlease save and restart.",
-        "Connection Lost!", JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
+        "Connection Lost!", JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
   }
 
   public IChatPanel getChatPanel() {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -58,7 +58,6 @@ import games.strategy.net.MacFinder;
 import games.strategy.net.Messengers;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
 public class ClientModel implements IMessengerErrorListener {
@@ -144,8 +143,7 @@ public class ClientModel implements IMessengerErrorListener {
     ClientSetting.flush();
     final int port = props.getPort();
     if (port >= 65536 || port <= 0) {
-      EventThreadJOptionPane.showMessageDialog(ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE,
-          new CountDownLatchHandler());
+      EventThreadJOptionPane.showMessageDialog(ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE);
       return false;
     }
     final String address = props.getHost();
@@ -158,7 +156,7 @@ public class ClientModel implements IMessengerErrorListener {
     } catch (final Exception ioe) {
       ioe.printStackTrace(System.out);
       EventThreadJOptionPane.showMessageDialog(ui, "Unable to connect:" + ioe.getMessage(), "Error",
-          JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
+          JOptionPane.ERROR_MESSAGE);
       return false;
     }
     m_messenger.addErrorListener(this);
@@ -271,7 +269,7 @@ public class ClientModel implements IMessengerErrorListener {
     public void cannotJoinGame(final String reason) {
       SwingUtilities.invokeLater(() -> {
         m_typePanelModel.showSelectType();
-        EventThreadJOptionPane.showMessageDialog(m_ui, "Could not join game: " + reason, new CountDownLatchHandler());
+        EventThreadJOptionPane.showMessageDialog(m_ui, "Could not join game: " + reason);
       });
     }
   };
@@ -412,7 +410,7 @@ public class ClientModel implements IMessengerErrorListener {
     // In case for example there are many game windows open, it may not be clear which game disconnected.
     GameRunner.getChat().sendMessage("*** Was Disconnected ***", false);
     EventThreadJOptionPane.showMessageDialog(m_ui, "Connection to game host lost.\nPlease save and restart.",
-        "Connection Lost!", JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
+        "Connection Lost!", JOptionPane.ERROR_MESSAGE);
   }
 
   public IChatPanel getChatPanel() {

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -41,7 +41,6 @@ import games.strategy.engine.lobby.server.ModeratorController;
 import games.strategy.net.INode;
 import games.strategy.triplea.ui.menubar.LobbyMenu;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
 public class LobbyFrame extends JFrame {
@@ -339,6 +338,6 @@ public class LobbyFrame extends JFrame {
   private void connectionToServerLost() {
     EventThreadJOptionPane.showMessageDialog(LobbyFrame.this,
         "Connection to Server Lost.  Please close this instance and reconnect to the lobby.", "Connection Lost",
-        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
+        JOptionPane.ERROR_MESSAGE);
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -339,6 +339,6 @@ public class LobbyFrame extends JFrame {
   private void connectionToServerLost() {
     EventThreadJOptionPane.showMessageDialog(LobbyFrame.this,
         "Connection to Server Lost.  Please close this instance and reconnect to the lobby.", "Connection Lost",
-        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
+        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -28,7 +28,6 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.LocalizeHtml;
 import games.strategy.util.Match;
@@ -296,9 +295,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         }
         // this is currently the ONLY instance of JOptionPane that is allowed outside of the UI classes. maybe there is
         // a better way?
-        stopGame = (JOptionPane.OK_OPTION != EventThreadJOptionPane.showConfirmDialog(null,
-            ("<html>" + displayMessage + "</html>"), "Continue Game?  (" + title + ")", JOptionPane.YES_NO_OPTION,
-            new CountDownLatchHandler()));
+        stopGame = JOptionPane.OK_OPTION != EventThreadJOptionPane.showConfirmDialog(null,
+            "<html>" + displayMessage + "</html>", "Continue Game?  (" + title + ")", JOptionPane.YES_NO_OPTION);
       }
       if (stopGame) {
         bridge.stopGameSequence();

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -298,7 +298,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // a better way?
         stopGame = (JOptionPane.OK_OPTION != EventThreadJOptionPane.showConfirmDialog(null,
             ("<html>" + displayMessage + "</html>"), "Continue Game?  (" + title + ")", JOptionPane.YES_NO_OPTION,
-            new CountDownLatchHandler(true)));
+            new CountDownLatchHandler()));
       }
       if (stopGame) {
         bridge.stopGameSequence();

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -122,7 +122,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       setWidgetActivation();
       if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Must Pick An Unowned Territory",
-            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));
+            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
         currentAction = null;
         if (currentHighlightedTerritory != null) {
           getMap().clearTerritoryOverlay(currentHighlightedTerritory);
@@ -134,7 +134,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
       if (!pickedUnits.isEmpty() && !unitChoices.containsAll(pickedUnits)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Invalid Units?!?", "Invalid Units?!?",
-            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));
+            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
         currentAction = null;
         pickedUnits.clear();
         setWidgetActivation();
@@ -142,7 +142,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
       if (pickedUnits.size() > Math.max(0, unitsPerPick)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Too Many Units?!?", "Too Many Units?!?",
-            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));
+            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
         currentAction = null;
         pickedUnits.clear();
         setWidgetActivation();
@@ -159,7 +159,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           pickedUnits.addAll(Match.getNMatches(unitChoices, unitsPerPick, Match.always()));
         } else {
           EventThreadJOptionPane.showMessageDialog(parent, "Must Choose Units For This Territory",
-              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));
+              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
           currentAction = null;
           setWidgetActivation();
           return;
@@ -185,7 +185,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           false, getMap().getUiContext());
       unitChooser.setMaxAndShowMaxButton(unitsPerPick);
       if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
-          JOptionPane.OK_CANCEL_OPTION, new CountDownLatchHandler(true))) {
+          JOptionPane.OK_CANCEL_OPTION, new CountDownLatchHandler())) {
         pickedUnits.clear();
         pickedUnits.addAll(unitChooser.getSelected());
       }
@@ -214,7 +214,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         if (!territoryChoices.contains(territory)) {
           EventThreadJOptionPane.showMessageDialog(parent,
               "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
-              JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));
+              JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
           return;
         }
         pickedTerritory = territory;

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -19,7 +19,6 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -122,7 +121,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       setWidgetActivation();
       if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Must Pick An Unowned Territory",
-            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
+            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE);
         currentAction = null;
         if (currentHighlightedTerritory != null) {
           getMap().clearTerritoryOverlay(currentHighlightedTerritory);
@@ -134,7 +133,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
       if (!pickedUnits.isEmpty() && !unitChoices.containsAll(pickedUnits)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Invalid Units?!?", "Invalid Units?!?",
-            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
+            JOptionPane.WARNING_MESSAGE);
         currentAction = null;
         pickedUnits.clear();
         setWidgetActivation();
@@ -142,7 +141,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
       if (pickedUnits.size() > Math.max(0, unitsPerPick)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Too Many Units?!?", "Too Many Units?!?",
-            JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
+            JOptionPane.WARNING_MESSAGE);
         currentAction = null;
         pickedUnits.clear();
         setWidgetActivation();
@@ -159,7 +158,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           pickedUnits.addAll(Match.getNMatches(unitChoices, unitsPerPick, Match.always()));
         } else {
           EventThreadJOptionPane.showMessageDialog(parent, "Must Choose Units For This Territory",
-              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
+              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE);
           currentAction = null;
           setWidgetActivation();
           return;
@@ -185,7 +184,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           false, getMap().getUiContext());
       unitChooser.setMaxAndShowMaxButton(unitsPerPick);
       if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
-          JOptionPane.OK_CANCEL_OPTION, new CountDownLatchHandler())) {
+          JOptionPane.OK_CANCEL_OPTION)) {
         pickedUnits.clear();
         pickedUnits.addAll(unitChooser.getSelected());
       }
@@ -214,7 +213,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         if (!territoryChoices.contains(territory)) {
           EventThreadJOptionPane.showMessageDialog(parent,
               "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
-              JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler());
+              JOptionPane.WARNING_MESSAGE);
           return;
         }
         pickedTerritory = territory;

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -751,8 +751,8 @@ public class TripleAFrame extends MainGameFrame {
     if (messageAndDialogThreadPool == null) {
       return;
     }
-    messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialog(TripleAFrame.this, displayMessage,
-        "Error", JOptionPane.ERROR_MESSAGE, true, getUiContext().getCountDownLatchHandler()));
+    messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialogWithScrollPane(TripleAFrame.this,
+        displayMessage, "Error", JOptionPane.ERROR_MESSAGE, getUiContext().getCountDownLatchHandler()));
   }
 
   /**
@@ -782,8 +782,8 @@ public class TripleAFrame extends MainGameFrame {
     }
     final String displayMessage = LocalizeHtml.localizeImgLinksInHtml(message);
     if (messageAndDialogThreadPool != null) {
-      messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialog(TripleAFrame.this,
-          displayMessage, title, JOptionPane.INFORMATION_MESSAGE, true, getUiContext().getCountDownLatchHandler()));
+      messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialogWithScrollPane(TripleAFrame.this,
+          displayMessage, title, JOptionPane.INFORMATION_MESSAGE, getUiContext().getCountDownLatchHandler()));
     }
   }
 

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
-import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
 public final class Util {
@@ -72,7 +71,7 @@ public final class Util {
 
   public static void notifyError(final Component parent, final String message) {
     EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parent), message, "Error",
-        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
+        JOptionPane.ERROR_MESSAGE);
   }
 
   /**

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -72,7 +72,7 @@ public final class Util {
 
   public static void notifyError(final Component parent, final String message) {
     EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parent), message, "Error",
-        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
+        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler());
   }
 
   /**

--- a/src/main/java/games/strategy/util/CountDownLatchHandler.java
+++ b/src/main/java/games/strategy/util/CountDownLatchHandler.java
@@ -29,10 +29,8 @@ public class CountDownLatchHandler {
   }
 
   /**
-   * If "releaseLatchOnInterrupt" was set to true (defaults to false) on construction of this handler, then
-   * interruptLatch will release and
-   * remove the latch.
-   * Otherwise does nothing.
+   * If {@code releaseLatchOnInterrupt} was set to true upon construction of this handler, then this method will release
+   * and remove the latch; otherwise it does nothing.
    */
   public void interruptLatch(final CountDownLatch latch) {
     if (releaseLatchOnInterrupt) {
@@ -70,8 +68,8 @@ public class CountDownLatchHandler {
   }
 
   /**
-   * Add a latch that will be released when this handler shuts down.
-   * If this handler is already shutdown, then we will release the latch immediately.
+   * Add a latch that will be released when this handler shuts down. If this handler is already shutdown, then we will
+   * release the latch immediately.
    */
   public void addShutdownLatch(final CountDownLatch latch) {
     synchronized (this) {

--- a/src/main/java/games/strategy/util/CountDownLatchHandler.java
+++ b/src/main/java/games/strategy/util/CountDownLatchHandler.java
@@ -20,6 +20,10 @@ public class CountDownLatchHandler {
 
   private final boolean releaseLatchOnInterrupt;
 
+  public CountDownLatchHandler() {
+    this(true);
+  }
+
   public CountDownLatchHandler(final boolean releaseLatchOnInterrupt) {
     this.releaseLatchOnInterrupt = releaseLatchOnInterrupt;
   }

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -22,8 +22,14 @@ import com.google.common.annotations.VisibleForTesting;
  * Blocking JOptionPane calls that do their work in the swing event thread (to be thread safe).
  */
 public final class EventThreadJOptionPane {
-  private EventThreadJOptionPane() {
-    // do nothing
+  private EventThreadJOptionPane() {}
+
+  public static void showMessageDialog(
+      final Component parentComponent,
+      final Object message,
+      final String title,
+      final int messageType) {
+    showMessageDialog(parentComponent, message, title, messageType, false, new CountDownLatchHandler());
   }
 
   public static void showMessageDialog(final Component parentComponent, final Object message, final String title,
@@ -39,11 +45,8 @@ public final class EventThreadJOptionPane {
             useJLabel ? createJLabelInScrollPane((String) message) : message, title, messageType));
   }
 
-  public static void showMessageDialog(final Component parentComponent, final Object message,
-      final CountDownLatchHandler latchHandler) {
-    invokeAndWait(
-        latchHandler,
-        () -> JOptionPane.showMessageDialog(parentComponent, message));
+  public static void showMessageDialog(final Component parentComponent, final Object message) {
+    invokeAndWait(new CountDownLatchHandler(), () -> JOptionPane.showMessageDialog(parentComponent, message));
   }
 
   private static void invokeAndWait(final CountDownLatchHandler latchHandler, final Runnable runnable) {
@@ -117,6 +120,14 @@ public final class EventThreadJOptionPane {
         latchHandler,
         () -> JOptionPane.showOptionDialog(parentComponent, message, title, optionType, messageType, icon, options,
             initialValue));
+  }
+
+  public static int showConfirmDialog(
+      final Component parentComponent,
+      final Object message,
+      final String title,
+      final int optionType) {
+    return showConfirmDialog(parentComponent, message, title, optionType, new CountDownLatchHandler());
   }
 
   public static int showConfirmDialog(final Component parentComponent, final Object message, final String title,

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -1,5 +1,7 @@
 package games.strategy.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Toolkit;
@@ -9,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JLabel;
@@ -25,27 +28,40 @@ public final class EventThreadJOptionPane {
   private EventThreadJOptionPane() {}
 
   public static void showMessageDialog(
-      final Component parentComponent,
-      final Object message,
-      final String title,
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
       final int messageType) {
-    showMessageDialog(parentComponent, message, title, messageType, false, new CountDownLatchHandler());
+    showMessageDialog(parentComponent, message, title, messageType, new CountDownLatchHandler());
   }
 
-  public static void showMessageDialog(final Component parentComponent, final Object message, final String title,
-      final int messageType, final CountDownLatchHandler latchHandler) {
+  public static void showMessageDialog(
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
+      final int messageType,
+      final CountDownLatchHandler latchHandler) {
+    checkNotNull(latchHandler);
+
     showMessageDialog(parentComponent, message, title, messageType, false, latchHandler);
   }
 
-  public static void showMessageDialog(final Component parentComponent, final Object message, final String title,
-      final int messageType, final boolean useJLabel, final CountDownLatchHandler latchHandler) {
+  public static void showMessageDialog(
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
+      final int messageType,
+      final boolean useJLabel,
+      final CountDownLatchHandler latchHandler) {
+    checkNotNull(latchHandler);
+
     invokeAndWait(
         latchHandler,
         () -> JOptionPane.showMessageDialog(parentComponent,
             useJLabel ? createJLabelInScrollPane((String) message) : message, title, messageType));
   }
 
-  public static void showMessageDialog(final Component parentComponent, final Object message) {
+  public static void showMessageDialog(final @Nullable Component parentComponent, final @Nullable Object message) {
     invokeAndWait(new CountDownLatchHandler(), () -> JOptionPane.showMessageDialog(parentComponent, message));
   }
 
@@ -68,9 +84,7 @@ public final class EventThreadJOptionPane {
       result.set(supplier.get());
       latch.countDown();
     });
-    if (latchHandler != null) {
-      latchHandler.addShutdownLatch(latch);
-    }
+    latchHandler.addShutdownLatch(latch);
     awaitLatch(latchHandler, latch);
     return result.get();
   }
@@ -103,19 +117,25 @@ public final class EventThreadJOptionPane {
         latch.await();
         done = true;
       } catch (final InterruptedException e) {
-        if (latchHandler != null) {
-          latchHandler.interruptLatch(latch);
-        }
+        latchHandler.interruptLatch(latch);
       }
     }
-    if (latchHandler != null) {
-      latchHandler.removeShutdownLatch(latch);
-    }
+
+    latchHandler.removeShutdownLatch(latch);
   }
 
-  public static int showOptionDialog(final Component parentComponent, final Object message, final String title,
-      final int optionType, final int messageType, final Icon icon, final Object[] options, final Object initialValue,
+  public static int showOptionDialog(
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
+      final int optionType,
+      final int messageType,
+      final @Nullable Icon icon,
+      final @Nullable Object[] options,
+      final @Nullable Object initialValue,
       final CountDownLatchHandler latchHandler) {
+    checkNotNull(latchHandler);
+
     return invokeAndWait(
         latchHandler,
         () -> JOptionPane.showOptionDialog(parentComponent, message, title, optionType, messageType, icon, options,
@@ -123,15 +143,21 @@ public final class EventThreadJOptionPane {
   }
 
   public static int showConfirmDialog(
-      final Component parentComponent,
-      final Object message,
-      final String title,
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
       final int optionType) {
     return showConfirmDialog(parentComponent, message, title, optionType, new CountDownLatchHandler());
   }
 
-  public static int showConfirmDialog(final Component parentComponent, final Object message, final String title,
-      final int optionType, final CountDownLatchHandler latchHandler) {
+  public static int showConfirmDialog(
+      final @Nullable Component parentComponent,
+      final @Nullable Object message,
+      final @Nullable String title,
+      final int optionType,
+      final CountDownLatchHandler latchHandler) {
+    checkNotNull(latchHandler);
+
     return invokeAndWait(
         latchHandler,
         () -> JOptionPane.showConfirmDialog(parentComponent, message, title, optionType));

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -27,6 +27,12 @@ import com.google.common.annotations.VisibleForTesting;
 public final class EventThreadJOptionPane {
   private EventThreadJOptionPane() {}
 
+  /**
+   * Shows a message dialog using a {@code CountDownLatchHandler} that will release its associated latches upon
+   * interruption.
+   *
+   * @see JOptionPane#showMessageDialog(Component, Object, String, int)
+   */
   public static void showMessageDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,
@@ -35,6 +41,13 @@ public final class EventThreadJOptionPane {
     showMessageDialog(parentComponent, message, title, messageType, new CountDownLatchHandler());
   }
 
+  /**
+   * Shows a message dialog using the specified {@code CountDownLatchHandler}.
+   *
+   * @param latchHandler The handler with which to associate the latch used to await the dialog.
+   *
+   * @see JOptionPane#showMessageDialog(Component, Object, String, int)
+   */
   public static void showMessageDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,
@@ -46,6 +59,16 @@ public final class EventThreadJOptionPane {
     showMessageDialog(parentComponent, message, title, messageType, false, latchHandler);
   }
 
+  /**
+   * Shows a message dialog using the specified {@code CountDownLatchHandler} and with the option to embed the
+   * {@code message} in a scrollable {@code JLabel}.
+   *
+   * @param useJLabel {@code true} to embed the {@code message}, which must be a {@code String}, in a scrollable
+   *        {@code JLabel}; otherwise {@code false} to display the {@code message} unmodified.
+   * @param latchHandler The handler with which to associate the latch used to await the dialog.
+   *
+   * @see JOptionPane#showMessageDialog(Component, Object, String, int)
+   */
   public static void showMessageDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,
@@ -61,6 +84,12 @@ public final class EventThreadJOptionPane {
             useJLabel ? createJLabelInScrollPane((String) message) : message, title, messageType));
   }
 
+  /**
+   * Shows a message dialog using a {@code CountDownLatchHandler} that will release its associated latches upon
+   * interruption.
+   *
+   * @see JOptionPane#showMessageDialog(Component, Object)
+   */
   public static void showMessageDialog(final @Nullable Component parentComponent, final @Nullable Object message) {
     invokeAndWait(new CountDownLatchHandler(), () -> JOptionPane.showMessageDialog(parentComponent, message));
   }
@@ -124,6 +153,13 @@ public final class EventThreadJOptionPane {
     latchHandler.removeShutdownLatch(latch);
   }
 
+  /**
+   * Shows an option dialog using the specified {@code CountDownLatchHandler}.
+   *
+   * @param latchHandler The handler with which to associate the latch used to await the dialog.
+   *
+   * @see JOptionPane#showOptionDialog(Component, Object, String, int, int, Icon, Object[], Object)
+   */
   public static int showOptionDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,
@@ -142,6 +178,12 @@ public final class EventThreadJOptionPane {
             initialValue));
   }
 
+  /**
+   * Shows a confirmation dialog using a {@code CountDownLatchHandler} that will release its associated latches upon
+   * interruption.
+   *
+   * @see JOptionPane#showConfirmDialog(Component, Object, String, int)
+   */
   public static int showConfirmDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,
@@ -150,6 +192,13 @@ public final class EventThreadJOptionPane {
     return showConfirmDialog(parentComponent, message, title, optionType, new CountDownLatchHandler());
   }
 
+  /**
+   * Shows a confirmation dialog using the specified {@code CountDownLatchHandler}.
+   *
+   * @param latchHandler The handler with which to associate the latch used to await the dialog.
+   *
+   * @see JOptionPane#showConfirmDialog(Component, Object, String, int)
+   */
   public static int showConfirmDialog(
       final @Nullable Component parentComponent,
       final @Nullable Object message,

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -82,15 +82,6 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRunSuccessfullyWhenLatchHandlerIsNull() {
-    final Object expectedResult = new Object();
-
-    final Object actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> Optional.of(expectedResult)).get();
-
-    assertThat(actualResult, is(expectedResult));
-  }
-
-  @Test
   public void testInvokeAndWaitWithIntSupplier_ShouldReturnIntSupplierResult() {
     final int expectedResult = 42;
 

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -26,7 +26,7 @@ public final class EventThreadJOptionPaneTest {
   public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
 
   @Spy
-  private final CountDownLatchHandler latchHandler = new CountDownLatchHandler(true);
+  private final CountDownLatchHandler latchHandler = new CountDownLatchHandler();
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread()


### PR DESCRIPTION
While recently fixing the thread safety issues in `CountDownLatchHandler` (#2245), I noticed some improvements that could be made to simplify the usage of this class.

#### Functional changes

None.

#### Refactoring changes

##### Add default `CountDownLatchHandler` constructor

All but one call to the `CountDownLatchHandler` constructor passes `true` for the `releaseLatchOnInterrupt` parameter.  I added a default constructor that sets `releaseLatchOnInterrupt` to `true` to cover this apparently near-universal use case.

##### Add `EventThreadJOptionPane` overloads that do not require a `CountDownLatchHandler`

There are only two sources for `CountDownLatchHandler` parameters to the various `EventThreadJOptionPane` methods:

1. Create a new instance at the call site.
1. Use the instance from `IUIContext#getCountDownLatchHandler()`.

To simplify case (1), I added additional overloads to `EventThreadJOptionPane` that automatically create the `CountDownLatchHandler` instance instead of requiring it to be passed in.  This decoupled a lot of code from having any knowledge of `CountDownLatchHandler`.

##### Nullity annotations

I added annotations to the public methods in `EventThreadJOptionPane` to document which parameters can and cannot be `null`.  At this time, I confirmed that no `CountDownLatchHandler` parameter will ever be `null`.  Given the two possible sources above, the only potentially `null` value would be that returned by `IUIContext#getCountDownLatchHandler()`.  However, the only implementation of this method in `AbstractUIContext` will always return a non-`null` value.  Therefore, I was able to remove all the `null` checks we performed on the `CountDownLatchHandler` parameters.

##### Javadocs

I updated some existing Javadocs and added missing Javadocs in the classes that were modified.