### PR TITLE
Checkstyle: Fix abbreviation violations in method names (part 2)

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -133,7 +133,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     return m_whoAmI;
   }
 
-  public boolean isAI() {
+  public boolean isAi() {
     return m_whoAmI.split(":")[0].equalsIgnoreCase("AI");
   }
 

--- a/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -228,11 +228,11 @@ public class ResourceCollection extends GameDataComponent {
     return sb.toString().replaceFirst(lineSeparator, "");
   }
 
-  public String toStringForHTML() {
-    return toStringForHTML(m_resources, getData());
+  public String toStringForHtml() {
+    return toStringForHtml(m_resources, getData());
   }
 
-  public static String toStringForHTML(final IntegerMap<Resource> resources, final GameData data) {
+  public static String toStringForHtml(final IntegerMap<Resource> resources, final GameData data) {
     return toString(resources, data, "<br />");
   }
 

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -346,7 +346,7 @@ public class GameDataExporter {
     xmlfile.append("    </attachmentList>\n");
   }
 
-  private static String printAttachmentOptionsBasedOnOriginalXML(
+  private static String printAttachmentOptionsBasedOnOriginalXml(
       final ArrayList<Tuple<String, String>> attachmentPlusValues, final IAttachment attachment) {
     if (attachmentPlusValues.isEmpty()) {
       return "";
@@ -376,7 +376,7 @@ public class GameDataExporter {
     try {
       // TODO: none of the attachment exporter classes have been updated since TripleA version 1.3.2.2
       final String attachmentOptions;
-      attachmentOptions = printAttachmentOptionsBasedOnOriginalXML(attachmentPlusValues.getSecond(), attachment);
+      attachmentOptions = printAttachmentOptionsBasedOnOriginalXml(attachmentPlusValues.getSecond(), attachment);
       final NamedAttachable attachTo = (NamedAttachable) attachment.getAttachedTo();
       // TODO: keep this list updated
       String type = "";

--- a/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -37,7 +37,7 @@ public class SetupPanelModel extends Observable {
     setGameTypePanel(new LocalSetupPanel(m_gameSelectorModel));
   }
 
-  public void showPBEM() {
+  public void showPbem() {
     setGameTypePanel(new PBEMSetupPanel(m_gameSelectorModel));
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -120,7 +120,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void setupListeners() {
     startLocal.addActionListener(e -> model.showLocal());
-    startPbem.addActionListener(e -> model.showPBEM());
+    startPbem.addActionListener(e -> model.showPbem());
     hostGame.addActionListener(e -> model.showServer(MetaSetupPanel.this));
     connectToHostedGame.addActionListener(e -> model.showClient(MetaSetupPanel.this));
     connectToLobby.addActionListener(e -> connectToLobby());

--- a/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -56,7 +56,7 @@ public class RemoteRandom implements IRemoteRandom {
     m_annotation = annotation;
     m_max = max;
     m_localNumbers = m_plainRandom.getRandom(max, count, annotation);
-    m_game.getVault().waitForID(remoteVaultId, 15000);
+    m_game.getVault().waitForId(remoteVaultId, 15000);
     if (!m_game.getVault().knowsAbout(remoteVaultId)) {
       throw new IllegalStateException(
           "Vault id not known, have:" + m_game.getVault().knownIds() + " looking for:" + remoteVaultId);

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -300,7 +300,7 @@ public class Vault {
    * Waits until we know about a given vault id.
    * waits for at most timeout milliseconds
    */
-  public void waitForID(final VaultID id, final long timeoutMs) {
+  public void waitForId(final VaultID id, final long timeoutMs) {
     if (timeoutMs <= 0) {
       throw new IllegalArgumentException("Must suppply positive timeout argument");
     }

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -71,7 +71,7 @@ public class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("getmac");
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -86,7 +86,7 @@ public class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("ipconfig -all");
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -96,7 +96,7 @@ public class MacFinder {
     try {
       // ipconfig -all does not work on my computer, while ipconfig /all does not work on others computers
       final String results = executeCommandAndGetResults("ipconfig /all");
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -115,7 +115,7 @@ public class MacFinder {
       final String results = executeCommandAndGetResults("ifconfig -a");
       // Allow the parser to try adding a zero to
       // the beginning
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList(":", "-", "."), true);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), true);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -134,7 +134,7 @@ public class MacFinder {
       final String results = executeCommandAndGetResults("/sbin/ifconfig -a");
       // Allow the parser to try adding a zero to
       // the beginning
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList(":", "-", "."), true);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), true);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -150,7 +150,7 @@ public class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("dmesg");
-      final String mac = tryToParseMACFromOutput(results, Arrays.asList(":", "-", "."), false);
+      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -213,7 +213,7 @@ public class MacFinder {
     return !(periodCount != 5 || mac.equals("00.00.00.00.00.E0") || nonZeroNumberCount == 0);
   }
 
-  private static String tryToParseMACFromOutput(final String output, final List<String> possibleSeparators,
+  private static String tryToParseMacFromOutput(final String output, final List<String> possibleSeparators,
       final boolean allowAppendedZeroCheck) {
     if (output == null || output.trim().length() < 6) {
       return null;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -448,8 +448,8 @@ public class ProAI extends AbstractAI {
 
     // Calculate battle results
     final ProBattleResult result = calc.calculateBattleResults(unitTerritory, attackers, defenders, new HashSet<>());
-    ProLogger.debug(player.getName() + " sub attack TUVSwing=" + result.getTUVSwing());
-    return result.getTUVSwing() > 0;
+    ProLogger.debug(player.getName() + " sub attack TUVSwing=" + result.getTuvSwing());
+    return result.getTuvSwing() > 0;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -204,7 +204,7 @@ class ProCombatMoveAI {
       final int isNotNeutralAdjacentToMyCapital =
           (isAdjacentToMyCapital && ProMatches.territoryIsEnemyNotNeutralLand(player, data).match(t)) ? 1 : 0;
       final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 1 : 0;
-      final int isFfa = ProUtils.isFFA(data, player) ? 1 : 0;
+      final int isFfa = ProUtils.isFfa(data, player) ? 1 : 0;
 
       // Determine production value and if it is an enemy capital
       int production = 0;
@@ -218,7 +218,7 @@ class ProCombatMoveAI {
       }
 
       // Calculate attack value for prioritization
-      double tuvSwing = patd.getMaxBattleResult().getTUVSwing();
+      double tuvSwing = patd.getMaxBattleResult().getTuvSwing();
       if (isFfa == 1 && tuvSwing > 0) {
         tuvSwing *= 0.5;
       }
@@ -294,7 +294,7 @@ class ProCombatMoveAI {
 
     // Log prioritized territories
     for (final ProTerritory patd : attackOptions) {
-      ProLogger.debug("AttackValue=" + patd.getValue() + ", TUVSwing=" + patd.getMaxBattleResult().getTUVSwing()
+      ProLogger.debug("AttackValue=" + patd.getValue() + ", TUVSwing=" + patd.getMaxBattleResult().getTuvSwing()
           + ", isAmphib=" + patd.isNeedAmphibUnits() + ", " + patd.getTerritory().getName());
     }
     return attackOptions;
@@ -435,13 +435,13 @@ class ProCombatMoveAI {
         // Determine counter attack results to see if I can hold it
         final ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
             remainingUnitsToDefendWith, enemyAttackOptions.getMax(t).getMaxBombardUnits());
-        final boolean canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
+        final boolean canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTuvSwing() < 0)
             || (result2.getWinPercentage() < ProData.minWinPercentage);
         patd.setCanHold(canHold);
         ProLogger.debug(
             t + ", CanHold=" + canHold + ", MyDefenders=" + remainingUnitsToDefendWith.size() + ", EnemyAttackers="
                 + patd.getMaxEnemyUnits().size() + ", win%=" + result2.getWinPercentage() + ", EnemyTUVSwing="
-                + result2.getTUVSwing() + ", hasLandUnitRemaining=" + result2.isHasLandUnitRemaining());
+                + result2.getTuvSwing() + ", hasLandUnitRemaining=" + result2.isHasLandUnitRemaining());
       } else {
         attackMap.get(t).setCanHold(true);
         ProLogger.debug(t + ", CanHold=true since no enemy counter attackers, value=" + territoryValueMap.get(t)
@@ -645,14 +645,14 @@ class ProCombatMoveAI {
             final ProBattleResult minResult = calc.calculateBattleResults(unloadTerritory,
                 enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(),
                 territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>());
-            final double minTuvSwing = Math.min(result.getTUVSwing(), minResult.getTUVSwing());
+            final double minTuvSwing = Math.min(result.getTuvSwing(), minResult.getTuvSwing());
             if (minTuvSwing > 0) {
               enemyTuvSwing += minTuvSwing;
             }
             ProLogger.trace(unloadTerritory + ", EnemyAttackers=" + enemyAttackers.size() + ", MaxDefenders="
-                + defenders.size() + ", MaxEnemyTUVSwing=" + result.getTUVSwing() + ", MinDefenders="
+                + defenders.size() + ", MaxEnemyTUVSwing=" + result.getTuvSwing() + ", MinDefenders="
                 + territoryTransportAndBombardMap.get(unloadTerritory).size() + ", MinEnemyTUVSwing="
-                + minResult.getTUVSwing());
+                + minResult.getTuvSwing());
           } else {
             ProLogger.trace("Territory=" + unloadTerritory.getName() + " has no enemy attackers");
           }
@@ -670,7 +670,7 @@ class ProCombatMoveAI {
             isEnemyCapital = 1;
           }
         }
-        final double attackValue = result.getTUVSwing() + production * (1 + 3 * isEnemyCapital);
+        final double attackValue = result.getTuvSwing() + production * (1 + 3 * isEnemyCapital);
         if (!patd.isStrafing() && (0.75 * enemyTuvSwing) > attackValue) {
           ProLogger.debug("Removing amphib territory: " + patd.getTerritory() + ", enemyTUVSwing="
               + enemyTuvSwing + ", attackValue=" + attackValue);
@@ -849,7 +849,7 @@ class ProCombatMoveAI {
           final ProBattleResult result2 = calc.estimateAttackBattleResults(t, attackers,
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet());
           final double unitValue = ProData.unitValueMap.getInt(unit.getType());
-          if ((result2.getTUVSwing() - unitValue / 3) > result.getTUVSwing()) {
+          if ((result2.getTuvSwing() - unitValue / 3) > result.getTuvSwing()) {
             attackMap.get(t).addUnit(unit);
             attackMap.get(t).setBattleResult(null);
             it.remove();
@@ -883,26 +883,26 @@ class ProCombatMoveAI {
               Matches.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().invert());
           ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
               remainingUnitsToDefendWith, patd.getMaxBombardUnits());
-          if (patd.isCanHold() && result2.getTUVSwing() > 0) {
+          if (patd.isCanHold() && result2.getTuvSwing() > 0) {
             final List<Unit> unusedUnits = new ArrayList<>(patd.getMaxUnits());
             unusedUnits.addAll(patd.getMaxAmphibUnits());
             unusedUnits.removeAll(usedUnits);
             unusedUnits.addAll(remainingUnitsToDefendWith);
             final ProBattleResult result3 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(), unusedUnits,
                 patd.getMaxBombardUnits());
-            if (result3.getTUVSwing() < result2.getTUVSwing()) {
+            if (result3.getTuvSwing() < result2.getTuvSwing()) {
               result2 = result3;
               remainingUnitsToDefendWith = unusedUnits;
             }
           }
-          canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
+          canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTuvSwing() < 0)
               || (result2.getWinPercentage() < ProData.minWinPercentage);
-          if (result2.getTUVSwing() > 0) {
-            enemyCounterTuvSwing = result2.getTUVSwing();
+          if (result2.getTuvSwing() > 0) {
+            enemyCounterTuvSwing = result2.getTuvSwing();
           }
           ProLogger.trace("Territory=" + t.getName() + ", CanHold=" + canHold + ", MyDefenders="
               + remainingUnitsToDefendWith.size() + ", EnemyAttackers=" + patd.getMaxEnemyUnits().size() + ", win%="
-              + result2.getWinPercentage() + ", EnemyTUVSwing=" + result2.getTUVSwing() + ", hasLandUnitRemaining="
+              + result2.getWinPercentage() + ", EnemyTUVSwing=" + result2.getTuvSwing() + ", hasLandUnitRemaining="
               + result2.isHasLandUnitRemaining());
         }
 
@@ -912,7 +912,7 @@ class ProCombatMoveAI {
         final int isCanHold = canHold ? 1 : 0;
         final int isCantHoldAmphib = !canHold && !patd.getAmphibAttackMap().isEmpty() ? 1 : 0;
         final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 1 : 0;
-        final int isFfa = ProUtils.isFFA(data, player) ? 1 : 0;
+        final int isFfa = ProUtils.isFfa(data, player) ? 1 : 0;
         final int production = TerritoryAttachment.getProduction(t);
         double capitalValue = 0;
         final TerritoryAttachment ta = TerritoryAttachment.get(t);
@@ -922,7 +922,7 @@ class ProCombatMoveAI {
         final double territoryValue =
             (1 + isLand - isCantHoldAmphib + isFactory + isCanHold * (1 + 2 * isFfa + 2 * isFactory)) * production
                 + capitalValue;
-        double tuvSwing = result.getTUVSwing();
+        double tuvSwing = result.getTuvSwing();
         if (isFfa == 1 && tuvSwing > 0) {
           tuvSwing *= 0.5;
         }
@@ -1112,7 +1112,7 @@ class ProCombatMoveAI {
               Matches.territoryIsInList(ProUtils.getLiveAlliedCapitals(data, player))).match(t);
           final int range = TripleAUnit.get(unit).getMovementLeft();
           final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+              ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
           final boolean usesMoreThanHalfOfRange = distance > range / 2;
           if (isAirUnit && !isEnemyCapital && !isAdjacentToAlliedCapital && usesMoreThanHalfOfRange) {
             continue;
@@ -1169,7 +1169,7 @@ class ProCombatMoveAI {
               .match(t);
           final int range = TripleAUnit.get(unit).getMovementLeft();
           final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+              ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
           final boolean usesMoreThanHalfOfRange = distance > range / 2;
           final boolean territoryValueIsLessThanUnitValue =
               patd.getValue() < ProData.unitValueMap.getInt(unit.getType());
@@ -1490,7 +1490,7 @@ class ProCombatMoveAI {
       final ProBattleResult result = calc.estimateDefendBattleResults(myCapital,
           new ArrayList<>(enemyAttackingUnits), defenders, enemyAttackOptions.getMax(myCapital).getMaxBombardUnits());
       ProLogger.trace("Current capital result hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", TUVSwing="
-          + result.getTUVSwing() + ", defenders=" + defenders.size() + ", attackers=" + enemyAttackingUnits.size());
+          + result.getTuvSwing() + ", defenders=" + defenders.size() + ", attackers=" + enemyAttackingUnits.size());
 
       // Determine attack that uses the most units per value from capital and remove it
       if (result.isHasLandUnitRemaining()) {
@@ -1562,7 +1562,7 @@ class ProCombatMoveAI {
     // Print prioritization
     ProLogger.debug("Prioritized territories:");
     for (final ProTerritory attackTerritoryData : prioritizedTerritories) {
-      ProLogger.trace("  " + attackTerritoryData.getMaxBattleResult().getTUVSwing() + "  "
+      ProLogger.trace("  " + attackTerritoryData.getMaxBattleResult().getTuvSwing() + "  "
           + attackTerritoryData.getValue() + "  " + attackTerritoryData.getTerritory().getName());
     }
 
@@ -1658,7 +1658,7 @@ class ProCombatMoveAI {
         .territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
     final int range = TripleAUnit.get(unit).getMovementLeft();
     final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-        ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+        ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
     final boolean usesMoreThanHalfOfRange = distance > range / 2;
     return isAdjacentToAlliedFactory || !usesMoreThanHalfOfRange;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -68,7 +68,7 @@ public class ProData {
     minCostPerHitPoint = getMinCostPerHitPoint(purchaseOptions.getLandOptions());
   }
 
-  public static ProAI getProAI() {
+  public static ProAI getProAi() {
     return proAI;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -363,10 +363,10 @@ class ProNonCombatMoveAI {
       final ProBattleResult minResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
           minDefendingUnitsAndNotAa, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       patd.setMinBattleResult(minResult);
-      if (minResult.getTUVSwing() <= 0 && !minDefendingUnitsAndNotAa.isEmpty()) {
+      if (minResult.getTuvSwing() <= 0 && !minDefendingUnitsAndNotAa.isEmpty()) {
         ProLogger.debug("Territory=" + t.getName() + ", CanHold=true" + ", MinDefenders="
             + minDefendingUnitsAndNotAa.size() + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", win%="
-            + minResult.getWinPercentage() + ", EnemyTUVSwing=" + minResult.getTUVSwing() + ", hasLandUnitRemaining="
+            + minResult.getWinPercentage() + ", EnemyTUVSwing=" + minResult.getTuvSwing() + ", hasLandUnitRemaining="
             + minResult.isHasLandUnitRemaining());
         continue;
       }
@@ -392,11 +392,11 @@ class ProNonCombatMoveAI {
       final double extraUnitValue = TuvUtils.getTuv(extraUnits, ProData.unitValueMap);
       final double holdValue = extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2 * isMyCapital);
       if (minDefendingUnitsAndNotAa.size() != defendingUnitsAndNotAa.size()
-          && (result.getTUVSwing() - holdValue) < minResult.getTUVSwing()) {
+          && (result.getTuvSwing() - holdValue) < minResult.getTuvSwing()) {
         ProLogger
             .debug("Territory=" + t.getName() + ", CanHold=true" + ", MaxDefenders=" + defendingUnitsAndNotAa.size()
-                + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTUVSwing()
-                + ", win%=" + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTUVSwing()
+                + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTuvSwing()
+                + ", win%=" + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTuvSwing()
                 + ", hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", holdValue=" + holdValue);
         continue;
       }
@@ -404,8 +404,8 @@ class ProNonCombatMoveAI {
       // Can't hold territory
       patd.setCanHold(false);
       ProLogger.debug("Can't hold Territory=" + t.getName() + ", MaxDefenders=" + defendingUnitsAndNotAa.size()
-          + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTUVSwing() + ", win%="
-          + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTUVSwing() + ", hasLandUnitRemaining="
+          + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTuvSwing() + ", win%="
+          + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTuvSwing() + ", hasLandUnitRemaining="
           + result.isHasLandUnitRemaining() + ", holdValue=" + holdValue);
     }
   }
@@ -496,9 +496,9 @@ class ProNonCombatMoveAI {
       final boolean isLandAndCanOnlyBeAttackedByAir =
           !t.isWater() && !maxEnemyUnits.isEmpty() && Match.allMatch(maxEnemyUnits, Matches.unitIsAir());
       final boolean isNotFactoryAndShouldHold =
-          !hasFactory && (minResult.getTUVSwing() <= 0 || !minResult.isHasLandUnitRemaining());
+          !hasFactory && (minResult.getTuvSwing() <= 0 || !minResult.isHasLandUnitRemaining());
       final boolean canAlreadyBeHeld =
-          minResult.getTUVSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.winPercentage);
+          minResult.getTuvSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.winPercentage);
       final boolean isNotFactoryAndHasNoEnemyNeighbors = !t.isWater() && !hasFactory
           && !ProMatches
               .territoryHasNeighborOwnedByAndHasLandUnit(data, ProUtils.getPotentialEnemyPlayers(player))
@@ -507,7 +507,7 @@ class ProNonCombatMoveAI {
           && Match.noneMatch(moveMap.get(t).getMaxUnits(), Matches.unitIsLand()) && cantMoveUnitValue < 5;
       if (!patd.isCanHold() || patd.getValue() <= 0 || isLandAndCanOnlyBeAttackedByAir || isNotFactoryAndShouldHold
           || canAlreadyBeHeld || isNotFactoryAndHasNoEnemyNeighbors || isNotFactoryAndOnlyAmphib) {
-        final double tuvSwing = minResult.getTUVSwing();
+        final double tuvSwing = minResult.getTuvSwing();
         final boolean hasRemainingLandUnit = minResult.isHasLandUnitRemaining();
         ProLogger.debug("Removing territory=" + t.getName() + ", value=" + patd.getValue() + ", CanHold="
             + patd.isCanHold() + ", isLandAndCanOnlyBeAttackedByAir=" + isLandAndCanOnlyBeAttackedByAir
@@ -656,7 +656,7 @@ class ProNonCombatMoveAI {
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
-                  || result.getTUVSwing() >= 0)) {
+                  || result.getTuvSwing() >= 0)) {
             maxWinTerritory = t;
             maxWinPercentage = result.getWinPercentage();
           }
@@ -708,7 +708,7 @@ class ProNonCombatMoveAI {
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
-                  || result.getTUVSwing() >= 0)) {
+                  || result.getTuvSwing() >= 0)) {
             maxWinTerritory = t;
             maxWinPercentage = result.getWinPercentage();
           }
@@ -750,7 +750,7 @@ class ProNonCombatMoveAI {
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
-              if (result.getTUVSwing() > 0) {
+              if (result.getTuvSwing() > 0) {
                 moveMap.get(t).addTempUnit(transport);
                 moveMap.get(t).setBattleResult(null);
                 alreadyMovedTransports.add(transport);
@@ -797,7 +797,7 @@ class ProNonCombatMoveAI {
           final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
           if ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
               || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
-              || result.getTUVSwing() > 0) {
+              || result.getTuvSwing() > 0) {
 
             // Get all units that have already moved
             final List<Unit> alreadyMovedUnits = new ArrayList<>();
@@ -920,12 +920,12 @@ class ProNonCombatMoveAI {
         }
 
         // Check if its worth defending
-        if ((result.getTUVSwing() - holdValue) > patd.getMinBattleResult().getTUVSwing() || (!hasHigherStrategicValue
-            && (result.getTUVSwing() + extraUnitValue / 2) >= patd.getMinBattleResult().getTUVSwing())) {
+        if ((result.getTuvSwing() - holdValue) > patd.getMinBattleResult().getTuvSwing() || (!hasHigherStrategicValue
+            && (result.getTuvSwing() + extraUnitValue / 2) >= patd.getMinBattleResult().getTuvSwing())) {
           areSuccessful = false;
         }
         ProLogger.debug(patd.getResultString() + ", holdValue=" + holdValue + ", minTUVSwing="
-            + patd.getMinBattleResult().getTUVSwing() + ", hasHighStrategicValue=" + hasHigherStrategicValue
+            + patd.getMinBattleResult().getTuvSwing() + ", hasHighStrategicValue=" + hasHigherStrategicValue
             + ", defenders=" + defendingUnits + ", attackers=" + moveMap.get(t).getMaxEnemyUnits());
       }
 
@@ -1355,10 +1355,10 @@ class ProNonCombatMoveAI {
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
-              ProLogger.trace(t.getName() + " TUVSwing=" + result.getTUVSwing() + ", Win%=" + result.getWinPercentage()
+              ProLogger.trace(t.getName() + " TUVSwing=" + result.getTuvSwing() + ", Win%=" + result.getWinPercentage()
                   + ", enemyAttackers=" + moveMap.get(t).getMaxEnemyUnits().size() + ", defenders="
                   + defendingUnits.size());
-              if (result.getWinPercentage() > (100 - ProData.winPercentage) || result.getTUVSwing() > 0) {
+              if (result.getWinPercentage() > (100 - ProData.winPercentage) || result.getTuvSwing() > 0) {
                 ProLogger.trace(u + " added sea to defend transport at " + t);
                 moveMap.get(t).addTempUnit(u);
                 moveMap.get(t).setBattleResult(null);
@@ -1399,10 +1399,10 @@ class ProNonCombatMoveAI {
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
-              ProLogger.trace(t.getName() + " TUVSwing=" + result.getTUVSwing() + ", Win%=" + result.getWinPercentage()
+              ProLogger.trace(t.getName() + " TUVSwing=" + result.getTuvSwing() + ", Win%=" + result.getWinPercentage()
                   + ", enemyAttackers=" + moveMap.get(t).getMaxEnemyUnits().size() + ", defenders="
                   + defendingUnits.size());
-              if (result.getWinPercentage() > (100 - ProData.winPercentage) || result.getTUVSwing() > 0) {
+              if (result.getWinPercentage() > (100 - ProData.winPercentage) || result.getTuvSwing() > 0) {
                 ProLogger.trace(u + " added air to defend transport at " + t);
                 moveMap.get(t).addTempUnit(u);
                 moveMap.get(t).setBattleResult(null);
@@ -1515,7 +1515,7 @@ class ProNonCombatMoveAI {
           isWater = 1;
         }
         final double extraUnitValue = TuvUtils.getTuv(moveMap.get(t).getTempUnits(), ProData.unitValueMap);
-        final double holdValue = result.getTUVSwing() - (extraUnitValue / 8 * (1 + isWater));
+        final double holdValue = result.getTuvSwing() - (extraUnitValue / 8 * (1 + isWater));
 
         // Find min result without temp units
         final List<Unit> minDefendingUnits = new ArrayList<>(defendingUnits);
@@ -1524,17 +1524,17 @@ class ProNonCombatMoveAI {
             minDefendingUnits, moveMap.get(t).getMaxEnemyBombardUnits());
 
         // Check if territory is worth defending with temp units
-        if (holdValue > minResult.getTUVSwing()) {
+        if (holdValue > minResult.getTuvSwing()) {
           areSuccessful = false;
           moveMap.get(t).setCanHold(false);
           moveMap.get(t).setValue(0);
           moveMap.get(t).setSeaValue(0);
           ProLogger.trace(t + " unable to defend so removing with holdValue=" + holdValue + ", minTUVSwing="
-              + minResult.getTUVSwing() + ", defenders=" + defendingUnits + ", enemyAttackers="
+              + minResult.getTuvSwing() + ", defenders=" + defendingUnits + ", enemyAttackers="
               + moveMap.get(t).getMaxEnemyUnits());
         }
         ProLogger.trace(
-            moveMap.get(t).getResultString() + ", holdValue=" + holdValue + ", minTUVSwing=" + minResult.getTUVSwing());
+            moveMap.get(t).getResultString() + ", holdValue=" + holdValue + ", minTUVSwing=" + minResult.getTuvSwing());
       }
 
       // Determine whether to try more territories, remove a territory, or end
@@ -1758,9 +1758,9 @@ class ProNonCombatMoveAI {
               defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
         }
         final ProBattleResult result = moveMap.get(t).getBattleResult();
-        ProLogger.trace(t + ", TUVSwing=" + result.getTUVSwing() + ", win%=" + result.getWinPercentage()
+        ProLogger.trace(t + ", TUVSwing=" + result.getTuvSwing() + ", win%=" + result.getWinPercentage()
             + ", defendingUnits=" + defendingUnits + ", enemyAttackers=" + moveMap.get(t).getMaxEnemyUnits());
-        if (result.getWinPercentage() >= ProData.minWinPercentage || result.getTUVSwing() > 0) {
+        if (result.getWinPercentage() >= ProData.minWinPercentage || result.getTuvSwing() > 0) {
           moveMap.get(t).setCanHold(false);
           continue;
         }
@@ -1770,7 +1770,7 @@ class ProNonCombatMoveAI {
         final ProBattleResult result2 = calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
             myDefenders, moveMap.get(t).getMaxEnemyBombardUnits());
         int cantHoldWithoutAllies = 0;
-        if (result2.getWinPercentage() >= ProData.minWinPercentage || result2.getTUVSwing() > 0) {
+        if (result2.getWinPercentage() >= ProData.minWinPercentage || result2.getTuvSwing() > 0) {
           cantHoldWithoutAllies = 1;
         }
 
@@ -1877,7 +1877,7 @@ class ProNonCombatMoveAI {
                   defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
             }
             final ProBattleResult result = moveMap.get(t).getBattleResult();
-            if (result.getWinPercentage() >= ProData.minWinPercentage || result.getTUVSwing() > 0) {
+            if (result.getWinPercentage() >= ProData.minWinPercentage || result.getTuvSwing() > 0) {
               moveMap.get(t).setCanHold(false);
               continue;
             }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -172,7 +172,7 @@ class ProPurchaseAI {
 
       // Prioritize land place options purchase AA then land units
       final List<ProPlaceTerritory> prioritizedLandTerritories = prioritizeLandTerritories(purchaseTerritories);
-      purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
+      purchaseAaUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
       purchaseLandUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions, territoryValueMap);
 
       // Prioritize sea territories that need defended and purchase additional defenders
@@ -264,7 +264,7 @@ class ProPurchaseAI {
 
     // Prioritize land place options purchase AA then land units
     final List<ProPlaceTerritory> prioritizedLandTerritories = prioritizeLandTerritories(purchaseTerritories);
-    purchaseAAUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
+    purchaseAaUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions.getAaOptions());
     purchaseLandUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions, territoryValueMap);
 
     // Prioritize sea territories that need defended and purchase additional defenders
@@ -449,14 +449,14 @@ class ProPurchaseAI {
               ProData.unitValueMap);
           holdValue = unitValue / 8;
         }
-        ProLogger.trace(t.getName() + " TUVSwing=" + result.getTUVSwing() + ", win%=" + result.getWinPercentage()
+        ProLogger.trace(t.getName() + " TUVSwing=" + result.getTuvSwing() + ", win%=" + result.getWinPercentage()
             + ", hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", holdValue=" + holdValue
             + ", enemyAttackers=" + enemyAttackingUnits + ", defenders=" + placeTerritory.getDefendingUnits());
 
         // If it can't currently be held then add to list
         final boolean isLandAndCanOnlyBeAttackedByAir =
             !t.isWater() && !enemyAttackingUnits.isEmpty() && Match.allMatch(enemyAttackingUnits, Matches.unitIsAir());
-        if ((!t.isWater() && result.isHasLandUnitRemaining()) || result.getTUVSwing() > holdValue
+        if ((!t.isWater() && result.isHasLandUnitRemaining()) || result.getTuvSwing() > holdValue
             || (t.equals(ProData.myCapital) && !isLandAndCanOnlyBeAttackedByAir
                 && result.getWinPercentage() > (100 - ProData.winPercentage))) {
           needToDefendTerritories.add(placeTerritory);
@@ -616,9 +616,9 @@ class ProPurchaseAI {
               enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
           // Break if it can be held
-          if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTUVSwing() <= 0)
+          if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTuvSwing() <= 0)
               || (t.equals(ProData.myCapital) && finalResult.getWinPercentage() < (100 - ProData.winPercentage)
-                  && finalResult.getTUVSwing() <= 0)) {
+                  && finalResult.getTuvSwing() <= 0)) {
             break;
           }
         }
@@ -628,19 +628,19 @@ class ProPurchaseAI {
       final boolean hasLocalSuperiority =
           ProBattleUtils.territoryHasLocalLandSuperiority(t, ProBattleUtils.SHORT_RANGE, player, purchaseTerritories);
       if (!finalResult.isHasLandUnitRemaining()
-          || (finalResult.getTUVSwing() - resourceTracker.getTempPUs(data) / 2) < placeTerritory.getMinBattleResult()
-              .getTUVSwing()
+          || (finalResult.getTuvSwing() - resourceTracker.getTempPUs(data) / 2) < placeTerritory.getMinBattleResult()
+              .getTuvSwing()
           || t.equals(ProData.myCapital) || (!t.isWater() && hasLocalSuperiority)) {
         resourceTracker.confirmTempPurchases();
         ProLogger.trace(
-            t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + finalResult.getTUVSwing() + ", hasLandUnitRemaining="
+            t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + finalResult.getTuvSwing() + ", hasLandUnitRemaining="
                 + finalResult.isHasLandUnitRemaining() + ", hasLocalSuperiority=" + hasLocalSuperiority);
         addUnitsToPlaceTerritory(placeTerritory, unitsToPlace, purchaseTerritories);
       } else {
         resourceTracker.clearTempPurchases();
         setCantHoldPlaceTerritory(placeTerritory, purchaseTerritories);
         ProLogger.trace(t + ", unable to defend with placedUnits=" + unitsToPlace + ", TUVSwing="
-            + finalResult.getTUVSwing() + ", minTUVSwing=" + placeTerritory.getMinBattleResult().getTUVSwing());
+            + finalResult.getTuvSwing() + ", minTUVSwing=" + placeTerritory.getMinBattleResult().getTuvSwing());
       }
     }
   }
@@ -683,7 +683,7 @@ class ProPurchaseAI {
     return prioritizedLandTerritories;
   }
 
-  private void purchaseAAUnits(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+  private void purchaseAaUnits(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
       final List<ProPlaceTerritory> prioritizedLandTerritories, final List<ProPurchaseOption> specialPurchaseOptions) {
 
     if (resourceTracker.isEmpty()) {
@@ -926,15 +926,15 @@ class ProPurchaseAI {
             defenders, enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
         // Check if it can't be held or if it can then that it wasn't conquered this turn
-        if (result.isHasLandUnitRemaining() || result.getTUVSwing() > 0) {
+        if (result.isHasLandUnitRemaining() || result.getTuvSwing() > 0) {
           territoriesThatCantBeHeld.add(t);
           ProLogger.trace("Can't hold territory: " + t.getName() + ", hasLandUnitRemaining="
-              + result.isHasLandUnitRemaining() + ", TUVSwing=" + result.getTUVSwing() + ", enemyAttackers="
+              + result.isHasLandUnitRemaining() + ", TUVSwing=" + result.getTuvSwing() + ", enemyAttackers="
               + enemyAttackingUnits.size() + ", myDefenders=" + defenders.size());
         } else {
           purchaseFactoryTerritories.add(t);
           ProLogger.trace("Possible factory: " + t.getName() + ", hasLandUnitRemaining="
-              + result.isHasLandUnitRemaining() + ", TUVSwing=" + result.getTUVSwing() + ", enemyAttackers="
+              + result.isHasLandUnitRemaining() + ", TUVSwing=" + result.getTuvSwing() + ", enemyAttackers="
               + enemyAttackingUnits.size() + ", myDefenders=" + defenders.size());
         }
       }
@@ -1182,7 +1182,7 @@ class ProPurchaseAI {
 
             // If it can be held then break
             if (!hasOnlyRetreatingSubs
-                && (result.getTUVSwing() < -1 || result.getWinPercentage() < ProData.winPercentage)) {
+                && (result.getTuvSwing() < -1 || result.getWinPercentage() < ProData.winPercentage)) {
               break;
             }
 
@@ -1214,7 +1214,7 @@ class ProPurchaseAI {
             }
             ProLogger
                 .trace(t + ", added sea defender for defense: " + selectedOption.getUnitType().getName() + ", TUVSwing="
-                    + result.getTUVSwing() + ", win%=" + result.getWinPercentage() + ", unusedCarrierCapacity="
+                    + result.getTuvSwing() + ", win%=" + result.getWinPercentage() + ", unusedCarrierCapacity="
                     + unusedCarrierCapacity + ", unusedLocalCarrierCapacity=" + unusedLocalCarrierCapacity);
 
             // Find current battle result
@@ -1231,15 +1231,15 @@ class ProPurchaseAI {
         }
 
         // Check to see if its worth trying to defend the territory
-        if (result.getTUVSwing() < 0 || result.getWinPercentage() < ProData.winPercentage) {
+        if (result.getTuvSwing() < 0 || result.getWinPercentage() < ProData.winPercentage) {
           resourceTracker.confirmTempPurchases();
-          ProLogger.trace(t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + result.getTUVSwing()
+          ProLogger.trace(t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + result.getTuvSwing()
               + ", hasLandUnitRemaining=" + result.isHasLandUnitRemaining());
           addUnitsToPlaceTerritory(placeTerritory, unitsToPlace, purchaseTerritories);
         } else {
           resourceTracker.clearTempPurchases();
           setCantHoldPlaceTerritory(placeTerritory, purchaseTerritories);
-          ProLogger.trace(t + ", can't defend TUVSwing=" + result.getTUVSwing() + ", win%=" + result.getWinPercentage()
+          ProLogger.trace(t + ", can't defend TUVSwing=" + result.getTuvSwing() + ", win%=" + result.getWinPercentage()
               + ", tried to placeDefenders=" + unitsToPlace + ", enemyAttackers="
               + enemyAttackOptions.getMax(t).getMaxUnits());
           continue;
@@ -1849,23 +1849,23 @@ class ProPurchaseAI {
             enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
         // Break if it can be held
-        if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTUVSwing() <= 0)
+        if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTuvSwing() <= 0)
             || (t.equals(ProData.myCapital) && finalResult.getWinPercentage() < (100 - ProData.winPercentage)
-                && finalResult.getTUVSwing() <= 0)) {
+                && finalResult.getTuvSwing() <= 0)) {
           break;
         }
       }
 
       // Check to see if its worth trying to defend the territory
       if (!finalResult.isHasLandUnitRemaining()
-          || finalResult.getTUVSwing() < placeTerritory.getMinBattleResult().getTUVSwing()
+          || finalResult.getTuvSwing() < placeTerritory.getMinBattleResult().getTuvSwing()
           || t.equals(ProData.myCapital)) {
-        ProLogger.trace(t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + finalResult.getTUVSwing());
+        ProLogger.trace(t + ", placedUnits=" + unitsToPlace + ", TUVSwing=" + finalResult.getTuvSwing());
         doPlace(t, unitsToPlace, placeDelegate);
       } else {
         setCantHoldPlaceTerritory(placeTerritory, placeNonConstructionTerritories);
         ProLogger.trace(t + ", unable to defend with placedUnits=" + unitsToPlace + ", TUVSwing="
-            + finalResult.getTUVSwing() + ", minTUVSwing=" + placeTerritory.getMinBattleResult().getTUVSwing());
+            + finalResult.getTuvSwing() + ", minTUVSwing=" + placeTerritory.getMinBattleResult().getTuvSwing());
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -89,7 +89,7 @@ class ProRetreatAI {
     if (result.isHasLandUnitRemaining() || Match.noneMatch(attackers, Matches.unitIsAir())) {
       territoryValue = result.getWinPercentage() / 100 * (2 * production * (1 + isFactory) * (1 + isCapital));
     }
-    double battleValue = result.getTUVSwing() + territoryValue;
+    double battleValue = result.getTuvSwing() + territoryValue;
     if (!isAttacker) {
       battleValue = -battleValue;
     }
@@ -114,12 +114,12 @@ class ProRetreatAI {
         }
       }
       ProLogger.debug(player.getName() + " retreating from territory " + battleTerritory + " to " + retreatTerritory
-          + " because AttackValue=" + battleValue + ", TUVSwing=" + result.getTUVSwing() + ", possibleTerritories="
+          + " because AttackValue=" + battleValue + ", TUVSwing=" + result.getTuvSwing() + ", possibleTerritories="
           + possibleTerritories.size());
       return retreatTerritory;
     }
     ProLogger.debug(player.getName() + " not retreating from territory " + battleTerritory + " with AttackValue="
-        + battleValue + ", TUVSwing=" + result.getTUVSwing());
+        + battleValue + ", TUVSwing=" + result.getTuvSwing());
 
     return null;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
@@ -51,8 +51,8 @@ class ProScrambleAI {
     final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
     final ProBattleResult minResult = calc.calculateBattleResults(scrambleTo, attackers, defenders, bombardingUnits);
     ProLogger
-        .debug(scrambleTo + ", minTUVSwing=" + minResult.getTUVSwing() + ", minWin%=" + minResult.getWinPercentage());
-    if (minResult.getTUVSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.minWinPercentage)) {
+        .debug(scrambleTo + ", minTUVSwing=" + minResult.getTuvSwing() + ", minWin%=" + minResult.getWinPercentage());
+    if (minResult.getTuvSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.minWinPercentage)) {
       return null;
     }
 
@@ -78,8 +78,8 @@ class ProScrambleAI {
     defenders.addAll(allScramblers);
     final ProBattleResult maxResult = calc.calculateBattleResults(scrambleTo, attackers, defenders, bombardingUnits);
     ProLogger
-        .debug(scrambleTo + ", maxTUVSwing=" + maxResult.getTUVSwing() + ", maxWin%=" + maxResult.getWinPercentage());
-    if (maxResult.getTUVSwing() >= minResult.getTUVSwing()) {
+        .debug(scrambleTo + ", maxTUVSwing=" + maxResult.getTuvSwing() + ", maxWin%=" + maxResult.getWinPercentage());
+    if (maxResult.getTuvSwing() >= minResult.getTuvSwing()) {
       return null;
     }
 
@@ -114,13 +114,13 @@ class ProScrambleAI {
       final List<Unit> currentDefenders = (List<Unit>) battle.getDefendingUnits();
       currentDefenders.addAll(unitsToScramble);
       result = calc.calculateBattleResults(scrambleTo, attackers, currentDefenders, bombardingUnits);
-      ProLogger.debug(scrambleTo + ", TUVSwing=" + result.getTUVSwing() + ", Win%=" + result.getWinPercentage()
+      ProLogger.debug(scrambleTo + ", TUVSwing=" + result.getTuvSwing() + ", Win%=" + result.getWinPercentage()
           + ", addedUnit=" + u);
-      if (result.getTUVSwing() <= 0 && result.getWinPercentage() < (100 - ProData.minWinPercentage)) {
+      if (result.getTuvSwing() <= 0 && result.getWinPercentage() < (100 - ProData.minWinPercentage)) {
         break;
       }
     }
-    if (result.getTUVSwing() >= minResult.getTUVSwing()) {
+    if (result.getTuvSwing() >= minResult.getTuvSwing()) {
       return null;
     }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProBattleResult.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProBattleResult.java
@@ -38,7 +38,7 @@ public class ProBattleResult {
     return winPercentage;
   }
 
-  public double getTUVSwing() {
+  public double getTuvSwing() {
     return TUVSwing;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -297,7 +297,7 @@ public class ProTerritory {
       return "territory=" + territory.getName();
     } else {
       return "territory=" + territory.getName() + ", win%=" + battleResult.getWinPercentage() + ", TUVSwing="
-          + battleResult.getTUVSwing() + ", hasRemainingLandUnit=" + battleResult.isHasLandUnitRemaining();
+          + battleResult.getTuvSwing() + ", hasRemainingLandUnit=" + battleResult.isHasLandUnitRemaining();
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -119,7 +119,7 @@ public class ProTerritoryManager {
 
       // Check if I can win without amphib units and ignore AA since max units might have lots of planes
       List<Unit> defenders =
-          Matches.getMatches(patd.getMaxEnemyDefenders(player, data), ProMatches.unitIsEnemyAndNotAA(player, data));
+          Matches.getMatches(patd.getMaxEnemyDefenders(player, data), ProMatches.unitIsEnemyAndNotAa(player, data));
       if (isIgnoringRelationships) {
         defenders = new ArrayList<>(t.getUnits().getUnits());
       }
@@ -799,7 +799,7 @@ public class ProTerritoryManager {
         for (final Territory potentialTerritory : potentialTerritories) {
 
           // Find route ignoring impassable and territories with AA
-          Match<Territory> canFlyOverMatch = ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, isCombatMove);
+          Match<Territory> canFlyOverMatch = ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, isCombatMove);
           if (isCheckingEnemyAttacks) {
             canFlyOverMatch = ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove);
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
@@ -35,7 +35,7 @@ public class ProLogUI {
     settingsWindow.setVisible(true);
   }
 
-  static void notifyAILogMessage(final Level level, final String message) {
+  static void notifyAiLogMessage(final Level level, final String message) {
     if (settingsWindow == null) {
       return;
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogger.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogger.java
@@ -58,7 +58,7 @@ public class ProLogger {
     if (logDepth.equals(Level.FINER) && level.equals(Level.FINEST)) {
       return;
     }
-    ProLogUI.notifyAILogMessage(level, addIndentationCompensation(message, level));
+    ProLogUI.notifyAiLogMessage(level, addIndentationCompensation(message, level));
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -41,7 +41,7 @@ public class ProMatches {
         Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
-  public static Match<Territory> territoryCanMoveAirUnitsAndNoAA(final PlayerID player, final GameData data,
+  public static Match<Territory> territoryCanMoveAirUnitsAndNoAa(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.allOf(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
         Matches.territoryHasEnemyAaForAnything(player, data).invert());
@@ -444,7 +444,7 @@ public class ProMatches {
     return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAir());
   }
 
-  public static Match<Unit> unitIsEnemyAndNotAA(final PlayerID player, final GameData data) {
+  public static Match<Unit> unitIsEnemyAndNotAa(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAaForAnything().invert());
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -89,7 +89,7 @@ public class ProMoveUtils {
 
           // Air unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
-              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, isCombatMove));
+              ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, isCombatMove));
         }
         if (route == null) {
           ProLogger.warn(data.getSequence().getRound() + "-" + data.getSequence().getStep().getName()
@@ -286,7 +286,7 @@ public class ProMoveUtils {
         Route route = null;
         if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.unitIsAir())) {
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
-              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+              ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
         }
         moveRoutes.add(route);
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -71,7 +71,7 @@ public class ProPurchaseUtils {
     if (isBid) {
       placeDelegate = (AbstractPlaceDelegate) data.getDelegateList().getDelegate("placeBid");
     }
-    final IDelegateBridge bridge = new ProDummyDelegateBridge(ProData.getProAI(), player, data);
+    final IDelegateBridge bridge = new ProDummyDelegateBridge(ProData.getProAi(), player, data);
     placeDelegate.setDelegateBridgeAndPlayer(bridge);
     final String s = placeDelegate.canUnitsBePlaced(t, units, player);
     return s == null;

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -207,14 +207,14 @@ public class ProSortMoveOptionsUtils {
           for (final Territory t : o1.getValue()) {
             if (!attackMap.get(t).isCurrentlyWins()) {
               distance1 += data.getMap().getDistance_IgnoreEndForCondition(unitTerritoryMap.get(o1.getKey()), t,
-                  ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+                  ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
             }
           }
           int distance2 = 0;
           for (final Territory t : o2.getValue()) {
             if (!attackMap.get(t).isCurrentlyWins()) {
               distance2 += data.getMap().getDistance_IgnoreEndForCondition(unitTerritoryMap.get(o2.getKey()), t,
-                  ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+                  ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, true));
             }
           }
           if (distance1 != distance2) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -236,7 +236,7 @@ public class ProUtils {
    * Returns whether the game is a FFA based on whether any of the player's enemies
    * are enemies of each other.
    */
-  public static boolean isFFA(final GameData data, final PlayerID player) {
+  public static boolean isFfa(final GameData data, final PlayerID player) {
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
     final Set<PlayerID> enemies = relationshipTracker.getEnemies(player);
     for (final PlayerID enemy : enemies) {

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -781,7 +781,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (m_resources != null) {
         if (useHtml) {
           sb.append("&nbsp;&nbsp;&nbsp;&nbsp;")
-              .append((m_resources.toStringForHTML()).replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
+              .append((m_resources.toStringForHtml()).replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
         } else {
           sb.append(m_resources.toString());
         }

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -114,7 +114,7 @@ class AAInMoveUtil implements Serializable {
           // get rid of units already killed, so we don't target them twice
           validTargetedUnitsForThisRoll.removeAll(m_casualties);
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
-            dice[0] = DiceRoll.rollAA(validTargetedUnitsForThisRoll, currentPossibleAa, m_bridge, territory, true);
+            dice[0] = DiceRoll.rollAa(validTargetedUnitsForThisRoll, currentPossibleAa, m_bridge, territory, true);
           }
         }
       };

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -174,7 +174,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   }
 
   protected void showEndTurnReport(final String endTurnReport) {
-    if (endTurnReport != null && endTurnReport.trim().length() > 6 && !m_player.isAI()) {
+    if (endTurnReport != null && endTurnReport.trim().length() > 6 && !m_player.isAi()) {
       final ITripleAPlayer currentPlayer = getRemotePlayer(m_player);
       final String player = m_player.getName();
       currentPlayer.reportMessage("<html><b style=\"font-size:120%\" >" + END_TURN_REPORT_STRING + player

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -477,7 +477,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!at.isWater()) {
       return null;
     }
-    if (!canMoveExistingFightersToNewCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData())) {
+    if (!canMoveExistingFightersToNewCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData())) {
       return null;
     }
     if (Match.noneMatch(units, Matches.unitIsCarrier())) {
@@ -886,9 +886,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         placeableUnits.addAll(Matches.getMatches(units, Match.allOf(
             Matches.unitIsAir(),
             Matches.unitIsNotConstruction())));
-      } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
+      } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
           && Match.anyMatch(allProducedUnits, Matches.unitIsCarrier()))
-          || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
+          || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
               && Match.anyMatch(to.getUnits().getUnits(), Matches.unitIsCarrier()))) {
         placeableUnits.addAll(Matches.getMatches(units, Match.allOf(
             Matches.unitIsAir(),

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -164,7 +164,7 @@ public class AirMovementValidator {
         Matches.isUnitAllied(player, data), Matches.unitIsCarrier());
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
     // Matches.isUnitAllied(player, data), Matches.unitIsAir(), Matches.unitCanLandOnCarrier());
-    final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLHTRCarrierProduction(data)
+    final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     // final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
     final List<Unit> carriersInProductionQueue = player.getUnits().getMatches(Matches.unitIsCarrier());

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -27,7 +27,7 @@ public class AirThatCantLandUtil {
     m_bridge = bridge;
   }
 
-  public static boolean isLHTRCarrierProduction(final GameData data) {
+  public static boolean isLhtrCarrierProduction(final GameData data) {
     return Properties.getLHTRCarrierProductionRules(data);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -103,7 +103,7 @@ public class BattleCalculator {
     final GameData data = bridge.getData();
     final boolean allowMultipleHitsPerUnit =
         !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.unitAaShotDamageableInsteadOfKillingInstantly());
-    if (isChooseAA(data)) {
+    if (isChooseAa(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
       return selectCasualties(null, hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
           amphibiousLandAttackers, terr, territoryEffects, bridge, text, dice, defending, battleId, false,
@@ -114,10 +114,10 @@ public class BattleCalculator {
       } else {
         // priority goes: choose -> individually -> random
         // if none are set, we roll individually
-        if (isRollAAIndividually(data)) {
+        if (isRollAaIndividually(data)) {
           return individuallyFiredAaCasualties(defending, planes, defendingAa, dice, bridge, allowMultipleHitsPerUnit);
         }
-        if (isRandomAACasualties(data)) {
+        if (isRandomAaCasualties(data)) {
           return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
         }
         return individuallyFiredAaCasualties(defending, planes, defendingAa, dice, bridge, allowMultipleHitsPerUnit);
@@ -995,21 +995,21 @@ public class BattleCalculator {
   /**
    * @return Random AA Casualties - casualties randomly assigned.
    */
-  private static boolean isRandomAACasualties(final GameData data) {
+  private static boolean isRandomAaCasualties(final GameData data) {
     return Properties.getRandomAACasualties(data);
   }
 
   /**
    * @return Roll AA Individually - roll against each aircraft.
    */
-  private static boolean isRollAAIndividually(final GameData data) {
+  private static boolean isRollAaIndividually(final GameData data) {
     return Properties.getRollAAIndividually(data);
   }
 
   /**
    * @return Choose AA - attacker selects casualties.
    */
-  private static boolean isChooseAA(final GameData data) {
+  private static boolean isChooseAa(final GameData data) {
     return Properties.getChoose_AA_Casualties(data);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -112,7 +112,7 @@ public class DiceRoll implements Externalizable {
     return totalAAattacksNormal + totalAAattacksSurplus;
   }
 
-  static DiceRoll rollAA(final Collection<Unit> validAttackingUnitsForThisRoll,
+  static DiceRoll rollAa(final Collection<Unit> validAttackingUnitsForThisRoll,
       final Collection<Unit> defendingAaForThisRoll, final IDelegateBridge bridge, final Territory location,
       final boolean defending) {
     {
@@ -193,7 +193,7 @@ public class DiceRoll implements Externalizable {
       return Triple.of(0, 0, false);
     }
     // we want to make sure the higher powers fire
-    sortAAHighToLow(defendingAa, data, defending);
+    sortAaHighToLow(defendingAa, data, defending);
     // this is confusing, but what we want to do is the following:
     // any aa that are NOT infinite attacks, and NOT overstack, will fire first individually ((because their
     // power/dicesides might be
@@ -318,7 +318,7 @@ public class DiceRoll implements Externalizable {
     return Triple.of(totalPower, hits, (rolledAt.size() == 1));
   }
 
-  private static void sortAAHighToLow(final List<Unit> units, final GameData data, final boolean defending) {
+  private static void sortAaHighToLow(final List<Unit> units, final GameData data, final boolean defending) {
     final Comparator<Unit> comparator = (u1, u2) -> {
       final Tuple<Integer, Integer> tuple1 = getAAattackAndMaxDiceSides(Collections.singleton(u1), data, defending);
       final Tuple<Integer, Integer> tuple2 = getAAattackAndMaxDiceSides(Collections.singleton(u2), data, defending);

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -597,7 +597,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   private void removeAirThatCantLand() {
     final GameData data = getData();
-    final boolean lhtrCarrierProd = AirThatCantLandUtil.isLHTRCarrierProduction(data)
+    final boolean lhtrCarrierProd = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     boolean hasProducedCarriers = false;
     for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, m_player)) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -293,7 +293,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return m_attacker.getName() + " attack " + m_defender.getName() + " in " + m_battleSite.getName();
   }
 
-  private void updateDefendingAAUnits() {
+  private void updateDefendingAaUnits() {
     final Collection<Unit> canFire = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
     canFire.addAll(m_defendingUnits);
     canFire.addAll(m_defendingWaitingToDie);
@@ -308,7 +308,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     Collections.reverse(m_defendingAAtypes);
   }
 
-  private void updateOffensiveAAUnits() {
+  private void updateOffensiveAaUnits() {
     final Collection<Unit> canFire = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
     canFire.addAll(m_attackingUnits);
     canFire.addAll(m_attackingWaitingToDie);
@@ -360,8 +360,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     addDependentUnits(transporting(m_defendingUnits));
     addDependentUnits(transporting(m_attackingUnits));
     // determine any AA
-    updateOffensiveAAUnits();
-    updateDefendingAAUnits();
+    updateOffensiveAaUnits();
+    updateDefendingAaUnits();
     // list the steps
     m_stepStrings = determineStepStrings(true);
     final ITripleADisplay display = getDisplay(bridge);
@@ -978,8 +978,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (!m_isOver) {
           m_round++;
           // determine any AA
-          updateOffensiveAAUnits();
-          updateDefendingAAUnits();
+          updateOffensiveAaUnits();
+          updateDefendingAaUnits();
           m_stepStrings = determineStepStrings(false);
           final ITripleADisplay display = getDisplay(bridge);
           display.listBattleSteps(m_battleID, m_stepStrings);
@@ -2188,7 +2188,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
               m_dice =
-                  DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, m_defending);
+                  DiceRoll.rollAa(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, m_defending);
               if (!m_headless) {
                 if (currentTypeAa.equals("AA")) {
                   if (m_dice.getHits() > 0) {
@@ -2233,7 +2233,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyCasualtiesAA(bridge, currentTypeAa);
+              notifyCasualtiesAa(bridge, currentTypeAa);
               removeCasualties(m_casualties.getKilled(), ReturnFire.ALL, !m_defending, bridge, m_defending);
             }
           }
@@ -2257,7 +2257,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           m_amphibiousLandAttackers);
     }
 
-    private void notifyCasualtiesAA(final IDelegateBridge bridge, final String currentTypeAa) {
+    private void notifyCasualtiesAa(final IDelegateBridge bridge, final String currentTypeAa) {
       if (m_headless) {
         return;
       }
@@ -2295,14 +2295,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private boolean canFireDefendingAa() {
     if (m_defendingAA == null) {
-      updateDefendingAAUnits();
+      updateDefendingAaUnits();
     }
     return m_defendingAA.size() > 0;
   }
 
   private boolean canFireOffensiveAa() {
     if (m_offensiveAA == null) {
-      updateOffensiveAAUnits();
+      updateOffensiveAaUnits();
     }
     return m_offensiveAA.size() > 0;
   }

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -56,7 +56,7 @@ public class RocketsFireHelper {
     return Properties.getRocketAttacksPerFactoryInfinite(data);
   }
 
-  private static boolean isPUCap(final GameData data) {
+  private static boolean isPuCap(final GameData data) {
     return Properties.getPUCap(data);
   }
 
@@ -370,7 +370,7 @@ public class RocketsFireHelper {
       // in WW2V2, limit rocket attack cost to production value of factory.
     } else if (isWW2V2(data) || isLimitRocketDamageToProduction(data)) {
       // If we are limiting total PUs lost then take that into account
-      if (isPUCap(data) || isLimitRocketDamagePerTurn(data)) {
+      if (isPuCap(data) || isLimitRocketDamagePerTurn(data)) {
         final int alreadyLost = DelegateFinder.moveDelegate(data).pusAlreadyLost(attackedTerritory);
         territoryProduction -= alreadyLost;
         territoryProduction = Math.max(0, territoryProduction);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -227,7 +227,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               "Bombing raid costs " + m_bombingRaidTotal + " " + MyFormatter.pluralize("PU", m_bombingRaidTotal));
         }
         // TODO remove the reference to the constant.japanese- replace with a rule
-        if (isPacificTheater() || isSBRVictoryPoints()) {
+        if (isPacificTheater() || isSbrVictoryPoints()) {
           if (m_defender.getName().equals(Constants.PLAYER_NAME_JAPANESE)) {
             final Change changeVp;
             final PlayerAttachment pa = PlayerAttachment.get(m_defender);
@@ -369,7 +369,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              m_dice = DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, true);
+              m_dice = DiceRoll.rollAa(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, true);
               if (currentTypeAa.equals("AA")) {
                 if (m_dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT, m_defender);
@@ -410,7 +410,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyAAHits(bridge, m_dice, m_casualties, currentTypeAa);
+              notifyAaHits(bridge, m_dice, m_casualties, currentTypeAa);
             }
           }
         };
@@ -443,19 +443,19 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     return Properties.getWW2V2(m_data);
   }
 
-  private boolean isLimitSBRDamageToProduction() {
+  private boolean isLimitSbrDamageToProduction() {
     return Properties.getLimitRocketAndSBRDamageToProduction(m_data);
   }
 
-  private static boolean isLimitSBRDamagePerTurn(final GameData data) {
+  private static boolean isLimitSbrDamagePerTurn(final GameData data) {
     return Properties.getLimitSBRDamagePerTurn(data);
   }
 
-  private static boolean isPUCap(final GameData data) {
+  private static boolean isPuCap(final GameData data) {
     return Properties.getPUCap(data);
   }
 
-  private boolean isSBRVictoryPoints() {
+  private boolean isSbrVictoryPoints() {
     return Properties.getSBRVictoryPoint(m_data);
   }
 
@@ -490,7 +490,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     return casualties;
   }
 
-  private void notifyAAHits(final IDelegateBridge bridge, final DiceRoll dice, final CasualtyDetails casualties,
+  private void notifyAaHits(final IDelegateBridge bridge, final DiceRoll dice, final CasualtyDetails casualties,
       final String currentTypeAa) {
     getDisplay(bridge).casualtyNotification(m_battleID, REMOVE_PREFIX + currentTypeAa + CASUALTIES_SUFFIX, dice,
         m_attacker, new ArrayList<>(casualties.getKilled()), new ArrayList<>(casualties.getDamaged()),
@@ -696,7 +696,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       int cost = 0;
       final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(m_data);
       int index = 0;
-      final boolean limitDamage = isWW2V2() || isLimitSBRDamageToProduction();
+      final boolean limitDamage = isWW2V2() || isLimitSbrDamageToProduction();
       final List<Die> dice = new ArrayList<>();
       final HashMap<Unit, List<Die>> targetToDiceMap = new HashMap<>();
       // limit to maxDamage
@@ -751,7 +751,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       // Limit PUs lost if we would like to cap PUs lost at territory value
-      if (isPUCap(m_data) || isLimitSBRDamagePerTurn(m_data)) {
+      if (isPuCap(m_data) || isLimitSbrDamagePerTurn(m_data)) {
         final int alreadyLost = DelegateFinder.moveDelegate(m_data).pusAlreadyLost(m_battleSite);
         final int limit = Math.max(0, damageLimit - alreadyLost);
         cost = Math.min(cost, limit);

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -176,7 +176,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     return Properties.getSelectableTechRoll(getData());
   }
 
-  private boolean isLL_TECH_ONLY() {
+  private boolean isLowLuckTechOnly() {
     return Properties.getLL_TECH_ONLY(getData());
   }
 
@@ -217,7 +217,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       final ITripleAPlayer tripleaPlayer = getRemotePlayer();
       random = tripleaPlayer.selectFixedDice(techRolls, diceSides, true, annotation, diceSides);
       techHits = getTechHits(random);
-    } else if (isLL_TECH_ONLY()) {
+    } else if (isLowLuckTechOnly()) {
       techHits = techRolls / diceSides;
       remainder = techRolls % diceSides;
       if (remainder > 0) {
@@ -235,7 +235,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     }
     final boolean isRevisedModel = isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel());
     final String directedTechInfo = isRevisedModel ? " for " + techToRollFor.getTechs().get(0) : "";
-    final DiceRoll renderDice = (isLL_TECH_ONLY() ? new DiceRoll(random, techHits, remainder, false)
+    final DiceRoll renderDice = (isLowLuckTechOnly() ? new DiceRoll(random, techHits, remainder, false)
         : new DiceRoll(random, techHits, diceSides - 1, true));
     m_bridge.getHistoryWriter()
         .startEvent(

--- a/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -96,7 +96,7 @@ public class MapImage {
     propertyMapFont = font;
   }
 
-  public static void setPropertyTerritoryNameAndPUAndCommentcolor(final Color color) {
+  public static void setPropertyTerritoryNameAndPuAndCommentColor(final Color color) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING, color.getRGB());
     propertyTerritoryNameAndPuAndCommentColor = color;
@@ -126,7 +126,7 @@ public class MapImage {
     propertyMapFont = new Font("Ariel", Font.BOLD, 12);
   }
 
-  public static void resetPropertyTerritoryNameAndPUAndCommentcolor() {
+  public static void resetPropertyTerritoryNameAndPuAndCommentColor() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING);
     propertyTerritoryNameAndPuAndCommentColor = Color.black;

--- a/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -21,7 +21,7 @@ public class PlayersPanel {
         .build();
     for (final String player : game.getPlayerManager().getPlayers()) {
       final PlayerID playerId = game.getData().getPlayerList().getPlayerID(player);
-      if (playerId.isAI()) {
+      if (playerId.isAi()) {
         panel.add(new JLabel(playerId.getWhoAmI().split(":")[1] + " is " + playerId.getName(), JLabel.RIGHT));
       } else {
         panel.add(

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -271,10 +271,10 @@ public class ProductionPanel extends JPanel {
       final int numberOfUnitsGiven = rule.getResults().totalValues();
       final String text;
       if (numberOfUnitsGiven > 1) {
-        text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "<br>" + "for " + numberOfUnitsGiven
+        text = "<html> x " + ResourceCollection.toStringForHtml(cost, data) + "<br>" + "for " + numberOfUnitsGiven
             + "<br>" + " units</html>";
       } else {
-        text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "</html>";
+        text = "<html> x " + ResourceCollection.toStringForHtml(cost, data) + "</html>";
       }
       final JLabel label =
           icon.isPresent() ? new JLabel(text, icon.get(), SwingConstants.LEFT) : new JLabel(text, SwingConstants.LEFT);

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -245,7 +245,7 @@ public class ProductionRepairPanel extends JPanel {
       final TripleAUnit taUnit = (TripleAUnit) repairUnit;
       final Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(type, id,
           Matches.unitHasTakenSomeBombingUnitDamage().match(repairUnit), Matches.unitIsDisabled().match(repairUnit));
-      final String text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "</html>";
+      final String text = "<html> x " + ResourceCollection.toStringForHtml(cost, data) + "</html>";
 
       final JLabel label =
           icon.isPresent() ? new JLabel(text, icon.get(), SwingConstants.LEFT) : new JLabel(text, SwingConstants.LEFT);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -801,7 +801,7 @@ public class TripleAFrame extends MainGameFrame {
       sb.append("<li>").append(t.getName()).append("</li>");
     }
     sb.append("</ul></html>");
-    final boolean lhtrProd = AirThatCantLandUtil.isLHTRCarrierProduction(data)
+    final boolean lhtrProd = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     int carrierCount = 0;
     for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, id)) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -140,7 +140,7 @@ public class HelpMenu {
           i++;
           hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
               .append(">").append("<td>").append(getUnitImageUrl(ut, player, iuiContext)).append("</td>").append("<td>")
-              .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHTML())
+              .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHtml())
               .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
         }
         i++;

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -427,14 +427,14 @@ class ViewMenu {
           JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, 2);
       if (result == 1) {
         MapImage.resetPropertyMapFont();
-        MapImage.resetPropertyTerritoryNameAndPUAndCommentcolor();
+        MapImage.resetPropertyTerritoryNameAndPuAndCommentColor();
         MapImage.resetPropertyUnitCountColor();
         MapImage.resetPropertyUnitFactoryDamageColor();
         MapImage.resetPropertyUnitHitDamageColor();
         frame.getMapPanel().resetMap();
       } else if (result == 0) {
         MapImage.setPropertyMapFont(new Font("Ariel", Font.BOLD, fontsize.getValue()));
-        MapImage.setPropertyTerritoryNameAndPUAndCommentcolor((Color) territoryNameColor.getValue());
+        MapImage.setPropertyTerritoryNameAndPuAndCommentColor((Color) territoryNameColor.getValue());
         MapImage.setPropertyUnitCountColor((Color) unitCountColor.getValue());
         MapImage.setPropertyUnitFactoryDamageColor((Color) factoryDamageColor.getValue());
         MapImage.setPropertyUnitHitDamageColor((Color) hitDamageColor.getValue());

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -96,7 +96,7 @@ public class VaultTest {
   public void temporarilyDisabledSoPleaseRunManuallytestServerLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
     final VaultID id = serverVault.lock(data);
-    clientVault.waitForID(id, 1000);
+    clientVault.waitForId(id, 1000);
     assertTrue(clientVault.knowsAbout(id));
     serverVault.unlock(id);
     clientVault.waitForIdToUnlock(id, 1000);
@@ -110,7 +110,7 @@ public class VaultTest {
   public void testClientLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
     final VaultID id = clientVault.lock(data);
-    serverVault.waitForID(id, 1000);
+    serverVault.waitForId(id, 1000);
     assertTrue(serverVault.knowsAbout(id));
     clientVault.unlock(id);
     serverVault.waitForIdToUnlock(id, 1000);
@@ -129,8 +129,8 @@ public class VaultTest {
     final byte[] data2 = new byte[] {0xE, 0xF, 2, 1, 3, 1, 2, 12, 3, 31, 124, 12, 1};
     final VaultID id1 = serverVault.lock(data1);
     final VaultID id2 = serverVault.lock(data2);
-    clientVault.waitForID(id1, 2000);
-    clientVault.waitForID(id2, 2000);
+    clientVault.waitForId(id1, 2000);
+    clientVault.waitForId(id2, 2000);
     assertTrue(clientVault.knowsAbout(id1));
     assertTrue(clientVault.knowsAbout(id2));
     serverVault.unlock(id1);

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -92,7 +92,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -120,7 +120,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -163,7 +163,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -202,7 +202,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -232,7 +232,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -266,7 +266,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
@@ -297,7 +297,7 @@ public class BattleCalculatorTest {
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -230,11 +230,11 @@ public class DiceRollTest {
     // aa hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll hit =
-        DiceRoll.rollAA(bomber(gameData).create(1, british(gameData)), aaGunList, bridge, westRussia, true);
+        DiceRoll.rollAa(bomber(gameData).create(1, british(gameData)), aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
     // aa missses at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
-    final DiceRoll miss = DiceRoll.rollAA(bombers, aaGunList, bridge, westRussia, true);
+    final DiceRoll miss = DiceRoll.rollAa(bombers, aaGunList, bridge, westRussia, true);
     assertThat(miss.getHits(), is(0));
   }
 
@@ -254,7 +254,7 @@ public class DiceRollTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll hit =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
@@ -265,7 +265,7 @@ public class DiceRollTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll miss =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
@@ -277,7 +277,7 @@ public class DiceRollTest {
     fighterList = fighterType.create(6, russians);
     final DiceRoll hitNoRoll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
@@ -303,7 +303,7 @@ public class DiceRollTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll hit =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
@@ -330,7 +330,7 @@ public class DiceRollTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll hit =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches.unitIsOfTypes(
                         UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
@@ -340,7 +340,7 @@ public class DiceRollTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll miss =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
@@ -352,7 +352,7 @@ public class DiceRollTest {
     fighterList = fighterType.create(6, russians);
     final DiceRoll hitNoRoll =
         DiceRoll
-            .rollAA(
+            .rollAa(
                 Matches.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -143,7 +143,7 @@ public class WW2V3Year41Test {
     // don't allow rolling, 6 of each is deterministic
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
-        DiceRoll.rollAA(
+        DiceRoll.rollAa(
             Matches.getMatches(planes,
                 Matches
                     .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
@@ -174,7 +174,7 @@ public class WW2V3Year41Test {
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll.rollAA(
+        DiceRoll.rollAa(
             Matches.getMatches(planes,
                 Matches
                     .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
@@ -208,7 +208,7 @@ public class WW2V3Year41Test {
         new ScriptedRandomSource(new int[] {5, 0, 0, 0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll.rollAA(
+        DiceRoll.rollAa(
             Matches.getMatches(planes,
                 Matches
                     .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in method names.  In one case, I expanded the abbreviation `LL` to `LowLuck` because `Ll` looks even weirder than `Aa`. :smile:

I avoided renaming methods which may be invoked via reflection (e.g. methods related to attachment properties).

This is one part in a series of related PRs in order to keep the review size reasonable.