### PR TITLE
Fix Error Prone errors

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
@@ -35,7 +35,7 @@ public class HashedPassword {
    * Returns the value of this HashedPassword object with all characters replaces with asterisks.
    */
   public String mask() {
-    return value.replaceAll(".", "*");
+    return Strings.repeat("*", value.length());
   }
 }
 


### PR DESCRIPTION
The Gradle build fails due to an Error Prone error that slipped in between the time #2331 was opened and merged.