### PR TITLE
Checkstyle: Fix top-level class violations

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -679,35 +679,34 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     sb.append(channelMessenger);
     return sb.toString();
   }
-}
 
+  private static final class ServerProps {
+    private String name;
+    private int port;
+    private String password;
 
-class ServerProps {
-  private String name;
-  private int port;
-  private String password;
+    String getPassword() {
+      return password;
+    }
 
-  public String getPassword() {
-    return password;
-  }
+    void setPassword(final String password) {
+      this.password = password;
+    }
 
-  public void setPassword(final String password) {
-    this.password = password;
-  }
+    String getName() {
+      return name;
+    }
 
-  public String getName() {
-    return name;
-  }
+    void setName(final String name) {
+      this.name = name;
+    }
 
-  public void setName(final String name) {
-    this.name = name;
-  }
+    int getPort() {
+      return port;
+    }
 
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(final int port) {
-    this.port = port;
+    void setPort(final int port) {
+      this.port = port;
+    }
   }
 }

--- a/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
+++ b/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.history;
+
+import games.strategy.engine.data.Change;
+
+class ChangeSerializationWriter implements SerializationWriter {
+  private static final long serialVersionUID = -3802807345707883606L;
+  private final Change aChange;
+
+  public ChangeSerializationWriter(final Change change) {
+    aChange = change;
+  }
+
+  @Override
+  public void write(final HistoryWriter writer) {
+    writer.addChange(aChange);
+  }
+}

--- a/src/main/java/games/strategy/engine/history/Event.java
+++ b/src/main/java/games/strategy/engine/history/Event.java
@@ -29,23 +29,3 @@ public class Event extends IndexedHistoryNode implements Renderable {
     return new EventHistorySerializer(m_description, m_renderingData);
   }
 }
-
-
-class EventHistorySerializer implements SerializationWriter {
-  private static final long serialVersionUID = 6404070330823708974L;
-  private final String m_eventName;
-  private final Object m_renderingData;
-
-  public EventHistorySerializer(final String eventName, final Object renderingData) {
-    m_eventName = eventName;
-    m_renderingData = renderingData;
-  }
-
-  @Override
-  public void write(final HistoryWriter writer) {
-    writer.startEvent(m_eventName);
-    if (m_renderingData != null) {
-      writer.setRenderingData(m_renderingData);
-    }
-  }
-}

--- a/src/main/java/games/strategy/engine/history/EventChild.java
+++ b/src/main/java/games/strategy/engine/history/EventChild.java
@@ -26,20 +26,3 @@ public class EventChild extends HistoryNode implements Renderable {
     return new EventChildWriter(m_text, m_renderingData);
   }
 }
-
-
-class EventChildWriter implements SerializationWriter {
-  private static final long serialVersionUID = -7143658060171295697L;
-  private final String m_text;
-  private final Object m_renderingData;
-
-  public EventChildWriter(final String text, final Object renderingData) {
-    m_text = text;
-    m_renderingData = renderingData;
-  }
-
-  @Override
-  public void write(final HistoryWriter writer) {
-    writer.addChildToEvent(new EventChild(m_text, m_renderingData));
-  }
-}

--- a/src/main/java/games/strategy/engine/history/EventChildWriter.java
+++ b/src/main/java/games/strategy/engine/history/EventChildWriter.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.history;
+
+class EventChildWriter implements SerializationWriter {
+  private static final long serialVersionUID = -7143658060171295697L;
+  private final String m_text;
+  private final Object m_renderingData;
+
+  public EventChildWriter(final String text, final Object renderingData) {
+    m_text = text;
+    m_renderingData = renderingData;
+  }
+
+  @Override
+  public void write(final HistoryWriter writer) {
+    writer.addChildToEvent(new EventChild(m_text, m_renderingData));
+  }
+}

--- a/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
+++ b/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
@@ -1,0 +1,20 @@
+package games.strategy.engine.history;
+
+class EventHistorySerializer implements SerializationWriter {
+  private static final long serialVersionUID = 6404070330823708974L;
+  private final String m_eventName;
+  private final Object m_renderingData;
+
+  public EventHistorySerializer(final String eventName, final Object renderingData) {
+    m_eventName = eventName;
+    m_renderingData = renderingData;
+  }
+
+  @Override
+  public void write(final HistoryWriter writer) {
+    writer.startEvent(m_eventName);
+    if (m_renderingData != null) {
+      writer.setRenderingData(m_renderingData);
+    }
+  }
+}

