### PR TITLE
Generate checksums for release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,8 @@ deploy:
   provider: releases
   api_key:
     secure: nxaqYrkXLGL3W20/eCnf63DLjMrQAhEuW44jggh1/nI383goa+u6w0bBtWCxRdVzos7t4dpVfS6+kv6oIHacm9zVA+RYrqy5opzCJhq8lmXVVRijbALzUeiFif2HURMaKWj0ynRNVlAyBHzazPTLZVWywifpdSubSkuMWkl20cmuKu/Hg3c1EC9se3OYhhTHx3Hya7xSrctrDEYLsEBAUZzkKfscqRVqwwltS88CgIMtRISDpSBGrtH0t1uAH6NitTSguGgb+QEpqnELcRLymX2G1yzMA4Xr5c/L34MfbBKf8vIuG9t411xYuLoyKoUbroTWxSnPwlSy6PHz+QJ7UCXbDkATOGO3chxlKxglppvI/G3n2YP5Zf2dAaDlHblpvarh55i/4i4sKB2AbvvzkIHrQJwUgmLCbpN8/Vp9GWcGkd6i5U7F8tNInCs6ttX3oGvGOfYEXs02Ctyiea4LAqk4S7GZTuV2QXqxXglL4eRIwZ4UETiwgoAAtHma63Eq7+9t2ykMlk7zAK96FGwJrB97wa08aPuSxL94IYEBmn9Ht/vKXRiNQMvpnfp4rWQtL3cqbVyYAg5EjKb4PsBmnb91+RXtnWFOY1RpZGt8sPXYd+KZYzN1BXTFJEpaLLsIDN6r7nMcAvJDUmucaM+m7giPXz1ZBGAic3UBM1qMCgI=
