### PR TITLE
Add setting non-air that moved to no moves left at end of move phases

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -208,6 +208,12 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // while loading.
     if (GameStepPropertiesHelper.isResetUnitStateAtEnd(data)) {
       resetUnitStateAndDelegateState();
+    } else {
+
+      // Only air units can move during both CM and NCM in the same turn so moved units are set to no moves left
+      final List<Unit> alreadyMovedUnits =
+          Matches.getMatches(data.getUnits().getUnits(), Match.allOf(Matches.unitHasMoved(), Matches.unitIsNotAir()));
+      m_bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedUnits));
     }
     m_needToInitialize = true;
     m_needToDoRockets = true;

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -211,9 +211,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
     } else {
 
       // Only air units can move during both CM and NCM in the same turn so moved units are set to no moves left
-      final List<Unit> alreadyMovedUnits =
+      final List<Unit> alreadyMovedNonAirUnits =
           Matches.getMatches(data.getUnits().getUnits(), Match.allOf(Matches.unitHasMoved(), Matches.unitIsNotAir()));
-      m_bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedUnits));
+      m_bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedNonAirUnits));
     }
     m_needToInitialize = true;
     m_needToDoRockets = true;


### PR DESCRIPTION
Addresses #2266 and #2259 

Add setting non-air units that moved to no moves left at end of move phases unless movement is being reset. For almost all maps this means at the end of combat move, any non-air unit that moved during combat move will be set to have no movement remaining since non-air units can only move during either CM or NCM (not both in the same turn).


