### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 11)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -428,7 +428,7 @@ class ProCombatMoveAI {
         final ProBattleResult result = calc.estimateAttackBattleResults(t, new ArrayList<>(attackingUnits),
             patd.getMaxEnemyDefenders(player, data), patd.getMaxBombardUnits());
         final List<Unit> remainingUnitsToDefendWith =
-            Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
+            Match.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().invert());
         ProLogger.debug(t + ", value=" + territoryValueMap.get(t) + ", averageAttackFromValue=" + averageValue
             + ", MyAttackers=" + attackingUnits.size() + ", RemainingUnits=" + remainingUnitsToDefendWith.size());
 
@@ -880,7 +880,7 @@ class ProCombatMoveAI {
         if (enemyAttackOptions.getMax(t) != null
             && !ProMatches.territoryIsWaterAndAdjacentToOwnedFactory(player, data).match(t)) {
           List<Unit> remainingUnitsToDefendWith =
-              Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
+              Match.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().invert());
           ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
               remainingUnitsToDefendWith, patd.getMaxBombardUnits());
           if (patd.isCanHold() && result2.getTUVSwing() > 0) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -494,7 +494,7 @@ class ProNonCombatMoveAI {
       final int cantMoveUnitValue = TuvUtils.getTuv(moveMap.get(t).getCantMoveUnits(), ProData.unitValueMap);
       final List<Unit> maxEnemyUnits = patd.getMaxEnemyUnits();
       final boolean isLandAndCanOnlyBeAttackedByAir =
-          !t.isWater() && !maxEnemyUnits.isEmpty() && Match.allMatch(maxEnemyUnits, Matches.UnitIsAir);
+          !t.isWater() && !maxEnemyUnits.isEmpty() && Match.allMatch(maxEnemyUnits, Matches.unitIsAir());
       final boolean isNotFactoryAndShouldHold =
           !hasFactory && (minResult.getTUVSwing() <= 0 || !minResult.isHasLandUnitRemaining());
       final boolean canAlreadyBeHeld =
@@ -684,13 +684,13 @@ class ProNonCombatMoveAI {
         Territory maxWinTerritory = null;
         double maxWinPercentage = -1;
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
-          if (t.isWater() && Matches.UnitIsAir.match(unit)) {
+          if (t.isWater() && Matches.unitIsAir().match(unit)) {
             if (!ProTransportUtils.validateCarrierCapacity(player, t,
                 moveMap.get(t).getAllDefendersForCarrierCalcs(data, player), unit)) {
               continue; // skip moving air to water if not enough carrier capacity
             }
           }
-          if (!t.isWater() && !t.getOwner().equals(player) && Matches.UnitIsAir.match(unit)
+          if (!t.isWater() && !t.getOwner().equals(player) && Matches.unitIsAir().match(unit)
               && !ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
             continue; // skip moving air units to allied land without a factory
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -455,7 +455,7 @@ class ProPurchaseAI {
 
         // If it can't currently be held then add to list
         final boolean isLandAndCanOnlyBeAttackedByAir =
-            !t.isWater() && !enemyAttackingUnits.isEmpty() && Match.allMatch(enemyAttackingUnits, Matches.UnitIsAir);
+            !t.isWater() && !enemyAttackingUnits.isEmpty() && Match.allMatch(enemyAttackingUnits, Matches.unitIsAir());
         if ((!t.isWater() && result.isHasLandUnitRemaining()) || result.getTUVSwing() > holdValue
             || (t.equals(ProData.myCapital) && !isLandAndCanOnlyBeAttackedByAir
                 && result.getWinPercentage() > (100 - ProData.winPercentage))) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -86,7 +86,7 @@ class ProRetreatAI {
 
     // Calculate current attack value
     double territoryValue = 0;
-    if (result.isHasLandUnitRemaining() || Match.noneMatch(attackers, Matches.UnitIsAir)) {
+    if (result.isHasLandUnitRemaining() || Match.noneMatch(attackers, Matches.unitIsAir())) {
       territoryValue = result.getWinPercentage() / 100 * (2 * production * (1 + isFactory) * (1 + isCapital));
     }
     double battleValue = result.getTUVSwing() + territoryValue;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -107,7 +107,7 @@ final class ProTechAI {
       float strength = 0.0F;
       enemyPlayer = playerIter.next();
       final Match<Unit> enemyPlane = Match.allOf(
-          Matches.UnitIsAir,
+          Matches.unitIsAir(),
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanMove());
       final Match<Unit> enemyTransport = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
@@ -461,7 +461,10 @@ final class ProTechAI {
     final Queue<Territory> q = new LinkedList<>();
     Territory lz = null;
     Territory ac = null;
-    final Match<Unit> enemyPlane = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.unitCanMove());
+    final Match<Unit> enemyPlane = Match.allOf(
+        Matches.unitIsAir(),
+        Matches.unitIsOwnedBy(player),
+        Matches.unitCanMove());
     final Match<Unit> enemyCarrier =
         Match.allOf(Matches.unitIsCarrier(), Matches.unitIsOwnedBy(player), Matches.unitCanMove());
     q.add(start);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -355,7 +355,7 @@ public class ProMatches {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsAir());
       return match.match(u);
     });
   }
@@ -433,15 +433,15 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsAlliedNotOwnedAir(final PlayerID player, final GameData data) {
-    return Match.allOf(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
+    return Match.allOf(unitIsAlliedNotOwned(player, data), Matches.unitIsAir());
   }
 
   static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
+    return Match.allOf(Matches.isUnitAllied(player, data), Matches.unitIsAir());
   }
 
   public static Match<Unit> unitIsEnemyAir(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsAir);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAir());
   }
 
   public static Match<Unit> unitIsEnemyAndNotAA(final PlayerID player, final GameData data) {
@@ -465,7 +465,7 @@ public class ProMatches {
   }
 
   static Match<Unit> unitIsOwnedAir(final PlayerID player) {
-    return Match.allOf(Matches.unitOwnedBy(player), Matches.UnitIsAir);
+    return Match.allOf(Matches.unitOwnedBy(player), Matches.unitIsAir());
   }
 
   public static Match<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -85,7 +85,7 @@ public class ProMoveUtils {
           // Land unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t, ProMatches
               .territoryCanMoveLandUnitsThrough(player, data, u, startTerritory, isCombatMove, new ArrayList<>()));
-        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsAir)) {
+        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.unitIsAir())) {
 
           // Air unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
@@ -284,7 +284,7 @@ public class ProMoveUtils {
 
         // Determine route and add to move list
         Route route = null;
-        if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsAir)) {
+        if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.unitIsAir())) {
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
               ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -67,7 +67,7 @@ public class ProOddsCalculator {
     final double strengthDifference = ProBattleUtils.estimateStrengthDifference(t, attackingUnits, defendingUnits);
     if (strengthDifference > 55) {
       final boolean isLandAndCanOnlyBeAttackedByAir =
-          !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.UnitIsAir);
+          !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.unitIsAir());
       return new ProBattleResult(100 + strengthDifference, 999 + strengthDifference, !isLandAndCanOnlyBeAttackedByAir,
           attackingUnits, new ArrayList<>(), 1);
     }
@@ -90,7 +90,7 @@ public class ProOddsCalculator {
 
     final boolean hasNoDefenders = Match.noneMatch(defendingUnits, Matches.unitIsNotInfrastructure());
     final boolean isLandAndCanOnlyBeAttackedByAir =
-        !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.UnitIsAir);
+        !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.unitIsAir());
     if (attackingUnits.size() == 0) {
       return new ProBattleResult();
     } else if (hasNoDefenders && isLandAndCanOnlyBeAttackedByAir) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -520,7 +520,7 @@ public class WeakAI extends AbstractAI {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.territoryIsImpassable().invert(), data);
       final Collection<Unit> airToLand =
