### PR TITLE
Requires units to move check starting territory

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -658,7 +658,7 @@ public class MoveValidator {
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
       // Check requiresUnitsToMove conditions
-      for (final Territory t : route.getSteps()) {
+      for (final Territory t : route.getAllTerritories()) {
         if (!Match.allMatch(units, Matches.unitHasRequiredUnitsToMove(t))) {
           return result.setErrorReturnResult(
               t.getName() + " doesn't have the required units to allow moving the selected units into it");

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -150,8 +150,14 @@ public class MoveValidatorTest extends DelegateTest {
         new HashMap<>(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
-    // Add germanRail to destination so move succeeds
+    // Add germanRail to only destination so it fails
     addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, twwGameData);
+    assertFalse(results.isMoveValid());
+
+    // Add germanRail to start so move succeeds
+    addTo(berlin, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());


### PR DESCRIPTION
Have requiresUnitsToMove check starting territory as well as all steps in route. This makes more logical sense as this feature is primarily used for rails/roads/etc which need to be in all territories in route including start territory.