--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.history;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -179,78 +178,5 @@ public class History extends DefaultTreeModel {
 
   GameData getGameData() {
     return m_data;
-  }
-}
-
-
-/**
- * DefaultTreeModel is not serializable across jdk versions
- * Instead we use an instance of this class to store our data.
- */
-class SerializedHistory implements Serializable {
-  private static final long serialVersionUID = -5808427923253751651L;
-  private final List<SerializationWriter> m_Writers = new ArrayList<>();
-  private final GameData m_data;
-
-  public SerializedHistory(final History history, final GameData data, final List<Change> changes) {
-    m_data = data;
-    int changeIndex = 0;
-    final Enumeration<?> enumeration = ((DefaultMutableTreeNode) history.getRoot()).preorderEnumeration();
-    enumeration.nextElement();
-    while (enumeration.hasMoreElements()) {
-      final HistoryNode node = (HistoryNode) enumeration.nextElement();
-      // write the changes to the start of the node
-      if (node instanceof IndexedHistoryNode) {
-        while (changeIndex < ((IndexedHistoryNode) node).getChangeStartIndex()) {
-          m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
-          changeIndex++;
-        }
-      }
-      // write the node itself
-      m_Writers.add(node.getWriter());
-    }
-    // write out remaining changes
-    while (changeIndex < changes.size()) {
-      m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
-      changeIndex++;
-    }
-  }
-
-  public Object readResolve() {
-    final History history = new History(m_data);
-    final HistoryWriter historyWriter = history.getHistoryWriter();
-    for (final SerializationWriter element : m_Writers) {
-      element.write(historyWriter);
-    }
-    return history;
-  }
-}
-
-
-class RootHistoryNode extends HistoryNode {
-  private static final long serialVersionUID = 625147613043836829L;
-
-  public RootHistoryNode(final String title) {
-    super(title);
-  }
-
-  @Override
-  public SerializationWriter getWriter() {
-    throw new IllegalStateException("Not implemented");
-  }
-}
-
-
-class ChangeSerializationWriter implements SerializationWriter {
-  private static final long serialVersionUID = -3802807345707883606L;
-  private final Change aChange;
-
-  public ChangeSerializationWriter(final Change change) {
-    aChange = change;
-  }
-
-  @Override
-  public void write(final HistoryWriter writer) {
-    writer.addChange(aChange);
   }
 }

--- a/src/main/java/games/strategy/engine/history/RootHistoryNode.java
+++ b/src/main/java/games/strategy/engine/history/RootHistoryNode.java
@@ -1,0 +1,14 @@
+package games.strategy.engine.history;
+
+class RootHistoryNode extends HistoryNode {
+  private static final long serialVersionUID = 625147613043836829L;
+
+  public RootHistoryNode(final String title) {
+    super(title);
+  }
+
+  @Override
+  public SerializationWriter getWriter() {
+    throw new IllegalStateException("Not implemented");
+  }
+}

--- a/src/main/java/games/strategy/engine/history/Round.java
+++ b/src/main/java/games/strategy/engine/history/Round.java
@@ -18,18 +18,3 @@ public class Round extends IndexedHistoryNode {
     return new RoundHistorySerializer(m_RoundNo);
   }
 }
-
-
-class RoundHistorySerializer implements SerializationWriter {
-  private static final long serialVersionUID = 9006488114384654514L;
-  private final int m_roundNo;
-
-  public RoundHistorySerializer(final int roundNo) {
-    m_roundNo = roundNo;
-  }
-
-  @Override
-  public void write(final HistoryWriter writer) {
-    writer.startNextRound(m_roundNo);
-  }
-}

--- a/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
+++ b/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
@@ -1,0 +1,15 @@
+package games.strategy.engine.history;
+
+class RoundHistorySerializer implements SerializationWriter {
+  private static final long serialVersionUID = 9006488114384654514L;
+  private final int m_roundNo;
+
+  public RoundHistorySerializer(final int roundNo) {
+    m_roundNo = roundNo;
+  }
+
+  @Override
+  public void write(final HistoryWriter writer) {
+    writer.startNextRound(m_roundNo);
+  }
+}