-          t.getUnits().getMatches(Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
+          t.getUnits().getMatches(Match.allOf(Matches.unitIsAir(), Matches.unitIsOwnedBy(player)));
       // dont bother to see if all the air units have enough movement points
       // to move without aa guns firing
       // simply move first over no aa, then with aa

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -272,7 +272,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, m_player);
     } else if (Match.anyMatch(units, Matches.unitIsSea())) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, m_player);
-    } else if (Match.anyMatch(units, Matches.UnitIsAir)) {
+    } else if (Match.anyMatch(units, Matches.unitIsAir())) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_AIR, m_player);
     } else {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_LAND, m_player);
@@ -882,12 +882,16 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final Match<Unit> seaOrLandMatch = water ? Matches.unitIsSea() : Matches.unitIsLand();
       placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.unitIsNotConstruction())));
       if (!water) {
-        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction())));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(
+            Matches.unitIsAir(),
+            Matches.unitIsNotConstruction())));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
           && Match.anyMatch(allProducedUnits, Matches.unitIsCarrier()))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
               && Match.anyMatch(to.getUnits().getUnits(), Matches.unitIsCarrier()))) {
-        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier())));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(
+            Matches.unitIsAir(),
+            Matches.unitCanLandOnCarrier())));
       }
     }
     if (Match.anyMatch(units, Matches.unitIsConstruction())) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -42,7 +42,7 @@ public class AirMovementValidator {
       final Route route, final PlayerID player, final MoveValidationResult result) {
     // First check if we even need to check
     if (getEditMode(data) || // Edit Mode, no need to check
-        !Match.anyMatch(units, Matches.UnitIsAir) || // No Airunits, nothing to check
+        !Match.anyMatch(units, Matches.unitIsAir()) || // No Airunits, nothing to check
         route.hasNoSteps() || // if there are no steps, we didn't move, so it is always OK!
         // we can land at the end, nothing left to check
         Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd())
@@ -61,7 +61,7 @@ public class AirMovementValidator {
     final Territory routeStart = route.getStart();
     // we cannot forget to account for allied air at our location already
     final Match<Unit> airAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
+        Matches.isUnitAllied(player, data), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
     final HashSet<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(routeEnd.getUnits().getUnits(), airAlliedNotOwned));
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(units, airAlliedNotOwned));
@@ -163,7 +163,7 @@ public class AirMovementValidator {
     final Match<Unit> carrierAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.unitIsCarrier());
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
-    // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
+    // Matches.isUnitAllied(player, data), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
     final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLHTRCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     // final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
@@ -200,9 +200,9 @@ public class AirMovementValidator {
       final Collection<Unit> airNotToConsider, final PlayerID player, final Route route, final GameData data) {
     final Match<Unit> ownedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsCarrier());
     final Match<Unit> ownedAirMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedAirMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
-        Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
+        Matches.isUnitAllied(player, data), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
     final Match<Unit> alliedNotOwnedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.unitIsCarrier());
     final Territory routeEnd = route.getEnd();
