### PR TITLE
Checkstyle: Rename "rVal" local variables (part 3)

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -76,14 +76,14 @@ public abstract class AbstractBattle implements IBattle {
 
   @Override
   public Collection<Unit> getDependentUnits(final Collection<Unit> units) {
-    final Collection<Unit> rVal = new ArrayList<>();
+    final Collection<Unit> dependentUnits = new ArrayList<>();
     for (final Unit unit : units) {
       final Collection<Unit> dependent = m_dependentUnits.get(unit);
       if (dependent != null) {
-        rVal.addAll(dependent);
+        dependentUnits.addAll(dependent);
       }
     }
-    return rVal;
+    return dependentUnits;
   }
 
   protected void removeUnitsThatNoLongerExist() {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -137,11 +137,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   protected Collection<Unit> getAlreadyProduced(final Territory t) {
     // this list might be modified later
-    final Collection<Unit> rVal = new ArrayList<>();
+    final Collection<Unit> alreadyProducedUnits = new ArrayList<>();
     if (m_produced.containsKey(t)) {
-      rVal.addAll(m_produced.get(t));
+      alreadyProducedUnits.addAll(m_produced.get(t));
     }
-    return rVal;
+    return alreadyProducedUnits;
   }
 
   @Override
@@ -1032,10 +1032,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   protected IntegerMap<Territory> getMaxUnitsToBePlacedMap(final Collection<Unit> units, final Territory to,
       final PlayerID player, final boolean countSwitchedProductionToNeighbors) {
-    final IntegerMap<Territory> rVal = new IntegerMap<>();
+    final IntegerMap<Territory> maxUnitsToBePlacedMap = new IntegerMap<>();
     final List<Territory> producers = getAllProducers(to, player, units);
     if (producers.isEmpty()) {
-      return rVal;
+      return maxUnitsToBePlacedMap;
     }
     Collections.sort(producers, getBestProducerComparator(to, units, player));
     final Collection<Territory> notUsableAsOtherProducers = new ArrayList<>();
@@ -1047,9 +1047,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
           : new ArrayList<>(units));
       final int prodT = getMaxUnitsToBePlacedFrom(producerTerritory, unitsCanBePlacedByThisProducer, to, player,
           countSwitchedProductionToNeighbors, notUsableAsOtherProducers, currentAvailablePlacementForOtherProducers);
-      rVal.put(producerTerritory, prodT);
+      maxUnitsToBePlacedMap.put(producerTerritory, prodT);
     }
-    return rVal;
+    return maxUnitsToBePlacedMap;
   }
 
   /**
@@ -1685,9 +1685,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   protected Collection<Territory> getListedTerritories(final String[] list) {
-    final List<Territory> rVal = new ArrayList<>();
+    final List<Territory> territories = new ArrayList<>();
     if (list == null) {
-      return rVal;
+      return territories;
     }
     for (final String name : list) {
       // Validate all territories exist
@@ -1695,9 +1695,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (territory == null) {
         throw new IllegalStateException("Rules & Conditions: No territory called:" + name);
       }
-      rVal.add(territory);
+      territories.add(territory);
     }
-    return rVal;
+    return territories;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -420,9 +420,9 @@ public class DiceRoll implements Externalizable {
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers, final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap,
       final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap) {
-    final Map<Unit, Tuple<Integer, Integer>> rVal = new HashMap<>();
+    final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRolls = new HashMap<>();
     if (unitsGettingPowerFor == null || unitsGettingPowerFor.isEmpty()) {
-      return rVal;
+      return unitPowerAndRolls;
     }
     // get all supports, friendly and enemy
     final Set<List<UnitSupportAttachment>> supportRulesFriendly = new HashSet<>();
@@ -505,9 +505,9 @@ public class DiceRoll implements Externalizable {
           strength = 0;
         }
       }
-      rVal.put(current, Tuple.of(strength, rolls));
+      unitPowerAndRolls.put(current, Tuple.of(strength, rolls));
     }
-    return rVal;
+    return unitPowerAndRolls;
   }
 
   public static int getTotalPower(final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap,
@@ -610,9 +610,9 @@ public class DiceRoll implements Externalizable {
       dice.add(new Die(random[0], rollFor, hit ? DieType.HIT : DieType.MISS));
     }
     // Create DiceRoll object
-    final DiceRoll rVal = new DiceRoll(dice, hitCount);
-    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), rVal);
-    return rVal;
+    final DiceRoll diceRoll = new DiceRoll(dice, hitCount);
+    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), diceRoll);
+    return diceRoll;
   }
 
   /**
@@ -937,9 +937,9 @@ public class DiceRoll implements Externalizable {
         }
       }
     }
-    final DiceRoll rVal = new DiceRoll(dice, hitCount);
-    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), rVal);
-    return rVal;
+    final DiceRoll diceRoll = new DiceRoll(dice, hitCount);
+    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), diceRoll);
+    return diceRoll;
   }
 
   /**
@@ -1016,9 +1016,9 @@ public class DiceRoll implements Externalizable {
         }
       }
     }
-    final DiceRoll rVal = new DiceRoll(dice, hitCount);
-    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), rVal);
-    return rVal;
+    final DiceRoll diceRoll = new DiceRoll(dice, hitCount);
+    bridge.getHistoryWriter().addChildToEvent(annotation + " : " + MyFormatter.asDice(random), diceRoll);
+    return diceRoll;
   }
 
   private static boolean isFirstTurnLimitedRoll(final PlayerID player, final GameData data) {
@@ -1104,13 +1104,13 @@ public class DiceRoll implements Externalizable {
    *         0..MAX_DICE
    */
   public List<Die> getRolls(final int rollAt) {
-    final List<Die> rVal = new ArrayList<>();
+    final List<Die> dice = new ArrayList<>();
     for (final Die die : m_rolls) {
       if (die.getRolledAt() == rollAt) {
-        rVal.add(die);
+        dice.add(die);
       }
     }
-    return rVal;
+    return dice;
   }
 
   public int size() {

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -320,7 +320,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
    */
   private static ResourceCollection getResourceProduction(final Collection<Territory> territories,
       final GameData data) {
-    final ResourceCollection rVal = new ResourceCollection(data);
+    final ResourceCollection resources = new ResourceCollection(data);
     for (final Territory current : territories) {
       final TerritoryAttachment attachment = TerritoryAttachment.get(current);
       if (attachment == null) {
@@ -332,9 +332,9 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       }
       // Match will Check if territory is originally owned convoy center, or if contested
       if (Matches.territoryCanCollectIncomeFrom(current.getOwner(), data).match(current)) {
-        rVal.add(toAdd);
+        resources.add(toAdd);
       }
     }
-    return rVal;
+    return resources;
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -471,10 +471,10 @@ public class MovePerformer implements Serializable {
       m_aaInMoveUtil = new AAInMoveUtil();
     }
     m_aaInMoveUtil.initialize(m_bridge);
-    final Collection<Unit> rVal =
+    final Collection<Unit> unitsToRemove =
         m_aaInMoveUtil.fireAA(route, units, UnitComparator.getLowestToHighestMovementComparator(), m_currentMove);
     m_aaInMoveUtil = null;
-    return rVal;
+    return unitsToRemove;
   }
 
   private static boolean isIgnoreTransportInMovement(final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -55,16 +55,16 @@ public class OriginalOwnerTracker implements Serializable {
   }
 
   public static Collection<Territory> getOriginallyOwned(final GameData data, final PlayerID player) {
-    final Collection<Territory> rVal = new ArrayList<>();
+    final Collection<Territory> territories = new ArrayList<>();
     for (final Territory t : data.getMap()) {
       PlayerID originalOwner = getOriginalOwner(t);
       if (originalOwner == null) {
         originalOwner = PlayerID.NULL_PLAYERID;
       }
       if (originalOwner.equals(player)) {
-        rVal.add(t);
+        territories.add(t);
       }
     }
-    return rVal;
+    return territories;
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -26,15 +26,15 @@ public class TechTracker implements Serializable {
    * tech frontier).
    */
   public static Collection<TechAdvance> getCurrentTechAdvances(final PlayerID id, final GameData data) {
-    final Collection<TechAdvance> rVal = new ArrayList<>();
+    final Collection<TechAdvance> techAdvances = new ArrayList<>();
     final TechAttachment attachment = TechAttachment.get(id);
     // search all techs
     for (final TechAdvance ta : TechAdvance.getTechAdvances(data)) {
       if (ta.hasTech(attachment)) {
-        rVal.add(ta);
+        techAdvances.add(ta);
       }
     }
-    return rVal;
+    return techAdvances;
   }
 
   /**
@@ -43,7 +43,7 @@ public class TechTracker implements Serializable {
    * already.
    */
   public static Collection<TechnologyFrontier> getFullyResearchedPlayerTechCategories(final PlayerID id) {
-    final Collection<TechnologyFrontier> rVal = new ArrayList<>();
+    final Collection<TechnologyFrontier> technologyFrontiers = new ArrayList<>();
     final TechAttachment attachment = TechAttachment.get(id);
     for (final TechnologyFrontier tf : TechAdvance.getPlayerTechCategories(id)) {
       boolean has = true;
@@ -54,10 +54,10 @@ public class TechTracker implements Serializable {
         }
       }
       if (has) {
-        rVal.add(tf);
+        technologyFrontiers.add(tf);
       }
     }
-    return rVal;
+    return technologyFrontiers;
   }
 
   public static synchronized void addAdvance(final PlayerID player, final IDelegateBridge bridge,

--- a/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -58,28 +58,28 @@ public class TerritoryEffectHelper {
   }
 
   public static Set<UnitType> getUnitTypesThatLostBlitz(final Collection<Territory> steps) {
-    final Set<UnitType> rVal = new HashSet<>();
+    final Set<UnitType> unitTypes = new HashSet<>();
     for (final Territory location : steps) {
       for (final TerritoryEffect effect : getEffects(location)) {
-        rVal.addAll(TerritoryEffectAttachment.get(effect).getNoBlitz());
+        unitTypes.addAll(TerritoryEffectAttachment.get(effect).getNoBlitz());
       }
     }
-    return rVal;
+    return unitTypes;
   }
 
   public static Set<UnitType> getUnitTypesForUnitsNotAllowedIntoTerritory(final Territory location) {
-    final Set<UnitType> rVal = new HashSet<>();
+    final Set<UnitType> unitTypes = new HashSet<>();
     for (final TerritoryEffect effect : getEffects(location)) {
-      rVal.addAll(TerritoryEffectAttachment.get(effect).getUnitsNotAllowed());
+      unitTypes.addAll(TerritoryEffectAttachment.get(effect).getUnitsNotAllowed());
     }
-    return rVal;
+    return unitTypes;
   }
 
   static Set<UnitType> getUnitTypesForUnitsNotAllowedIntoTerritory(final Collection<Territory> steps) {
-    final Set<UnitType> rVal = new HashSet<>();
+    final Set<UnitType> unitTypes = new HashSet<>();
     for (final Territory location : steps) {
-      rVal.addAll(getUnitTypesForUnitsNotAllowedIntoTerritory(location));
+      unitTypes.addAll(getUnitTypesForUnitsNotAllowedIntoTerritory(location));
     }
-    return rVal;
+    return unitTypes;
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -218,7 +218,7 @@ public class TransportTracker {
   }
 
   static Collection<Unit> getUnitsLoadedOnAlliedTransportsThisTurn(final Collection<Unit> units) {
-    final Collection<Unit> rVal = new ArrayList<>();
+    final Collection<Unit> loadedUnits = new ArrayList<>();
     for (final Unit u : units) {
       // a unit loaded onto an allied transport
       // cannot be unloaded in the same turn, so
@@ -231,10 +231,10 @@ public class TransportTracker {
       if (taUnit.getWasLoadedThisTurn() && taUnit.getTransportedBy() != null
           // an allied transport if the owner of the transport is not the owner of the unit
           && !taUnit.getTransportedBy().getOwner().equals(taUnit.getOwner())) {
-        rVal.add(u);
+        loadedUnits.add(u);
       }
     }
-    return rVal;
+    return loadedUnits;
   }
 
   static boolean hasTransportUnloadedInPreviousPhase(final Unit transport) {

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -174,9 +174,9 @@ public final class TileImageFactory {
 
   private Image getImage(final String fileName, final boolean transparent) {
     synchronized (m_mutex) {
-      final Image rVal = isImageLoaded(fileName);
-      if (rVal != null) {
-        return rVal;
+      final Image image = isImageLoaded(fileName);
+      if (image != null) {
+        return image;
       }
       // This is null if there is no image
       final URL url = m_resourceLoader.getResource(fileName);

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -165,7 +165,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
   private AggregateResults calculate(final int count) {
     isRunning = true;
     final long start = System.currentTimeMillis();
-    final AggregateResults rVal = new AggregateResults(count);
+    final AggregateResults aggregateResults = new AggregateResults(count);
     final BattleTracker battleTracker = new BattleTracker();
     // CasualtySortingCaching can cause issues if there is more than 1 one battle being calced at the same time (like if
     // the AI and a human
@@ -191,17 +191,17 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       // battle.setAttackingFromAndMap(attackingFromMap);
       bridge1.setBattle(battle);
       battle.fight(bridge);
-      rVal.addResult(new BattleResults(battle, gameData));
+      aggregateResults.addResult(new BattleResults(battle, gameData));
       // restore the game to its original state
       gameData.performChange(allChanges.invert());
       battleTracker.clear();
       battleTracker.clearBattleRecords();
     }
     // BattleCalculator.DisableCasualtySortingCaching();
-    rVal.setTime(System.currentTimeMillis() - start);
+    aggregateResults.setTime(System.currentTimeMillis() - start);
     isRunning = false;
     cancelled = false;
-    return rVal;
+    return aggregateResults;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
@@ -40,13 +40,13 @@ public abstract class AbstractStatPanel extends JPanel {
    * @return all the alliances with more than one player.
    */
   public Collection<String> getAlliances() {
-    final Collection<String> rVal = new TreeSet<>();
+    final Collection<String> alliances = new TreeSet<>();
     for (final String alliance : gameData.getAllianceTracker().getAlliances()) {
       if (gameData.getAllianceTracker().getPlayersInAlliance(alliance).size() > 1) {
-        rVal.add(alliance);
+        alliances.add(alliance);
       }
     }
-    return rVal;
+    return alliances;
   }
 
   public List<PlayerID> getPlayers() {

--- a/src/main/java/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUIContext.java
@@ -240,25 +240,25 @@ public abstract class AbstractUIContext implements IUIContext {
    */
   public static Map<String, String> getSkins(final GameData data) {
     final String mapName = data.getProperties().get(Constants.MAP_NAME).toString();
-    final Map<String, String> rVal = new LinkedHashMap<>();
-    rVal.put("Original", mapName);
-    rVal.putAll(getSkins(mapName));
-    return rVal;
+    final Map<String, String> skinsByDisplayName = new LinkedHashMap<>();
+    skinsByDisplayName.put("Original", mapName);
+    skinsByDisplayName.putAll(getSkins(mapName));
+    return skinsByDisplayName;
   }
 
   private static Map<String, String> getSkins(final String mapName) {
-    final Map<String, String> rVal = new HashMap<>();
+    final Map<String, String> skinsByDisplayName = new HashMap<>();
     final File[] files = ClientFileSystemHelper.getUserMapsFolder().listFiles();
     if (files == null) {
-      return rVal;
+      return skinsByDisplayName;
     }
     for (final File f : files) {
       if (mapSkinNameMatchesMapName(f.getName(), mapName)) {
         final String displayName = f.getName().replace(mapName + "-", "").replace("-master", "").replace(".zip", "");
-        rVal.put(displayName, f.getName());
+        skinsByDisplayName.put(displayName, f.getName());
       }
     }
-    return rVal;
+    return skinsByDisplayName;
   }
 
   private static boolean mapSkinNameMatchesMapName(final String mapSkin, final String mapName) {

--- a/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -152,12 +152,12 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     buttonsBox.add(viewbutton);
     buttonsBox.add(cancelButton);
     buttonsBox.add(Box.createHorizontalGlue());
-    final Box rVal = new Box(BoxLayout.Y_AXIS);
-    rVal.add(unitsBox);
-    rVal.add(textBox);
-    rVal.add(buttonsBox);
-    rVal.add(new JLabel(" "));
-    return rVal;
+    final Box containerBox = new Box(BoxLayout.Y_AXIS);
+    containerBox.add(unitsBox);
+    containerBox.add(textBox);
+    containerBox.add(buttonsBox);
+    containerBox.add(new JLabel(" "));
+    return containerBox;
   }
 
   public int getCountOfMovesMade() {

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -278,7 +278,7 @@ public class MovePanel extends AbstractMovePanel {
     }
     allUnitsInSelectedTransports.retainAll(candidateUnits);
     sortUnitsToMove(allUnitsInSelectedTransports, route);
-    final List<Unit> rVal = new ArrayList<>();
+    final List<Unit> selectedUnitsToUnload = new ArrayList<>();
     final List<Unit> sortedTransports = new ArrayList<>(chosenTransports);
     Collections.sort(sortedTransports, UnitComparator.getIncreasingCapacityComparator(sortedTransports));
     final Collection<Unit> selectedUnits = new ArrayList<>(unitsToUnload);
@@ -294,7 +294,7 @@ public class MovePanel extends AbstractMovePanel {
           if (selected.getType().equals(candidate.getType()) && selected.getOwner().equals(candidate.getOwner())
               && selected.getHits() == candidate.getHits()) {
             hasChanged = true;
-            rVal.add(candidate);
+            selectedUnitsToUnload.add(candidate);
             allUnitsInSelectedTransports.remove(candidate);
             selectedIter.remove();
             break;
@@ -313,13 +313,13 @@ public class MovePanel extends AbstractMovePanel {
         final Unit candidate = candidateIter.next();
         if (selected.getType().equals(candidate.getType()) && selected.getOwner().equals(candidate.getOwner())
             && selected.getHits() == candidate.getHits()) {
-          rVal.add(candidate);
+          selectedUnitsToUnload.add(candidate);
           candidateIter.remove();
           break;
         }
       }
     }
-    return rVal;
+    return selectedUnitsToUnload;
   }
 
   private Match<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {
@@ -1424,9 +1424,9 @@ public class MovePanel extends AbstractMovePanel {
   @Override
   protected boolean doneMoveAction() {
     if (undoableMovesPanel.getCountOfMovesMade() == 0) {
-      final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(MovePanel.this),
+      final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(MovePanel.this),
           "Are you sure you dont want to move?", "End Move", JOptionPane.YES_NO_OPTION);
-      return rVal == JOptionPane.YES_OPTION;
+      return selectedOption == JOptionPane.YES_OPTION;
     }
     return true;
   }

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -200,9 +200,9 @@ public class PoliticsPanel extends ActionPanel {
   });
 
   private boolean youSureDoNothing() {
-    final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PoliticsPanel.this),
+    final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PoliticsPanel.this),
         "Are you sure you dont want to do anything?", "End Politics", JOptionPane.YES_NO_OPTION);
-    return rVal == JOptionPane.YES_OPTION;
+    return selectedOption == JOptionPane.YES_OPTION;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -148,9 +148,9 @@ public class PurchasePanel extends ActionPanel {
     public void actionPerformed(final ActionEvent event) {
       final boolean hasPurchased = purchase.totalValues() != 0;
       if (!hasPurchased) {
-        final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PurchasePanel.this),
+        final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PurchasePanel.this),
             "Are you sure you dont want to buy anything?", "End Purchase", JOptionPane.YES_NO_OPTION);
-        if (rVal != JOptionPane.YES_OPTION) {
+        if (selectedOption != JOptionPane.YES_OPTION) {
           return;
         }
       }
@@ -185,9 +185,9 @@ public class PurchasePanel extends ActionPanel {
         if (!bid && totalProduced + unitsNeedingFactory.size() > totalProd && !isUnlimitedProduction(player)) {
           final String text = "You have purchased " + (totalProduced + unitsNeedingFactory.size())
               + " units, and can only place " + totalProd + " of them. Continue with purchase?";
-          final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PurchasePanel.this), text,
-              "End Purchase", JOptionPane.YES_NO_OPTION);
-          if (rVal != JOptionPane.YES_OPTION) {
+          final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PurchasePanel.this),
+              text, "End Purchase", JOptionPane.YES_NO_OPTION);
+          if (selectedOption != JOptionPane.YES_OPTION) {
             return;
           }
         }

--- a/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -119,9 +119,9 @@ public class RepairPanel extends ActionPanel {
     public void actionPerformed(final ActionEvent event) {
       final boolean hasPurchased = getTotalValues(repair) != 0;
       if (!hasPurchased) {
-        final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(RepairPanel.this),
+        final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(RepairPanel.this),
             "Are you sure you dont want to repair anything?", "End Purchase", JOptionPane.YES_NO_OPTION);
-        if (rVal != JOptionPane.YES_OPTION) {
+        if (selectedOption != JOptionPane.YES_OPTION) {
           return;
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -562,10 +562,10 @@ public class TripleAFrame extends MainGameFrame {
 
   @Override
   public void shutdown() {
-    final int rVal = EventThreadJOptionPane.showConfirmDialog(this,
+    final int selectedOption = EventThreadJOptionPane.showConfirmDialog(this,
         "Are you sure you want to exit TripleA?\nUnsaved game data will be lost.", "Exit Program",
         JOptionPane.YES_NO_OPTION, getUiContext().getCountDownLatchHandler());
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     stopGame();
@@ -574,10 +574,10 @@ public class TripleAFrame extends MainGameFrame {
 
   @Override
   public void leaveGame() {
-    final int rVal = EventThreadJOptionPane.showConfirmDialog(this,
+    final int selectedOption = EventThreadJOptionPane.showConfirmDialog(this,
         "Are you sure you want to leave the current game?\nUnsaved game data will be lost.", "Leave Game",
         JOptionPane.YES_NO_OPTION, getUiContext().getCountDownLatchHandler());
-    if (rVal != JOptionPane.OK_OPTION) {
+    if (selectedOption != JOptionPane.OK_OPTION) {
       return;
     }
     if (game instanceof ServerGame) {
@@ -1043,7 +1043,7 @@ public class TripleAFrame extends MainGameFrame {
       }
     }
     actionButtons.changeToPickTerritoryAndUnits(player);
-    final Tuple<Territory, Set<Unit>> rVal =
+    final Tuple<Territory, Set<Unit>> territoryAndUnits =
         actionButtons.waitForPickTerritoryAndUnits(territoryChoices, unitChoices, unitsPerPick);
     final int index = tabsPanel == null ? -1 : tabsPanel.indexOfTab("Actions");
     if (index != -1 && inHistory) {
@@ -1064,7 +1064,7 @@ public class TripleAFrame extends MainGameFrame {
     if (actionButtons != null && actionButtons.getCurrent() != null) {
       actionButtons.getCurrent().setActive(false);
     }
-    return rVal;
+    return territoryAndUnits;
   }
 
   public HashMap<Territory, IntegerMap<Unit>> selectKamikazeSuicideAttacks(

--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -227,9 +227,9 @@ public class UserActionPanel extends ActionPanel {
     }
 
     private boolean youSureDoNothing() {
-      final int rVal = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(UserActionPanel.this),
+      final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(UserActionPanel.this),
           "Are you sure you dont want to do anything?", "End Actions", JOptionPane.YES_NO_OPTION);
-      return rVal == JOptionPane.YES_OPTION;
+      return selectedOption == JOptionPane.YES_OPTION;
     }
   };
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -387,8 +387,8 @@ public class LobbyMenu extends JMenuBar {
       return;
     }
     final CreateUpdateAccountPanel panel = CreateUpdateAccountPanel.newUpdatePanel(user);
-    final CreateUpdateAccountPanel.ReturnValue rVal = panel.show(lobbyFrame);
-    if (rVal == CreateUpdateAccountPanel.ReturnValue.CANCEL) {
+    final CreateUpdateAccountPanel.ReturnValue returnValue = panel.show(lobbyFrame);
+    if (returnValue == CreateUpdateAccountPanel.ReturnValue.CANCEL) {
       return;
     }
     //TODO: Replace MD5Crypt.crypt with an encryption algorithm

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -80,8 +80,8 @@ public class TripleAMenuBar extends JMenuBar {
       return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
     } else { // Non-Mac platforms should use the normal Swing JFileChooser
       final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
-      final int rVal = fileChooser.showSaveDialog(frame);
-      if (rVal != JFileChooser.APPROVE_OPTION) {
+      final int selectedOption = fileChooser.showSaveDialog(frame);
+      if (selectedOption != JFileChooser.APPROVE_OPTION) {
         return null;
       }
       File f = fileChooser.getSelectedFile();

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -112,18 +112,18 @@ public class TileManager {
     }
     acquireLock();
     try {
-      final List<Tile> rVal = new ArrayList<>();
+      final List<Tile> tilesInBounds = new ArrayList<>();
       for (final Tile tile : tiles) {
         final Rectangle tileBounds = tile.getBounds();
         if (bounds.contains(tileBounds) || tileBounds.intersects(bounds)) {
-          rVal.add(tile);
+          tilesInBounds.add(tile);
         }
       }
       if (boundsXshift != null) {
         for (final Tile tile : tiles) {
           final Rectangle tileBounds = tile.getBounds();
           if (boundsXshift.contains(tileBounds) || tileBounds.intersects(boundsXshift)) {
-            rVal.add(tile);
+            tilesInBounds.add(tile);
           }
         }
       }
@@ -131,11 +131,11 @@ public class TileManager {
         for (final Tile tile : tiles) {
           final Rectangle tileBounds = tile.getBounds();
           if (boundsYshift.contains(tileBounds) || tileBounds.intersects(boundsYshift)) {
-            rVal.add(tile);
+            tilesInBounds.add(tile);
           }
         }
       }
-      return rVal;
+      return tilesInBounds;
     } finally {
       releaseLock();
     }
@@ -420,8 +420,8 @@ public class TileManager {
           bounds.y = mapDataHeight - bounds.height;
         }
       }
-      final Image rVal = Util.createImage(squareLength, squareLength, false);
-      final Graphics2D graphics = (Graphics2D) rVal.getGraphics();
+      final Image territoryImage = Util.createImage(squareLength, squareLength, false);
+      final Graphics2D graphics = (Graphics2D) territoryImage.getGraphics();
       graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
       graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
           RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
@@ -459,7 +459,7 @@ public class TileManager {
         bounds.y += mapDataHeight;
       }
       graphics.dispose();
-      return rVal;
+      return territoryImage;
     } finally {
       releaseLock();
     }

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -226,8 +226,7 @@ public class UnitsDrawer implements IDrawable {
     } else {
       selectedUnitsBuilder.add(Matches.unitHasNotTakenAnyBombingUnitDamage());
     }
-    final List<Unit> rVal = t.getUnits().getMatches(selectedUnitsBuilder.all());
-    return Tuple.of(t, rVal);
+    return Tuple.of(t, t.getUnits().getMatches(selectedUnitsBuilder.all()));
   }
 
   @Override

--- a/src/main/java/games/strategy/util/IllegalCharacterRemover.java
+++ b/src/main/java/games/strategy/util/IllegalCharacterRemover.java
@@ -12,28 +12,28 @@ public class IllegalCharacterRemover {
    * Designed to remove / \b \n \r \t \0 \f ` ? * \ < > | " ' : . , ^ [ ] = + ;
    */
   public static String removeIllegalCharacter(final String text) {
-    final StringBuilder rVal = new StringBuilder();
+    final StringBuilder sb = new StringBuilder();
     for (int i = 0; i < text.length(); ++i) {
       if (!isIllegalFileNameChar(text.charAt(i))) {
-        rVal.append(text.charAt(i));
+        sb.append(text.charAt(i));
       }
     }
-    return rVal.toString();
+    return sb.toString();
   }
 
   /**
    * Designed to replace / \b \n \r \t \0 \f ` ? * \ < > | " ' : . , ^ [ ] = + ;
    */
   public static String replaceIllegalCharacter(final String text, final char replacement) {
-    final StringBuilder rVal = new StringBuilder();
+    final StringBuilder sb = new StringBuilder();
     for (int i = 0; i < text.length(); ++i) {
       if (!isIllegalFileNameChar(text.charAt(i))) {
-        rVal.append(text.charAt(i));
+        sb.append(text.charAt(i));
       } else {
-        rVal.append(replacement);
+        sb.append(replacement);
       }
     }
-    return rVal.toString();
+    return sb.toString();
   }
 
   private static boolean isIllegalFileNameChar(final char c) {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule due to local variables named `rVal` whose purpose is to store a method return value.

This is the **final part** in a series of related PRs.