### PR TITLE
Sign release artifact checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
+before_script: ./.travis/setup_gpg
 script: ./gradlew check jacocoTestReport -x validateYamls
-after_success: 
+after_success:
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:

--- a/.travis/generate_artifact_checksums
+++ b/.travis/generate_artifact_checksums
@@ -22,3 +22,19 @@ done
 for engine in ${ENGINES[@]}; do
   mv ${checksum_files[$engine]} ./${engine}.txt
 done
+
+# Sign checksum files
+#
+# We use detached signatures so that
+#
+# a) users can verify the checksum files using *sum without any warnings about
+#    incorrectly-formatted lines, and
+# b) signing the checksum file itself is susceptible to spoofing because the
+#    *sum commands will process checksums outside the signature block (see
+#    https://github.com/nodejs/node/issues/6821#issuecomment-220033176)
+for engine in ${ENGINES[@]}; do
+  echo "Signing artifact checksums for '$engine'..."
+  gpg2 --batch --no-tty --yes --armor --detach-sign \
+      --passphrase-file <(echo "$GPG_PRIVATE_KEY_PASSPHRASE") \
+      ./${engine}.txt
+done

--- a/.travis/setup_gpg
+++ b/.travis/setup_gpg
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+#
+# This script sets up GnuPG (GPG) for use during a Travis build.
+#
+
+if [[ -z "$GPG_PRIVATE_KEY" ]]; then
+  echo "GPG_PRIVATE_KEY not set; GPG operations will not be available in this build"
+else
+  gpg2 --import <(echo "$GPG_PRIVATE_KEY")
+fi


### PR DESCRIPTION
This PR signs the release artifact checksums that were added in #2442 to ensure their integrity in the event a third-party hosts our releases.

#### Build changes

* A GPG public/private keypair was created for `tripleabuilderbot`.  The private key is used to sign the checksum files that are created during the build.  The signatures are "detached;" that is, they are stored in a parallel file:
    * `md5sum.txt` <--> `md5sum.txt.asc`
    * `sha1sum.txt` <--> `sha1sum.txt.asc`
    * `sha256sum.txt` <--> `sha256sum.txt.asc`
* The Travis configuration was updated to include secure environment variables for the private key (`GPG_PRIVATE_KEY`) and its associated passphrase (`GPG_PRIVATE_KEY_PASSPHRASE`).
* The project's master secrets document was updated to include the private key, its passphrase, and its revocation certificate.

#### Build issues for review

* I chose to use detached signatures instead of embedding the signature directly in the checksum files for two reasons:
    1. If the signatures are embedded in the checksum file, the various `*sum` tools will output warnings about incorrectly-formatted lines when verifying the checksums.
    1. If the signatures are embedded in the checksum file, the checksum file itself becomes susceptible to spoofing because the `*sum` tools will process checksums outside the signature block (see [here](https://github.com/nodejs/node/issues/6821#issuecomment-220033176) for a related discussion).

#### Testing

I created a release branch in my fork to build these changes. You can see a sample release with the signed checksums included [here](https://github.com/ssoloff/triplea-game-triplea/releases/tag/ssoloff-1.9.0.1202).

I downloaded all files from the above release on a machine different from the one on which I generated the `tripleabuilderbot` GPG keypair.  I imported the `tripleabuilderbot` public key and signed it with my personal GPG private key to ensure it is considered valid.

I first verified the checksum signatures:

```
$ gpg2 --verify md5sum.txt.asc
gpg: assuming signed data in 'md5sum.txt'
gpg: Signature made 10/02/17 14:13:10 Eastern Daylight Time using RSA key ID 5B474E6A
gpg: Good signature from "tripleabuilderbot <tripleabuilderbot@gmail.com>" [full]
$ gpg2 --verify sha1sum.txt.asc
gpg: assuming signed data in 'sha1sum.txt'
gpg: Signature made 10/02/17 14:13:10 Eastern Daylight Time using RSA key ID 5B474E6A
gpg: Good signature from "tripleabuilderbot <tripleabuilderbot@gmail.com>" [full]
$ gpg2 --verify sha256sum.txt.asc
gpg: assuming signed data in 'sha256sum.txt'
gpg: Signature made 10/02/17 14:13:10 Eastern Daylight Time using RSA key ID 5B474E6A
gpg: Good signature from "tripleabuilderbot <tripleabuilderbot@gmail.com>" [full]
```

I then verified the checksums match:

```
$ md5sum -c md5sum.txt
triplea-1.9.0.1202-all.jar: OK
triplea-1.9.0.1202-all_platforms.zip: OK
TripleA_1.9.0.1202_macos.dmg: OK
triplea-1.9.0.1202-server.zip: OK
TripleA_1.9.0.1202_unix.sh: OK
TripleA_1.9.0.1202_windows-32bit.exe: OK
TripleA_1.9.0.1202_windows-64bit.exe: OK
$ sha1sum -c sha1sum.txt
triplea-1.9.0.1202-all.jar: OK
triplea-1.9.0.1202-all_platforms.zip: OK
TripleA_1.9.0.1202_macos.dmg: OK
triplea-1.9.0.1202-server.zip: OK
TripleA_1.9.0.1202_unix.sh: OK
TripleA_1.9.0.1202_windows-32bit.exe: OK
TripleA_1.9.0.1202_windows-64bit.exe: OK
$ sha256sum -c sha256sum.txt
triplea-1.9.0.1202-all.jar: OK
triplea-1.9.0.1202-all_platforms.zip: OK
TripleA_1.9.0.1202_macos.dmg: OK
triplea-1.9.0.1202-server.zip: OK
TripleA_1.9.0.1202_unix.sh: OK
TripleA_1.9.0.1202_windows-32bit.exe: OK
TripleA_1.9.0.1202_windows-64bit.exe: OK
```

#### Notes

There is some minimal risk that merging this PR will result in a broken build.  I may have fat-fingered the Travis configuration when adding the GPG environment variables, which will cause a failure in the `generate_artifact_checksums` script.  As stated above, I tested this on my fork, but I can't test the release process in this repo until this PR is merged.  **If it's acceptable to the team, I would prefer to self-merge this PR after it is approved so I can fight any fires that may arise.**

After this PR is merged, I will create an issue to discuss where we should provide instructions to users on how to verify the checksum signatures.  This information will probably also include a copy of the `tripleabuilderbot` public key (or we may decide to distribute the public key to a public keyserver).  At this time, I think the Downloads page on the website is probably the best place, but we may decide that some other page or host (e.g. the GitHub wiki) is better.