### PR TITLE
Extract helpers for reading from and writing to in-memory streams

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -11,6 +10,7 @@ import java.util.List;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.io.IoUtils;
 
 /**
  * Downloads a map index file, parses it and returns a <code>List</code> of <code>DownloadFileDescription</code>.
@@ -47,7 +47,7 @@ public class DownloadRunnable {
       tempFile.deleteOnExit();
       DownloadUtils.downloadToFile(urlString, tempFile);
       final byte[] contents = Files.readAllBytes(tempFile.toPath());
-      return DownloadFileParser.parse(new ByteArrayInputStream(contents));
+      return IoUtils.readFromMemory(contents, DownloadFileParser::parse);
     } catch (final IOException e) {
       ClientLogger.logError("Error - will show an empty list of downloads. Failed to get files from: " + urlString, e);
       return new ArrayList<>();
@@ -58,7 +58,7 @@ public class DownloadRunnable {
     final File targetFile = new File(urlString);
     try {
       final byte[] contents = Files.readAllBytes(targetFile.toPath());
-      final List<DownloadFileDescription> downloads = DownloadFileParser.parse(new ByteArrayInputStream(contents));
+      final List<DownloadFileDescription> downloads = IoUtils.readFromMemory(contents, DownloadFileParser::parse);
       checkNotNull(downloads);
       return downloads;
     } catch (final IOException e) {

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -41,6 +40,7 @@ import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.MessengerException;
 import games.strategy.engine.random.CryptoRandomSource;
+import games.strategy.io.IoUtils;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
@@ -312,9 +312,7 @@ public class ServerLauncher extends AbstractLauncher {
   }
 
   private static byte[] gameDataToBytes(final GameData data) throws IOException {
-    final ByteArrayOutputStream sink = new ByteArrayOutputStream(25000);
-    GameDataManager.saveGame(sink, data);
-    return sink.toByteArray();
+    return IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
   }
 
   public void connectionLost(final INode node) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.startup.mc;
 
 import java.awt.Component;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,6 +47,7 @@ import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
+import games.strategy.io.IoUtils;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.IClientMessenger;
@@ -299,7 +299,7 @@ public class ClientModel implements IMessengerErrorListener {
     try {
       // this normally takes a couple seconds, but can take
       // up to 60 seconds for a freaking huge game
-      data = GameDataManager.loadGame(new ByteArrayInputStream(gameData));
+      data = IoUtils.readFromMemory(gameData, GameDataManager::loadGame);
     } catch (final IOException ex) {
       ClientLogger.logQuietly(ex);
       return;

--- a/src/main/java/games/strategy/io/IoUtils.java
+++ b/src/main/java/games/strategy/io/IoUtils.java
@@ -1,0 +1,120 @@
+package games.strategy.io;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A collection of useful methods related to I/O.
+ */
+public final class IoUtils {
+  private IoUtils() {}
+
+  /**
+   * Invokes the specified consumer with an in-memory input stream that wraps the specified byte array.
+   *
+   * @param bytes The byte array from which to read.
+   * @param consumer The consumer that will accept the input stream containing {@code bytes}.
+   *
+   * @throws IOException If {@code consumer} encounters an error while reading from the input stream.
+   */
+  public static void consumeFromMemory(final byte[] bytes, final InputStreamConsumer consumer) throws IOException {
+    checkNotNull(bytes);
+    checkNotNull(consumer);
+
+    readFromMemory(bytes, is -> {
+      consumer.accept(is);
+      return null;
+    });
+  }
+
+  /**
+   * Applies the specified function to an in-memory input stream that wraps the specified byte array and returns the
+   * function result.
+   *
+   * @param bytes The byte array from which to read.
+   * @param function The function to apply to an input stream containing {@code bytes}.
+   *
+   * @return The function result.
+   *
+   * @throws IOException If {@code function} encounters an error while reading from the input stream.
+   */
+  public static <T> T readFromMemory(final byte[] bytes, final InputStreamFunction<T> function) throws IOException {
+    checkNotNull(bytes);
+    checkNotNull(function);
+
+    // NB: ByteArrayInputStream does not need to be closed
+    return function.apply(new ByteArrayInputStream(bytes));
+  }
+
+  /**
+   * Invokes the specified consumer with an in-memory output stream and returns the bytes written.
+   *
+   * @param consumer The consumer whose output will be captured and returned.
+   *
+   * @return The bytes written by the consumer to the output stream.
+   *
+   * @throws IOException If {@code consumer} encounters an error while writing to the output stream.
+   */
+  public static byte[] writeToMemory(final OutputStreamConsumer consumer) throws IOException {
+    checkNotNull(consumer);
+
+    // NB: ByteArrayOutputStream does not need to be closed
+    final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    consumer.accept(os);
+    return os.toByteArray();
+  }
+
+  /**
+   * An operation that accepts an {@link InputStream} and returns no result.
+   */
+  @FunctionalInterface
+  public interface InputStreamConsumer {
+    /**
+     * Performs the operation using the specified input stream.
+     *
+     * @param is The input stream from which the consumer will read.
+     *
+     * @throws IOException If an I/O error occurs while reading from the input stream.
+     */
+    void accept(InputStream is) throws IOException;
+  }
+
+  /**
+   * A function that accepts an {@link InputStream} and produces a result.
+   *
+   * @param <R> The type of the function result.
+   */
+  @FunctionalInterface
+  public interface InputStreamFunction<R> {
+    /**
+     * Applies this function to the specified input stream.
+     *
+     * @param is The input stream from which the function will read.
+     *
+     * @return The function result.
+     *
+     * @throws IOException If an I/O error occurs while reading from the input stream.
+     */
+    R apply(InputStream is) throws IOException;
+  }
+
+  /**
+   * An operation that accepts an {@link OutputStream} and returns no result.
+   */
+  @FunctionalInterface
+  public interface OutputStreamConsumer {
+    /**
+     * Performs the operation using the specified output stream.
+     *
+     * @param os The output stream to which the consumer will write.
+     *
+     * @throws IOException If an I/O error occurs while writing to the output stream.
+     */
+    void accept(OutputStream os) throws IOException;
+  }
+}

