### PR TITLE
Ensure UI component creation occurs on EDT (#2323)

### DIFF
--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -85,7 +85,9 @@ public final class EventThreadJOptionPane {
       final CountDownLatchHandler latchHandler) {
     checkNotNull(latchHandler);
 
-    showMessageDialog(parentComponent, createJLabelInScrollPane(message), title, messageType, latchHandler);
+    invokeAndWait(
+        latchHandler,
+        () -> JOptionPane.showMessageDialog(parentComponent, createJLabelInScrollPane(message), title, messageType));
   }
 
   private static void invokeAndWait(final CountDownLatchHandler latchHandler, final Runnable runnable) {


### PR DESCRIPTION
This PR fixes the `UiThreadingViolationException` errors reported in #2323.

#### Functional changes

`EventThreadJOptionPane#showMessageDialogWithScrollPane()` was modified to ensure the `createJLabelInScrollPane()` method is run on the EDT regardless of the identity of the calling thread.

#### Testing

I first reproduced the problem by switching to the Substance L&F and forcing a call to the `showMessageDialogWithScrollPane()` method from a thread other than the EDT and observed numerous `UiThreadingViolationException` errors in the console.  Running the same test after this change resulted in no errors being reported in the console.