--- a/src/main/java/games/strategy/engine/history/SerializedHistory.java
+++ b/src/main/java/games/strategy/engine/history/SerializedHistory.java
@@ -1,0 +1,54 @@
+package games.strategy.engine.history;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
+
+/**
+ * DefaultTreeModel is not serializable across jdk versions
+ * Instead we use an instance of this class to store our data.
+ */
+class SerializedHistory implements Serializable {
+  private static final long serialVersionUID = -5808427923253751651L;
+  private final List<SerializationWriter> m_Writers = new ArrayList<>();
+  private final GameData m_data;
+
+  public SerializedHistory(final History history, final GameData data, final List<Change> changes) {
+    m_data = data;
+    int changeIndex = 0;
+    final Enumeration<?> enumeration = ((DefaultMutableTreeNode) history.getRoot()).preorderEnumeration();
+    enumeration.nextElement();
+    while (enumeration.hasMoreElements()) {
+      final HistoryNode node = (HistoryNode) enumeration.nextElement();
+      // write the changes to the start of the node
+      if (node instanceof IndexedHistoryNode) {
+        while (changeIndex < ((IndexedHistoryNode) node).getChangeStartIndex()) {
+          m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
+          changeIndex++;
+        }
+      }
+      // write the node itself
+      m_Writers.add(node.getWriter());
+    }
+    // write out remaining changes
+    while (changeIndex < changes.size()) {
+      m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
+      changeIndex++;
+    }
+  }
+
+  public Object readResolve() {
+    final History history = new History(m_data);
+    final HistoryWriter historyWriter = history.getHistoryWriter();
+    for (final SerializationWriter element : m_Writers) {
+      element.write(historyWriter);
+    }
+    return history;
+  }
+}

--- a/src/main/java/games/strategy/engine/history/Step.java
+++ b/src/main/java/games/strategy/engine/history/Step.java
@@ -34,25 +34,3 @@ public class Step extends IndexedHistoryNode {
     return m_stepName;
   }
 }
-
-
-class StepHistorySerializer implements SerializationWriter {
-  private static final long serialVersionUID = 3546486775516371557L;
-  private final String m_stepName;
-  private final String m_delegateName;
-  private final PlayerID m_playerID;
-  private final String m_displayName;
-
-  public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerId,
-      final String displayName) {
-    m_stepName = stepName;
-    m_delegateName = delegateName;
-    m_playerID = playerId;
-    m_displayName = displayName;
-  }
-
-  @Override
-  public void write(final HistoryWriter writer) {
-    writer.startNextStep(m_stepName, m_delegateName, m_playerID, m_displayName);
-  }
-}

--- a/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
+++ b/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
@@ -1,0 +1,24 @@
+package games.strategy.engine.history;
+
+import games.strategy.engine.data.PlayerID;
+
+class StepHistorySerializer implements SerializationWriter {
+  private static final long serialVersionUID = 3546486775516371557L;
+  private final String m_stepName;
+  private final String m_delegateName;
+  private final PlayerID m_playerID;
+  private final String m_displayName;
+
+  public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerId,
+      final String displayName) {
+    m_stepName = stepName;
+    m_delegateName = delegateName;
+    m_playerID = playerId;
+    m_displayName = displayName;
+  }
+
+  @Override
+  public void write(final HistoryWriter writer) {
+    writer.startNextStep(m_stepName, m_delegateName, m_playerID, m_displayName);
+  }
+}

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -582,12 +582,3 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     };
   }
 }
-
-
-class EndTurnExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = -3939461840835898284L;
-  Serializable superState;
-  // add other variables here:
-  public boolean m_needToInitialize;
-  public boolean m_hasPostedTurnSummary;
-}

--- a/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
@@ -1,0 +1,9 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class BaseDelegateState implements Serializable {
+  private static final long serialVersionUID = 7130686697155151908L;
+  public boolean m_startBaseStepsFinished = false;
+  public boolean m_endBaseStepsFinished = false;
+}

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -128,10 +128,3 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     return (ITripleAPlayer) bridge.getRemotePlayer(player);
   }
 }
