### PR TITLE
Checkstyle: Upgrade to version 8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ check {
 }
 
 checkstyle {
-    toolVersion = "7.6.1"
+    toolVersion = "8.0"
     configProperties = [samedir: configFile.parent]
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -97,6 +97,11 @@
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
         </module>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>


### PR DESCRIPTION
This PR upgrades the Checkstyle engine and the Google ruleset to version 8.0.  There were no new violations introduced.  (In a previous PR, I had suggested that 8.x introduced breaking changes that trigger several hundred new violations in our code.  However, those changes appear to have been introduced in version 8.1, not 8.0.)

While Checkstyle 8.2 is the latest release, the latest Eclipse Checkstyle plugin only includes version 8.0.  Therefore, to ensure compatibility between the Gradle and IDE builds, I chose to only upgrade the Gradle build to version 8.0.

:warning: Devs using Eclipse will have to upgrade to version 8.0 of the [Eclipse Checkstyle plugin](http://eclipse-cs.sourceforge.net/) after this PR is merged (this should be as simple as running **Help > Check for Updates**).  Otherwise, the current 7.6 plugin will report an error upon the next restart when it attempts to read the modified Checkstyle configuration.  Presumably, a similar plugin upgrade is required for devs using IntelliJ.

#### Testing

I verified no new violations are reported in the Gradle build.

I verified the Eclipse Checkstyle plugin has no issues with these changes after upgrading said plugin to version 8.0 and restarting Eclipse.