### PR TITLE
Fix selection box client setting reset actions

### DIFF
--- a/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -362,13 +362,13 @@ final class SelectionComponentFactory {
 
       @Override
       public void resetToDefault() {
-        comboBox.setSelectedItem(clientSetting.value());
+        comboBox.setSelectedItem(clientSetting.defaultValue);
         clearError();
       }
 
       @Override
       public void reset() {
-        comboBox.setSelectedItem(clientSetting.defaultValue);
+        comboBox.setSelectedItem(clientSetting.value());
         clearError();
       }
     };


### PR DESCRIPTION
While testing the L&F client setting, I noticed that the actions of the **Reset** and **Reset To Default** buttons appeared to be reversed.  (**Reset** should reset to the current value, while **Reset To Default** should reset to the default value, as defined in `ClientSetting`.)  Sure enough, the code in `reset()` and `resetToDefault()` for the anonymous class returned from `SelectionComponentFactory#selectionBox()` were performing each other's action.  This PR simply swaps the implementation of these two methods.