### PR TITLE
Move BadWordController#removeBannedWord()

### DIFF
--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
 import org.junit.Test;
 
 import games.strategy.util.Util;
@@ -11,12 +14,12 @@ import games.strategy.util.Util;
 public class BadWordControllerIntegrationTest {
 
   @Test
-  public void testInsertAndRemoveBadWord() {
+  public void testInsertAndRemoveBadWord() throws Exception {
     final BadWordController controller = new BadWordController();
     final String word = Util.createUniqueTimeStamp();
     controller.addBadWord(word);
     assertTrue(controller.list().contains(word));
-    controller.removeBannedWord(word);
+    removeBadWord(word);
     assertFalse(controller.list().contains(word));
   }
 
@@ -29,5 +32,14 @@ public class BadWordControllerIntegrationTest {
     controller.addBadWord(word);
     assertTrue(controller.list().contains(word));
     assertEquals(previousCount + 1, controller.list().size());
+  }
+
+  private static void removeBadWord(final String word) throws Exception {
+    try (final Connection con = Database.getPostgresConnection();
+        final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?")) {
+      ps.setString(1, word);
+      ps.execute();
+      con.commit();
+    }
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -25,17 +25,6 @@ public final class BadWordController implements BadWordDao {
     }
   }
 
-  void removeBannedWord(final String word) {
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?")) {
-      ps.setString(1, word);
-      ps.execute();
-      con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error deleting banned word:" + word, sqle);
-    }
-  }
-
   @Override
   public List<String> list() {
     final String sql = "select word from bad_words";


### PR DESCRIPTION
The `BadWordController#removeBannedWord()` method is only used by test code.  This PR simply moves it to the only test fixture that uses it.  I also renamed "banned" to "bad" for consistency with the surrounding code.