### PR TITLE
Allow bombers to target units even if they are at max damage

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -171,8 +171,7 @@ public class MovePerformer implements Serializable {
           // could it be a bombing raid
           final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = Matches.getMatches(enemyUnits,
-              Match.allOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
-                  Matches.unitIsBeingTransported().invert()));
+              Match.allOf(Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
           final Match.CompositeBuilder<Unit> allBombingRaidBuilder = Match.newCompositeBuilder(
               Matches.unitIsStrategicBomber());
           final boolean canCreateAirBattle =
@@ -276,8 +275,8 @@ public class MovePerformer implements Serializable {
         // actually move the units
         if (route.getStart() != null && route.getEnd() != null) {
           // ChangeFactory.addUnits(route.getEnd(), arrived);
-          Change remove = ChangeFactory.removeUnits(route.getStart(), units);
-          Change add = ChangeFactory.addUnits(route.getEnd(), arrived);
+          final Change remove = ChangeFactory.removeUnits(route.getStart(), units);
+          final Change add = ChangeFactory.addUnits(route.getEnd(), arrived);
           change.add(add, remove);
         }
         m_bridge.addChange(change);
@@ -395,7 +394,7 @@ public class MovePerformer implements Serializable {
     // load the transports
     if (route.isLoad() || paratroopsLanding) {
       // mark transports as having transported
-      for (Unit load : transporting.keySet()) {
+      for (final Unit load : transporting.keySet()) {
         final Unit transport = transporting.get(load);
         if (!TransportTracker.transporting(transport).contains(load)) {
           final Change change = TransportTracker.loadTransportChange((TripleAUnit) transport, load);
@@ -429,7 +428,7 @@ public class MovePerformer implements Serializable {
       // any pending battles in the unloading zone?
       final BattleTracker tracker = getBattleTracker();
       final boolean pendingBattles = tracker.getPendingBattle(route.getStart(), false, BattleType.NORMAL) != null;
-      for (Unit unit : units) {
+      for (final Unit unit : units) {
         if (Matches.unitIsAir().match(unit)) {
           continue;
         }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -93,7 +93,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
     final Match<Unit> defenders = Match.allOf(Matches.enemyUnit(m_attacker, m_data),
-        Match.anyOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
+        Match.anyOf(Matches.unitCanBeDamaged(),
             Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
                 Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data)));
     if (m_targets.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -168,8 +168,8 @@ public class UndoableMove extends AbstractUndoableMove {
         System.err.println(undoableMoves);
         throw new IllegalStateException("other should not be null");
       }
-      if (// if the other move has moves that depend on this
-      !Util.intersection(other.getUnits(), this.getUnits()).isEmpty()
+      // if the other move has moves that depend on this
+      if (!Util.intersection(other.getUnits(), this.getUnits()).isEmpty()
           // if the other move has transports that we are loading
           || !Util.intersection(other.m_units, this.m_loaded).isEmpty()
           // or we are moving through a previously conqueured territory

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -128,8 +128,7 @@ public class UndoableMove extends AbstractUndoableMove {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
                 .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerID(), data),
-                    Matches.unitIsAtMaxDamageOrNotCanBeDamaged(end).invert(),
-                    Matches.unitIsBeingTransported().invert()));
+                    Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Matches.getMatches(enemyTargetsTotal,
                 Matches.unitIsOfTypes(UnitAttachment.getAllowedBombingTargetsIntersection(
                     Matches.getMatches(Collections.singleton(unit), Matches.unitIsStrategicBomber()), data)));
@@ -170,7 +169,7 @@ public class UndoableMove extends AbstractUndoableMove {
         throw new IllegalStateException("other should not be null");
       }
       if (// if the other move has moves that depend on this
-          !Util.intersection(other.getUnits(), this.getUnits()).isEmpty()
+      !Util.intersection(other.getUnits(), this.getUnits()).isEmpty()
           // if the other move has transports that we are loading
           || !Util.intersection(other.m_units, this.m_loaded).isEmpty()
           // or we are moving through a previously conqueured territory


### PR DESCRIPTION
Fixes #2322.

Changes the bombing target check to allow targets already at max damage. Tested the global 1940 example provided in the issue to move tact bombers the UK. It allows it both alone or with strat bombers.