### PR TITLE
Remove unnecessary Javadocs from method overrides

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -226,10 +226,6 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
     }
   }
 
-  /**
-   * @param players
-   *        - a collection of Strings representing player names.
-   */
   @Override
   public synchronized void updatePlayerList(final Collection<INode> players) {
     final Runnable runner = () -> {

--- a/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -32,9 +32,6 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     setAttachedTo(attachable);
   }
 
-  /**
-   * Called after ALL attachments are created.
-   */
   @Override
   public abstract void validate(final GameData data) throws GameParseException;
 

--- a/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
@@ -149,7 +149,11 @@ public class RelationshipInterpreter extends GameDataComponent {
    * Convenience method to get RelationshipType so you can do relationshipChecks on the relationship between these 2
    * players.
    *
-   * @return RelationshipType between these to players
+   * @param p1
+   *        Player1 in the relationship
+   * @param p2
+   *        Player2 in the relationship
+   * @return the current RelationshipType between those two players
    */
   RelationshipType getRelationshipType(final PlayerID p1, final PlayerID p2) {
     return getData().getRelationshipTracker().getRelationshipType(p1, p2);

--- a/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -36,15 +36,6 @@ public class RelationshipTracker extends RelationshipInterpreter {
     m_relationships.put(new RelatedPlayers(p1, p2), new Relationship(r, roundValue));
   }
 
-  /**
-   * will give you the relationshipType that currently exists between 2 players.
-   *
-   * @param p1
-   *        Player1 in the relationship
-   * @param p2
-   *        Player2 in the relationship
-   * @return the current RelationshipType between those two players
-   */
   @Override
   public RelationshipType getRelationshipType(final PlayerID p1, final PlayerID p2) {
     return getRelationship(p1, p2).getRelationshipType();

--- a/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -103,9 +103,6 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
     return m_relationshipTypes.get(name);
   }
 
-  /**
-   * returns a relationshipTypeIterator.
-   */
   @Override
   public Iterator<RelationshipType> iterator() {
     return m_relationshipTypes.values().iterator();

--- a/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -27,9 +27,6 @@ public class BooleanProperty extends AEditableProperty {
     mValue = value;
   }
 
-  /**
-   * @return component used to edit this property.
-   */
   @Override
   public JComponent getEditorComponent() {
     final JCheckBox box = new JCheckBox("");

--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -66,9 +66,6 @@ public class DefaultDelegateBridge implements IDelegateBridge {
     return random;
   }
 
-  /**
-   * Delegates should not use random data that comes from any other source.
-   */
   @Override
   public int[] getRandom(final int max, final int count, final PlayerID player, final DiceType diceType,
       final String annotation) throws IllegalArgumentException, IllegalStateException {
@@ -91,9 +88,6 @@ public class DefaultDelegateBridge implements IDelegateBridge {
     }
   }
 
-  /**
-   * Returns the current step name.
-   */
   @Override
   public String getStepName() {
     return m_data.getSequence().getStep().getName();

--- a/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -46,11 +46,15 @@ public interface IDelegate {
   IDelegateBridge getBridge();
 
   /**
+   * Returns the state of the Delegate.
+   *
    * @return state of the Delegate.
    */
   Serializable saveState();
 
   /**
+   * Loads the delegate state.
+   *
    * @param state
    *        the delegates state.
    */

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -54,12 +54,6 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
     }
   }
 
-  /**
-   * Loads cached game options into the gameData.
-   *
-   * @param gameData
-   *        the game to load the cached game options into
-   */
   @Override
   @SuppressWarnings("unchecked")
   // generics are compile time only, and lost during serialization

--- a/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -43,9 +43,6 @@ public class DefaultPlayerBridge implements IPlayerBridge {
     m_game.addGameStepListener(gameStepListener);
   }
 
-  /**
-   * Get the name of the current step being executed.
-   */
   @Override
   public String getStepName() {
     return m_currentStep;
@@ -56,9 +53,6 @@ public class DefaultPlayerBridge implements IPlayerBridge {
     return m_game.isGameOver();
   }
 
-  /**
-   * Return the game data.
-   */
   @Override
   public GameData getGameData() {
     return m_game.getData();

--- a/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
@@ -28,7 +28,7 @@ public interface IPlayerBridge {
   IRemote getRemotePersistentDelegate(String name);
 
   /**
-   * Get the name of the current step being exectued.
+   * Get the name of the current step being executed.
    */
   String getStepName();
 

--- a/src/main/java/games/strategy/engine/lobby/server/IUserManager.java
+++ b/src/main/java/games/strategy/engine/lobby/server/IUserManager.java
@@ -8,6 +8,9 @@ public interface IUserManager extends IRemote {
   RemoteName USER_MANAGER =
       new RemoteName("games.strategy.engine.lobby.server.USER_MANAGER", IUserManager.class);
 
+  /**
+   * Update the user info, returning an error string if an error occurs.
+   */
   String updateUser(String userName, String emailAddress, String hashedPassword);
 
   DBUser getUserInfo(String userName);

--- a/src/main/java/games/strategy/engine/lobby/server/UserManager.java
+++ b/src/main/java/games/strategy/engine/lobby/server/UserManager.java
@@ -16,9 +16,6 @@ public class UserManager implements IUserManager {
     messenger.registerRemote(this, IUserManager.USER_MANAGER);
   }
 
-  /**
-   * Update the user info, returning an error string if an error occurs.
-   */
   @Override
   public String updateUser(final String userName, final String emailAddress, final String hashedPassword) {
     final INode remote = MessageContext.getSender();
@@ -49,9 +46,6 @@ public class UserManager implements IUserManager {
     return null;
   }
 
-  /**
-   * Update the user info, returning an error string if an error occurs.
-   */
   @Override
   public DBUser getUserInfo(final String userName) {
     final INode remote = MessageContext.getSender();

--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -192,44 +192,22 @@ public class GenericEmailSender implements IEmailSender {
     }
   }
 
-  /**
-   * Get the user name used to login to the smtp server to send the email.
-   *
-   * @return the userName or null if no authentication is required
-   */
   @Override
   public String getUserName() {
     return USE_TRANSIENT_CREDENTIAL.equals(m_userName) ? transientUserName : m_userName;
   }
 
-  /**
-   * Set the userName used for authentication with the smtp server.
-   *
-   * @param userName
-   *        the userName or null if no authentication is required
-   */
   @Override
   public void setUserName(final String userName) {
     m_userName = credentialsSaved ? userName : USE_TRANSIENT_CREDENTIAL;
     transientUserName = userName;
   }
 
-  /**
-   * Get the password used to authenticate.
-   *
-   * @return the password or null
-   */
   @Override
   public String getPassword() {
     return USE_TRANSIENT_CREDENTIAL.equals(m_password) ? transientPassword : m_password;
   }
 
-  /**
-   * Set the password to authenticate with.
-   *
-   * @param password
-   *        the password or null
-   */
   @Override
   public void setPassword(final String password) {
     m_password = credentialsSaved ? password : USE_TRANSIENT_CREDENTIAL;
@@ -335,11 +313,6 @@ public class GenericEmailSender implements IEmailSender {
     m_toAddress = to;
   }
 
-  /**
-   * Get the To address configured.
-   *
-   * @return the to address, or multiple separated by space
-   */
   @Override
   public String getToAddress() {
     return m_toAddress;

--- a/src/main/java/games/strategy/engine/pbem/IEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/IEmailSender.java
@@ -46,8 +46,18 @@ public interface IEmailSender extends IBean {
    */
   IEmailSender doClone();
 
+  /**
+   * Get the user name used to login to the smtp server to send the email.
+   *
+   * @return the userName or null if no authentication is required
+   */
   String getUserName();
 
+  /**
+   * Get the password used to authenticate.
+   *
+   * @return the password or null
+   */
   String getPassword();
 
   /**
@@ -58,8 +68,20 @@ public interface IEmailSender extends IBean {
    */
   boolean areCredentialsSaved();
 
+  /**
+   * Set the userName used for authentication with the smtp server.
+   *
+   * @param userName
+   *        the userName or null if no authentication is required
+   */
   void setUserName(String userName);
 
+  /**
+   * Set the password to authenticate with.
+   *
+   * @param password
+   *        the password or null
+   */
   void setPassword(String password);
 
   /**

--- a/src/main/java/games/strategy/engine/pbem/IForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/IForumPoster.java
@@ -85,9 +85,6 @@ public interface IForumPoster extends IBean {
    */
   boolean getCanViewPosted();
 
-  /**
-   * Get the user name to login with.
-   */
   @Override
   String getDisplayName();
 

--- a/src/main/java/games/strategy/engine/xml/TestDelegate.java
+++ b/src/main/java/games/strategy/engine/xml/TestDelegate.java
@@ -55,17 +55,11 @@ public final class TestDelegate extends AbstractDelegate {
     return IRemote.class;
   }
 
-  /**
-   * Returns the state of the Delegate.
-   */
   @Override
   public Serializable saveState() {
     return null;
   }
 
-  /**
-   * Loads the delegates state.
-   */
   @Override
   public void loadState(final Serializable state) {}
 

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -101,9 +101,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     listeners.remove(listener);
   }
 
-  /**
-   * Get a list of nodes.
-   */
   @Override
   public Set<INode> getNodes() {
     final Set<INode> nodes = new HashSet<>(nodeToChannel.keySet());
@@ -136,9 +133,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     return !shutdown;
   }
 
-  /**
-   * Send a message to the given node.
-   */
   @Override
   public void send(final Serializable msg, final INode to) {
     if (shutdown) {
@@ -160,9 +154,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     nioSocket.send(socketChannel, header);
   }
 
-  /**
-   * Send a message to all nodes.
-   */
   @Override
   public void broadcast(final Serializable msg) {
     final MessageHeader header = new MessageHeader(node, msg);

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -148,9 +148,6 @@ public class TripleA implements IGameLoader {
     }
   }
 
-  /**
-   * Return an array of player types that can play on the server.
-   */
   @Override
   public String[] getServerPlayerTypes() {
     return new String[] {HUMAN_PLAYER_TYPE, WEAK_COMPUTER_PLAYER_TYPE, FAST_COMPUTER_PLAYER_TYPE,

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -579,33 +579,21 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     return ui.getBattlePanel().getBombardment(unit, unitTerritory, territories, noneAvailable);
   }
 
-  /*
-   * Ask if the player wants to attack subs
-   */
   @Override
   public boolean selectAttackSubs(final Territory unitTerritory) {
     return ui.getBattlePanel().getAttackSubs(unitTerritory);
   }
 
-  /*
-   * Ask if the player wants to attack transports
-   */
   @Override
   public boolean selectAttackTransports(final Territory unitTerritory) {
     return ui.getBattlePanel().getAttackTransports(unitTerritory);
   }
 
-  /*
-   * Ask if the player wants to attack units
-   */
   @Override
   public boolean selectAttackUnits(final Territory unitTerritory) {
     return ui.getBattlePanel().getAttackUnits(unitTerritory);
   }
 
-  /*
-   * Ask if the player wants to shore bombard
-   */
   @Override
   public boolean selectShoreBombard(final Territory unitTerritory) {
     return ui.getBattlePanel().getShoreBombard(unitTerritory);

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -442,9 +442,6 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
     return dice;
   }
 
-  /**
-   * The given phase has started. We parse the phase name and call the appropriate method.
-   */
   @Override
   public final void start(final String name) {
     super.start(name);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -394,15 +394,6 @@ public class ProAI extends AbstractAI {
     return myCasualties;
   }
 
-  /**
-   * Ask the player which units, if any, they want to scramble to defend against the attacker.
-   *
-   * @param scrambleTo
-   *        - the territory we are scrambling to defend in, where the units will end up if scrambled
-   * @param possibleScramblers
-   *        - possible units which we could scramble, with where they are from and how many allowed from that location
-   * @return a list of units to scramble mapped to where they are coming from
-   */
   @Override
   public HashMap<Territory, Collection<Unit>> scrambleUnitsQuery(final Territory scrambleTo,
       final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> possibleScramblers) {

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1147,11 +1147,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return found >= m_techCount;
   }
 
-  /**
-   * Called after the attachment is created.
-   *
-   * @throws GameParseException validation failed
-   */
   @Override
   public void validate(final GameData data) throws GameParseException {
     super.validate(data);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -32,9 +32,6 @@ public abstract class AbstractDelegate implements IDelegate {
     m_displayName = displayName;
   }
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     m_bridge = delegateBridge;
@@ -78,18 +75,11 @@ public abstract class AbstractDelegate implements IDelegate {
     return null;
   }
 
-  /**
-   * Loads the delegate state.
-   */
   @Override
   public void loadState(final Serializable state) {
     // nothing to save
   }
 
-  /**
-   * If this class implements an interface which inherits from IRemote, returns the class of that interface.
-   * Otherwise, returns null.
-   */
   @Override
   public abstract Class<? extends IRemote> getRemoteType();
 

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -56,9 +56,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, data);
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     // figure out our current PUs before we do anything else, including super methods
@@ -182,9 +179,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     }
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();

--- a/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -35,9 +35,6 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
 
   public AbstractMoveDelegate() {}
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();
@@ -48,9 +45,6 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     }
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();
@@ -225,8 +219,14 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     return poster.post(m_bridge.getHistoryWriter(), title, includeSaveGame);
   }
 
+  /**
+   * @return The number of PUs that have been lost by bombing, rockets, etc.
+   */
   public abstract int pusAlreadyLost(final Territory t);
 
+  /**
+   * Add more PUs lost to a territory due to bombing, rockets, etc.
+   */
   public abstract void pusLost(final Territory t, final int amt);
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -67,9 +67,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     super.start();
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();
@@ -1607,11 +1604,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     return null;
   }
 
-  /**
-   * Get what air units must move before the end of the players turn.
-   *
-   * @return a list of Territories with air units that must move
-   */
   @Override
   public Collection<Territory> getTerritoriesWhereAirCantLand() {
     return new AirThatCantLandUtil(m_bridge).getTerritoriesWhereAirCantLand(m_player);

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -14,17 +14,11 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
   private static final String EDITMODE_ON = "Turning on Edit Mode";
   private static final String EDITMODE_OFF = "Turning off Edit Mode";
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     super.setDelegateBridgeAndPlayer(new GameDelegateBridge(delegateBridge));
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/BasePersistentDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BasePersistentDelegate.java
@@ -15,19 +15,11 @@ public abstract class BasePersistentDelegate extends AbstractDelegate implements
     super();
   }
 
-  /**
-   * Called before the delegate will run.
-   * All classes should call super.start if they override this.
-   */
   @Override
   public void start() {
     super.start();
   }
 
-  /**
-   * Called before the delegate will stop running.
-   * All classes should call super.end if they override this.
-   */
   @Override
   public void end() {
     super.end();

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -65,10 +65,6 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     m_endBaseStepsFinished = false;
   }
 
-  /**
-   * Returns the state of the Delegate.
-   * All classes should super.saveState if they override this.
-   */
   @Override
   public Serializable saveState() {
     final BaseDelegateState state = new BaseDelegateState();

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -60,17 +60,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private boolean m_needToCleanup = true;
   protected IBattle m_currentBattle = null;
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     super.setDelegateBridgeAndPlayer(new GameDelegateBridge(delegateBridge));
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();
@@ -103,9 +97,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     m_battleTracker.fightBattleIfOnlyOne(m_bridge);
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     if (m_needToRecordBattleStatistics) {

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -65,9 +65,6 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     return false;
   }
 
-  /**
-   * subclasses can over ride this method to use different restrictions as to what a player can buy.
-   */
   @Override
   protected boolean canAfford(final IntegerMap<Resource> costs, final PlayerID player) {
     final ResourceCollection bidCollection = new ResourceCollection(getData());
@@ -93,9 +90,6 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     return (m_bid - m_spent) + " PU unused";
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();

--- a/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -20,9 +20,18 @@ public abstract class DependentBattle extends AbstractBattle {
     super(battleSite, attacker, battleTracker, false, BattleType.NORMAL, data);
   }
 
+  /**
+   * Return attacking from Collection.
+   */
   public abstract Collection<Territory> getAttackingFrom();
 
+  /**
+   * Return attacking from Map.
+   */
   public abstract Map<Territory, Collection<Unit>> getAttackingFromMap();
 
+  /**
+   * @return territories where there are amphibious attacks.
+   */
   public abstract Collection<Territory> getAmphibiousAttackTerritories();
 }

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -30,9 +30,6 @@ import games.strategy.util.Triple;
  * Edit game state.
  */
 public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -43,9 +43,6 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   /** Creates a new instance of EndRoundDelegate. */
   public EndRoundDelegate() {}
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
@@ -57,9 +57,6 @@ public class GameDelegateBridge implements IDelegateBridge {
     return m_bridge.getRandom(max, player, diceType, annotation);
   }
 
-  /**
-   * Delegates should not use random data that comes from any other source.
-   */
   @Override
   public int[] getRandom(final int max, final int count, final PlayerID player, final DiceType diceType,
       final String annotation) {

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -43,9 +43,6 @@ public class InitializationDelegate extends BaseTripleADelegate {
     m_displayName = displayName;
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -55,17 +55,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   public MoveDelegate() {}
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     super.setDelegateBridgeAndPlayer(new GameDelegateBridge(delegateBridge));
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();
@@ -183,9 +177,6 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();
@@ -620,17 +611,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
   }
 
-  /**
-   * @return The number of PUs that have been lost by bombing, rockets, etc.
-   */
   @Override
   public int pusAlreadyLost(final Territory t) {
     return m_PUsLost.getInt(t);
   }
 
-  /**
-   * Add more PUs lost to a territory due to bombing, rockets, etc.
-   */
   @Override
   public void pusLost(final Territory t, final int amt) {
     m_PUsLost.add(t, amt);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2793,25 +2793,16 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return TransportTracker.transporting(units);
   }
 
-  /**
-   * Return attacking from Collection.
-   */
   @Override
   public Collection<Territory> getAttackingFrom() {
     return m_attackingFrom;
   }
 
-  /**
-   * Return attacking from Map.
-   */
   @Override
   public Map<Territory, Collection<Unit>> getAttackingFromMap() {
     return m_attackingFromMap;
   }
 
-  /**
-   * @return territories where there are amphibious attacks.
-   */
   @Override
   public Collection<Territory> getAmphibiousAttackTerritories() {
     return m_amphibiousAttackFrom;

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -180,25 +180,16 @@ public class NonFightingBattle extends DependentBattle {
     }
   }
 
-  /**
-   *  Return attacking from Collection.
-   */
   @Override
   public Collection<Territory> getAttackingFrom() {
     return m_attackingFrom;
   }
 
-  /**
-   *  Return attacking from Map.
-   */
   @Override
   public Map<Territory, Collection<Unit>> getAttackingFromMap() {
     return m_attackingFromMap;
   }
 
-  /**
-   * @return territories where there are amphibious attacks.
-   */
   @Override
   public Collection<Territory> getAmphibiousAttackTerritories() {
     return m_amphibiousAttackFrom;

--- a/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
@@ -21,9 +21,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
  */
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {
-  /**
-   * @return gets the production of the territory.
-   */
   @Override
   protected int getProduction(final Territory territory) {
     // Can be null!

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -42,9 +42,6 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   /** Creates new PoliticsDelegate. */
   public PoliticsDelegate() {}
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -52,9 +52,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   private boolean m_needToInitialize = true;
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();
@@ -149,9 +146,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     return player.getResources().has(costs);
   }
 
-  /**
-   * Returns an error code, or null if all is good.
-   */
   @Override
   public String purchase(final IntegerMap<ProductionRule> productionRules) {
     final IntegerMap<Resource> costs = getCosts(productionRules);
@@ -240,9 +234,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     return null;
   }
 
-  /**
-   * Returns an error code, or null if all is good.
-   */
   @Override
   public String purchaseRepair(final Map<Unit, IntegerMap<RepairRule>> repairRules) {
     final IntegerMap<Resource> costs = getRepairCosts(repairRules, m_player);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -44,9 +44,6 @@ public class RandomStartDelegate extends BaseTripleADelegate {
     setupBoard();
   }
 
-  /**
-   * Called before the delegate will stop running.
-   */
   @Override
   public void end() {
     super.end();

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -44,9 +44,6 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   // private boolean m_allowAirborne = true;
   public SpecialMoveDelegate() {}
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     super.setDelegateBridgeAndPlayer(new GameDelegateBridge(delegateBridge));

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -57,17 +57,11 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     m_techCost = -1;
   }
 
-  /**
-   * Called before the delegate will run, AND before "start" is called.
-   */
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     super.setDelegateBridgeAndPlayer(new GameDelegateBridge(delegateBridge));
   }
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -26,9 +26,6 @@ import games.strategy.triplea.ui.UserActionText;
 public class UserActionDelegate extends BaseTripleADelegate implements IUserActionDelegate {
   public UserActionDelegate() {}
 
-  /**
-   * Called before the delegate will run.
-   */
   @Override
   public void start() {
     super.start();

--- a/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -17,5 +17,8 @@ public interface IPurchaseDelegate extends IRemote, IDelegate {
    */
   String purchase(IntegerMap<ProductionRule> productionRules);
 
+  /**
+   * Returns an error code, or null if all is good.
+   */
   String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
 }

--- a/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -242,11 +242,6 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
     return "AxisAndAllies.org";
   }
 
-  /**
-   * Create a clone of the poster.
-   *
-   * @return a copy
-   */
   @Override
   public IForumPoster doClone() {
     final AxisAndAlliesForumPoster clone = new AxisAndAlliesForumPoster();

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -120,9 +120,6 @@ public class MapPanel extends ImageScrollerLargeView {
       private boolean is5Pressed = false;
       private int lastActive = -1;
 
-      /**
-       * Invoked when the mouse exits a component.
-       */
       @Override
       public void mouseExited(final MouseEvent e) {
         if (unitsChanged(null)) {

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -88,9 +88,6 @@ public class TripleADisplay implements ITripleADisplay {
     ui.getBattlePanel().notifyRetreat(retreating);
   }
 
-  /**
-   * Show dice for the given battle and step.
-   */
   @Override
   public void notifyDice(final DiceRoll dice, final String stepName) {
     ui.getBattlePanel().showDice(dice, stepName);

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -80,10 +80,6 @@ public class TestDelegateBridge implements ITestDelegateBridge {
     return randomSource.getRandom(max, count, annotation);
   }
 
-  /**
-   * Changing the player has the effect of commiting the current transaction.
-   * Player is initialized to the player specified in the xml data.
-   */
   @Override
   public void setPlayerId(final PlayerID playerId) {
     this.playerId = playerId;


### PR DESCRIPTION
This PR removes unnecessary Javadocs from method overrides.  The changes fall into the following categories:

1. Javadoc on method override simply restated all or some of the Javadoc from the inherited method.  Resolution: remove Javadoc from the method override.
1. No Javadoc on original method, and the Javadoc on the method override(s) were general and did not contain any implementation-specific details (most likely, a base class or interface was extracted at some point and the Javadoc wasn't moved).  Resolution: move the Javadoc from the overridden method(s) to the base class or interface.
1. No Javadoc on original method, and the Javadoc on the method override was just wrong.  Resolution: remove the erroneous Javadoc from the method override.
