### PR TITLE
Rename integration tests to include "IntegrationTest" suffix

### DIFF
--- a/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.core.Is.is;
 
 import org.junit.Test;
 
-public class ClientContextTest {
+public class ClientContextIntegrationTest {
 
   @Test
   public void verifyClientContext() {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -27,7 +27,7 @@ import games.strategy.net.Node;
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
-public class ModeratorControllerTest {
+public class ModeratorControllerIntegrationTest {
   private final IServerMessenger serverMessenger = mock(IServerMessenger.class);
   private ModeratorController moderatorController;
   private ConnectionChangeListener connectionChangeListener;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 import games.strategy.util.Util;
 
-public class BadWordControllerTest {
+public class BadWordControllerIntegrationTest {
 
   @Test
   public void testInsertAndRemoveBadWord() {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
@@ -16,7 +16,7 @@ import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
-public class BannedMacControllerTest {
+public class BannedMacControllerIntegrationTest {
 
   private final BannedMacController controller = spy(new BannedMacController());
   private final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
-public class BannedUsernameControllerTest {
+public class BannedUsernameControllerIntegrationTest {
 
   private final BannedUsernameController controller = spy(new BannedUsernameController());
   private final String username = Util.createUniqueTimeStamp();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -18,7 +18,7 @@ import games.strategy.util.Util;
  * More information: http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
  * This class checks if those lengths are supported.
  */
-public class EmailLimitTest {
+public class EmailLimitIntegrationTest {
 
   private static Connection connection;
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
-public class MutedMacControllerTest {
+public class MutedMacControllerIntegrationTest {
 
   private final MutedMacController controller = spy(new MutedMacController());
   final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 import games.strategy.util.Util;
 
-public class MutedUsernameControllerTest {
+public class MutedUsernameControllerIntegrationTest {
 
   private final MutedUsernameController controller = spy(new MutedUsernameController());
   private final String username = Util.createUniqueTimeStamp();

--- a/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -19,7 +19,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.test.TestUtil;
 import games.strategy.util.ThreadUtil;
 
-public class MessengerTest {
+public class MessengerIntegrationTest {
   private int serverPort = -1;
   private IServerMessenger serverMessenger;
   private IMessenger client1Messenger;


### PR DESCRIPTION
So, for the third time since we introduced the concept of integration tests, I ran into the issue where I tried to add a new unit test class and discovered there was already an integration test class with the same name.  We currently have a mixed convention for integration test classes: some end with a `Test` suffix and some end with an `IntegrationTest` suffix.  In order to avoid a name collision for a fourth time :smile:, this PR simply renames the integration test classes so that they all consistently use the `IntegrationTest` suffix.