### PR TITLE
Remove copyJRE task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,11 +139,10 @@ task jacocoRootReport(type: JacocoReport) {
     }
 }
 
-def assetsDirectory = file("${buildDir}/assets")
 git {
     assets {
         url 'https://github.com/triplea-game/assets.git'
-        directory assetsDirectory
+        directory file("${buildDir}/assets")
         branch 'master'
         singleBranch true
     }
@@ -212,15 +211,8 @@ task lobbyServer(type: Zip, group: 'release', dependsOn: renameShadowJar) {
 
 task generateZipReleases(group: 'release', dependsOn: [allPlatform, lobbyServer]) {}
 
-task copyJRE(type: Copy, dependsOn: [updateAssets]) {
-    from "${assetsDirectory}/install4j/windows-x86-1.8.0_66.tar.gz"
-    from "${assetsDirectory}/install4j/macosx-amd64-1.8.0_66.tar.gz"
-    from "${assetsDirectory}/install4j/windows-amd64-1.8.0_66.tar.gz"
-    into "${System.properties['user.home']}/.install4j6/jres"
-}
-
 import com.install4j.gradle.Install4jTask
-task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, copyJRE], group: 'release') {
+task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, updateAssets], group: 'release') {
     projectFile = file('build.install4j')
     release project.version
     doFirst {


### PR DESCRIPTION
This is a follow-up to #2369.

I now understand how the installer's bundled JREs "magically" appeared under `~/.install4j6/jres`.  I had previously theorized that install4j 6 must have automatically downloaded the bundled JREs from the URLs we provided if it could not find them in one of its predefined local search locations (`~/.install4j6/jres` being one of them).  After upgrading to install4j 7, install4j complained it could no longer find the bundled JREs, so I had assumed the magic automatic download feature must have been removed.

Nope...  It turns out we were copying the bundled JREs as part of the Gradle build via the `copyJRE` task.  Since that task was hard-coded to copy to `~/.install4j6/jres`, install4j 7 couldn't find them when it looked under `~/.install4j7/jres`.

In #2369, I modified the install4j build script to reference the bundled JREs directly from where the assets repo is cloned locally, so as to no longer depend on install4j's predefined search locations.  I still think that's a better solution than maintaining a copy task in a separate file, so this PR simply removes the `copyJRE` task, which is no longer required.

#### Testing

I removed `~/.install4j6` and ran `./gradlew clean release` locally.  I verified:

* All installers were built successfully.
* `~/.install4j6` was not created during the build.