### PR TITLE
Use map folder override setting if present (#2316)

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -11,11 +11,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.config.client.GameEnginePropertyReader;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.GameSetting;
 import games.strategy.util.Version;
 
 /**
@@ -157,9 +160,7 @@ public final class ClientFileSystemHelper {
    *     retained between engine installations. Users can override this location in settings.
    */
   public static File getUserMapsFolder() {
-    final String path = ClientSetting.USER_MAPS_FOLDER_PATH.value();
-
-
+    final String path = getUserMapsFolderPath(ClientSetting.USER_MAPS_FOLDER_PATH, ClientSetting.MAP_FOLDER_OVERRIDE);
     final File mapsFolder = new File(path);
     if (!mapsFolder.exists()) {
       try {
@@ -172,6 +173,15 @@ public final class ClientFileSystemHelper {
       ClientLogger.logError("Error, downloaded maps folder does not exist: " + mapsFolder.getAbsolutePath());
     }
     return mapsFolder;
+  }
+
+  @VisibleForTesting
+  static String getUserMapsFolderPath(
+      final GameSetting currentUserMapsFolderPathSetting,
+      final GameSetting overrideUserMapsFolderPathSetting) {
+    return overrideUserMapsFolderPathSetting.isSet()
+        ? overrideUserMapsFolderPathSetting.value()
+        : currentUserMapsFolderPathSetting.value();
   }
 
   /** Create a temporary file, checked exceptions are re-thrown as unchecked. */

--- a/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -5,7 +5,7 @@ package games.strategy.triplea.settings;
  * course of the game, either directly or indirectly. For example, default window size may saved here,
  * which could be set from a UI control or it could be based on the last window size used.
  */
-interface GameSetting {
+public interface GameSetting {
   /**
    * @return True if the setting has been specified by the user or updated from default.
    */

--- a/src/test/java/games/strategy/engine/ClientFileSystemHelperTests.java
+++ b/src/test/java/games/strategy/engine/ClientFileSystemHelperTests.java
@@ -1,0 +1,47 @@
+package games.strategy.engine;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import games.strategy.triplea.settings.GameSetting;
+
+@RunWith(Enclosed.class)
+public final class ClientFileSystemHelperTests {
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
+  public static final class GetUserMapsFolderPathTest {
+    @Mock
+    private GameSetting currentSetting;
+
+    @Mock
+    private GameSetting overrideSetting;
+
+    private String getUserMapsFolderPath() {
+      return ClientFileSystemHelper.getUserMapsFolderPath(currentSetting, overrideSetting);
+    }
+
+    @Test
+    public void shouldReturnCurrentPathWhenOverridePathNotSet() {
+      when(overrideSetting.isSet()).thenReturn(false);
+      final String currentPath = "/path/to/current";
+      when(currentSetting.value()).thenReturn(currentPath);
+
+      assertThat(getUserMapsFolderPath(), is(currentPath));
+    }
+
+    @Test
+    public void shouldReturnOverridePathWhenOverridePathSet() {
+      when(overrideSetting.isSet()).thenReturn(true);
+      final String overridePath = "/path/to/override";
+      when(overrideSetting.value()).thenReturn(overridePath);
+
+      assertThat(getUserMapsFolderPath(), is(overridePath));
+    }
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import org.junit.After;
 import org.junit.Test;
 
+import games.strategy.triplea.settings.ClientSetting;
+
 public class ArgParserTest {
 
 
@@ -23,7 +25,7 @@ public class ArgParserTest {
     assertThat("check precondition, system property for our test key should not be set yet.",
         System.getProperty(TestData.propKey), nullValue());
 
-    boolean result = ArgParser.handleCommandLineArgs(
+    final boolean result = ArgParser.handleCommandLineArgs(
         TestData.sampleArgInput, TestData.samplePropertyNameSet);
 
     assertThat("prop key was supplied as an available value, "
@@ -52,7 +54,7 @@ public class ArgParserTest {
           try {
             ArgParser.handleCommandLineArgs(invalidInput, new String[] {"a"});
             fail("Did not throw an exception as expected on input: " + Arrays.asList(invalidInput));
-          } catch (IllegalArgumentException expected) {
+          } catch (final IllegalArgumentException expected) {
             // expected
           }
         });
@@ -98,6 +100,24 @@ public class ArgParserTest {
             ArgParser.handleCommandLineArgs(invalidInput, validKeys), is(false)));
   }
 
+  @Test
+  public void mapFolderOverrideClientSettingIsSetWhenSpecified() {
+    ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
+    final String mapFolderPath = "/path/to/maps";
+
+    ArgParser.handleCommandLineArgs(new String[] {"mapFolder=" + mapFolderPath}, new String[] {GameRunner.MAP_FOLDER});
+
+    assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));
+  }
+
+  @Test
+  public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
+    ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
+
+    ArgParser.handleCommandLineArgs(new String[0], new String[0]);
+
+    assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue));
+  }
 
   private interface TestData {
     String propKey = "key";


### PR DESCRIPTION
This PR addresses #2316 by ensuring the map folder override path specified on the command line is used instead of the configured client setting.

#### Functional changes

* `ClientFileSystemHelper#getUserMapsFolder()` was modified to use the value of the `MAP_FOLDER_OVERRIDE` setting if it is set; otherwise it uses `USER_MAPS_FOLDER_PATH` as before.
* **The `MAP_FOLDER_OVERRIDE` setting is reset to its default value at every application startup** (application being either `GameRunner` or `HeadlessGameServer`).  See the next section for why this was necessary.

#### Functional issues for review

As noted above, I had to explicitly reset `MAP_FOLDER_OVERRIDE` during application startup.  Due to how the client settings subsystem works, the "override" will be persisted between runs.  From the user's perspective, they probably only expect the override to be used for the run in which they provided the command line argument.  If they subsequently run the application again without the command line argument, they would expect the original setting to take effect.  To ensure this expectation is met, we have to reset this client setting when the application starts to ensure the normal client setting (`USER_MAPS_FOLDER_PATH`) will be used instead of an override from a previous run.

This makes me think that `MAP_FOLDER_OVERRIDE` should not be a client setting at all due to the hoops that we have to jump through to ensure the correct behavior.  **I considered simply changing it back to a system property,** which has the desired transient behavior.  @DanVanAtta, I'd appreciate any input you have here regarding this issue.  I'm not sure the client settings subsystem should be used for transient or temporary overrides of other client settings.  Unless, of course, we built that functionality into the subsystem itself.  For example, each setting would have potentially three values (in order of preference): temporary/override, current, default.  But that might be overkill for this one use case.

#### Refactoring changes

* There was good test coverage in the main bits of `ArgParser`, so I cleaned it up a bit to separate the concerns between handling system properties and client settings.

#### Testing

I manually verified that specifying the `mapFolder` command line argument correctly overrides the user's maps folder.  Similarly, I verified that not specifying this command line argument resulted in using the maps folder stored in the user preferences.

Note that I ran these tests using the normal game client (i.e. `GameRunner`), but they should apply equally well to `HeadlessGameServer` because both of these applications use the same `ArgParser` and `ClientFileSystemHelper` classes.