### PR TITLE
Change to check all allied units instead of just owned

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1902,7 +1902,7 @@ public final class Matches {
   /**
    * Check if unit meets requiredUnitsToMove criteria and can move into territory.
    */
-  public static Match<Unit> unitHasRequiredUnitsToMove(final Territory t) {
+  public static Match<Unit> unitHasRequiredUnitsToMove(final Territory t, final GameData data) {
     return Match.of(unit -> {
 
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
@@ -1911,7 +1911,7 @@ public final class Matches {
       }
 
       final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
-          Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsNotDisabled());
+          Matches.isUnitAllied(unit.getOwner(), data), Matches.unitIsNotDisabled());
       final List<Unit> units = Match.getMatches(t.getUnits().getUnits(), unitIsOwnedByAndNotDisabled);
 
       for (final String[] array : ua.getRequiresUnitsToMove()) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -659,7 +659,7 @@ public class MoveValidator {
       }
       // Check requiresUnitsToMove conditions
       for (final Territory t : route.getAllTerritories()) {
-        if (!Match.allMatch(units, Matches.unitHasRequiredUnitsToMove(t))) {
+        if (!Match.allMatch(units, Matches.unitHasRequiredUnitsToMove(t, data))) {
           return result.setErrorReturnResult(
               t.getName() + " doesn't have the required units to allow moving the selected units into it");
         }

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -95,6 +95,15 @@ public class GameDataTestUtil {
   }
 
   /**
+   * Get the Japan PlayerID for the given GameData object.
+   *
+   * @return A Japan PlayerID.
+   */
+  public static PlayerID japan(final GameData data) {
+    return data.getPlayerList().getPlayerID("Japan");
+  }
+
+  /**
    * Get the chinese PlayerID for the given GameData object.
    *
    * @return A chinese PlayerID.

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -151,13 +151,27 @@ public class MoveValidatorTest extends DelegateTest {
     assertFalse(results.isMoveValid());
 
     // Add germanRail to only destination so it fails
-    addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
+    final Collection<Unit> germanRail = GameDataTestUtil.germanRail(twwGameData).create(1, germans);
+    addTo(easternGermany, germanRail);
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to start so move succeeds
     addTo(berlin, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, twwGameData);
+    assertTrue(results.isMoveValid());
+
+    // Remove germanRail from destination so move fails
+    GameDataTestUtil.removeFrom(easternGermany, germanRail);
+    results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
+        new HashMap<>(), false, null, twwGameData);
+    assertFalse(results.isMoveValid());
+
+    // Add allied owned germanRail to destination so move succeeds
+    final PlayerID japan = GameDataTestUtil.japan(twwGameData);
+    addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, japan));
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());


### PR DESCRIPTION
Check all allied units instead of just owned units. This is better aligned with other movement options such as "givesMovement".