### PR TITLE
Serialization proxy: Add proxy for UnitCollection

### DIFF
--- a/src/main/java/games/strategy/engine/data/Unit.java
+++ b/src/main/java/games/strategy/engine/data/Unit.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.data;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.net.GUID;
@@ -14,12 +14,21 @@ public class Unit extends GameDataComponent {
   private final UnitType m_type;
 
   /**
-   * Creates new Unit. Should use a call to UnitType.create(). Owner can be null
+   * Creates new Unit. Owner can be null.
    */
   public Unit(final UnitType type, final PlayerID owner, final GameData data) {
+    this(type, owner, data, new GUID());
+  }
+
+  public Unit(final UnitType type, final PlayerID owner, final GameData data, final GUID id) {
     super(data);
-    m_type = Preconditions.checkNotNull(type);
-    m_uid = new GUID();
+
+    checkNotNull(type);
+    checkNotNull(id);
+
+    m_type = type;
+    m_uid = id;
+
     setOwner(owner);
   }
 

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework;
 import games.strategy.internal.persistence.serializable.AaRadarAdvanceProxy;
 import games.strategy.internal.persistence.serializable.DestroyerBombardTechAdvanceProxy;
 import games.strategy.internal.persistence.serializable.GameDataProxy;
+import games.strategy.internal.persistence.serializable.GuidProxy;
 import games.strategy.internal.persistence.serializable.HeavyBomberAdvanceProxy;
 import games.strategy.internal.persistence.serializable.ImprovedArtillerySupportAdvanceProxy;
 import games.strategy.internal.persistence.serializable.ImprovedShipyardsAdvanceProxy;
@@ -44,6 +45,7 @@ final class ProxyRegistries {
         AaRadarAdvanceProxy.FACTORY,
         DestroyerBombardTechAdvanceProxy.FACTORY,
         GameDataProxy.FACTORY,
+        GuidProxy.FACTORY,
         HeavyBomberAdvanceProxy.FACTORY,
         ImprovedArtillerySupportAdvanceProxy.FACTORY,
         ImprovedShipyardsAdvanceProxy.FACTORY,

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -27,6 +27,7 @@ import games.strategy.internal.persistence.serializable.SuperSubsAdvanceProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierListProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierProxy;
 import games.strategy.internal.persistence.serializable.TripleAProxy;
+import games.strategy.internal.persistence.serializable.UnitProxy;
 import games.strategy.internal.persistence.serializable.UnitTypeProxy;
 import games.strategy.internal.persistence.serializable.VersionProxy;
 import games.strategy.internal.persistence.serializable.WarBondsAdvanceProxy;
@@ -69,6 +70,7 @@ final class ProxyRegistries {
         TechnologyFrontierProxy.FACTORY,
         TechnologyFrontierListProxy.FACTORY,
         TripleAProxy.FACTORY,
+        UnitProxy.FACTORY,
         UnitTypeProxy.FACTORY,
         VersionProxy.FACTORY,
         WarBondsAdvanceProxy.FACTORY);

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -25,6 +25,7 @@ import games.strategy.internal.persistence.serializable.SuperSubsAdvanceProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierListProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierProxy;
 import games.strategy.internal.persistence.serializable.TripleAProxy;
+import games.strategy.internal.persistence.serializable.UnitTypeProxy;
 import games.strategy.internal.persistence.serializable.VersionProxy;
 import games.strategy.internal.persistence.serializable.WarBondsAdvanceProxy;
 import games.strategy.persistence.serializable.ProxyRegistry;
@@ -64,6 +65,7 @@ final class ProxyRegistries {
         TechnologyFrontierProxy.FACTORY,
         TechnologyFrontierListProxy.FACTORY,
         TripleAProxy.FACTORY,
+        UnitTypeProxy.FACTORY,
         VersionProxy.FACTORY,
         WarBondsAdvanceProxy.FACTORY);
   }

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -27,6 +27,7 @@ import games.strategy.internal.persistence.serializable.SuperSubsAdvanceProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierListProxy;
 import games.strategy.internal.persistence.serializable.TechnologyFrontierProxy;
 import games.strategy.internal.persistence.serializable.TripleAProxy;
+import games.strategy.internal.persistence.serializable.UnitCollectionProxy;
 import games.strategy.internal.persistence.serializable.UnitProxy;
 import games.strategy.internal.persistence.serializable.UnitTypeProxy;
 import games.strategy.internal.persistence.serializable.VersionProxy;
@@ -71,6 +72,7 @@ final class ProxyRegistries {
         TechnologyFrontierListProxy.FACTORY,
         TripleAProxy.FACTORY,
         UnitProxy.FACTORY,
+        UnitCollectionProxy.FACTORY,
         UnitTypeProxy.FACTORY,
         VersionProxy.FACTORY,
         WarBondsAdvanceProxy.FACTORY);

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -13,6 +13,7 @@ import games.strategy.internal.persistence.serializable.JetPowerAdvanceProxy;
 import games.strategy.internal.persistence.serializable.LongRangeAircraftAdvanceProxy;
 import games.strategy.internal.persistence.serializable.MechanizedInfantryAdvanceProxy;
 import games.strategy.internal.persistence.serializable.ParatroopersAdvanceProxy;
+import games.strategy.internal.persistence.serializable.PlayerIdProxy;
 import games.strategy.internal.persistence.serializable.ProductionFrontierProxy;
 import games.strategy.internal.persistence.serializable.ProductionRuleProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
@@ -53,6 +54,7 @@ final class ProxyRegistries {
         LongRangeAircraftAdvanceProxy.FACTORY,
         MechanizedInfantryAdvanceProxy.FACTORY,
         ParatroopersAdvanceProxy.FACTORY,
+        PlayerIdProxy.FACTORY,
         ProductionFrontierProxy.FACTORY,
         ProductionRuleProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,

--- a/src/main/java/games/strategy/internal/persistence/serializable/GuidProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/GuidProxy.java
@@ -1,0 +1,36 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.rmi.dgc.VMID;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.net.GUID;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link GUID} class.
+ */
+@Immutable
+public final class GuidProxy implements Proxy {
+  private static final long serialVersionUID = -9043396346551185991L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(GUID.class, GuidProxy::new);
+
+  private final int id;
+  private final VMID prefix;
+
+  public GuidProxy(final GUID guid) {
+    checkNotNull(guid);
+
+    id = guid.getId();
+    prefix = guid.getPrefix();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new GUID(prefix, id);
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/PlayerIdProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/PlayerIdProxy.java
@@ -1,0 +1,43 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.IAttachment;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link PlayerID} class.
+ */
+@Immutable
+public final class PlayerIdProxy implements Proxy {
+  private static final long serialVersionUID = -8737466123516860123L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(PlayerID.class, PlayerIdProxy::new);
+
+  private final Map<String, IAttachment> attachments;
+  private final GameData gameData;
+  private final String name;
+  // TODO: add other attributes
+
+  public PlayerIdProxy(final PlayerID playerId) {
+    checkNotNull(playerId);
+
+    attachments = playerId.getAttachments();
+    gameData = playerId.getData();
+    name = playerId.getName();
+  }
+
+  @Override
+  public Object readResolve() {
+    final PlayerID playerId = new PlayerID(name, gameData);
+    attachments.forEach(playerId::addAttachment);
+    return playerId;
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/UnitCollectionProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/UnitCollectionProxy.java
@@ -1,0 +1,43 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Collection;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.NamedUnitHolder;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitCollection;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link UnitCollection} class.
+ */
+@Immutable
+public final class UnitCollectionProxy implements Proxy {
+  private static final long serialVersionUID = 3937405630115769153L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(UnitCollection.class, UnitCollectionProxy::new);
+
+  private final GameData gameData;
+  private final NamedUnitHolder namedUnitHolder;
+  private final Collection<Unit> units;
+
+  public UnitCollectionProxy(final UnitCollection unitCollection) {
+    checkNotNull(unitCollection);
+
+    gameData = unitCollection.getData();
+    namedUnitHolder = unitCollection.getHolder();
+    units = unitCollection.getUnits();
+  }
+
+  @Override
+  public Object readResolve() {
+    final UnitCollection unitCollection = new UnitCollection(namedUnitHolder, gameData);
+    unitCollection.addAll(units);
+    return unitCollection;
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/UnitProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/UnitProxy.java
@@ -1,0 +1,46 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.net.GUID;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link Unit} class.
+ */
+@Immutable
+public final class UnitProxy implements Proxy {
+  private static final long serialVersionUID = 1949624850507306628L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(Unit.class, UnitProxy::new);
+
+  private final GameData gameData;
+  private final int hits;
+  private final GUID id;
+  private final PlayerID owner;
+  private final UnitType type;
+
+  public UnitProxy(final Unit unit) {
+    checkNotNull(unit);
+
+    gameData = unit.getData();
+    hits = unit.getHits();
+    id = unit.getID();
+    owner = unit.getOwner();
+    type = unit.getType();
+  }
+
+  @Override
+  public Object readResolve() {
+    final Unit unit = new Unit(type, owner, gameData, id);
+    unit.setHits(hits);
+    return unit;
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/UnitTypeProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/UnitTypeProxy.java
@@ -1,0 +1,42 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.IAttachment;
+import games.strategy.engine.data.UnitType;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link UnitType} class.
+ */
+@Immutable
+public final class UnitTypeProxy implements Proxy {
+  private static final long serialVersionUID = 1588408878724586338L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(UnitType.class, UnitTypeProxy::new);
+
+  private final Map<String, IAttachment> attachments;
+  private final GameData gameData;
+  private final String name;
+
+  public UnitTypeProxy(final UnitType unitType) {
+    checkNotNull(unitType);
+
+    attachments = unitType.getAttachments();
+    gameData = unitType.getData();
+    name = unitType.getName();
+  }
+
+  @Override
+  public Object readResolve() {
+    final UnitType unitType = new UnitType(name, gameData);
+    attachments.forEach(unitType::addAttachment);
+    return unitType;
+  }
+}

--- a/src/main/java/games/strategy/net/GUID.java
+++ b/src/main/java/games/strategy/net/GUID.java
@@ -1,5 +1,7 @@
 package games.strategy.net;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -8,12 +10,11 @@ import java.rmi.dgc.VMID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * A globally unique id. <br>
+ * A globally unique id.
  * Backed by a java.rmi.dgc.VMID.
- * Written across the network often, so this class is
- * externalizable to increase effeciency
+ * Written across the network often, so this class is externalizable to increase efficiency.
  */
-public class GUID implements Externalizable {
+public final class GUID implements Externalizable {
   private static final long serialVersionUID = 8426441559602874190L;
   // this prefix is unique across vms
   private static VMID vmPrefix = new VMID();
@@ -32,6 +33,21 @@ public class GUID implements Externalizable {
       vmPrefix = new VMID();
       lastId = new AtomicInteger();
     }
+  }
+
+  public GUID(final VMID prefix, final int id) {
+    checkNotNull(prefix);
+
+    m_id = id;
+    m_prefix = prefix;
+  }
+
+  public int getId() {
+    return m_id;
+  }
+
+  public VMID getPrefix() {
+    return m_prefix;
   }
 
   @Override

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -83,6 +83,11 @@ public final class EngineDataEqualityComparators {
       ParatroopersAdvance.class,
       EngineDataEqualityComparators::techAdvanceEquals);
 
+  public static final EqualityComparator PLAYER_ID = EqualityComparator.newInstance(
+      PlayerID.class,
+      // TODO: add comparisons for other attributes
+      EngineDataEqualityComparators::namedAttachableEquals);
+
   public static final EqualityComparator PRODUCTION_FRONTIER = EqualityComparator.newInstance(
       ProductionFrontier.class,
       (context, o1, o2) -> defaultNamedEquals(context, o1, o2)

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -133,6 +133,10 @@ public final class EngineDataEqualityComparators {
       (context, o1, o2) -> gameDataComponentEquals(context, o1, o2)
           && context.equals(o1.getFrontiers(), o2.getFrontiers()));
 
+  public static final EqualityComparator UNIT_TYPE = EqualityComparator.newInstance(
+      UnitType.class,
+      EngineDataEqualityComparators::namedAttachableEquals);
+
   public static final EqualityComparator WAR_BONDS_ADVANCE = EqualityComparator.newInstance(
       WarBondsAdvance.class,
       EngineDataEqualityComparators::techAdvanceEquals);

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -138,6 +138,14 @@ public final class EngineDataEqualityComparators {
       (context, o1, o2) -> gameDataComponentEquals(context, o1, o2)
           && context.equals(o1.getFrontiers(), o2.getFrontiers()));
 
+  public static final EqualityComparator UNIT = EqualityComparator.newInstance(
+      Unit.class,
+      (context, o1, o2) -> gameDataComponentEquals(context, o1, o2)
+          && (o1.getHits() == o2.getHits())
+          && context.equals(o1.getID(), o2.getID())
+          && context.equals(o1.getOwner(), o2.getOwner())
+          && context.equals(o1.getType(), o2.getType()));
+
   public static final EqualityComparator UNIT_TYPE = EqualityComparator.newInstance(
       UnitType.class,
       EngineDataEqualityComparators::namedAttachableEquals);

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -146,6 +146,12 @@ public final class EngineDataEqualityComparators {
           && context.equals(o1.getOwner(), o2.getOwner())
           && context.equals(o1.getType(), o2.getType()));
 
+  public static final EqualityComparator UNIT_COLLECTION = EqualityComparator.newInstance(
+      UnitCollection.class,
+      (context, o1, o2) -> gameDataComponentEquals(context, o1, o2)
+          && context.equals(o1.getHolder(), o2.getHolder())
+          && context.equals(o1.getUnits(), o2.getUnits()));
+
   public static final EqualityComparator UNIT_TYPE = EqualityComparator.newInstance(
       UnitType.class,
       EngineDataEqualityComparators::namedAttachableEquals);

--- a/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -1,6 +1,10 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.MoreObjects;
 
@@ -9,12 +13,15 @@ import games.strategy.engine.data.annotations.InternalDoNotExport;
 /**
  * Fake implementation of {@link IAttachment} useful for testing.
  */
+@Immutable
 public final class FakeAttachment implements IAttachment {
   private static final long serialVersionUID = 3686559484645729844L;
 
   private final String name;
 
   public FakeAttachment(final String name) {
+    checkNotNull(name);
+
     this.name = name;
   }
 

--- a/src/test/java/games/strategy/engine/data/FakeNamedUnitHolder.java
+++ b/src/test/java/games/strategy/engine/data/FakeNamedUnitHolder.java
@@ -1,0 +1,73 @@
+package games.strategy.engine.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Fake implementation of {@link NamedUnitHolder} useful for testing.
+ */
+@Immutable
+public final class FakeNamedUnitHolder implements NamedUnitHolder, Serializable {
+  private static final long serialVersionUID = -1802836924862350594L;
+
+  private final String name;
+  private final String type;
+
+  public FakeNamedUnitHolder(final String name, final String type) {
+    checkNotNull(name);
+    checkNotNull(type);
+
+    this.name = name;
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (!(obj instanceof FakeNamedUnitHolder)) {
+      return false;
+    }
+
+    final FakeNamedUnitHolder other = (FakeNamedUnitHolder) obj;
+    return Objects.equals(name, other.name)
+        && Objects.equals(type, other.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("type", type)
+        .toString();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public UnitCollection getUnits() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void notifyChanged() {}
+}

--- a/src/test/java/games/strategy/engine/data/FakeNamedUnitHolderTest.java
+++ b/src/test/java/games/strategy/engine/data/FakeNamedUnitHolderTest.java
@@ -1,0 +1,12 @@
+package games.strategy.engine.data;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public final class FakeNamedUnitHolderTest {
+  @Test
+  public void shouldBeEquatableAndHashable() {
+    EqualsVerifier.forClass(FakeNamedUnitHolder.class).verify();
+  }
+}

--- a/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
@@ -28,6 +28,24 @@ public final class TestGameDataComponentFactory {
   }
 
   /**
+   * Creates a new {@link PlayerID} instance.
+   *
+   * @param gameData The game data that owns the component.
+   * @param name The component name.
+   *
+   * @return A new {@link PlayerID} instance.
+   */
+  public static PlayerID newPlayerId(final GameData gameData, final String name) {
+    checkNotNull(gameData);
+    checkNotNull(name);
+
+    final PlayerID playerId = new PlayerID(name, gameData);
+    // TODO: initialize other attributes
+    initializeAttachable(playerId);
+    return playerId;
+  }
+
+  /**
    * Creates a new {@link ProductionRule} instance.
    *
    * @param gameData The game data that owns the component.
@@ -102,6 +120,23 @@ public final class TestGameDataComponentFactory {
         newFakeTechAdvance(gameData, "Tech Advance 1"),
         newFakeTechAdvance(gameData, "Tech Advance 2")));
     return technologyFrontier;
+  }
+
+  /**
+   * Creates a new {@link UnitType} instance.
+   *
+   * @param gameData The game data that owns the component.
+   * @param name The component name.
+   *
+   * @return A new {@link UnitType} instance.
+   */
+  public static UnitType newUnitType(final GameData gameData, final String name) {
+    checkNotNull(gameData);
+    checkNotNull(name);
+
+    final UnitType unitType = new UnitType(name, gameData);
+    initializeAttachable(unitType);
+    return unitType;
   }
 
   /**

--- a/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Arrays;
 
+import games.strategy.net.GUID;
 import games.strategy.triplea.delegate.FakeTechAdvance;
 import games.strategy.util.IntegerMap;
 
@@ -120,6 +121,25 @@ public final class TestGameDataComponentFactory {
         newFakeTechAdvance(gameData, "Tech Advance 1"),
         newFakeTechAdvance(gameData, "Tech Advance 2")));
     return technologyFrontier;
+  }
+
+  /**
+   * Creates a new {@link Unit} instance.
+   *
+   * @param gameData The game data that owns the component.
+   * @param owner The player that owns the unit.
+   * @param typeName The name of the unit type.
+   *
+   * @return A new {@link Unit} instance.
+   */
+  public static Unit newUnit(final GameData gameData, final PlayerID owner, final String typeName) {
+    checkNotNull(gameData);
+    checkNotNull(owner);
+    checkNotNull(typeName);
+
+    final Unit unit = new Unit(newUnitType(gameData, typeName), owner, gameData, new GUID());
+    unit.setHits(42);
+    return unit;
   }
 
   /**

--- a/src/test/java/games/strategy/internal/persistence/serializable/GuidProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/GuidProxyAsProxyTest.java
@@ -1,0 +1,25 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.rmi.dgc.VMID;
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.net.GUID;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+public final class GuidProxyAsProxyTest extends AbstractProxyTestCase<GUID> {
+  public GuidProxyAsProxyTest() {
+    super(GUID.class);
+  }
+
+  @Override
+  protected Collection<GUID> createPrincipals() {
+    return Arrays.asList(new GUID(new VMID(), 42));
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return Arrays.asList(GuidProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/PlayerIdProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/PlayerIdProxyAsProxyTest.java
@@ -1,0 +1,36 @@
+package games.strategy.internal.persistence.serializable;
+
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+
+public final class PlayerIdProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<PlayerID> {
+  public PlayerIdProxyAsProxyTest() {
+    super(PlayerID.class);
+  }
+
+  @Override
+  protected PlayerID newGameDataComponent(final GameData gameData) {
+    final PlayerID playerId = new PlayerID("playerId", gameData);
+    // TODO: initialize other attributes
+    initializeAttachable(playerId);
+    return playerId;
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.PLAYER_ID);
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(PlayerIdProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/PlayerIdProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/PlayerIdProxyAsProxyTest.java
@@ -1,6 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+import static games.strategy.engine.data.TestGameDataComponentFactory.newPlayerId;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,10 +18,7 @@ public final class PlayerIdProxyAsProxyTest extends AbstractGameDataComponentPro
 
   @Override
   protected PlayerID newGameDataComponent(final GameData gameData) {
-    final PlayerID playerId = new PlayerID("playerId", gameData);
-    // TODO: initialize other attributes
-    initializeAttachable(playerId);
-    return playerId;
+    return newPlayerId(gameData, "playerId");
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/UnitCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/UnitCollectionProxyAsProxyTest.java
@@ -7,19 +7,24 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.FakeNamedUnitHolder;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitCollection;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.test.EqualityComparator;
 
-public final class UnitProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<Unit> {
-  public UnitProxyAsProxyTest() {
-    super(Unit.class);
+public final class UnitCollectionProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<UnitCollection> {
+  public UnitCollectionProxyAsProxyTest() {
+    super(UnitCollection.class);
   }
 
   @Override
-  protected Unit newGameDataComponent(final GameData gameData) {
-    return newUnit(gameData, newPlayerId(gameData, "playerId"), "unitType");
+  protected UnitCollection newGameDataComponent(final GameData gameData) {
+    final UnitCollection unitCollection = new UnitCollection(new FakeNamedUnitHolder("name", "type"), gameData);
+    unitCollection.addAll(Arrays.asList(
+        newUnit(gameData, newPlayerId(gameData, "playerId1"), "unitType1"),
+        newUnit(gameData, newPlayerId(gameData, "playerId2"), "unitType2")));
+    return unitCollection;
   }
 
   @Override
@@ -27,6 +32,7 @@ public final class UnitProxyAsProxyTest extends AbstractGameDataComponentProxyTe
     return Arrays.asList(
         EngineDataEqualityComparators.PLAYER_ID,
         EngineDataEqualityComparators.UNIT,
+        EngineDataEqualityComparators.UNIT_COLLECTION,
         EngineDataEqualityComparators.UNIT_TYPE);
   }
 
@@ -36,6 +42,7 @@ public final class UnitProxyAsProxyTest extends AbstractGameDataComponentProxyTe
         GuidProxy.FACTORY,
         PlayerIdProxy.FACTORY,
         UnitProxy.FACTORY,
+        UnitCollectionProxy.FACTORY,
         UnitTypeProxy.FACTORY);
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/UnitProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/UnitProxyAsProxyTest.java
@@ -1,0 +1,48 @@
+package games.strategy.internal.persistence.serializable;
+
+import static games.strategy.engine.data.TestGameDataComponentFactory.newPlayerId;
+import static games.strategy.engine.data.TestGameDataComponentFactory.newUnitType;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Unit;
+import games.strategy.net.GUID;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+
+public final class UnitProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<Unit> {
+  public UnitProxyAsProxyTest() {
+    super(Unit.class);
+  }
+
+  @Override
+  protected Unit newGameDataComponent(final GameData gameData) {
+    final Unit unit = new Unit(
+        newUnitType(gameData, "unitType"),
+        newPlayerId(gameData, "playerId"),
+        gameData,
+        new GUID());
+    unit.setHits(42);
+    return unit;
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(
+        EngineDataEqualityComparators.PLAYER_ID,
+        EngineDataEqualityComparators.UNIT,
+        EngineDataEqualityComparators.UNIT_TYPE);
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(
+        GuidProxy.FACTORY,
+        PlayerIdProxy.FACTORY,
+        UnitProxy.FACTORY,
+        UnitTypeProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/UnitTypeProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/UnitTypeProxyAsProxyTest.java
@@ -1,0 +1,35 @@
+package games.strategy.internal.persistence.serializable;
+
+import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.UnitType;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+
+public final class UnitTypeProxyAsProxyTest extends AbstractGameDataComponentProxyTestCase<UnitType> {
+  public UnitTypeProxyAsProxyTest() {
+    super(UnitType.class);
+  }
+
+  @Override
+  protected UnitType newGameDataComponent(final GameData gameData) {
+    final UnitType unitType = new UnitType("unitType", gameData);
+    initializeAttachable(unitType);
+    return unitType;
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getAdditionalEqualityComparators() {
+    return Arrays.asList(EngineDataEqualityComparators.UNIT_TYPE);
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getAdditionalProxyFactories() {
+    return Arrays.asList(UnitTypeProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/UnitTypeProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/UnitTypeProxyAsProxyTest.java
@@ -1,6 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.TestGameDataComponentFactory.initializeAttachable;
+import static games.strategy.engine.data.TestGameDataComponentFactory.newUnitType;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -18,9 +18,7 @@ public final class UnitTypeProxyAsProxyTest extends AbstractGameDataComponentPro
 
   @Override
   protected UnitType newGameDataComponent(final GameData gameData) {
-    final UnitType unitType = new UnitType("unitType", gameData);
-    initializeAttachable(unitType);
-    return unitType;
+    return newUnitType(gameData, "unitType");
   }
 
   @Override

--- a/src/test/java/games/strategy/net/GuidTest.java
+++ b/src/test/java/games/strategy/net/GuidTest.java
@@ -1,0 +1,15 @@
+package games.strategy.net;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public final class GuidTest {
+  @Test
+  public void shouldBeEquatableAndHashable() {
+    EqualsVerifier.forClass(GUID.class)
+        .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+        .verify();
+  }
+}


### PR DESCRIPTION
This PR adds a serialization proxy for `UnitCollection` and its dependencies:

* `GUID`
* `PlayerID` (incomplete due to circular dependency)
* `Unit`
* `UnitType`

Most of the changes in this PR are boilerplate serialization proxy stuff.  However, reviewers should scrutinize the changes in the production types `GUID` and `Unit` that were required to create instances of these types from their respective proxies.