### PR TITLE
Add check to see if player owns capital when units are repairing others

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1702,7 +1702,8 @@ public final class Matches {
 
   static Match<Unit> unitCanRepairOthers() {
     return Match.of(unit -> {
-      if (unitIsDisabled().match(unit) || unitIsBeingTransported().match(unit)) {
+      if (unitIsDisabled().match(unit) || unitIsBeingTransported().match(unit)
+          || !TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(unit.getOwner(), unit.getData())) {
         return false;
       }
       final UnitAttachment ua = UnitAttachment.get(unit.getType());


### PR DESCRIPTION
Addresses #2256 

Add check to see if player has enough capitals to produce and if they don't then they can't use facilities to repair units.