-
-
-class BaseDelegateState implements Serializable {
-  private static final long serialVersionUID = 7130686697155151908L;
-  public boolean m_startBaseStepsFinished = false;
-  public boolean m_endBaseStepsFinished = false;
-}

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1572,21 +1572,3 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     return m_currentBattle;
   }
 }
-
-
-class BattleExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 7899007486408723505L;
-  Serializable superState;
-  // add other variables here:
-  BattleTracker m_battleTracker = new BattleTracker();
-  // public OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
-  public boolean m_needToInitialize;
-  boolean m_needToScramble;
-  boolean m_needToKamikazeSuicideAttacks;
-  boolean m_needToClearEmptyAirBattleAttacks;
-  boolean m_needToAddBombardmentSources;
-  boolean m_needToRecordBattleStatistics;
-  boolean m_needToCheckDefendingPlanesCanLand;
-  boolean m_needToCleanup;
-  IBattle m_currentBattle;
-}

--- a/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -1,0 +1,20 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class BattleExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 7899007486408723505L;
+  Serializable superState;
+  // add other variables here:
+  BattleTracker m_battleTracker = new BattleTracker();
+  // public OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
+  public boolean m_needToInitialize;
+  boolean m_needToScramble;
+  boolean m_needToKamikazeSuicideAttacks;
+  boolean m_needToClearEmptyAirBattleAttacks;
+  boolean m_needToAddBombardmentSources;
+  boolean m_needToRecordBattleStatistics;
+  boolean m_needToCheckDefendingPlanesCanLand;
+  boolean m_needToCleanup;
+  IBattle m_currentBattle;
+}

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -130,12 +130,3 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     m_hasBid = s.m_hasBid;
   }
 }
-
-
-class BidPurchaseExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 6896164200767186673L;
-  Serializable superState;
-  int m_bid;
-  int m_spent;
-  boolean m_hasBid;
-}

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
@@ -1,0 +1,11 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class BidPurchaseExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 6896164200767186673L;
+  Serializable superState;
+  int m_bid;
+  int m_spent;
+  boolean m_hasBid;
+}

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -363,12 +363,3 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     return null;
   }
 }
-
-
-class EndRoundExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 8770361633528374127L;
-  Serializable superState;
-  // add other variables here:
-  public boolean m_gameOver = false;
-  public Collection<PlayerID> m_winners = new ArrayList<>();
-}

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
@@ -1,0 +1,15 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import games.strategy.engine.data.PlayerID;
+
+class EndRoundExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 8770361633528374127L;
+  Serializable superState;
+  // add other variables here:
+  public boolean m_gameOver = false;
+  public Collection<PlayerID> m_winners = new ArrayList<>();
+}

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
@@ -1,0 +1,11 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class EndTurnExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = -3939461840835898284L;
+  Serializable superState;
+  // add other variables here:
+  public boolean m_needToInitialize;
+  public boolean m_hasPostedTurnSummary;
+}

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -354,10 +354,3 @@ public class InitializationDelegate extends BaseTripleADelegate {
     return null;
   }
 }
-
-
-class InitializationExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = -9000446777655823735L;
-  Serializable superState;
-  public boolean m_needToInitialize;
-}

--- a/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
@@ -1,0 +1,9 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class InitializationExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = -9000446777655823735L;
+  Serializable superState;
+  public boolean m_needToInitialize;
+}

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -625,14 +625,3 @@ public class MoveDelegate extends AbstractMoveDelegate {
     m_PUsLost.add(t, amt);
   }
 }
-
-
-class MoveExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 5352248885420819215L;
-  Serializable superState;
-  // add other variables here:
-  public boolean m_firstRun = true;
-  public boolean m_needToInitialize;
-  public boolean m_needToDoRockets;
-  public IntegerMap<Territory> m_PUsLost;
-}

--- a/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
@@ -1,0 +1,16 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.util.IntegerMap;
+
+class MoveExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 5352248885420819215L;
+  Serializable superState;
+  // add other variables here:
+  public boolean m_firstRun = true;
+  public boolean m_needToInitialize;
+  public boolean m_needToDoRockets;
+  public IntegerMap<Territory> m_PUsLost;
+}

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -600,11 +600,3 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
   }
 }