@@ -520,7 +520,7 @@ public class AirMovementValidator {
   private static List<Unit> getAirUnitsToValidate(final Collection<Unit> units, final Route route,
       final PlayerID player) {
     final Match<Unit> ownedAirMatch =
-        Match.allOf(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.unitIsKamikaze().invert());
+        Match.allOf(Matches.unitIsAir(), Matches.unitOwnedBy(player), Matches.unitIsKamikaze().invert());
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(Match.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
     ownedAir.addAll(Match.getMatches(units, ownedAirMatch));
@@ -610,7 +610,7 @@ public class AirMovementValidator {
    */
   public static boolean canLand(final Collection<Unit> airUnits, final Territory territory, final PlayerID player,
       final GameData data) {
-    if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.UnitIsAir)) {
+    if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.unitIsAir())) {
       throw new IllegalArgumentException("can only test if air will land");
     }
     if (!territory.isWater() && AbstractMoveDelegate.getBattleTracker(data).wasConquered(territory)) {
@@ -680,7 +680,7 @@ public class AirMovementValidator {
         if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
-              .getMatches(Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier()));
+              .getMatches(Match.allOf(Matches.unitIsAir(), Matches.unitCanLandOnCarrier()));
           for (final Unit airUnit : airCargo) {
             final TripleAUnit taUnit = (TripleAUnit) airUnit;
             if (taUnit.getTransportedBy() != null && taUnit.getTransportedBy().equals(unit)) {

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -41,7 +41,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = data.getMap().getTerritories().iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player));
+      final Match<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.unitIsOwnedBy(player));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
@@ -56,7 +56,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = getTerritoriesWhereAirCantLand(player).iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(player, data));
+      final Match<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player)).size() > 0;

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -333,7 +333,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         }
         final Collection<Unit> neighbourUnits = attackingFromMap.get(neighbor);
         // If all units from a territory are air- no bombard
-        if (!neighbourUnits.isEmpty() && Match.allMatch(neighbourUnits, Matches.UnitIsAir)) {
+        if (!neighbourUnits.isEmpty() && Match.allMatch(neighbourUnits, Matches.unitIsAir())) {
           continue;
         }
         Collection<IBattle> battles = possibleBombardingTerritories.get(neighbor);
@@ -917,7 +917,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               }
             }
           }
