### PR TITLE
Checkstyle: Restore LeftCurly rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -56,6 +56,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
+        <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>


### PR DESCRIPTION
This is a partial revert of #2425.  The `maxLineLength` property of the `LeftCurly` rule was deprecated in Checkstyle 6.10 and finally removed in Checkstyle 8.2.  It is presumed that the presence of this property was the cause of the parsing error thrown by the IntelliJ Checkstyle plugin, but that the `LeftCurly` rule itself is fine.

Therefore, this PR restores the `LeftCurly` rule with default values for all properties, which matches the latest Google Style rules in Checkstyle 8.2.