### PR TITLE
Checkstyle: Rename "rVal" local variables (part 2)

### DIFF
--- a/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.annotations.InternalDoNotExport;
 import games.strategy.triplea.Constants;
 import games.strategy.util.PropertyUtil;
@@ -35,6 +37,35 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
    */
   @Override
   public abstract void validate(final GameData data) throws GameParseException;
+
+  /**
+   * Gets the attachment with the specified name and type from the specified object.
+   *
+   * @param namedAttachable The object from which the attachment is to be retrieved.
+   * @param attachmentName The name of the attachment to retrieve.
+   * @param attachmentType The type of the attachment to retrieve.
+   *
+   * @return The requested attachment.
+   *
+   * @throws IllegalStateException If the requested attachment is not found in the specified object.
+   * @throws ClassCastException If the requested attachment is not of the specified type.
+   */
+  protected static <T extends IAttachment> T getAttachment(
+      final NamedAttachable namedAttachable,
+      final String attachmentName,
+      final Class<T> attachmentType) {
+    checkNotNull(namedAttachable);
+    checkNotNull(attachmentName);
+    checkNotNull(attachmentType);
+
+    final T attachment = attachmentType.cast(namedAttachable.getAttachment(attachmentName));
+    if (attachment == null) {
+      throw new IllegalStateException(String.format("No attachment named '%s' of type '%s' for object named '%s'",
+          attachmentName, attachmentType, namedAttachable.getName()));
+    }
+
+    return attachment;
+  }
 
   /**
    * Throws an error if format is invalid.

--- a/src/main/java/games/strategy/engine/message/ChannelMessenger.java
+++ b/src/main/java/games/strategy/engine/message/ChannelMessenger.java
@@ -24,9 +24,8 @@ public class ChannelMessenger implements IChannelMessenger {
   public IChannelSubscribor getChannelBroadcastor(final RemoteName channelName) {
     final InvocationHandler ih =
         new UnifiedInvocationHandler(m_unifiedMessenger, channelName.getName(), true, channelName.getClazz());
-    final IChannelSubscribor rVal = (IChannelSubscribor) Proxy
+    return (IChannelSubscribor) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class<?>[] {channelName.getClazz()}, ih);
-    return rVal;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/message/RemoteMessenger.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMessenger.java
@@ -24,9 +24,8 @@ public class RemoteMessenger implements IRemoteMessenger {
   public IRemote getRemote(final RemoteName remoteName, final boolean ignoreResults) {
     final InvocationHandler ih =
         new UnifiedInvocationHandler(m_unifiedMessenger, remoteName.getName(), ignoreResults, remoteName.getClazz());
-    final IRemote rVal = (IRemote) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+    return (IRemote) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
         new Class<?>[] {remoteName.getClazz()}, ih);
-    return rVal;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -87,51 +87,51 @@ public class RemoteMethodCall implements Externalizable {
   }
 
   private static Class<?>[] stringsToClasses(final String[] strings, final Object[] args) {
-    final Class<?>[] rVal = new Class<?>[strings.length];
+    final Class<?>[] classes = new Class<?>[strings.length];
     for (int i = 0; i < strings.length; i++) {
       try {
         // null if we skipped writing because the arg is the expected
         // class, this saves some space since generally the arg will
         // be of the correct type
         if (strings[i] == null) {
-          rVal[i] = args[i].getClass();
+          classes[i] = args[i].getClass();
         } else if (strings[i].equals("int")) {
-          rVal[i] = Integer.TYPE;
+          classes[i] = Integer.TYPE;
         } else if (strings[i].equals("short")) {
-          rVal[i] = Short.TYPE;
+          classes[i] = Short.TYPE;
         } else if (strings[i].equals("byte")) {
-          rVal[i] = Byte.TYPE;
+          classes[i] = Byte.TYPE;
         } else if (strings[i].equals("long")) {
-          rVal[i] = Long.TYPE;
+          classes[i] = Long.TYPE;
         } else if (strings[i].equals("float")) {
-          rVal[i] = Float.TYPE;
+          classes[i] = Float.TYPE;
         } else if (strings[i].equals("double")) {
-          rVal[i] = Double.TYPE;
+          classes[i] = Double.TYPE;
         } else if (strings[i].equals("boolean")) {
-          rVal[i] = Boolean.TYPE;
+          classes[i] = Boolean.TYPE;
         } else {
-          rVal[i] = Class.forName(strings[i]);
+          classes[i] = Class.forName(strings[i]);
         }
       } catch (final ClassNotFoundException e) {
         throw new IllegalStateException(e);
       }
     }
-    return rVal;
+    return classes;
   }
 
   private static String[] classesToString(final Class<?>[] classes, final Object[] args) {
     // as an optimization, if args[i].getClass == classes[i] then leave classes[i] as null
     // this will reduce the amount of info we write over the network in the common
     // case where the object is the same type as its arg
-    final String[] rVal = new String[classes.length];
+    final String[] string = new String[classes.length];
     for (int i = 0; i < classes.length; i++) {
       if (args != null && args[i] != null && classes[i] == args[i].getClass()) {
-        rVal[i] = null;
+        string[i] = null;
       } else {
-        rVal[i] = classes[i].getName();
+        string[i] = classes[i].getName();
       }
     }
-    return rVal;
+    return string;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCallResults.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCallResults.java
@@ -49,8 +49,8 @@ public class RemoteMethodCallResults implements Externalizable {
 
   @Override
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
-    final boolean rVal = in.read() == 1;
-    if (rVal) {
+    final boolean hasReturnValue = in.read() == 1;
+    if (hasReturnValue) {
       m_rVal = in.readObject();
     } else {
       m_exception = (Throwable) in.readObject();

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -76,9 +76,9 @@ class EndPoint {
       throw new IllegalArgumentException(m_remoteClass + " is not assignable from " + implementor.getClass());
     }
     synchronized (m_implementorsMutext) {
-      final boolean rVal = m_implementors.isEmpty();
+      final boolean isFirstImplementor = m_implementors.isEmpty();
       m_implementors.add(implementor);
-      return rVal;
+      return isFirstImplementor;
     }
   }
 

--- a/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -41,15 +41,27 @@ public class CryptoRandomSource implements IRandomSource {
     return ints;
   }
 
-  static int[] xor(final int[] val1, final int[] val2, final int max) {
+  /**
+   * Mixes the values from the specified sources ensuring that all of the mixed values are in the range [0, max).
+   *
+   * @param val1 The first source of values.
+   * @param val2 The second source of values.
+   * @param max The maximum mixed value, exclusive.
+   *
+   * @return The mixed values.
+   *
+   * @throws IllegalArgumentException If {@code val1} and {@code val2} have different lengths.
+   */
+  static int[] mix(final int[] val1, final int[] val2, final int max) {
     if (val1.length != val2.length) {
       throw new IllegalArgumentException("Arrays not of same length");
     }
-    final int[] xorValues = new int[val1.length];
+
+    final int[] mixedValues = new int[val1.length];
     for (int i = 0; i < val1.length; i++) {
-      xorValues[i] = (val1[i] + val2[i]) % max;
+      mixedValues[i] = (val1[i] + val2[i]) % max;
     }
-    return xorValues;
+    return mixedValues;
   }
 
   // the remote players who involved in rolling the dice