--- a/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/src/main/java/games/strategy/net/nio/Decoder.java
@@ -1,6 +1,5 @@
 package games.strategy.net.nio;
 
-import java.io.ByteArrayInputStream;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -15,6 +14,7 @@ import games.strategy.engine.message.HubInvocationResults;
 import games.strategy.engine.message.HubInvoke;
 import games.strategy.engine.message.SpokeInvocationResults;
 import games.strategy.engine.message.SpokeInvoke;
+import games.strategy.io.IoUtils;
 import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.INode;
 import games.strategy.net.IObjectStreamFactory;
@@ -70,9 +70,14 @@ class Decoder {
         if (logger.isLoggable(Level.FINEST)) {
           logger.finest("Decoding packet:" + data);
         }
-        final ByteArrayInputStream stream = new ByteArrayInputStream(data.getData());
         try {
-          final MessageHeader header = readMessageHeader(data.getChannel(), objectStreamFactory.create(stream));
+          final MessageHeader header = IoUtils.readFromMemory(data.getData(), is -> {
+            try {
+              return readMessageHeader(data.getChannel(), objectStreamFactory.create(is));
+            } catch (final ClassNotFoundException e) {
+              throw new IOException(e);
+            }
+          });
           if (logger.isLoggable(Level.FINEST)) {
             logger.log(Level.FINEST, "header decoded:" + header);
           }

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -1,6 +1,5 @@
 package games.strategy.net.nio;
 
-import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -8,6 +7,7 @@ import java.nio.channels.SocketChannel;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import games.strategy.io.IoUtils;
 import games.strategy.net.IObjectStreamFactory;
 import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
@@ -38,9 +38,8 @@ class Encoder {
       throw new IllegalArgumentException("No to channel!");
     }
     try {
-      final ByteArrayOutputStream sink = new ByteArrayOutputStream(512);
-      write(header, objectStreamFactory.create(sink), to);
-      final SocketWriteData data = new SocketWriteData(sink.toByteArray(), sink.size());
+      final byte[] bytes = IoUtils.writeToMemory(os -> write(header, objectStreamFactory.create(os), to));
+      final SocketWriteData data = new SocketWriteData(bytes, bytes.length);
       if (logger.isLoggable(Level.FINER)) {
         logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
       }

--- a/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -2,9 +2,7 @@ package games.strategy.engine.data;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collection;
@@ -15,6 +13,7 @@ import org.junit.Test;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.framework.GameObjectStreamFactory;
+import games.strategy.io.IoUtils;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
 
@@ -31,15 +30,18 @@ public class ChangeTripleATest {
   }
 
   private Change serialize(final Change change) throws Exception {
-    final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-    try (final ObjectOutputStream output = new GameObjectOutputStream(sink)) {
-      output.writeObject(change);
-    }
-    final InputStream source = new ByteArrayInputStream(sink.toByteArray());
-    try (final ObjectInputStream input =
-        new GameObjectInputStream(new GameObjectStreamFactory(gameData), source)) {
-      return (Change) input.readObject();
-    }
+    final byte[] bytes = IoUtils.writeToMemory(os -> {
+      try (final ObjectOutputStream output = new GameObjectOutputStream(os)) {
+        output.writeObject(change);
+      }
+    });
+    return IoUtils.readFromMemory(bytes, is -> {
+      try (final ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameData), is)) {
+        return (Change) input.readObject();
+      } catch (final ClassNotFoundException e) {
+        throw new IOException(e);
+      }
+    });
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
+++ b/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
@@ -1,0 +1,24 @@
+package games.strategy.engine.data.properties;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public final class GamePropertiesTest {
+  @Test
+  public void shouldBeAbleToRoundTripEditableProperties() throws Exception {
+    final List<IEditableProperty> expected = Arrays.asList(
+        new StringProperty("name1", "description1", "value1"),
+        new StringProperty("name2", "description2", "value2"),
+        new StringProperty("name3", "description3", "value3"));
+
+    final byte[] bytes = GameProperties.writeEditableProperties(expected);
+    final List<IEditableProperty> actual = GameProperties.readEditableProperties(bytes);
+
+    assertThat(actual, is(expected));
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -3,11 +3,12 @@ package games.strategy.engine.framework.map.download;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import games.strategy.io.IoUtils;
 
 public class DownloadFileParserTest {
 
@@ -15,9 +16,8 @@ public class DownloadFileParserTest {
 
 
   @Test
-  public void testParseMap() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
-    final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
+  public void testParseMap() throws Exception {
+    final List<DownloadFileDescription> games = parse(buildTestData());
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(0);
     assertThat(desc.getUrl(), is("http://example.com/games/game.zip"));
@@ -31,9 +31,8 @@ public class DownloadFileParserTest {
   }
 
   @Test
-  public void testParseModSkin() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
-    final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
+  public void testParseModSkin() throws Exception {
+    final List<DownloadFileDescription> games = parse(buildTestData());
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(2);
     assertThat(desc.isMap(), is(false));
@@ -42,9 +41,8 @@ public class DownloadFileParserTest {
   }
 
   @Test
-  public void testParseMapTool() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
-    final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
+  public void testParseMapTool() throws Exception {
+    final List<DownloadFileDescription> games = parse(buildTestData());
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(3);
     assertThat(desc.isMap(), is(false));
@@ -52,6 +50,9 @@ public class DownloadFileParserTest {
     assertThat(desc.isMapTool(), is(true));
   }
 
+  private static List<DownloadFileDescription> parse(final byte[] bytes) throws Exception {
+    return IoUtils.readFromMemory(bytes, DownloadFileParser::parse);
+  }
 
   private static String createTypeTag(final DownloadFileParser.ValueType type) {
     return "  " + DownloadFileParser.Tags.mapType + ": " + type + "\n";
@@ -91,9 +92,8 @@ public class DownloadFileParserTest {
 
 
   @Test
-  public void testMapTypeDefaultsToMap() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(createSimpleGameXmlWithNoTypeTag());
-    final DownloadFileDescription download = DownloadFileParser.parse(inputStream).get(0);
+  public void testMapTypeDefaultsToMap() throws Exception {
+    final DownloadFileDescription download = parse(createSimpleGameXmlWithNoTypeTag()).get(0);
 
     assertThat(download.isMap(), is(true));
     assertThat(download.isMapSkin(), is(false));

--- a/src/test/java/games/strategy/io/IoUtilsTest.java
+++ b/src/test/java/games/strategy/io/IoUtilsTest.java
@@ -1,0 +1,59 @@
+package games.strategy.io;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.InputStream;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import games.strategy.io.IoUtils.InputStreamConsumer;
+import games.strategy.io.IoUtils.InputStreamFunction;
+
+public final class IoUtilsTest {
+  private final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+
+  private void thenStreamContainsExpectedBytes(final InputStream is) throws Exception {
+    final byte[] bytesRead = new byte[bytes.length];
+    is.read(bytesRead, 0, bytesRead.length);
+    assertThat(bytesRead, is(bytes));
+    assertThat(is.read(), is(-1));
+  }
+
+  @Test
+  public void consumeFromMemory_ShouldPassBytesToConsumer() throws Exception {
+    final InputStreamConsumer consumer = mock(InputStreamConsumer.class);
+
+    IoUtils.consumeFromMemory(bytes, consumer);
+
+    final ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(consumer).accept(inputStreamCaptor.capture());
+    thenStreamContainsExpectedBytes(inputStreamCaptor.getValue());
+  }
+
+  @Test
+  public void readFromMemory_ShouldPassBytesToFunction() throws Exception {
+    final InputStreamFunction<?> function = mock(InputStreamFunction.class);
+
+    IoUtils.readFromMemory(bytes, function);
+
+    final ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    verify(function).apply(inputStreamCaptor.capture());
+    thenStreamContainsExpectedBytes(inputStreamCaptor.getValue());
+  }
+
+  @Test
+  public void readFromMemory_ShouldReturnFunctionResult() throws Exception {
+    final Object result = new Object();
+
+    assertThat(IoUtils.readFromMemory(bytes, is -> result), is(result));
+  }
+
+  @Test
+  public void writeToMemory_ShouldReturnBytesWrittenByConsumer() throws Exception {
+    assertThat(IoUtils.writeToMemory(os -> os.write(bytes)), is(bytes));
+  }
+}

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
@@ -7,11 +7,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayOutputStream;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import games.strategy.io.IoUtils;
 
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public final class ProxyableObjectOutputStreamTest {
@@ -20,12 +20,14 @@ public final class ProxyableObjectOutputStreamTest {
     final Object obj = Integer.valueOf(42);
     final Object expectedReplacedObj = "42";
     final ProxyRegistry proxyRegistry = givenProxyRegistryFor(obj, expectedReplacedObj);
-    try (final ProxyableObjectOutputStream oos = newProxyableObjectOutputStream(proxyRegistry)) {
-      final Object actualReplacedObj = oos.replaceObject(obj);
+    IoUtils.writeToMemory(os -> {
+      try (final ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
+        final Object actualReplacedObj = oos.replaceObject(obj);
 
-      verify(proxyRegistry).getProxyFor(obj);
-      assertThat(actualReplacedObj, is(expectedReplacedObj));
-    }
+        verify(proxyRegistry).getProxyFor(obj);
+        assertThat(actualReplacedObj, is(expectedReplacedObj));
+      }
+    });
   }
 
   private static ProxyRegistry givenProxyRegistryFor(final Object principal, final Object proxy) {
@@ -34,17 +36,14 @@ public final class ProxyableObjectOutputStreamTest {
     return proxyRegistry;
   }
 
-  private static ProxyableObjectOutputStream newProxyableObjectOutputStream(final ProxyRegistry proxyRegistry)
-      throws Exception {
-    return new ProxyableObjectOutputStream(new ByteArrayOutputStream(), proxyRegistry);
-  }
-
   @Test
   public void replaceObject_ShouldReturnNullWhenObjectIsNull() throws Exception {
-    try (final ProxyableObjectOutputStream oos = newProxyableObjectOutputStream(ProxyRegistry.newInstance())) {
-      final Object replacedObj = oos.replaceObject(null);
+    IoUtils.writeToMemory(os -> {
+      try (final ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, ProxyRegistry.newInstance())) {
+        final Object replacedObj = oos.replaceObject(null);
 
-      assertThat(replacedObj, is(nullValue()));
-    }
+        assertThat(replacedObj, is(nullValue()));
+      }
+    });
   }
 }


### PR DESCRIPTION
Per a [discussion](https://github.com/triplea-game/triplea/pull/2461#discussion_r142019043) in #2461 where it was noted we should try to reduce the confusion over whether or not `ByteArrayInputStream` and `ByteArrayOutputStream` need to be closed.  Prior to this change, code was inconsistently split between not closing and closing (usually through try-with-resources) these types of streams.

This PR extracts some helper methods to the new `g.s.io.IoUtils` class for reading from and writing to in-memory streams.  The primary goal being to remove explicit references to `ByteArrayInputStream` and `ByteArrayOutputStream` if at all possible.  These methods also help to ensure filter output streams around an in-memory stream are closed before subsequently reading from the resulting buffer.  If the filter output streams are not closed before reading from the buffer, there is a possibility that reading from the associated memory input stream will end prematurely.

There are several other refactorings that could have been made in this PR (e.g. extracting methods specifically for reading/writing an object from/to an `ObjectInputStream`/`ObjectOutputStream`), but I felt this PR was big enough.  I'll probably submit follow-up PRs for those other refactorings in the future.

It should be easier to review this PR with whitespace changes ignored (`?w=1`).

#### Refactoring changes

In addition to the primary method extraction, I made a few other related refactoring changes:

* `GameProperties`
    * Changed the signature of the `toOutputStream()` method to return a byte array instead of writing to the passed-in `OutputStream`.  All callers of this method always passed a `ByteArrayOutputStream` from which they subsequently called `toByteArray()`.  So I just bypassed the intermediate output stream and returned the byte array directly.
    * Renamed `toOutputStream()` to `writeEditableProperties()` and `streamToIEditablePropertiesList()` to `readEditableProperties()` for consistency.

#### Testing

I added some new unit tests for code that was easily testable before refactoring to ensure I didn't break anything.  But the majority of the refactored code was not testable, and some would require unsafe refactorings to get there.

To cover the changes that affected network code, I ran one round of a network game with AI players and combat initiated by both the client and server human players.  No problems were observed, and I was able to resume play without issue from save games.

#### Notes

Given that this PR is low-to-moderate risk, it may be safer to hold off merging it until after the next release, which is hopefully only a few days away. 🤞 