-  ## This is the list of files to be deployed to github releases
-  file:
-    - build/libs/triplea-${ENGINE_VERSION}-all.jar
-    - build/releases/TripleA_${ENGINE_VERSION}_windows-64bit.exe
-    - build/releases/TripleA_${ENGINE_VERSION}_windows-32bit.exe
-    - build/releases/TripleA_${ENGINE_VERSION}_macos.dmg
-    - build/releases/TripleA_${ENGINE_VERSION}_unix.sh
-    - build/distributions/triplea-${ENGINE_VERSION}-all_platforms.zip
-    - build/distributions/triplea-${ENGINE_VERSION}-server.zip
+  file_glob: true
+  file: build/artifacts/*
   skip_cleanup: true
   prerelease: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
 - ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- ./.travis/generate_artifact_checksums
 - ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:

--- a/.travis/generate_artifact_checksums
+++ b/.travis/generate_artifact_checksums
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+#
+# This script generates checksums for all release artifacts.
+#
+
+readonly ARTIFACTS_DIR=./build/artifacts
+readonly -a ENGINES=(md5sum sha1sum sha256sum)
+
+# Change to artifacts directory so file names in checksum files are bare
+cd $ARTIFACTS_DIR
+
+# Write checksum files outside the artifacts directory so they are not
+# considered by subsequent engines 
+declare -A checksum_files=()
+for engine in ${ENGINES[@]}; do
+  echo "Generating artifact checksums using '$engine'..."
+  checksum_files[$engine]=$(mktemp)
+  eval "$engine * > ${checksum_files[$engine]}"
+done
+
+# Move checksum files to artifacts directory after all engines have run
+for engine in ${ENGINES[@]}; do
+  mv ${checksum_files[$engine]} ./${engine}.txt
+done

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,9 @@ description = 'TripleA is a free online turn based strategy game and board game 
 mainClassName = "games.strategy.engine.framework.GameRunner"
 
 ext {
-    rootFilesDir = file("$buildDir/rootFiles")
+    artifactsDir = file("$buildDir/artifacts")
     releasesDir = file("$buildDir/releases")
+    rootFilesDir = file("$buildDir/rootFiles")
     schemasDir = file('config/triplea/schemas')
 
     gameEnginePropertiesFile = file('game_engine.properties')
@@ -160,7 +161,7 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
 }
 
 task renameShadowJar(type: Copy, group: 'release', dependsOn: [shadowJar]) {
-    ext.output = file("$project.buildDir/libs/all/triplea.jar")
+    ext.output = file("$libsDir/all/triplea.jar")
     from shadowJar.archivePath
     into ext.output.parent
     rename shadowJar.archivePath.name, output.name
@@ -226,7 +227,31 @@ task prepareInstallers(group: 'release', dependsOn: [generateInstallers]) {
     }
 }
 
-task release(group: 'release', dependsOn: [generateZipReleases, prepareInstallers]) {}
+task prepareArtifacts(group: 'release', dependsOn: [generateZipReleases, prepareInstallers]) {
+    doLast {
+        def artifacts = [
+            file("$libsDir/triplea-$version-all.jar"),
+            file("$distsDir/triplea-$version-all_platforms.zip"),
+            file("$distsDir/triplea-$version-server.zip"),
+            file("$releasesDir/TripleA_${version}_macos.dmg"),
+            file("$releasesDir/TripleA_${version}_unix.sh"),
+            file("$releasesDir/TripleA_${version}_windows-32bit.exe"),
+            file("$releasesDir/TripleA_${version}_windows-64bit.exe")
+        ]
+        artifacts.each {
+            if (!it.exists()) {
+                throw new GradleException("artifact '$it' does not exist")
+            }
+        }
+
+        copy {
+            from artifacts
+            into artifactsDir
+        }
+    }
+}
+
+task release(group: 'release', dependsOn: [prepareArtifacts]) {}
 
 gradle.taskGraph.whenReady { graph ->
     graph.getAllTasks().any({


### PR DESCRIPTION
This PR is in response to a few requests I've seen in the past year for installer checksums (e.g. latest one [here](https://forums.triplea-game.org/topic/332/checksums-available)).

#### Build changes

* The definition of the files to be included in a GitHub release has been moved from `.travis.yml` to the new `prepareArtifacts` Gradle task.  These files are collected into the `build/artifacts` folder to make it easier to process them.
* MD5, SHA-1, and SHA-256 checksums are generated for all files in the `build/artifacts` folder during the Travis build via the new `generate_artifact_checksums` script.  The checksum files produced by this script are included in the GitHub release.

#### Build changes for review

* I wasn't sure which checksum algorithms we should use because I don't know the requirements of the various sites that want to host TripleA files.  Observing that MD5, SHA-1, and SHA-256 seem to all still be popular today (see list of examples below), I went ahead and included them all.  Please advise if any of these should be removed or others added.
    * Apache OpenOffice: Provides MD5 and SHA-256 checksums.
    * Eclipse: Provides only SHA-512 checksums.
    * MySQL: Provides only MD5 checksums.
    * Java: Provides only SHA-256 checksums.
    * https://github.com/syncthing/syncthing: Provides SHA-1 and SHA-256 checksums.
    * http://onlinemd5.com/: A tool for calculating MD5, SHA-1, and SHA-256 checksums.
* As long as a user downloads or views the checksum files directly from GitHub over an HTTPS connection, they shouldn't have to worry about someone spoofing the checksums themselves.  However, we probably should eventually GPG sign these checksum files for the cases where they may be hosted off GitHub.  I plan on investigating that in a separate PR in the future.

#### Testing

I created a release branch in my fork to build these changes.  You can see a sample release with the checksums included [here](https://github.com/ssoloff/triplea-game-triplea/releases/tag/ssoloff-1.9.0.0.1165).

I downloaded the checksum files and checksummed files from the above release.  I then verified the checksums match locally:

```
$ md5sum -c md5sum.txt 
triplea-1.9.0.0.1165-all.jar: OK
triplea-1.9.0.0.1165-all_platforms.zip: OK
TripleA_1.9.0.0.1165_macos.dmg: OK
triplea-1.9.0.0.1165-server.zip: OK
TripleA_1.9.0.0.1165_unix.sh: OK
TripleA_1.9.0.0.1165_windows-32bit.exe: OK
TripleA_1.9.0.0.1165_windows-64bit.exe: OK

$ sha1sum -c sha1sum.txt 
triplea-1.9.0.0.1165-all.jar: OK
triplea-1.9.0.0.1165-all_platforms.zip: OK
TripleA_1.9.0.0.1165_macos.dmg: OK
triplea-1.9.0.0.1165-server.zip: OK
TripleA_1.9.0.0.1165_unix.sh: OK
TripleA_1.9.0.0.1165_windows-32bit.exe: OK
TripleA_1.9.0.0.1165_windows-64bit.exe: OK

$ sha256sum -c sha256sum.txt 
triplea-1.9.0.0.1165-all.jar: OK
triplea-1.9.0.0.1165-all_platforms.zip: OK
TripleA_1.9.0.0.1165_macos.dmg: OK
triplea-1.9.0.0.1165-server.zip: OK
TripleA_1.9.0.0.1165_unix.sh: OK
TripleA_1.9.0.0.1165_windows-32bit.exe: OK
TripleA_1.9.0.0.1165_windows-64bit.exe: OK
```