### PR TITLE
Checkstyle: Fix abbreviation violations in method names (part 3)

### DIFF
--- a/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -72,7 +72,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
         final List<Icon> icons = new ArrayList<>(players.size());
         for (final String player : players) {
           if (uiContext != null && uiContext.getFlagImageFactory() != null) {
-            icons.add(new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(playerList.getPlayerID(player))));
+            icons.add(new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(playerList.getPlayerId(player))));
           }
         }
         maxIconCounter = Math.max(maxIconCounter, icons.size());

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -248,7 +248,7 @@ public class GameData implements Serializable {
   public UnitHolder getUnitHolder(final String name, final String type) {
     ensureLockHeld();
     if (type.equals(UnitHolder.PLAYER)) {
-      return playerList.getPlayerID(name);
+      return playerList.getPlayerId(name);
     } else if (type.equals(UnitHolder.TERRITORY)) {
       return map.getTerritory(name);
     } else {

--- a/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -53,7 +53,7 @@ public class GameObjectStreamData implements Externalizable {
     try {
       switch (m_type) {
         case PLAYERID:
-          return data.getPlayerList().getPlayerID(m_name);
+          return data.getPlayerList().getPlayerId(m_name);
         case TERRITORY:
           return data.getMap().getTerritory(m_name);
         case UNITTYPE:

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -293,7 +293,7 @@ public class GameParser {
    */
   private PlayerID getPlayerId(final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
-    return getValidatedObject(element, attribute, mustFind, data.getPlayerList()::getPlayerID, "player");
+    return getValidatedObject(element, attribute, mustFind, data.getPlayerList()::getPlayerId, "player");
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -32,7 +32,7 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
     return m_players.size();
   }
 
-  public PlayerID getPlayerID(final String name) {
+  public PlayerID getPlayerId(final String name) {
     if (PlayerID.NULL_PLAYERID.getName().equals(name)) {
       return PlayerID.NULL_PLAYERID;
     }

--- a/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -90,26 +90,26 @@ public class PlayerManager {
     PlayerID local = null;
     for (final String player : m_playerMapping.keySet()) {
       if (m_playerMapping.get(player).equals(localNode)) {
-        local = data.getPlayerList().getPlayerID(player);
+        local = data.getPlayerList().getPlayerId(player);
         break;
       }
     }
     // we arent playing anyone, return any
     if (local == null) {
       final String remote = m_playerMapping.keySet().iterator().next();
-      return data.getPlayerList().getPlayerID(remote);
+      return data.getPlayerList().getPlayerId(remote);
     }
     String any = null;
     for (final String player : m_playerMapping.keySet()) {
       if (!m_playerMapping.get(player).equals(localNode)) {
         any = player;
-        final PlayerID remotePlayerId = data.getPlayerList().getPlayerID(player);
+        final PlayerID remotePlayerId = data.getPlayerList().getPlayerId(player);
         if (!data.getRelationshipTracker().isAllied(local, remotePlayerId)) {
           return remotePlayerId;
         }
       }
     }
     // no un allied players were found, any will do
-    return data.getPlayerList().getPlayerID(any);
+    return data.getPlayerList().getPlayerId(any);
   }
 }

--- a/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
@@ -35,7 +35,7 @@ class ChangeResourceChange extends Change {
   @Override
   protected void perform(final GameData data) {
     final Resource resource = data.getResourceList().getResource(m_resource);
-    final ResourceCollection resources = data.getPlayerList().getPlayerID(m_player).getResources();
+    final ResourceCollection resources = data.getPlayerList().getPlayerId(m_player).getResources();
     if (m_quantity > 0) {
       resources.addResource(resource, m_quantity);
     } else if (m_quantity < 0) {

--- a/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
@@ -43,7 +43,7 @@ class OwnerChange extends Change {
     if (name == null) {
       return null;
     }
-    return data.getPlayerList().getPlayerID(name);
+    return data.getPlayerList().getPlayerId(name);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -52,7 +52,7 @@ class PlayerOwnerChange extends Change {
         throw new IllegalStateException("Wrong owner, expecting" + m_old.get(id) + " but got " + unit.getOwner());
       }
       final String owner = m_new.get(id);
-      final PlayerID player = data.getPlayerList().getPlayerID(owner);
+      final PlayerID player = data.getPlayerList().getPlayerId(owner);
       unit.setOwner(player);
     }
     data.getMap().getTerritory(m_location).notifyChanged();

--- a/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
@@ -24,7 +24,7 @@ class PlayerWhoAmIChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    final PlayerID player = data.getPlayerList().getPlayerID(m_player);
+    final PlayerID player = data.getPlayerList().getPlayerId(m_player);
     player.setWhoAmI(m_endWhoAmI);
   }
 

--- a/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
@@ -28,7 +28,7 @@ class ProductionFrontierChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    final PlayerID player = data.getPlayerList().getPlayerID(m_player);
+    final PlayerID player = data.getPlayerList().getPlayerId(m_player);
     final ProductionFrontier frontier = data.getProductionFrontierList().getProductionFrontier(m_endFrontier);
     player.setProductionFrontier(frontier);
   }

--- a/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -41,14 +41,14 @@ class RelationshipChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    data.getRelationshipTracker().setRelationship(data.getPlayerList().getPlayerID(m_player1),
-        data.getPlayerList().getPlayerID(m_player2), data.getRelationshipTypeList().getRelationshipType(m_NewRelation));
+    data.getRelationshipTracker().setRelationship(data.getPlayerList().getPlayerId(m_player1),
+        data.getPlayerList().getPlayerId(m_player2), data.getRelationshipTypeList().getRelationshipType(m_NewRelation));
     // now redraw territories in case of new hostility
     if (Matches.relationshipTypeIsAtWar().match(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
       for (final Territory t : Matches.getMatches(data.getMap().getTerritories(),
           Match.allOf(
-              Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player1)),
-              Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player2))))) {
+              Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(m_player1)),
+              Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(m_player2))))) {
         t.notifyChanged();
       }
     }

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -65,7 +65,7 @@ public abstract class AbstractGame implements IGame {
   private void setupLocalPlayers(final Set<IGamePlayer> localPlayers) {
     final PlayerList playerList = m_data.getPlayerList();
     for (final IGamePlayer gp : localPlayers) {
-      final PlayerID player = playerList.getPlayerID(gp.getName());
+      final PlayerID player = playerList.getPlayerId(gp.getName());
       m_gamePlayers.put(player, gp);
       final IPlayerBridge bridge = new DefaultPlayerBridge(this);
       gp.initialize(bridge, player);

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -172,7 +172,7 @@ public class ClientGame extends AbstractGame {
         PlayerID player;
         m_data.acquireReadLock();
         try {
-          player = m_data.getPlayerList().getPlayerID(gp.getName());
+          player = m_data.getPlayerList().getPlayerId(gp.getName());
         } finally {
           m_data.releaseReadLock();
         }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -573,7 +573,7 @@ public class ServerGame extends AbstractGame {
                   + ((player.getName().endsWith("s") || player.getName().endsWith("ese")
                       || player.getName().endsWith("ish")) ? " are" : " is")
                   + " now being played by: " + player.getType());
-      final PlayerID p = data.getPlayerList().getPlayerID(player.getName());
+      final PlayerID p = data.getPlayerList().getPlayerId(player.getName());
       final String newWhoAmI = ((isHuman ? "Human" : "AI") + ":" + player.getType());
       if (!p.getWhoAmI().equals(newWhoAmI)) {
         change.add(ChangeFactory.changePlayerWhoAmIChange(p, newWhoAmI));
@@ -586,7 +586,7 @@ public class ServerGame extends AbstractGame {
       bridge.getHistoryWriter().addChildToEvent(
           player + ((player.endsWith("s") || player.endsWith("ese") || player.endsWith("ish")) ? " are" : " is")
               + " now being played by: Human:Client");
-      final PlayerID p = data.getPlayerList().getPlayerID(player);
+      final PlayerID p = data.getPlayerList().getPlayerId(player);
       final String newWhoAmI = "Human:Client";
       if (!p.getWhoAmI().equals(newWhoAmI)) {
         change.add(ChangeFactory.changePlayerWhoAmIChange(p, newWhoAmI));

--- a/src/main/java/games/strategy/triplea/ai/AIPoliticalUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIPoliticalUtils.java
@@ -78,8 +78,8 @@ public class AIPoliticalUtils {
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
       final String[] relationshipChange = relationshipChangeString.split(":");
-      final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
@@ -97,8 +97,8 @@ public class AIPoliticalUtils {
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
       final String[] relationshipChange = relationshipChangeString.split(":");
-      final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -200,7 +200,7 @@ public class ProAI extends AbstractAI {
         data.releaseReadLock();
       }
       calc.setData(dataCopy);
-      final PlayerID playerCopy = dataCopy.getPlayerList().getPlayerID(player.getName());
+      final PlayerID playerCopy = dataCopy.getPlayerList().getPlayerId(player.getName());
       final IMoveDelegate moveDel = DelegateFinder.moveDelegate(dataCopy);
       final IDelegateBridge bridge = new ProDummyDelegateBridge(this, playerCopy, dataCopy);
       moveDel.setDelegateBridgeAndPlayer(bridge);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -61,8 +61,8 @@ class ProPoliticsAI {
       final List<PlayerID> warPlayers = new ArrayList<>();
       for (final String relationshipChange : action.getRelationshipChange()) {
         final String[] s = relationshipChange.split(":");
-        final PlayerID player1 = data.getPlayerList().getPlayerID(s[0]);
-        final PlayerID player2 = data.getPlayerList().getPlayerID(s[1]);
+        final PlayerID player1 = data.getPlayerList().getPlayerId(s[0]);
+        final PlayerID player2 = data.getPlayerList().getPlayerId(s[1]);
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
         final RelationshipType newRelation = data.getRelationshipTypeList().getRelationshipType(s[2]);
         if (!oldRelation.equals(newRelation) && Matches.relationshipTypeIsAtWar().match(newRelation)

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -62,7 +62,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   public void setPlayers(final String names) throws GameParseException {
     final PlayerList pl = getData().getPlayerList();
     for (final String p : names.split(":")) {
-      final PlayerID player = pl.getPlayerID(p);
+      final PlayerID player = pl.getPlayerId(p);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + p + thisErrorMsg());
       }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -100,7 +100,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   public void setActionAccept(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_actionAccept.add(tempPlayer);
       } else {

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -427,7 +427,7 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setGiveUnitControl(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_giveUnitControl.add(tempPlayer);
       } else {
@@ -460,7 +460,7 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_captureUnitOnEnteringBy.add(tempPlayer);
       } else {
@@ -493,7 +493,7 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setShareTechnology(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_shareTechnology.add(tempPlayer);
       } else {
@@ -526,7 +526,7 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setHelpPayTechCost(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_helpPayTechCost.add(tempPlayer);
       } else {

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -87,11 +87,11 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:newRelation\n" + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[0]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[0]) == null) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
           + " unknown in: " + getName() + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[1]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[1]) == null) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
           + " unknown in: " + getName() + thisErrorMsg());
     }
@@ -126,8 +126,8 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     final HashSet<PlayerID> otherPlayers = new HashSet<>();
     for (final String relationshipChange : m_relationshipChange) {
       final String[] s = relationshipChange.split(":");
-      otherPlayers.add(getData().getPlayerList().getPlayerID(s[0]));
-      otherPlayers.add(getData().getPlayerList().getPlayerID(s[1]));
+      otherPlayers.add(getData().getPlayerList().getPlayerId(s[0]));
+      otherPlayers.add(getData().getPlayerList().getPlayerId(s[1]));
     }
     otherPlayers.remove((getAttachedTo()));
     return otherPlayers;

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -189,11 +189,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       throw new GameParseException(
           "battle must have at least 5 fields, attacker:defender:resultType:round:territory1..." + thisErrorMsg());
     }
-    final PlayerID attacker = getData().getPlayerList().getPlayerID(s[0]);
+    final PlayerID attacker = getData().getPlayerList().getPlayerId(s[0]);
     if (attacker == null && !s[0].equalsIgnoreCase("any")) {
       throw new GameParseException("no player named: " + s[0] + thisErrorMsg());
     }
-    final PlayerID defender = getData().getPlayerList().getPlayerID(s[1]);
+    final PlayerID defender = getData().getPlayerList().getPlayerId(s[1]);
     if (defender == null && !s[1].equalsIgnoreCase("any")) {
       throw new GameParseException("no player named: " + s[1] + thisErrorMsg());
     }
@@ -252,11 +252,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           "relationship should have value=\"playername1:playername2:relationshiptype:numberOfRoundsExisting\""
               + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[0]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[0]) == null) {
       throw new GameParseException(
           "playername: " + s[0] + " isn't valid in condition with relationship: " + value + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[1]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[1]) == null) {
       throw new GameParseException(
           "playername: " + s[1] + " isn't valid in condition with relationship: " + value + thisErrorMsg());
     }
@@ -574,7 +574,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     }
     m_atWarPlayers = new HashSet<>();
     for (int i = count == -1 ? 0 : 1; i < s.length; i++) {
-      final PlayerID player = getData().getPlayerList().getPlayerID(s[i]);
+      final PlayerID player = getData().getPlayerList().getPlayerId(s[i]);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + s[i] + thisErrorMsg());
       }
@@ -833,8 +833,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       for (final Tuple<String, ArrayList<Territory>> entry : m_battle) {
         final String[] type = entry.getFirst().split(":");
         // they could be "any", and if they are "any" then this would be null, which is good!
-        final PlayerID attacker = data.getPlayerList().getPlayerID(type[0]);
-        final PlayerID defender = data.getPlayerList().getPlayerID(type[1]);
+        final PlayerID attacker = data.getPlayerList().getPlayerId(type[0]);
+        final PlayerID defender = data.getPlayerList().getPlayerId(type[1]);
         final String resultType = type[2];
         final String roundType = type[3];
         int start = 0;
@@ -895,8 +895,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private boolean checkRelationships() {
     for (final String encodedRelationCheck : m_relationship) {
       final String[] relationCheck = encodedRelationCheck.split(":");
-      final PlayerID p1 = getData().getPlayerList().getPlayerID(relationCheck[0]);
-      final PlayerID p2 = getData().getPlayerList().getPlayerID(relationCheck[1]);
+      final PlayerID p1 = getData().getPlayerList().getPlayerId(relationCheck[0]);
+      final PlayerID p2 = getData().getPlayerList().getPlayerId(relationCheck[1]);
       final int relationshipsExistance = Integer.parseInt(relationCheck[3]);
       final Relationship currentRelationship = getData().getRelationshipTracker().getRelationship(p1, p2);
       final RelationshipType currentRelationshipType = currentRelationship.getRelationshipType();

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -56,7 +56,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final Territory current : data.getMap().getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final PlayerID whoseCapital = data.getPlayerList().getPlayerID(ta.getCapital());
+        final PlayerID whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
         if (whoseCapital == null) {
           throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
         }
@@ -94,7 +94,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final Territory current : data.getMap().getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final PlayerID whoseCapital = data.getPlayerList().getPlayerID(ta.getCapital());
+        final PlayerID whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
         if (whoseCapital == null) {
           throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
         }
@@ -121,7 +121,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final Territory current : data.getMap().getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final PlayerID whoseCapital = data.getPlayerList().getPlayerID(ta.getCapital());
+        final PlayerID whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
         if (whoseCapital == null) {
           throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
         }
@@ -288,7 +288,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       m_capital = null;
       return;
     }
-    final PlayerID p = getData().getPlayerList().getPlayerID(value);
+    final PlayerID p = getData().getPlayerList().getPlayerId(value);
     if (p == null) {
       throw new GameParseException("No Player named: " + value + thisErrorMsg());
     }
@@ -397,7 +397,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (player == null) {
       m_originalOwner = null;
     }
-    final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(player);
+    final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(player);
     if (tempPlayer == null) {
       throw new GameParseException("No player named: " + player + thisErrorMsg());
     }
@@ -437,7 +437,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void setChangeUnitOwners(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_changeUnitOwners.add(tempPlayer);
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
@@ -472,7 +472,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_captureUnitOnEnteringBy.add(tempPlayer);
       } else {
@@ -509,7 +509,7 @@ public class TerritoryAttachment extends DefaultAttachment {
           "whenCapturedByGoesTo must have 2 player names separated by a colon" + thisErrorMsg());
     }
     for (final String name : s) {
-      final PlayerID player = getData().getPlayerList().getPlayerID(name);
+      final PlayerID player = getData().getPlayerList().getPlayerId(name);
       if (player == null) {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -620,11 +620,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:oldRelation:newRelation\n" + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[0]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[0]) == null) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
           + " unknown " + thisErrorMsg());
     }
-    if (getData().getPlayerList().getPlayerID(s[1]) == null) {
+    if (getData().getPlayerList().getPlayerId(s[1]) == null) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
           + " unknown " + thisErrorMsg());
     }
@@ -892,7 +892,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public void setPlayers(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
-      final PlayerID player = getData().getPlayerList().getPlayerID(element);
+      final PlayerID player = getData().getPlayerList().getPlayerId(element);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
       }
@@ -1463,12 +1463,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
     }
     if (!s[1].equalsIgnoreCase("any")) {
-      final PlayerID oldOwner = getData().getPlayerList().getPlayerID(s[1]);
+      final PlayerID oldOwner = getData().getPlayerList().getPlayerId(s[1]);
       if (oldOwner == null) {
         throw new GameParseException("No such player: " + s[1] + thisErrorMsg());
       }
     }
-    final PlayerID newOwner = getData().getPlayerList().getPlayerID(s[2]);
+    final PlayerID newOwner = getData().getPlayerList().getPlayerId(s[2]);
     if (newOwner == null) {
       throw new GameParseException("No such player: " + s[2] + thisErrorMsg());
     }
@@ -1998,8 +1998,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
       for (final String relationshipChange : t.getRelationshipChange()) {
         final String[] s = relationshipChange.split(":");
-        final PlayerID player1 = data.getPlayerList().getPlayerID(s[0]);
-        final PlayerID player2 = data.getPlayerList().getPlayerID(s[1]);
+        final PlayerID player1 = data.getPlayerList().getPlayerId(s[0]);
+        final PlayerID player2 = data.getPlayerList().getPlayerId(s[1]);
         final RelationshipType currentRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
         if (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY)
             || (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
@@ -2266,8 +2266,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           territories.add(territorySet);
         }
         // if null, then is must be "any", so then any player
-        final PlayerID oldOwner = data.getPlayerList().getPlayerID(s[1]);
-        final PlayerID newOwner = data.getPlayerList().getPlayerID(s[2]);
+        final PlayerID oldOwner = data.getPlayerList().getPlayerId(s[1]);
+        final PlayerID newOwner = data.getPlayerList().getPlayerId(s[2]);
         final boolean captured = getBool(s[3]);
         for (final Territory terr : territories) {
           final PlayerID currentOwner = terr.getOwner();

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -370,7 +370,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setCanBeGivenByTerritoryTo(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_canBeGivenByTerritoryTo.add(tempPlayer);
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
@@ -405,7 +405,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setCanBeCapturedOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_canBeCapturedOnEnteringBy.add(tempPlayer);
       } else {
@@ -442,11 +442,11 @@ public class UnitAttachment extends DefaultAttachment {
           + "playerFrom:playerTo:keepAttributes:unitType:howMany "
           + "(you may have additional unitType:howMany:unitType:howMany, etc" + thisErrorMsg());
     }
-    final PlayerID pfrom = getData().getPlayerList().getPlayerID(s[0]);
+    final PlayerID pfrom = getData().getPlayerList().getPlayerId(s[0]);
     if (pfrom == null && !s[0].equals("any")) {
       throw new GameParseException("whenCapturedChangesInto: No player named: " + s[0] + thisErrorMsg());
     }
-    final PlayerID pto = getData().getPlayerList().getPlayerID(s[1]);
+    final PlayerID pto = getData().getPlayerList().getPlayerId(s[1]);
     if (pto == null && !s[1].equals("any")) {
       throw new GameParseException("whenCapturedChangesInto: No player named: " + s[1] + thisErrorMsg());
     }
@@ -490,16 +490,16 @@ public class UnitAttachment extends DefaultAttachment {
     // this is called by
     // destroyedWhenCapturedBy
     String byOrFrom = "BY";
-    if (value.startsWith("BY:") && getData().getPlayerList().getPlayerID("BY") == null) {
+    if (value.startsWith("BY:") && getData().getPlayerList().getPlayerId("BY") == null) {
       byOrFrom = "BY";
       value = value.replaceFirst("BY:", "");
-    } else if (value.startsWith("FROM:") && getData().getPlayerList().getPlayerID("FROM") == null) {
+    } else if (value.startsWith("FROM:") && getData().getPlayerList().getPlayerId("FROM") == null) {
       byOrFrom = "FROM";
       value = value.replaceFirst("FROM:", "");
     }
     final String[] temp = value.split(":");
     for (final String name : temp) {
-      final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(name);
+      final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
         m_destroyedWhenCapturedBy.add(Tuple.of(byOrFrom, tempPlayer));
       } else {

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -251,7 +251,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   public void setPlayers(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
-      final PlayerID player = getData().getPlayerList().getPlayerID(element);
+      final PlayerID player = getData().getPlayerList().getPlayerId(element);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
       } else {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -569,7 +569,7 @@ public class BattleTracker implements Serializable {
     // instead it is relying on the fact that the capital should be owned by the person it is attached to
     if (isTerritoryOwnerAnEnemy && ta.getCapital() != null) {
       // if the capital is owned by the capitols player take the money
-      final PlayerID whoseCapital = data.getPlayerList().getPlayerID(ta.getCapital());
+      final PlayerID whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
       final PlayerAttachment pa = PlayerAttachment.get(id);
       final PlayerAttachment paWhoseCapital = PlayerAttachment.get(whoseCapital);
       final List<Territory> capitalsList =
@@ -652,8 +652,8 @@ public class BattleTracker implements Serializable {
     if (isTerritoryOwnerAnEnemy && newOwner.equals(id) && Matches.territoryHasWhenCapturedByGoesTo().match(territory)) {
       for (final String value : ta.getWhenCapturedByGoesTo()) {
         final String[] s = value.split(":");
-        final PlayerID capturingPlayer = data.getPlayerList().getPlayerID(s[0]);
-        final PlayerID goesToPlayer = data.getPlayerList().getPlayerID(s[1]);
+        final PlayerID capturingPlayer = data.getPlayerList().getPlayerId(s[0]);
+        final PlayerID goesToPlayer = data.getPlayerList().getPlayerId(s[1]);
         if (capturingPlayer.equals(goesToPlayer)) {
           continue;
         }
@@ -796,11 +796,11 @@ public class BattleTracker implements Serializable {
         final PlayerID currentOwner = u.getOwner();
         for (final String value : map.keySet()) {
           final String[] s = value.split(":");
-          if (!(s[0].equals("any") || data.getPlayerList().getPlayerID(s[0]).equals(currentOwner))) {
+          if (!(s[0].equals("any") || data.getPlayerList().getPlayerId(s[0]).equals(currentOwner))) {
             continue;
           }
           // we could use "id" or "newOwner" here... not sure which to use
-          if (!(s[1].equals("any") || data.getPlayerList().getPlayerID(s[1]).equals(id))) {
+          if (!(s[1].equals("any") || data.getPlayerList().getPlayerId(s[1]).equals(id))) {
             continue;
           }
           final CompositeChange changes = new CompositeChange();

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -55,7 +55,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     String victoryMessage = null;
     final GameData data = getData();
     if (isPacificTheater()) {
-      final PlayerID japanese = data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_JAPANESE);
+      final PlayerID japanese = data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_JAPANESE);
       final PlayerAttachment pa = PlayerAttachment.get(japanese);
       if (pa != null && pa.getVps() >= 22) {
         victoryMessage = "Axis achieve VP victory";
@@ -132,11 +132,11 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     }
     final PlayerList playerList = data.getPlayerList();
     // now test older maps that only use these 5 players, to see if someone has won
-    final PlayerID russians = playerList.getPlayerID(Constants.PLAYER_NAME_RUSSIANS);
-    final PlayerID germans = playerList.getPlayerID(Constants.PLAYER_NAME_GERMANS);
-    final PlayerID british = playerList.getPlayerID(Constants.PLAYER_NAME_BRITISH);
-    final PlayerID japanese = playerList.getPlayerID(Constants.PLAYER_NAME_JAPANESE);
-    final PlayerID americans = playerList.getPlayerID(Constants.PLAYER_NAME_AMERICANS);
+    final PlayerID russians = playerList.getPlayerId(Constants.PLAYER_NAME_RUSSIANS);
+    final PlayerID germans = playerList.getPlayerId(Constants.PLAYER_NAME_GERMANS);
+    final PlayerID british = playerList.getPlayerId(Constants.PLAYER_NAME_BRITISH);
+    final PlayerID japanese = playerList.getPlayerId(Constants.PLAYER_NAME_JAPANESE);
+    final PlayerID americans = playerList.getPlayerId(Constants.PLAYER_NAME_AMERICANS);
     if (germans == null || russians == null || british == null || japanese == null || americans == null
         || playerList.size() > 5) {
       return;

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -45,7 +45,7 @@ public class GameStepPropertiesHelper {
       if (allowedPlayers != null) {
         allowedIDs = new HashSet<>();
         for (final String p : allowedPlayers.split(":")) {
-          final PlayerID id = data.getPlayerList().getPlayerID(p);
+          final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
                 + GameStep.PROPERTY_turnSummaryPlayers + " player: " + p + " DOES NOT EXIST");
@@ -241,7 +241,7 @@ public class GameStepPropertiesHelper {
       }
       if (allowedPlayers != null) {
         for (final String p : allowedPlayers.split(":")) {
-          final PlayerID id = data.getPlayerList().getPlayerID(p);
+          final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
                 + GameStep.PROPERTY_combinedTurns + " player: " + p + " DOES NOT EXIST");
@@ -325,7 +325,7 @@ public class GameStepPropertiesHelper {
       }
       if (allowedPlayers != null) {
         for (final String p : allowedPlayers.split(":")) {
-          final PlayerID id = data.getPlayerList().getPlayerID(p);
+          final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
                 + GameStep.PROPERTY_repairPlayers + " player: " + p + " DOES NOT EXIST");

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2278,8 +2278,8 @@ public final class Matches {
     return Match.of(paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
         final String[] relationshipChange = relationshipChangeString.split(":");
-        final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-        final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
         if (player != null && !(p1.equals(player) || p2.equals(player))) {
           continue;
         }
@@ -2298,8 +2298,8 @@ public final class Matches {
     return Match.of(paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
         final String[] relationshipChange = relationshipChangeString.split(":");
-        final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-        final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
         if (!currentPlayer.equals(p1)) {
           if (p1.amNotDeadYet(data)) {
             return true;

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -360,8 +360,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChange : paa.getRelationshipChange()) {
       final String[] s = relationshipChange.split(":");
-      final PlayerID player1 = getData().getPlayerList().getPlayerID(s[0]);
-      final PlayerID player2 = getData().getPlayerList().getPlayerID(s[1]);
+      final PlayerID player1 = getData().getPlayerList().getPlayerId(s[0]);
+      final PlayerID player2 = getData().getPlayerList().getPlayerId(s[1]);
       final RelationshipType oldRelation = getData().getRelationshipTracker().getRelationshipType(player1, player2);
       final RelationshipType newRelation = getData().getRelationshipTypeList().getRelationshipType(s[2]);
       if (oldRelation.equals(newRelation)) {
@@ -431,8 +431,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
       final String[] relationshipChange = relationshipChangeString.split(":");
-      final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
@@ -473,8 +473,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
       final String[] relationshipChange = relationshipChangeString.split(":");
-      final PlayerID p1 = data.getPlayerList().getPlayerID(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerID(relationshipChange[1]);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -420,7 +420,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              removeAAHits(bridge, m_casualties, currentTypeAa);
+              removeAaHits(bridge, m_casualties, currentTypeAa);
             }
           }
         };
@@ -521,7 +521,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
   }
 
-  private void removeAAHits(final IDelegateBridge bridge, final CasualtyDetails casualties,
+  private void removeAaHits(final IDelegateBridge bridge, final CasualtyDetails casualties,
       final String currentTypeAa) {
     final List<Unit> killed = casualties.getKilled();
     if (!killed.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -131,9 +131,9 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       throw new IllegalStateException("Called set calculation before setting game data!");
     }
     this.attacker =
-        gameData.getPlayerList().getPlayerID(attacker == null ? PlayerID.NULL_PLAYERID.getName() : attacker.getName());
+        gameData.getPlayerList().getPlayerId(attacker == null ? PlayerID.NULL_PLAYERID.getName() : attacker.getName());
     this.defender =
-        gameData.getPlayerList().getPlayerID(defender == null ? PlayerID.NULL_PLAYERID.getName() : defender.getName());
+        gameData.getPlayerList().getPlayerId(defender == null ? PlayerID.NULL_PLAYERID.getName() : defender.getName());
     this.location = gameData.getMap().getTerritory(location.getName());
     attackingUnits = GameDataUtils.translateIntoOtherGameData(attacking, gameData);
     defendingUnits = GameDataUtils.translateIntoOtherGameData(defending, gameData);

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -210,7 +210,7 @@ public class ObjectivePanel extends AbstractStatPanel {
         if (key[0].startsWith(ObjectiveProperties.GROUP_PROPERTY)) {
           continue;
         }
-        final PlayerID player = gameData.getPlayerList().getPlayerID(key[0]);
+        final PlayerID player = gameData.getPlayerList().getPlayerId(key[0]);
         if (player == null) {
           // could be an old map, or an old save, so we don't want to stop the game from running.
           System.err.println("objective.properties player does not exist: " + key[0]);

--- a/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -20,7 +20,7 @@ public class PlayersPanel {
         .verticalBoxLayout()
         .build();
     for (final String player : game.getPlayerManager().getPlayers()) {
-      final PlayerID playerId = game.getData().getPlayerList().getPlayerID(player);
+      final PlayerID playerId = game.getData().getPlayerList().getPlayerId(player);
       if (playerId.isAi()) {
         panel.add(new JLabel(playerId.getWhoAmI().split(":")[1] + " is " + playerId.getName(), JLabel.RIGHT));
       } else {

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -258,10 +258,10 @@ public class PoliticsPanel extends ActionPanel {
       final RelationshipType paa1NewType = relationshipTypeList.getRelationshipType(paa1RelationChange[2]);
       final RelationshipType paa2NewType = relationshipTypeList.getRelationshipType(paa2RelationChange[2]);
       // sort by player
-      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerID(paa1RelationChange[0]);
-      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerID(paa1RelationChange[1]);
-      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerID(paa2RelationChange[0]);
-      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerID(paa2RelationChange[1]);
+      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerId(paa1RelationChange[0]);
+      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerId(paa1RelationChange[1]);
+      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerId(paa2RelationChange[0]);
+      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerId(paa2RelationChange[1]);
       final PlayerID paa1OtherPlayer = (player.equals(paa1p1) ? paa1p2 : paa1p1);
       final PlayerID paa2OtherPlayer = (player.equals(paa2p1) ? paa2p2 : paa2p1);
       if (!paa1OtherPlayer.equals(paa2OtherPlayer)) {

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -141,7 +141,7 @@ public class StatPanel extends AbstractStatPanel {
   }
 
   protected ImageIcon getIcon(final String playerName) {
-    final PlayerID player = gameData.getPlayerList().getPlayerID(playerName);
+    final PlayerID player = gameData.getPlayerList().getPlayerId(playerName);
     if (player == null) {
       return null;
     }

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -179,7 +179,7 @@ class ExportMenu {
       // the players for the stat panel are only relevant with respect to
       // the game data they belong to
       for (int i = 0; i < players.length; i++) {
-        players[i] = clone.getPlayerList().getPlayerID(players[i].getName());
+        players[i] = clone.getPlayerList().getPlayerId(players[i].getName());
       }
       text.append(defaultFileName + ",");
       text.append("\n");

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -309,7 +309,7 @@ public class TileManager {
     }
     drawing.add(new TerritoryNameDrawable(territory.getName(), uiContext));
     if (ta != null && ta.isCapital() && mapData.drawCapitolMarkers()) {
-      final PlayerID capitalOf = data.getPlayerList().getPlayerID(ta.getCapital());
+      final PlayerID capitalOf = data.getPlayerList().getPlayerId(ta.getCapital());
       drawing.add(new CapitolMarkerDrawable(capitalOf, territory, uiContext));
     }
     if (ta != null && (ta.getVictoryCity() != 0)) {

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -89,7 +89,7 @@ public class UnitsDrawer implements IDrawable {
     if (type == null) {
       throw new IllegalStateException("Type not found:" + unitType);
     }
-    final PlayerID owner = data.getPlayerList().getPlayerID(playerName);
+    final PlayerID owner = data.getPlayerList().getPlayerId(playerName);
     final Optional<Image> img =
         uiContext.getUnitImageFactory().getImage(type, owner, damaged > 0 || bombingUnitDamage > 0, disabled);
 
@@ -215,7 +215,7 @@ public class UnitsDrawer implements IDrawable {
     final UnitType type = data.getUnitTypeList().getUnitType(unitType);
     final Match.CompositeBuilder<Unit> selectedUnitsBuilder = Match.newCompositeBuilder(
         Matches.unitIsOfType(type),
-        Matches.unitIsOwnedBy(data.getPlayerList().getPlayerID(playerName)));
+        Matches.unitIsOwnedBy(data.getPlayerList().getPlayerId(playerName)));
     if (damaged > 0) {
       selectedUnitsBuilder.add(Matches.unitHasTakenSomeDamage());
     } else {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -31,7 +31,7 @@ public class CapitolMarkerDrawable implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     // Changed back to use Large flags
-    final Image img = uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerID(player));
+    final Image img = uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerId(player));
     final Point point = mapData.getCapitolMarkerLocation(data.getMap().getTerritory(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -30,9 +30,9 @@ public class ConvoyZoneDrawable implements IDrawable {
       final AffineTransform unscaled, final AffineTransform scaled) {
     Image img;
     if (mapData.useNation_convoyFlags()) {
-      img = uiContext.getFlagImageFactory().getConvoyFlag(data.getPlayerList().getPlayerID(player));
+      img = uiContext.getFlagImageFactory().getConvoyFlag(data.getPlayerList().getPlayerId(player));
     } else {
-      img = uiContext.getFlagImageFactory().getFlag(data.getPlayerList().getPlayerID(player));
+      img = uiContext.getFlagImageFactory().getFlag(data.getPlayerList().getPlayerId(player));
     }
     final Point point = mapData.getConvoyMarkerLocation(data.getMap().getTerritory(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);

--- a/src/main/java/games/strategy/twoIfBySea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/twoIfBySea/delegate/EndTurnDelegate.java
@@ -19,8 +19,8 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
   protected String doNationalObjectivesAndOtherEndTurnEffects(final IDelegateBridge bridge) {
     final GameData data = getData();
     final PlayerList playerList = data.getPlayerList();
-    final PlayerID british = playerList.getPlayerID(Constants.PLAYER_NAME_BRITISH);
-    final PlayerID japanese = playerList.getPlayerID(Constants.PLAYER_NAME_JAPANESE);
+    final PlayerID british = playerList.getPlayerId(Constants.PLAYER_NAME_BRITISH);
+    final PlayerID japanese = playerList.getPlayerId(Constants.PLAYER_NAME_JAPANESE);
     // Quick check to see who still owns their own capital
     final boolean britain =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(british, data).getOwner().equals(british);

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -19,8 +19,8 @@ public class AllianceTrackerTest {
 
   @Test
   public void testAddAlliance() throws Exception {
-    final PlayerID bush = gameData.getPlayerList().getPlayerID("bush");
-    final PlayerID castro = gameData.getPlayerList().getPlayerID("castro");
+    final PlayerID bush = gameData.getPlayerList().getPlayerId("bush");
+    final PlayerID castro = gameData.getPlayerList().getPlayerId("castro");
     final AllianceTracker allianceTracker = gameData.getAllianceTracker();
     final RelationshipTracker relationshipTracker = gameData.getRelationshipTracker();
     assertFalse(relationshipTracker.isAllied(bush, castro));

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -93,7 +93,7 @@ public class ChangeTest {
   @Test
   public void testUnitsAddPlayer() {
     // make sure we know where we are starting
-    final PlayerID chretian = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID chretian = gameData.getPlayerList().getPlayerId("chretian");
     assertEquals(10, chretian.getUnits().getUnitCount());
     // add some units
     final Change change =
@@ -109,7 +109,7 @@ public class ChangeTest {
   @Test
   public void testUnitsRemovePlayer() {
     // make sure we know where we are starting
-    final PlayerID chretian = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID chretian = gameData.getPlayerList().getPlayerId("chretian");
     assertEquals(10, chretian.getUnits().getUnitCount());
     // remove some units
     final Collection<Unit> units =
@@ -159,7 +159,7 @@ public class ChangeTest {
 
   @Test
   public void testProductionFrontierChange() {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     final ProductionFrontier uspf = gameData.getProductionFrontierList().getProductionFrontier("usProd");
     final ProductionFrontier canpf = gameData.getProductionFrontierList().getProductionFrontier("canProd");
     assertEquals(can.getProductionFrontier(), canpf);
@@ -172,7 +172,7 @@ public class ChangeTest {
 
   @Test
   public void testChangeResourcesChange() {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     final Resource gold = gameData.getResourceList().getResource("gold");
     final Change change = ChangeFactory.changeResourcesChange(can, gold, 50);
     assertEquals(can.getResources().getQuantity(gold), 100);
@@ -184,7 +184,7 @@ public class ChangeTest {
 
   @Test
   public void testSerializeResourceChange() throws Exception {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     final Resource gold = gameData.getResourceList().getResource("gold");
     Change change = ChangeFactory.changeResourcesChange(can, gold, 50);
     change = serialize(change);
@@ -195,8 +195,8 @@ public class ChangeTest {
 
   @Test
   public void testChangeOwner() {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerId("bush");
     final Territory greenland = gameData.getMap().getTerritory("greenland");
     final Change change = ChangeFactory.changeOwner(greenland, us);
     assertEquals(greenland.getOwner(), can);
@@ -208,8 +208,8 @@ public class ChangeTest {
 
   @Test
   public void testChangeOwnerSerialize() throws Exception {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerId("bush");
     final Territory greenland = gameData.getMap().getTerritory("greenland");
     Change change = ChangeFactory.changeOwner(greenland, us);
     change = serialize(change);
@@ -224,8 +224,8 @@ public class ChangeTest {
 
   @Test
   public void testPlayerOwnerChange() throws Exception {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerId("bush");
     final UnitType infantry = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     final Unit inf1 = infantry.create(1, can).iterator().next();
     final Unit inf2 = infantry.create(1, us).iterator().next();
@@ -246,8 +246,8 @@ public class ChangeTest {
 
   @Test
   public void testPlayerOwnerChangeSerialize() throws Exception {
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerId("bush");
     final UnitType infantry = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     final Unit inf1 = infantry.create(1, can).iterator().next();
     final Unit inf2 = infantry.create(1, us).iterator().next();
@@ -272,7 +272,7 @@ public class ChangeTest {
   public void testChangeProductionFrontier() throws Exception {
     final ProductionFrontier usProd = gameData.getProductionFrontierList().getProductionFrontier("usProd");
     final ProductionFrontier canProd = gameData.getProductionFrontierList().getProductionFrontier("canProd");
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     assertEquals(can.getProductionFrontier(), canProd);
     Change prodChange = ChangeFactory.changeProductionFrontier(can, usProd);
     gameData.performChange(prodChange);

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -39,9 +39,9 @@ public class SerializationTest {
 
   @Test
   public void testWritePlayerId() throws Exception {
-    final PlayerID id = gameDataSource.getPlayerList().getPlayerID("chretian");
+    final PlayerID id = gameDataSource.getPlayerList().getPlayerId("chretian");
     final PlayerID readId = (PlayerID) serialize(id);
-    final PlayerID localId = gameDataSink.getPlayerList().getPlayerID("chretian");
+    final PlayerID localId = gameDataSink.getPlayerList().getPlayerId("chretian");
     assertTrue(localId != readId);
   }
 

--- a/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -77,8 +77,8 @@ public class ParserTest {
   @Test
   public void testAllianceMade() {
     final PlayerList players = gameData.getPlayerList();
-    final PlayerID castro = players.getPlayerID("castro");
-    final PlayerID chretian = players.getPlayerID("chretian");
+    final PlayerID castro = players.getPlayerId("castro");
+    final PlayerID chretian = players.getPlayerId("chretian");
     final RelationshipTracker alliances = gameData.getRelationshipTracker();
     assertEquals(true, alliances.isAllied(castro, chretian));
   }
@@ -107,7 +107,7 @@ public class ParserTest {
   @Test
   public void testPlayerProduction() {
     final ProductionFrontier cf = gameData.getProductionFrontierList().getProductionFrontier("canProd");
-    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     assertEquals(can.getProductionFrontier(), cf);
   }
 
@@ -121,7 +121,7 @@ public class ParserTest {
     assertEquals(att.getValue(), "inf");
     att = (TestAttachment) gameData.getMap().getTerritory("us").getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
     assertEquals(att.getValue(), "us of a");
-    att = (TestAttachment) gameData.getPlayerList().getPlayerID("chretian")
+    att = (TestAttachment) gameData.getPlayerList().getPlayerId("chretian")
         .getAttachment(Constants.PLAYER_ATTACHMENT_NAME);
     assertEquals(att.getValue(), "liberal");
   }
@@ -138,7 +138,7 @@ public class ParserTest {
 
   @Test
   public void testUnitsHeldInitialized() {
-    final PlayerID bush = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID bush = gameData.getPlayerList().getPlayerId("bush");
     assertEquals(bush.getUnits().getUnitCount(), 20);
   }
 
@@ -150,7 +150,7 @@ public class ParserTest {
 
   @Test
   public void testResourcesGiven() {
-    final PlayerID chretian = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID chretian = gameData.getPlayerList().getPlayerId("chretian");
     final Resource resource = gameData.getResourceList().getResource("silver");
     assertEquals(200, chretian.getResources().getQuantity(resource));
   }

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -37,7 +37,7 @@ public class GameDataTestUtil {
    * @return A german PlayerID.
    */
   public static PlayerID germans(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_GERMANS);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_GERMANS);
   }
 
   /**
@@ -46,7 +46,7 @@ public class GameDataTestUtil {
    * @return A german PlayerID.
    */
   public static PlayerID germany(final GameData data) {
-    return data.getPlayerList().getPlayerID("Germany");
+    return data.getPlayerList().getPlayerId("Germany");
   }
 
   /**
@@ -55,7 +55,7 @@ public class GameDataTestUtil {
    * @return A italian PlayerID.
    */
   static PlayerID italians(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_ITALIANS);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_ITALIANS);
   }
 
   /**
@@ -64,7 +64,7 @@ public class GameDataTestUtil {
    * @return A russian PlayerID.
    */
   public static PlayerID russians(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_RUSSIANS);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_RUSSIANS);
   }
 
   /**
@@ -73,7 +73,7 @@ public class GameDataTestUtil {
    * @return A american PlayerID.
    */
   public static PlayerID americans(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_AMERICANS);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_AMERICANS);
   }
 
   /**
@@ -82,7 +82,7 @@ public class GameDataTestUtil {
    * @return A british PlayerID.
    */
   public static PlayerID british(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_BRITISH);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_BRITISH);
   }
 
   /**
@@ -91,7 +91,7 @@ public class GameDataTestUtil {
    * @return A japanese PlayerID.
    */
   public static PlayerID japanese(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_JAPANESE);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_JAPANESE);
   }
 
   /**
@@ -100,7 +100,7 @@ public class GameDataTestUtil {
    * @return A Japan PlayerID.
    */
   public static PlayerID japan(final GameData data) {
-    return data.getPlayerList().getPlayerID("Japan");
+    return data.getPlayerList().getPlayerId("Japan");
   }
 
   /**
@@ -109,7 +109,7 @@ public class GameDataTestUtil {
    * @return A chinese PlayerID.
    */
   public static PlayerID chinese(final GameData data) {
-    return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_CHINESE);
+    return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_CHINESE);
   }
 
   /**


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in method names.

I avoided renaming methods which may be invoked via reflection (e.g. methods related to attachment properties).

This is one part in a series of related PRs in order to keep the review size reasonable.