-
-
-class PoliticsExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = -3829812751864156598L;
-  Serializable superState;
-  // add other variables here:
-  // public HashMap<ICondition, Boolean> m_testedConditions = null;
-}

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsExtendedDelegateState.java
@@ -1,0 +1,10 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class PoliticsExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = -3829812751864156598L;
+  Serializable superState;
+  // add other variables here:
+  // public HashMap<ICondition, Boolean> m_testedConditions = null;
+}

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -381,11 +381,3 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   }
 
 }
-
-
-class PurchaseExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 2326864364534284490L;
-  Serializable superState;
-  // add other variables here:
-  public boolean m_needToInitialize;
-}

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
@@ -1,0 +1,10 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class PurchaseExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 2326864364534284490L;
+  Serializable superState;
+  // add other variables here:
+  public boolean m_needToInitialize;
+}

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -264,11 +264,3 @@ public class RandomStartDelegate extends BaseTripleADelegate {
     }
   }
 }
-
-
-class RandomStartExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 607794506772555083L;
-  Serializable superState;
-  // add other variables here:
-  public PlayerID m_currentPickingPlayer;
-}

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
@@ -1,0 +1,12 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+import games.strategy.engine.data.PlayerID;
+
+class RandomStartExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 607794506772555083L;
+  Serializable superState;
+  // add other variables here:
+  public PlayerID m_currentPickingPlayer;
+}

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -349,10 +349,3 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   @Override
   public void pusLost(final Territory t, final int amt) {}
 }
-
-
-class SpecialMoveExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 7781410008392307104L;
-  Serializable superState;
-  public boolean m_needToInitialize;
-}

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
@@ -1,0 +1,9 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class SpecialMoveExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 7781410008392307104L;
+  Serializable superState;
+  public boolean m_needToInitialize;
+}

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -158,10 +158,3 @@ public class TechActivationDelegate extends BaseTripleADelegate {
     return null;
   }
 }
-
-
-class TechActivationExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = 1742776261442260882L;
-  Serializable superState;
-  public boolean m_needToInitialize;
-}

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
@@ -1,0 +1,9 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class TechActivationExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = 1742776261442260882L;
+  Serializable superState;
+  public boolean m_needToInitialize;
+}

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -431,12 +431,3 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     return ITechDelegate.class;
   }
 }
-
-
-class TechnologyExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = -1375328472343199099L;
-  Serializable superState;
-  // add other variables here:
-  public boolean m_needToInitialize;
-  public HashMap<PlayerID, Collection<TechAdvance>> m_techs;
-}

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
@@ -1,0 +1,15 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+
+import games.strategy.engine.data.PlayerID;
+
+class TechnologyExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = -1375328472343199099L;
+  Serializable superState;
+  // add other variables here:
+  public boolean m_needToInitialize;
+  public HashMap<PlayerID, Collection<TechAdvance>> m_techs;
+}

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -295,9 +295,3 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     return IUserActionDelegate.class;
   }
 }
-
-
-class UserActionExtendedDelegateState implements Serializable {
-  private static final long serialVersionUID = -7521031770074984272L;
-  Serializable superState;
-}

--- a/src/main/java/games/strategy/triplea/delegate/UserActionExtendedDelegateState.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionExtendedDelegateState.java
@@ -1,0 +1,8 @@
+package games.strategy.triplea.delegate;
+
+import java.io.Serializable;
+
+class UserActionExtendedDelegateState implements Serializable {
+  private static final long serialVersionUID = -7521031770074984272L;
+  Serializable superState;
+}


### PR DESCRIPTION
This PR fixes the remaining violations of the Checkstyle OneTopLevelClass rule.

The majority of the changes simply promote serializable package-private classes to their own files.  These changes were performed via automatic refactoring, and no additional changes were made to the affected classes.  This type of change should have no effect on compatibility.

The one exception was the `g.s.engine.framework.startup.mc.ServerProps` class, which is not serializable.  I manually made it a private nested class of the `ServerModel` class, as that was its only user.

#### Testing

To ensure compatibility wasn't broken by moving the serializable classes to their own files, I tested a network game with a 3635 client and a server from this branch.  I also loaded a save game from a 3635 client into a client running on this branch.  No problems were observed.