### PR TITLE
Checkstyle: Fix abbreviation violations in method names (part 4)

### DIFF
--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -46,7 +46,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public PlayerID getPlayerID() {
+  public PlayerID getPlayerId() {
     return m_data.getSequence().getStep().getPlayerId();
   }
 
@@ -105,7 +105,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
 
   @Override
   public IRemotePlayer getRemotePlayer() {
-    return getRemotePlayer(getPlayerID());
+    return getRemotePlayer(getPlayerId());
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -32,7 +32,7 @@ public interface IDelegateBridge {
    */
   IRemotePlayer getRemotePlayer(PlayerID id);
 
-  PlayerID getPlayerID();
+  PlayerID getPlayerId();
 
   /**
    * Returns the current step name.

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -69,7 +69,7 @@ public abstract class AbstractGame implements IGame {
       m_gamePlayers.put(player, gp);
       final IPlayerBridge bridge = new DefaultPlayerBridge(this);
       gp.initialize(bridge, player);
-      final RemoteName descriptor = ServerGame.getRemoteName(gp.getPlayerID(), m_data);
+      final RemoteName descriptor = ServerGame.getRemoteName(gp.getPlayerId(), m_data);
       m_remoteMessenger.registerRemote(gp, descriptor);
     }
   }

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -177,7 +177,7 @@ public class ClientGame extends AbstractGame {
           m_data.releaseReadLock();
         }
         m_gamePlayers.put(player, gp);
-        m_remoteMessenger.unregisterRemote(ServerGame.getRemoteName(gp.getPlayerID(), m_data));
+        m_remoteMessenger.unregisterRemote(ServerGame.getRemoteName(gp.getPlayerId(), m_data));
         m_remoteMessenger.unregisterRemote(ServerGame.getRemoteRandomName(player));
       }
     } catch (final RuntimeException e) {

--- a/src/main/java/games/strategy/engine/framework/LocalPlayers.java
+++ b/src/main/java/games/strategy/engine/framework/LocalPlayers.java
@@ -23,7 +23,7 @@ public class LocalPlayers {
       return false;
     }
     for (final IGamePlayer gamePlayer : m_localPlayers) {
-      if (gamePlayer.getPlayerID().equals(id) && AbstractHumanPlayer.class.isAssignableFrom(gamePlayer.getClass())) {
+      if (gamePlayer.getPlayerId().equals(id) && AbstractHumanPlayer.class.isAssignableFrom(gamePlayer.getClass())) {
         return true;
       }
     }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -322,7 +322,7 @@ public class ServerGame extends AbstractGame {
       final Iterator<IGamePlayer> localPlayersIter = m_gamePlayers.values().iterator();
       while (localPlayersIter.hasNext()) {
         final IGamePlayer gp = localPlayersIter.next();
-        m_remoteMessenger.unregisterRemote(getRemoteName(gp.getPlayerID(), m_data));
+        m_remoteMessenger.unregisterRemote(getRemoteName(gp.getPlayerId(), m_data));
       }
       final Iterator<IDelegate> delegateIter = m_data.getDelegateList().iterator();
       while (delegateIter.hasNext()) {

--- a/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
@@ -12,5 +12,5 @@ public interface IRemotePlayer extends IRemote {
   /**
    * @return The id of this player. This id is initialized by the initialize method in IGamePlayer.
    */
-  PlayerID getPlayerID();
+  PlayerID getPlayerId();
 }

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -110,7 +110,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     // (ISomeDelegate) getPlayerBridge().getRemote()
     // We should never touch the game data directly. All changes to game data are done through the remote,
     // which then changes the game using the DelegateBridge -> change factory
-    ui.requiredTurnSeries(getPlayerID());
+    ui.requiredTurnSeries(getPlayerId());
     boolean badStep = false;
     enableEditModeMenu();
     if (name.endsWith("Tech")) {
@@ -123,7 +123,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);
       move(nonCombat, name);
       if (!nonCombat) {
-        ui.waitForMoveForumPoster(getPlayerID(), getPlayerBridge());
+        ui.waitForMoveForumPoster(getPlayerId(), getPlayerBridge());
         // TODO only do forum post if there is a combat
       }
     } else if (name.endsWith("Battle")) {
@@ -203,7 +203,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     }
 
     final PoliticalActionAttachment actionChoice =
-        ui.getPoliticalActionChoice(getPlayerID(), firstRun, politicsDelegate);
+        ui.getPoliticalActionChoice(getPlayerId(), firstRun, politicsDelegate);
     if (actionChoice != null) {
       politicsDelegate.attemptAction(actionChoice);
       politics(false);
@@ -225,7 +225,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(errorContext, e);
     }
-    final UserActionAttachment actionChoice = ui.getUserActionChoice(getPlayerID(), firstRun, userActionDelegate);
+    final UserActionAttachment actionChoice = ui.getUserActionChoice(getPlayerId(), firstRun, userActionDelegate);
     if (actionChoice != null) {
       userActionDelegate.attemptAction(actionChoice);
       userActions(false);
@@ -236,10 +236,10 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   public boolean acceptAction(final PlayerID playerSendingProposal, final String acceptanceQuestion,
       final boolean politics) {
     final GameData data = getGameData();
-    if (!getPlayerID().amNotDeadYet(data) || getPlayerBridge().isGameOver()) {
+    if (!getPlayerId().amNotDeadYet(data) || getPlayerBridge().isGameOver()) {
       return true;
     }
-    return ui.acceptAction(playerSendingProposal, "To " + getPlayerID().getName() + ": " + acceptanceQuestion,
+    return ui.acceptAction(playerSendingProposal, "To " + getPlayerId().getName() + ": " + acceptanceQuestion,
         politics);
   }
 
@@ -260,7 +260,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     }
 
 
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     if (!m_soundPlayedAlreadyTechnology) {
       ClipPlayer.play(SoundPath.CLIP_PHASE_TECHNOLOGY, id);
       m_soundPlayedAlreadyTechnology = true;
@@ -294,7 +294,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       throw new IllegalStateException(errorContext, e);
     }
 
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
 
     if (nonCombat && !m_soundPlayedAlreadyNonCombatMove) {
       ClipPlayer.play(SoundPath.CLIP_PHASE_MOVE_NONCOMBAT, id);
@@ -349,7 +349,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (airCantLand.isEmpty()) {
       return true;
     } else {
-      return ui.getOkToLetAirDie(getPlayerID(), airCantLand, movePhase);
+      return ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
     }
   }
 
@@ -375,7 +375,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       return;
     }
 
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     // play a sound for this phase
     if (!bid && !m_soundPlayedAlreadyPurchase) {
       ClipPlayer.play(SoundPath.CLIP_PHASE_PURCHASE, id);
@@ -456,7 +456,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       throw new IllegalStateException(errorContext, e);
     }
 
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     while (true) {
       if (getPlayerBridge().isGameOver()) {
         return;
@@ -494,7 +494,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (getPlayerBridge().isGameOver()) {
       return;
     }
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     final IAbstractPlaceDelegate placeDel;
     try {
       placeDel = (IAbstractPlaceDelegate) getPlayerBridge().getRemoteDelegate();
@@ -546,14 +546,14 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(errorContext, e);
     }
-    if (!m_soundPlayedAlreadyEndTurn && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(getPlayerID(), data)) {
+    if (!m_soundPlayedAlreadyEndTurn && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(getPlayerId(), data)) {
       // do not play if we are reloading a savegame from pbem (gets annoying)
       if (!endTurnDelegate.getHasPostedTurnSummary()) {
-        ClipPlayer.play(SoundPath.CLIP_PHASE_END_TURN, getPlayerID());
+        ClipPlayer.play(SoundPath.CLIP_PHASE_END_TURN, getPlayerId());
       }
       m_soundPlayedAlreadyEndTurn = true;
     }
-    ui.waitForEndTurn(getPlayerID(), getPlayerBridge());
+    ui.waitForEndTurn(getPlayerId(), getPlayerBridge());
   }
 
   @Override
@@ -628,7 +628,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   }
 
   @Override
-  public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
+  public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
     final String question = "Your units will be fired on in: "
         + MyFormatter.defaultNamedToTextList(aaFiringTerritories, " and ", false) + ".  Do you still want to move?";
     return ui.getOk(question);
@@ -689,7 +689,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   @Override
   public HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       final HashMap<Territory, Collection<Unit>> possibleUnitsToAttack) {
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     final PlayerAttachment pa = PlayerAttachment.get(id);
     if (pa == null) {
       return null;
@@ -742,6 +742,6 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (territoryChoices == null || territoryChoices.isEmpty() || unitsPerPick < 1) {
       return Tuple.of(null, new HashSet<Unit>());
     }
-    return ui.pickTerritoryAndUnits(this.getPlayerID(), territoryChoices, unitChoices, unitsPerPick);
+    return ui.pickTerritoryAndUnits(this.getPlayerId(), territoryChoices, unitChoices, unitsPerPick);
   }
 }

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -177,7 +177,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   }
 
   @Override
-  public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
+  public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
     return true;
   }
 
