### PR TITLE
Revert "Temporarily disable validateYamls task in Travis build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-script: ./gradlew check jacocoTestReport -x validateYamls
+script: ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle


### PR DESCRIPTION
Follow up of #2401
The servers are back up again...

BTW @ron-murhammer It seems that there is a way to configure sourceforge redirection for the index: https://sourceforge.net/p/forge/documentation/Wiki/
If it allows to redirect to external URLs you should enter triplea-game.org