-          if (Match.anyMatch(attackingUnits, Matches.UnitIsAir.invert())) {
+          if (Match.anyMatch(attackingUnits, Matches.unitIsAir().invert())) {
             // TODO: for now, we will hack and say that the attackers came from Everywhere, and hope the user will
             // choose the correct place
             // to retreat to! (TODO: Fix this)
@@ -1066,7 +1066,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = m_battleTracker.getDefendingAirThatCanNotLand();
     final boolean isWW2v2orIsSurvivingAirMoveToLand = Properties.getWW2V2(data)
         || Properties.getSurvivingAirMoveToLand(data);
-    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.unitWasScrambled().invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.unitIsAir(), Matches.unitWasScrambled().invert());
     for (final Entry<Territory, Collection<Unit>> entry : defendingAirThatCanNotLand.entrySet()) {
       final Territory battleSite = entry.getKey();
       final Collection<Unit> defendingAir = entry.getValue();
@@ -1092,7 +1092,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // Set up match criteria for allied carriers
       final Match<Unit> alliedCarrier = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(defender, data));
       // Set up match criteria for allied planes
-      final Match<Unit> alliedPlane = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedPlane = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(defender, data));
       // See if neighboring carriers have any capacity available
       for (final Territory currentTerritory : areSeaNeighbors) {
         // get the capacity of the carriers and cost of fighters

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -497,7 +497,7 @@ public class BattleTracker implements Serializable {
       // Total Attacking Sea units = all units - land units - air units - submerged subs
       // Also subtract transports & subs (if they can't control sea zones)
       totalMatches = arrivedUnits.size() - Match.countMatches(arrivedUnits, Matches.unitIsLand())
-          - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
+          - Match.countMatches(arrivedUnits, Matches.unitIsAir())
           - Match.countMatches(arrivedUnits, Matches.unitIsSubmerged());
       // If transports are restricted from controlling sea zones, subtract them
       final Match<Unit> transportsCanNotControl = Match.allOf(

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -116,7 +116,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Match<Unit> groundUnits =
         // we add factories and constructions later
         Match.allOf(Matches.unitIsLand(), Matches.unitIsNotConstruction());
-    final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction());
+    final Match<Unit> airUnits = Match.allOf(Matches.unitIsAir(), Matches.unitIsNotConstruction());
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
     if (Match.anyMatch(units, Matches.unitIsConstruction())) {

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -90,13 +90,13 @@ class EditValidator {
             return "Can't add land units to water without enough transports";
           }
         }
-        if (Match.anyMatch(units, Matches.UnitIsAir)) {
-          if (Match.anyMatch(units, Match.allOf(Matches.UnitIsAir, Matches.unitCanLandOnCarrier().invert()))) {
+        if (Match.anyMatch(units, Matches.unitIsAir())) {
+          if (Match.anyMatch(units, Match.allOf(Matches.unitIsAir(), Matches.unitCanLandOnCarrier().invert()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
           final Match<Unit> friendlyCarriers = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
-          final Match<Unit> friendlyAirUnits = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyAirUnits = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =
               AirMovementValidator.carrierCapacity(territory.getUnits().getMatches(friendlyCarriers), territory)

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -67,7 +67,7 @@ import games.strategy.util.Util;
  * </p>
  *
  * <pre>
- * boolean hasLand = Match.anyMatch(someCollection, Matches.UnitIsAir);
+ * boolean hasLand = Match.anyMatch(someCollection, Matches.unitIsAir());
  * </pre>
  *
  * <p>
@@ -251,7 +251,9 @@ public final class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsAir = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
+  public static Match<Unit> unitIsAir() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
+  }
 
   public static Match<Unit> unitIsNotAir() {
     return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsAir());

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -325,7 +325,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         Matches.unitIsOwnedBy(player).invert(), Matches.unitIsCarrier(),
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsAir(),
             Matches.unitCanLandOnCarrier(), Matches.unitHasMovementLeft());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -259,9 +259,9 @@ public class MovePerformer implements Serializable {
                 continue;
               }
               if ((t.equals(route.getEnd()) && !arrivedCopyForBattles.isEmpty()
-                  && Match.allMatch(arrivedCopyForBattles, Matches.UnitIsAir))
+                  && Match.allMatch(arrivedCopyForBattles, Matches.unitIsAir()))
                   || (!t.equals(route.getEnd()) && !presentFromStartTilEnd.isEmpty()
-                      && Match.allMatch(presentFromStartTilEnd, Matches.UnitIsAir))) {
+                      && Match.allMatch(presentFromStartTilEnd, Matches.unitIsAir()))) {
                 continue;
               }
               // createdBattle = true;
@@ -348,7 +348,7 @@ public class MovePerformer implements Serializable {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
-      for (final Unit unit : Match.getMatches(units, Match.allOf(Matches.unitIsSub(), Matches.UnitIsAir.invert()))) {
+      for (final Unit unit : Match.getMatches(units, Match.allOf(Matches.unitIsSub(), Matches.unitIsAir().invert()))) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }
@@ -428,7 +428,7 @@ public class MovePerformer implements Serializable {
       final BattleTracker tracker = getBattleTracker();
       final boolean pendingBattles = tracker.getPendingBattle(route.getStart(), false, BattleType.NORMAL) != null;
       for (Unit unit : units) {
-        if (Matches.UnitIsAir.match(unit)) {
+        if (Matches.unitIsAir().match(unit)) {
           continue;
         }
         final Unit transportedBy = ((TripleAUnit) unit).getTransportedBy();

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -167,7 +167,7 @@ public class MoveValidator {
             return result;
           }
         }
-        if (Match.anyMatch(units, Matches.UnitIsAir)) {
+        if (Match.anyMatch(units, Matches.unitIsAir())) {
           if (!data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(player, t.getOwner())) {
             result.setError(player.getName() + " may not move air units over land owned by " + t.getOwner().getName());
             return result;
@@ -280,7 +280,7 @@ public class MoveValidator {
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
-          && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
+          && (units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir()))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
       for (final Unit u : Match.getMatches(units, Match.allOf(
@@ -297,7 +297,7 @@ public class MoveValidator {
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
-          && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
+          && (units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir()))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle into enemy territory");
       }
     }
@@ -310,7 +310,7 @@ public class MoveValidator {
     }
     // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
-      if ((units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) && !isNeutralsBlitzable(data)) {
+      if ((units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
@@ -334,7 +334,7 @@ public class MoveValidator {
           return result.setErrorReturnResult("Cannot blitz on that route");
         }
       } else if (allEnemyBlitzable && !(route.getStart().isWater() || route.getEnd().isWater())) {
-        final Match<Unit> blitzingUnit = Match.anyOf(Matches.unitCanBlitz(), Matches.UnitIsAir);
+        final Match<Unit> blitzingUnit = Match.anyOf(Matches.unitCanBlitz(), Matches.unitIsAir());
         final Match<Unit> nonBlitzing = blitzingUnit.invert();
         final Collection<Unit> nonBlitzingUnits = Match.getMatches(units, nonBlitzing);
         // remove any units that gain blitz due to certain abilities
@@ -365,7 +365,7 @@ public class MoveValidator {
         }
       }
     }
-    if (Match.anyMatch(units, Matches.UnitIsAir)) { // check aircraft
+    if (Match.anyMatch(units, Matches.unitIsAir())) { // check aircraft
       if (route.hasSteps()
           && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         if (Match.anyMatch(route.getMiddleSteps(), Matches.territoryIsNeutralButNotWater())) {
@@ -376,7 +376,7 @@ public class MoveValidator {
     // make sure no conquered territories on route
     if (MoveValidator.hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
       // unless we are all air or we are in non combat OR the route is water (was a bug in convoy zone movement)
-      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir())) {
         // what if we are paratroopers?
         return result.setErrorReturnResult("Cannot move through newly captured territories");
       }
@@ -440,7 +440,7 @@ public class MoveValidator {
             Matches.enemyUnit(player, data).invert(),
             Matches.unitIsSubmerged());
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
-            && !(!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir) && end.isWater())) {
+            && !(!units.isEmpty() && Match.allMatch(units, Matches.unitIsAir()) && end.isWater())) {
           if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsSub())
               || !Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
 
@@ -451,7 +451,7 @@ public class MoveValidator {
     }
     // if there are enemy units on the path blocking us, that is validated elsewhere (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
-    if ((!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir))
+    if ((!units.isEmpty() && Match.allMatch(units, Matches.unitIsAir()))
         || (Match.noneMatch(units, Matches.unitIsSea()) && !nonParatroopersPresent(player, units))) {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
@@ -519,7 +519,7 @@ public class MoveValidator {
       return result;
     }
     // if we are all air, then its ok
-    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)) {
+    if (!units.isEmpty() && Match.allMatch(units, Matches.unitIsAir())) {
       return result;
     }
     // subs may possibly carry units...
@@ -647,7 +647,7 @@ public class MoveValidator {
       }
       // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
       if (route.hasNeutralBeforeEnd()) {
-        if ((units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) && !isNeutralsBlitzable(data)) {
+        if ((units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
           return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
         }
       }
@@ -904,7 +904,7 @@ public class MoveValidator {
   }
 
   private static Collection<Unit> getNonLand(final Collection<Unit> units) {
-    return Match.getMatches(units, Match.anyOf(Matches.UnitIsAir, Matches.unitIsSea()));
+    return Match.getMatches(units, Match.anyOf(Matches.unitIsAir(), Matches.unitIsSea()));
   }
 
   public static int getMaxMovement(final Collection<Unit> units) {
@@ -959,7 +959,7 @@ public class MoveValidator {
       final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route, final PlayerID player,
       final Collection<Unit> transportsToLoad, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
-    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)) {
+    if (!units.isEmpty() && Match.allMatch(units, Matches.unitIsAir())) {
       return result;
     }
     if (!route.hasWater()) {
@@ -1051,7 +1051,7 @@ public class MoveValidator {
     // if we are land make sure no water in route except for transport
     // situations
     final Collection<Unit> land = Match.getMatches(units, Matches.unitIsLand());
-    final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.unitIsLand(), Matches.UnitIsAir));
+    final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.unitIsLand(), Matches.unitIsAir()));
     // make sure we can be transported
     final Match<Unit> cantBeTransported = Matches.unitCanBeTransported().invert();
     for (final Unit unit : Match.getMatches(land, cantBeTransported)) {
@@ -1178,7 +1178,7 @@ public class MoveValidator {
     // some units that can't be paratrooped
     if (units.isEmpty()
         || !Match.allMatch(units, Match.anyOf(Matches.unitIsAirTransportable(), Matches.unitIsAirTransport(),
-            Matches.UnitIsAir))) {
+            Matches.unitIsAir()))) {
       return false;
     }
     // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
@@ -1203,7 +1203,7 @@ public class MoveValidator {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
-    if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.unitIsLand()))) {
+    if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.unitIsAir(), Matches.unitIsLand()))) {
       return true;
     }
     for (final Unit unit : Match.getMatches(units, Matches.unitIsNotAirTransportable())) {
@@ -1485,7 +1485,7 @@ public class MoveValidator {
   public static Route getBestRoute(final Territory start, final Territory end, final GameData data,
       final PlayerID player, final Collection<Unit> units, final boolean forceLandOrSeaRoute) {
     final boolean hasLand = Match.anyMatch(units, Matches.unitIsLand());
-    final boolean hasAir = Match.anyMatch(units, Matches.UnitIsAir);
+    final boolean hasAir = Match.anyMatch(units, Matches.unitIsAir());
     // final boolean hasSea = Match.anyMatch(units, Matches.unitIsSea());
     final boolean isNeutralsImpassable =
         isNeutralsImpassable(data) || (hasAir && !Properties.getNeutralFlyoverAllowed(data));

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -220,7 +220,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         // Dependencies count both land and air units. Land units could be allied or owned, while air is just allied
         // since owned already
         // launched at beginning of turn
-        fighters.retainAll(Match.getMatches(fighters, Matches.UnitIsAir));
+        fighters.retainAll(Match.getMatches(fighters, Matches.unitIsAir()));
         for (final Unit fighter : fighters) {
           // Set transportedBy for fighter
           change.add(ChangeFactory.unitPropertyChange(fighter, carrier, TripleAUnit.TRANSPORTED_BY));
@@ -388,8 +388,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         } else {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_NORMAL, m_attacker);
         }
-      } else if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
-          && !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsAir)) {
+      } else if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsAir())
+          && !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.unitIsAir())) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR, m_attacker);
       } else {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_LAND, m_attacker);
@@ -584,8 +584,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
       // if(!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && Match.allMatch(m_attackingUnits,
-      // Matches.UnitIsAir))
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+      // Matches.unitIsAir()))
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsAir()) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
       }
     }
@@ -594,9 +594,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
       // if(!Match.anyMatch(m_attackingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_attackingUnits,
-      // Matches.UnitIsAir) &&
+      // Matches.unitIsAir()) &&
       // Match.anyMatch(m_defendingUnits, Matches.unitIsSub()))
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsAir()) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(AIR_ATTACK_NON_SUBS);
       }
     }
