### PR TITLE
Edit Mode Add Unit Include Bonus Movement

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.remote.IEditDelegate;
@@ -110,6 +111,9 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     logEvent("Adding units owned by " + units.iterator().next().getOwner().getName() + " to " + territory.getName()
         + ": " + MyFormatter.unitsToTextNoOwner(units), units);
     m_bridge.addChange(ChangeFactory.addUnits(territory, units));
+    if (Properties.getUnitsMayGiveBonusMovement(getData()) && GameStepPropertiesHelper.isGiveBonusMovement(data)) {
+      m_bridge.addChange(MoveDelegate.giveBonusMovementToUnits(player, data, territory, units));
+    }
     if (mapLoading != null && !mapLoading.isEmpty()) {
       for (final Entry<Unit, Unit> entry : mapLoading.entrySet()) {
         m_bridge.addChange(TransportTracker.loadTransportChange((TripleAUnit) entry.getValue(), entry.getKey()));

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -367,7 +367,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     return change;
   }
 
-  public static Change giveBonusMovementToUnits(final PlayerID player, final GameData data, final Territory t,
+  static Change giveBonusMovementToUnits(final PlayerID player, final GameData data, final Territory t,
       final Collection<Unit> units) {
     final CompositeChange change = new CompositeChange();
     for (final Unit u : t.getUnits().getUnits()) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -362,41 +362,48 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final GameData data = bridge.getData();
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      for (final Unit u : t.getUnits().getUnits()) {
-        if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(t, player, data).match(u)) {
-          if (!Matches.isUnitAllied(player, data).match(u)) {
-            continue;
+      change.add(giveBonusMovementToUnits(player, data, t, t.getUnits().getUnits()));
+    }
+    return change;
+  }
+
+  public static Change giveBonusMovementToUnits(final PlayerID player, final GameData data, final Territory t,
+      final Collection<Unit> units) {
+    final CompositeChange change = new CompositeChange();
+    for (final Unit u : t.getUnits().getUnits()) {
+      if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(t, player, data).match(u)) {
+        if (!Matches.isUnitAllied(player, data).match(u)) {
+          continue;
+        }
+        int bonusMovement = Integer.MIN_VALUE;
+        final Collection<Unit> givesBonusUnits = new ArrayList<>();
+        final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
+            Matches.unitCanGiveBonusMovementToThisUnit(u));
+        givesBonusUnits.addAll(Matches.getMatches(t.getUnits().getUnits(), givesBonusUnit));
+        if (Matches.unitIsSea().match(u)) {
+          final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.unitIsLand());
+          final List<Territory> neighbors =
+              new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsLand()));
+          for (final Territory current : neighbors) {
+            givesBonusUnits.addAll(Matches.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
           }
-          int bonusMovement = Integer.MIN_VALUE;
-          final Collection<Unit> givesBonusUnits = new ArrayList<>();
-          final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
-              Matches.unitCanGiveBonusMovementToThisUnit(u));
-          givesBonusUnits.addAll(Matches.getMatches(t.getUnits().getUnits(), givesBonusUnit));
-          if (Matches.unitIsSea().match(u)) {
-            final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.unitIsLand());
-            final List<Territory> neighbors =
-                new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsLand()));
-            for (final Territory current : neighbors) {
-              givesBonusUnits.addAll(Matches.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
-            }
-          } else if (Matches.unitIsLand().match(u)) {
-            final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.unitIsSea());
-            final List<Territory> neighbors =
-                new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsWater()));
-            for (final Territory current : neighbors) {
-              givesBonusUnits.addAll(Matches.getMatches(current.getUnits().getUnits(), givesBonusUnitSea));
-            }
+        } else if (Matches.unitIsLand().match(u)) {
+          final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.unitIsSea());
+          final List<Territory> neighbors =
+              new ArrayList<>(data.getMap().getNeighbors(t, Matches.territoryIsWater()));
+          for (final Territory current : neighbors) {
+            givesBonusUnits.addAll(Matches.getMatches(current.getUnits().getUnits(), givesBonusUnitSea));
           }
-          for (final Unit bonusGiver : givesBonusUnits) {
-            final int tempBonus = UnitAttachment.get(bonusGiver.getType()).getGivesMovement().getInt(u.getType());
-            if (tempBonus > bonusMovement) {
-              bonusMovement = tempBonus;
-            }
+        }
+        for (final Unit bonusGiver : givesBonusUnits) {
+          final int tempBonus = UnitAttachment.get(bonusGiver.getType()).getGivesMovement().getInt(u.getType());
+          if (tempBonus > bonusMovement) {
+            bonusMovement = tempBonus;
           }
-          if (bonusMovement != Integer.MIN_VALUE && bonusMovement != 0) {
-            bonusMovement = Math.max(bonusMovement, (UnitAttachment.get(u.getType()).getMovement(player) * -1));
-            change.add(ChangeFactory.unitPropertyChange(u, bonusMovement, TripleAUnit.BONUS_MOVEMENT));
-          }
+        }
+        if (bonusMovement != Integer.MIN_VALUE && bonusMovement != 0) {
+          bonusMovement = Math.max(bonusMovement, (UnitAttachment.get(u.getType()).getMovement(player) * -1));
+          change.add(ChangeFactory.unitPropertyChange(u, bonusMovement, TripleAUnit.BONUS_MOVEMENT));
         }
       }
     }


### PR DESCRIPTION
Addresses #2372.

**Functional Changes**
When adding units through edit mode, make sure to give them bonus movement from other units such as airfields/harbors/etc. This checks to make sure the property UnitsMayGiveBonusMovement=true and current phase is marked to give bonus movement (usually combat move).

**Testing**
Manually tested on TWW by adding a tact bomber to a territory that has an airfield during combat move. Before the change, it has only 2 movement but after the change, it now correctly has 5 movement.

**Notes**
First commit is just refactoring to expose the appropriate method outside of MoveDelegate (no functional changes). Second commit is adding giveBonusMovement to edit mode add units.