### PR TITLE
Checkstyle: Fix line length violations

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -718,8 +718,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (scrambleTerrs.isEmpty()) {
       return;
     }
-    final HashMap<Tuple<Territory, PlayerID>, Collection<HashMap<Territory, Tuple<Collection<Unit>, Collection<Unit>>>>> scramblersByTerritoryPlayer =
-        new HashMap<>();
+    final HashMap<Tuple<Territory, PlayerID>, //
+        Collection<HashMap<Territory, //
+            Tuple<Collection<Unit>, Collection<Unit>>>>> scramblersByTerritoryPlayer = new HashMap<>();
     for (final Territory to : scrambleTerrs.keySet()) {
       final HashMap<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers =
           new HashMap<>();

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -718,8 +718,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (scrambleTerrs.isEmpty()) {
       return;
     }
-    final HashMap<Tuple<Territory, PlayerID>, //
-        Collection<HashMap<Territory, //
+    final HashMap<//
+        Tuple<Territory, PlayerID>, //
+        Collection<HashMap<//
+            Territory, //
             Tuple<Collection<Unit>, Collection<Unit>>>>> scramblersByTerritoryPlayer = new HashMap<>();
     for (final Territory to : scrambleTerrs.keySet()) {
       final HashMap<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers =

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -80,7 +80,8 @@ public class BattleTracker implements Serializable {
   private BattleRecords m_battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
-  private final Collection<Tuple<Tuple<PlayerID, PlayerID>, //
+  private final Collection<Tuple<//
+      Tuple<PlayerID, PlayerID>, //
       Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn = new ArrayList<>();
 
   /**
@@ -165,7 +166,8 @@ public class BattleTracker implements Serializable {
   private boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
-    for (final Tuple<Tuple<PlayerID, PlayerID>, //
+    for (final Tuple<//
+        Tuple<PlayerID, PlayerID>, //
         Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
       final Tuple<PlayerID, PlayerID> players = t.getFirst();
       if (players.getFirst().equals(p1)) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -80,8 +80,8 @@ public class BattleTracker implements Serializable {
   private BattleRecords m_battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
-  private final Collection<Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn =
-      new ArrayList<>();
+  private final Collection<Tuple<Tuple<PlayerID, PlayerID>, //
+      Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn = new ArrayList<>();
 
   /**
    * @param t
@@ -165,7 +165,8 @@ public class BattleTracker implements Serializable {
   private boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
-    for (final Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
+    for (final Tuple<Tuple<PlayerID, PlayerID>, //
+        Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
       final Tuple<PlayerID, PlayerID> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
         if (!players.getSecond().equals(p2)) {


### PR DESCRIPTION
This PR fixes the remaining violations of the Checkstyle LineLength rule.

The fixes aren't pretty and don't really even improve readability.  However, the code at least now fits within the editor window. :smile:

It would be nice if Java supported type aliases, as that would be the preferred way to fix these violations.  However, since it doesn't, I'm open to any alternative suggestions for fixing these violations including simply closing this PR and not fixing them at this time.