@@ -622,9 +622,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
       // if(!Match.anyMatch(m_defendingUnits, Matches.unitIsDestroyer()) && Match.anyMatch(m_defendingUnits,
-      // Matches.UnitIsAir) &&
+      // Matches.unitIsAir()) &&
       // Match.anyMatch(m_attackingUnits, Matches.unitIsSub()))
-      if (Match.anyMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
+      if (Match.anyMatch(m_defendingUnits, Matches.unitIsAir()) && !canAirAttackSubs(m_attackingUnits, units)) {
         steps.add(AIR_DEFEND_NON_SUBS);
       }
     }
@@ -666,7 +666,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // a sea zone, we always have to have the retreat
     // option shown
     // later, if our sea units die, we may ask the user to retreat
-    final boolean someAirAtSea = m_battleSite.isWater() && Match.anyMatch(m_attackingUnits, Matches.UnitIsAir);
+    final boolean someAirAtSea = m_battleSite.isWater() && Match.anyMatch(m_attackingUnits, Matches.unitIsAir());
     if (canAttackerRetreat() || someAirAtSea || canAttackerRetreatPartialAmphib() || canAttackerRetreatPlanes()) {
       steps.add(m_attacker.getName() + ATTACKER_WITHDRAW);
     }
@@ -1182,7 +1182,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private boolean canAttackerRetreatPlanes() {
     return (isWW2V2() || isAttackerRetreatPlanes() || isPartialAmphibiousRetreat()) && m_isAmphibious
-        && Match.anyMatch(m_attackingUnits, Matches.UnitIsAir);
+        && Match.anyMatch(m_attackingUnits, Matches.unitIsAir());
   }
 
   private boolean canAttackerRetreatPartialAmphib() {
@@ -1205,7 +1205,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // non-paratrooper non-amphibious
     // land units.
     // If attacker is all planes, just return collection of current territory
-    if (m_headless || (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir))
+    if (m_headless || (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsAir()))
         || Properties.getRetreatingUnitsRemainInPlace(m_data)) {
 
       final Collection<Territory> oneTerritory = new ArrayList<>(2);
@@ -1232,7 +1232,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (isWW2V2() || isWW2V3()) {
       possible = Match.getMatches(possible, Match.of(t -> {
         final Collection<Unit> units = m_attackingFromMap.get(t);
-        return units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir);
+        return units.isEmpty() || !Match.allMatch(units, Matches.unitIsAir());
       }));
     }
 