@@ -99,6 +111,6 @@ public class CryptoRandomSource implements IRandomSource {
     vault.unlock(localId);
     remote.verifyNumbers();
     // finally, we join the two together to get the real value
-    return xor(localRandom, remoteNumbers, max);
+    return mix(localRandom, remoteNumbers, max);
   }
 }

--- a/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -18,14 +18,14 @@ public class CryptoRandomSource implements IRandomSource {
    * converts an int[] to a byte[].
    */
   public static byte[] intsToBytes(final int[] ints) {
-    final byte[] rVal = new byte[ints.length * 4];
+    final byte[] bytes = new byte[ints.length * 4];
     for (int i = 0; i < ints.length; i++) {
-      rVal[4 * i] = (byte) (0x000000FF & ints[i]);
-      rVal[(4 * i) + 1] = (byte) ((0x000000FF & (ints[i] >> 8)));
-      rVal[(4 * i) + 2] = (byte) ((0x000000FF & (ints[i] >> 16)));
-      rVal[(4 * i) + 3] = (byte) ((0x000000FF & (ints[i] >> 24)));
+      bytes[4 * i] = (byte) (0x000000FF & ints[i]);
+      bytes[(4 * i) + 1] = (byte) ((0x000000FF & (ints[i] >> 8)));
+      bytes[(4 * i) + 2] = (byte) ((0x000000FF & (ints[i] >> 16)));
+      bytes[(4 * i) + 3] = (byte) ((0x000000FF & (ints[i] >> 24)));
     }
-    return rVal;
+    return bytes;
   }
 
   static int byteToIntUnsigned(final byte val) {
@@ -33,23 +33,23 @@ public class CryptoRandomSource implements IRandomSource {
   }
 
   static int[] bytesToInts(final byte[] bytes) {
-    final int[] rVal = new int[bytes.length / 4];
-    for (int i = 0; i < rVal.length; i++) {
-      rVal[i] = byteToIntUnsigned(bytes[4 * i]) + (byteToIntUnsigned(bytes[4 * i + 1]) << 8)
+    final int[] ints = new int[bytes.length / 4];
+    for (int i = 0; i < ints.length; i++) {
+      ints[i] = byteToIntUnsigned(bytes[4 * i]) + (byteToIntUnsigned(bytes[4 * i + 1]) << 8)
           + (byteToIntUnsigned(bytes[4 * i + 2]) << 16) + (byteToIntUnsigned(bytes[4 * i + 3]) << 24);
     }
-    return rVal;
+    return ints;
   }
 
   static int[] xor(final int[] val1, final int[] val2, final int max) {
     if (val1.length != val2.length) {
       throw new IllegalArgumentException("Arrays not of same length");
     }
-    final int[] rVal = new int[val1.length];
+    final int[] xorValues = new int[val1.length];
     for (int i = 0; i < val1.length; i++) {
-      rVal[i] = (val1[i] + val2[i]) % max;
+      xorValues[i] = (val1[i] + val2[i]) % max;
     }
-    return rVal;
+    return xorValues;
   }
 
   // the remote players who involved in rolling the dice

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -200,17 +200,17 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       throw new IOException("Cound not find end index");
     }
     final StringTokenizer tokenizer = new StringTokenizer(string.substring(startIndex, endIndex), " ,", false);
-    final int[] rVal = new int[count];
+    final int[] dice = new int[count];
     for (int i = 0; i < count; i++) {
       try {
         // -1 since we are 0 based
-        rVal[i] = Integer.parseInt(tokenizer.nextToken()) - 1;
+        dice[i] = Integer.parseInt(tokenizer.nextToken()) - 1;
       } catch (final NumberFormatException ex) {
         ClientLogger.logQuietly("Number format parsing: " + string, ex);
         throw new IOException(ex.getMessage());
       }
     }
-    return rVal;
+    return dice;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -78,7 +78,7 @@ public class RemoteRandom implements IRemoteRandom {
       e1.printStackTrace();
       throw new IllegalStateException("Could not unlock numbers, cheating suspected");
     }
-    final int[] verifiedNumbers = CryptoRandomSource.xor(remoteNumbers, m_localNumbers, m_max);
+    final int[] verifiedNumbers = CryptoRandomSource.mix(remoteNumbers, m_localNumbers, m_max);
     addVerifiedRandomNumber(new VerifiedRandomNumbers(m_annotation, verifiedNumbers));
     m_waitingForUnlock = false;
   }

--- a/src/main/java/games/strategy/engine/random/ScriptedRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/ScriptedRandomSource.java
@@ -86,18 +86,18 @@ public class ScriptedRandomSource implements IRandomSource {
       throw new IllegalArgumentException("count must be > 0, annotation:" + annotation);
     }
     m_rolled += count;
-    final int[] rVal = new int[count];
+    final int[] numbers = new int[count];
     for (int i = 0; i < count; i++) {
       if (m_numbers[m_currentIndex] == ERROR) {
         throw new IllegalStateException("Random number generator generating scripted error");
       }
-      rVal[i] = m_numbers[m_currentIndex];
+      numbers[i] = m_numbers[m_currentIndex];
       m_currentIndex++;
       if (m_currentIndex >= m_numbers.length) {
         m_currentIndex = 0;
       }
     }
-    return rVal;
+    return numbers;
   }
 
   public int getTotalRolled() {

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -212,9 +212,9 @@ public class Vault {
   }
 
   public List<VaultID> knownIds() {
-    final ArrayList<VaultID> rVal = new ArrayList<>(m_verifiedValues.keySet());
-    rVal.addAll(m_unverifiedValues.keySet());
-    return rVal;
+    final ArrayList<VaultID> knownIds = new ArrayList<>(m_verifiedValues.keySet());
+    knownIds.addAll(m_unverifiedValues.keySet());
+    return knownIds;
   }
 
   /**

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -106,9 +106,9 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
    */
   @Override
   public Set<INode> getNodes() {
-    final Set<INode> rVal = new HashSet<>(nodeToChannel.keySet());
-    rVal.add(node);
-    return rVal;
+    final Set<INode> nodes = new HashSet<>(nodeToChannel.keySet());
+    nodes.add(node);
+    return nodes;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -127,8 +127,8 @@ public class ResourceLoader implements Closeable {
     }
     ClientLogger.logQuietly("Loading map: " + mapName + ", from: " + match.get().getAbsolutePath());
 
-    final List<String> rVal = new ArrayList<>();
-    rVal.add(match.get().getAbsolutePath());
+    final List<String> paths = new ArrayList<>();
+    paths.add(match.get().getAbsolutePath());
     // find dependencies
     try (final URLClassLoader url = new URLClassLoader(new URL[] {match.get().toURI().toURL()})) {
       final URL dependencesUrl = url.getResource("dependencies.txt");
@@ -143,7 +143,7 @@ public class ResourceLoader implements Closeable {
             final StringTokenizer tokens = new StringTokenizer(dependencies, ",", false);
             while (tokens.hasMoreTokens()) {
               // add the dependencies recursivly
-              rVal.addAll(getPaths(tokens.nextToken()));
+              paths.addAll(getPaths(tokens.nextToken()));
             }
           }
         }
@@ -152,7 +152,7 @@ public class ResourceLoader implements Closeable {
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(e.getMessage());
     }
-    return rVal;
+    return paths;
   }
 
 
@@ -190,8 +190,7 @@ public class ResourceLoader implements Closeable {
   }
 
   public boolean hasPath(final String path) {
-    final URL rVal = m_loader.getResource(path);
-    return rVal != null;
+    return m_loader.getResource(path) != null;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -721,8 +721,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (attackTokens.size() <= 0) {
       return null;
     }
-    final HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> rVal =
-        new HashMap<>();
+    final HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> kamikazeSuicideAttacks = new HashMap<>();
     for (final Entry<Resource, Integer> entry : attackTokens.entrySet()) {
       final Resource r = entry.getKey();
       final int max = entry.getValue();
@@ -730,7 +729,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           ui.selectKamikazeSuicideAttacks(possibleUnitsToAttack, r, max);
       for (final Entry<Territory, IntegerMap<Unit>> selectionEntry : selection.entrySet()) {
         final Territory t = selectionEntry.getKey();
-        HashMap<Unit, IntegerMap<Resource>> currentTerr = rVal.get(t);
+        HashMap<Unit, IntegerMap<Resource>> currentTerr = kamikazeSuicideAttacks.get(t);
         if (currentTerr == null) {
           currentTerr = new HashMap<>();
         }
@@ -743,10 +742,10 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           currentUnit.add(r, unitEntry.getValue());
           currentTerr.put(u, currentUnit);
         }
-        rVal.put(t, currentTerr);
+        kamikazeSuicideAttacks.put(t, currentTerr);
       }
     }
-    return rVal;
+    return kamikazeSuicideAttacks;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -161,13 +161,13 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   @Override
   public Collection<Unit> getNumberOfFightersToMoveToNewCarrier(final Collection<Unit> fightersThatCanBeMoved,
       final Territory from) {
-    final List<Unit> rVal = new ArrayList<>();
+    final List<Unit> fighters = new ArrayList<>();
     for (final Unit fighter : fightersThatCanBeMoved) {
       if (Math.random() < 0.8) {
-        rVal.add(fighter);
+        fighters.add(fighter);
       }
     }
-    return rVal;
+    return fighters;
   }
 
   @Override
@@ -265,7 +265,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
     if (attackTokens.size() <= 0) {
       return null;
     }
-    final HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> rVal = new HashMap<>();
+    final HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> kamikazeSuicideAttacks = new HashMap<>();
     for (final Entry<Territory, Collection<Unit>> entry : possibleUnitsToAttack.entrySet()) {
       if (attackTokens.size() <= 0) {
         continue;
@@ -282,19 +282,19 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         final int num = Math.min(attackTokens.getInt(r),
             (UnitAttachment.get(u.getType()).getHitPoints() * (Math.random() < .3 ? 1 : (Math.random() < .5 ? 2 : 3))));
         resourceMap.put(r, num);
-        HashMap<Unit, IntegerMap<Resource>> attMap = rVal.get(t);
+        HashMap<Unit, IntegerMap<Resource>> attMap = kamikazeSuicideAttacks.get(t);
         if (attMap == null) {
           attMap = new HashMap<>();
         }
         attMap.put(u, resourceMap);
-        rVal.put(t, attMap);
+        kamikazeSuicideAttacks.put(t, attMap);
         attackTokens.add(r, -num);
         if (attackTokens.getInt(r) <= 0) {
           attackTokens.removeKey(r);
         }
       }
     }
-    return rVal;
+    return kamikazeSuicideAttacks;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -590,7 +590,7 @@ final class ProTechAI {
    */
   private static List<Territory> getNeighboringLandTerritories(final GameData data, final PlayerID player,
       final Territory check) {
-    final ArrayList<Territory> territories = new ArrayList<>();
+    final List<Territory> territories = new ArrayList<>();
     final List<Territory> checkList = getExactNeighbors(check, 1, data, false);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).match(t)

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -590,15 +590,15 @@ final class ProTechAI {
    */
   private static List<Territory> getNeighboringLandTerritories(final GameData data, final PlayerID player,
       final Territory check) {
-    final ArrayList<Territory> rVal = new ArrayList<>();
+    final ArrayList<Territory> territories = new ArrayList<>();
     final List<Territory> checkList = getExactNeighbors(check, 1, data, false);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).match(t)
           && Matches.territoryIsNotImpassableToLandUnits(player, data).match(t)) {
-        rVal.add(t);
+        territories.add(t);
       }
     }
-    return rVal;
+    return territories;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -20,15 +20,15 @@ class Utils {
    * All the territories that border one of our territories.
    */
   static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
-    final ArrayList<Territory> rVal = new ArrayList<>();
+    final ArrayList<Territory> territories = new ArrayList<>();
     for (final Territory t : data.getMap()) {
       if (Matches.isTerritoryEnemy(player, data).match(t) && !t.getOwner().isNull()) {
         if (!data.getMap().getNeighbors(t, Matches.isTerritoryOwnedBy(player)).isEmpty()) {
-          rVal.add(t);
+          territories.add(t);
         }
       }
     }
-    return rVal;
+    return territories;
   }
 
   static List<Unit> getUnitsUpToStrength(final double maxStrength, final Collection<Unit> units,
@@ -36,14 +36,14 @@ class Utils {
     if (AIUtils.strength(units, true, sea) < maxStrength) {
       return new ArrayList<>(units);
     }
-    final ArrayList<Unit> rVal = new ArrayList<>();
+    final ArrayList<Unit> unitsUpToStrength = new ArrayList<>();
     for (final Unit u : units) {
-      rVal.add(u);
-      if (AIUtils.strength(rVal, true, sea) > maxStrength) {
-        return rVal;
+      unitsUpToStrength.add(u);
+      if (AIUtils.strength(unitsUpToStrength, true, sea) > maxStrength) {
+        return unitsUpToStrength;
       }
     }
-    return rVal;
+    return unitsUpToStrength;
   }
 
   static float getStrengthOfPotentialAttackers(final Territory location, final GameData data) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -20,7 +20,7 @@ class Utils {
    * All the territories that border one of our territories.
    */
   static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
-    final ArrayList<Territory> territories = new ArrayList<>();
+    final List<Territory> territories = new ArrayList<>();
     for (final Territory t : data.getMap()) {
       if (Matches.isTerritoryEnemy(player, data).match(t) && !t.getOwner().isNull()) {
         if (!data.getMap().getNeighbors(t, Matches.isTerritoryOwnedBy(player)).isEmpty()) {
@@ -36,7 +36,7 @@ class Utils {
     if (AIUtils.strength(units, true, sea) < maxStrength) {
       return new ArrayList<>(units);
     }
-    final ArrayList<Unit> unitsUpToStrength = new ArrayList<>();
+    final List<Unit> unitsUpToStrength = new ArrayList<>();
     for (final Unit u : units) {
       unitsUpToStrength.add(u);
       if (AIUtils.strength(unitsUpToStrength, true, sea) > maxStrength) {

--- a/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -67,11 +67,11 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
    * @return new rule attachment
    */
   public static RulesAttachment get(final PlayerID player) {
-    final RulesAttachment rVal = player.getRulesAttachment();
-    if (rVal == null) {
+    final RulesAttachment rulesAttachment = player.getRulesAttachment();
+    if (rulesAttachment == null) {
       throw new IllegalStateException("Rules & Conditions: No rule attachment for:" + player.getName());
     }
-    return rVal;
+    return rulesAttachment;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -351,11 +351,11 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         // Get the list of territories
         return getListedTerritories(terrs, true, true);
       } else {
-        final Set<Territory> rVal = getTerritoriesBasedOnStringName(terrs[1], players, data);
+        final Set<Territory> territories = getTerritoriesBasedOnStringName(terrs[1], players, data);
         // set it a second time, since getTerritoriesBasedOnStringName also sets it (so do it
         setTerritoryCount(String.valueOf(terrs[0]));
         // after the method call).
-        return rVal;
+        return territories;
       }
     } else {
       // Get the list of territories
@@ -377,10 +377,10 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
    */
   public Set<Territory> getListedTerritories(final String[] list, final boolean testFirstItemForCount,
       final boolean mustSetTerritoryCount) {
-    final Set<Territory> rVal = new HashSet<>();
+    final Set<Territory> territories = new HashSet<>();
     // this list is null, empty, or contains "", so return a blank list of territories
     if (list == null || list.length == 0 || (list.length == 1 && (list[0] == null || list[0].length() == 0))) {
-      return rVal;
+      return territories;
     }
     boolean haveSetCount = false;
     for (int i = 0; i < list.length; i++) {
@@ -417,13 +417,13 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       if (territory == null) {
         throw new IllegalStateException("No territory called:" + name + thisErrorMsg());
       }
-      rVal.add(territory);
+      territories.add(territory);
     }
     if (mustSetTerritoryCount && !haveSetCount) {
       // if we have not set it, then set it to be the size of this list
-      setTerritoryCount(String.valueOf(rVal.size()));
+      setTerritoryCount(String.valueOf(territories.size()));
     }
-    return rVal;
+    return territories;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -63,12 +63,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   static CanalAttachment get(final Territory t, final String nameOfAttachment) {
-    final CanalAttachment canalAttachment = (CanalAttachment) t.getAttachment(nameOfAttachment);
-    if (canalAttachment == null) {
-      throw new IllegalStateException(
-          "CanalAttachment: No canal attachment for:" + t.getName() + " with name: " + nameOfAttachment);
-    }
-    return canalAttachment;
+    return getAttachment(t, nameOfAttachment, CanalAttachment.class);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)

--- a/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -29,7 +29,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   public static Set<Territory> getAllCanalSeaZones(final String canalName, final GameData data) {
-    final Set<Territory> rVal = new HashSet<>();
+    final Set<Territory> territories = new HashSet<>();
     for (final Territory t : data.getMap()) {
       final Set<CanalAttachment> canalAttachments = get(t);
       if (canalAttachments.isEmpty()) {
@@ -37,38 +37,38 @@ public class CanalAttachment extends DefaultAttachment {
       }
       for (final CanalAttachment canalAttachment : canalAttachments) {
         if (canalAttachment.getCanalName().equals(canalName)) {
-          rVal.add(t);
+          territories.add(t);
         }
       }
     }
-    if (rVal.size() != 2) {
+    if (territories.size() != 2) {
       throw new IllegalStateException(
-          "Wrong number of sea zones for canal (exactly 2 sea zones may have the same canalName):" + rVal);
+          "Wrong number of sea zones for canal (exactly 2 sea zones may have the same canalName):" + territories);
     }
-    return rVal;
+    return territories;
   }
 
   public static Set<CanalAttachment> get(final Territory t) {
-    final Set<CanalAttachment> rVal = new HashSet<>();
+    final Set<CanalAttachment> canalAttachments = new HashSet<>();
     final Map<String, IAttachment> map = t.getAttachments();
     final Iterator<String> iter = map.keySet().iterator();
     while (iter.hasNext()) {
       final IAttachment attachment = map.get(iter.next());
       final String name = attachment.getName();
       if (name.startsWith(Constants.CANAL_ATTACHMENT_PREFIX)) {
-        rVal.add((CanalAttachment) attachment);
+        canalAttachments.add((CanalAttachment) attachment);
       }
     }
-    return rVal;
+    return canalAttachments;
   }
 
   static CanalAttachment get(final Territory t, final String nameOfAttachment) {
-    final CanalAttachment rVal = (CanalAttachment) t.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final CanalAttachment canalAttachment = (CanalAttachment) t.getAttachment(nameOfAttachment);
+    if (canalAttachment == null) {
       throw new IllegalStateException(
           "CanalAttachment: No canal attachment for:" + t.getName() + " with name: " + nameOfAttachment);
     }
-    return rVal;
+    return canalAttachment;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -32,11 +32,11 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   static PlayerAttachment get(final PlayerID p, final String nameOfAttachment) {
-    final PlayerAttachment rVal = p.getPlayerAttachment(); // (PlayerAttachment) p.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final PlayerAttachment playerAttachment = p.getPlayerAttachment();
+    if (playerAttachment == null) {
       throw new IllegalStateException("No player attachment for:" + p.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return playerAttachment;
   }
 
   private int m_vps = 0;

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -47,21 +47,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * @return RelationshipTypeAttachment belonging to the RelationshipType pr
    */
   public static RelationshipTypeAttachment get(final RelationshipType pr) {
-    final RelationshipTypeAttachment relationshipTypeAttachment =
-        (RelationshipTypeAttachment) pr.getAttachment(Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME);
-    if (relationshipTypeAttachment == null) {
-      throw new IllegalStateException("No relationshipType attachment for:" + pr.getName());
-    }
-    return relationshipTypeAttachment;
+    return get(pr, Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME);
   }
 
   static RelationshipTypeAttachment get(final RelationshipType pr, final String nameOfAttachment) {
-    final RelationshipTypeAttachment relationshipTypeAttachment =
-        (RelationshipTypeAttachment) pr.getAttachment(nameOfAttachment);
-    if (relationshipTypeAttachment == null) {
-      throw new IllegalStateException("No relationshipType attachment for:" + pr.getName());
-    }
-    return relationshipTypeAttachment;
+    return getAttachment(pr, nameOfAttachment, RelationshipTypeAttachment.class);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -47,20 +47,21 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * @return RelationshipTypeAttachment belonging to the RelationshipType pr
    */
   public static RelationshipTypeAttachment get(final RelationshipType pr) {
-    final RelationshipTypeAttachment rVal =
+    final RelationshipTypeAttachment relationshipTypeAttachment =
         (RelationshipTypeAttachment) pr.getAttachment(Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME);
-    if (rVal == null) {
+    if (relationshipTypeAttachment == null) {
       throw new IllegalStateException("No relationshipType attachment for:" + pr.getName());
     }
-    return rVal;
+    return relationshipTypeAttachment;
   }
 
   static RelationshipTypeAttachment get(final RelationshipType pr, final String nameOfAttachment) {
-    final RelationshipTypeAttachment rVal = (RelationshipTypeAttachment) pr.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final RelationshipTypeAttachment relationshipTypeAttachment =
+        (RelationshipTypeAttachment) pr.getAttachment(nameOfAttachment);
+    if (relationshipTypeAttachment == null) {
       throw new IllegalStateException("No relationshipType attachment for:" + pr.getName());
     }
-    return rVal;
+    return relationshipTypeAttachment;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -49,21 +49,19 @@ public class TechAbilityAttachment extends DefaultAttachment {
         return hardCodedTechAttachment;
       }
     }
-    final TechAbilityAttachment rVal =
-        (TechAbilityAttachment) type.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
-    return rVal;
+    return (TechAbilityAttachment) type.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
   }
 
   /**
    * Convenience method.
    */
   public static TechAbilityAttachment get(final TechAdvance type, final String nameOfAttachment) {
-    final TechAbilityAttachment rVal = (TechAbilityAttachment) type.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final TechAbilityAttachment techAbilityAttachment = (TechAbilityAttachment) type.getAttachment(nameOfAttachment);
+    if (techAbilityAttachment == null) {
       throw new IllegalStateException(
           "No technology attachment for:" + type.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return techAbilityAttachment;
   }
 
   // unitAbilitiesGained Static Strings
@@ -1026,24 +1024,24 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   public static HashMap<String, HashSet<UnitType>> getAirborneTargettedByAA(final PlayerID player,
       final GameData data) {
-    final HashMap<String, HashSet<UnitType>> rVal = new HashMap<>();
+    final HashMap<String, HashSet<UnitType>> airborneTargettedByAa = new HashMap<>();
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
       if (taa != null) {
         final HashMap<String, HashSet<UnitType>> mapAa = taa.getAirborneTargettedByAA();
         if (mapAa != null && !mapAa.isEmpty()) {
           for (final Entry<String, HashSet<UnitType>> entry : mapAa.entrySet()) {
-            HashSet<UnitType> current = rVal.get(entry.getKey());
+            HashSet<UnitType> current = airborneTargettedByAa.get(entry.getKey());
             if (current == null) {
               current = new HashSet<>();
             }
             current.addAll(entry.getValue());
-            rVal.put(entry.getKey(), current);
+            airborneTargettedByAa.put(entry.getKey(), current);
           }
         }
       }
     }
-    return rVal;
+    return airborneTargettedByAa;
   }
 
   public void clearAirborneTargettedByAA() {

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -56,12 +56,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Convenience method.
    */
   public static TechAbilityAttachment get(final TechAdvance type, final String nameOfAttachment) {
-    final TechAbilityAttachment techAbilityAttachment = (TechAbilityAttachment) type.getAttachment(nameOfAttachment);
-    if (techAbilityAttachment == null) {
-      throw new IllegalStateException(
-          "No technology attachment for:" + type.getName() + " with name:" + nameOfAttachment);
-    }
-    return techAbilityAttachment;
+    return getAttachment(type, nameOfAttachment, TechAbilityAttachment.class);
   }
 
   // unitAbilitiesGained Static Strings

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -141,11 +141,11 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   static TerritoryAttachment get(final Territory t, final String nameOfAttachment) {
-    final TerritoryAttachment rVal = (TerritoryAttachment) t.getAttachment(nameOfAttachment);
-    if (rVal == null && !t.isWater()) {
+    final TerritoryAttachment territoryAttachment = (TerritoryAttachment) t.getAttachment(nameOfAttachment);
+    if (territoryAttachment == null && !t.isWater()) {
       throw new IllegalStateException("No territory attachment for:" + t.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return territoryAttachment;
   }
 
   /**
@@ -674,7 +674,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   public static Set<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(final Territory t, final GameData data) {
-    final Set<Territory> rVal = new HashSet<>();
+    final Set<Territory> territories = new HashSet<>();
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta == null || !ta.getConvoyRoute()) {
       return null;
@@ -685,10 +685,10 @@ public class TerritoryAttachment extends DefaultAttachment {
         continue;
       }
       if (cta.getConvoyAttached().contains(t)) {
-        rVal.add(current);
+        territories.add(current);
       }
     }
-    return rVal;
+    return territories;
   }
 
   public String toStringForInfo(final boolean useHtml, final boolean includeAttachedToName) {

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -33,26 +33,13 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
 
   /**
    * Convenience method.
-   *
-   * @return TerritoryEffectAttachment belonging to the RelationshipType pr
    */
   public static TerritoryEffectAttachment get(final TerritoryEffect te) {
-    final TerritoryEffectAttachment territoryEffectAttachment =
-        (TerritoryEffectAttachment) te.getAttachment(Constants.TERRITORYEFFECT_ATTACHMENT_NAME);
-    if (territoryEffectAttachment == null) {
-      throw new IllegalStateException("No territoryEffect attachment for:" + te.getName());
-    }
-    return territoryEffectAttachment;
+    return get(te, Constants.TERRITORYEFFECT_ATTACHMENT_NAME);
   }
 
   static TerritoryEffectAttachment get(final TerritoryEffect te, final String nameOfAttachment) {
-    final TerritoryEffectAttachment territoryEffectAttachment =
-        (TerritoryEffectAttachment) te.getAttachment(nameOfAttachment);
-    if (territoryEffectAttachment == null) {
-      throw new IllegalStateException(
-          "No territoryEffect attachment for:" + te.getName() + " with name:" + nameOfAttachment);
-    }
-    return territoryEffectAttachment;
+    return getAttachment(te, nameOfAttachment, TerritoryEffectAttachment.class);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -37,21 +37,22 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
    * @return TerritoryEffectAttachment belonging to the RelationshipType pr
    */
   public static TerritoryEffectAttachment get(final TerritoryEffect te) {
-    final TerritoryEffectAttachment rVal =
+    final TerritoryEffectAttachment territoryEffectAttachment =
         (TerritoryEffectAttachment) te.getAttachment(Constants.TERRITORYEFFECT_ATTACHMENT_NAME);
-    if (rVal == null) {
+    if (territoryEffectAttachment == null) {
       throw new IllegalStateException("No territoryEffect attachment for:" + te.getName());
     }
-    return rVal;
+    return territoryEffectAttachment;
   }
 
   static TerritoryEffectAttachment get(final TerritoryEffect te, final String nameOfAttachment) {
-    final TerritoryEffectAttachment rVal = (TerritoryEffectAttachment) te.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final TerritoryEffectAttachment territoryEffectAttachment =
+        (TerritoryEffectAttachment) te.getAttachment(nameOfAttachment);
+    if (territoryEffectAttachment == null) {
       throw new IllegalStateException(
           "No territoryEffect attachment for:" + te.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return territoryEffectAttachment;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -48,20 +48,11 @@ public class UnitAttachment extends DefaultAttachment {
    * Convenience method.
    */
   public static UnitAttachment get(final UnitType type) {
-    final UnitAttachment unitAttachment = (UnitAttachment) type.getAttachment(Constants.UNIT_ATTACHMENT_NAME);
-    if (unitAttachment == null) {
-      throw new IllegalStateException("No unit type attachment for:" + type.getName());
-    }
-    return unitAttachment;
+    return get(type, Constants.UNIT_ATTACHMENT_NAME);
   }
 
   static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
-    final UnitAttachment unitAttachment = (UnitAttachment) type.getAttachment(nameOfAttachment);
-    if (unitAttachment == null) {
-      throw new IllegalStateException(
-          "No unit type attachment for:" + type.getName() + " with name:" + nameOfAttachment);
-    }
-    return unitAttachment;
+    return getAttachment(type, nameOfAttachment, UnitAttachment.class);
   }
 
   private static Collection<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -48,20 +48,20 @@ public class UnitAttachment extends DefaultAttachment {
    * Convenience method.
    */
   public static UnitAttachment get(final UnitType type) {
-    final UnitAttachment rVal = (UnitAttachment) type.getAttachment(Constants.UNIT_ATTACHMENT_NAME);
-    if (rVal == null) {
+    final UnitAttachment unitAttachment = (UnitAttachment) type.getAttachment(Constants.UNIT_ATTACHMENT_NAME);
+    if (unitAttachment == null) {
       throw new IllegalStateException("No unit type attachment for:" + type.getName());
     }
-    return rVal;
+    return unitAttachment;
   }
 
   static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
-    final UnitAttachment rVal = (UnitAttachment) type.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final UnitAttachment unitAttachment = (UnitAttachment) type.getAttachment(nameOfAttachment);
+    if (unitAttachment == null) {
       throw new IllegalStateException(
           "No unit type attachment for:" + type.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return unitAttachment;
   }
 
   private static Collection<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {
@@ -2363,9 +2363,9 @@ public class UnitAttachment extends DefaultAttachment {
     for (final Unit u : aaUnitsAlreadyVerified) {
       aaSet.add(UnitAttachment.get(u.getType()).getTypeAA());
     }
-    final List<String> rVal = new ArrayList<>(aaSet);
-    Collections.sort(rVal);
-    return rVal;
+    final List<String> aaTypes = new ArrayList<>(aaSet);
+    Collections.sort(aaTypes);
+    return aaTypes;
   }
 
   /**
@@ -2788,29 +2788,29 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public Collection<UnitType> getListedUnits(final String[] list) {
-    final List<UnitType> rVal = new ArrayList<>();
+    final List<UnitType> unitTypes = new ArrayList<>();
     for (final String name : list) {
       // Validate all units exist
       final UnitType ut = getData().getUnitTypeList().getUnitType(name);
       if (ut == null) {
         throw new IllegalStateException("No unit called: " + name + thisErrorMsg());
       }
-      rVal.add(ut);
+      unitTypes.add(ut);
     }
-    return rVal;
+    return unitTypes;
   }
 
   private Collection<Territory> getListedTerritories(final String[] list) throws GameParseException {
-    final List<Territory> rVal = new ArrayList<>();
+    final List<Territory> territories = new ArrayList<>();
     for (final String name : list) {
       // Validate all territories exist
       final Territory territory = getData().getMap().getTerritory(name);
       if (territory == null) {
         throw new GameParseException("No territory called: " + name + thisErrorMsg());
       }
-      rVal.add(territory);
+      territories.add(territory);
     }
-    return rVal;
+    return territories;
   }
 
   private static boolean playerHasRockets(final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -68,11 +68,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   static UnitSupportAttachment get(final UnitType u, final String nameOfAttachment) {
-    final UnitSupportAttachment unitSupportAttachment = (UnitSupportAttachment) u.getAttachment(nameOfAttachment);
-    if (unitSupportAttachment == null) {
-      throw new IllegalStateException("No unit type attachment for:" + u.getName() + " with name:" + nameOfAttachment);
-    }
-    return unitSupportAttachment;
+    return getAttachment(u, nameOfAttachment, UnitSupportAttachment.class);
   }
 
   public static Set<UnitSupportAttachment> get(final GameData data) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -68,11 +68,11 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   static UnitSupportAttachment get(final UnitType u, final String nameOfAttachment) {
-    final UnitSupportAttachment rVal = (UnitSupportAttachment) u.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final UnitSupportAttachment unitSupportAttachment = (UnitSupportAttachment) u.getAttachment(nameOfAttachment);
+    if (unitSupportAttachment == null) {
       throw new IllegalStateException("No unit type attachment for:" + u.getName() + " with name:" + nameOfAttachment);
     }
-    return rVal;
+    return unitSupportAttachment;
   }
 
   public static Set<UnitSupportAttachment> get(final GameData data) {

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -47,12 +47,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   static UserActionAttachment get(final PlayerID player, final String nameOfAttachment) {
-    final UserActionAttachment userActionAttachment = (UserActionAttachment) player.getAttachment(nameOfAttachment);
-    if (userActionAttachment == null) {
-      throw new IllegalStateException(
-          "UserActionAttachment: No attachment for:" + player.getName() + " with name: " + nameOfAttachment);
-    }
-    return userActionAttachment;
+    return getAttachment(player, nameOfAttachment, UserActionAttachment.class);
   }
 
   // instance variables:

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -47,12 +47,12 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   static UserActionAttachment get(final PlayerID player, final String nameOfAttachment) {
-    final UserActionAttachment rVal = (UserActionAttachment) player.getAttachment(nameOfAttachment);
-    if (rVal == null) {
+    final UserActionAttachment userActionAttachment = (UserActionAttachment) player.getAttachment(nameOfAttachment);
+    if (userActionAttachment == null) {
       throw new IllegalStateException(
           "UserActionAttachment: No attachment for:" + player.getName() + " with name: " + nameOfAttachment);
     }
-    return rVal;
+    return userActionAttachment;
   }
 
   // instance variables:

--- a/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -1,0 +1,52 @@
+package games.strategy.engine.data;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public final class DefaultAttachmentTest {
+  @Mock
+  private NamedAttachable namedAttachable;
+
+  @Test
+  public void getAttachment_ShouldReturnAttachmentWhenAttachmentIsPresent() {
+    final String attachmentName = "attachmentName";
+    final FakeAttachment expected = new FakeAttachment(attachmentName);
+    when(namedAttachable.getAttachment(attachmentName)).thenReturn(expected);
+
+    final FakeAttachment actual =
+        DefaultAttachment.getAttachment(namedAttachable, attachmentName, FakeAttachment.class);
+
+    assertThat(actual, is(sameInstance(expected)));
+  }
+
+  @Test
+  public void getAttachment_ShouldThrowExceptionWhenAttachmentIsAbsent() {
+    when(namedAttachable.getAttachment(any())).thenReturn(null);
+
+    catchException(() -> DefaultAttachment.getAttachment(namedAttachable, "attachmentName", FakeAttachment.class));
+
+    assertThat(caughtException(), is(instanceOf(IllegalStateException.class)));
+  }
+
+  @Test
+  public void getAttachment_ShouldThrowExceptionWhenAttachmentHasWrongType() {
+    when(namedAttachable.getAttachment(any())).thenReturn(mock(IAttachment.class));
+
+    catchException(() -> DefaultAttachment.getAttachment(namedAttachable, "attachmentName", FakeAttachment.class));
+
+    assertThat(caughtException(), is(instanceOf(ClassCastException.class)));
+  }
+}

--- a/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
@@ -1,0 +1,64 @@
+package games.strategy.engine.message;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public final class RemoteMethodCallTest {
+  @Test
+  public void stringToClass_ShouldReturnArgWhenStringIsNull() {
+    assertThat(RemoteMethodCall.stringToClass(null, new Object()), is(Object.class));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveIntegerTypeWhenStringIsInt() {
+    assertThat(RemoteMethodCall.stringToClass("int", null), is(Integer.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveShortTypeWhenStringIsShort() {
+    assertThat(RemoteMethodCall.stringToClass("short", null), is(Short.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveByteTypeWhenStringIsByte() {
+    assertThat(RemoteMethodCall.stringToClass("byte", null), is(Byte.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveLongTypeWhenStringIsLong() {
+    assertThat(RemoteMethodCall.stringToClass("long", null), is(Long.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveFloatTypeWhenStringIsFloat() {
+    assertThat(RemoteMethodCall.stringToClass("float", null), is(Float.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveDoubleTypeWhenStringIsDouble() {
+    assertThat(RemoteMethodCall.stringToClass("double", null), is(Double.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnPrimitiveBooleanTypeWhenStringIsBoolean() {
+    assertThat(RemoteMethodCall.stringToClass("boolean", null), is(Boolean.TYPE));
+  }
+
+  @Test
+  public void stringToClass_ShouldReturnClassWhenStringIsKnownClassName() {
+    assertThat(RemoteMethodCall.stringToClass("java.lang.String", null), is(String.class));
+  }
+
+  @Test
+  public void stringToClass_ShouldThrowExceptionWhenStringIsUnknownClassName() {
+    catchException(() -> RemoteMethodCall.stringToClass("some.unknown.Type", null));
+
+    assertThat(caughtException(), is(instanceOf(IllegalStateException.class)));
+    assertThat(caughtException().getCause(), is(instanceOf(ClassNotFoundException.class)));
+  }
+}

--- a/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 public final class RemoteMethodCallTest {
   @Test
-  public void stringToClass_ShouldReturnArgWhenStringIsNull() {
+  public void stringToClass_ShouldReturnClassOfArgWhenStringIsNull() {
     assertThat(RemoteMethodCall.stringToClass(null, new Object()), is(Object.class));
   }
 

--- a/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
@@ -1,6 +1,8 @@
 package games.strategy.engine.random;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -21,6 +23,17 @@ public class CryptoRandomSourceTest {
     assertEquals(CryptoRandomSource.byteToIntUnsigned((byte) 0), 0);
     assertEquals(CryptoRandomSource.byteToIntUnsigned((byte) 1), 1);
     assertEquals(CryptoRandomSource.byteToIntUnsigned(((byte) 0xFF)), 0xFF);
+  }
+
+  @Test
+  public void testMix() {
+    final int[] val1 = {0, 0, 0, 1, 1, 1, 2, 2, 2};
+    final int[] val2 = {0, 1, 2, 0, 1, 2, 0, 1, 2};
+    final int max = 3;
+
+    final int[] mixedValues = CryptoRandomSource.mix(val1, val2, max);
+
+    assertThat(mixedValues, is(new int[] {0, 1, 2, 1, 2, 0, 2, 0, 1}));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
@@ -9,20 +9,27 @@ import org.junit.Test;
 public class CryptoRandomSourceTest {
 
   @Test
-  public void testIntToRandom() {
-    final byte[] bytes = CryptoRandomSource.intsToBytes(new int[] {0xDDCCBBAA});
-    assertEquals(bytes.length, 4);
-    assertEquals(bytes[0], (byte) 0xAA);
-    assertEquals(bytes[1], (byte) 0xBB);
-    assertEquals(bytes[2], (byte) 0xCC);
-    assertEquals(bytes[3], (byte) 0xDD);
+  public void testIntsToBytes() {
+    final byte[] bytes = CryptoRandomSource.intsToBytes(new int[] { 0xD1C2B3A4, 0x1A2B3C4D });
+    assertEquals(8, bytes.length);
+    assertEquals((byte) 0xA4, bytes[0]);
+    assertEquals((byte) 0xB3, bytes[1]);
+    assertEquals((byte) 0xC2, bytes[2]);
+    assertEquals((byte) 0xD1, bytes[3]);
+    assertEquals((byte) 0x4D, bytes[4]);
+    assertEquals((byte) 0x3C, bytes[5]);
+    assertEquals((byte) 0x2B, bytes[6]);
+    assertEquals((byte) 0x1A, bytes[7]);
   }
 
   @Test
-  public void testBytes() {
-    assertEquals(CryptoRandomSource.byteToIntUnsigned((byte) 0), 0);
-    assertEquals(CryptoRandomSource.byteToIntUnsigned((byte) 1), 1);
-    assertEquals(CryptoRandomSource.byteToIntUnsigned(((byte) 0xFF)), 0xFF);
+  public void testBytesToInts() {
+    final int[] ints = CryptoRandomSource.bytesToInts(new byte[] {
+        (byte) 0xA4, (byte) 0xB3, (byte) 0xC2, (byte) 0xD1,
+        (byte) 0x4D, (byte) 0x3C, (byte) 0x2B, (byte) 0x1A });
+    assertEquals(2, ints.length);
+    assertEquals(0xD1C2B3A4, ints[0]);
+    assertEquals(0x1A2B3C4D, ints[1]);
   }
 
   @Test


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule due to local variables named `rVal` whose purpose is to store a method return value.

This is one part in a series of related PRs in order to keep the review size reasonable.