### PR TITLE
Ignore Gradle cache during Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
+.gradle
 bin
 build


### PR DESCRIPTION
The `.gradle` folder may contain hundreds of MiB of cached files that are not necessary to build our Docker images.