@@ -1313,7 +1313,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Territory> possible = new ArrayList<>(2);
     possible.add(m_battleSite);
     // retreat planes
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsAir())) {
       queryRetreat(false, RetreatType.PLANES, bridge, possible);
     }
   }
@@ -1400,7 +1400,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (subs) {
       units = Match.getMatches(units, Matches.unitIsSub());
     } else if (planes) {
-      units = Match.getMatches(units, Matches.UnitIsAir);
+      units = Match.getMatches(units, Matches.unitIsAir());
     } else if (partialAmphib) {
       units = Match.getMatches(units, Matches.unitWasNotAmphibious());
     }
@@ -1659,7 +1659,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // Remove air from battle
     final Collection<Unit> units = defender ? m_defendingUnits : m_attackingUnits;
     final Collection<Unit> unitsRetreated = defender ? m_defendingUnitsRetreated : m_attackingUnitsRetreated;
-    units.removeAll(Match.getMatches(units, Matches.UnitIsAir));
+    units.removeAll(Match.getMatches(units, Matches.unitIsAir()));
     // add all land units' dependents
     // retreating.addAll(getDependentUnits(retreating));
     retreating.addAll(getDependentUnits(units));
@@ -1731,7 +1731,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void checkUndefendedTransports(final IDelegateBridge bridge, final PlayerID player) {
     // if we are the attacker, we can retreat instead of dying
     if (player.equals(m_attacker)
-        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.UnitIsAir))) {
+        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.unitIsAir()))) {
       return;
     }
     // Get all allied transports in the territory
@@ -1772,7 +1772,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void checkForUnitsThatCanRollLeft(final IDelegateBridge bridge, final boolean attacker) {
     // if we are the attacker, we can retreat instead of dying
     if (attacker
-        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.UnitIsAir))) {
+        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.unitIsAir()))) {
       return;
     }
     if (m_attackingUnits.isEmpty() || m_defendingUnits.isEmpty()) {
@@ -1818,14 +1818,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
+    if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsAir())
         && Match.anyMatch(m_defendingUnits, Matches.unitIsSub())) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.unitIsSub());
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
-    } else if (!m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
+    } else if (!m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.unitIsAir())
         && Match.anyMatch(m_attackingUnits, Matches.unitIsSub())) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.unitIsSub());
@@ -1844,7 +1844,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     units = Match.getMatches(units, Matches.unitIsNotSub());
     // if restricted, remove aircraft from attackers
     if (isAirAttackSubRestricted() && !canAirAttackSubs(m_attackingUnits, units)) {
-      units.removeAll(Match.getMatches(units, Matches.UnitIsAir));
+      units.removeAll(Match.getMatches(units, Matches.unitIsAir()));
     }
     if (units.isEmpty()) {
       return;
@@ -1869,7 +1869,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units = Match.getMatches(units, Matches.unitIsOwnedBy(m_attacker));
     }
     if (!canAirAttackSubs(m_defendingUnits, units)) {
-      units = Match.getMatches(units, Matches.UnitIsAir);
+      units = Match.getMatches(units, Matches.unitIsAir());
       final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_defendingUnits, Matches.unitIsNotSub());
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
@@ -1893,7 +1893,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     units.addAll(m_defendingWaitingToDie);
 
     if (!canAirAttackSubs(m_attackingUnits, units)) {
-      units = Match.getMatches(units, Matches.UnitIsAir);
+      units = Match.getMatches(units, Matches.unitIsAir());
       final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_attackingUnits, Matches.unitIsNotSub());
       if (enemyUnitsNotSubs.isEmpty()) {
         return;
@@ -1920,7 +1920,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // if restricted, remove aircraft from attackers
     if (isAirAttackSubRestricted() && !canAirAttackSubs(m_defendingUnits, units)) {
-      units.removeAll(Match.getMatches(units, Matches.UnitIsAir));
+      units.removeAll(Match.getMatches(units, Matches.unitIsAir()));
     }
     if (units.isEmpty()) {
       return;
@@ -2043,7 +2043,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.unitIsSub()));
     }
     if (!suicideAttackers.isEmpty() && Match.allMatch(suicideAttackers, Matches.unitIsSub())) {
-      attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsAir));
+      attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.unitIsAir()));
     }
     if (suicideAttackers.size() == 0 || attackedDefenders.size() == 0) {
       return;
@@ -2074,7 +2074,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.unitIsSub()));
     }
     if (!suicideDefenders.isEmpty() && Match.allMatch(suicideDefenders, Matches.unitIsSub())) {
-      suicideDefenders.removeAll(Match.getMatches(suicideDefenders, Matches.UnitIsAir));
+      suicideDefenders.removeAll(Match.getMatches(suicideDefenders, Matches.unitIsAir()));
     }
     if (suicideDefenders.size() == 0 || attackedAttackers.size() == 0) {
       return;
@@ -2323,7 +2323,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
     // remove any allied air units that are stuck on damaged carriers (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Match.allOf(Matches.unitIsBeingTransported(),
-        Matches.UnitIsAir, Matches.unitCanLandOnCarrier())));
+        Matches.unitIsAir(), Matches.unitCanLandOnCarrier())));
     // remove any units that were in air combat (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Matches.unitWasInAirBattle()));
     return unitList;
