### PR TITLE
Checkstyle: Rename "rVal" local variables (part 1)

### DIFF
--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -64,15 +64,15 @@ public class Chat {
   }
 
   private static LinkedHashSet<String> getTagText(final Tag tag) {
-    final LinkedHashSet<String> rVal = new LinkedHashSet<>();
+    final LinkedHashSet<String> tagText = new LinkedHashSet<>();
     if (tag == Tag.NONE) {
       return null;
     }
     if (tag == Tag.MODERATOR) {
-      rVal.add(TAG_MODERATOR);
+      tagText.add(TAG_MODERATOR);
     }
     // add more here....
-    return rVal;
+    return tagText;
   }
 
   String getNotesForNode(final INode node) {

--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -65,12 +65,12 @@ public class AllianceTracker implements Serializable {
    * @return a set of all the games alliances, this will return an empty set if you aren't using alliances.
    */
   public Set<String> getAlliances() {
-    final Iterator<PlayerID> keys = alliances.keySet().iterator();
-    final Set<String> rVal = new HashSet<>();
+    final Iterator<PlayerID> keys = this.alliances.keySet().iterator();
+    final Set<String> alliances = new HashSet<>();
     while (keys.hasNext()) {
-      rVal.addAll(alliances.get(keys.next()));
+      alliances.addAll(this.alliances.get(keys.next()));
     }
-    return rVal;
+    return alliances;
   }
 
   /**
@@ -82,20 +82,20 @@ public class AllianceTracker implements Serializable {
    */
   public Set<PlayerID> getPlayersInAlliance(final String allianceName) {
     final Iterator<PlayerID> keys = alliances.keySet().iterator();
-    final HashSet<PlayerID> rVal = new HashSet<>();
+    final HashSet<PlayerID> playersInAlliance = new HashSet<>();
     while (keys.hasNext()) {
       final PlayerID player = keys.next();
       if (alliances.get(player).contains(allianceName)) {
-        rVal.add(player);
+        playersInAlliance.add(player);
       }
     }
-    return rVal;
+    return playersInAlliance;
   }
 
   public Collection<String> getAlliancesPlayerIsIn(final PlayerID player) {
-    final Collection<String> rVal = alliances.get(player);
-    if (!rVal.isEmpty()) {
-      return rVal;
+    final Collection<String> alliancesPlayerIsIn = alliances.get(player);
+    if (!alliancesPlayerIsIn.isEmpty()) {
+      return alliancesPlayerIsIn;
     } else {
       return Collections.singleton(player.getName());
     }

--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -82,7 +82,7 @@ public class AllianceTracker implements Serializable {
    */
   public Set<PlayerID> getPlayersInAlliance(final String allianceName) {
     final Iterator<PlayerID> keys = alliances.keySet().iterator();
-    final HashSet<PlayerID> playersInAlliance = new HashSet<>();
+    final Set<PlayerID> playersInAlliance = new HashSet<>();
     while (keys.hasNext()) {
       final PlayerID player = keys.next();
       if (alliances.get(player).contains(allianceName)) {

--- a/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -62,14 +62,14 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
 
   protected static IllegalArgumentException getSetterExceptionMessage(final DefaultAttachment failingObject,
       final String propertyName, final String givenValue, final String... allowedValues) {
-    final StringBuilder rVal = new StringBuilder();
-    rVal.append(failingObject.getClass().getName()).append(": ").append(failingObject.getName()).append(": property ")
+    final StringBuilder sb = new StringBuilder();
+    sb.append(failingObject.getClass().getName()).append(": ").append(failingObject.getName()).append(": property ")
         .append(propertyName).append(" must be either ");
-    rVal.append(allowedValues[0]);
+    sb.append(allowedValues[0]);
     for (int i = 1; i < allowedValues.length; ++i) {
-      rVal.append(" or ").append(allowedValues[i]);
+      sb.append(" or ").append(allowedValues[i]);
     }
-    return new IllegalArgumentException(rVal.toString() + " ([Not Allowed] Given: " + givenValue + ")");
+    return new IllegalArgumentException(sb.toString() + " ([Not Allowed] Given: " + givenValue + ")");
   }
 
   protected String thisErrorMsg() {

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -290,9 +290,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         other.
    */
   public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance, final Match<Territory> cond) {
-    final Set<Territory> rVal = getNeighbors(frontier, new HashSet<>(frontier), distance, cond);
-    rVal.removeAll(frontier);
-    return rVal;
+    final Set<Territory> neighbors = getNeighbors(frontier, new HashSet<>(frontier), distance, cond);
+    neighbors.removeAll(frontier);
+    return neighbors;
   }
 
   /**
@@ -301,9 +301,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         other.
    */
   public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance) {
-    final Set<Territory> rVal = getNeighbors(frontier, new HashSet<>(frontier), distance);
-    rVal.removeAll(frontier);
-    return rVal;
+    final Set<Territory> neighbors = getNeighbors(frontier, new HashSet<>(frontier), distance);
+    neighbors.removeAll(frontier);
+    return neighbors;
   }
 
   private Set<Territory> getNeighbors(final Set<Territory> frontier, final Set<Territory> searched, int distance,
@@ -498,14 +498,14 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
 
   public IntegerMap<Territory> getDistance(final Territory target, final Collection<Territory> territories,
       final Match<Territory> condition) {
-    final IntegerMap<Territory> rVal = new IntegerMap<>();
+    final IntegerMap<Territory> distances = new IntegerMap<>();
     if (target == null || territories == null || territories.isEmpty()) {
-      return rVal;
+      return distances;
     }
     for (final Territory t : territories) {
-      rVal.put(t, getDistance(target, t, condition));
+      distances.put(t, getDistance(target, t, condition));
     }
-    return rVal;
+    return distances;
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -454,14 +454,14 @@ public class GameParser {
   }
 
   private static List<Node> getNonTextNodesIgnoring(final Node node, final String ignore) {
-    final List<Node> rVal = getNonTextNodes(node);
-    final Iterator<Node> iter = rVal.iterator();
+    final List<Node> nonTextNodes = getNonTextNodes(node);
+    final Iterator<Node> iter = nonTextNodes.iterator();
     while (iter.hasNext()) {
       if (((Element) iter.next()).getTagName().equals(ignore)) {
         iter.remove();
       }
     }
-    return rVal;
+    return nonTextNodes;
   }
 
   private static List<Node> getNonTextNodes(final Node node) {
@@ -976,13 +976,13 @@ public class GameParser {
   }
 
   private static Properties pareStepProperties(final List<Element> properties) {
-    final Properties rVal = new Properties();
+    final Properties stepProperties = new Properties();
     for (final Element stepProperty : properties) {
       final String name = stepProperty.getAttribute("name");
       final String value = stepProperty.getAttribute("value");
-      rVal.setProperty(name, value);
+      stepProperties.setProperty(name, value);
     }
-    return rVal;
+    return stepProperties;
   }
 
   private void parseProduction(final Node root) throws GameParseException {

--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -172,14 +172,14 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   }
 
   public static LinkedHashMap<String, String> currentPlayers(final GameData data) {
-    final LinkedHashMap<String, String> rVal = new LinkedHashMap<>();
+    final LinkedHashMap<String, String> currentPlayers = new LinkedHashMap<>();
     if (data == null) {
-      return rVal;
+      return currentPlayers;
     }
     for (final PlayerID player : data.getPlayerList().getPlayers()) {
-      rVal.put(player.getName(), player.getWhoAmI().split(":")[1]);
+      currentPlayers.put(player.getName(), player.getWhoAmI().split(":")[1]);
     }
-    return rVal;
+    return currentPlayers;
   }
 
   public RulesAttachment getRulesAttachment() {

--- a/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -66,13 +66,13 @@ public class PlayerManager {
   }
 
   public Set<String> getPlayedBy(final INode playerNode) {
-    final Set<String> rVal = new HashSet<>();
+    final Set<String> players = new HashSet<>();
     for (final String player : m_playerMapping.keySet()) {
       if (m_playerMapping.get(player).equals(playerNode)) {
-        rVal.add(player);
+        players.add(player);
       }
     }
-    return rVal;
+    return players;
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -94,16 +94,16 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
     if (maxUnits < 0) {
       throw new IllegalArgumentException("value must be positiive.  Instead its:" + maxUnits);
     }
-    final Collection<Unit> rVal = new ArrayList<>();
+    final Collection<Unit> units = new ArrayList<>();
     for (final Unit current : m_units) {
       if (current.getType().equals(type)) {
-        rVal.add(current);
-        if (rVal.size() == maxUnits) {
-          return rVal;
+        units.add(current);
+        if (units.size() == maxUnits) {
+          return units;
         }
       }
     }
-    return rVal;
+    return units;
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -92,35 +92,35 @@ public class UnitType extends NamedAttachable {
    */
   public static Map<PlayerID, List<UnitType>> getAllPlayerUnitsWithImages(final GameData data,
       final IUIContext uiContext, final boolean forceIncludeNeutralPlayer) {
-    final LinkedHashMap<PlayerID, List<UnitType>> rVal = new LinkedHashMap<>();
+    final LinkedHashMap<PlayerID, List<UnitType>> unitTypes = new LinkedHashMap<>();
     data.acquireReadLock();
     try {
       for (final PlayerID p : data.getPlayerList().getPlayers()) {
-        rVal.put(p, getPlayerUnitsWithImages(p, data, uiContext));
+        unitTypes.put(p, getPlayerUnitsWithImages(p, data, uiContext));
       }
       final HashSet<UnitType> unitsSoFar = new HashSet<>();
-      for (final List<UnitType> l : rVal.values()) {
+      for (final List<UnitType> l : unitTypes.values()) {
         unitsSoFar.addAll(l);
       }
       final Set<UnitType> all = data.getUnitTypeList().getAllUnitTypes();
       all.removeAll(unitsSoFar);
       if (forceIncludeNeutralPlayer || !all.isEmpty()) {
-        rVal.put(PlayerID.NULL_PLAYERID, getPlayerUnitsWithImages(PlayerID.NULL_PLAYERID, data, uiContext));
-        unitsSoFar.addAll(rVal.get(PlayerID.NULL_PLAYERID));
+        unitTypes.put(PlayerID.NULL_PLAYERID, getPlayerUnitsWithImages(PlayerID.NULL_PLAYERID, data, uiContext));
+        unitsSoFar.addAll(unitTypes.get(PlayerID.NULL_PLAYERID));
         all.removeAll(unitsSoFar);
         if (!all.isEmpty()) {
-          rVal.put(null, new ArrayList<>(all));
+          unitTypes.put(null, new ArrayList<>(all));
         }
       }
     } finally {
       data.releaseReadLock();
     }
-    return rVal;
+    return unitTypes;
   }
 
   private static List<UnitType> getPlayerUnitsWithImages(final PlayerID player, final GameData data,
       final IUIContext uiContext) {
-    final ArrayList<UnitType> rVal = new ArrayList<>();
+    final ArrayList<UnitType> unitTypes = new ArrayList<>();
     data.acquireReadLock();
     try {
       // add first based on current production ability
@@ -129,8 +129,8 @@ public class UnitType extends NamedAttachable {
           for (final Entry<NamedAttachable, Integer> entry : productionRule.getResults().entrySet()) {
             if (UnitType.class.isAssignableFrom(entry.getKey().getClass())) {
               final UnitType ut = (UnitType) entry.getKey();
-              if (!rVal.contains(ut)) {
-                rVal.add(ut);
+              if (!unitTypes.contains(ut)) {
+                unitTypes.add(ut);
               }
             }
           }
@@ -144,22 +144,22 @@ public class UnitType extends NamedAttachable {
         for (final Unit u : t.getUnits()) {
           if (u.getOwner().equals(player)) {
             final UnitType ut = u.getType();
-            if (!rVal.contains(ut)) {
-              rVal.add(ut);
+            if (!unitTypes.contains(ut)) {
+              unitTypes.add(ut);
             }
           }
         }
       }
       // now check if we have the art for anything that is left
       for (final UnitType ut : data.getUnitTypeList().getAllUnitTypes()) {
-        if (!rVal.contains(ut)) {
+        if (!unitTypes.contains(ut)) {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
               final Optional<Image> unitImage = imageFactory.getImage(ut, player, false, false);
               if (unitImage.isPresent()) {
-                if (!rVal.contains(ut)) {
-                  rVal.add(ut);
+                if (!unitTypes.contains(ut)) {
+                  unitTypes.add(ut);
                 }
               }
             }
@@ -172,6 +172,6 @@ public class UnitType extends NamedAttachable {
     } finally {
       data.releaseReadLock();
     }
-    return rVal;
+    return unitTypes;
   }
 }

--- a/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
@@ -31,9 +31,9 @@ public abstract class AEditableProperty implements IEditableProperty, Serializab
 
   @Override
   public JComponent getViewComponent() {
-    final JComponent rVal = getEditorComponent();
-    rVal.setEnabled(false);
-    return rVal;
+    final JComponent component = getEditorComponent();
+    component.setEnabled(false);
+    return component;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -72,9 +72,9 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public int[] getRandom(final int max, final int count, final PlayerID player, final DiceType diceType,
       final String annotation) throws IllegalArgumentException, IllegalStateException {
-    final int[] rVal = m_randomSource.getRandom(max, count, annotation);
-    m_randomStats.addRandom(rVal, player, diceType);
-    return rVal;
+    final int[] randomValues = m_randomSource.getRandom(max, count, annotation);
+    m_randomStats.addRandom(randomValues, player, diceType);
+    return randomValues;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -57,8 +57,8 @@ public class DelegateExecutionManager {
    * </p>
    */
   public boolean blockDelegateExecution(final int timeToWaitMs) throws InterruptedException {
-    final boolean rVal = m_readWriteLock.writeLock().tryLock(timeToWaitMs, TimeUnit.MILLISECONDS);
-    if (!rVal) {
+    final boolean lockAcquired = m_readWriteLock.writeLock().tryLock(timeToWaitMs, TimeUnit.MILLISECONDS);
+    if (!lockAcquired) {
       if (sm_logger.isLoggable(Level.FINE)) {
         sm_logger.fine("Could not block delegate execution. Read Lock count: " + m_readWriteLock.getReadLockCount()
             + " Write Hold count: " + m_readWriteLock.getWriteHoldCount() + " Queue Length: "
@@ -79,7 +79,7 @@ public class DelegateExecutionManager {
         sm_logger.fine(Thread.currentThread().getName() + " block delegate execution.");
       }
     }
-    return rVal;
+    return lockAcquired;
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -201,8 +201,8 @@ public class GameRunner {
   public static Optional<File> showSaveGameFileChooser() {
     // Non-Mac platforms should use the normal Swing JFileChooser
     final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
-    final int rVal = fileChooser.showOpenDialog(mainFrame);
-    if (rVal == JFileChooser.APPROVE_OPTION) {
+    final int selectedOption = fileChooser.showOpenDialog(mainFrame);
+    if (selectedOption == JFileChooser.APPROVE_OPTION) {
       return Optional.of(fileChooser.getSelectedFile());
     }
     return Optional.empty();

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -86,9 +86,9 @@ public class AvailableGames {
   }
 
   private static List<File> allMapFiles() {
-    final List<File> rVal = new ArrayList<>();
-    rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
-    return rVal;
+    final List<File> files = new ArrayList<>();
+    files.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
+    return files;
   }
 
   private static List<File> safeListFiles(final File f) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -30,7 +30,7 @@ final class DownloadFileParser {
   public static List<DownloadFileDescription> parse(final InputStream is) {
     final JSONArray yamlData = new JSONArray(new Yaml().loadAs(is, List.class));
 
-    final List<DownloadFileDescription> rVal = new ArrayList<>();
+    final List<DownloadFileDescription> downloads = new ArrayList<>();
     StreamSupport.stream(yamlData.spliterator(), false).map(JSONObject.class::cast).forEach(yaml -> {
       final String url = yaml.getString(Tags.url.toString());
       final String description = yaml.getString(Tags.description.toString());
@@ -50,8 +50,8 @@ final class DownloadFileParser {
       final String img = yaml.optString(Tags.img.toString());
       final DownloadFileDescription dl =
           new DownloadFileDescription(url, description, mapName, version, downloadType, mapCategory, img);
-      rVal.add(dl);
+      downloads.add(dl);
     });
-    return rVal;
+    return downloads;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -21,13 +21,13 @@ class DownloadFileProperties {
     if (!fromZip(zipFile).exists()) {
       return new DownloadFileProperties();
     }
-    final DownloadFileProperties rVal = new DownloadFileProperties();
+    final DownloadFileProperties downloadFileProperties = new DownloadFileProperties();
     try (final FileInputStream fis = new FileInputStream(fromZip(zipFile))) {
-      rVal.props.load(fis);
+      downloadFileProperties.props.load(fis);
     } catch (final IOException e) {
       ClientLogger.logError("Failed to read property file: " + fromZip(zipFile).getAbsolutePath(), e);
     }
-    return rVal;
+    return downloadFileProperties;
   }
 
   static void saveForZip(final File zipFile, final DownloadFileProperties props) {

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
@@ -37,9 +37,9 @@ public class BanPlayerAction extends AbstractAction {
       JOptionPane.showMessageDialog(m_parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    final int rVal =
+    final int selectedOption =
         JOptionPane.showConfirmDialog(m_parent, combo, "Select player to ban", JOptionPane.OK_CANCEL_OPTION);
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     final String name = (String) combo.getSelectedItem();

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/BootPlayerAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/BootPlayerAction.java
@@ -37,9 +37,9 @@ public class BootPlayerAction extends AbstractAction {
       JOptionPane.showMessageDialog(m_parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    final int rVal =
+    final int selectedOption =
         JOptionPane.showConfirmDialog(m_parent, combo, "Select player to remove", JOptionPane.OK_CANCEL_OPTION);
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     final String name = (String) combo.getSelectedItem();

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/ChangeToAutosaveClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/ChangeToAutosaveClientAction.java
@@ -26,11 +26,11 @@ public class ChangeToAutosaveClientAction extends AbstractAction {
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    final int rVal = JOptionPane.showConfirmDialog(m_parent,
+    final int selectedOption = JOptionPane.showConfirmDialog(m_parent,
         new JLabel("Change Game To: " + m_typeOfAutosave.toString().toLowerCase()),
         "Change Game To: " + m_typeOfAutosave.toString().toLowerCase(), JOptionPane.OK_CANCEL_OPTION,
         JOptionPane.QUESTION_MESSAGE);
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     m_clientMessenger.changeToLatestAutosave(m_typeOfAutosave);

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
@@ -37,9 +37,9 @@ public class MutePlayerAction extends AbstractAction {
       JOptionPane.showMessageDialog(m_parent, "No remote players", "No Remote Players", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    final int rVal =
+    final int selectedOption =
         JOptionPane.showConfirmDialog(m_parent, combo, "Select player to mute", JOptionPane.OK_CANCEL_OPTION);
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     final String name = (String) combo.getSelectedItem();

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/SetMapClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/SetMapClientAction.java
@@ -41,8 +41,9 @@ public class SetMapClientAction extends AbstractAction {
       JOptionPane.showMessageDialog(m_parent, "No available games", "No available games", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    final int rVal = JOptionPane.showConfirmDialog(m_parent, combo, "Change Game To: ", JOptionPane.OK_CANCEL_OPTION);
-    if (rVal != JOptionPane.OK_OPTION) {
+    final int selectedOption =
+        JOptionPane.showConfirmDialog(m_parent, combo, "Change Game To: ", JOptionPane.OK_CANCEL_OPTION);
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     final String name = (String) combo.getSelectedItem();

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/SetPasswordAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/SetPasswordAction.java
@@ -35,9 +35,9 @@ public class SetPasswordAction extends AbstractAction {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(m_parent), panel, "Enter Password",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION) {
+    final int selectedOption = JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(m_parent), panel,
+        "Enter Password", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     final String password = new String(passwordField.getPassword());

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -28,7 +28,7 @@ import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.IRemoteModelListener;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
+import games.strategy.engine.framework.ui.SaveGameFileChooser.AUTOSAVE_TYPE;
 
 public class ClientSetupPanel extends SetupPanel {
   private static final long serialVersionUID = 6942605803526295372L;
@@ -298,16 +298,16 @@ public class ClientSetupPanel extends SetupPanel {
     if (!isServerHeadless) {
       return new ArrayList<>();
     }
-    final List<Action> rVal = new ArrayList<>();
-    rVal.add(clientModel.getHostBotSetMapClientAction(this));
-    rVal.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
-    rVal.add(clientModel.getHostBotChangeGameToSaveGameClientAction());
-    rVal.add(clientModel.getHostBotChangeToAutosaveClientAction(this, SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE));
-    rVal.add(clientModel.getHostBotChangeToAutosaveClientAction(this, SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE2));
-    rVal.add(clientModel.getHostBotChangeToAutosaveClientAction(this, SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_ODD));
-    rVal.add(clientModel.getHostBotChangeToAutosaveClientAction(this, SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN));
-    rVal.add(clientModel.getHostBotGetGameSaveClientAction(this));
-    return rVal;
+    final List<Action> actions = new ArrayList<>();
+    actions.add(clientModel.getHostBotSetMapClientAction(this));
+    actions.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
+    actions.add(clientModel.getHostBotChangeGameToSaveGameClientAction());
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE2));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_ODD));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_EVEN));
+    actions.add(clientModel.getHostBotGetGameSaveClientAction(this));
+    return actions;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -99,11 +99,11 @@ public class InGameLobbyWatcher {
 
       @Override
       public Map<String, String> getProperties(final Map<String, String> challengProperties) {
-        final Map<String, String> rVal = new HashMap<>();
-        rVal.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-        rVal.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-        rVal.put(LobbyLoginValidator.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
-        return rVal;
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+        properties.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+        properties.put(LobbyLoginValidator.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
+        return properties;
       }
     };
     try {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -468,17 +468,17 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
 
   @Override
   public List<Action> getUserActions() {
-    final List<Action> rVal = new ArrayList<>();
-    rVal.add(new BootPlayerAction(this, model.getMessenger()));
-    rVal.add(new BanPlayerAction(this, model.getMessenger()));
-    rVal.add(new MutePlayerAction(this, model.getMessenger()));
-    rVal.add(
+    final List<Action> actions = new ArrayList<>();
+    actions.add(new BootPlayerAction(this, model.getMessenger()));
+    actions.add(new BanPlayerAction(this, model.getMessenger()));
+    actions.add(new MutePlayerAction(this, model.getMessenger()));
+    actions.add(
         new SetPasswordAction(this, lobbyWatcher, (ClientLoginValidator) model.getMessenger().getLoginValidator()));
     if (lobbyWatcher != null && lobbyWatcher.isActive()) {
-      rVal.add(new EditGameCommentAction(lobbyWatcher, ServerSetupPanel.this));
-      rVal.add(new RemoveGameFromLobbyAction(lobbyWatcher));
+      actions.add(new EditGameCommentAction(lobbyWatcher, ServerSetupPanel.this));
+      actions.add(new RemoveGameFromLobbyAction(lobbyWatcher));
     }
-    return rVal;
+    return actions;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -55,9 +55,9 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
   }
 
   private static List<File> allMapFiles() {
-    final List<File> rVal = new ArrayList<>();
-    rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
-    return rVal;
+    final List<File> files = new ArrayList<>();
+    files.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
+    return files;
   }
 
   private static List<File> safeListFiles(final File f) {

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -55,9 +55,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
   }
 
   private static List<File> allMapFiles() {
-    final List<File> files = new ArrayList<>();
-    files.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
-    return files;
+    return new ArrayList<>(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
   }
 
   private static List<File> safeListFiles(final File f) {

--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -29,10 +29,9 @@ public class PropertiesSelector {
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
     if (!SwingUtilities.isEventDispatchThread()) {
-      // throw new IllegalStateException("Must run from EventDispatchThread");
-      final AtomicReference<Object> rVal = new AtomicReference<>();
-      SwingAction.invokeAndWait(() -> rVal.set(showDialog(parent, title, properties, buttonOptions)));
-      return rVal.get();
+      final AtomicReference<Object> buttonRef = new AtomicReference<>();
+      SwingAction.invokeAndWait(() -> buttonRef.set(showDialog(parent, title, properties, buttonOptions)));
+      return buttonRef.get();
     } else {
       return showDialog(parent, title, properties, buttonOptions);
     }

--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -217,12 +217,12 @@ class SerializedHistory implements Serializable {
   }
 
   public Object readResolve() {
-    final History rVal = new History(m_data);
-    final HistoryWriter historyWriter = rVal.getHistoryWriter();
+    final History history = new History(m_data);
+    final HistoryWriter historyWriter = history.getHistoryWriter();
     for (final SerializationWriter element : m_Writers) {
       element.write(historyWriter);
     }
-    return rVal;
+    return history;
   }
 }
 

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -125,14 +125,14 @@ public class LobbyFrame extends JFrame {
     }
     final IModeratorController controller = (IModeratorController) m_client.getRemoteMessenger()
         .getRemote(ModeratorController.getModeratorControllerName());
-    final List<Action> rVal = new ArrayList<>();
-    rVal.add(SwingAction.of("Boot " + clickedOn.getName(), e -> {
+    final List<Action> actions = new ArrayList<>();
+    actions.add(SwingAction.of("Boot " + clickedOn.getName(), e -> {
       if (!confirm("Boot " + clickedOn.getName())) {
         return;
       }
       controller.boot(clickedOn);
     }));
-    rVal.add(SwingAction.of("Ban Player", e -> {
+    actions.add(SwingAction.of("Ban Player", e -> {
       final int resultBanType = JOptionPane.showOptionDialog(LobbyFrame.this,
           "<html>Select the type of ban: <br>"
               + "Please consult other admins before banning longer than 1 day. <br>"
@@ -196,7 +196,7 @@ public class LobbyFrame extends JFrame {
       controller.boot(clickedOn);
     }));
 
-    rVal.add(SwingAction.of("Mute Player", e -> {
+    actions.add(SwingAction.of("Mute Player", e -> {
       final int resultMuteType = JOptionPane.showOptionDialog(LobbyFrame.this,
           "<html>Select the type of mute: <br>Please consult other admins before muting longer than 1 day.</html>",
           "Select Mute Type", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
@@ -253,7 +253,7 @@ public class LobbyFrame extends JFrame {
         controller.muteMac(clickedOn, Date.from(expire));
       }
     }));
-    rVal.add(SwingAction.of("Quick Mute", e -> {
+    actions.add(SwingAction.of("Quick Mute", e -> {
       final JLabel label = new JLabel("How many minutes should this player be muted?");
       final JSpinner spinner = new JSpinner(new SpinnerNumberModel(10, 0, 60 * 24 * 2, 1));
       final JPanel panel = new JPanel();
@@ -275,14 +275,14 @@ public class LobbyFrame extends JFrame {
         controller.muteMac(clickedOn, Date.from(expire));
       }
     }));
-    rVal.add(SwingAction.of("Show player information", e -> {
+    actions.add(SwingAction.of("Show player information", e -> {
       final String text = controller.getInformationOn(clickedOn);
       final JTextPane textPane = new JTextPane();
       textPane.setEditable(false);
       textPane.setText(text);
       JOptionPane.showMessageDialog(null, textPane, "Player Info", JOptionPane.INFORMATION_MESSAGE);
     }));
-    return rVal;
+    return actions;
   }
 
   @VisibleForTesting
@@ -312,9 +312,9 @@ public class LobbyFrame extends JFrame {
   }
 
   private boolean confirm(final String question) {
-    final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(this), question, "Question",
-        JOptionPane.OK_CANCEL_OPTION);
-    return rVal == JOptionPane.OK_OPTION;
+    final int selectionOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(this), question,
+        "Question", JOptionPane.OK_CANCEL_OPTION);
+    return selectionOption == JOptionPane.OK_OPTION;
   }
 
   public LobbyClient getLobbyClient() {

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -198,21 +198,21 @@ class LobbyGamePanel extends JPanel {
   }
 
   private List<Action> getGamesListRightClickActions(final GameDescription description) {
-    final List<Action> rVal = new ArrayList<>();
-    rVal.add(getJoinGameAction());
-    rVal.add(getHostGameAction());
+    final List<Action> actions = new ArrayList<>();
+    actions.add(getJoinGameAction());
+    actions.add(getHostGameAction());
     if (isAdmin()) {
-      rVal.add(getHostSupportInfoAction(description));
-      rVal.add(getHostInfoAction());
-      rVal.add(getChatLogOfHeadlessHostBotAction(description));
-      rVal.add(getMutePlayerHeadlessHostBotAction(description));
-      rVal.add(getBootPlayerHeadlessHostBotAction(description));
-      rVal.add(getBanPlayerHeadlessHostBotAction(description));
-      rVal.add(getStopGameHeadlessHostBotAction(description));
-      rVal.add(getShutDownHeadlessHostBotAction(description));
-      rVal.add(getBootGameAction());
+      actions.add(getHostSupportInfoAction(description));
+      actions.add(getHostInfoAction());
+      actions.add(getChatLogOfHeadlessHostBotAction(description));
+      actions.add(getMutePlayerHeadlessHostBotAction(description));
+      actions.add(getBootPlayerHeadlessHostBotAction(description));
+      actions.add(getBanPlayerHeadlessHostBotAction(description));
+      actions.add(getStopGameHeadlessHostBotAction(description));
+      actions.add(getShutDownHeadlessHostBotAction(description));
+      actions.add(getBootGameAction());
     }
-    return rVal;
+    return actions;
   }
 
   private static Action getHostSupportInfoAction(final GameDescription description) {
@@ -381,9 +381,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());
@@ -451,9 +451,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());
@@ -490,9 +490,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());
@@ -541,9 +541,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());
@@ -575,9 +575,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());
@@ -608,9 +608,9 @@ class LobbyGamePanel extends JPanel {
     panel.setLayout(new BorderLayout());
     panel.add(label, BorderLayout.NORTH);
     panel.add(passwordField, BorderLayout.CENTER);
-    final int rVal = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel, "Host Remote Access Password?",
-        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
-    if (rVal != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
+    final int selectedOption = JOptionPane.showOptionDialog(getTopLevelAncestor(), panel,
+        "Host Remote Access Password?", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
+    if (selectedOption != JOptionPane.OK_OPTION || passwordField.getPassword() == null) {
       return;
     }
     final String password = new String(passwordField.getPassword());

--- a/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
@@ -27,10 +27,10 @@ public class EditGameCommentAction extends AbstractAction {
       return;
     }
     final String current = m_lobbyWatcher.getComments();
-    final String rVal = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(m_parent),
+    final String gameComments = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(m_parent),
         "Edit the comments for the game", current);
-    if (rVal != null) {
-      m_lobbyWatcher.setGameComments(rVal);
+    if (gameComments != null) {
+      m_lobbyWatcher.setGameComments(gameComments);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -99,8 +99,7 @@ class LobbyGameController implements ILobbyGameController {
   @Override
   public Map<GUID, GameDescription> listGames() {
     synchronized (m_mutex) {
-      final Map<GUID, GameDescription> rVal = new HashMap<>(m_allGames);
-      return rVal;
+      return new HashMap<>(m_allGames);
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -50,11 +50,11 @@ public class BadWordController {
     try (final Connection con = Database.getDerbyConnection();
         final PreparedStatement ps = con.prepareStatement(sql);
         final ResultSet rs = ps.executeQuery()) {
-      final List<String> rVal = new ArrayList<>();
+      final List<String> badWords = new ArrayList<>();
       while (rs.next()) {
-        rVal.add(rs.getString(1));
+        badWords.add(rs.getString(1));
       }
-      return rVal;
+      return badWords;
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error reading bad words", sqle);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -49,13 +49,13 @@ public class LobbyLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     // we need to give the user the salt key for the username
-    final Map<String, String> rVal = new HashMap<>();
+    final Map<String, String> challenge = new HashMap<>();
     final HashedPassword password = new DbUserController().getLegacyPassword(userName);
     if (password != null && Strings.emptyToNull(password.value) != null) {
-      rVal.put(SALT_KEY, MD5Crypt.getSalt(MD5Crypt.MAGIC, password.value));
+      challenge.put(SALT_KEY, MD5Crypt.getSalt(MD5Crypt.MAGIC, password.value));
     }
-    rVal.putAll(rsaAuthenticator.generatePublicKey());
-    return rVal;
+    challenge.putAll(rsaAuthenticator.generatePublicKey());
+    return challenge;
   }
 
   @Override


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule due to local variables named `rVal` whose purpose is to store a method return value.

This is one part in a series of related PRs in order to keep the review size reasonable.