### PR TITLE
Remove unused TestDelegate and TestDelegateBridge methods

### DIFF
--- a/src/main/java/games/strategy/engine/xml/TestDelegate.java
+++ b/src/main/java/games/strategy/engine/xml/TestDelegate.java
@@ -12,35 +12,15 @@ import games.strategy.triplea.delegate.AbstractDelegate;
 public final class TestDelegate extends AbstractDelegate {
   public TestDelegate() {}
 
-  public boolean supportsTransactions() {
-    return false;
-  }
-
-  public void initialize(final String name) {
-    m_name = name;
-  }
-
   @Override
   public void initialize(final String name, final String displayName) {
     m_name = name;
-  }
-
-  public void startTransaction() {}
-
-  public void rollback() {}
-
-  public void commit() {}
-
-  public boolean inTransaction() {
-    return false;
   }
 
   @Override
   public String getName() {
     return m_name;
   }
-
-  public void cancelTransaction() {}
 
   @Override
   public void end() {}

--- a/src/test/java/games/strategy/engine/data/ITestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/ITestDelegateBridge.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
  */
 public interface ITestDelegateBridge extends IDelegateBridge {
   /**
-   * Changing the player has the effect of commiting the current transaction.
    * Player is initialized to the player specified in the xml data.
    */
   void setPlayerId(PlayerID playerId);

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -85,10 +85,6 @@ public class TestDelegateBridge implements ITestDelegateBridge {
     this.playerId = playerId;
   }
 
-  public boolean inTransaction() {
-    return false;
-  }
-
   @Override
   public PlayerID getPlayerId() {
     return playerId;


### PR DESCRIPTION
This PR removes some unused methods in the `TestDelegate` and `TestDelegateBridge` classes.  They all appear to have something to do with "transactions," whatever those might be in the context of a delegate.

These methods go all the way back to when these classes were introduced in 317bfa3 (2002).  They never appeared on `IDelegate` (formerly known as `Delegate`) or `IDelegateBridge` (formerly known as `DelegateBridge`), so they weren't inherited.  Walking the history, I could never find where the implementation of these methods were ever even changed from the initial code.

Just in case, I tried searching for reflective uses of these methods, but came up empty.

The only other non-transaction-related method I removed was `TestDelegate#initialize()`.  Again, this seems to have been the original signature for delegate initialization back in 2002, and seems to have been subsequently replaced with the two-parameter version.  Apparently, the old implementation was never removed from this class.