### PR TITLE
GameDataUtils.java - close stream resources and remove redundant initialization

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -19,12 +19,10 @@ public class GameDataUtils {
    * <strong>You should have the game data's read or write lock before calling this method</strong>
    */
   public static GameData cloneGameData(final GameData data, final boolean copyDelegates) {
-    try {
-      try (ByteArrayOutputStream sink = new ByteArrayOutputStream(10000)) {
-        GameDataManager.saveGame(sink, data, copyDelegates);
-        final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray());
-        return GameDataManager.loadGame(source);
-      }
+    try (ByteArrayOutputStream sink = new ByteArrayOutputStream(10000)) {
+      GameDataManager.saveGame(sink, data, copyDelegates);
+      final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray());
+      return GameDataManager.loadGame(source);
     } catch (final IOException ex) {
       ClientLogger.logQuietly(ex);
       return null;
@@ -37,19 +35,17 @@ public class GameDataUtils {
    */
   @SuppressWarnings("unchecked")
   public static <T> T translateIntoOtherGameData(final T object, final GameData translateInto) {
-    try {
-      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1024);
-           final GameObjectOutputStream out = new GameObjectOutputStream(sink)) {
-        out.writeObject(object);
+    try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1024);
+        final GameObjectOutputStream out = new GameObjectOutputStream(sink)) {
+      out.writeObject(object);
 
-        try (final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray())) {
-          final GameObjectStreamFactory factory = new GameObjectStreamFactory(translateInto);
-          try (final ObjectInputStream in = factory.create(source)) {
-            try {
-              return (T) in.readObject();
-            } catch (final ClassNotFoundException ex) {
-              throw new RuntimeException(ex);
-            }
+      try (final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray())) {
+        final GameObjectStreamFactory factory = new GameObjectStreamFactory(translateInto);
+        try (final ObjectInputStream in = factory.create(source)) {
+          try {
+            return (T) in.readObject();
+          } catch (final ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
           }
         }
       }


### PR DESCRIPTION
- `sink = null` is redundant to standard scoping rules, the two lines were removed.
- Otherwise we are wrapping with try with resources blocks a few unclosed resources and removing the explicit 'close()' calls.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
`