### PR TITLE
Temporarily disable validateYamls task in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-script: ./gradlew check jacocoTestReport
+script: ./gradlew check jacocoTestReport -x validateYamls
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle


### PR DESCRIPTION
SourceForge is currently experiencing an outage with no ETA provided for restoration of service.

https://twitter.com/sfnet_ops/status/912673956712341514