### PR TITLE
Chat.java cleanup, combine constructor with init method.

### DIFF
--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -82,15 +82,11 @@ public class Chat {
         new RemoteName(chatChannelName, IChatChannel.class));
     final Tuple<Map<INode, Tag>, Long> init = controller.joinChat();
     final Map<INode, Tag> chatters = init.getFirst();
-    synchronized (mutexNodes) {
-      nodes = new ArrayList<>(chatters.keySet());
-    }
+    nodes = new ArrayList<>(chatters.keySet());
     chatInitVersion = init.getSecond();
-    synchronized (mutexQueue) {
-      queuedInitMessages.forEach(Runnable::run);
-      assignNodeTags(chatters);
-      queuedInitMessages = null;
-    }
+    queuedInitMessages.forEach(Runnable::run);
+    assignNodeTags(chatters);
+    queuedInitMessages = null;
     updateConnections();
   }
 
@@ -106,6 +102,7 @@ public class Chat {
       }
     }
   }
+  
   private void addToNotesMap(final INode node, final Tag tag) {
     if (tag == Tag.NONE) {
       return;


### PR DESCRIPTION
- Add missing 'final' keywords that can be added
- Replace queuedInitMessages for loop with a one-liner lambda
- Move method 'queuedInitMessages' closer to its usage
- Reduce method scope where possible

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