@@ -209,7 +209,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   public boolean acceptAction(final PlayerID playerSendingProposal, final String acceptanceQuestion,
       final boolean politics) {
     // we are dead, just accept
-    if (!getPlayerID().amNotDeadYet(getGameData())) {
+    if (!getPlayerId().amNotDeadYet(getGameData())) {
       return true;
     }
     // not related to politics? just accept i guess
@@ -217,23 +217,23 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       return true;
     }
     // politics from ally? accept
-    if (Matches.isAllied(getPlayerID(), getGameData()).match(playerSendingProposal)) {
+    if (Matches.isAllied(getPlayerId(), getGameData()).match(playerSendingProposal)) {
       return true;
     }
     // would we normally be allies?
     final List<String> allies = Arrays.asList(Constants.PLAYER_NAME_AMERICANS,
         Constants.PLAYER_NAME_AUSTRALIANS, Constants.PLAYER_NAME_BRITISH, Constants.PLAYER_NAME_CANADIANS,
         Constants.PLAYER_NAME_CHINESE, Constants.PLAYER_NAME_FRENCH, Constants.PLAYER_NAME_RUSSIANS);
-    if (allies.contains(getPlayerID().getName()) && allies.contains(playerSendingProposal.getName())) {
+    if (allies.contains(getPlayerId().getName()) && allies.contains(playerSendingProposal.getName())) {
       return true;
     }
     final List<String> axis = Arrays.asList(Constants.PLAYER_NAME_GERMANS, Constants.PLAYER_NAME_ITALIANS,
         Constants.PLAYER_NAME_JAPANESE, Constants.PLAYER_NAME_PUPPET_STATES);
-    if (axis.contains(getPlayerID().getName()) && axis.contains(playerSendingProposal.getName())) {
+    if (axis.contains(getPlayerId().getName()) && axis.contains(playerSendingProposal.getName())) {
       return true;
     }
     final Collection<String> myAlliances =
-        new HashSet<>(getGameData().getAllianceTracker().getAlliancesPlayerIsIn(getPlayerID()));
+        new HashSet<>(getGameData().getAllianceTracker().getAlliancesPlayerIsIn(getPlayerId()));
     myAlliances.retainAll(getGameData().getAllianceTracker().getAlliancesPlayerIsIn(playerSendingProposal));
     if (!myAlliances.isEmpty()) {
       return true;
@@ -244,7 +244,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   @Override
   public HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       final HashMap<Territory, Collection<Unit>> possibleUnitsToAttack) {
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     // we are going to just assign random attacks to each unit randomly, til we run out of tokens to attack with.
     final PlayerAttachment pa = PlayerAttachment.get(id);
     if (pa == null) {
@@ -302,7 +302,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       final List<Unit> unitChoices, final int unitsPerPick) {
     pause();
     final GameData data = getGameData();
-    final PlayerID me = getPlayerID();
+    final PlayerID me = getPlayerId();
     final Territory picked;
     if (territoryChoices == null || territoryChoices.isEmpty()) {
       picked = null;
@@ -445,7 +445,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   @Override
   public final void start(final String name) {
     super.start(name);
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     if (name.endsWith("Bid")) {
       final IPurchaseDelegate purchaseDelegate = (IPurchaseDelegate) getPlayerBridge().getRemoteDelegate();
       final String propertyName = id.getName() + " bid";
@@ -587,7 +587,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   protected void politicalActions() {
     final IPoliticsDelegate remotePoliticsDelegate = (IPoliticsDelegate) getPlayerBridge().getRemoteDelegate();
     final GameData data = getGameData();
-    final PlayerID id = getPlayerID();
+    final PlayerID id = getPlayerId();
     final float numPlayers = data.getPlayerList().getPlayers().size();
     final PoliticsDelegate politicsDelegate = DelegateFinder.politicsDelegate(data);
     // We want to test the conditions each time to make sure they are still valid

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -279,7 +279,7 @@ public class ProAI extends AbstractAI {
 
     // Get battle data
     final GameData data = getGameData();
-    final PlayerID player = getPlayerID();
+    final PlayerID player = getPlayerId();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
@@ -344,7 +344,7 @@ public class ProAI extends AbstractAI {
 
       // Get battle data
       final GameData data = getGameData();
-      final PlayerID player = getPlayerID();
+      final PlayerID player = getPlayerId();
       final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
       final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
@@ -401,7 +401,7 @@ public class ProAI extends AbstractAI {
 
     // Get battle data
     final GameData data = getGameData();
-    final PlayerID player = getPlayerID();
+    final PlayerID player = getPlayerId();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle = delegate.getBattleTracker().getPendingBattle(scrambleTo, false, BattleType.NORMAL);
 
@@ -423,7 +423,7 @@ public class ProAI extends AbstractAI {
 
     // Get battle data
     final GameData data = getGameData();
-    final PlayerID player = getPlayerID();
+    final PlayerID player = getPlayerId();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle = delegate.getBattleTracker().getPendingBattle(unitTerritory, false, BattleType.NORMAL);
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -41,7 +41,7 @@ public class ProData {
   public static double minCostPerHitPoint = Double.MAX_VALUE;
 
   public static void initialize(final ProAI proAi) {
-    hiddenInitialize(proAi, proAi.getGameData(), proAi.getPlayerID(), false);
+    hiddenInitialize(proAi, proAi.getGameData(), proAi.getPlayerId(), false);
   }
 
   public static void initializeSimulation(final ProAI proAi, final GameData data, final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
@@ -77,7 +77,7 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public PlayerID getPlayerID() {
+  public PlayerID getPlayerId() {
     return m_player;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -169,7 +169,7 @@ public class WeakAI extends AbstractAI {
       return;
     }
     List<Unit> unitsToLoad = capitol.getUnits().getMatches(Matches.unitIsInfrastructure().invert());
-    unitsToLoad = Matches.getMatches(unitsToLoad, Matches.unitIsOwnedBy(getPlayerID()));
+    unitsToLoad = Matches.getMatches(unitsToLoad, Matches.unitIsOwnedBy(getPlayerId()));
     for (final Territory neighbor : data.getMap().getNeighbors(capitol)) {
       if (!neighbor.isWater()) {
         continue;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -219,7 +219,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
             + diceSides + " Result: " + rollResult + "  for " + MyFormatter.attachmentNameToText(this.getName()) + ")";
     bridge.getHistoryWriter().startEvent(notificationMessage);
     changeChanceDecrementOrIncrementOnSuccessOrFailure(bridge, testChance, true);
-    ((ITripleAPlayer) bridge.getRemotePlayer(bridge.getPlayerID())).reportMessage(notificationMessage,
+    ((ITripleAPlayer) bridge.getRemotePlayer(bridge.getPlayerId())).reportMessage(notificationMessage,
         notificationMessage);
     return testChance;
   }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -880,7 +880,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             + MyFormatter.attachmentNameToText(this.getName()) + ")";
         delegateBridge.getHistoryWriter().startEvent(notificationMessage);
         changeChanceDecrementOrIncrementOnSuccessOrFailure(delegateBridge, objectiveMet, true);
-        ((ITripleAPlayer) delegateBridge.getRemotePlayer(delegateBridge.getPlayerID()))
+        ((ITripleAPlayer) delegateBridge.getRemotePlayer(delegateBridge.getPlayerId()))
             .reportMessage(notificationMessage, notificationMessage);
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -40,7 +40,7 @@ class AAInMoveUtil implements Serializable {
 
   public AAInMoveUtil initialize(final IDelegateBridge bridge) {
     m_bridge = bridge;
-    m_player = bridge.getPlayerID();
+    m_player = bridge.getPlayerId();
     return this;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -35,7 +35,7 @@ public abstract class AbstractDelegate implements IDelegate {
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
     m_bridge = delegateBridge;
-    m_player = delegateBridge.getPlayerID();
+    m_player = delegateBridge.getPlayerId();
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -61,8 +61,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     // figure out our current PUs before we do anything else, including super methods
     final GameData data = m_bridge.getData();
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
-    final int leftOverPUs = m_bridge.getPlayerID().getResources().getQuantity(pus);
-    final IntegerMap<Resource> leftOverResources = m_bridge.getPlayerID().getResources().getResourcesCopy();
+    final int leftOverPUs = m_bridge.getPlayerId().getResources().getQuantity(pus);
+    final IntegerMap<Resource> leftOverResources = m_bridge.getPlayerId().getResources().getResourcesCopy();
     super.start();
     if (!m_needToInitialize) {
       return;
@@ -160,7 +160,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       }
     }
     if (GameStepPropertiesHelper.isRepairUnits(data)) {
-      MoveDelegate.repairMultipleHitPointUnits(m_bridge, m_bridge.getPlayerID());
+      MoveDelegate.repairMultipleHitPointUnits(m_bridge, m_bridge.getPlayerId());
     }
     if (isGiveUnitsByTerritory() && pa != null && pa.getGiveUnitControl() != null
         && !pa.getGiveUnitControl().isEmpty()) {
@@ -284,7 +284,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   }
 
   private static void changeUnitOwnership(final IDelegateBridge bridge) {
-    final PlayerID player = bridge.getPlayerID();
+    final PlayerID player = bridge.getPlayerId();
     final PlayerAttachment pa = PlayerAttachment.get(player);
     final Collection<PlayerID> possibleNewOwners = pa.getGiveUnitControl();
     final Collection<Territory> territories = bridge.getData().getMap().getTerritories();

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -74,7 +74,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   protected void doAfterEnd() {
-    final PlayerID player = m_bridge.getPlayerID();
+    final PlayerID player = m_bridge.getPlayerId();
     // clear all units not placed
     final Collection<Unit> units = player.getUnits().getUnits();
     final GameData data = getData();

--- a/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -55,7 +55,7 @@ public abstract class AbstractUndoableMove implements Serializable {
   final void undo(final IDelegateBridge delegateBridge) {
     // undo any changes to the game data
     delegateBridge.getHistoryWriter().startEvent(
-        delegateBridge.getPlayerID().getName() + " undo move " + (getIndex() + 1) + ".", getDescriptionObject());
+        delegateBridge.getPlayerId().getName() + " undo move " + (getIndex() + 1) + ".", getDescriptionObject());
     delegateBridge.addChange(m_change.invert());
     undoSpecific(delegateBridge);
   }

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -305,7 +305,7 @@ public class AirBattle extends AbstractBattle {
       if (!bombers.isEmpty()) {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
-            .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerID(), m_data),
+            .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerId(), m_data),
                 Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
         for (final Unit unit : bombers) {
           final Collection<Unit> enemyTargets =

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -49,7 +49,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
 
   private String checkPlayerId() {
     final IRemotePlayer remotePlayer = getRemotePlayer();
-    if (!m_bridge.getPlayerID().equals(remotePlayer.getPlayerID())) {
+    if (!m_bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
       return "Edit actions can only be performed during players turn";
     }
     return null;
@@ -68,7 +68,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
 
   public String setEditMode(final boolean editMode) {
     final IRemotePlayer remotePlayer = getRemotePlayer();
-    if (!m_bridge.getPlayerID().equals(remotePlayer.getPlayerID())) {
+    if (!m_bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
       return "Edit Mode can only be toggled during players turn";
     }
     logEvent((editMode ? EDITMODE_ON : EDITMODE_OFF), null);

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -246,7 +246,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
    * Add bombardment units to battles. Made public for test purposes only.
    */
   void addBombardmentSources() {
-    final PlayerID attacker = m_bridge.getPlayerID();
+    final PlayerID attacker = m_bridge.getPlayerId();
     final ITripleAPlayer remotePlayer = getRemotePlayer();
     final Match<Unit> ownedAndCanBombard =
         Match.allOf(Matches.unitCanBombard(attacker), Matches.unitIsOwnedBy(attacker));
@@ -408,7 +408,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
    */
   private static void setupUnitsInSameTerritoryBattles(final BattleTracker battleTracker,
       final IDelegateBridge bridge) {
-    final PlayerID player = bridge.getPlayerID();
+    final PlayerID player = bridge.getPlayerId();
     final GameData data = bridge.getData();
     final boolean ignoreTransports = isIgnoreTransportInMovement(data);
     final boolean ignoreSubs = isIgnoreSubInMovement(data);
@@ -561,7 +561,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (!Properties.getAbandonedTerritoriesMayBeTakenOverImmediately(data)) {
       return;
     }
-    final PlayerID player = bridge.getPlayerID();
+    final PlayerID player = bridge.getPlayerId();
     final Iterator<Territory> battleTerritories = Matches
         .getMatches(
             data.getMap().getTerritories(),

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1161,7 +1161,7 @@ public class BattleTracker implements Serializable {
     final List<Unit> sortedUnitsList = new ArrayList<>(Matches.getMatches(defenders,
         Matches.unitCanBeInBattle(true, !territory.isWater(), 1, false, true, true)));
     Collections.sort(sortedUnitsList,
-        new UnitBattleComparator(false, TuvUtils.getCostsForTuv(bridge.getPlayerID(), gameData),
+        new UnitBattleComparator(false, TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
             TerritoryEffectHelper.getEffects(territory), gameData, false, false));
     Collections.reverse(sortedUnitsList);
     return sortedUnitsList;

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -79,7 +79,7 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     if (m_hasBid) {
       return;
     }
-    m_bid = getBidAmount(m_bridge.getData(), m_bridge.getPlayerID());
+    m_bid = getBidAmount(m_bridge.getData(), m_bridge.getPlayerId());
     m_spent = 0;
   }
 
@@ -98,8 +98,8 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
       return;
     }
     m_bridge.getHistoryWriter()
-        .startEvent(m_bridge.getPlayerID().getName() + " retains " + unspent + " PUS not spent in bid phase");
-    final Change unspentChange = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(),
+        .startEvent(m_bridge.getPlayerId().getName() + " retains " + unspent + " PUS not spent in bid phase");
+    final Change unspentChange = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(),
         super.getData().getResourceList().getResource(Constants.PUS), unspent);
     m_bridge.addChange(unspentChange);
     m_hasBid = false;

--- a/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
@@ -44,8 +44,8 @@ public class GameDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public PlayerID getPlayerID() {
-    return m_bridge.getPlayerID();
+  public PlayerID getPlayerId() {
+    return m_bridge.getPlayerId();
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -188,9 +188,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // WW2V2/WW2V3, fires at end of combat move
     // WW2V1, fires at end of non combat move
     if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (m_needToDoRockets && TechTracker.hasRocket(m_bridge.getPlayerID())) {
+      if (m_needToDoRockets && TechTracker.hasRocket(m_bridge.getPlayerId())) {
         final RocketsFireHelper helper = new RocketsFireHelper();
-        helper.fireRockets(m_bridge, m_bridge.getPlayerID());
+        helper.fireRockets(m_bridge, m_bridge.getPlayerId());
         m_needToDoRockets = false;
       }
     }
@@ -557,7 +557,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     aaInMoveUtil.initialize(m_bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
-      if (!getRemotePlayer().confirmMoveInFaceOfAA(aaFiringTerritores)) {
+      if (!getRemotePlayer().confirmMoveInFaceOfAa(aaFiringTerritores)) {
         return null;
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -53,7 +53,7 @@ public class MovePerformer implements Serializable {
   void initialize(final AbstractMoveDelegate delegate) {
     m_moveDelegate = delegate;
     m_bridge = delegate.getBridge();
-    m_player = m_bridge.getPlayerID();
+    m_player = m_bridge.getPlayerId();
     if (m_aaInMoveUtil != null) {
       m_aaInMoveUtil.initialize(m_bridge);
     }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2677,7 +2677,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Match<Unit> unitTypes = Matches.unitCanBeInBattle(attack, !m_battleSite.isWater(), 1, false, !attack, true);
     final List<Unit> sortedUnits = new ArrayList<>(Matches.getMatches(units, unitTypes));
     Collections.sort(sortedUnits, new UnitBattleComparator(!attack,
-        TuvUtils.getCostsForTuv(bridge.getPlayerID(), m_data),
+        TuvUtils.getCostsForTuv(bridge.getPlayerId(), m_data),
         TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
     Collections.reverse(sortedUnits);
     unitsToRemove.addAll(sortedUnits);

--- a/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -32,7 +32,7 @@ public class NoPUPurchaseDelegate extends PurchaseDelegate {
   public void start() {
     super.start();
     isPacific = isPacificTheater();
-    final PlayerID player = m_bridge.getPlayerID();
+    final PlayerID player = m_bridge.getPlayerId();
     final Collection<Territory> territories = getData().getMap().getTerritoriesOwnedBy(player);
     final Collection<Unit> units = getProductionUnits(territories, player);
     final Change productionChange = ChangeFactory.addUnits(player, units);

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -267,13 +267,13 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     if (cost > 0) {
       // don't notify user of spending money anymore
       // notifyMoney(paa, true);
-      final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " PU on Political Action: "
+      final String transcriptText = m_bridge.getPlayerId().getName() + " spend " + cost + " PU on Political Action: "
           + MyFormatter.attachmentNameToText(paa.getName());
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
-      final String transcriptText = m_bridge.getPlayerID().getName() + " takes Political Action: "
+      final String transcriptText = m_bridge.getPlayerId().getName() + " takes Political Action: "
           + MyFormatter.attachmentNameToText(paa.getName());
       // we must start an event anyway
       m_bridge.getHistoryWriter().startEvent(transcriptText);
@@ -288,7 +288,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private boolean checkEnoughMoney(final PoliticalActionAttachment paa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = paa.getCostPU();
-    final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
+    final int has = m_bridge.getPlayerId().getResources().getQuantity(pus);
     return has >= cost;
   }
 
@@ -301,7 +301,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private void notifyFailure(final PoliticalActionAttachment paa) {
     getSoundChannel().playSoundForAll(SoundPath.CLIP_POLITICAL_ACTION_FAILURE, m_player);
     final String transcriptText =
-        m_bridge.getPlayerID().getName() + " fails on action: " + MyFormatter.attachmentNameToText(paa.getName());
+        m_bridge.getPlayerId().getName() + " fails on action: " + MyFormatter.attachmentNameToText(paa.getName());
     m_bridge.getHistoryWriter().addChildToEvent(transcriptText);
     sendNotification(PoliticsText.getInstance().getNotificationFailure(paa.getText()));
     notifyOtherPlayers(PoliticsText.getInstance().getNotificationFailureOthers(paa.getText()));
@@ -366,7 +366,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       }
       change.add(ChangeFactory.relationshipChange(player1, player2, oldRelation, newRelation));
       m_bridge.getHistoryWriter()
-          .addChildToEvent(m_bridge.getPlayerID().getName() + " succeeds on action: "
+          .addChildToEvent(m_bridge.getPlayerId().getName() + " succeeds on action: "
               + MyFormatter.attachmentNameToText(paa.getName()) + ": Changing Relationship for " + player1.getName()
               + " and " + player2.getName() + " from " + oldRelation.getName() + " to " + newRelation.getName());
       MoveDelegate.getBattleTracker(getData()).addRelationshipChangesThisTurn(player1, player2, oldRelation,

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -124,7 +124,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     aaInMoveUtil.initialize(m_bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
-      if (!getRemotePlayer().confirmMoveInFaceOfAA(aaFiringTerritores)) {
+      if (!getRemotePlayer().confirmMoveInFaceOfAa(aaFiringTerritores)) {
         return null;
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -197,7 +197,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         final String transcriptText = m_player.getName() + " No more available tech advances.";
         m_bridge.getHistoryWriter().startEvent(transcriptText);
         final Change removeTokens =
-            ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), techTokens, -currTokens);
+            ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), techTokens, -currTokens);
         m_bridge.addChange(removeTokens);
       }
       return new TechResults("No more available tech advances.");
@@ -245,7 +245,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
           + (techHits > 0 ? "successful" : "unsuccessful") + " research.";
       m_bridge.getHistoryWriter().startEvent(transcriptText);
       final Change removeTokens =
-          ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), techTokens, -currTokens);
+          ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), techTokens, -currTokens);
       m_bridge.addChange(removeTokens);
     }
     final Collection<TechAdvance> advances;
@@ -291,7 +291,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
-      final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
+      final int has = m_bridge.getPlayerId().getResources().getQuantity(pus);
       return has >= cost;
     } else {
       int runningTotal = 0;
@@ -311,9 +311,9 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
-      final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " on tech rolls";
+      final String transcriptText = m_bridge.getPlayerId().getName() + " spend " + cost + " on tech rolls";
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
       for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
@@ -331,7 +331,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     }
     if (isWW2V3TechModel()) {
       final Resource tokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
-      final Change newTokens = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), tokens, rolls);
+      final Change newTokens = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), tokens, rolls);
       m_bridge.addChange(newTokens);
     }
   }
@@ -399,7 +399,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   private List<TechAdvance> getAvailableAdvances() {
-    return getAvailableTechs(m_bridge.getPlayerID(), getData());
+    return getAvailableTechs(m_bridge.getPlayerId(), getData());
   }
 
   public static List<TechAdvance> getAvailableTechs(final PlayerID player, final GameData data) {
@@ -410,7 +410,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
 
   private List<TechAdvance> getAvailableAdvancesForCategory(final TechnologyFrontier techCategory) {
     final Collection<TechAdvance> playersAdvances =
-        TechTracker.getCurrentTechAdvances(m_bridge.getPlayerID(), getData());
+        TechTracker.getCurrentTechAdvances(m_bridge.getPlayerId(), getData());
     final List<TechAdvance> available = Util.difference(techCategory.getTechs(), playersAdvances);
     return available;
   }

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -95,7 +95,7 @@ public class UndoableMove extends AbstractUndoableMove {
   protected void undoSpecific(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     final BattleTracker battleTracker = DelegateFinder.battleDelegate(data).getBattleTracker();
-    battleTracker.undoBattle(m_route, m_units, bridge.getPlayerID(), bridge);
+    battleTracker.undoBattle(m_route, m_units, bridge.getPlayerId(), bridge);
     // clean up dependencies
     final Iterator<UndoableMove> iter1 = m_iDependOn.iterator();
     while (iter1.hasNext()) {
@@ -127,7 +127,7 @@ public class UndoableMove extends AbstractUndoableMove {
           if (routeUnitUsedToMove != null && routeUnitUsedToMove.getEnd() != null) {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
-                .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerID(), data),
+                .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerId(), data),
                     Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Matches.getMatches(enemyTargetsTotal,
                 Matches.unitIsOfTypes(UnitAttachment.getAllowedBombingTargetsIntersection(
@@ -136,7 +136,7 @@ public class UndoableMove extends AbstractUndoableMove {
                 && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
                 && !Properties.getRaidsMayBePreceededByAirBattles(data)) {
               while (target == null) {
-                target = ((ITripleAPlayer) bridge.getRemotePlayer(bridge.getPlayerID())).whatShouldBomberBomb(end,
+                target = ((ITripleAPlayer) bridge.getRemotePlayer(bridge.getPlayerId())).whatShouldBomberBomb(end,
                     enemyTargets, Collections.singletonList(unit));
               }
             } else if (!enemyTargets.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -116,7 +116,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   private boolean checkEnoughMoney(final UserActionAttachment uaa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = uaa.getCostPU();
-    final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
+    final int has = m_bridge.getPlayerId().getResources().getQuantity(pus);
     return has >= cost;
   }
 
@@ -132,14 +132,14 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     if (cost > 0) {
       // don't notify user of spending money anymore
       // notifyMoney(uaa, true);
-      final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " PU on User Action: "
+      final String transcriptText = m_bridge.getPlayerId().getName() + " spend " + cost + " PU on User Action: "
           + MyFormatter.attachmentNameToText(uaa.getName());
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
       final String transcriptText =
-          m_bridge.getPlayerID().getName() + " takes action: " + MyFormatter.attachmentNameToText(uaa.getName());
+          m_bridge.getPlayerId().getName() + " takes action: " + MyFormatter.attachmentNameToText(uaa.getName());
       // we must start an event anyway
       m_bridge.getHistoryWriter().startEvent(transcriptText);
     }
@@ -250,7 +250,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     // play a sound
     getSoundChannel().playSoundForAll(SoundPath.CLIP_USER_ACTION_FAILURE, m_player);
     final String transcriptText =
-        m_bridge.getPlayerID().getName() + " fails on action: " + MyFormatter.attachmentNameToText(uaa.getName());
+        m_bridge.getPlayerId().getName() + " fails on action: " + MyFormatter.attachmentNameToText(uaa.getName());
     m_bridge.getHistoryWriter().addChildToEvent(transcriptText);
     sendNotification(UserActionText.getInstance().getNotificationFailure(uaa.getText()));
     notifyOtherPlayers(UserActionText.getInstance().getNotificationFailureOthers(uaa.getText()));

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -441,7 +441,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     }
 
     @Override
-    public PlayerID getPlayerID() {
+    public PlayerID getPlayerId() {
       return attacker;
     }
 
@@ -568,7 +568,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     protected void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {}
 
     @Override
-    public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
+    public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
+++ b/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
@@ -64,7 +64,7 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
   }
 
   @Override
-  public final PlayerID getPlayerID() {
+  public final PlayerID getPlayerId() {
     return playerID;
   }
 
@@ -90,7 +90,7 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
         i++;
         if (i > 30 && !shownErrorMessage) {
           System.out.println("Start step: " + stepName + " does not match player bridge step: " + bridgeStep
-              + ". Player Bridge GameOver=" + getPlayerBridge().isGameOver() + ", PlayerID: " + getPlayerID().getName()
+              + ". Player Bridge GameOver=" + getPlayerBridge().isGameOver() + ", PlayerID: " + getPlayerId().getName()
               + ", Game: " + getGameData().getGameName()
               + ". Something wrong or very laggy. Will keep trying for 30 more seconds. ");
           shownErrorMessage = true;
@@ -100,7 +100,7 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
           System.err.println("Start step: " + stepName + " still does not match player bridge step: " + bridgeStep
               + " even after waiting more than 30 seconds. This will probably result in a ClassCastException very "
               + "soon. Player Bridge GameOver=" + getPlayerBridge().isGameOver()
-              + ", PlayerID: " + getPlayerID().getName() + ", Game: " + getGameData().getGameName());
+              + ", PlayerID: " + getPlayerId().getName() + ", Game: " + getGameData().getGameName());
           // waited more than 30 seconds, so just let stuff run (an error will pop up surely...)
           break;
         }

--- a/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -192,7 +192,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    * @param aaFiringTerritories
    *        - the territories where aa will fire
    */
-  boolean confirmMoveInFaceOfAA(Collection<Territory> aaFiringTerritories);
+  boolean confirmMoveInFaceOfAa(Collection<Territory> aaFiringTerritories);
 
   /**
    * The attempted move will kill some air units.

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -260,8 +260,8 @@ public class BattlePanel extends ActionPanel {
         PBEMDiceRoller.setFocusWindow(battleFrame);
         boolean foundHumanInBattle = false;
         for (final IGamePlayer gamePlayer : getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {
-          if ((gamePlayer.getPlayerID().equals(attacker) && gamePlayer instanceof TripleAPlayer)
-              || (gamePlayer.getPlayerID().equals(defender) && gamePlayer instanceof TripleAPlayer)) {
+          if ((gamePlayer.getPlayerId().equals(attacker) && gamePlayer instanceof TripleAPlayer)
+              || (gamePlayer.getPlayerId().equals(defender) && gamePlayer instanceof TripleAPlayer)) {
             foundHumanInBattle = true;
             break;
           }

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -675,7 +675,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     }
 
     @Override
-    public PlayerID getPlayerID() {
+    public PlayerID getPlayerId() {
       return PlayerID.NULL_PLAYERID;
     }
 
@@ -755,7 +755,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     }
 
     @Override
-    public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
+    public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -90,7 +90,7 @@ public class TestDelegateBridge implements ITestDelegateBridge {
   }
 
   @Override
-  public PlayerID getPlayerID() {
+  public PlayerID getPlayerId() {
     return playerId;
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -313,7 +313,7 @@ public class RevisedTest {
     bridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    when(dummyPlayer.confirmMoveInFaceOfAA(any())).thenReturn(true);
+    when(dummyPlayer.confirmMoveInFaceOfAa(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setRandomSource(new ScriptedRandomSource(0));
     final Territory uk = territory("United Kingdom", gameData);
@@ -335,7 +335,7 @@ public class RevisedTest {
     bridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    when(dummyPlayer.confirmMoveInFaceOfAA(any())).thenReturn(true);
+    when(dummyPlayer.confirmMoveInFaceOfAa(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setRandomSource(new ScriptedRandomSource(0, 4));
     final Territory uk = territory("United Kingdom", gameData);
@@ -363,7 +363,7 @@ public class RevisedTest {
     bridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    when(dummyPlayer.confirmMoveInFaceOfAA(any())).thenReturn(true);
+    when(dummyPlayer.confirmMoveInFaceOfAa(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setRandomSource(new ScriptedRandomSource(0));
     final Territory uk = territory("United Kingdom", gameData);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in method names.

The methods renamed in this PR are callable via RMI:

* `IDelegateBridge#getPlayerID()`
* `IRemotePlayer#getPlayerID()`
* `ITripleAPlayer#confirmMoveInFaceOfAA()`

However, the new method names do not change the sort order of the methods because they only change the case of the last character of the name.  (RMI invokes remote methods by ordinal, and the method sort order is how RMI maps between ordinal and method name).  I verified these changes cause no RMI compatibility issues by running the following network games:

* Server: this branch, Client: 3635
* Server: 3635, Client: this branch

This is the **final part** in a series of related PRs.