### PR TITLE
ConsoleHandler.java - remove unused constructor

### DIFF
--- a/src/main/java/games/strategy/debug/ConsoleHandler.java
+++ b/src/main/java/games/strategy/debug/ConsoleHandler.java
@@ -18,7 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
  * {@code System.err} and log records of all other levels to {@code System.out}.
  *
  * <p>
- * <strong>Configuration:</string> This handler does not currently support configuration through the {@link LogManager}.
+ * Configuration: This handler does not currently support configuration through the {@link LogManager}.
  * It always uses the following default configuration:
  * </p>
  *
@@ -33,6 +33,7 @@ public final class ConsoleHandler extends Handler {
   private final Supplier<PrintStream> errSupplier;
   private final Supplier<PrintStream> outSupplier;
 
+  @SuppressWarnings("unused")
   public ConsoleHandler() {
     this(() -> System.out, () -> System.err);
   }


### PR DESCRIPTION
- Also fix up javadoc, #strong tag was mismatched with its end tag, instead of fixing
just removed the html markup instead

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