@@ -2378,7 +2378,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_headless) {
       return;
     }
-    final Collection<Unit> attackingNonAir = Match.getMatches(m_attackingUnits, Matches.UnitIsAir.invert());
+    final Collection<Unit> attackingNonAir = Match.getMatches(m_attackingUnits, Matches.unitIsAir().invert());
     final Change noMovementChange = ChangeFactory.markNoMovementChange(attackingNonAir);
     if (!noMovementChange.isEmpty()) {
       bridge.addChange(noMovementChange);
@@ -2551,7 +2551,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     if (!m_headless) {
       if (Matches.territoryIsWater().match(m_battleSite)) {
-        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)) {
+        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsAir())) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR_SUCCESSFUL,
               m_attacker);
         } else {
@@ -2563,7 +2563,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         // no sounds for a successful land battle, because land battle means we are going to capture a territory, and we
         // have capture sounds
         // for that
-        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)) {
+        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitIsAir())) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR_SUCCESSFUL,
               m_attacker);
         }
@@ -2586,7 +2586,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO: why do we keep checking throughout this entire class if the units in m_defendingUnits are allied with
     // defender, and if the
     // units in m_attackingUnits are allied with the attacker? Does it really matter?
-    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.unitWasScrambled().invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.unitIsAir(), Matches.unitWasScrambled().invert());
     final Collection<Unit> defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
     // no planes, exit
     if (defendingAir.isEmpty()) {
@@ -2629,7 +2629,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.unitIsCarrier());
     if (!carriers.isEmpty() && !Properties.getAlliedAirIndependent(data)) {
       final Match<Unit> alliedFighters = Match.allOf(Matches.isUnitAllied(attacker, data),
-          Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.unitCanLandOnCarrier());
+          Matches.unitIsOwnedBy(attacker).invert(), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
       final Collection<Unit> alliedAirInTerr = Match.getMatches(attackingUnits, alliedFighters);
       for (final Unit fighter : alliedAirInTerr) {
         final TripleAUnit taUnit = (TripleAUnit) fighter;

--- a/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -59,9 +59,9 @@ public class UnitBattleComparator implements Comparator<Unit> {
       }
       return 0;
     }
-    final boolean airOrCarrierOrTransport1 = Matches.UnitIsAir.match(u1) || Matches.unitIsCarrier().match(u1)
+    final boolean airOrCarrierOrTransport1 = Matches.unitIsAir().match(u1) || Matches.unitIsCarrier().match(u1)
         || (!transporting1 && Matches.unitIsTransport().match(u1));
-    final boolean airOrCarrierOrTransport2 = Matches.UnitIsAir.match(u2) || Matches.unitIsCarrier().match(u2)
+    final boolean airOrCarrierOrTransport2 = Matches.unitIsAir().match(u2) || Matches.unitIsCarrier().match(u2)
         || (!transporting2 && Matches.unitIsTransport().match(u2));
     final boolean subDestroyer1 = Matches.unitIsSub().match(u1) || Matches.unitIsDestroyer().match(u1);
     final boolean subDestroyer2 = Matches.unitIsSub().match(u2) || Matches.unitIsDestroyer().match(u2);

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -595,7 +595,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       if (submerge) {
         // submerge if all air vs subs
         final Match<Unit> seaSub = Match.allOf(Matches.unitIsSea(), Matches.unitIsSub());
-        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.unitIsDestroyer().invert());
+        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.unitIsAir(), Matches.unitIsDestroyer().invert());
         final List<Unit> ourUnits = getOurUnits();
         final List<Unit> enemyUnits = getEnemyUnits();
         if (ourUnits == null || enemyUnits == null) {
@@ -618,7 +618,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
           return null;
         }
         final Collection<Unit> unitsLeft = isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits();
