### PR TITLE
Download required assets instead of cloning entire repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.12.0'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.install4j.gradle' version '7.0.1'
-    id "de.qaware.seu.as.code.git" version "2.2.0"
+    id 'de.undercouch.download' version '3.2.0'
     id "net.ltgt.errorprone" version "0.0.11"
 }
 
@@ -140,15 +140,6 @@ task jacocoRootReport(type: JacocoReport) {
     }
 }
 
-git {
-    assets {
-        url 'https://github.com/triplea-game/assets.git'
-        directory file("${buildDir}/assets")
-        branch 'master'
-        singleBranch true
-    }
-}
-
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {
     doLast {
         def lobbyServerYamlFile = file('lobby_server.yaml')
@@ -167,7 +158,26 @@ task renameShadowJar(type: Copy, group: 'release', dependsOn: [shadowJar]) {
     rename shadowJar.archivePath.name, output.name
 }
 
-task updateAssets(dependsOn: ['gitCloneAssets', 'gitPullAssets']) {
+task downloadAssets(group: 'release') {
+    doLast {
+        [
+            'icons/triplea_icon_16_16.png',
+            'icons/triplea_icon_32_32.png',
+            'icons/triplea_icon_48_48.png',
+            'icons/triplea_icon_64_64.png',
+            'icons/triplea_icon_128_128.png',
+            'icons/triplea_icon_256_256.png',
+            'install4j/macosx-amd64-1.8.0_144.tar.gz',
+            'install4j/windows-amd64-1.8.0_144.tar.gz',
+            'install4j/windows-x86-1.8.0_144.tar.gz'
+        ].each { path ->
+            download {
+                src "https://raw.githubusercontent.com/triplea-game/assets/master/$path"
+                dest "$buildDir/assets/$path"
+                overwrite false
+            }
+        }
+    }
 }
 
 task prepareGameEngineProperties() {
@@ -185,7 +195,7 @@ task prepareGameEngineProperties() {
     }
 }
 
-task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updateAssets, prepareGameEngineProperties]) {
+task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, prepareGameEngineProperties]) {
     classifier 'all_platforms'
     ['assets', 'dice_servers'].each { folder ->
         from(folder) {
@@ -213,7 +223,7 @@ task lobbyServer(type: Zip, group: 'release', dependsOn: renameShadowJar) {
 task generateZipReleases(group: 'release', dependsOn: [allPlatform, lobbyServer]) {}
 
 import com.install4j.gradle.Install4jTask
-task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, updateAssets], group: 'release') {
+task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, downloadAssets], group: 'release') {
     projectFile = file('build.install4j')
     release project.version
     doFirst {


### PR DESCRIPTION
This PR addresses the issue we have during the Gradle build in which the entire `triplea-game/assets` repo is cloned.  Cloning this repo requires downloading ~500 MiB of content, which will only continue to increase as new assets are added to the repo.

The easiest solution to this problem would have been to perform a shallow clone of the repo.  While that still would have downloaded unnecessary files (e.g. bundled JREs for the previous release), it would have been acceptable.  Unfortunately, JGit (which all Gradle Git plugins use) does not support shallow clones at this time.

The solution offered in this PR is to simply download the required assets directly from GitHub instead of cloning the repo.

#### Build changes

The `updateAssets` task, which cloned the assets repo, was replaced with the `downloadAssets` task, which downloads the nine files our build currently requires from the assets repo.  It uses the `de.undercouch.download` Gradle plugin to perform this task.

#### Build issues for review

Unfortunately, GitHub does [not support conditional HTTP requests](https://github.com/isaacs/github/issues/692) at this time.  Thus, it is not possible to make use of the `onlyIfNewer` option of the Download task.  Therefore, in order to prevent repeated downloads of the assets, I set the `overwrite` option to `false`.  If on the off chance an asset is updated in the repo after it has been downloaded locally, a dev will be required to either manually delete the individual local asset or simply run the `clean` task in order to force the updated asset(s) to be downloaded.

This issue only affects devs who need to build the installer.  It does not affect the Travis build, which always starts from a clean slate.

#### Testing

I created a release branch in my fork to test these changes.  The [Travis build](https://travis-ci.org/ssoloff/triplea-game-triplea/builds/281737101) appeared to work fine.

I also did some local testing to ensure the assets are not re-downloaded if they are already present locally.