### PR TITLE
Checkstyle: Fix abbreviation violations in method names (part 1)

### DIFF
--- a/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -83,7 +83,7 @@ public class BattleRecordsList extends GameDataComponent {
   }
 
   // Interpretation stuff below
-  public static int getTUVdamageCausedByPlayer(final PlayerID attacker, final BattleRecordsList brl,
+  public static int getTuvDamageCausedByPlayer(final PlayerID attacker, final BattleRecordsList brl,
       final int beginningRound, final int endRound, final boolean currentRoundOnly, final boolean includeNullPlayer) {
     int damageCausedByAttacker = 0;
     final Collection<BattleRecords> brs = new ArrayList<>();
@@ -109,7 +109,7 @@ public class BattleRecordsList extends GameDataComponent {
     }
     for (final BattleRecords br : brs) {
       damageCausedByAttacker += BattleRecords
-          .getLostTUVforBattleRecords(BattleRecords.getRecordsForPlayerID(attacker, br), false, includeNullPlayer);
+          .getLostTuvForBattleRecords(BattleRecords.getRecordsForPlayerId(attacker, br), false, includeNullPlayer);
     }
     return damageCausedByAttacker;
   }
@@ -142,7 +142,7 @@ public class BattleRecordsList extends GameDataComponent {
     // null for attacker means any attacker
     for (final BattleRecords br : brs) {
       if (BattleRecords.getWereThereBattlesInTerritoriesMatching(
-          (attacker == null ? BattleRecords.getAllRecords(br) : BattleRecords.getRecordsForPlayerID(attacker, br)),
+          (attacker == null ? BattleRecords.getAllRecords(br) : BattleRecords.getRecordsForPlayerId(attacker, br)),
           attacker, defender, battleType, anyOfTheseTerritories)) {
         return true;
       }

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -481,7 +481,7 @@ public class GameData implements Serializable {
     final Iterator<GameStep> stepIter = sequence.iterator();
     while (stepIter.hasNext()) {
       final GameStep step = stepIter.next();
-      if (playersWhoShouldBeRemoved.contains(step.getPlayerID())) {
+      if (playersWhoShouldBeRemoved.contains(step.getPlayerId())) {
         stepIter.remove();
         if (index < currentIndex) {
           toSubtract++;

--- a/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -52,7 +52,7 @@ public class GameObjectInputStream extends ObjectInputStream {
   private Object resolveUnit(final Unit unit) {
     m_dataSource.getData().acquireReadLock();
     try {
-      final Unit local = m_dataSource.getData().getUnits().get(unit.getID());
+      final Unit local = m_dataSource.getData().getUnits().get(unit.getId());
       if (local != null) {
         return local;
       }

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -754,7 +754,7 @@ public class GameParser {
       final String defaultType = current.getAttribute("defaultType");
       final boolean isHidden = current.getAttribute("isHidden").equals("true");
       final PlayerID newPlayer = new PlayerID(name, isOptional, canBeDisabled, defaultType, isHidden, data);
-      playerList.addPlayerID(newPlayer);
+      playerList.addPlayerId(newPlayer);
     }
   }
 

--- a/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -31,7 +31,7 @@ public class GameSequence extends GameDataComponent implements Iterable<GameStep
     for (int i = 0; i < m_steps.size(); i++) {
       final GameStep step = m_steps.get(i);
       if (step != null && step.getDisplayName().equalsIgnoreCase(stepDisplayName)) {
-        if ((player == null && step.getPlayerID() == null) || (player != null && player.equals(step.getPlayerID()))) {
+        if ((player == null && step.getPlayerId() == null) || (player != null && player.equals(step.getPlayerId()))) {
           m_currentIndex = i;
           found = true;
           break;

--- a/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/src/main/java/games/strategy/engine/data/GameStep.java
@@ -67,7 +67,7 @@ public class GameStep extends GameDataComponent {
     return m_name;
   }
 
-  public PlayerID getPlayerID() {
+  public PlayerID getPlayerId() {
     return m_player;
   }
 

--- a/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -24,7 +24,7 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
     super(data);
   }
 
-  protected void addPlayerID(final PlayerID player) {
+  void addPlayerId(final PlayerID player) {
     m_players.put(player.getName(), player);
   }
 

--- a/src/main/java/games/strategy/engine/data/Unit.java
+++ b/src/main/java/games/strategy/engine/data/Unit.java
@@ -32,7 +32,7 @@ public class Unit extends GameDataComponent {
     setOwner(owner);
   }
 
-  public GUID getID() {
+  public GUID getId() {
     return m_uid;
   }
 
@@ -122,7 +122,7 @@ public class Unit extends GameDataComponent {
                   ? "UNKNOWN OWNER" : m_owner.getName())
               + " in territory: " + ((this.getData() != null && this.getData().getMap() != null)
                   ? getTerritoryUnitIsIn() : "UNKNOWN TERRITORY")
-              + " with id: " + getID();
+              + " with id: " + getId();
       UnitDeserializationErrorLazyMessage.printError(text);
       return 0;
     }
@@ -139,7 +139,7 @@ public class Unit extends GameDataComponent {
                   ? "UNKNOWN OWNER" : m_owner.getName())
               + " in territory: " + ((this.getData() != null && this.getData().getMap() != null)
                   ? getTerritoryUnitIsIn() : "UNKNOWN TERRITORY")
-              + " with id: " + getID();
+              + " with id: " + getId();
       UnitDeserializationErrorLazyMessage.printError(text);
       return text;
     }

--- a/src/main/java/games/strategy/engine/data/UnitsList.java
+++ b/src/main/java/games/strategy/engine/data/UnitsList.java
@@ -21,7 +21,7 @@ public class UnitsList implements Serializable, Iterable<Unit> {
   }
 
   public void put(final Unit unit) {
-    m_allUnits.put(unit.getID(), unit);
+    m_allUnits.put(unit.getId(), unit);
   }
 
   /*

--- a/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
@@ -39,7 +39,7 @@ class OwnerChange extends Change {
     return player.getName();
   }
 
-  private static PlayerID getPlayerID(final String name, final GameData data) {
+  private static PlayerID getPlayerId(final String name, final GameData data) {
     if (name == null) {
       return null;
     }
@@ -54,7 +54,7 @@ class OwnerChange extends Change {
   @Override
   protected void perform(final GameData data) {
     // both names could be null
-    data.getMap().getTerritory(m_territory).setOwner(getPlayerID(m_new, data));
+    data.getMap().getTerritory(m_territory).setOwner(getPlayerId(m_new, data));
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -28,8 +28,8 @@ class PlayerOwnerChange extends Change {
     m_new = new HashMap<>();
     m_location = location.getName();
     for (final Unit unit : units) {
-      m_old.put(unit.getID(), unit.getOwner().getName());
-      m_new.put(unit.getID(), newOwner.getName());
+      m_old.put(unit.getId(), unit.getOwner().getName());
+      m_new.put(unit.getId(), newOwner.getName());
     }
   }
 

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -540,8 +540,8 @@ public class GameDataExporter {
           | IllegalAccessException e) {
         ClientLogger.logError("An Error occured whilst trying to sequence in game " + data.getGameName(), e);
       }
-      if (step.getPlayerID() != null) {
-        xmlfile.append(" player=\"").append(step.getPlayerID().getName()).append("\"");
+      if (step.getPlayerId() != null) {
+        xmlfile.append(" player=\"").append(step.getPlayerId().getName()).append("\"");
       }
       if (step.getDisplayName() != null) {
         xmlfile.append(" display=\"").append(step.getDisplayName()).append("\"");
@@ -694,7 +694,7 @@ public class GameDataExporter {
     xmlfile.append("</game>\n");
   }
 
-  public String getXML() {
+  public String getXml() {
     return xmlfile.toString();
   }
 }

--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -47,7 +47,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
 
   @Override
   public PlayerID getPlayerID() {
-    return m_data.getSequence().getStep().getPlayerID();
+    return m_data.getSequence().getStep().getPlayerId();
   }
 
   public void setRandomSource(final IRandomSource randomSource) {

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -74,7 +74,7 @@ public class ClientGame extends AbstractGame {
               m_data.getHistory().getHistoryWriter().startNextRound(++currentRound);
             }
             while (!m_data.getSequence().getStep().getName().equals(stepName)
-                || !m_data.getSequence().getStep().getPlayerID().equals(player)
+                || !m_data.getSequence().getStep().getPlayerId().equals(player)
                 || !m_data.getSequence().getStep().getDelegate().getName().equals(delegateName)) {
               m_data.getSequence().next();
               if (m_data.getSequence().testWeAreOnLastStep()) {

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -515,7 +515,7 @@ public class ServerGame extends AbstractGame {
   }
 
   private void waitForPlayerToFinishStep() {
-    final PlayerID playerId = getCurrentStep().getPlayerID();
+    final PlayerID playerId = getCurrentStep().getPlayerId();
     // no player specified for the given step
     if (playerId == null) {
       return;
@@ -542,7 +542,7 @@ public class ServerGame extends AbstractGame {
     final String delegateName = currentStep.getDelegate().getName();
     final String displayName = currentStep.getDisplayName();
     final int round = m_data.getSequence().getRound();
-    final PlayerID id = currentStep.getPlayerID();
+    final PlayerID id = currentStep.getPlayerId();
     notifyGameStepListeners(stepName, delegateName, id, round, displayName);
     getGameModifiedBroadcaster().stepChanged(stepName, delegateName, id, round, displayName, loadedFromSavedGame);
   }
@@ -553,7 +553,7 @@ public class ServerGame extends AbstractGame {
     // potential bugs with adding changes to a game that has not yet started and has no history nodes yet. So wait for
     // the first delegate to
     // start before making changes.
-    if (getCurrentStep() == null || getCurrentStep().getPlayerID() == null || (m_firstRun)) {
+    if (getCurrentStep() == null || getCurrentStep().getPlayerId() == null || (m_firstRun)) {
       m_firstRun = false;
       return;
     }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -54,7 +54,7 @@ public class AvailableGames {
    * Can return null.
    */
   public GameData getGameData(final String gameName) {
-    return getGameDataFromXML(availableGames.get(gameName));
+    return getGameDataFromXml(availableGames.get(gameName));
   }
 
   /**
@@ -184,7 +184,7 @@ public class AvailableGames {
     return false;
   }
 
-  private static GameData getGameDataFromXML(final URI uri) {
+  private static GameData getGameDataFromXml(final URI uri) {
     if (uri == null) {
       return null;
     }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -115,7 +115,7 @@ public class ClientModel implements IMessengerErrorListener {
     options.setLocationRelativeTo(ui);
     options.setVisible(true);
     options.dispose();
-    if (!options.getOKPressed()) {
+    if (!options.getOkPressed()) {
       return null;
     }
     final ClientProps props = new ClientProps();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -63,7 +63,7 @@ public class GameSelectorModel extends Observable {
     if (entry.getGameData() != null) {
       ClientSetting.DEFAULT_GAME_NAME_PREF.save(entry.getGameData().getGameName());
     }
-    ClientSetting.DEFAULT_GAME_URI_PREF.save(entry.getURI().toString());
+    ClientSetting.DEFAULT_GAME_URI_PREF.save(entry.getUri().toString());
     ClientSetting.flush();
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -197,7 +197,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     options.setLocationRelativeTo(ui);
     options.setVisible(true);
     options.dispose();
-    if (!options.getOKPressed()) {
+    if (!options.getOkPressed()) {
       return null;
     }
     final String name = options.getName();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
@@ -108,7 +108,7 @@ public class ClientOptions extends JDialog {
     content.add(buttons, BorderLayout.SOUTH);
   }
 
-  public boolean getOKPressed() {
+  public boolean getOkPressed() {
     return okPressed;
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -147,7 +147,7 @@ public class ServerOptions extends JDialog {
     content.add(buttons, BorderLayout.SOUTH);
   }
 
-  public boolean getOKPressed() {
+  public boolean getOkPressed() {
     return okPressed;
   }
 

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -143,7 +143,7 @@ public class NewGameChooserEntry {
     return gameData;
   }
 
-  public URI getURI() {
+  public URI getUri() {
     return url;
   }
 

--- a/src/main/java/games/strategy/engine/history/Step.java
+++ b/src/main/java/games/strategy/engine/history/Step.java
@@ -17,7 +17,7 @@ public class Step extends IndexedHistoryNode {
     m_player = player;
   }
 
-  public PlayerID getPlayerID() {
+  public PlayerID getPlayerId() {
     return m_player;
   }
 

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -320,7 +320,7 @@ class LobbyGamePanel extends JPanel {
     options.setLocationRelativeTo(JOptionPane.getFrameForComponent(this));
     options.setNameEditable(false);
     options.setVisible(true);
-    if (!options.getOKPressed()) {
+    if (!options.getOkPressed()) {
       return;
     }
     GameRunner.hostGame(options.getPort(), options.getName(), options.getComments(), options.getPassword(),

--- a/src/main/java/games/strategy/engine/message/InvocationInProgress.java
+++ b/src/main/java/games/strategy/engine/message/InvocationInProgress.java
@@ -48,7 +48,7 @@ class InvocationInProgress {
     return m_results;
   }
 
-  GUID getMethodCallID() {
+  GUID getMethodCallId() {
     return m_methodCall.methodCallID;
   }
 

--- a/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -173,7 +173,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
       if (invocation.isWaitingOn(to)) {
         final RemoteMethodCallResults results =
             new RemoteMethodCallResults(new ConnectionLostException("Connection to " + to.getName() + " lost"));
-        final HubInvocationResults hubResults = new HubInvocationResults(results, invocation.getMethodCallID());
+        final HubInvocationResults hubResults = new HubInvocationResults(results, invocation.getMethodCallId());
         results(hubResults, to);
       }
     }

--- a/src/main/java/games/strategy/engine/vault/VaultID.java
+++ b/src/main/java/games/strategy/engine/vault/VaultID.java
@@ -8,14 +8,14 @@ public class VaultID implements Serializable {
   private static final long serialVersionUID = 8863728184933393296L;
   private static long currentId;
 
-  private static synchronized long getNextID() {
+  private static synchronized long getNextId() {
     return currentId++;
   }
 
   private final INode m_generatedOn;
   // this is a unique and monotone increasing id
   // unique in this vm
-  private final long m_uniqueID = getNextID();
+  private final long m_uniqueID = getNextId();
 
   VaultID(final INode generatedOn) {
     m_generatedOn = generatedOn;
@@ -31,7 +31,7 @@ public class VaultID implements Serializable {
   /**
    * @return Returns the id.
    */
-  long getUniqueID() {
+  long getUniqueId() {
     return m_uniqueID;
   }
 

--- a/src/main/java/games/strategy/internal/persistence/serializable/UnitProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/UnitProxy.java
@@ -38,7 +38,7 @@ public final class UnitProxy implements Proxy {
 
     gameData = unit.getData();
     hits = unit.getHits();
-    id = unit.getID();
+    id = unit.getId();
     type = unit.getType();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
+++ b/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
@@ -41,7 +41,7 @@ public class AggregateEstimate extends AggregateResults {
   }
 
   @Override
-  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
+  public Tuple<Double, Double> getAverageTuvOfUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
       final IntegerMap<UnitType> defenderCostsForTuv) {
     final double attackerTuv = TuvUtils.getTuv(remainingAttackingUnits, attackerCostsForTuv);
     final double defenderTuv = TuvUtils.getTuv(remainingDefendingUnits, defenderCostsForTuv);
@@ -49,13 +49,13 @@ public class AggregateEstimate extends AggregateResults {
   }
 
   @Override
-  public double getAverageTUVswing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
+  public double getAverageTuvSwing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
       final Collection<Unit> defenders, final GameData data) {
     final IntegerMap<UnitType> attackerCostsForTuv = TuvUtils.getCostsForTuv(attacker, data);
     final IntegerMap<UnitType> defenderCostsForTuv = TuvUtils.getCostsForTuv(defender, data);
     final int attackerTotalTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
     final int defenderTotalTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
-    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
+    final Tuple<Double, Double> average = getAverageTuvOfUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
     final double attackerLost = attackerTotalTuv - average.getFirst();
     final double defenderLost = defenderTotalTuv - average.getSecond();
     return defenderLost - attackerLost;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -141,7 +141,7 @@ public class ProAI extends AbstractAI {
   protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data,
       final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOOLCache();
+    BattleCalculator.clearOolCache();
     ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     calc.setData(data);
@@ -164,7 +164,7 @@ public class ProAI extends AbstractAI {
   protected void purchase(final boolean purchaseForBid, int pusToSpend, final IPurchaseDelegate purchaseDelegate,
       final GameData data, final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOOLCache();
+    BattleCalculator.clearOolCache();
     ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     if (pusToSpend <= 0) {
@@ -215,11 +215,11 @@ public class ProAI extends AbstractAI {
       final int nextStepIndex = dataCopy.getSequence().getStepIndex() + 1;
       for (int i = nextStepIndex; i < gameSteps.size(); i++) {
         final GameStep step = gameSteps.get(i);
-        if (!playerCopy.equals(step.getPlayerID())) {
+        if (!playerCopy.equals(step.getPlayerId())) {
           continue;
         }
         dataCopy.getSequence().setRoundAndStep(dataCopy.getSequence().getRound(), step.getDisplayName(),
-            step.getPlayerID());
+            step.getPlayerId());
         final String stepName = step.getName();
         ProLogger.info("Simulating phase: " + stepName);
         if (stepName.endsWith("NonCombatMove")) {
@@ -259,7 +259,7 @@ public class ProAI extends AbstractAI {
   protected void place(final boolean bid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
       final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOOLCache();
+    BattleCalculator.clearOolCache();
     ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     purchaseAI.place(storedPurchaseTerritories, placeDelegate);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -172,7 +172,7 @@ class ProPurchaseAI {
 
       // Prioritize land place options purchase AA then land units
       final List<ProPlaceTerritory> prioritizedLandTerritories = prioritizeLandTerritories(purchaseTerritories);
-      purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAAOptions());
+      purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
       purchaseLandUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions, territoryValueMap);
 
       // Prioritize sea territories that need defended and purchase additional defenders
@@ -264,7 +264,7 @@ class ProPurchaseAI {
 
     // Prioritize land place options purchase AA then land units
     final List<ProPlaceTerritory> prioritizedLandTerritories = prioritizeLandTerritories(purchaseTerritories);
-    purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAAOptions());
+    purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
     purchaseLandUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions, territoryValueMap);
 
     // Prioritize sea territories that need defended and purchase additional defenders

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -189,7 +189,7 @@ public class ProPurchaseOptionMap {
     return seaSubOptions;
   }
 
-  public List<ProPurchaseOption> getAAOptions() {
+  public List<ProPurchaseOption> getAaOptions() {
     return aaOptions;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -142,11 +142,11 @@ public class ProOddsCalculator {
         Matches.getMatches(attackingUnits, Matches.unitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
     final List<Unit> mainCombatDefenders =
         Matches.getMatches(defendingUnits, Matches.unitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
-    double tuvSwing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
+    double tuvSwing = results.getAverageTuvSwing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
     if (Matches.territoryIsNeutralButNotWater().match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = TuvUtils.getTuv(mainCombatAttackers, ProData.unitValueMap);
       final double remainingUnitValue =
-          results.getAverageTUVofUnitsLeftOver(ProData.unitValueMap, ProData.unitValueMap).getFirst();
+          results.getAverageTuvOfUnitsLeftOver(ProData.unitValueMap, ProData.unitValueMap).getFirst();
       tuvSwing = remainingUnitValue - attackingUnitValue;
     }
     final List<Unit> defendingTransportedUnits = Matches.getMatches(defendingUnits, Matches.unitIsBeingTransported());

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -48,10 +48,10 @@ public class ProUtils {
         currentIndex -= sequence.size();
       }
       final GameStep step = sequence.getStep(currentIndex);
-      final PlayerID stepPlayer = step.getPlayerID();
+      final PlayerID stepPlayer = step.getPlayerId();
       if (step.getName().endsWith("CombatMove") && stepPlayer != null && !stepPlayer.equals(player)
           && !players.contains(stepPlayer)) {
-        players.add(step.getPlayerID());
+        players.add(step.getPlayerId());
       }
     }
     return players;
@@ -250,7 +250,7 @@ public class ProUtils {
   public static boolean isNeutralPlayer(final PlayerID player) {
     final GameData data = ProData.getData();
     for (final GameStep gameStep : data.getSequence()) {
-      if (player.equals(gameStep.getPlayerID())) {
+      if (player.equals(gameStep.getPlayerId())) {
         return false;
       }
     }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -339,7 +339,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
    * Takes the raw data from the xml, and turns it into an actual territory list.
    * Will also set territoryCount.
    */
-  protected Set<Territory> getTerritoryListBasedOnInputFromXML(final String[] terrs, final Collection<PlayerID> players,
+  protected Set<Territory> getTerritoryListBasedOnInputFromXml(final String[] terrs, final Collection<PlayerID> players,
       final GameData data) {
     // If there's only 1, it might be a 'group' (original, controlled, controlledNoWater, all)
     if (terrs.length == 1) {

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -683,49 +683,49 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (objectiveMet && getDirectPresenceTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getDirectPresenceTerritories();
-      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "direct", getTerritoryCount(), players, data);
     }
     // Check for unit presence (Veqryn)
     if (objectiveMet && getAlliedPresenceTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getAlliedPresenceTerritories();
-      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "allied", getTerritoryCount(), players, data);
     }
     // Check for unit presence (Veqryn)
     if (objectiveMet && getEnemyPresenceTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getEnemyPresenceTerritories();
-      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXML(terrs, players, data), "enemy",
+      objectiveMet = checkUnitPresence(getTerritoryListBasedOnInputFromXml(terrs, players, data), "enemy",
           getTerritoryCount(), players, data);
     }
     // Check for direct unit exclusions (veqryn)
     if (objectiveMet && getDirectExclusionTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getDirectExclusionTerritories();
-      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "direct", getTerritoryCount(), players, data);
     }
     // Check for allied unit exclusions
     if (objectiveMet && getAlliedExclusionTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getAlliedExclusionTerritories();
-      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "allied", getTerritoryCount(), players, data);
     }
     // Check for enemy unit exclusions (ANY UNITS)
     if (objectiveMet && getEnemyExclusionTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getEnemyExclusionTerritories();
-      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "enemy", getTerritoryCount(), players, data);
     }
     // Check for enemy unit exclusions (SURFACE UNITS with ATTACK POWER)
     if (objectiveMet && getEnemySurfaceExclusionTerritories() != null) {
       // Get the listed territories
       final String[] terrs = getEnemySurfaceExclusionTerritories();
-      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXML(terrs, players, data),
+      objectiveMet = checkUnitExclusions(getTerritoryListBasedOnInputFromXml(terrs, players, data),
           "enemy_surface", getTerritoryCount(), players, data);
     }
     // Check for Territory Ownership rules
@@ -738,31 +738,31 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           final Collection<PlayerID> allies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAlliedWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, allies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, allies, data);
         } else if (terrs[0].equals("enemy")) {
           final Collection<PlayerID> enemies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAtWarWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, enemies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, enemies, data);
         } else {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         }
       } else if (terrs.length == 2) {
         if (terrs[1].equals("original")) {
           final Collection<PlayerID> allies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAlliedWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, allies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, allies, data);
         } else if (terrs[1].equals("enemy")) {
           final Collection<PlayerID> enemies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAtWarWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, enemies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, enemies, data);
         } else {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         }
       } else {
-        listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+        listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
       }
       objectiveMet = checkAlliedOwnership(listedTerritories, getTerritoryCount(), players, data);
     }
@@ -773,28 +773,28 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       Set<Territory> listedTerritories;
       if (terrs.length == 1) {
         if (terrs[0].equals("original")) {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         } else if (terrs[0].equals("enemy")) {
           final Collection<PlayerID> enemies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAtWarWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, enemies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, enemies, data);
         } else {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         }
       } else if (terrs.length == 2) {
         if (terrs[1].equals("original")) {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         } else if (terrs[1].equals("enemy")) {
           final Collection<PlayerID> enemies =
               Matches.getMatches(data.getPlayerList().getPlayers(),
                   Matches.isAtWarWithAnyOfThesePlayers(players, data));
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, enemies, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, enemies, data);
         } else {
-          listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+          listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
         }
       } else {
-        listedTerritories = getTerritoryListBasedOnInputFromXML(terrs, players, data);
+        listedTerritories = getTerritoryListBasedOnInputFromXml(terrs, players, data);
       }
       objectiveMet = checkDirectOwnership(listedTerritories, getTerritoryCount(), players);
     }
@@ -816,7 +816,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       final int requiredDestroyedTuv = getInt(s[0]);
       if (requiredDestroyedTuv >= 0) {
         final boolean justCurrentRound = s[1].equals("currentRound");
-        final int destroyedTuvForThisRoundSoFar = BattleRecordsList.getTUVdamageCausedByPlayer(playerAttachedTo,
+        final int destroyedTuvForThisRoundSoFar = BattleRecordsList.getTuvDamageCausedByPlayer(playerAttachedTo,
             data.getBattleRecordsList(), 0, data.getSequence().getRound(), justCurrentRound, false);
         if (requiredDestroyedTuv > destroyedTuvForThisRoundSoFar) {
           objectiveMet = false;

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -48,11 +48,11 @@ class AAInMoveUtil implements Serializable {
     return m_bridge.getData();
   }
 
-  private boolean isAlwaysONAAEnabled() {
+  private boolean isAlwaysOnAaEnabled() {
     return Properties.getAlwaysOnAA(getData());
   }
 
-  private boolean isAATerritoryRestricted() {
+  private boolean isAaTerritoryRestricted() {
     return Properties.getAATerritoryRestricted(getData());
   }
 
@@ -67,7 +67,7 @@ class AAInMoveUtil implements Serializable {
   /**
    * Fire aa guns. Returns units to remove.
    */
-  Collection<Unit> fireAA(final Route route, final Collection<Unit> units, final Comparator<Unit> decreasingMovement,
+  Collection<Unit> fireAa(final Route route, final Collection<Unit> units, final Comparator<Unit> decreasingMovement,
       final UndoableMove currentMove) {
     if (m_executionStack.isEmpty()) {
       populateExecutionStack(route, units, decreasingMovement, currentMove);
@@ -79,7 +79,7 @@ class AAInMoveUtil implements Serializable {
   /**
    * Fire the aa units in the given territory, hits are removed from units.
    */
-  private void fireAA(final Territory territory, final Collection<Unit> units, final UndoableMove currentMove) {
+  private void fireAa(final Territory territory, final Collection<Unit> units, final UndoableMove currentMove) {
     if (units.isEmpty()) {
       return;
     }
@@ -163,13 +163,13 @@ class AAInMoveUtil implements Serializable {
     // select units with lowest movement first
     targets.sort(decreasingMovement);
     final List<IExecutable> executables = new ArrayList<>();
-    for (Territory location : getTerritoriesWhereAAWillFire(route, units)) {
+    for (Territory location : getTerritoriesWhereAaWillFire(route, units)) {
       executables.add(new IExecutable() {
         private static final long serialVersionUID = -1545771595683434276L;
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireAA(location, targets, currentMove);
+          fireAa(location, targets, currentMove);
         }
       });
     }
@@ -177,10 +177,10 @@ class AAInMoveUtil implements Serializable {
     m_executionStack.push(executables);
   }
 
-  Collection<Territory> getTerritoriesWhereAAWillFire(final Route route, final Collection<Unit> units) {
-    final boolean alwaysOnAa = isAlwaysONAAEnabled();
+  Collection<Territory> getTerritoriesWhereAaWillFire(final Route route, final Collection<Unit> units) {
+    final boolean alwaysOnAa = isAlwaysOnAaEnabled();
     // Just the attacked territory will have AA firing
-    if (!alwaysOnAa && isAATerritoryRestricted()) {
+    if (!alwaysOnAa && isAaTerritoryRestricted()) {
       return Collections.emptyList();
     }
     final GameData data = getData();
@@ -268,7 +268,7 @@ class AAInMoveUtil implements Serializable {
   private void selectCasualties(final DiceRoll dice, final Collection<Unit> allFriendlyUnits,
       final Collection<Unit> validTargetedUnitsForThisRoll, final Collection<Unit> defendingAa,
       final Collection<Unit> allEnemyUnits, final Territory territory, final String currentTypeAa) {
-    final CasualtyDetails casualties = BattleCalculator.getAACasualties(false, validTargetedUnitsForThisRoll,
+    final CasualtyDetails casualties = BattleCalculator.getAaCasualties(false, validTargetedUnitsForThisRoll,
         allFriendlyUnits, defendingAa, allEnemyUnits, dice, m_bridge, territory.getOwner(), m_player, null, territory,
         TerritoryEffectHelper.getEffects(territory), false, new ArrayList<>());
     getRemotePlayer().reportMessage(casualties.size() + " " + currentTypeAa + " hits in " + territory.getName(),

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -53,7 +53,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
     return getEditMode(getData());
   }
 
-  protected String checkPlayerID() {
+  private String checkPlayerId() {
     final IRemotePlayer remotePlayer = getRemotePlayer();
     if (!m_bridge.getPlayerID().equals(remotePlayer.getPlayerID())) {
       return "Edit actions can only be performed during players turn";
@@ -62,7 +62,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
   }
 
   protected String checkEditMode() {
-    final String result = checkPlayerID();
+    final String result = checkPlayerId();
     if (null != result) {
       return result;
     }
@@ -84,7 +84,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
 
   public String addComment(final String message) {
     String result = null;
-    if (null != (result = checkPlayerID())) {
+    if (null != (result = checkPlayerId())) {
       return result;
     }
     logEvent("COMMENT: " + message, null);

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -47,7 +47,7 @@ import games.strategy.util.Tuple;
 public class BattleCalculator {
   private static final Map<String, List<UnitType>> oolCache = new ConcurrentHashMap<>();
 
-  public static void clearOOLCache() {
+  public static void clearOolCache() {
     oolCache.clear();
   }
 
@@ -92,7 +92,7 @@ public class BattleCalculator {
   /**
    * Choose plane casualties according to specified rules.
    */
-  public static CasualtyDetails getAACasualties(final boolean defending, final Collection<Unit> planes,
+  static CasualtyDetails getAaCasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> allFriendlyUnits, final Collection<Unit> defendingAa, final Collection<Unit> allEnemyUnits,
       final DiceRoll dice, final IDelegateBridge bridge, final PlayerID firingPlayer, final PlayerID hitPlayer,
       final GUID battleId, final Territory terr, final Collection<TerritoryEffect> territoryEffects,
@@ -110,7 +110,7 @@ public class BattleCalculator {
           dice.getHits(), allowMultipleHitsPerUnit);
     } else {
       if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
-        return getLowLuckAACasualties(defending, planes, defendingAa, dice, bridge, allowMultipleHitsPerUnit);
+        return getLowLuckAaCasualties(defending, planes, defendingAa, dice, bridge, allowMultipleHitsPerUnit);
       } else {
         // priority goes: choose -> individually -> random
         // if none are set, we roll individually
@@ -153,7 +153,7 @@ public class BattleCalculator {
     return Tuple.of(groupsOfSize, toRoll);
   }
 
-  private static CasualtyDetails getLowLuckAACasualties(final boolean defending, final Collection<Unit> planes,
+  private static CasualtyDetails getLowLuckAaCasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> defendingAa, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
     {
@@ -183,7 +183,7 @@ public class BattleCalculator {
     }
     final int chosenDiceSize = attackThenDiceSides.getSecond();
     final Triple<Integer, Integer, Boolean> triple =
-        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAa,
+        DiceRoll.getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAa,
             planes, data, false);
     final boolean allSameAttackPower = triple.getThird();
     // multiple HP units need to be counted multiple times:
@@ -395,7 +395,7 @@ public class BattleCalculator {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Triple<Integer, Integer, Boolean> triple =
-        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAa,
+        DiceRoll.getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAa,
             planes, bridge.getData(), false);
     final boolean allSameAttackPower = triple.getThird();
     if (!allSameAttackPower) {

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -149,7 +149,7 @@ public class DiceRoll implements Externalizable {
     // LOW LUCK
     if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
       final String annotation = "Roll " + typeAa + " in " + location.getName();
-      final Triple<Integer, Integer, Boolean> triple = getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
+      final Triple<Integer, Integer, Boolean> triple = getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
           null, null, defending, defendingAa, validAttackingUnitsForThisRoll, data, false);
       final int totalPower = triple.getFirst();
       hits += getLowLuckHits(bridge, sortedDice, totalPower, chosenDiceSizeForAll, defendingAa.get(0).getOwner(),
@@ -158,7 +158,7 @@ public class DiceRoll implements Externalizable {
       final String annotation = "Roll " + typeAa + " in " + location.getName();
       final int[] dice = bridge.getRandom(chosenDiceSizeForAll, totalAAattacksTotal, defendingAa.get(0).getOwner(),
           DiceType.COMBAT, annotation);
-      hits += getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(dice, sortedDice, defending, defendingAa,
+      hits += getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(dice, sortedDice, defending, defendingAa,
           validAttackingUnitsForThisRoll, data, true).getSecond();
     }
     final DiceRoll roll = new DiceRoll(sortedDice, hits);
@@ -182,7 +182,7 @@ public class DiceRoll implements Externalizable {
    *         true, but if one
    *         roll is at 1 and another roll is at 2, then we return false)
    */
-  public static Triple<Integer, Integer, Boolean> getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
+  public static Triple<Integer, Integer, Boolean> getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
       final int[] dice, final List<Die> sortedDice, final boolean defending,
       final Collection<Unit> defendingAaForThisRoll, final Collection<Unit> validAttackingUnitsForThisRoll,
       final GameData data, final boolean fillInSortedDiceAndRecordHits) {
@@ -1026,7 +1026,7 @@ public class DiceRoll implements Externalizable {
     if (player.isNull() || data.getSequence().getRound() != 1 || isNegateDominatingFirstRoundAttack(player)) {
       return false;
     }
-    return isDominatingFirstRoundAttack(data.getSequence().getStep().getPlayerID());
+    return isDominatingFirstRoundAttack(data.getSequence().getStep().getPlayerId());
   }
 
   private static boolean isDominatingFirstRoundAttack(final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -221,7 +221,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     final Collection<Territory> territories = data.getMap().getTerritories();
     while (allianceIter.hasNext()) {
       allianceName = allianceIter.next();
-      final int vcAmount = getVCAmount(data, allianceName, victoryType);
+      final int vcAmount = getVcAmount(data, allianceName, victoryType);
       final Set<PlayerID> teamMembers = data.getAllianceTracker().getPlayersInAlliance(allianceName);
       int teamVCs = 0;
       for (final Territory t : territories) {
@@ -245,7 +245,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     return data.getProperties().get(alliance + " Economic Victory", 200);
   }
 
-  private static int getVCAmount(final GameData data, final String alliance, final String type) {
+  private static int getVcAmount(final GameData data, final String alliance, final String type) {
     int defaultVc = 20;
     if (type.equals(" Total Victory VCs")) {
       defaultVc = 18;

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -73,7 +73,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
   private String createUnits(final IDelegateBridge bridge) {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
-    final PlayerID player = data.getSequence().getStep().getPlayerID();
+    final PlayerID player = data.getSequence().getStep().getPlayerId();
     final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesUnits());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
@@ -164,7 +164,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
 
     // Find total unit generated resources for all owned units
     final GameData data = getData();
-    final PlayerID player = data.getSequence().getStep().getPlayerID();
+    final PlayerID player = data.getSequence().getStep().getPlayerId();
     final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesResources());
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
@@ -210,7 +210,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
    */
   private String determineNationalObjectives(final IDelegateBridge bridge) {
     final GameData data = getData();
-    final PlayerID player = data.getSequence().getStep().getPlayerID();
+    final PlayerID player = data.getSequence().getStep().getPlayerId();
     // First figure out all the conditions that will be tested, so we can test them all at the same time.
     final HashSet<TriggerAttachment> toFirePossible = new HashSet<>();
     final HashSet<ICondition> allConditionsNeeded = new HashSet<>();

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -215,7 +215,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
     // so remove the bid steps that arent used
     for (final GameStep step : data.getSequence()) {
       if (step.getDelegate() instanceof BidPlaceDelegate || step.getDelegate() instanceof BidPurchaseDelegate) {
-        if (!BidPurchaseDelegate.doesPlayerHaveBid(data, step.getPlayerID())) {
+        if (!BidPurchaseDelegate.doesPlayerHaveBid(data, step.getPlayerId())) {
           step.setMaxRunCount(0);
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -557,7 +557,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // allow user to cancel move if aa guns will fire
     final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
     aaInMoveUtil.initialize(m_bridge);
-    final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAAWillFire(route, units);
+    final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
       if (!getRemotePlayer().confirmMoveInFaceOfAA(aaFiringTerritores)) {
         return null;

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -108,7 +108,7 @@ public class MovePerformer implements Serializable {
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        final Collection<Unit> aaCasualties = fireAA(route, units);
+        final Collection<Unit> aaCasualties = fireAa(route, units);
         final Set<Unit> aaCasualtiesWithDependents = new HashSet<>();
         // need to remove any dependents here
         if (aaCasualties != null) {
@@ -466,13 +466,13 @@ public class MovePerformer implements Serializable {
   /**
    * Fire aa guns. Returns units to remove.
    */
-  private Collection<Unit> fireAA(final Route route, final Collection<Unit> units) {
+  private Collection<Unit> fireAa(final Route route, final Collection<Unit> units) {
     if (m_aaInMoveUtil == null) {
       m_aaInMoveUtil = new AAInMoveUtil();
     }
     m_aaInMoveUtil.initialize(m_bridge);
     final Collection<Unit> unitsToRemove =
-        m_aaInMoveUtil.fireAA(route, units, UnitComparator.getLowestToHighestMovementComparator(), m_currentMove);
+        m_aaInMoveUtil.fireAa(route, units, UnitComparator.getLowestToHighestMovementComparator(), m_currentMove);
     m_aaInMoveUtil = null;
     return unitsToRemove;
   }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -487,14 +487,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   List<String> determineStepStrings(final boolean showFirstRun) {
     final List<String> steps = new ArrayList<>();
-    if (canFireOffensiveAA()) {
+    if (canFireOffensiveAa()) {
       for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
         steps.add(m_attacker.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
         steps.add(m_defender.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
         steps.add(m_defender.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
       }
     }
-    if (canFireDefendingAA()) {
+    if (canFireDefendingAa()) {
       for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
         steps.add(m_defender.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
         steps.add(m_attacker.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
@@ -679,15 +679,15 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void addFightStartToStack(final boolean firstRun, final List<IExecutable> steps) {
-    final boolean offensiveAa = canFireOffensiveAA();
-    final boolean defendingAa = canFireDefendingAA();
+    final boolean offensiveAa = canFireOffensiveAa();
+    final boolean defendingAa = canFireDefendingAa();
     if (offensiveAa) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = 3802352588499530533L;
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireOffensiveAAGuns();
+          fireOffensiveAaGuns();
         }
       });
     }
@@ -697,7 +697,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireDefensiveAAGuns();
+          fireDefensiveAaGuns();
         }
       });
     }
@@ -2144,11 +2144,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return Properties.getTransportCasualtiesRestricted(m_data);
   }
 
-  private void fireOffensiveAAGuns() {
+  private void fireOffensiveAaGuns() {
     m_stack.push(new FireAA(false));
   }
 
-  private void fireDefensiveAAGuns() {
+  private void fireDefensiveAaGuns() {
     m_stack.push(new FireAA(true));
   }
 
@@ -2165,7 +2165,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
     @Override
     public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-      if ((m_defending && !canFireDefendingAA()) || (!m_defending && !canFireOffensiveAA())) {
+      if ((m_defending && !canFireDefendingAa()) || (!m_defending && !canFireOffensiveAa())) {
         return;
       }
       for (final String currentTypeAa : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
@@ -2250,7 +2250,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // send defender the dice roll so he can see what the dice are while he waits for attacker to select casualties
       getDisplay(bridge).notifyDice(m_dice, (m_defending ? m_attacker.getName() : m_defender.getName())
           + SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
-      return BattleCalculator.getAACasualties(!m_defending, validAttackingUnitsForThisRoll,
+      return BattleCalculator.getAaCasualties(!m_defending, validAttackingUnitsForThisRoll,
           (m_defending ? m_attackingUnits : m_defendingUnits), defendingAa,
           (m_defending ? m_defendingUnits : m_attackingUnits), m_dice, bridge, (m_defending ? m_defender : m_attacker),
           (m_defending ? m_attacker : m_defender), m_battleID, m_battleSite, m_territoryEffects, m_isAmphibious,
@@ -2293,14 +2293,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
   }
 
-  private boolean canFireDefendingAA() {
+  private boolean canFireDefendingAa() {
     if (m_defendingAA == null) {
       updateDefendingAAUnits();
     }
     return m_defendingAA.size() > 0;
   }
 
-  private boolean canFireOffensiveAA() {
+  private boolean canFireOffensiveAa() {
     if (m_offensiveAA == null) {
       updateOffensiveAAUnits();
     }

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -125,7 +125,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     // allow user to cancel move if aa guns will fire
     final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
     aaInMoveUtil.initialize(m_bridge);
-    final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAAWillFire(route, units);
+    final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
       if (!getRemotePlayer().confirmMoveInFaceOfAA(aaFiringTerritores)) {
         return null;

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -478,7 +478,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           /* defending */false, m_battleID, /* head-less */false, 0, allowMultipleHitsPerUnit);
       return casualtySelection;
     }
-    final CasualtyDetails casualties = BattleCalculator.getAACasualties(false, validAttackingUnitsForThisRoll,
+    final CasualtyDetails casualties = BattleCalculator.getAaCasualties(false, validAttackingUnitsForThisRoll,
         m_attackingUnits, defendingAa, m_defendingUnits, dice, bridge, m_defender, m_attacker, m_battleID, m_battleSite,
         m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
     final int totalExpectingHits =

--- a/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -131,7 +131,7 @@ public class TechTracker implements Serializable {
     return TechAttachment.get(player).getIncreasedFactoryProduction();
   }
 
-  public static boolean hasAARadar(final PlayerID player) {
+  public static boolean hasAaRadar(final PlayerID player) {
     return TechAttachment.get(player).getAARadar();
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
@@ -169,11 +169,11 @@ public class BattleRecord implements Serializable {
     this.defender = defender;
   }
 
-  protected int getAttackerLostTUV() {
+  int getAttackerLostTuv() {
     return attackerLostTUV;
   }
 
-  protected int getDefenderLostTUV() {
+  int getDefenderLostTuv() {
     return defenderLostTUV;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -76,7 +76,7 @@ public class BattleRecords implements Serializable {
     return records;
   }
 
-  public static Collection<BattleRecord> getRecordsForPlayerID(final PlayerID player, final BattleRecords brs) {
+  public static Collection<BattleRecord> getRecordsForPlayerId(final PlayerID player, final BattleRecords brs) {
     final Collection<BattleRecord> playerRecords = new ArrayList<>();
     if (brs.m_records.get(player) == null) {
       return playerRecords;
@@ -87,7 +87,7 @@ public class BattleRecords implements Serializable {
     return playerRecords;
   }
 
-  public static int getLostTUVforBattleRecords(final Collection<BattleRecord> brs, final boolean attackerLostTuv,
+  public static int getLostTuvForBattleRecords(final Collection<BattleRecord> brs, final boolean attackerLostTuv,
       final boolean includeNullPlayer) {
     int lostTuv = 0;
     for (final BattleRecord br : brs) {
@@ -96,9 +96,9 @@ public class BattleRecords implements Serializable {
         continue;
       }
       if (attackerLostTuv) {
-        lostTuv += br.getAttackerLostTUV();
+        lostTuv += br.getAttackerLostTuv();
       } else {
-        lostTuv += br.getDefenderLostTUV();
+        lostTuv += br.getDefenderLostTuv();
       }
     }
     return lostTuv;

--- a/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -55,7 +55,7 @@ public class MapImage {
     return propertyMapFont;
   }
 
-  public static Color getPropertyTerritoryNameAndPUAndCommentcolor() {
+  public static Color getPropertyTerritoryNameAndPuAndCommentColor() {
     if (propertyTerritoryNameAndPuAndCommentColor == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
       propertyTerritoryNameAndPuAndCommentColor =

--- a/src/main/java/games/strategy/triplea/image/PUImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/PUImageFactory.java
@@ -3,7 +3,7 @@ package games.strategy.triplea.image;
 import java.awt.Image;
 
 public class PUImageFactory extends ImageFactory {
-  public Image getPUImage(final int value) {
+  public Image getPuImage(final int value) {
     return getImage("PUs/" + value + ".png", false);
   }
 }

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -135,11 +135,11 @@ public class UnitImageFactory {
     return Optional.of(scaledImage);
   }
 
-  public Optional<URL> getBaseImageURL(final String baseImageName, final PlayerID id) {
-    return getBaseImageURL(baseImageName, id, m_resourceLoader);
+  public Optional<URL> getBaseImageUrl(final String baseImageName, final PlayerID id) {
+    return getBaseImageUrl(baseImageName, id, m_resourceLoader);
   }
 
-  private static Optional<URL> getBaseImageURL(final String baseImageName, final PlayerID id,
+  private static Optional<URL> getBaseImageUrl(final String baseImageName, final PlayerID id,
       final ResourceLoader resourceLoader) {
     // URL uses '/' not '\'
     final String fileName = FILE_NAME_BASE + id.getName() + "/" + baseImageName + ".png";
@@ -148,10 +148,10 @@ public class UnitImageFactory {
   }
 
   private Optional<Image> getBaseImage(final String baseImageName, final PlayerID id) {
-    final Optional<URL> imageLocation = getBaseImageURL(baseImageName, id);
+    final Optional<URL> imageLocation = getBaseImageUrl(baseImageName, id);
     Image image = null;
     if (imageLocation.isPresent()) {
-      image = Toolkit.getDefaultToolkit().getImage(getBaseImageURL(baseImageName, id).get());
+      image = Toolkit.getDefaultToolkit().getImage(getBaseImageUrl(baseImageName, id).get());
       Util.ensureImageLoaded(image);
     }
     return Optional.ofNullable(image);
@@ -207,14 +207,14 @@ public class UnitImageFactory {
         if (TechTracker.hasRocket(id) && UnitAttachment.get(type).getIsRocket()) {
           name = new StringBuilder("rockets");
         }
-        if (TechTracker.hasAARadar(id) && Matches.unitTypeIsAaForAnything().match(type)) {
+        if (TechTracker.hasAaRadar(id) && Matches.unitTypeIsAaForAnything().match(type)) {
           name.append("_r");
         }
       } else if (UnitAttachment.get(type).getIsRocket() && Matches.unitTypeIsAaForAnything().match(type)) {
         if (TechTracker.hasRocket(id)) {
           name.append("_rockets");
         }
-        if (TechTracker.hasAARadar(id)) {
+        if (TechTracker.hasAaRadar(id)) {
           name.append("_r");
         }
       } else if (UnitAttachment.get(type).getIsRocket()) {
@@ -222,7 +222,7 @@ public class UnitImageFactory {
           name.append("_rockets");
         }
       } else if (Matches.unitTypeIsAaForAnything().match(type)) {
-        if (TechTracker.hasAARadar(id)) {
+        if (TechTracker.hasAaRadar(id)) {
           name.append("_r");
         }
       }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -79,7 +79,7 @@ public class AggregateResults implements Serializable {
   /**
    * First is Attacker, Second is Defender.
    */
-  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
+  public Tuple<Double, Double> getAverageTuvOfUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
       final IntegerMap<UnitType> defenderCostsForTuv) {
     if (m_results.isEmpty()) { // can be empty!
       return Tuple.of(0.0, 0.0);
@@ -93,7 +93,7 @@ public class AggregateResults implements Serializable {
     return Tuple.of(attackerTuv / m_results.size(), defenderTuv / m_results.size());
   }
 
-  public double getAverageTUVswing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
+  public double getAverageTuvSwing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
       final Collection<Unit> defenders, final GameData data) {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
@@ -103,7 +103,7 @@ public class AggregateResults implements Serializable {
     final int attackerTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
     final int defenderTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
     // could we possibly cause a bug by comparing UnitType's from one game data, to a different game data's UnitTypes?
-    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
+    final Tuple<Double, Double> average = getAverageTuvOfUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
     final double attackerLost = attackerTuv - average.getFirst();
     final double defenderLost = defenderTuv - average.getSecond();
     return defenderLost - attackerLost;

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -145,9 +145,9 @@ class OddsCalculatorPanel extends JPanel {
       try {
         landBattleCheckBox.setSelected(!location.isWater());
         // default to the current player
-        if (data.getSequence().getStep().getPlayerID() != null
-            && !data.getSequence().getStep().getPlayerID().isNull()) {
-          attackerCombo.setSelectedItem(data.getSequence().getStep().getPlayerID());
+        if (data.getSequence().getStep().getPlayerId() != null
+            && !data.getSequence().getStep().getPlayerId().isNull()) {
+          attackerCombo.setSelectedItem(data.getSequence().getStep().getPlayerId());
         }
         if (!location.isWater()) {
           defenderCombo.setSelectedItem(location.getOwner());
@@ -447,7 +447,7 @@ class OddsCalculatorPanel extends JPanel {
       roundsAverage.setText("" + formatValue(results.get().getAverageBattleRoundsFought()));
       try {
         data.acquireReadLock();
-        averageChangeInTUV.setText("" + formatValue(results.get().getAverageTUVswing(getAttacker(),
+        averageChangeInTUV.setText("" + formatValue(results.get().getAverageTuvSwing(getAttacker(),
             mainCombatAttackers, getDefender(), mainCombatDefenders, data)));
       } finally {
         data.releaseReadLock();

--- a/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -42,7 +42,7 @@ public class PlayerOrder {
           && (currentStep.getName().endsWith("Bid") || currentStep.getName().endsWith("BidPlace"))) {
         continue;
       }
-      final PlayerID currentPlayerId = currentStep.getPlayerID();
+      final PlayerID currentPlayerId = currentStep.getPlayerId();
       if (currentPlayerId != null && !currentPlayerId.isNull()) {
         playerSet.add(currentPlayerId);
       }

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -132,7 +132,7 @@ public class CommentPanel extends JPanel {
         final Pattern p = Pattern.compile("^COMMENT: (.*)");
         final Matcher m = p.matcher(title);
         if (m.matches()) {
-          final PlayerID playerId = data.getSequence().getStep().getPlayerID();
+          final PlayerID playerId = data.getSequence().getStep().getPlayerId();
           final int round = data.getSequence().getRound();
           final String player = playerId.getName();
           final Icon icon = iconMap.get(playerId);
@@ -177,7 +177,7 @@ public class CommentPanel extends JPanel {
       if (node instanceof Round) {
         round++;
       } else if (node instanceof Step) {
-        final PlayerID playerId = ((Step) node).getPlayerID();
+        final PlayerID playerId = ((Step) node).getPlayerId();
         if (playerId != null) {
           player = playerId.getName();
           icon = iconMap.get(playerId);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -412,7 +412,7 @@ public class TripleAFrame extends MainGameFrame {
         PlayerID player1 = null;
         data.acquireReadLock();
         try {
-          player1 = data.getSequence().getStep().getPlayerID();
+          player1 = data.getSequence().getStep().getPlayerId();
         } finally {
           data.releaseReadLock();
         }
@@ -1416,7 +1416,7 @@ public class TripleAFrame extends MainGameFrame {
     try {
       round = data.getSequence().getRound();
       stepDisplayName = data.getSequence().getStep().getDisplayName();
-      player = data.getSequence().getStep().getPlayerID();
+      player = data.getSequence().getStep().getPlayerId();
     } finally {
       data.releaseReadLock();
     }
@@ -1756,7 +1756,7 @@ public class TripleAFrame extends MainGameFrame {
               enumeration.nextElement();
               int round = 0;
               String stepDisplayName = datacopy.getSequence().getStep(0).getDisplayName();
-              PlayerID currentPlayer = datacopy.getSequence().getStep(0).getPlayerID();
+              PlayerID currentPlayer = datacopy.getSequence().getStep(0).getPlayerId();
               while (enumeration.hasMoreElements()) {
                 final HistoryNode node = (HistoryNode) enumeration.nextElement();
                 if (node instanceof Round) {
@@ -1764,7 +1764,7 @@ public class TripleAFrame extends MainGameFrame {
                   currentPlayer = null;
                   stepDisplayName = node.getTitle();
                 } else if (node instanceof Step) {
-                  currentPlayer = ((Step) node).getPlayerID();
+                  currentPlayer = ((Step) node).getPlayerId();
                   stepDisplayName = node.getTitle();
                 }
               }

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -96,7 +96,7 @@ public class HistoryLog extends JFrame {
       curNode = (HistoryNode) curNode.getPreviousNode();
     }
     if (stepNode != null) {
-      curPlayer = stepNode.getPlayerID();
+      curPlayer = stepNode.getPlayerId();
       if (players.isEmpty()) {
         players.add(curPlayer);
       }
@@ -107,10 +107,10 @@ public class HistoryLog extends JFrame {
         if (stepNode == null) {
           break;
         }
-        if (stepNode.getPlayerID() == null) {
+        if (stepNode.getPlayerId() == null) {
           break;
         }
-        if (!players.contains(stepNode.getPlayerID())) {
+        if (!players.contains(stepNode.getPlayerId())) {
           break;
         }
       }
@@ -129,7 +129,7 @@ public class HistoryLog extends JFrame {
       for (final Object pathNode : pathToNode) {
         final HistoryNode node = (HistoryNode) pathNode;
         if (node instanceof Step) {
-          curPlayer = ((Step) node).getPlayerID();
+          curPlayer = ((Step) node).getPlayerId();
         }
       }
     }
@@ -139,7 +139,7 @@ public class HistoryLog extends JFrame {
         final HistoryNode node = (HistoryNode) nodeEnum.nextElement();
         if (node instanceof Step) {
           final String title = node.getTitle();
-          final PlayerID playerId = ((Step) node).getPlayerID();
+          final PlayerID playerId = ((Step) node).getPlayerId();
           if (!title.equals("Initializing Delegates")) {
             if (playerId != null) {
               curPlayer = playerId;
@@ -148,7 +148,7 @@ public class HistoryLog extends JFrame {
         }
       }
       curNode = curNode.getNextSibling();
-    } while ((curNode instanceof Step) && ((Step) curNode).getPlayerID().equals(curPlayer));
+    } while ((curNode instanceof Step) && ((Step) curNode).getPlayerId().equals(curPlayer));
     return curPlayer;
   }
 
@@ -172,7 +172,7 @@ public class HistoryLog extends JFrame {
           logWriter.println();
         }
         if (node instanceof Step) {
-          currentPlayer = ((Step) node).getPlayerID();
+          currentPlayer = ((Step) node).getPlayerId();
         }
       }
     }
@@ -351,7 +351,7 @@ public class HistoryLog extends JFrame {
             logWriter.println(indent + title);
           }
         } else if (node instanceof Step) {
-          final PlayerID playerId = ((Step) node).getPlayerID();
+          final PlayerID playerId = ((Step) node).getPlayerId();
           if (!title.equals("Initializing Delegates")) {
             logWriter.println();
             logWriter.print(indent + title);
@@ -373,7 +373,7 @@ public class HistoryLog extends JFrame {
         }
       } // while (nodeEnum.hasMoreElements())
       curNode = curNode.getNextSibling();
-    } while (curNode != null && (curNode instanceof Step) && players.contains(((Step) curNode).getPlayerID()));
+    } while (curNode != null && (curNode instanceof Step) && players.contains(((Step) curNode).getPlayerId()));
     // if we are mid-phase, this might not get flushed
     if (moving && !moveList.isEmpty()) {
       final Iterator<String> moveIter = moveList.iterator();
@@ -407,7 +407,7 @@ public class HistoryLog extends JFrame {
     PlayerID player;
     data.acquireReadLock();
     try {
-      player = data.getSequence().getStep().getPlayerID();
+      player = data.getSequence().getStep().getPlayerId();
       territories = data.getMap().getTerritories();
     } finally {
       data.releaseReadLock();

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -410,7 +410,7 @@ public class HistoryPanel extends JPanel {
     public Component getTreeCellRendererComponent(final JTree tree, final Object value, final boolean sel,
         final boolean expanded, final boolean leaf, final int row, final boolean haveFocus) {
       if (value instanceof Step) {
-        final PlayerID player = ((Step) value).getPlayerID();
+        final PlayerID player = ((Step) value).getPlayerId();
         if (player != null) {
           if (uiContext != null) {
             super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -104,7 +104,7 @@ class ExportMenu {
     try {
       gameData.acquireReadLock();
       final GameDataExporter exporter = new GameDataExporter(gameData);
-      xmlFile = exporter.getXML();
+      xmlFile = exporter.getXml();
     } finally {
       gameData.releaseReadLock();
     }
@@ -322,18 +322,18 @@ class ExportMenu {
           continue;
         }
         final Step step = (Step) element;
-        if (step.getPlayerID() == null || step.getPlayerID().isNull()) {
+        if (step.getPlayerId() == null || step.getPlayerId().isNull()) {
           continue;
         }
         // this is to stop from having multiple entries for each players turn.
         if (!showPhaseStats) {
-          if (step.getPlayerID() == currentPlayer) {
+          if (step.getPlayerId() == currentPlayer) {
             continue;
           }
         }
-        currentPlayer = step.getPlayerID();
+        currentPlayer = step.getPlayerId();
         clone.getHistory().gotoNode(element);
-        final String playerName = step.getPlayerID() == null ? "" : step.getPlayerID().getName() + ": ";
+        final String playerName = step.getPlayerId() == null ? "" : step.getPlayerId().getName() + ": ";
         String stepName = step.getStepName();
         // copied directly from TripleAPlayer, will probably have to be updated in the future if more delegates are made
         if (stepName.endsWith("Bid")) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -69,7 +69,7 @@ class FileMenu {
         gameData.acquireReadLock();
         final GameStep step = gameData.getSequence().getStep();
         final PlayerID currentPlayer = (step == null ? PlayerID.NULL_PLAYERID
-            : (step.getPlayerID() == null ? PlayerID.NULL_PLAYERID : step.getPlayerID()));
+            : (step.getPlayerId() == null ? PlayerID.NULL_PLAYERID : step.getPlayerId()));
         final int round = gameData.getSequence().getRound();
         final HistoryLog historyLog = new HistoryLog();
         historyLog.printFullTurn(gameData, true, GameStepPropertiesHelper.getTurnSummaryPlayers(gameData));

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -159,7 +159,7 @@ public class HelpMenu {
     if (player == null || unitImageFactory == null) {
       return "no image";
     }
-    final Optional<URL> imageUrl = unitImageFactory.getBaseImageURL(unitType.getName(), player);
+    final Optional<URL> imageUrl = unitImageFactory.getBaseImageUrl(unitType.getName(), player);
     final String imageLocation = imageUrl.isPresent() ? imageUrl.get().toString() : "";
 
     return "<img src=\"" + imageLocation + "\" border=\"0\"/>";

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -399,7 +399,7 @@ class ViewMenu {
       final NumberProperty fontsize =
           new NumberProperty("Font Size", null, 60, 0, MapImage.getPropertyMapFont().getSize());
       final ColorProperty territoryNameColor = new ColorProperty("Territory Name and PU Color", null,
-          MapImage.getPropertyTerritoryNameAndPUAndCommentcolor());
+          MapImage.getPropertyTerritoryNameAndPuAndCommentColor());
       final ColorProperty unitCountColor =
           new ColorProperty("Unit Count Color", null, MapImage.getPropertyUnitCountColor());
       final ColorProperty factoryDamageColor =

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -71,7 +71,7 @@ public class TerritoryNameDrawable implements IDrawable {
     }
 
     graphics.setFont(MapImage.getPropertyMapFont());
-    graphics.setColor(MapImage.getPropertyTerritoryNameAndPUAndCommentcolor());
+    graphics.setColor(MapImage.getPropertyTerritoryNameAndPuAndCommentColor());
     final FontMetrics fm = graphics.getFontMetrics();
 
     // if we specify a placement point, use it otherwise try to center it
@@ -105,7 +105,7 @@ public class TerritoryNameDrawable implements IDrawable {
     }
     // draw the PUs.
     if (ta != null && ta.getProduction() > 0 && mapData.drawResources()) {
-      final Image img = uiContext.getPuImageFactory().getPUImage(ta.getProduction());
+      final Image img = uiContext.getPuImageFactory().getPuImage(ta.getProduction());
       final String prod = Integer.valueOf(ta.getProduction()).toString();
       final Optional<Point> place = mapData.getPuPlacementPoint(territory);
       // if pu_place.txt is specified draw there

--- a/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
+++ b/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
@@ -31,7 +31,7 @@ public class PlayerOrderComparator implements Comparator<PlayerID> {
       gameData.releaseReadLock();
     }
     for (final GameStep s : sequence) {
-      if (s.getPlayerID() == null) {
+      if (s.getPlayerId() == null) {
         continue;
       }
       final IDelegate delegate;
@@ -52,9 +52,9 @@ public class PlayerOrderComparator implements Comparator<PlayerID> {
       } else if (s.getName() != null && (s.getName().endsWith("Bid") || s.getName().endsWith("BidPlace"))) {
         continue;
       }
-      if (s.getPlayerID().equals(p1)) {
+      if (s.getPlayerId().equals(p1)) {
         return -1;
-      } else if (s.getPlayerID().equals(p2)) {
+      } else if (s.getPlayerId().equals(p2)) {
         return 1;
       }
     }

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -152,7 +152,7 @@ public final class EngineDataEqualityComparators {
       Unit.class,
       (context, o1, o2) -> gameDataComponentEquals(context, o1, o2)
           && (o1.getHits() == o2.getHits())
-          && context.equals(o1.getID(), o2.getID())
+          && context.equals(o1.getId(), o2.getId())
           && context.equals(o1.getOwner(), o2.getOwner())
           && context.equals(o1.getType(), o2.getType()));
 

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -170,7 +170,7 @@ public class GameSelectorModelTest {
     when(mockEntry.getGameData()).thenReturn(mockGameData);
     prepareMockGameDataExpectations();
     try {
-      when(mockEntry.getURI()).thenReturn(new URI("abc"));
+      when(mockEntry.getUri()).thenReturn(new URI("abc"));
     } catch (final URISyntaxException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -55,7 +55,7 @@ public class BattleCalculatorTest {
         territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
     assertEquals(1, randomSource.getTotalRolled());
@@ -73,7 +73,7 @@ public class BattleCalculatorTest {
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     TripleAUnit.get(planes.get(0)).setAlreadyMoved(1);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
   }
@@ -97,7 +97,7 @@ public class BattleCalculatorTest {
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
                 defendingAa, bridge, territory("Germany", data), true);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
@@ -126,7 +126,7 @@ public class BattleCalculatorTest {
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // two extra rolls to pick which units are hit
@@ -169,7 +169,7 @@ public class BattleCalculatorTest {
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
+        BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // we selected all bombers
@@ -208,7 +208,7 @@ public class BattleCalculatorTest {
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
+        BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // we selected all bombers
@@ -239,7 +239,7 @@ public class BattleCalculatorTest {
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // a second roll for choosing which unit
@@ -273,7 +273,7 @@ public class BattleCalculatorTest {
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
@@ -304,7 +304,7 @@ public class BattleCalculatorTest {
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 2 fighters and 1 bombers

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -148,7 +148,7 @@ public class WW2V3Year41Test {
                 Matches
                     .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
             defendingAa, bridge, territory("Germany", gameData), true);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
@@ -181,7 +181,7 @@ public class WW2V3Year41Test {
             defendingAa, bridge, territory("Germany", gameData), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 1 fighter and 2 bombers
@@ -216,7 +216,7 @@ public class WW2V3Year41Test {
     assertEquals(roll.getHits(), 2);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
+    final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in method names.

I avoided renaming methods which may be invoked via reflection (e.g. methods related to attachment properties).  In a few cases, I also reduced the accessibility of a method if it was possible to do so.

This is one part in a series of related PRs in order to keep the review size reasonable.