-        final Collection<Unit> airLeft = Match.getMatches(unitsLeft, Matches.UnitIsAir);
+        final Collection<Unit> airLeft = Match.getMatches(unitsLeft, Matches.unitIsAir());
         if (retreatWhenOnlyAirLeft) {
           // lets say we have a bunch of 3 attack air unit, and a 4 attack non-air unit,
           // and we want to retreat when we have all air units left + that 4 attack non-air (cus it gets taken

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -559,7 +559,7 @@ public class MovePanel extends AbstractMovePanel {
     if (!route.isLoad()) {
       return Collections.emptyList();
     }
-    if (Match.anyMatch(unitsToLoad, Matches.UnitIsAir)) {
+    if (Match.anyMatch(unitsToLoad, Matches.unitIsAir())) {
       return Collections.emptyList();
     }
     final Collection<Unit> endOwnedUnits = route.getEnd().getUnits().getUnits();
@@ -1266,8 +1266,8 @@ public class MovePanel extends AbstractMovePanel {
             // which the route may actually change much)
             if (unitsThatCanMoveOnRoute.size() < selectedUnits.size() && (unitsThatCanMoveOnRoute.size() == 0
                 || (!unitsThatCanMoveOnRoute.isEmpty()
-                    && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir)))) {
-              final Collection<Unit> airUnits = Match.getMatches(selectedUnits, Matches.UnitIsAir);
+                    && Match.allMatch(unitsThatCanMoveOnRoute, Matches.unitIsAir())))) {
+              final Collection<Unit> airUnits = Match.getMatches(selectedUnits, Matches.unitIsAir());
               if (airUnits.size() > 0) {
                 route = getRoute(getFirstSelectedTerritory(), territory, airUnits);
                 updateUnitsThatCanMoveOnRoute(airUnits, route);

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -75,7 +75,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(balkans, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
     // jsut the original german fighter
-    assertEquals(1, balkans.getUnits().getMatches(Matches.UnitIsAir).size());
+    assertEquals(1, balkans.getUnits().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -90,7 +90,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(1, cantLand.size());
     assertEquals(sz55, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
-    assertEquals(0, sz55.getUnits().getMatches(Matches.UnitIsAir).size());
+    assertEquals(0, sz55.getUnits().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
     airThatCantLandUtil.removeAirThatCantLand(player, true);
-    assertEquals(2, sz55.getUnits().getMatches(Matches.UnitIsAir).size());
+    assertEquals(2, sz55.getUnits().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -119,7 +119,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(sz52, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
     // just the original american fighter, plus one that can land on the carrier
-    assertEquals(2, sz52.getUnits().getMatches(Matches.UnitIsAir).size());
+    assertEquals(2, sz52.getUnits().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -146,7 +146,7 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(ChangeFactory.addUnits(sz44, fighterType.create(1, americans)));
     // Get total number of defending units before the battle
     final int preCountSz52 = sz52.getUnits().size();
-    final int preCountAirSz44 = sz44.getUnits().getMatches(Matches.UnitIsAir).size();
+    final int preCountAirSz44 = sz44.getUnits().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     bridge.setStepName("CombatMove");
@@ -243,7 +243,7 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(ChangeFactory.addUnits(sz9, fighterType.create(1, americans)));
     // Get total number of defending units before the battle
     final int preCountCanada = eastCanada.getUnits().size();
-    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.UnitIsAir).size();
+    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     bridge.setStepName("CombatMove");
@@ -293,7 +293,7 @@ public class AirThatCantLandUtilTest {
     initDel.end();
     // Get total number of defending units before the battle
     final int preCountCanada = eastCanada.getUnits().size();
-    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.UnitIsAir).size();
+    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     bridge.setStepName("CombatMove");

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -124,7 +124,7 @@ public class LhtrTest {
     route.setStart(gameData.getMap().getTerritory("Ukraine S.S.R."));
     route.add(gameData.getMap().getTerritory("Caucasus"));
     route.add(gameData.getMap().getTerritory("West Russia"));
-    final List<Unit> fighter = route.getStart().getUnits().getMatches(Matches.UnitIsAir);
+    final List<Unit> fighter = route.getStart().getUnits().getMatches(Matches.unitIsAir());
     delegate.move(fighter, route);
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -220,7 +220,7 @@ public class RevisedTest {
     moveDelegate.undoMove(0);
     assertTrue(battle.getBattleTracker().wasConquered(sinkiang));
     // now move the planes into the territory
-    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.UnitIsAir), r));
+    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.unitIsAir()), r));
     // make sure they can't land, they can't because the territory was conquered
     assertEquals(1, moveDelegate.getTerritoriesWhereAirCantLand().size());
   }
@@ -717,7 +717,7 @@ public class RevisedTest {
     final Route sz50To45 = new Route();
     sz50To45.setStart(sz50);
     sz50To45.add(sz45);
-    String error = moveDelegate.move(sz50.getUnits().getMatches(Matches.UnitIsAir), sz50To45);
+    String error = moveDelegate.move(sz50.getUnits().getMatches(Matches.unitIsAir()), sz50To45);
     assertNull(error);
     assertEquals(1, AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattleSites(false).size());
     // we should be able to move the sub out of the sz

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -379,7 +379,7 @@ public class WW2V3Year41Test {
     // attack from bulgraia
     move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
     // add an air attack from east poland
-    move(poland.getUnits().getMatches(Matches.UnitIsAir), new Route(poland, eastPoland, ukraine));
+    move(poland.getUnits().getMatches(Matches.unitIsAir()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
     // that territory is still owned by the enemy
     final MustFightBattle battle =
@@ -1124,7 +1124,7 @@ public class WW2V3Year41Test {
     move(sz8.getUnits().getUnits(), route);
     // make sure the fighter moved
     assertTrue(sz8.getUnits().getUnits().isEmpty());
-    assertFalse(sz1.getUnits().getMatches(Matches.UnitIsAir).isEmpty());
+    assertFalse(sz1.getUnits().getMatches(Matches.unitIsAir()).isEmpty());
   }
 
   @Test
@@ -1418,7 +1418,7 @@ public class WW2V3Year41Test {
           }
         });
     bridge.setRemote(dummyPlayer);
-    move(uk.getUnits().getMatches(Matches.UnitIsAir), gameData.getMap().getRoute(uk, sz5));
+    move(uk.getUnits().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(uk, sz5));
     // move units for amphib assault
     moveDelegate(gameData).end();
     bridge.setStepName("Combat");
@@ -1448,7 +1448,7 @@ public class WW2V3Year41Test {
     final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
         territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
     // the fighter should be able to move, and hover in the sea zone until the carrier is placed
-    move(neEurope.getUnits().getMatches(Matches.UnitIsAir), route);
+    move(neEurope.getUnits().getMatches(Matches.unitIsAir()), route);
   }
 
   @Test
@@ -1465,7 +1465,7 @@ public class WW2V3Year41Test {
     final Territory neEurope = territory("Northwestern Europe", gameData);
     final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
         territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(neEurope.getUnits().getMatches(Matches.UnitIsAir), route);
+    final String error = moveDelegate(gameData).move(neEurope.getUnits().getMatches(Matches.unitIsAir()), route);
     assertNotNull(error);
   }
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is the **final part** in a series of related PRs.