### PR TITLE
DB enhancements

### DIFF
--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -1,94 +1,56 @@
-create table bad_words (
-    word character varying(40) not null
+CREATE TABLE ta_users (
+    username character varying(40) NOT NULL PRIMARY KEY,
+    password character varying(60) NOT NULL,
+    email character varying(254) NOT NULL,
+    joined timestamp with time zone,
+    lastlogin timestamp with time zone,
+    admin integer NOT NULL
 );
+ALTER TABLE ta_users owner TO postgres;
 
-
-alter table bad_words owner to postgres;
-
-
-create table banned_ips (
-    ip character varying(40) not null,
-    ban_till timestamp without time zone
+CREATE TABLE bad_words (
+    word character varying(40) NOT NULL PRIMARY KEY
 );
+ALTER TABLE bad_words owner TO postgres;
 
 
-alter table banned_ips owner to postgres;
-
-
-create table banned_macs (
-    mac character varying(40) not null,
-    ban_till timestamp without time zone
+CREATE TABLE banned_ips (
+    ip character varying(40) NOT NULL PRIMARY KEY,
+    ban_till timestamp with time zone
 );
+ALTER TABLE banned_ips owner TO postgres;
 
 
-alter table banned_macs owner to postgres;
-
-
-create table banned_usernames (
-    username character varying(40) not null,
-    ban_till timestamp without time zone
+CREATE TABLE banned_macs (
+    mac character varying(40) NOT NULL PRIMARY KEY,
+    ban_till timestamp with time zone
 );
+ALTER TABLE banned_macs owner TO postgres;
 
 
-alter table banned_usernames owner to postgres;
-
-create table muted_ips (
-    ip character varying(40) not null,
-    mute_till timestamp without time zone
+CREATE TABLE banned_usernames (
+    username character varying(40) NOT NULL PRIMARY KEY REFERENCES ta_users ON DELETE CASCADE ON UPDATE CASCADE,
+    ban_till timestamp with time zone
 );
+ALTER TABLE banned_usernames owner TO postgres;
 
 
-alter table muted_ips owner to postgres;
-
-create table muted_macs (
-    mac character varying(40) not null,
-    mute_till timestamp without time zone
+CREATE TABLE muted_ips (
+    ip character varying(40) NOT NULL PRIMARY KEY,
+    mute_till timestamp with time zone
 );
+ALTER TABLE muted_ips owner TO postgres;
 
 
-alter table muted_macs owner to postgres;
-
-create table muted_usernames (
-    username character varying(40) not null,
-    mute_till timestamp without time zone
+CREATE TABLE muted_macs (
+    mac character varying(40) NOT NULL PRIMARY KEY,
+    mute_till timestamp with time zone
 );
+ALTER TABLE muted_macs owner TO postgres;
 
 
-alter table muted_usernames owner to postgres;
-
-create table ta_users (
-    username character varying(40) not null,
-    password character varying(60) not null,
-    email character varying(40) not null,
-    joined timestamp without time zone not null,
-    lastlogin timestamp without time zone not null,
-    admin integer not null
+CREATE TABLE muted_usernames (
+    username character varying(40) NOT NULL PRIMARY KEY REFERENCES ta_users ON DELETE CASCADE ON UPDATE CASCADE,
+    mute_till timestamp with time zone
 );
-
-
-alter table ta_users owner to postgres;
-
-
-alter table only bad_words
-    add constraint bad_words_pkey primary key (word);
-
-alter table only banned_ips
-    add constraint banned_ips_pkey primary key (ip);
-
-alter table only banned_macs
-    add constraint banned_macs_pkey primary key (mac);
-
-alter table only banned_usernames
-    add constraint banned_usernames_pkey primary key (username);
-
-alter table only muted_ips
-    add constraint muted_ips_pkey primary key (ip);
-
-alter table only muted_macs
-    add constraint muted_macs_pkey primary key (mac);
-
-alter table only muted_usernames
-    add constraint muted_usernames_pkey primary key (username);
-
-alter table only ta_users
-    add constraint ta_users_pkey primary key (username);
+ALTER TABLE muted_usernames owner TO postgres;

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -3,20 +3,17 @@ create table bad_words (
 );
 alter table bad_words owner to postgres;
 
-
 create table banned_ips (
     ip character varying(40) not null primary key,
     ban_till timestamp without time zone
 );
 alter table banned_ips owner to postgres;
 
-
 create table banned_macs (
     mac character varying(40) not null primary key,
     ban_till timestamp without time zone
 );
 alter table banned_macs owner to postgres;
-
 
 create table banned_usernames (
     username character varying(40) not null primary key,

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -29,7 +29,7 @@ alter table banned_macs owner to postgres;
 
 
 create table banned_usernames (
-    username character varying(40) not null primary key references ta_users on delete cascade on update cascade,
+    username character varying(40) not null primary key, -- references ta_users on delete cascade on update cascade,
     ban_till timestamp with time zone
 );
 alter table banned_usernames owner to postgres;
@@ -50,7 +50,7 @@ alter table muted_macs owner to postgres;
 
 
 create table muted_usernames (
-    username character varying(40) not null primary key references ta_users on delete cascade on update cascade,
+    username character varying(40) not null primary key, -- references ta_users on delete cascade on update cascade,
     mute_till timestamp with time zone
 );
 alter table muted_usernames owner to postgres;

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -14,13 +14,6 @@ create table bad_words (
 alter table bad_words owner to postgres;
 
 
-create table banned_ips (
-    ip character varying(40) not null primary key,
-    ban_till timestamp with time zone
-);
-alter table banned_ips owner to postgres;
-
-
 create table banned_macs (
     mac character(34) not null primary key,
     ban_till timestamp with time zone
@@ -33,13 +26,6 @@ create table banned_usernames (
     ban_till timestamp with time zone
 );
 alter table banned_usernames owner to postgres;
-
-
-create table muted_ips (
-    ip character varying(40) not null primary key,
-    mute_till timestamp with time zone
-);
-alter table muted_ips owner to postgres;
 
 
 create table muted_macs (

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -1,42 +1,53 @@
-create table ta_users (
-    username character varying(40) not null primary key,
-    password character varying(60) not null,
-    email character varying(254) not null,
-    joined timestamp with time zone not null default current_timestamp,
-    lastlogin timestamp with time zone not null default current_timestamp,
-    admin boolean not null default false
-);
-alter table ta_users owner to postgres;
-
 create table bad_words (
     word character varying(40) not null primary key
 );
 alter table bad_words owner to postgres;
 
 
+create table banned_ips (
+    ip character varying(40) not null primary key,
+    ban_till timestamp without time zone
+);
+alter table banned_ips owner to postgres;
+
+
 create table banned_macs (
-    mac character(34) not null primary key,
-    ban_till timestamp with time zone
+    mac character varying(40) not null primary key,
+    ban_till timestamp without time zone
 );
 alter table banned_macs owner to postgres;
 
 
 create table banned_usernames (
-    username character varying(40) not null primary key, -- references ta_users on delete cascade on update cascade,
-    ban_till timestamp with time zone
+    username character varying(40) not null primary key,
+    ban_till timestamp without time zone
 );
 alter table banned_usernames owner to postgres;
 
+create table muted_ips (
+    ip character varying(40) not null primary key,
+    mute_till timestamp without time zone
+);
+alter table muted_ips owner to postgres;
 
 create table muted_macs (
-    mac character(34) not null primary key,
-    mute_till timestamp with time zone
+    mac character varying(40) not null primary key,
+    mute_till timestamp without time zone
 );
 alter table muted_macs owner to postgres;
 
-
 create table muted_usernames (
-    username character varying(40) not null primary key, -- references ta_users on delete cascade on update cascade,
-    mute_till timestamp with time zone
+    username character varying(40) not null primary key,
+    mute_till timestamp without time zone
 );
 alter table muted_usernames owner to postgres;
+
+create table ta_users (
+    username character varying(40) not null primary key,
+    password character varying(60) not null,
+    email character varying(40) not null,
+    joined timestamp without time zone not null,
+    lastlogin timestamp without time zone not null,
+    admin integer not null
+);
+alter table ta_users owner to postgres;

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -1,56 +1,56 @@
-CREATE TABLE ta_users (
-    username character varying(40) NOT NULL PRIMARY KEY,
-    password character varying(60) NOT NULL,
-    email character varying(254) NOT NULL,
+create table ta_users (
+    username character varying(40) not null primary key,
+    password character varying(60) not null,
+    email character varying(254) not null,
     joined timestamp with time zone,
     lastlogin timestamp with time zone,
-    admin integer NOT NULL
+    admin integer not null
 );
-ALTER TABLE ta_users owner TO postgres;
+alter table ta_users owner to postgres;
 
-CREATE TABLE bad_words (
-    word character varying(40) NOT NULL PRIMARY KEY
+create table bad_words (
+    word character varying(40) not null primary key
 );
-ALTER TABLE bad_words owner TO postgres;
+alter table bad_words owner to postgres;
 
 
-CREATE TABLE banned_ips (
-    ip character varying(40) NOT NULL PRIMARY KEY,
+create table banned_ips (
+    ip character varying(40) not null primary key,
     ban_till timestamp with time zone
 );
-ALTER TABLE banned_ips owner TO postgres;
+alter table banned_ips owner to postgres;
 
 
-CREATE TABLE banned_macs (
-    mac character varying(40) NOT NULL PRIMARY KEY,
+create table banned_macs (
+    mac character varying(40) not null primary key,
     ban_till timestamp with time zone
 );
-ALTER TABLE banned_macs owner TO postgres;
+alter table banned_macs owner to postgres;
 
 
-CREATE TABLE banned_usernames (
-    username character varying(40) NOT NULL PRIMARY KEY REFERENCES ta_users ON DELETE CASCADE ON UPDATE CASCADE,
+create table banned_usernames (
+    username character varying(40) not null primary key references ta_users on delete cascade on update cascade,
     ban_till timestamp with time zone
 );
-ALTER TABLE banned_usernames owner TO postgres;
+alter table banned_usernames owner to postgres;
 
 
-CREATE TABLE muted_ips (
-    ip character varying(40) NOT NULL PRIMARY KEY,
+create table muted_ips (
+    ip character varying(40) not null primary key,
     mute_till timestamp with time zone
 );
-ALTER TABLE muted_ips owner TO postgres;
+alter table muted_ips owner to postgres;
 
 
-CREATE TABLE muted_macs (
-    mac character varying(40) NOT NULL PRIMARY KEY,
+create table muted_macs (
+    mac character varying(40) not null primary key,
     mute_till timestamp with time zone
 );
-ALTER TABLE muted_macs owner TO postgres;
+alter table muted_macs owner to postgres;
 
 
-CREATE TABLE muted_usernames (
-    username character varying(40) NOT NULL PRIMARY KEY REFERENCES ta_users ON DELETE CASCADE ON UPDATE CASCADE,
+create table muted_usernames (
+    username character varying(40) not null primary key references ta_users on delete cascade on update cascade,
     mute_till timestamp with time zone
 );
-ALTER TABLE muted_usernames owner TO postgres;
+alter table muted_usernames owner to postgres;

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -22,7 +22,7 @@ alter table banned_ips owner to postgres;
 
 
 create table banned_macs (
-    mac character varying(40) not null primary key,
+    mac character(34) not null primary key,
     ban_till timestamp with time zone
 );
 alter table banned_macs owner to postgres;
@@ -43,7 +43,7 @@ alter table muted_ips owner to postgres;
 
 
 create table muted_macs (
-    mac character varying(40) not null primary key,
+    mac character(34) not null primary key,
     mute_till timestamp with time zone
 );
 alter table muted_macs owner to postgres;

--- a/config/lobby/db/001_create_tables
+++ b/config/lobby/db/001_create_tables
@@ -2,9 +2,9 @@ create table ta_users (
     username character varying(40) not null primary key,
     password character varying(60) not null,
     email character varying(254) not null,
-    joined timestamp with time zone,
-    lastlogin timestamp with time zone,
-    admin integer not null
+    joined timestamp with time zone not null default current_timestamp,
+    lastlogin timestamp with time zone not null default current_timestamp,
+    admin boolean not null default false
 );
 alter table ta_users owner to postgres;
 

--- a/config/lobby/db/002_update_tables
+++ b/config/lobby/db/002_update_tables
@@ -12,7 +12,8 @@ alter table ta_users
 drop table banned_ips;
 
 alter table banned_macs
-    alter column mac type character(34),
+    alter column mac type character(28),
+	add constraint banned_macs_mac_check check (char_length(mac)=28),
     alter column ban_till type timestamptz;
 
 alter table banned_usernames alter column ban_till type timestamptz;
@@ -20,9 +21,42 @@ alter table banned_usernames alter column ban_till type timestamptz;
 drop table muted_ips;
 
 alter table muted_macs
-    alter column mac type character(34),
+    alter column mac type character(28),
+	add constraint muted_macs_mac_check check (char_length(mac)=28),
     alter column mute_till type timestamptz;
 
 alter table muted_usernames alter column mute_till type timestamptz;
+
+
+-- Comments
+comment on database ta_users is 'The Database of the TripleA Lobby';
+
+comment on table ta_users is 'The table storing all the information about TripleA users.';
+comment on column ta_users.username is 'Defines the in-game username of everyone. The primary key constraint should probably be moved to an id column, preferably using pseudo_encrypt(nextval(''something'')) as default value.';
+comment on column ta_users.email is 'Email storage of every user. Large size to match the maximum email length. More information here: https://stackoverflow.com/a/574698 Should be made unique in the future.';
+comment on column ta_users.joined is 'The timestamp of the creation of the account. Is created automatically by the DB, should never be modified, e.g. considered immutable';
+comment on column ta_users.lastlogin is 'The timestamp of the last successful login, is altered by the game engine.';
+comment on column ta_users.admin is 'The role of the user, controls privileges. If true the user is able to ban and mute other people. Might be changed to another type once more "ranks" become neccessary. Defaults to false.';
+
+comment on table bad_words is 'A table representing a blacklist of words, used to filter chat messages and prohibit usernames in the lobby.';
+comment on column bad_words.word is 'This column stores all the banned words. The primary key constraint might be replaced with a unique constraint.';
+
+comment on table banned_macs is 'A Table storing banned mac adresses.';
+comment on column banned_macs.mac is 'An MD5Crypted/hashed MAC address. This hashing method should be replaced by SHA-2 or SHA-3 for performance and collision reasons (salting is not needed).  The hash must be of length 28.';
+comment on column banned_macs.ban_till is 'A timestamp indicating how long the ban should be active, if NULL the ban is forever.';
+comment on constraint banned_macs_mac_check on banned_macs is 'Ensures the hashed mac always has the right length.';
+
+comment on table banned_usernames is 'A Table storing banned usernames.';
+comment on column banned_usernames.username is 'The username of the banned user. Actually no direct reference to the ta_users.username, the engine allows to define prohibited usernames, should probably be avoided, and an SQL reference created instead.';
+comment on column banned_usernames.ban_till is 'A timestamp indicating how long the ban should be active, if NULL the ban is forever.';
+
+comment on table muted_macs is 'A Table storing muted mac adresses.';
+comment on column muted_macs.mac is 'An MD5Crypted/hashed MAC address. This hashing method should be replaced by SHA-2 or SHA-3 for performance and collision reasons (salting is not needed). The hash must be of length 28.';
+comment on column muted_macs.mute_till is 'A timestamp indicating how long the mute should be active, if NULL the mute is forever.';
+comment on constraint muted_macs_mac_check on muted_macs is 'Ensures the hashed mac always has the right length.';
+
+comment on table muted_usernames is 'A Table storing muted usernames.';
+comment on column muted_usernames.username is 'The username of the muted user. Actually no direct reference to the ta_users.username for whatever reason using an SQL reference would make the mute change along with the username of a user.';
+comment on column muted_usernames.mute_till is 'A timestamp indicating how long the mute should be active, if NULL the mute is forever.';
 
 commit;

--- a/config/lobby/db/002_update_tables
+++ b/config/lobby/db/002_update_tables
@@ -1,3 +1,5 @@
+start transaction;
+
 alter table ta_users
     alter column email type varchar(254),
     alter column joined type timestamptz,
@@ -22,3 +24,5 @@ alter table muted_macs
     alter column mute_till type timestamptz;
 
 alter table muted_usernames alter column mute_till type timestamptz;
+
+commit;

--- a/config/lobby/db/002_update_tables
+++ b/config/lobby/db/002_update_tables
@@ -11,21 +11,31 @@ alter table ta_users
 
 drop table banned_ips;
 
+delete from banned_macs where ban_till <= now();
 alter table banned_macs
     alter column mac type character(28),
 	add constraint banned_macs_mac_check check (char_length(mac)=28),
-    alter column ban_till type timestamptz;
+    alter column ban_till type timestamptz,
+	add constraint banned_macs_ban_till_check check (ban_till is null or ban_till > now());
 
-alter table banned_usernames alter column ban_till type timestamptz;
+delete from banned_usernames where ban_till <= now();
+alter table banned_usernames
+    alter column ban_till type timestamptz,
+	add constraint banned_usernames_ban_till_check check (ban_till is null or ban_till > now());
 
 drop table muted_ips;
 
+delete from muted_macs where mute_till <= now();
 alter table muted_macs
     alter column mac type character(28),
 	add constraint muted_macs_mac_check check (char_length(mac)=28),
-    alter column mute_till type timestamptz;
+    alter column mute_till type timestamptz,
+	add constraint muted_macs_mute_till_check check (mute_till is null or mute_till > now());
 
-alter table muted_usernames alter column mute_till type timestamptz;
+delete from muted_usernames where mute_till <= now();
+alter table muted_usernames
+    alter column mute_till type timestamptz,
+	add constraint muted_usernames_mute_till_check check (mute_till is null or mute_till > now());
 
 
 -- Comments
@@ -45,18 +55,22 @@ comment on table banned_macs is 'A Table storing banned mac adresses.';
 comment on column banned_macs.mac is 'An MD5Crypted/hashed MAC address. This hashing method should be replaced by SHA-2 or SHA-3 for performance and collision reasons (salting is not needed).  The hash must be of length 28.';
 comment on column banned_macs.ban_till is 'A timestamp indicating how long the ban should be active, if NULL the ban is forever.';
 comment on constraint banned_macs_mac_check on banned_macs is 'Ensures the hashed mac always has the right length.';
+comment on constraint banned_macs_ban_till_check on banned_macs is 'Ensures no storage is being wasted by banning someone backdated to the past.';
 
 comment on table banned_usernames is 'A Table storing banned usernames.';
 comment on column banned_usernames.username is 'The username of the banned user. Actually no direct reference to the ta_users.username, the engine allows to define prohibited usernames, should probably be avoided, and an SQL reference created instead.';
 comment on column banned_usernames.ban_till is 'A timestamp indicating how long the ban should be active, if NULL the ban is forever.';
+comment on constraint banned_usernames_ban_till_check on banned_usernames is 'Ensures no storage is being wasted by banning someone backdated to the past.';
 
 comment on table muted_macs is 'A Table storing muted mac adresses.';
 comment on column muted_macs.mac is 'An MD5Crypted/hashed MAC address. This hashing method should be replaced by SHA-2 or SHA-3 for performance and collision reasons (salting is not needed). The hash must be of length 28.';
 comment on column muted_macs.mute_till is 'A timestamp indicating how long the mute should be active, if NULL the mute is forever.';
 comment on constraint muted_macs_mac_check on muted_macs is 'Ensures the hashed mac always has the right length.';
+comment on constraint muted_macs_mute_till_check on muted_macs is 'Ensures no storage is being wasted by muting someone backdated to the past.';
 
 comment on table muted_usernames is 'A Table storing muted usernames.';
 comment on column muted_usernames.username is 'The username of the muted user. Actually no direct reference to the ta_users.username for whatever reason using an SQL reference would make the mute change along with the username of a user.';
 comment on column muted_usernames.mute_till is 'A timestamp indicating how long the mute should be active, if NULL the mute is forever.';
+comment on constraint muted_usernames_mute_till_check on muted_usernames is 'Ensures no storage is being wasted by muting someone backdated to the past.';
 
 commit;

--- a/config/lobby/db/002_update_tables
+++ b/config/lobby/db/002_update_tables
@@ -1,25 +1,24 @@
-alter table ta_users alter column email type varchar(254);
-alter table ta_users alter column joined type timestamptz;
-alter table ta_users alter column joined set default current_timestamp;
-alter table ta_users alter column lastlogin type timestamptz;
-alter table ta_users alter column lastlogin set default current_timestamp;
-alter table ta_users alter column admin type boolean using case when admin=0 then false else true end;
-alter table ta_users alter column admin set default false;
+alter table ta_users
+    alter column email type varchar(254),
+    alter column joined type timestamptz,
+    alter column joined set default current_timestamp,
+    alter column lastlogin type timestamptz,
+    alter column lastlogin set default current_timestamp,
+    alter column admin type boolean using case when admin=0 then false else true end,
+    alter column admin set default false;
 
 drop table banned_ips;
 
-alter table banned_macs alter column mac type character(34);
-alter table banned_macs alter column ban_till type timestamptz;
+alter table banned_macs
+    alter column mac type character(34),
+    alter column ban_till type timestamptz;
 
--- delete from banned_usernames where username not in (select username from ta_users);
--- alter table banned_usernames add constraint banned_usernames_username_fkey foreign key (username) references ta_users (username) on update cascade on delete cascade;
 alter table banned_usernames alter column ban_till type timestamptz;
 
 drop table muted_ips;
 
-alter table muted_macs alter column mac type character(34);
-alter table muted_macs alter column mute_till type timestamptz;
+alter table muted_macs
+    alter column mac type character(34),
+    alter column mute_till type timestamptz;
 
--- delete from muted_usernames where username not in (select username from ta_users);
--- alter table muted_usernames add constraint muted_usernames_username_fkey foreign key (username) references ta_users (username) on update cascade on delete cascade;
 alter table muted_usernames alter column mute_till type timestamptz;

--- a/config/lobby/db/002_update_tables
+++ b/config/lobby/db/002_update_tables
@@ -1,0 +1,25 @@
+alter table ta_users alter column email type varchar(254);
+alter table ta_users alter column joined type timestamptz;
+alter table ta_users alter column joined set default current_timestamp;
+alter table ta_users alter column lastlogin type timestamptz;
+alter table ta_users alter column lastlogin set default current_timestamp;
+alter table ta_users alter column admin type boolean using case when admin=0 then false else true end;
+alter table ta_users alter column admin set default false;
+
+drop table banned_ips;
+
+alter table banned_macs alter column mac type character(34);
+alter table banned_macs alter column ban_till type timestamptz;
+
+-- delete from banned_usernames where username not in (select username from ta_users);
+-- alter table banned_usernames add constraint banned_usernames_username_fkey foreign key (username) references ta_users (username) on update cascade on delete cascade;
+alter table banned_usernames alter column ban_till type timestamptz;
+
+drop table muted_ips;
+
+alter table muted_macs alter column mac type character(34);
+alter table muted_macs alter column mute_till type timestamptz;
+
+-- delete from muted_usernames where username not in (select username from ta_users);
+-- alter table muted_usernames add constraint muted_usernames_username_fkey foreign key (username) references ta_users (username) on update cascade on delete cascade;
+alter table muted_usernames alter column mute_till type timestamptz;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
@@ -42,7 +42,7 @@ public class ModeratorControllerTest {
 
     final UserController userController = new UserController();
     userController.createUser(dbUser, new HashedPassword(MD5Crypt.crypt(adminName)));
-    userController.makeAdmin(dbUser, true);
+    userController.makeAdmin(dbUser);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
@@ -2,7 +2,6 @@ package games.strategy.engine.lobby.server;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -14,7 +13,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -40,12 +38,11 @@ public class ModeratorControllerTest {
     moderatorController = new ModeratorController(serverMessenger, null);
     final String adminName = Util.createUniqueTimeStamp();
 
-    new UserController().createUser(
-        new DBUser(
-            new DBUser.UserName(adminName),
-            new DBUser.UserEmail("n@n.n"),
-            DBUser.Role.ADMIN),
-        new HashedPassword(MD5Crypt.crypt(adminName)));
+    final DBUser dbUser = new DBUser(new DBUser.UserName(adminName), new DBUser.UserEmail("n@n.n"), DBUser.Role.ADMIN);
+
+    final UserController userController = new UserController();
+    userController.createUser(dbUser, new HashedPassword(MD5Crypt.crypt(adminName)));
+    userController.makeAdmin(dbUser, true);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.lobby.server.db;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -10,12 +11,23 @@ import games.strategy.util.Util;
 public class BadWordControllerTest {
 
   @Test
-  public void testCrud() {
+  public void testInsertAndRemoveBadWord() {
     final BadWordController controller = new BadWordController();
     final String word = Util.createUniqueTimeStamp();
     controller.addBadWord(word);
     assertTrue(controller.list().contains(word));
     controller.removeBannedWord(word);
     assertFalse(controller.list().contains(word));
+  }
+
+  @Test
+  public void testDuplicateBadWord() {
+    final BadWordController controller = new BadWordController();
+    final String word = Util.createUniqueTimeStamp();
+    final int previousCount = controller.list().size();
+    controller.addBadWord(word);
+    controller.addBadWord(word);
+    assertTrue(controller.list().contains(word));
+    assertEquals(previousCount + 1, controller.list().size());
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -57,11 +57,11 @@ public class BannedMacControllerTest {
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertTrue(macDetails.getFirst());
     assertNull(macDetails.getSecond());
-    final Instant banTill = Instant.now().plusSeconds(100L);
-    controller.addBannedMac(hashedMac, banTill);
+    final Instant banUntill = Instant.now().plusSeconds(100L);
+    controller.addBannedMac(hashedMac, banUntill);
     final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
     assertTrue(macDetails2.getFirst());
-    assertEquals(banTill, macDetails2.getSecond().toInstant());
+    assertEquals(banUntill, macDetails2.getSecond().toInstant());
   }
 
   private String banMac(final Instant length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -30,13 +30,12 @@ public class BannedMacControllerTest {
 
   @Test
   public void testBanMac() {
-    final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
+    final Instant banUntil = Instant.now().plusSeconds(100L);
     final String hashedMac = banMac(banUntil);
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertTrue(macDetails.getFirst());
     assertEquals(banUntil, macDetails.getSecond().toInstant());
-    when(controller.now()).thenCallRealMethod();
+    when(controller.now()).thenReturn(banUntil.plusSeconds(1L));
     final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
     assertFalse(macDetails2.getFirst());
     assertEquals(banUntil, macDetails2.getSecond().toInstant());
@@ -50,7 +49,7 @@ public class BannedMacControllerTest {
     assertFalse(macDetails.getFirst());
     assertNull(macDetails.getSecond());
   }
-  
+
   @Test
   public void testBanMacInTooNearFuture() {
     final Instant banUntil = Instant.now();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -64,16 +64,6 @@ public class BannedMacControllerTest {
   }
 
   @Test
-  public void testBanMacInTooNearFuture() {
-    final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(banUntil.minusSeconds(10L));
-    final String hashedMac = banMac(banUntil);
-    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
-    assertFalse(macDetails.getFirst());
-    assertNull(macDetails.getSecond());
-  }
-
-  @Test
   public void testBanMacUpdate() {
     final String hashedMac = banMac(null);
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -31,7 +31,7 @@ public class BannedMacControllerTest {
   @Test
   public void testBanMac() {
     final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
     final String hashedMac = banMac(banUntil);
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertTrue(macDetails.getFirst());
@@ -48,7 +48,17 @@ public class BannedMacControllerTest {
     final String hashedMac = banMac(banUntil);
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertFalse(macDetails.getFirst());
-    assertEquals(banUntil, macDetails.getSecond().toInstant());
+    assertNull(macDetails.getSecond());
+  }
+  
+  @Test
+  public void testBanMacInTooNearFuture() {
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(banUntil.minusSeconds(10L));
+    final String hashedMac = banMac(banUntil);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertFalse(macDetails.getFirst());
+    assertNull(macDetails.getSecond());
   }
 
   @Test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -42,6 +42,19 @@ public class BannedMacControllerTest {
   }
 
   @Test
+  public void testUnbanMac() {
+    final Instant banUntil = Instant.now().plusSeconds(100L);
+    final String hashedMac = banMac(banUntil);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertTrue(macDetails.getFirst());
+    assertEquals(banUntil, macDetails.getSecond().toInstant());
+    controller.addBannedMac(hashedMac, Instant.now().minusSeconds(10L));
+    final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
+    assertFalse(macDetails2.getFirst());
+    assertNull(macDetails2.getSecond().toInstant());
+  }
+
+  @Test
   public void testBanMacInThePast() {
     final Instant banUntil = Instant.now().minusSeconds(10L);
     final String hashedMac = banMac(banUntil);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -67,11 +67,10 @@ public class BannedMacControllerTest {
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertTrue(macDetails.getFirst());
     assertNull(macDetails.getSecond());
-    final Instant banUntill = Instant.now().plusSeconds(100L);
-    controller.addBannedMac(hashedMac, banUntill);
+    final Instant banUntil = banMacForSeconds(100L);
     final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
     assertTrue(macDetails2.getFirst());
-    assertEquals(banUntill, macDetails2.getSecond().toInstant());
+    assertEquals(banUntil, macDetails2.getSecond().toInstant());
   }
 
   private Instant banMacForSeconds(final long length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -1,0 +1,72 @@
+package games.strategy.engine.lobby.server.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.Test;
+
+import games.strategy.util.MD5Crypt;
+import games.strategy.util.ThreadUtil;
+import games.strategy.util.Tuple;
+import games.strategy.util.Util;
+
+public class BannedMacControllerTest {
+
+  private final BannedMacController controller = new BannedMacController();
+
+  @Test
+  public void testBanMacForever() {
+    final String hashedMac = banMac(null);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertTrue(macDetails.getFirst());
+    assertNull(macDetails.getSecond());
+  }
+
+  @Test
+  public void testBanMac() {
+    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final String hashedMac = banMac(banUntil);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertTrue(macDetails.getFirst());
+    assertEquals(banUntil, macDetails.getSecond().toInstant());
+    while (banUntil.isAfter(Instant.now())) {
+      ThreadUtil.sleep(100);
+    }
+    final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
+    assertFalse(macDetails2.getFirst());
+    assertEquals(banUntil, macDetails2.getSecond().toInstant());
+  }
+
+  @Test
+  public void testBanMacInThePast() {
+    final Instant banUntil = Instant.now().minusSeconds(10L);
+    final String hashedMac = banMac(banUntil);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertFalse(macDetails.getFirst());
+    assertEquals(banUntil, macDetails.getSecond().toInstant());
+  }
+
+  @Test
+  public void testBanMacUpdate() {
+    final String hashedMac = banMac(null);
+    final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
+    assertTrue(macDetails.getFirst());
+    assertNull(macDetails.getSecond());
+    final Instant banTill = Instant.now().plusSeconds(100L);
+    controller.addBannedMac(hashedMac, banTill);
+    final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
+    assertTrue(macDetails2.getFirst());
+    assertEquals(banTill, macDetails2.getSecond().toInstant());
+  }
+
+  private String banMac(final Instant length) {
+    final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+    controller.addBannedMac(hashedMac, length);
+    return hashedMac;
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -11,13 +13,12 @@ import java.time.Instant;
 import org.junit.Test;
 
 import games.strategy.util.MD5Crypt;
-import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
 public class BannedMacControllerTest {
 
-  private final BannedMacController controller = new BannedMacController();
+  private final BannedMacController controller = spy(new BannedMacController());
 
   @Test
   public void testBanMacForever() {
@@ -29,14 +30,13 @@ public class BannedMacControllerTest {
 
   @Test
   public void testBanMac() {
-    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
     final String hashedMac = banMac(banUntil);
     final Tuple<Boolean, Timestamp> macDetails = controller.isMacBanned(hashedMac);
     assertTrue(macDetails.getFirst());
     assertEquals(banUntil, macDetails.getSecond().toInstant());
-    while (banUntil.isAfter(Instant.now())) {
-      ThreadUtil.sleep(100);
-    }
+    when(controller.now()).thenCallRealMethod();
     final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
     assertFalse(macDetails2.getFirst());
     assertEquals(banUntil, macDetails2.getSecond().toInstant());

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerTest.java
@@ -51,7 +51,7 @@ public class BannedMacControllerTest {
     controller.addBannedMac(hashedMac, Instant.now().minusSeconds(10L));
     final Tuple<Boolean, Timestamp> macDetails2 = controller.isMacBanned(hashedMac);
     assertFalse(macDetails2.getFirst());
-    assertNull(macDetails2.getSecond().toInstant());
+    assertNull(macDetails2.getSecond());
   }
 
   @Test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -22,7 +22,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameForever() {
-    banUsername(Long.MAX_VALUE);
+    banUsernameForSeconds(Long.MAX_VALUE);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
@@ -30,7 +30,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsername() {
-    final Instant banUntil = banUsername(100L);
+    final Instant banUntil = banUsernameForSeconds(100L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
@@ -42,11 +42,11 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testUnbanUsername() {
-    final Instant banUntil = banUsername(100L);
+    final Instant banUntil = banUsernameForSeconds(100L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
-    controller.addBannedUsername(username, Instant.now().minusSeconds(10L));
+    banUsernameForSeconds(-10L);
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
     assertFalse(usernameDetails2.getFirst());
     assertNull(usernameDetails2.getSecond());
@@ -54,7 +54,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameInThePast() {
-    banUsername(-10L);
+    banUsernameForSeconds(-10L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertFalse(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
@@ -62,20 +62,19 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameUpdate() {
-    banUsername(Long.MAX_VALUE);
+    banUsernameForSeconds(Long.MAX_VALUE);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
-    final Instant banUntill = Instant.now().plusSeconds(100L);
-    controller.addBannedUsername(username, banUntill);
+    final Instant banUntil = banUsernameForSeconds(100L);
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
     assertTrue(usernameDetails2.getFirst());
-    assertEquals(banUntill, usernameDetails2.getSecond().toInstant());
+    assertEquals(banUntil, usernameDetails2.getSecond().toInstant());
   }
 
-  private Instant banUsername(final long length) {
-    final Instant endBan = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addBannedUsername(username, endBan);
-    return endBan;
+  private Instant banUsernameForSeconds(final long length) {
+    final Instant banEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
+    controller.addBannedUsername(username, banEnd);
+    return banEnd;
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -29,13 +29,12 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsername() {
-    final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
+    final Instant banUntil = Instant.now().plusSeconds(100L);
     final String hashedUsername = banUsername(banUntil);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
-    when(controller.now()).thenCallRealMethod();
+    when(controller.now()).thenReturn(banUntil.plusSeconds(1L));
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
     assertFalse(usernameDetails2.getFirst());
     assertEquals(banUntil, usernameDetails2.getSecond().toInstant());
@@ -48,8 +47,8 @@ public class BannedUsernameControllerTest {
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertFalse(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
-  }  
-  
+  }
+
   @Test
   public void testBanMacInTooNearFuture() {
     final Instant banUntil = Instant.now();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -63,16 +63,6 @@ public class BannedUsernameControllerTest {
   }
 
   @Test
-  public void testBanMacInTooNearFuture() {
-    final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(banUntil.minusSeconds(10L));
-    final String hashedMac = banUsername(banUntil);
-    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedMac);
-    assertFalse(usernameDetails.getFirst());
-    assertNull(usernameDetails.getSecond());
-  }
-
-  @Test
   public void testBanUsernameUpdate() {
     final String username = banUsername(null);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -41,6 +41,19 @@ public class BannedUsernameControllerTest {
   }
 
   @Test
+  public void testUnban() {
+    final Instant banUntil = Instant.now().plusSeconds(100L);
+    final String username = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
+    assertTrue(usernameDetails.getFirst());
+    assertEquals(banUntil, usernameDetails.getSecond().toInstant());
+    controller.addBannedUsername(username, Instant.now().minusSeconds(10L));
+    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
+    assertFalse(usernameDetails2.getFirst());
+    assertNull(usernameDetails2.getSecond().toInstant());
+  }
+
+  @Test
   public void testBanUsernameInThePast() {
     final Instant banUntil = Instant.now().minusSeconds(10L);
     final String hashedUsername = banUsername(banUntil);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -21,46 +21,46 @@ public class BannedUsernameControllerTest {
   @Test
   public void testBanUsernameForever() {
     final String hashedUsername = banUsername(null);
-    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
-    assertTrue(UsernameDetails.getFirst());
-    assertNull(UsernameDetails.getSecond());
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(usernameDetails.getFirst());
+    assertNull(usernameDetails.getSecond());
   }
 
   @Test
   public void testBanUsername() {
     final Instant banUntil = Instant.now().plusSeconds(2L);
     final String hashedUsername = banUsername(banUntil);
-    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
-    assertTrue(UsernameDetails.getFirst());
-    assertEquals(banUntil, UsernameDetails.getSecond().toInstant());
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(usernameDetails.getFirst());
+    assertEquals(banUntil, usernameDetails.getSecond().toInstant());
     while (banUntil.isAfter(Instant.now())) {
       ThreadUtil.sleep(100);
     }
-    final Tuple<Boolean, Timestamp> UsernameDetails2 = controller.isUsernameBanned(hashedUsername);
-    assertFalse(UsernameDetails2.getFirst());
-    assertEquals(banUntil, UsernameDetails2.getSecond().toInstant());
+    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    assertFalse(usernameDetails2.getFirst());
+    assertEquals(banUntil, usernameDetails2.getSecond().toInstant());
   }
 
   @Test
   public void testBanUsernameInThePast() {
     final Instant banUntil = Instant.now().minusSeconds(10L);
     final String hashedUsername = banUsername(banUntil);
-    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
-    assertFalse(UsernameDetails.getFirst());
-    assertEquals(banUntil, UsernameDetails.getSecond().toInstant());
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertFalse(usernameDetails.getFirst());
+    assertEquals(banUntil, usernameDetails.getSecond().toInstant());
   }
 
   @Test
   public void testBanUsernameUpdate() {
     final String hashedUsername = banUsername(null);
-    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
-    assertTrue(UsernameDetails.getFirst());
-    assertNull(UsernameDetails.getSecond());
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(usernameDetails.getFirst());
+    assertNull(usernameDetails.getSecond());
     final Instant banTill = Instant.now().plusSeconds(100L);
     controller.addBannedUsername(hashedUsername, banTill);
-    final Tuple<Boolean, Timestamp> UsernameDetails2 = controller.isUsernameBanned(hashedUsername);
-    assertTrue(UsernameDetails2.getFirst());
-    assertEquals(banTill, UsernameDetails2.getSecond().toInstant());
+    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    assertTrue(usernameDetails2.getFirst());
+    assertEquals(banTill, usernameDetails2.getSecond().toInstant());
   }
 
   private String banUsername(final Instant length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -18,10 +18,11 @@ import games.strategy.util.Util;
 public class BannedUsernameControllerTest {
 
   private final BannedUsernameController controller = spy(new BannedUsernameController());
+  private final String username = Util.createUniqueTimeStamp();
 
   @Test
   public void testBanUsernameForever() {
-    final String username = banUsername(null);
+    banUsername(Long.MAX_VALUE);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
@@ -29,8 +30,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsername() {
-    final Instant banUntil = Instant.now().plusSeconds(100L);
-    final String username = banUsername(banUntil);
+    final Instant banUntil = banUsername(100L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
@@ -42,8 +42,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testUnbanUsername() {
-    final Instant banUntil = Instant.now().plusSeconds(100L);
-    final String username = banUsername(banUntil);
+    final Instant banUntil = banUsername(100L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
@@ -55,8 +54,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameInThePast() {
-    final Instant banUntil = Instant.now().minusSeconds(10L);
-    final String username = banUsername(banUntil);
+    banUsername(-10L);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertFalse(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
@@ -64,7 +62,7 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameUpdate() {
-    final String username = banUsername(null);
+    banUsername(Long.MAX_VALUE);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
@@ -75,9 +73,9 @@ public class BannedUsernameControllerTest {
     assertEquals(banUntill, usernameDetails2.getSecond().toInstant());
   }
 
-  private String banUsername(final Instant length) {
-    final String username = Util.createUniqueTimeStamp();
-    controller.addBannedUsername(username, length);
-    return username;
+  private Instant banUsername(final long length) {
+    final Instant endBan = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
+    controller.addBannedUsername(username, endBan);
+    return endBan;
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -21,8 +21,8 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameForever() {
-    final String hashedUsername = banUsername(null);
-    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    final String username = banUsername(null);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
   }
@@ -30,12 +30,12 @@ public class BannedUsernameControllerTest {
   @Test
   public void testBanUsername() {
     final Instant banUntil = Instant.now().plusSeconds(100L);
-    final String hashedUsername = banUsername(banUntil);
-    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    final String username = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
     when(controller.now()).thenReturn(banUntil.plusSeconds(1L));
-    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
     assertFalse(usernameDetails2.getFirst());
     assertEquals(banUntil, usernameDetails2.getSecond().toInstant());
   }
@@ -56,8 +56,8 @@ public class BannedUsernameControllerTest {
   @Test
   public void testBanUsernameInThePast() {
     final Instant banUntil = Instant.now().minusSeconds(10L);
-    final String hashedUsername = banUsername(banUntil);
-    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    final String username = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertFalse(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
   }
@@ -74,20 +74,20 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsernameUpdate() {
-    final String hashedUsername = banUsername(null);
-    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
+    final String username = banUsername(null);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
     final Instant banUntill = Instant.now().plusSeconds(100L);
-    controller.addBannedUsername(hashedUsername, banUntill);
-    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    controller.addBannedUsername(username, banUntill);
+    final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
     assertTrue(usernameDetails2.getFirst());
     assertEquals(banUntill, usernameDetails2.getSecond().toInstant());
   }
 
   private String banUsername(final Instant length) {
-    final String hashedUsername = Util.createUniqueTimeStamp();
-    controller.addBannedUsername(hashedUsername, length);
-    return hashedUsername;
+    final String username = Util.createUniqueTimeStamp();
+    controller.addBannedUsername(username, length);
+    return username;
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -4,19 +4,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 
 import org.junit.Test;
 
-import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
 public class BannedUsernameControllerTest {
 
-  private final BannedUsernameController controller = new BannedUsernameController();
+  private final BannedUsernameController controller = spy(new BannedUsernameController());
 
   @Test
   public void testBanUsernameForever() {
@@ -28,14 +29,13 @@ public class BannedUsernameControllerTest {
 
   @Test
   public void testBanUsername() {
-    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
     final String hashedUsername = banUsername(banUntil);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertTrue(usernameDetails.getFirst());
     assertEquals(banUntil, usernameDetails.getSecond().toInstant());
-    while (banUntil.isAfter(Instant.now())) {
-      ThreadUtil.sleep(100);
-    }
+    when(controller.now()).thenCallRealMethod();
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
     assertFalse(usernameDetails2.getFirst());
     assertEquals(banUntil, usernameDetails2.getSecond().toInstant());

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -56,11 +56,11 @@ public class BannedUsernameControllerTest {
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertTrue(usernameDetails.getFirst());
     assertNull(usernameDetails.getSecond());
-    final Instant banTill = Instant.now().plusSeconds(100L);
-    controller.addBannedUsername(hashedUsername, banTill);
+    final Instant banUntill = Instant.now().plusSeconds(100L);
+    controller.addBannedUsername(hashedUsername, banUntill);
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(hashedUsername);
     assertTrue(usernameDetails2.getFirst());
-    assertEquals(banTill, usernameDetails2.getSecond().toInstant());
+    assertEquals(banUntill, usernameDetails2.getSecond().toInstant());
   }
 
   private String banUsername(final Instant length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -30,7 +30,7 @@ public class BannedUsernameControllerTest {
   @Test
   public void testBanUsername() {
     final Instant banUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
     final String hashedUsername = banUsername(banUntil);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertTrue(usernameDetails.getFirst());
@@ -47,7 +47,17 @@ public class BannedUsernameControllerTest {
     final String hashedUsername = banUsername(banUntil);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedUsername);
     assertFalse(usernameDetails.getFirst());
-    assertEquals(banUntil, usernameDetails.getSecond().toInstant());
+    assertNull(usernameDetails.getSecond());
+  }  
+  
+  @Test
+  public void testBanMacInTooNearFuture() {
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(banUntil.minusSeconds(10L));
+    final String hashedMac = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(hashedMac);
+    assertFalse(usernameDetails.getFirst());
+    assertNull(usernameDetails.getSecond());
   }
 
   @Test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -41,7 +41,7 @@ public class BannedUsernameControllerTest {
   }
 
   @Test
-  public void testUnban() {
+  public void testUnbanUsername() {
     final Instant banUntil = Instant.now().plusSeconds(100L);
     final String username = banUsername(banUntil);
     final Tuple<Boolean, Timestamp> usernameDetails = controller.isUsernameBanned(username);
@@ -50,7 +50,7 @@ public class BannedUsernameControllerTest {
     controller.addBannedUsername(username, Instant.now().minusSeconds(10L));
     final Tuple<Boolean, Timestamp> usernameDetails2 = controller.isUsernameBanned(username);
     assertFalse(usernameDetails2.getFirst());
-    assertNull(usernameDetails2.getSecond().toInstant());
+    assertNull(usernameDetails2.getSecond());
   }
 
   @Test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerTest.java
@@ -1,0 +1,71 @@
+package games.strategy.engine.lobby.server.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.Test;
+
+import games.strategy.util.ThreadUtil;
+import games.strategy.util.Tuple;
+import games.strategy.util.Util;
+
+public class BannedUsernameControllerTest {
+
+  private final BannedUsernameController controller = new BannedUsernameController();
+
+  @Test
+  public void testBanUsernameForever() {
+    final String hashedUsername = banUsername(null);
+    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(UsernameDetails.getFirst());
+    assertNull(UsernameDetails.getSecond());
+  }
+
+  @Test
+  public void testBanUsername() {
+    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final String hashedUsername = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(UsernameDetails.getFirst());
+    assertEquals(banUntil, UsernameDetails.getSecond().toInstant());
+    while (banUntil.isAfter(Instant.now())) {
+      ThreadUtil.sleep(100);
+    }
+    final Tuple<Boolean, Timestamp> UsernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    assertFalse(UsernameDetails2.getFirst());
+    assertEquals(banUntil, UsernameDetails2.getSecond().toInstant());
+  }
+
+  @Test
+  public void testBanUsernameInThePast() {
+    final Instant banUntil = Instant.now().minusSeconds(10L);
+    final String hashedUsername = banUsername(banUntil);
+    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertFalse(UsernameDetails.getFirst());
+    assertEquals(banUntil, UsernameDetails.getSecond().toInstant());
+  }
+
+  @Test
+  public void testBanUsernameUpdate() {
+    final String hashedUsername = banUsername(null);
+    final Tuple<Boolean, Timestamp> UsernameDetails = controller.isUsernameBanned(hashedUsername);
+    assertTrue(UsernameDetails.getFirst());
+    assertNull(UsernameDetails.getSecond());
+    final Instant banTill = Instant.now().plusSeconds(100L);
+    controller.addBannedUsername(hashedUsername, banTill);
+    final Tuple<Boolean, Timestamp> UsernameDetails2 = controller.isUsernameBanned(hashedUsername);
+    assertTrue(UsernameDetails2.getFirst());
+    assertEquals(banTill, UsernameDetails2.getSecond().toInstant());
+  }
+
+  private String banUsername(final Instant length) {
+    final String hashedUsername = Util.createUniqueTimeStamp();
+    controller.addBannedUsername(hashedUsername, length);
+    return hashedUsername;
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitTest.java
@@ -38,18 +38,18 @@ public class EmailLimitTest {
     createAccountWithEmail(getStringWithLength(64) + "@" + getStringWithLength(189));
   }
 
-  private String getStringWithLength(final int length) {
+  private static String getStringWithLength(final int length) {
     return Strings.padStart(Util.createUniqueTimeStamp(), length, 'a');
   }
 
-  private void createAccountWithEmail(final String email) {
-    try (PreparedStatement ps =
+  private static void createAccountWithEmail(final String email) {
+    try (final PreparedStatement ps =
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
       ps.setString(3, MD5Crypt.crypt("password"));
       ps.execute();
-    } catch (SQLException e) {
+    } catch (final SQLException e) {
       throw new AssertionError(e);
     }
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitTest.java
@@ -1,0 +1,61 @@
+package games.strategy.engine.lobby.server.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.base.Strings;
+
+import games.strategy.util.MD5Crypt;
+import games.strategy.util.Util;
+
+/**
+ * Emails have a limit of 254 chars, accepted by the IETF.
+ * More information: http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+ * This class checks if those lengths are supported.
+ */
+public class EmailLimitTest {
+
+  private static Connection connection;
+
+  @BeforeClass
+  public static void setup() throws SQLException {
+    connection = Database.getPostgresConnection();
+    connection.setAutoCommit(true);
+  }
+
+  @Test
+  public void testAllowsMaximumLentgh() {
+    createAccountWithEmail(getStringWithLength(60) + "@" + getStringWithLength(193));
+  }
+
+  @Test
+  public void testAllowsMaximumLocalLength() {
+    createAccountWithEmail(getStringWithLength(64) + "@" + getStringWithLength(189));
+  }
+
+  private String getStringWithLength(final int length) {
+    return Strings.padStart(Util.createUniqueTimeStamp(), length, 'a');
+  }
+
+  private void createAccountWithEmail(final String email) {
+    try (PreparedStatement ps =
+        connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
+      ps.setString(1, Util.createUniqueTimeStamp());
+      ps.setString(2, email);
+      ps.setString(3, MD5Crypt.crypt("password"));
+      ps.execute();
+    } catch (SQLException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() throws SQLException {
+    connection.close();
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -35,6 +35,16 @@ public class MutedMacControllerTest {
   }
 
   @Test
+  public void testUnmuteMac() {
+    final Instant muteUntil = Instant.now().plusSeconds(100L);
+    final String username = muteUsername(muteUntil);
+    assertTrue(controller.isMacMuted(username));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    controller.addMutedMac(username, Instant.now().minusSeconds(10L));
+    assertFalse(controller.isMacMuted(username));
+  }
+
+  @Test
   public void testMuteMacInThePast() {
     final Instant muteUntil = Instant.now().minusSeconds(10L);
     final String username = muteUsername(muteUntil);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -16,18 +16,18 @@ import games.strategy.util.Util;
 public class MutedMacControllerTest {
 
   private final MutedMacController controller = spy(new MutedMacController());
+  final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
 
   @Test
   public void testMuteMacForever() {
-    final String hashedMac = muteMac(null);
+    muteMac(Long.MAX_VALUE);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
   }
 
   @Test
   public void testMuteMac() {
-    final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String hashedMac = muteMac(muteUntil);
+    final Instant muteUntil = muteMac(100L);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
     when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
@@ -36,8 +36,7 @@ public class MutedMacControllerTest {
 
   @Test
   public void testUnmuteMac() {
-    final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String hashedMac = muteMac(muteUntil);
+    final Instant muteUntil = muteMac(100L);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
     controller.addMutedMac(hashedMac, Instant.now().minusSeconds(10L));
@@ -46,14 +45,13 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMacInThePast() {
-    final Instant muteUntil = Instant.now().minusSeconds(10L);
-    final String hashedMac = muteMac(muteUntil);
+    muteMac(-10L);
     assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testMuteMacUpdate() {
-    final String hashedMac = muteMac(null);
+    muteMac(Long.MAX_VALUE);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
     final Instant muteUntill = Instant.now().plusSeconds(100L);
@@ -62,9 +60,9 @@ public class MutedMacControllerTest {
     assertEquals(muteUntill, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
   }
 
-  private String muteMac(final Instant length) {
-    final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
-    controller.addMutedMac(hashedMac, length);
-    return hashedMac;
+  private Instant muteMac(final long length) {
+    final Instant muteEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
+    controller.addMutedMac(hashedMac, muteEnd);
+    return muteEnd;
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -26,12 +26,11 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMac() {
-    final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
+    final Instant muteUntil = Instant.now().plusSeconds(100L);
     final String username = muteUsername(muteUntil);
     assertTrue(controller.isMacMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
-    when(controller.now()).thenCallRealMethod();
+    when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
     assertFalse(controller.isMacMuted(username));
   }
 
@@ -41,7 +40,7 @@ public class MutedMacControllerTest {
     final String username = muteUsername(muteUntil);
     assertFalse(controller.isMacMuted(username));
   }
-  
+
 
   @Test
   public void testMuteMacInTooNearFuture() {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -20,14 +20,14 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMacForever() {
-    muteMac(Long.MAX_VALUE);
+    muteMacForSeconds(Long.MAX_VALUE);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
   }
 
   @Test
   public void testMuteMac() {
-    final Instant muteUntil = muteMac(100L);
+    final Instant muteUntil = muteMacForSeconds(100L);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
     when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
@@ -36,31 +36,30 @@ public class MutedMacControllerTest {
 
   @Test
   public void testUnmuteMac() {
-    final Instant muteUntil = muteMac(100L);
+    final Instant muteUntil = muteMacForSeconds(100L);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
-    controller.addMutedMac(hashedMac, Instant.now().minusSeconds(10L));
+    muteMacForSeconds(-10L);
     assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testMuteMacInThePast() {
-    muteMac(-10L);
+    muteMacForSeconds(-10L);
     assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testMuteMacUpdate() {
-    muteMac(Long.MAX_VALUE);
+    muteMacForSeconds(Long.MAX_VALUE);
     assertTrue(controller.isMacMuted(hashedMac));
     assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
-    final Instant muteUntill = Instant.now().plusSeconds(100L);
-    controller.addMutedMac(hashedMac, muteUntill);
+    final Instant muteUntil = muteMacForSeconds(100L);
     assertTrue(controller.isMacMuted(hashedMac));
-    assertEquals(muteUntill, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
   }
 
-  private Instant muteMac(final long length) {
+  private Instant muteMacForSeconds(final long length) {
     final Instant muteEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
     controller.addMutedMac(hashedMac, muteEnd);
     return muteEnd;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -1,0 +1,61 @@
+package games.strategy.engine.lobby.server.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import games.strategy.util.MD5Crypt;
+import games.strategy.util.ThreadUtil;
+import games.strategy.util.Util;
+
+public class MutedMacControllerTest {
+
+  private final MutedMacController controller = new MutedMacController();
+
+  @Test
+  public void testMuteMacForever() {
+    final String username = muteUsername(null);
+    assertTrue(controller.isMacMuted(username));
+    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(username));
+  }
+
+  @Test
+  public void testMuteMac() {
+    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final String username = muteUsername(banUntil);
+    assertTrue(controller.isMacMuted(username));
+    assertEquals(banUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    while (banUntil.isAfter(Instant.now())) {
+      ThreadUtil.sleep(100);
+    }
+    assertFalse(controller.isMacMuted(username));
+  }
+
+  @Test
+  public void testMuteMacInThePast() {
+    final Instant banUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(banUntil);
+    assertFalse(controller.isMacMuted(username));
+  }
+
+  @Test
+  public void testMuteMacUpdate() {
+    final String username = muteUsername(null);
+    assertTrue(controller.isMacMuted(username));
+    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(username));
+    final Instant banTill = Instant.now().plusSeconds(100L);
+    controller.addMutedMac(username, banTill);
+    assertTrue(controller.isMacMuted(username));
+    assertEquals(banTill, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+  }
+
+  private String muteUsername(final Instant length) {
+    final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+    controller.addMutedMac(hashedMac, length);
+    return hashedMac;
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -26,19 +26,19 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMac() {
-    final Instant banUntil = Instant.now();
+    final Instant muteUntil = Instant.now();
     when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
-    final String username = muteUsername(banUntil);
+    final String username = muteUsername(muteUntil);
     assertTrue(controller.isMacMuted(username));
-    assertEquals(banUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
     when(controller.now()).thenCallRealMethod();
     assertFalse(controller.isMacMuted(username));
   }
 
   @Test
   public void testMuteMacInThePast() {
-    final Instant banUntil = Instant.now().minusSeconds(10L);
-    final String username = muteUsername(banUntil);
+    final Instant muteUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(muteUntil);
     assertFalse(controller.isMacMuted(username));
   }
 
@@ -47,10 +47,10 @@ public class MutedMacControllerTest {
     final String username = muteUsername(null);
     assertTrue(controller.isMacMuted(username));
     assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(username));
-    final Instant banTill = Instant.now().plusSeconds(100L);
-    controller.addMutedMac(username, banTill);
+    final Instant muteUntill = Instant.now().plusSeconds(100L);
+    controller.addMutedMac(username, muteUntill);
     assertTrue(controller.isMacMuted(username));
-    assertEquals(banTill, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    assertEquals(muteUntill, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
   }
 
   private String muteUsername(final Instant length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -51,15 +51,6 @@ public class MutedMacControllerTest {
     assertFalse(controller.isMacMuted(hashedMac));
   }
 
-
-  @Test
-  public void testMuteMacInTooNearFuture() {
-    final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(muteUntil.minusSeconds(10L));
-    final String hashedMac = muteMac(muteUntil);
-    assertFalse(controller.isMacMuted(hashedMac));
-  }
-
   @Test
   public void testMuteMacUpdate() {
     final String hashedMac = muteMac(null);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -27,7 +27,7 @@ public class MutedMacControllerTest {
   @Test
   public void testMuteMac() {
     final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
     final String username = muteUsername(muteUntil);
     assertTrue(controller.isMacMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
@@ -38,6 +38,15 @@ public class MutedMacControllerTest {
   @Test
   public void testMuteMacInThePast() {
     final Instant muteUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(muteUntil);
+    assertFalse(controller.isMacMuted(username));
+  }
+  
+
+  @Test
+  public void testMuteMacInTooNearFuture() {
+    final Instant muteUntil = Instant.now();
+    when(controller.now()).thenReturn(muteUntil.minusSeconds(10L));
     final String username = muteUsername(muteUntil);
     assertFalse(controller.isMacMuted(username));
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -19,36 +19,36 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMacForever() {
-    final String username = muteUsername(null);
-    assertTrue(controller.isMacMuted(username));
-    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(username));
+    final String hashedMac = muteMac(null);
+    assertTrue(controller.isMacMuted(hashedMac));
+    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
   }
 
   @Test
   public void testMuteMac() {
     final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String username = muteUsername(muteUntil);
-    assertTrue(controller.isMacMuted(username));
-    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    final String hashedMac = muteMac(muteUntil);
+    assertTrue(controller.isMacMuted(hashedMac));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
     when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
-    assertFalse(controller.isMacMuted(username));
+    assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testUnmuteMac() {
     final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String username = muteUsername(muteUntil);
-    assertTrue(controller.isMacMuted(username));
-    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
-    controller.addMutedMac(username, Instant.now().minusSeconds(10L));
-    assertFalse(controller.isMacMuted(username));
+    final String hashedMac = muteMac(muteUntil);
+    assertTrue(controller.isMacMuted(hashedMac));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
+    controller.addMutedMac(hashedMac, Instant.now().minusSeconds(10L));
+    assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testMuteMacInThePast() {
     final Instant muteUntil = Instant.now().minusSeconds(10L);
-    final String username = muteUsername(muteUntil);
-    assertFalse(controller.isMacMuted(username));
+    final String hashedMac = muteMac(muteUntil);
+    assertFalse(controller.isMacMuted(hashedMac));
   }
 
 
@@ -56,22 +56,22 @@ public class MutedMacControllerTest {
   public void testMuteMacInTooNearFuture() {
     final Instant muteUntil = Instant.now();
     when(controller.now()).thenReturn(muteUntil.minusSeconds(10L));
-    final String username = muteUsername(muteUntil);
-    assertFalse(controller.isMacMuted(username));
+    final String hashedMac = muteMac(muteUntil);
+    assertFalse(controller.isMacMuted(hashedMac));
   }
 
   @Test
   public void testMuteMacUpdate() {
-    final String username = muteUsername(null);
-    assertTrue(controller.isMacMuted(username));
-    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(username));
+    final String hashedMac = muteMac(null);
+    assertTrue(controller.isMacMuted(hashedMac));
+    assertEquals(Long.MAX_VALUE, controller.getMacUnmuteTime(hashedMac));
     final Instant muteUntill = Instant.now().plusSeconds(100L);
-    controller.addMutedMac(username, muteUntill);
-    assertTrue(controller.isMacMuted(username));
-    assertEquals(muteUntill, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
+    controller.addMutedMac(hashedMac, muteUntill);
+    assertTrue(controller.isMacMuted(hashedMac));
+    assertEquals(muteUntill, Instant.ofEpochMilli(controller.getMacUnmuteTime(hashedMac)));
   }
 
-  private String muteUsername(final Instant length) {
+  private String muteMac(final Instant length) {
     final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
     controller.addMutedMac(hashedMac, length);
     return hashedMac;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerTest.java
@@ -3,18 +3,19 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 
 import org.junit.Test;
 
 import games.strategy.util.MD5Crypt;
-import games.strategy.util.ThreadUtil;
 import games.strategy.util.Util;
 
 public class MutedMacControllerTest {
 
-  private final MutedMacController controller = new MutedMacController();
+  private final MutedMacController controller = spy(new MutedMacController());
 
   @Test
   public void testMuteMacForever() {
@@ -25,13 +26,12 @@ public class MutedMacControllerTest {
 
   @Test
   public void testMuteMac() {
-    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
     final String username = muteUsername(banUntil);
     assertTrue(controller.isMacMuted(username));
     assertEquals(banUntil, Instant.ofEpochMilli(controller.getMacUnmuteTime(username)));
-    while (banUntil.isAfter(Instant.now())) {
-      ThreadUtil.sleep(100);
-    }
+    when(controller.now()).thenCallRealMethod();
     assertFalse(controller.isMacMuted(username));
   }
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -3,17 +3,18 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 
 import org.junit.Test;
 
-import games.strategy.util.ThreadUtil;
 import games.strategy.util.Util;
 
 public class MutedUsernameControllerTest {
 
-  private final MutedUsernameController controller = new MutedUsernameController();
+  private final MutedUsernameController controller = spy(new MutedUsernameController());
 
   @Test
   public void testMuteUsernameForever() {
@@ -24,13 +25,12 @@ public class MutedUsernameControllerTest {
 
   @Test
   public void testMuteUsername() {
-    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final Instant banUntil = Instant.now();
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
     final String username = muteUsername(banUntil);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(banUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
-    while (banUntil.isAfter(Instant.now())) {
-      ThreadUtil.sleep(100);
-    }
+    when(controller.now()).thenCallRealMethod();
     assertFalse(controller.isUsernameMuted(username));
   }
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -34,6 +34,16 @@ public class MutedUsernameControllerTest {
   }
 
   @Test
+  public void testUnmuteUsername() {
+    final Instant muteUntil = Instant.now().plusSeconds(100L);
+    final String username = muteUsername(muteUntil);
+    assertTrue(controller.isUsernameMuted(username));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
+    controller.addMutedUsername(username, Instant.now().minusSeconds(10L));
+    assertFalse(controller.isUsernameMuted(username));
+  }
+
+  @Test
   public void testMuteUsernameInThePast() {
     final Instant muteUntil = Instant.now().minusSeconds(10L);
     final String username = muteUsername(muteUntil);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -51,14 +51,6 @@ public class MutedUsernameControllerTest {
   }
 
   @Test
-  public void testMuteUsernameInTooNearFuture() {
-    final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(muteUntil.minusSeconds(10L));
-    final String username = muteUsername(muteUntil);
-    assertFalse(controller.isUsernameMuted(username));
-  }
-
-  @Test
   public void testMuteUsernameUpdate() {
     final String username = muteUsername(null);
     assertTrue(controller.isUsernameMuted(username));

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -25,19 +25,19 @@ public class MutedUsernameControllerTest {
 
   @Test
   public void testMuteUsername() {
-    final Instant banUntil = Instant.now();
+    final Instant muteUntil = Instant.now();
     when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
-    final String username = muteUsername(banUntil);
+    final String username = muteUsername(muteUntil);
     assertTrue(controller.isUsernameMuted(username));
-    assertEquals(banUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
     when(controller.now()).thenCallRealMethod();
     assertFalse(controller.isUsernameMuted(username));
   }
 
   @Test
   public void testMuteUsernameInThePast() {
-    final Instant banUntil = Instant.now().minusSeconds(10L);
-    final String username = muteUsername(banUntil);
+    final Instant muteUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(muteUntil);
     assertFalse(controller.isUsernameMuted(username));
   }
 
@@ -46,10 +46,10 @@ public class MutedUsernameControllerTest {
     final String username = muteUsername(null);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
-    final Instant banTill = Instant.now().plusSeconds(100L);
-    controller.addMutedUsername(username, banTill);
+    final Instant muteUntil = Instant.now().plusSeconds(100L);
+    controller.addMutedUsername(username, muteUntil);
     assertTrue(controller.isUsernameMuted(username));
-    assertEquals(banTill, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
+    assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
   }
 
   private String muteUsername(final Instant length) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -26,7 +26,7 @@ public class MutedUsernameControllerTest {
   @Test
   public void testMuteUsername() {
     final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1L));
+    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
     final String username = muteUsername(muteUntil);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
@@ -37,6 +37,14 @@ public class MutedUsernameControllerTest {
   @Test
   public void testMuteUsernameInThePast() {
     final Instant muteUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(muteUntil);
+    assertFalse(controller.isUsernameMuted(username));
+  }
+
+  @Test
+  public void testMuteUsernameInTooNearFuture() {
+    final Instant muteUntil = Instant.now();
+    when(controller.now()).thenReturn(muteUntil.minusSeconds(10L));
     final String username = muteUsername(muteUntil);
     assertFalse(controller.isUsernameMuted(username));
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -15,18 +15,18 @@ import games.strategy.util.Util;
 public class MutedUsernameControllerTest {
 
   private final MutedUsernameController controller = spy(new MutedUsernameController());
+  private final String username = Util.createUniqueTimeStamp();
 
   @Test
   public void testMuteUsernameForever() {
-    final String username = muteUsername(null);
+    muteUsernameForSeconds(Long.MAX_VALUE);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
   }
 
   @Test
   public void testMuteUsername() {
-    final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String username = muteUsername(muteUntil);
+    final Instant muteUntil = muteUsernameForSeconds(100L);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
     when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
@@ -35,8 +35,7 @@ public class MutedUsernameControllerTest {
 
   @Test
   public void testUnmuteUsername() {
-    final Instant muteUntil = Instant.now().plusSeconds(100L);
-    final String username = muteUsername(muteUntil);
+    final Instant muteUntil = muteUsernameForSeconds(100L);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
     controller.addMutedUsername(username, Instant.now().minusSeconds(10L));
@@ -45,14 +44,13 @@ public class MutedUsernameControllerTest {
 
   @Test
   public void testMuteUsernameInThePast() {
-    final Instant muteUntil = Instant.now().minusSeconds(10L);
-    final String username = muteUsername(muteUntil);
+    muteUsernameForSeconds(-10L);
     assertFalse(controller.isUsernameMuted(username));
   }
 
   @Test
   public void testMuteUsernameUpdate() {
-    final String username = muteUsername(null);
+    muteUsernameForSeconds(Long.MAX_VALUE);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
     final Instant muteUntil = Instant.now().plusSeconds(100L);
@@ -61,9 +59,9 @@ public class MutedUsernameControllerTest {
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
   }
 
-  private String muteUsername(final Instant length) {
-    final String username = Util.createUniqueTimeStamp();
-    controller.addMutedUsername(username, length);
-    return username;
+  private Instant muteUsernameForSeconds(final long length) {
+    final Instant endMute = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
+    controller.addMutedUsername(username, endMute);
+    return endMute;
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -1,0 +1,60 @@
+package games.strategy.engine.lobby.server.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import games.strategy.util.ThreadUtil;
+import games.strategy.util.Util;
+
+public class MutedUsernameControllerTest {
+
+  private final MutedUsernameController controller = new MutedUsernameController();
+
+  @Test
+  public void testMuteUsernameForever() {
+    final String username = muteUsername(null);
+    assertTrue(controller.isUsernameMuted(username));
+    assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
+  }
+
+  @Test
+  public void testMuteUsername() {
+    final Instant banUntil = Instant.now().plusSeconds(2L);
+    final String username = muteUsername(banUntil);
+    assertTrue(controller.isUsernameMuted(username));
+    assertEquals(banUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
+    while (banUntil.isAfter(Instant.now())) {
+      ThreadUtil.sleep(100);
+    }
+    assertFalse(controller.isUsernameMuted(username));
+  }
+
+  @Test
+  public void testMuteUsernameInThePast() {
+    final Instant banUntil = Instant.now().minusSeconds(10L);
+    final String username = muteUsername(banUntil);
+    assertFalse(controller.isUsernameMuted(username));
+  }
+
+  @Test
+  public void testMuteUsernameUpdate() {
+    final String username = muteUsername(null);
+    assertTrue(controller.isUsernameMuted(username));
+    assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
+    final Instant banTill = Instant.now().plusSeconds(100L);
+    controller.addMutedUsername(username, banTill);
+    assertTrue(controller.isUsernameMuted(username));
+    assertEquals(banTill, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
+  }
+
+  private String muteUsername(final Instant length) {
+    final String username = Util.createUniqueTimeStamp();
+    controller.addMutedUsername(username, length);
+    return username;
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -25,12 +25,11 @@ public class MutedUsernameControllerTest {
 
   @Test
   public void testMuteUsername() {
-    final Instant muteUntil = Instant.now();
-    when(controller.now()).thenReturn(Instant.now().minusSeconds(1000L));
+    final Instant muteUntil = Instant.now().plusSeconds(100L);
     final String username = muteUsername(muteUntil);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
-    when(controller.now()).thenCallRealMethod();
+    when(controller.now()).thenReturn(muteUntil.plusSeconds(1L));
     assertFalse(controller.isUsernameMuted(username));
   }
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerTest.java
@@ -53,15 +53,14 @@ public class MutedUsernameControllerTest {
     muteUsernameForSeconds(Long.MAX_VALUE);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(Long.MAX_VALUE, controller.getUsernameUnmuteTime(username));
-    final Instant muteUntil = Instant.now().plusSeconds(100L);
-    controller.addMutedUsername(username, muteUntil);
+    final Instant muteUntil = muteUsernameForSeconds(100L);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(muteUntil, Instant.ofEpochMilli(controller.getUsernameUnmuteTime(username)));
   }
 
   private Instant muteUsernameForSeconds(final long length) {
-    final Instant endMute = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addMutedUsername(username, endMute);
-    return endMute;
+    final Instant muteEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
+    controller.addMutedUsername(username, muteEnd);
+    return muteEnd;
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -6,27 +6,19 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * Utilitiy class to create/read/delete bad words (there is no update).
  */
 public class BadWordController {
-  private static final Logger logger = Logger.getLogger(BadWordController.class.getName());
-
   public void addBadWord(final String word) {
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("insert into bad_words (word) values (?)")) {
+        final PreparedStatement ps =
+            con.prepareStatement("insert into bad_words (word) values (?) on conflict do nothing")) {
       ps.setString(1, word);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {
-      if (sqle.getErrorCode() == 30000) {
-        // this is ok
-        // the word is bad as expected
-        logger.info("Tried to create duplicate banned word:" + word + " error:" + sqle.getMessage());
-        return;
-      }
       throw new IllegalStateException("Error inserting banned word:" + word, sqle);
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class BadWordController {
   public void addBadWord(final String word) {
     try (final Connection con = Database.getPostgresConnection();
+        // If the word already is present we don't need to add it twice.
         final PreparedStatement ps =
             con.prepareStatement("insert into bad_words (word) values (?) on conflict do nothing")) {
       ps.setString(1, word);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -36,21 +36,15 @@ public class BannedMacController {
     }
     Timestamp banTillTs = null;
     if (banTill != null) {
-      banTillTs = new Timestamp(banTill.toEpochMilli());
+      banTillTs = Timestamp.from(banTill);
     }
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)")) {
+        final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?) on conflict do update")) {
       ps.setString(1, mac);
       ps.setTimestamp(2, banTillTs);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {
-      if (sqle.getErrorCode() == 30000) {
-        // this is ok
-        // the mac is banned as expected
-        logger.info("Tried to create duplicate banned mac:" + mac + " error:" + sqle.getMessage());
-        return;
-      }
       throw new IllegalStateException("Error inserting banned mac:" + mac, sqle);
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -24,12 +24,9 @@ public class BannedMacController {
    * </p>
    */
   public void addBannedMac(final String mac, final Instant banTill) {
-    if (isMacBanned(mac).getFirst()) {
-      removeBannedMac(mac);
-    }
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)"
+            + " on conflict (mac) do update set ban_till=excluded.ban_till")) {
       ps.setString(1, mac);
       ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -17,13 +17,6 @@ public class BannedMacController {
   private static final Logger logger = Logger.getLogger(BannedMacController.class.getName());
 
   /**
-   * Ban the mac permanently.
-   */
-  public void addBannedMac(final String mac) {
-    addBannedMac(mac, null);
-  }
-
-  /**
    * Ban the given mac. If banTill is not null, the ban will expire when banTill is reached.
    *
    * <p>

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -24,7 +24,7 @@ public class BannedMacController extends TimedController {
    * </p>
    */
   public void addBannedMac(final String mac, final Instant banTill) {
-    if (banTill == null || banTill.isAfter(now().plusSeconds(10L))) {
+    if (banTill == null || banTill.isAfter(now())) {
       try (final Connection con = Database.getPostgresConnection();
           final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)"
               + " on conflict (mac) do update set ban_till=excluded.ban_till")) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -13,7 +13,7 @@ import games.strategy.util.Tuple;
 /**
  * Utilitiy class to create/read/delete banned macs (there is no update).
  */
-public class BannedMacController {
+public class BannedMacController extends TimedController {
   private static final Logger logger = Logger.getLogger(BannedMacController.class.getName());
 
   /**
@@ -61,7 +61,7 @@ public class BannedMacController {
         // If the ban has expired, allow the mac
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);
-          if (banTill != null && banTill.toInstant().isBefore(Instant.now())) {
+          if (banTill != null && banTill.toInstant().isBefore(now())) {
             logger.fine("Ban expired for:" + mac);
             removeBannedMac(mac);
             return Tuple.of(false, banTill);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -35,6 +35,8 @@ public class BannedMacController extends TimedController {
       } catch (final SQLException sqle) {
         throw new IllegalStateException("Error inserting banned mac:" + mac, sqle);
       }
+    } else {
+      removeBannedMac(mac);
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -34,15 +34,11 @@ public class BannedMacController {
     if (isMacBanned(mac).getFirst()) {
       removeBannedMac(mac);
     }
-    Timestamp banTillTs = null;
-    if (banTill != null) {
-      banTillTs = Timestamp.from(banTill);
-    }
     try (final Connection con = Database.getPostgresConnection();
         final PreparedStatement ps =
             con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?) on conflict do update")) {
       ps.setString(1, mac);
-      ps.setTimestamp(2, banTillTs);
+      ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -39,7 +39,8 @@ public class BannedMacController {
       banTillTs = Timestamp.from(banTill);
     }
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps =
+            con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?) on conflict do update")) {
       ps.setString(1, mac);
       ps.setTimestamp(2, banTillTs);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -41,9 +41,8 @@ public class BannedUsernameController {
     logger.fine("Banning username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement(
-                "insert into banned_usernames (username, ban_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps = con.prepareStatement(
+            "insert into banned_usernames (username, ban_till) values (?, ?) on conflict do update")) {
       ps.setString(1, username);
       ps.setTimestamp(2, banTillTs);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -24,7 +24,7 @@ public class BannedUsernameController extends TimedController {
    * </p>
    */
   public void addBannedUsername(final String username, final Instant banTill) {
-    if (banTill == null || banTill.isAfter(now().plusSeconds(10L))) {
+    if (banTill == null || banTill.isAfter(now())) {
       logger.fine("Banning username:" + username);
 
       try (final Connection con = Database.getPostgresConnection();

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -34,17 +34,13 @@ public class BannedUsernameController {
     if (isUsernameBanned(username).getFirst()) {
       removeBannedUsername(username);
     }
-    Timestamp banTillTs = null;
-    if (banTill != null) {
-      banTillTs = Timestamp.from(banTill);
-    }
     logger.fine("Banning username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
         final PreparedStatement ps = con.prepareStatement(
             "insert into banned_usernames (username, ban_till) values (?, ?) on conflict do update")) {
       ps.setString(1, username);
-      ps.setTimestamp(2, banTillTs);
+      ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -38,6 +38,8 @@ public class BannedUsernameController extends TimedController {
       } catch (final SQLException sqle) {
         throw new IllegalStateException("Error inserting banned username:" + username, sqle);
       }
+    } else {
+      removeBannedUsername(username);
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -13,7 +13,7 @@ import games.strategy.util.Tuple;
 /**
  * Utility class to create/read/delete banned usernames (there is no update).
  */
-public class BannedUsernameController {
+public class BannedUsernameController extends TimedController {
   private static final Logger logger = Logger.getLogger(BannedUsernameController.class.getName());
 
   /**
@@ -66,7 +66,7 @@ public class BannedUsernameController {
         // If the ban has expired, allow the username
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);
-          if (banTill != null && banTill.toInstant().isBefore(Instant.now())) {
+          if (banTill != null && banTill.toInstant().isBefore(now())) {
             logger.fine("Ban expired for:" + username);
             removeBannedUsername(username);
             return Tuple.of(false, banTill);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -24,18 +24,20 @@ public class BannedUsernameController extends TimedController {
    * </p>
    */
   public void addBannedUsername(final String username, final Instant banTill) {
-    logger.fine("Banning username:" + username);
+    if (banTill == null || banTill.isAfter(now().plusSeconds(10L))) {
+      logger.fine("Banning username:" + username);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
-                + " on conflict (username) do update set ban_till=excluded.ban_till")) {
-      ps.setString(1, username);
-      ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
-      ps.execute();
-      con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error inserting banned username:" + username, sqle);
+      try (final Connection con = Database.getPostgresConnection();
+          final PreparedStatement ps =
+              con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
+                  + " on conflict (username) do update set ban_till=excluded.ban_till")) {
+        ps.setString(1, username);
+        ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
+        ps.execute();
+        con.commit();
+      } catch (final SQLException sqle) {
+        throw new IllegalStateException("Error inserting banned username:" + username, sqle);
+      }
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -31,14 +31,12 @@ public class BannedUsernameController {
    * </p>
    */
   public void addBannedUsername(final String username, final Instant banTill) {
-    if (isUsernameBanned(username).getFirst()) {
-      removeBannedUsername(username);
-    }
     logger.fine("Banning username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(
-            "insert into banned_usernames (username, ban_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps =
+            con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
+                + " on conflict (username) do update set ban_till=excluded.ban_till")) {
       ps.setString(1, username);
       ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -22,17 +22,19 @@ public class MutedMacController extends TimedController {
    * </p>
    */
   public void addMutedMac(final String mac, final Instant muteTill) {
-    logger.fine("Muting mac:" + mac);
+    if (muteTill == null || muteTill.isAfter(now().plusSeconds(10L))) {
+      logger.fine("Muting mac:" + mac);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
-            + " on conflict (mac) do update set mute_till=excluded.mute_till")) {
-      ps.setString(1, mac);
-      ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
-      ps.execute();
-      con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error inserting muted mac:" + mac, sqle);
+      try (final Connection con = Database.getPostgresConnection();
+          final PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
+              + " on conflict (mac) do update set mute_till=excluded.mute_till")) {
+        ps.setString(1, mac);
+        ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
+        ps.execute();
+        con.commit();
+      } catch (final SQLException sqle) {
+        throw new IllegalStateException("Error inserting muted mac:" + mac, sqle);
+      }
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -22,7 +22,7 @@ public class MutedMacController extends TimedController {
    * </p>
    */
   public void addMutedMac(final String mac, final Instant muteTill) {
-    if (muteTill == null || muteTill.isAfter(now().plusSeconds(10L))) {
+    if (muteTill == null || muteTill.isAfter(now())) {
       logger.fine("Muting mac:" + mac);
 
       try (final Connection con = Database.getPostgresConnection();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -15,13 +15,6 @@ public class MutedMacController {
   private static final Logger logger = Logger.getLogger(MutedMacController.class.getName());
 
   /**
-   * Mute the mac permanently.
-   */
-  public void addMutedMac(final String mac) {
-    addMutedMac(mac, null);
-  }
-
-  /**
    * Mute the given mac. If muteTill is not null, the mute will expire when muteTill is reached.
    *
    * <p>

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -29,14 +29,11 @@ public class MutedMacController {
    * </p>
    */
   public void addMutedMac(final String mac, final Instant muteTill) {
-    if (isMacMuted(mac)) {
-      removeMutedMac(mac);
-    }
     logger.fine("Muting mac:" + mac);
 
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
+            + " on conflict (mac) do update set mute_till=excluded.mute_till")) {
       ps.setString(1, mac);
       ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -35,6 +35,8 @@ public class MutedMacController extends TimedController {
       } catch (final SQLException sqle) {
         throw new IllegalStateException("Error inserting muted mac:" + mac, sqle);
       }
+    } else {
+      removeMutedMac(mac);
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -32,17 +32,13 @@ public class MutedMacController {
     if (isMacMuted(mac)) {
       removeMutedMac(mac);
     }
-    Timestamp muteTillTs = null;
-    if (muteTill != null) {
-      muteTillTs = Timestamp.from(muteTill);
-    }
     logger.fine("Muting mac:" + mac);
 
     try (final Connection con = Database.getPostgresConnection();
         final PreparedStatement ps =
             con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?) on conflict do update")) {
       ps.setString(1, mac);
-      ps.setTimestamp(2, muteTillTs);
+      ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 /**
  * Utilitiy class to create/read/delete muted macs (there is no update).
  */
-public class MutedMacController {
+public class MutedMacController extends TimedController {
   private static final Logger logger = Logger.getLogger(MutedMacController.class.getName());
 
   /**
@@ -55,7 +55,7 @@ public class MutedMacController {
    */
   public boolean isMacMuted(final String mac) {
     final long muteTill = getMacUnmuteTime(mac);
-    return muteTill > System.currentTimeMillis();
+    return muteTill > now().toEpochMilli();
   }
 
   /**
@@ -74,7 +74,7 @@ public class MutedMacController {
           if (muteTill == null) {
             return Long.MAX_VALUE;
           }
-          if (muteTill.toInstant().isBefore(Instant.now())) {
+          if (muteTill.toInstant().isBefore(now())) {
             logger.fine("Mute expired for:" + mac);
             // If the mute has expired, allow the mac
             removeMutedMac(mac);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -71,6 +71,9 @@ public class MutedMacController {
         final boolean found = rs.next();
         if (found) {
           final Timestamp muteTill = rs.getTimestamp(2);
+          if (muteTill == null) {
+            return Long.MAX_VALUE;
+          }
           if (muteTill.toInstant().isBefore(Instant.now())) {
             logger.fine("Mute expired for:" + mac);
             // If the mute has expired, allow the mac

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -22,7 +22,7 @@ public class MutedUsernameController extends TimedController {
    * </p>
    */
   public void addMutedUsername(final String username, final Instant muteTill) {
-    if (muteTill == null || muteTill.isAfter(now().plusSeconds(10L))) {
+    if (muteTill == null || muteTill.isAfter(now())) {
       logger.fine("Muting username:" + username);
 
       try (final Connection con = Database.getPostgresConnection();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -39,9 +39,8 @@ public class MutedUsernameController {
     logger.fine("Muting username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement(
-                "insert into muted_usernames (username, mute_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps = con.prepareStatement(
+            "insert into muted_usernames (username, mute_till) values (?, ?) on conflict do update")) {
       ps.setString(1, username);
       ps.setTimestamp(2, muteTillTs);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -22,18 +22,20 @@ public class MutedUsernameController extends TimedController {
    * </p>
    */
   public void addMutedUsername(final String username, final Instant muteTill) {
-    logger.fine("Muting username:" + username);
+    if (muteTill == null || muteTill.isAfter(now().plusSeconds(10L))) {
+      logger.fine("Muting username:" + username);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps =
-            con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
-                + " on conflict (username) do update set mute_till=excluded.mute_till")) {
-      ps.setString(1, username);
-      ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
-      ps.execute();
-      con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error inserting muted username:" + username, sqle);
+      try (final Connection con = Database.getPostgresConnection();
+          final PreparedStatement ps =
+              con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
+                  + " on conflict (username) do update set mute_till=excluded.mute_till")) {
+        ps.setString(1, username);
+        ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
+        ps.execute();
+        con.commit();
+      } catch (final SQLException sqle) {
+        throw new IllegalStateException("Error inserting muted username:" + username, sqle);
+      }
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -15,13 +15,6 @@ public class MutedUsernameController {
   private static final Logger logger = Logger.getLogger(MutedUsernameController.class.getName());
 
   /**
-   * Mute the username permanently.
-   */
-  public void addMutedUsername(final String username) {
-    addMutedUsername(username, null);
-  }
-
-  /**
    * Mute the given username. If muteTill is not null, the mute will expire when muteTill is reached.
    *
    * <p>
@@ -70,8 +63,6 @@ public class MutedUsernameController {
    * Returns epoch milli's of when mute expires, or negative one if there is no active mute.
    */
   public long getUsernameUnmuteTime(final String username) {
-    long result = -1;
-    boolean expired = false;
     final String sql = "select username, mute_till from muted_usernames where username = ?";
 
     try (final Connection con = Database.getPostgresConnection();
@@ -81,24 +72,19 @@ public class MutedUsernameController {
         final boolean found = rs.next();
         if (found) {
           final Timestamp muteTill = rs.getTimestamp(2);
-          result = muteTill.getTime();
-          if (result < System.currentTimeMillis()) {
+          if (muteTill.toInstant().isBefore(Instant.now())) {
+            // If the mute has expired, allow the username
             logger.fine("Mute expired for:" + username);
-            expired = true;
+            removeMutedUsername(username);
+            // Signal as not-muted
+            return -1;
           }
-        } else {
-          result = -1;
+          return muteTill.getTime();
         }
+        return -1;
       }
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error for testing muted username existence:" + username, sqle);
     }
-    // If the mute has expired, allow the username
-    if (expired) {
-      removeMutedUsername(username);
-      // Signal as not-muted
-      result = -1;
-    }
-    return result;
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -72,6 +72,9 @@ public class MutedUsernameController {
         final boolean found = rs.next();
         if (found) {
           final Timestamp muteTill = rs.getTimestamp(2);
+          if (muteTill == null) {
+            return Long.MAX_VALUE;
+          }
           if (muteTill.toInstant().isBefore(Instant.now())) {
             // If the mute has expired, allow the username
             logger.fine("Mute expired for:" + username);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -29,14 +29,12 @@ public class MutedUsernameController {
    * </p>
    */
   public void addMutedUsername(final String username, final Instant muteTill) {
-    if (isUsernameMuted(username)) {
-      removeMutedUsername(username);
-    }
     logger.fine("Muting username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(
-            "insert into muted_usernames (username, mute_till) values (?, ?) on conflict do update")) {
+        final PreparedStatement ps =
+            con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
+                + " on conflict (username) do update set mute_till=excluded.mute_till")) {
       ps.setString(1, username);
       ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
       ps.execute();

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -32,17 +32,13 @@ public class MutedUsernameController {
     if (isUsernameMuted(username)) {
       removeMutedUsername(username);
     }
-    Timestamp muteTillTs = null;
-    if (muteTill != null) {
-      muteTillTs = Timestamp.from(muteTill);
-    }
     logger.fine("Muting username:" + username);
 
     try (final Connection con = Database.getPostgresConnection();
         final PreparedStatement ps = con.prepareStatement(
             "insert into muted_usernames (username, mute_till) values (?, ?) on conflict do update")) {
       ps.setString(1, username);
-      ps.setTimestamp(2, muteTillTs);
+      ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
       ps.execute();
       con.commit();
     } catch (final SQLException sqle) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 /**
  * Utilitiy class to create/read/delete muted usernames (there is no update).
  */
-public class MutedUsernameController {
+public class MutedUsernameController extends TimedController {
   private static final Logger logger = Logger.getLogger(MutedUsernameController.class.getName());
 
   /**
@@ -56,7 +56,7 @@ public class MutedUsernameController {
    */
   public boolean isUsernameMuted(final String username) {
     final long muteTill = getUsernameUnmuteTime(username);
-    return muteTill > System.currentTimeMillis();
+    return muteTill > now().toEpochMilli();
   }
 
   /**
@@ -75,7 +75,7 @@ public class MutedUsernameController {
           if (muteTill == null) {
             return Long.MAX_VALUE;
           }
-          if (muteTill.toInstant().isBefore(Instant.now())) {
+          if (muteTill.toInstant().isBefore(now())) {
             // If the mute has expired, allow the username
             logger.fine("Mute expired for:" + username);
             removeMutedUsername(username);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -36,6 +36,8 @@ public class MutedUsernameController extends TimedController {
       } catch (final SQLException sqle) {
         throw new IllegalStateException("Error inserting muted username:" + username, sqle);
       }
+    } else {
+      removeMutedUsername(username);
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/TimedController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/TimedController.java
@@ -1,0 +1,13 @@
+package games.strategy.engine.lobby.server.db;
+
+import java.time.Instant;
+
+/**
+ * This class allows integration Tests to override the "now time".
+ * This enables us to make Tests execution-time-independent which is a good thing.
+ */
+abstract class TimedController {
+  Instant now() {
+    return Instant.now();
+  }
+}

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import org.mindrot.jbcrypt.BCrypt;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import games.strategy.engine.lobby.server.userDB.DBUser;
@@ -82,6 +83,7 @@ public class UserController implements UserDao {
    * Does only affect the admin state of the given user.
    * The DB is updated with user.isAdmin()
    */
+  @VisibleForTesting
   public void makeAdmin(final DBUser user) {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -83,8 +83,8 @@ public class UserController implements UserDao {
     Preconditions.checkState(user.isValid(), user.getValidationErrorMessage());
 
     try (final Connection con = connectionSupplier.get();
-        final PreparedStatement ps = con.prepareStatement(
-            "insert into ta_users (username, password, email) values (?, ?, ?)")) {
+        final PreparedStatement ps =
+            con.prepareStatement("insert into ta_users (username, password, email, admin) values (?, ?, ?, ?)")) {
       ps.setString(1, user.getName());
       ps.setString(2, hashedPassword.value);
       ps.setString(3, user.getEmail());

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -77,6 +77,11 @@ public class UserController implements UserDao {
     }
   }
 
+  /**
+   * A method similar to update user, used by tests only.
+   * Does only affect the admin state of the given user.
+   * The DB is updated with user.isAdmin()
+   */
   public void makeAdmin(final DBUser user) {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -77,12 +77,12 @@ public class UserController implements UserDao {
     }
   }
 
-  public void makeAdmin(final DBUser user, final boolean admin) {
+  public void makeAdmin(final DBUser user) {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 
     try (final Connection con = connectionSupplier.get();
         final PreparedStatement ps = con.prepareStatement("update ta_users set admin=? where username = ?")) {
-      ps.setBoolean(1, admin);
+      ps.setBoolean(1, user.isAdmin());
       ps.setString(2, user.getName());
       ps.execute();
       con.commit();

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -5,6 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.function.Supplier;
 
 import org.mindrot.jbcrypt.BCrypt;
@@ -64,16 +65,15 @@ public class UserController implements UserDao {
 
     try (final Connection con = connectionSupplier.get();
         final PreparedStatement ps =
-            con.prepareStatement("update ta_users set password = ?,  email = ?, admin = ? where username = ?")) {
+            con.prepareStatement("update ta_users set password = ?,  email = ? where username = ?")) {
       ps.setString(1, hashedPassword.value);
       ps.setString(2, user.getEmail());
-      ps.setInt(3, user.isAdmin() ? 1 : 0);
-      ps.setString(4, user.getName());
+      ps.setString(3, user.getName());
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException(
-          "Error updating name:" + user.getName() + " email: " + user.getEmail() + " pwd: " + hashedPassword.mask(), e);
+      throw new IllegalStateException(String.format("Error updating name: %s email: %s pwd: %s",
+          user.getName(), user.getEmail(), hashedPassword.mask()), e);
     }
   }
 
@@ -84,13 +84,11 @@ public class UserController implements UserDao {
 
     try (final Connection con = connectionSupplier.get();
         final PreparedStatement ps = con.prepareStatement(
-            "insert into ta_users (username, password, email, joined, lastLogin, admin) values (?, ?, ?, ?, ?, ?)")) {
+            "insert into ta_users (username, password, email) values (?, ?, ?)")) {
       ps.setString(1, user.getName());
       ps.setString(2, hashedPassword.value);
       ps.setString(3, user.getEmail());
-      ps.setTimestamp(4, new Timestamp(System.currentTimeMillis()));
-      ps.setTimestamp(5, new Timestamp(System.currentTimeMillis()));
-      ps.setInt(6, user.isAdmin() ? 1 : 0);
+      ps.setBoolean(4, user.isAdmin());
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
@@ -126,7 +124,7 @@ public class UserController implements UserDao {
       // update last login time
       try (
           final PreparedStatement ps = con.prepareStatement("update ta_users set lastLogin = ? where username = ?")) {
-        ps.setTimestamp(1, new Timestamp(System.currentTimeMillis()));
+        ps.setTimestamp(1, Timestamp.from(Instant.now()));
         ps.setString(2, userName);
         ps.execute();
         con.commit();


### PR DESCRIPTION
Resolves #2347/The rest of it
The main focus of this PR is to allow for backwards compatibility between the two password systems. This backwards compatibility should be completely removed in the next incompatible lobby update.
The biggest part however does some general cleanup + enhances the code overall/makes it more resistent to failures by moving some of the logic to the DB itself (such as default values).
I will add some comments to explain some of the changes I made.
When updating the lobby with this patch, the database is going to need to be altered quite a lot, to match the stricter requirements.

I tested logins manually, created the account with the latest stable, logged in twice on a local lobby (which works great now that derby is no longer required :D) , and was able to login with the stable release once again.
First creating an account with my branch and then logging in with the latest stable works too.