### PR TITLE
Fix GameOverException when leaving game (#2453)

### DIFF
--- a/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
+++ b/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
@@ -4,6 +4,10 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
+/**
+ * Implementation of {@link InvocationHandler} that delegates the {@link Object#equals(Object)},
+ * {@link Object#hashCode()}, and {@link Object#toString()} methods to the specified object.
+ */
 public class WrappedInvocationHandler implements InvocationHandler {
   private final Object delegate;
 
@@ -25,7 +29,7 @@ public class WrappedInvocationHandler implements InvocationHandler {
     return false;
   }
 
-  public boolean shouldHandle(final Method method, final Object[] args) {
+  protected boolean shouldHandle(final Method method, final Object[] args) {
     if (method.getName().equals("equals") && args != null && args.length == 1) {
       return true;
     } else if (method.getName().equals("hashCode") && args == null) {
@@ -36,11 +40,11 @@ public class WrappedInvocationHandler implements InvocationHandler {
     return false;
   }
 
-  public Object handle(final Method method, final Object[] args) {
+  protected Object handle(final Method method, final Object[] args) {
     if (method.getName().equals("equals") && args != null && args.length == 1) {
       return wrappedEquals(args[0]);
     } else if (method.getName().equals("hashCode") && args == null) {
-      return wrappedashCode();
+      return delegate.hashCode();
     } else if (method.getName().equals("toString") && args == null) {
       return delegate.toString();
     } else {
@@ -48,14 +52,10 @@ public class WrappedInvocationHandler implements InvocationHandler {
     }
   }
 
-  public int wrappedashCode() {
-    return delegate.hashCode();
-  }
-
   @Override
-  public Object invoke(final Object arg0, final Method arg1, final Object[] arg2) throws Throwable {
-    if (shouldHandle(arg1, arg2)) {
-      return handle(arg1, arg2);
+  public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+    if (shouldHandle(method, args)) {
+      return handle(method, args);
     }
     throw new IllegalStateException("not configured");
   }

--- a/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
+++ b/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
@@ -30,6 +30,8 @@ public class WrappedInvocationHandler implements InvocationHandler {
       return true;
     } else if (method.getName().equals("hashCode") && args == null) {
       return true;
+    } else if (method.getName().equals("toString") && args == null) {
+      return true;
     }
     return false;
   }
@@ -39,6 +41,8 @@ public class WrappedInvocationHandler implements InvocationHandler {
       return wrappedEquals(args[0]);
     } else if (method.getName().equals("hashCode") && args == null) {
       return wrappedashCode();
+    } else if (method.getName().equals("toString") && args == null) {
+      return delegate.toString();
     } else {
       throw new IllegalStateException("how did we get here");
     }

--- a/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
+++ b/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
@@ -1,24 +1,58 @@
 package games.strategy.triplea.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
 import org.junit.Test;
 
 import games.strategy.test.TestUtil;
 
-public class WrappedInvocationHandlerTest {
+public final class WrappedInvocationHandlerTest {
+  private Object newProxy(final InvocationHandler handler) {
+    return Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler);
+  }
 
   @Test
-  public void testEquals() {
-    final String s1 = "test";
-    final WrappedInvocationHandler handler = new WrappedInvocationHandler(s1);
-    final Object o1 = Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler);
-    assertEquals(o1.hashCode(), s1.hashCode());
-    final String s2 = "test";
-    final WrappedInvocationHandler handler2 = new WrappedInvocationHandler(s2);
-    final Object o2 = Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler2);
-    assertEquals(o1, o2);
+  public void equals_ShouldReturnTrueWhenOtherInstanceIsWrappedInvocationHandlerProxyWithEqualDelegate() {
+    final Object proxy1 = newProxy(new WrappedInvocationHandler("test"));
+    final Object proxy2 = newProxy(new WrappedInvocationHandler("test"));
+
+    assertTrue(proxy1.equals(proxy2));
+  }
+
+  @Test
+  public void equals_ShouldReturnFalseWhenOtherInstanceIsWrappedInvocationHandlerProxyWithUnequalDelegate() {
+    final Object proxy1 = newProxy(new WrappedInvocationHandler("test1"));
+    final Object proxy2 = newProxy(new WrappedInvocationHandler("test2"));
+
+    assertFalse(proxy1.equals(proxy2));
+  }
+
+  @Test
+  public void equals_ShouldReturnFalseWhenOtherInstanceIsProxyWithoutWrappedInvocationHandler() {
+    final Object proxy1 = newProxy(new WrappedInvocationHandler("test"));
+    final Object proxy2 = newProxy((proxy, method, args) -> null);
+
+    assertFalse(proxy1.equals(proxy2));
+  }
+
+  @Test
+  public void hashCode_ShouldReturnHashCodeOfDelegate() {
+    final Object delegate = "test";
+    final Object proxy = newProxy(new WrappedInvocationHandler(delegate));
+
+    assertEquals(delegate.hashCode(), proxy.hashCode());
+  }
+
+  @Test
+  public void toString_ShouldReturnToStringOfDelegate() {
+    final Object delegate = "test";
+    final Object proxy = newProxy(new WrappedInvocationHandler(delegate));
+
+    assertEquals(delegate.toString(), proxy.toString());
   }
 }


### PR DESCRIPTION
This PR fixes the issue reported in #2453.

In #2411, a new check was added to `UnifiedMessenger#getImplementor()` to detect an unknown end point name.  The exception message (which is always constructed regardless of whether or not the exception is thrown), transitively invokes `EndPoint#toString()`.  `EndPoint#toString()` invokes `toString()` on the `EndPoint#m_implementors` collection.  This collection _may_ contain instances of `java.lang.reflect.Proxy` (and, in fact, it does in the scenario reported).

Per the [Javadocs](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Proxy.html), invoking the `equals()`, `hashCode()`, and `toString()` methods on a `Proxy` will be delegated to the associated `InvocationHandler`.  In the scenario reported, `toString()` is invoked on a `Proxy` associated with an anonymous implementation of `WrappedInvocationHandler` (see `DelegateExecutionManager#createInboundImplementation()`).  `WrappedInvocationHandler`, nor the anonymous implementation, handle `toString()`.  Thus, the `super.shouldHandle()` call in the anonymous implementation's `invoke()` method returns `false`, and the code proceeds on to `assertGameNotOver()`, which triggers the exception reported in #2453.

#### Functional changes

The fix is to add a handler for `toString()` to `WrappedInvocationHandler` that operates similarly to the `equals()` and `hashCode()` handlers, which simply delegate to the wrapped object.

#### Refactoring changes

I performed a few small refactorings in `WrappedInvocationHandler`:

* Reduce accessibility of `shouldHandle()` and `handle()` methods.
* Inline `wrapped[H]ashCode()` method.
* Rename `invoke()` method parameters.
* Add missing Javadocs.

#### Testing

I verified a `GameOverException` is no longer raised when running through the repro steps listed in #2453.

I added a few new unit tests to cover the new `toString()` handler in `WrappedInvocationHandler`, as well as to cover some uncovered branches in the `equals()` handler.

#### Notes

It will probably be easier to review this PR commit-by-commit.  d3a7f06 is the actual fix, while d28f137 contains all the refactoring.