### PR TITLE
Remove checkstyle property causing parse error.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -56,9 +56,6 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>


### PR DESCRIPTION
- Parse error: 'property max line length does not exist for left curly
brace'
- Here the property was simply removed, after this at least intellij is
able to load the config file. I tried to load the config file with all
versions of the checkstyle plugin available (7.4 thru 8.2), and all had
the same issue.
- This update is mandatory to load the checkstyle spec file in intellij,
we are unable to load it otherwise.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
