### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 10)

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -155,7 +155,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     boolean ownsLand = false;
     for (final Territory t : data.getMap().getTerritories()) {
       if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this),
-          Matches.unitHasAttackValueOfAtLeast(1), Matches.unitCanMove(), Matches.UnitIsLand))) {
+          Matches.unitHasAttackValueOfAtLeast(1), Matches.unitCanMove(), Matches.unitIsLand()))) {
         return true;
       }
       if (t.getOwner().equals(this)) {

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -404,7 +404,7 @@ public class TripleAUnit extends Unit {
         Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player),
         Matches.unitIsBeingTransported().invert());
     if (producer.isWater()) {
-      factoryMatchBuilder.add(Matches.UnitIsLand.invert());
+      factoryMatchBuilder.add(Matches.unitIsLand().invert());
     } else {
       factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -298,7 +298,7 @@ public class ProAI extends AbstractAI {
         + attackers.size() + ", defenders=" + defenders.size() + ", submerge=" + submerge + ", attacker=" + isAttacker
         + ", isStrafing=" + isStrafing);
     if ((isStrafing || (isAttacker && strengthDifference > 50))
-        && (battleTerritory.isWater() || Match.anyMatch(attackers, Matches.UnitIsLand))) {
+        && (battleTerritory.isWater() || Match.anyMatch(attackers, Matches.unitIsLand()))) {
       return null;
     }
     calc.setData(getGameData());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -549,7 +549,7 @@ class ProCombatMoveAI {
       final boolean hasAlliedLandUnits = Match.anyMatch(t.getUnits().getUnits(),
           ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
       final Set<Territory> enemyNeighbors = data.getMap().getNeighbors(t,
-          Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.UnitIsLand));
+          Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.unitIsLand()));
       enemyNeighbors.removeAll(territoriesToAttack);
       if (!t.isWater() && !hasAlliedLandUnits && !enemyNeighbors.isEmpty()) {
         int minCost = Integer.MAX_VALUE;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -304,7 +304,7 @@ class ProNonCombatMoveAI {
 
     // Set unit with the fewest move options in each territory
     for (final Unit unit : sortedUnitMoveOptions.keySet()) {
-      if (Matches.UnitIsLand.match(unit)) {
+      if (Matches.unitIsLand().match(unit)) {
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
           final int unitValue = ProData.unitValueMap.getInt(unit.getType());
           int production = 0;
@@ -504,7 +504,7 @@ class ProNonCombatMoveAI {
               .territoryHasNeighborOwnedByAndHasLandUnit(data, ProUtils.getPotentialEnemyPlayers(player))
               .match(t);
       final boolean isNotFactoryAndOnlyAmphib = !t.isWater() && !hasFactory
-          && Match.noneMatch(moveMap.get(t).getMaxUnits(), Matches.UnitIsLand) && cantMoveUnitValue < 5;
+          && Match.noneMatch(moveMap.get(t).getMaxUnits(), Matches.unitIsLand()) && cantMoveUnitValue < 5;
       if (!patd.isCanHold() || patd.getValue() <= 0 || isLandAndCanOnlyBeAttackedByAir || isNotFactoryAndShouldHold
           || canAlreadyBeHeld || isNotFactoryAndHasNoEnemyNeighbors || isNotFactoryAndOnlyAmphib) {
         final double tuvSwing = minResult.getTUVSwing();
@@ -1584,7 +1584,7 @@ class ProNonCombatMoveAI {
     // TODO: consider if territory ends up being safe
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext();) {
       final Unit u = it.next();
-      if (Matches.UnitIsLand.match(u)) {
+      if (Matches.unitIsLand().match(u)) {
         Territory maxValueTerritory = null;
         double maxValue = 0;
         int maxNeedAmphibUnitValue = Integer.MIN_VALUE;
@@ -1661,7 +1661,7 @@ class ProNonCombatMoveAI {
         ProMatches.territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(player, data)));
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext();) {
       final Unit u = it.next();
-      if (Matches.UnitIsLand.match(u)) {
+      if (Matches.unitIsLand().match(u)) {
         int minDistance = Integer.MAX_VALUE;
         Territory minTerritory = null;
         for (final Territory t : unitMoveMap.get(u)) {
@@ -1692,7 +1692,7 @@ class ProNonCombatMoveAI {
     // Move any remaining land units to safest territory (this is rarely used)
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext();) {
       final Unit u = it.next();
-      if (Matches.UnitIsLand.match(u)) {
+      if (Matches.unitIsLand().match(u)) {
 
         // Get all units that have already moved
         final List<Unit> alreadyMovedUnits = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -712,7 +712,7 @@ class ProPurchaseAI {
 
       // Check if territory needs AA
       final boolean enemyCanBomb =
-          Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
+          Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.unitIsStrategicBomber());
       final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged());
       final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly());
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -535,7 +535,7 @@ final class ProTechAI {
       return null;
     }
     final Match<Unit> sub = Match.allOf(Matches.unitIsSub().invert());
-    final Match<Unit> transport = Match.allOf(Matches.unitIsTransport().invert(), Matches.UnitIsLand.invert());
+    final Match<Unit> transport = Match.allOf(Matches.unitIsTransport().invert(), Matches.unitIsLand().invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.unitIsInfrastructure().invert(),
         Matches.alliedUnit(player, data).invert());

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -86,8 +86,8 @@ public class ProOtherMoveOptions {
           }
           final double currentStrength =
               ProBattleUtils.estimateStrength(t, new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
-          final boolean currentHasLandUnits = Match.anyMatch(currentUnits, Matches.UnitIsLand);
-          final boolean maxHasLandUnits = Match.anyMatch(maxUnits, Matches.UnitIsLand);
+          final boolean currentHasLandUnits = Match.anyMatch(currentUnits, Matches.unitIsLand());
+          final boolean maxHasLandUnits = Match.anyMatch(maxUnits, Matches.unitIsLand());
           if ((currentHasLandUnits && ((!maxHasLandUnits && !t.isWater()) || currentStrength > maxStrength))
               || ((!maxHasLandUnits || t.isWater()) && currentStrength > maxStrength)) {
             result.put(t, moveMap.get(t));

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -415,7 +415,7 @@ public class ProTerritoryManager {
 
   private void findBombingOptions() {
     for (final Unit unit : attackOptions.getUnitMoveMap().keySet()) {
-      if (Matches.UnitIsStrategicBomber.match(unit)) {
+      if (Matches.unitIsStrategicBomber().match(unit)) {
         attackOptions.getBomberMoveMap().put(unit, new HashSet<>(attackOptions.getUnitMoveMap().get(unit)));
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -258,7 +258,7 @@ public class ProMatches {
   public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
       final List<PlayerID> players) {
     final Match<Territory> territoryMatch = Match.allOf(Matches.isTerritoryOwnedBy(players),
-        Matches.territoryHasUnitsThatMatch(Matches.UnitIsLand));
+        Matches.territoryHasUnitsThatMatch(Matches.unitIsLand()));
     return Matches.territoryHasNeighborMatching(data, territoryMatch);
   }
 
@@ -312,7 +312,7 @@ public class ProMatches {
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
       final GameData data, final List<Territory> territoriesThatCantBeHeld) {
-    final Match<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
+    final Match<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsLand());
     final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
         Match.allOf(Matches.territoryIsLand(),
             Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
@@ -365,7 +365,7 @@ public class ProMatches {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsLand(),
           Matches.unitIsBeingTransported().invert());
       return match.match(u);
     });
@@ -424,7 +424,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
+    return Match.allOf(Matches.unitIsLand(), Matches.isUnitAllied(player, data),
         Matches.unitIsNotInfrastructure());
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -80,7 +80,7 @@ public class ProMoveUtils {
           // Sea unit (including carriers with planes)
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
               ProMatches.territoryCanMoveSeaUnitsThrough(player, data, isCombatMove));
-        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsLand)) {
+        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.unitIsLand())) {
 
           // Land unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t, ProMatches

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -160,7 +160,7 @@ public class ProOddsCalculator {
     territoryList.add(t);
     if (!territoryList.isEmpty() && Match.allMatch(territoryList, Matches.territoryIsLand())) {
       return new ProBattleResult(winPercentage, tuvSwing,
-          Match.anyMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
+          Match.anyMatch(averageAttackersRemaining, Matches.unitIsLand()), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());
     } else {
       return new ProBattleResult(winPercentage, tuvSwing, !averageAttackersRemaining.isEmpty(),

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -260,7 +260,7 @@ public class ProPurchaseUtils {
         Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player),
         Matches.unitIsBeingTransported().invert());
     if (territory.isWater()) {
-      factoryMatchBuilder.add(Matches.UnitIsLand.invert());
+      factoryMatchBuilder.add(Matches.unitIsLand().invert());
     } else {
       factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -213,7 +213,7 @@ public class WeakAI extends AbstractAI {
     }
     final Territory lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Territory landOn = amphibRoute.getEnd();
-    final Match<Unit> landAndOwned = Match.allOf(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> landAndOwned = Match.allOf(Matches.unitIsLand(), Matches.unitIsOwnedBy(player));
     final List<Unit> units = lastSeaZoneOnAmphib.getUnits().getMatches(landAndOwned);
     if (units.size() > 0) {
       // just try to make the move, the engine will stop us if it doesnt work
@@ -308,7 +308,7 @@ public class WeakAI extends AbstractAI {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
         // land units, move all towards the end point
-        if (t.getUnits().anyMatch(Matches.UnitIsLand)) {
+        if (t.getUnits().anyMatch(Matches.unitIsLand())) {
           // move along amphi route
           if (lastSeaZoneOnAmphib != null) {
             // two move route to end
@@ -372,7 +372,7 @@ public class WeakAI extends AbstractAI {
         final Collection<Territory> attackFrom = data.getMap().getNeighbors(enemy, Matches.territoryIsWater());
         for (final Territory owned : attackFrom) {
           // dont risk units we are carrying
-          if (owned.getUnits().anyMatch(Matches.UnitIsLand)) {
+          if (owned.getUnits().anyMatch(Matches.unitIsLand())) {
             dontMoveFrom.add(owned);
             continue;
           }
@@ -451,7 +451,7 @@ public class WeakAI extends AbstractAI {
           // we can never move factories
           Matches.unitCanMove(),
           Matches.unitIsNotInfrastructure(),
-          Matches.UnitIsLand);
+          Matches.unitIsLand());
       final Match<Territory> moveThrough =
           Match.allOf(Matches.territoryIsImpassable().invert(),
               Matches.territoryIsNeutralButNotWater().invert(), Matches.territoryIsLand());
@@ -611,7 +611,7 @@ public class WeakAI extends AbstractAI {
           final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnits().getUnits());
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
-            final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
+            final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsLand(),
                 Matches.unitIsNotInfrastructure(), Matches.unitCanMove(), Matches.unitIsNotAa(),
                 Matches.unitCanNotMoveDuringCombatMove().invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
@@ -641,7 +641,7 @@ public class WeakAI extends AbstractAI {
       if (enemyStrength > 0) {
         final Match<Unit> attackable = Match.allOf(
             Matches.unitIsOwnedBy(player),
-            Matches.UnitIsStrategicBomber.invert(),
+            Matches.unitIsStrategicBomber().invert(),
             Match.of(o -> !unitsAlreadyMoved.contains(o)),
             Matches.unitIsNotAa(),
             Matches.unitCanMove(),
@@ -697,7 +697,7 @@ public class WeakAI extends AbstractAI {
       final List<Route> moveRoutes, final PlayerID player) {
     final Match<Territory> enemyFactory = Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player,
         Matches.unitCanProduceUnitsAndCanBeDamaged());
-    final Match<Unit> ownBomber = Match.allOf(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownBomber = Match.allOf(Matches.unitIsStrategicBomber(), Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> bombers = t.getUnits().getMatches(ownBomber);
       if (bombers.isEmpty()) {
@@ -720,7 +720,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countLandUnits(final GameData data, final PlayerID player) {
-    final Match<Unit> ownedLandUnit = Match.allOf(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedLandUnit = Match.allOf(Matches.unitIsLand(), Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedLandUnit);
@@ -1045,7 +1045,7 @@ public class WeakAI extends AbstractAI {
         doPlace(seaPlaceAt, toPlace, placeDelegate);
       }
     }
-    final List<Unit> landUnits = new ArrayList<>(player.getUnits().getMatches(Matches.UnitIsLand));
+    final List<Unit> landUnits = new ArrayList<>(player.getUnits().getMatches(Matches.unitIsLand()));
     if (!landUnits.isEmpty()) {
       final int landPlaceCount = Math.min(placementLeft, landUnits.size());
       placementLeft -= landPlaceCount;

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -869,7 +869,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     final Collection<Unit> units = new ArrayList<>(allUnits);
     // if water, remove land. if land, remove water.
-    units.removeAll(Match.getMatches(units, water ? Matches.UnitIsLand : Matches.unitIsSea()));
+    units.removeAll(Match.getMatches(units, water ? Matches.unitIsLand() : Matches.unitIsSea()));
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> allProducedUnits = unitsPlacedInTerritorySoFar(to);
@@ -879,7 +879,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
     // we add factories and constructions later
     if (water || wasFactoryThereAtStart || (!water && isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player))) {
-      final Match<Unit> seaOrLandMatch = water ? Matches.unitIsSea() : Matches.UnitIsLand;
+      final Match<Unit> seaOrLandMatch = water ? Matches.unitIsSea() : Matches.unitIsLand();
       placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.unitIsNotConstruction())));
       if (!water) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction())));
@@ -1076,7 +1076,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player),
         Matches.unitIsBeingTransported().invert());
     if (producer.isWater()) {
-      factoryMatchBuilder.add(Matches.UnitIsLand.invert());
+      factoryMatchBuilder.add(Matches.unitIsLand().invert());
     } else {
       factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }
@@ -1558,7 +1558,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // land, and like sea if
     // in water.
     if (to.isWater()) {
-      factoryMatchBuilder.add(Matches.UnitIsLand.invert());
+      factoryMatchBuilder.add(Matches.unitIsLand().invert());
     } else {
       factoryMatchBuilder.add(Matches.unitIsSea().invert());
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -116,7 +116,7 @@ public class AirBattle extends AbstractBattle {
 
   private boolean shouldFightAirBattle() {
     if (m_isBombingRun) {
-      return Match.anyMatch(m_attackingUnits, Matches.UnitIsStrategicBomber) && !m_defendingUnits.isEmpty();
+      return Match.anyMatch(m_attackingUnits, Matches.unitIsStrategicBomber()) && !m_defendingUnits.isEmpty();
     } else {
       return !m_attackingUnits.isEmpty() && !m_defendingUnits.isEmpty();
     }
@@ -301,7 +301,7 @@ public class AirBattle extends AbstractBattle {
     // so we do not have to create normal battles, only bombing raids
     // setup new battle here
     if (m_isBombingRun) {
-      final Collection<Unit> bombers = Match.getMatches(m_attackingUnits, Matches.UnitIsStrategicBomber);
+      final Collection<Unit> bombers = Match.getMatches(m_attackingUnits, Matches.unitIsStrategicBomber());
       if (!bombers.isEmpty()) {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
@@ -348,7 +348,7 @@ public class AirBattle extends AbstractBattle {
     final String text;
     if (!m_attackingUnits.isEmpty()) {
       if (m_isBombingRun) {
-        if (Match.anyMatch(m_attackingUnits, Matches.UnitIsStrategicBomber)) {
+        if (Match.anyMatch(m_attackingUnits, Matches.unitIsStrategicBomber())) {
           m_whoWon = WhoWon.ATTACKER;
           if (m_defendingUnits.isEmpty()) {
             m_battleResultDescription = BattleRecord.BattleResultDescription.WON_WITHOUT_CONQUERING;

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -586,7 +586,7 @@ public class BattleCalculator {
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
     final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
-    final Match<Unit> match = Match.allOf(Matches.UnitIsLand, Matches.unitWasNotAmphibious());
+    final Match<Unit> match = Match.allOf(Matches.unitIsLand(), Matches.unitWasNotAmphibious());
     killedNonAmphibUnits.addAll(Match.getMatches(killed, match));
     // If all killed units are amphibious, just return them
     if (killedNonAmphibUnits.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -484,7 +484,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         attackingUnitsNeedToBeAdded.removeAll(battle.getAttackingUnits());
         attackingUnitsNeedToBeAdded.removeAll(battle.getDependentUnits(battle.getAttackingUnits()));
         if (territory.isWater()) {
-          attackingUnitsNeedToBeAdded = Match.getMatches(attackingUnitsNeedToBeAdded, Matches.UnitIsLand.invert());
+          attackingUnitsNeedToBeAdded = Match.getMatches(attackingUnitsNeedToBeAdded, Matches.unitIsLand().invert());
         } else {
           attackingUnitsNeedToBeAdded = Match.getMatches(attackingUnitsNeedToBeAdded, Matches.unitIsSea().invert());
         }

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -314,7 +314,7 @@ public class BattleTracker implements Serializable {
       if (changeTracker != null) {
         changeTracker.addChange(change);
       }
-      if (Match.anyMatch(units, Matches.UnitIsLand)
+      if (Match.anyMatch(units, Matches.unitIsLand())
           || Match.anyMatch(units, Matches.unitIsSea())) {
         addEmptyBattle(route, units, id, bridge, changeTracker, unitsNotUnloadedTilEndOfRoute);
       }
@@ -496,7 +496,7 @@ public class BattleTracker implements Serializable {
       int totalMatches = 0;
       // Total Attacking Sea units = all units - land units - air units - submerged subs
       // Also subtract transports & subs (if they can't control sea zones)
-      totalMatches = arrivedUnits.size() - Match.countMatches(arrivedUnits, Matches.UnitIsLand)
+      totalMatches = arrivedUnits.size() - Match.countMatches(arrivedUnits, Matches.unitIsLand())
           - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
           - Match.countMatches(arrivedUnits, Matches.unitIsSubmerged());
       // If transports are restricted from controlling sea zones, subtract them
@@ -733,7 +733,7 @@ public class BattleTracker implements Serializable {
     // if the territory being taken over is water, then do not say any land units were in combat
     // (they may want to unload from the transport and attack)
     if (Matches.territoryIsWater().match(territory) && arrivedUnits != null) {
-      arrivedUnits.removeAll(Match.getMatches(arrivedUnits, Matches.UnitIsLand));
+      arrivedUnits.removeAll(Match.getMatches(arrivedUnits, Matches.unitIsLand()));
     }
     markWasInCombat(arrivedUnits, bridge, changeTracker);
   }
@@ -881,7 +881,7 @@ public class BattleTracker implements Serializable {
     // make amphibious assaults dependent on possible naval invasions
     // its only a dependency if we are unloading
     final IBattle precede = getDependentAmphibiousAssault(route);
-    if (precede != null && Match.anyMatch(units, Matches.UnitIsLand)) {
+    if (precede != null && Match.anyMatch(units, Matches.unitIsLand())) {
       addDependency(battle, precede);
     }
     // dont let land battles in the same territory occur before bombing

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -36,7 +36,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final PlayerID player) {
     // we can place if no enemy units and its water
     if (to.isWater()) {
-      if (Match.anyMatch(units, Matches.UnitIsLand)) {
+      if (Match.anyMatch(units, Matches.unitIsLand())) {
         return "Cant place land units at sea";
       } else if (to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
         return "Cant place in sea zone containing enemy units";
@@ -115,7 +115,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final Match<Unit> groundUnits =
         // we add factories and constructions later
-        Match.allOf(Matches.UnitIsLand, Matches.unitIsNotConstruction());
+        Match.allOf(Matches.unitIsLand(), Matches.unitIsNotConstruction());
     final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction());
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -83,7 +83,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     Map<Unit, Unit> mapLoading = null;
     if (territory.isWater()) {
       if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSea())) {
-        if (Match.anyMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.unitIsLand())) {
           // this should be exact same as the one in the EditValidator
           if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
@@ -91,7 +91,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
           final Match<Unit> friendlySeaTransports =
               Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
-          final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
+          final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.unitIsLand());
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -70,14 +70,14 @@ class EditValidator {
     // check land/water sanity
     if (territory.isWater()) {
       if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSea())) {
-        if (Match.anyMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.unitIsLand())) {
           if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
               Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
-          final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
+          final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.unitIsLand());
           if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }

--- a/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -82,9 +82,9 @@ public class FinishedBattle extends AbstractBattle {
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.anyMatch(units, Matches.UnitIsLand)) {
+        && Match.anyMatch(units, Matches.unitIsLand())) {
       m_amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
-      m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.UnitIsLand));
+      m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.unitIsLand()));
       m_isAmphibious = true;
     }
     return ChangeFactory.EMPTY_CHANGE;
@@ -109,12 +109,12 @@ public class FinishedBattle extends AbstractBattle {
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
-        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.unitIsLand())) {
+        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.unitIsLand()));
       }
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
-      if (Match.noneMatch(attackingFromMapUnits, Matches.UnitIsLand)) {
+      if (Match.noneMatch(attackingFromMapUnits, Matches.unitIsLand())) {
         m_amphibiousAttackFrom.remove(attackingFrom);
         // do we have any amphibious attacks left?
         m_isAmphibious = !m_amphibiousAttackFrom.isEmpty();

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -123,12 +123,12 @@ public class InitializationDelegate extends BaseTripleADelegate {
         continue;
       }
       final Collection<Unit> units = current.getUnits().getUnits();
-      if (units.size() == 0 || !Match.anyMatch(units, Matches.UnitIsLand)) {
+      if (units.size() == 0 || !Match.anyMatch(units, Matches.unitIsLand())) {
         continue;
       }
       // map transports, try to fill
       final Collection<Unit> transports = Match.getMatches(units, Matches.unitIsTransport());
-      final Collection<Unit> land = Match.getMatches(units, Matches.UnitIsLand);
+      final Collection<Unit> land = Match.getMatches(units, Matches.unitIsLand());
       for (final Unit toLoad : land) {
         final UnitAttachment ua = UnitAttachment.get(toLoad.getType());
         final int cost = ua.getTransportCost();

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -181,11 +181,12 @@ public final class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsStrategicBomber =
-      Match.of(obj -> unitTypeIsStrategicBomber().match(obj.getType()));
+  public static Match<Unit> unitIsStrategicBomber() {
+    return Match.of(obj -> unitTypeIsStrategicBomber().match(obj.getType()));
+  }
 
   static Match<Unit> unitIsNotStrategicBomber() {
-    return UnitIsStrategicBomber.invert();
+    return unitIsStrategicBomber().invert();
   }
 
   static final Match<UnitType> unitTypeCanLandOnCarrier() {
@@ -1453,7 +1454,7 @@ public final class Matches {
   }
 
   public static Match<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
-    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(unitIsOwnedBy(player), UnitIsLand)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(unitIsOwnedBy(player), unitIsLand())));
   }
 
   public static Match<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
@@ -1487,7 +1488,7 @@ public final class Matches {
   }
 
   public static Match<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), UnitIsLand)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), unitIsLand())));
   }
 
   public static Match<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
@@ -1599,14 +1600,16 @@ public final class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), unitIsNotAir());
+  public static Match<Unit> unitIsLand() {
+    return Match.allOf(unitIsNotSea(), unitIsNotAir());
+  }
 
   public static Match<UnitType> unitTypeIsLand() {
     return Match.allOf(unitTypeIsNotSea(), unitTypeIsNotAir());
   }
 
   public static Match<Unit> unitIsNotLand() {
-    return UnitIsLand.invert();
+    return unitIsLand().invert();
   }
 
   public static Match<Unit> unitIsOfType(final UnitType type) {
@@ -1646,7 +1649,7 @@ public final class Matches {
   public static Match<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
     final Match<Unit> sub = Match.allOf(Matches.unitIsSub().invert());
     final Match<Unit> transport =
-        Match.allOf(Matches.unitIsTransportButNotCombatTransport().invert(), Matches.UnitIsLand.invert());
+        Match.allOf(Matches.unitIsTransportButNotCombatTransport().invert(), Matches.unitIsLand().invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.unitIsInfrastructure().invert(),
         Matches.alliedUnit(player, data).invert());
@@ -1709,7 +1712,7 @@ public final class Matches {
         return true;
       }
       if (Matches.unitIsSea().match(damagedUnit)) {
-        final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);
+        final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.unitIsLand());
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.territoryIsLand()));
         for (final Territory current : neighbors) {
@@ -1717,7 +1720,7 @@ public final class Matches {
             return true;
           }
         }
-      } else if (Matches.UnitIsLand.match(damagedUnit)) {
+      } else if (Matches.unitIsLand().match(damagedUnit)) {
         final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.unitIsSea());
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.territoryIsWater()));
@@ -1772,7 +1775,7 @@ public final class Matches {
         return true;
       }
       if (Matches.unitIsSea().match(unitWhichWillGetBonus)) {
-        final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.UnitIsLand);
+        final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.unitIsLand());
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.territoryIsLand()));
         for (final Territory current : neighbors) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -241,7 +241,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     moveableUnitOwnedByMeBuilder.add(Match.anyOf(
         Matches.unitHasMovementLeft(),
         Match.allOf(
-            Matches.UnitIsLand,
+            Matches.unitIsLand(),
             Matches.unitIsBeingTransported())));
 
     // if not non combat, cannot move aa units
@@ -367,13 +367,13 @@ public class MoveDelegate extends AbstractMoveDelegate {
               Matches.unitCanGiveBonusMovementToThisUnit(u));
           givesBonusUnits.addAll(Match.getMatches(t.getUnits().getUnits(), givesBonusUnit));
           if (Matches.unitIsSea().match(u)) {
-            final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.UnitIsLand);
+            final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.unitIsLand());
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsLand()));
             for (final Territory current : neighbors) {
               givesBonusUnits.addAll(Match.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
             }
-          } else if (Matches.UnitIsLand.match(u)) {
+          } else if (Matches.unitIsLand().match(u)) {
             final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.unitIsSea());
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsWater()));
@@ -481,13 +481,13 @@ public class MoveDelegate extends AbstractMoveDelegate {
         Matches.unitCanRepairOthers(), Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
     if (Matches.unitIsSea().match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);
+      final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.unitIsLand());
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.territoryIsLand()));
       for (final Territory current : neighbors) {
         repairUnitsForThisUnit.addAll(current.getUnits().getMatches(repairUnitLand));
       }
-    } else if (Matches.UnitIsLand.match(unitToBeRepaired)) {
+    } else if (Matches.unitIsLand().match(unitToBeRepaired)) {
       final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.unitIsSea());
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.territoryIsWater()));

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -174,7 +174,7 @@ public class MovePerformer implements Serializable {
               Match.allOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
                   Matches.unitIsBeingTransported().invert()));
           final Match.CompositeBuilder<Unit> allBombingRaidBuilder = Match.newCompositeBuilder(
-              Matches.UnitIsStrategicBomber);
+              Matches.unitIsStrategicBomber());
           final boolean canCreateAirBattle =
               !enemyTargetsTotal.isEmpty()
                   && Properties.getRaidsMayBePreceededByAirBattles(data)
@@ -186,7 +186,7 @@ public class MovePerformer implements Serializable {
           final Collection<Unit> enemyTargets =
               Match.getMatches(enemyTargetsTotal,
                   Matches.unitIsOfTypes(UnitAttachment
-                      .getAllowedBombingTargetsIntersection(Match.getMatches(arrived, Matches.UnitIsStrategicBomber),
+                      .getAllowedBombingTargetsIntersection(Match.getMatches(arrived, Matches.unitIsStrategicBomber()),
                           data)));
           final boolean targetsOrEscort = !enemyTargets.isEmpty()
               || (!enemyTargetsTotal.isEmpty() && canCreateAirBattle
@@ -338,7 +338,7 @@ public class MovePerformer implements Serializable {
     // if entered a non blitzed conquered territory, mark with 0 movement
     if (GameStepPropertiesHelper.isCombatMove(data)
         && (MoveDelegate.getEmptyNeutral(route).size() != 0 || hasConqueredNonBlitzed(route))) {
-      for (final Unit unit : Match.getMatches(units, Matches.UnitIsLand)) {
+      for (final Unit unit : Match.getMatches(units, Matches.unitIsLand())) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -161,7 +161,7 @@ public class MoveValidator {
       // make sure we avoid land
       // territories owned by nations with these 2 relationship type attachment options
       for (final Territory t : landOnRoute) {
-        if (Match.anyMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.unitIsLand())) {
           if (!data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(player, t.getOwner())) {
             result.setError(player.getName() + " may not move land units over land owned by " + t.getOwner().getName());
             return result;
@@ -314,7 +314,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
-    if (Match.anyMatch(units, Matches.UnitIsLand) && route.hasSteps()) {
+    if (Match.anyMatch(units, Matches.unitIsLand()) && route.hasSteps()) {
       // check all the territories but the end, if there are enemy territories, make sure they are blitzable
       // if they are not blitzable, or we aren't all blitz units fail
       int enemyCount = 0;
@@ -785,10 +785,10 @@ public class MoveValidator {
         Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsSub(), Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOnly =
         Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsTransportButNotCombatTransport(),
-            Matches.UnitIsLand, Matches.enemyUnit(player, data).invert());
+            Matches.unitIsLand(), Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOrSubOnly =
         Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsTransportButNotCombatTransport(),
-            Matches.UnitIsLand, Matches.unitIsSub(), Matches.enemyUnit(player, data).invert());
+            Matches.unitIsLand(), Matches.unitIsSub(), Matches.enemyUnit(player, data).invert());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
     boolean validMove = false;
@@ -1050,8 +1050,8 @@ public class MoveValidator {
     }
     // if we are land make sure no water in route except for transport
     // situations
-    final Collection<Unit> land = Match.getMatches(units, Matches.UnitIsLand);
-    final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.UnitIsLand, Matches.UnitIsAir));
+    final Collection<Unit> land = Match.getMatches(units, Matches.unitIsLand());
+    final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.unitIsLand(), Matches.UnitIsAir));
     // make sure we can be transported
     final Match<Unit> cantBeTransported = Matches.unitCanBeTransported().invert();
     for (final Unit unit : Match.getMatches(land, cantBeTransported)) {
@@ -1203,11 +1203,11 @@ public class MoveValidator {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
-    if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsLand))) {
+    if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.unitIsLand()))) {
       return true;
     }
     for (final Unit unit : Match.getMatches(units, Matches.unitIsNotAirTransportable())) {
-      if (Matches.UnitIsLand.match(unit)) {
+      if (Matches.unitIsLand().match(unit)) {
         return true;
       }
     }
@@ -1484,7 +1484,7 @@ public class MoveValidator {
    */
   public static Route getBestRoute(final Territory start, final Territory end, final GameData data,
       final PlayerID player, final Collection<Unit> units, final boolean forceLandOrSeaRoute) {
-    final boolean hasLand = Match.anyMatch(units, Matches.UnitIsLand);
+    final boolean hasLand = Match.anyMatch(units, Matches.unitIsLand());
     final boolean hasAir = Match.anyMatch(units, Matches.UnitIsAir);
     // final boolean hasSea = Match.anyMatch(units, Matches.unitIsSea());
     final boolean isNeutralsImpassable =
@@ -1552,7 +1552,7 @@ public class MoveValidator {
           && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
               || (forceLandOrSeaRoute
-                  && Match.anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsLand)))) {
+                  && Match.anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.unitIsLand())))) {
         defaultRoute = landRoute;
         mustGoLand = true;
       }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -162,12 +162,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
-        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.unitIsLand())) {
+        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.unitIsLand()));
       }
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
-      if (Match.noneMatch(attackingFromMapUnits, Matches.UnitIsLand)) {
+      if (Match.noneMatch(attackingFromMapUnits, Matches.unitIsLand())) {
         getAmphibiousAttackTerritories().remove(attackingFrom);
         // do we have any amphibious attacks left?
         m_isAmphibious = !getAmphibiousAttackTerritories().isEmpty();
@@ -203,9 +203,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     attackingFromMapUnits.addAll(attackingUnits);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.anyMatch(attackingUnits, Matches.UnitIsLand)) {
+        && Match.anyMatch(attackingUnits, Matches.unitIsLand())) {
       getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
-      m_amphibiousLandAttackers.addAll(Match.getMatches(attackingUnits, Matches.UnitIsLand));
+      m_amphibiousLandAttackers.addAll(Match.getMatches(attackingUnits, Matches.unitIsLand()));
       m_isAmphibious = true;
     }
     final Map<Unit, Collection<Unit>> dependencies = transporting(units);
@@ -1188,7 +1188,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private boolean canAttackerRetreatPartialAmphib() {
     if (m_isAmphibious && isPartialAmphibiousRetreat()) {
       // Only include land units when checking for allow amphibious retreat
-      final List<Unit> landUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsLand);
+      final List<Unit> landUnits = Match.getMatches(m_attackingUnits, Matches.unitIsLand());
       for (final Unit unit : landUnits) {
         final TripleAUnit taUnit = (TripleAUnit) unit;
         if (!taUnit.getWasAmphibious()) {
@@ -1247,7 +1247,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // the battle site is in the attacking from
     // if sea units are fighting a submerged sub
     possible.remove(m_battleSite);
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsLand) && !m_battleSite.isWater()) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsLand()) && !m_battleSite.isWater()) {
       possible = Match.getMatches(possible, Matches.territoryIsLand());
     }
     if (Match.anyMatch(m_attackingUnits, Matches.unitIsSea())) {
@@ -1475,7 +1475,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (!m_headless) {
           if (Match.anyMatch(units, Matches.unitIsSea())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
-          } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
+          } else if (Match.anyMatch(units, Matches.unitIsLand())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
           } else {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_AIR, m_attacker);
@@ -1490,7 +1490,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (!m_headless) {
           if (Match.anyMatch(units, Matches.unitIsSea())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
-          } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
+          } else if (Match.anyMatch(units, Matches.unitIsLand())) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
           } else {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_AIR, m_attacker);
@@ -1783,7 +1783,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (Matches.territoryIsLand().match(m_battleSite)) {
       notSubmergedAndTypeBuilder.add(Matches.unitIsSea().invert());
     } else {
-      notSubmergedAndTypeBuilder.add(Matches.UnitIsLand.invert());
+      notSubmergedAndTypeBuilder.add(Matches.unitIsLand().invert());
     }
     final Match<Unit> notSubmergedAndType = notSubmergedAndTypeBuilder.all();
     final Collection<Unit> unitsToKill;
@@ -2308,7 +2308,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final boolean doNotIncludeAa, final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
     final List<Unit> unitList = new ArrayList<>(units);
     if (m_battleSite.isWater()) {
-      unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsLand));
+      unitList.removeAll(Match.getMatches(unitList, Matches.unitIsLand()));
     }
     // still allow infrastructure type units that can provide support have combat abilities
     // remove infrastructure units that can't take part in combat (air/naval bases, etc...)

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -65,9 +65,9 @@ public class NonFightingBattle extends DependentBattle {
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.anyMatch(units, Matches.UnitIsLand)) {
+        && Match.anyMatch(units, Matches.unitIsLand())) {
       getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
-      m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.UnitIsLand));
+      m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.unitIsLand()));
       m_isAmphibious = true;
     }
     return ChangeFactory.EMPTY_CHANGE;
@@ -102,7 +102,7 @@ public class NonFightingBattle extends DependentBattle {
   }
 
   boolean hasAttackingUnits() {
-    final Match<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.UnitIsLand);
+    final Match<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.unitIsLand());
     return m_battleSite.getUnits().anyMatch(attackingLand);
   }
 
@@ -125,12 +125,12 @@ public class NonFightingBattle extends DependentBattle {
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
-        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.unitIsLand())) {
+        m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.unitIsLand()));
       }
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
-      if (Match.noneMatch(attackingFromMapUnits, Matches.UnitIsLand)) {
+      if (Match.noneMatch(attackingFromMapUnits, Matches.unitIsLand())) {
         getAmphibiousAttackTerritories().remove(attackingFrom);
         // do we have any amphibious attacks left?
         m_isAmphibious = !getAmphibiousAttackTerritories().isEmpty();

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -250,7 +250,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     if (steps.isEmpty() || !Match.allMatch(steps, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
       return result.setErrorReturnResult("May Only Fly Over Territories Where Air May Move");
     }
-    final boolean someLand = Match.anyMatch(airborne, Matches.UnitIsLand);
+    final boolean someLand = Match.anyMatch(airborne, Matches.unitIsLand());
     final boolean someSea = Match.anyMatch(airborne, Matches.unitIsSea());
     final boolean land = Matches.territoryIsLand().match(end);
     final boolean sea = Matches.territoryIsWater().match(end);
@@ -270,7 +270,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         final IBattle battle = battleTracker.getPendingBattle(end, false, BattleType.NORMAL);
         if (battle == null) {
           return result.setErrorReturnResult("Airborne May Only Attack Territories Already Under Assault");
-        } else if (land && someLand && !Match.anyMatch(battle.getAttackingUnits(), Matches.UnitIsLand)) {
+        } else if (land && someLand && !Match.anyMatch(battle.getAttackingUnits(), Matches.unitIsLand())) {
           return result.setErrorReturnResult("Battle Must Have Some Land Units Participating Already");
         } else if (sea && someSea && !Match.anyMatch(battle.getAttackingUnits(), Matches.unitIsSea())) {
           return result.setErrorReturnResult("Battle Must Have Some Sea Units Participating Already");

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -132,7 +132,7 @@ public class UndoableMove extends AbstractUndoableMove {
                     Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Match.getMatches(enemyTargetsTotal,
                 Matches.unitIsOfTypes(UnitAttachment.getAllowedBombingTargetsIntersection(
-                    Match.getMatches(Collections.singleton(unit), Matches.UnitIsStrategicBomber), data)));
+                    Match.getMatches(Collections.singleton(unit), Matches.unitIsStrategicBomber()), data)));
             if (enemyTargets.size() > 1
                 && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
                 && !Properties.getRaidsMayBePreceededByAirBattles(data)) {

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -28,7 +28,7 @@ public class UnitsThatCantFightUtil {
       final Match.CompositeBuilder<Unit> ownedUnitsMatchBuilder = Match.newCompositeBuilder(
           Matches.unitIsInfrastructure().invert());
       if (current.isWater()) {
-        ownedUnitsMatchBuilder.add(Matches.UnitIsLand.invert());
+        ownedUnitsMatchBuilder.add(Matches.unitIsLand().invert());
       }
       ownedUnitsMatchBuilder.add(Matches.unitIsOwnedBy(player));
       // All owned units

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -654,8 +654,8 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
         final List<Unit> notKilled = new ArrayList<>(selectFrom);
         notKilled.removeAll(killedUnits);
         // no land units left, but we have a non land unit to kill and land unit was killed
-        if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.unitIsNotLand())
-            && Match.anyMatch(killedUnits, Matches.UnitIsLand)) {
+        if (!Match.anyMatch(notKilled, Matches.unitIsLand()) && Match.anyMatch(notKilled, Matches.unitIsNotLand())
+            && Match.anyMatch(killedUnits, Matches.unitIsLand())) {
           final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.unitIsNotLand());
           // sort according to cost
           Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -131,7 +131,7 @@ public class MovePanel extends AbstractMovePanel {
 
     final Comparator<Unit> unitComparator;
     // sort units based on which transports are allowed to unload
-    if (route.isUnload() && Match.anyMatch(units, Matches.UnitIsLand)) {
+    if (route.isUnload() && Match.anyMatch(units, Matches.unitIsLand())) {
       unitComparator = UnitComparator.getUnloadableUnitsComparator(units, route, getUnitOwner(units));
     } else {
       unitComparator = UnitComparator.getMovableUnitsComparator(units, route);
@@ -323,7 +323,7 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   private Match<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {
-    return Match.allOf(getMovableMatch(route, units), Matches.UnitIsLand);
+    return Match.allOf(getMovableMatch(route, units), Matches.unitIsLand());
   }
 
   private Match<Unit> getMovableMatch(final Route route, final Collection<Unit> units) {
@@ -350,7 +350,7 @@ public class MovePanel extends AbstractMovePanel {
       });
       if (route.isUnload()) {
         final Match<Unit> notLandAndCanMove = Match.allOf(enoughMovement, Matches.unitIsNotLand());
-        final Match<Unit> landOrCanMove = Match.anyOf(Matches.UnitIsLand, notLandAndCanMove);
+        final Match<Unit> landOrCanMove = Match.anyOf(Matches.unitIsLand(), notLandAndCanMove);
         movableBuilder.add(landOrCanMove);
       } else {
         movableBuilder.add(enoughMovement);
@@ -458,7 +458,7 @@ public class MovePanel extends AbstractMovePanel {
     // when the
     // only consider the non land units
     if (route.getStart().isWater() && route.getEnd() != null && route.getEnd().isWater() && !route.isLoad()) {
-      best = Match.getMatches(best, Matches.UnitIsLand.invert());
+      best = Match.getMatches(best, Matches.unitIsLand().invert());
     }
     sortUnitsToMove(best, route);
     Collections.reverse(best);
@@ -1075,7 +1075,7 @@ public class MovePanel extends AbstractMovePanel {
       // are we unloading everything? if we are then we dont need to select the transports
       final Match.CompositeBuilder<Unit> unloadableBuilder = Match.newCompositeBuilder(
           Matches.unitIsOwnedBy(getCurrentPlayer()),
-          Matches.UnitIsLand);
+          Matches.unitIsLand());
       if (nonCombat) {
         unloadableBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
       }
@@ -1095,13 +1095,13 @@ public class MovePanel extends AbstractMovePanel {
           Matches.unitIsAirTransport(),
           Matches.unitIsAirTransportable());
       final boolean paratroopsLanding = Match.anyMatch(units, paratroopNBombersBuilder.all());
-      if (route.isLoad() && Match.anyMatch(units, Matches.UnitIsLand)) {
+      if (route.isLoad() && Match.anyMatch(units, Matches.unitIsLand())) {
         transports = getTransportsToLoad(route, units, false);
         if (transports.isEmpty()) {
           cancelMove();
           return;
         }
-      } else if ((route.isUnload() && Match.anyMatch(units, Matches.UnitIsLand)) || paratroopsLanding) {
+      } else if ((route.isUnload() && Match.anyMatch(units, Matches.unitIsLand())) || paratroopsLanding) {
         final List<Unit> unloadAble = Match.getMatches(selectedUnits, getUnloadableMatch());
         final Collection<Unit> canMove = new ArrayList<>(getUnitsToUnload(route, unloadAble));
         canMove.addAll(Match.getMatches(selectedUnits, getUnloadableMatch().invert()));

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -102,8 +102,8 @@ public class BattleCalculatorTest {
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
   }
 
   @Test
@@ -133,8 +133,8 @@ public class BattleCalculatorTest {
     // two extra rolls to pick which units are hit
     assertEquals(3, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 0);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 2);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 0);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
   }
 
   @Test
@@ -155,7 +155,7 @@ public class BattleCalculatorTest {
             final Collection<Unit> selectFrom = invocation.getArgument(0);
             final int count = invocation.getArgument(2);
 
-            final List<Unit> selected = Match.getNMatches(selectFrom, count, Matches.UnitIsStrategicBomber);
+            final List<Unit> selected = Match.getNMatches(selectFrom, count, Matches.unitIsStrategicBomber());
             return new CasualtyDetails(selected, new ArrayList<>(), false);
           }
         });
@@ -174,8 +174,8 @@ public class BattleCalculatorTest {
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // we selected all bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 2);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 0);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 2);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 0);
   }
 
   @Test
@@ -194,7 +194,7 @@ public class BattleCalculatorTest {
           public CasualtyDetails answer(final InvocationOnMock invocation) throws Throwable {
             final Collection<Unit> selectFrom = invocation.getArgument(0);
             final int count = invocation.getArgument(2);
-            final List<Unit> selected = Match.getNMatches(selectFrom, count, Matches.UnitIsStrategicBomber);
+            final List<Unit> selected = Match.getNMatches(selectFrom, count, Matches.unitIsStrategicBomber());
             return new CasualtyDetails(selected, new ArrayList<>(), false);
           }
         });
@@ -213,8 +213,8 @@ public class BattleCalculatorTest {
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // we selected all bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 3);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 0);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 3);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 0);
   }
 
   @Test
@@ -246,8 +246,8 @@ public class BattleCalculatorTest {
     // a second roll for choosing which unit
     assertEquals(2, randomSource.getTotalRolled());
     // should be 2 fighters and 1 bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 2);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
   }
 
   @Test
@@ -279,8 +279,8 @@ public class BattleCalculatorTest {
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
   }
 
   @Test
@@ -309,8 +309,8 @@ public class BattleCalculatorTest {
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 2 fighters and 1 bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 2);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
   }
   // Radar AA tests removed, because "revised" does not have radar tech.
 }

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -370,7 +370,7 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 3}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
@@ -387,7 +387,7 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
@@ -402,7 +402,7 @@ public class DiceRollTest {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
@@ -420,7 +420,7 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 3}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
@@ -439,7 +439,7 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {3, 2}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
@@ -457,7 +457,7 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
@@ -473,7 +473,7 @@ public class DiceRollTest {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final Territory location = gameData.getMap().getTerritory("United Kingdom");
     final Unit bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber).get(0);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber()).get(0);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(location);
     // default 1 roll
     assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(1));

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -157,8 +157,8 @@ public class LhtrTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
@@ -198,8 +198,8 @@ public class LhtrTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -123,9 +123,9 @@ public class MoveValidatorTest extends DelegateTest {
   @Test
   public void testHasSomeLand() {
     final Collection<Unit> units = transport.create(3, british);
-    assertTrue(!Match.anyMatch(units, Matches.UnitIsLand));
+    assertTrue(!Match.anyMatch(units, Matches.unitIsLand()));
     units.addAll(infantry.create(2, british));
-    assertTrue(Match.anyMatch(units, Matches.UnitIsLand));
+    assertTrue(Match.anyMatch(units, Matches.unitIsLand()));
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -320,11 +320,11 @@ public class RevisedTest {
     final Territory we = territory("Western Europe", gameData);
     final Territory se = territory("Southern Europe", gameData);
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
-    move(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), route);
+    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired. the bomber no longer exists
-    assertTrue(se.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
+    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -345,12 +345,12 @@ public class RevisedTest {
     final Territory balk = territory("Balkans", gameData);
     addTo(uk, bomber(gameData).create(1, british));
     final Route route = new Route(uk, sz7, we, se, balk);
-    move(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), route);
+    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired (one hit, one miss in each territory overflown). the bombers no longer exists
-    assertTrue(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(se.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(balk.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
+    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(balk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -379,11 +379,11 @@ public class RevisedTest {
     move(sz15.getUnits().getUnits(), new Route(sz15, sz14));
     move(sz14.getUnits().getMatches(Matches.unitIsInfantry()), new Route(sz14, se));
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
-    move(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), route);
+    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired and hit
-    assertTrue(se.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
-    assertTrue(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber).isEmpty());
+    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -844,7 +844,7 @@ public class RevisedTest {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
-    final List<Unit> bombers = uk.getUnits().getMatches(Matches.UnitIsStrategicBomber);
+    final List<Unit> bombers = uk.getUnits().getMatches(Matches.unitIsStrategicBomber());
     addTo(germany, bombers);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany), bombers, null);
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
@@ -923,8 +923,8 @@ public class RevisedTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,

--- a/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
@@ -87,8 +87,8 @@ public class StratBombTest {
     final StrategicBombingRaidBattle battle =
         (StrategicBombingRaidBattle) tracker.getPendingBattle(wgermany, true, null);
     battle.addAttackChange(gameData.getMap().getRoute(uk, wgermany),
-        uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
-    // addTo(wgermany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
+    // addTo(wgermany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), wgermany, battle.getBattleType());
     // aa guns rolls 1,3,2 first one hits, remaining bombers roll 1 dice each
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 3, 2, 5, 4}));

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -153,8 +153,8 @@ public class WW2V3Year41Test {
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
   }
 
   @Test
@@ -186,8 +186,8 @@ public class WW2V3Year41Test {
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 1 fighter and 2 bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 2);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 2);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
   }
 
   @Test
@@ -222,8 +222,8 @@ public class WW2V3Year41Test {
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 2 bombers
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
-    assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber.invert()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
+    assertEquals(Match.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
   }
 
   @Test
@@ -990,7 +990,7 @@ public class WW2V3Year41Test {
     // move troops from Libya
     move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
+    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1039,7 +1039,7 @@ public class WW2V3Year41Test {
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
+    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // Set the tech for DDs bombard
     // ww2v3 doesn't have this tech, so this does nothing...
@@ -1094,11 +1094,11 @@ public class WW2V3Year41Test {
     // move troops from Libya
     move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
+    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     // undo amphibious landing
     move.undoMove(move.getMovesMade().size() - 1);
     // move again
-    move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
+    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1214,7 +1214,7 @@ public class WW2V3Year41Test {
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
     final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
-    toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+    toMove.addAll(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, gameData);
@@ -1231,7 +1231,7 @@ public class WW2V3Year41Test {
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
     final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
-    toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
+    toMove.addAll(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, gameData);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -81,7 +81,7 @@ public class WW2V3Year42Test {
     // remove the russian units
     removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.unitCanBeDamaged().invert()));
     // move the bomber to attack
-    move(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber), new Route(germany, sz5, karrelia));
+    move(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()), new Route(germany, sz5, karrelia));
     // move an infantry to invade
     move(baltic.getUnits().getMatches(Matches.unitIsInfantry()), new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.