### PR TITLE
Revert temporary workaround for intermittent Travis build failures (#2244)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport
+script: ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
-- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- ./gradlew -PengineVersion="$ENGINE_VERSION" release
 - ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:


### PR DESCRIPTION
This PR reverts the temporary workaround submitted in #2252 used to address travis-ci/travis-ci#8272 (originally raised in #2244).

The latest Travis Trusty `stable` image deployed last week now defines the `_JAVA_OPTIONS` environment variable with the value `-Xmx2048m -Xms512m`.  This limits the Java heap size of each Gradle process to 2 GiB, as opposed to the 14.5 GiB seen previously.

#### Testing

I tested this change on my fork prior to submitting this PR.  I ran 20 builds with the workaround removed, and all 20 builds ran successfully.  I will continue to monitor the build over the next several days.  If the intermittent failures return, I'll reintroduce the 1 GiB maximum heap size, as that seems to have worked well for us during the past month.