### PR TITLE
Version fix

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -67,7 +67,7 @@ public final class ClientFileSystemHelper {
 
   private static String getTripleaJarWithEngineVersionStringPath() {
     final Version version = ClientContext.engineVersion();
-    return "triplea_" + version.toStringFull("_") + ".jar!";
+    return "triplea_" + version.toStringFull().replaceAll("\\.", "_") + ".jar!";
   }
 
   private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {

--- a/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -37,7 +37,7 @@ class EngineVersionProperties {
 
   private EngineVersionProperties(final Properties props) {
     latestVersionOut =
-        new Version(props.getProperty("LATEST", ClientContext.engineVersion().toStringFull(".")));
+        new Version(props.getProperty("LATEST", ClientContext.engineVersion().toStringFull()));
     link = props.getProperty("LINK", UrlConstants.TRIPLEA_WEBSITE.toString());
     linkAlt = props.getProperty("LINK_ALT", UrlConstants.DOWNLOAD_WEBSITE.toString());
     changelogLink = props.getProperty("CHANGELOG", UrlConstants.RELEASE_NOTES.toString());

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -115,7 +115,7 @@ public final class GameDataManager {
     try {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
-      if (!readVersion.equals(ClientContext.engineVersion(), true)) {
+      if (!readVersion.isCompatible(ClientContext.engineVersion())) {
         // a hack for now, but a headless server should not try to open any savegame that is not its version
         if (headless) {
           final String message = "Incompatible game save, we are: " + ClientContext.engineVersion()
@@ -137,8 +137,8 @@ public final class GameDataManager {
                 + "\nHowever, because the first 3 version numbers are the same as your current version, we can "
                 + "still open the savegame."
                 + "\n\nThis TripleA engine is version "
-                + ClientContext.engineVersion().toStringFull("_")
-                + " and you are trying to open a savegame made with version " + readVersion.toStringFull("_")
+                + ClientContext.engineVersion().toStringFull(".")
+                + " and you are trying to open a savegame made with version " + readVersion.toStringFull(".")
                 + "\n\nTo download the latest version of TripleA, Please visit "
                 + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE
                 + "\n\nIt is recommended that you upgrade to the latest version of TripleA before playing this "

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -129,7 +129,7 @@ public final class GameDataManager {
             + "\nTo download the latest version of TripleA, Please visit "
             + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE;
         throw new IOException(error);
-      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion(), false)) {
+      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion())) {
         // we can still load it because first 3 numbers of the version are the same, however this save was made by a
         // newer engine, so prompt the user to upgrade
         final String messageString =
@@ -137,8 +137,8 @@ public final class GameDataManager {
                 + "\nHowever, because the first 3 version numbers are the same as your current version, we can "
                 + "still open the savegame."
                 + "\n\nThis TripleA engine is version "
-                + ClientContext.engineVersion().toStringFull(".")
-                + " and you are trying to open a savegame made with version " + readVersion.toStringFull(".")
+                + ClientContext.engineVersion().toStringFull()
+                + " and you are trying to open a savegame made with version " + readVersion.toStringFull()
                 + "\n\nTo download the latest version of TripleA, Please visit "
                 + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE
                 + "\n\nIt is recommended that you upgrade to the latest version of TripleA before playing this "

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -140,7 +140,7 @@ public class GameRunner {
         testVersion = new Version(version);
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
-        if (!engineVersion.equals(testVersion, false)) {
+        if (!engineVersion.equals(testVersion)) {
           System.out.println("Current Engine version in use: " + engineVersion);
         }
       } catch (final Exception e) {
@@ -479,7 +479,7 @@ public class GameRunner {
     final boolean isCompatible = ClientContext.engineVersion().isCompatible(engineVersionOfGameToJoin);
     if (!isCompatible) {
       JOptionPane.showMessageDialog(parent,
-          "Host is using version " + engineVersionOfGameToJoin.toStringFull(".")
+          "Host is using version " + engineVersionOfGameToJoin.toStringFull()
               + ". You need to have a compatible engine version in order to join this game.",
           "Incompatible TripleA engine", JOptionPane.ERROR_MESSAGE);
       return;

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -413,8 +413,8 @@ public class GameRunner {
     }
 
     final String message = "<html>Would you like to download the tutorial map?<br><br>"
-            + "(You can always download it later using the Download Maps<br>"
-            + "command if you don't want to do it now.)</html>";
+        + "(You can always download it later using the Download Maps<br>"
+        + "command if you don't want to do it now.)</html>";
     SwingComponents.promptUser("Welcome to TripleA", message, () -> {
       DownloadMapsWindow.showDownloadMapsWindowAndDownload("Tutorial");
     });
@@ -476,11 +476,11 @@ public class GameRunner {
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
     final String newClassPath = null;
-    final boolean sameVersion = ClientContext.engineVersion().equals(engineVersionOfGameToJoin);
-    if (!sameVersion) {
+    final boolean isCompatible = ClientContext.engineVersion().isCompatible(engineVersionOfGameToJoin);
+    if (!isCompatible) {
       JOptionPane.showMessageDialog(parent,
-          "Host is using version " + engineVersionOfGameToJoin.toStringFull("_")
-              + ". You need to have the same engine version in order to join this game.",
+          "Host is using version " + engineVersionOfGameToJoin.toStringFull(".")
+              + ". You need to have a compatible engine version in order to join this game.",
           "Incompatible TripleA engine", JOptionPane.ERROR_MESSAGE);
       return;
     }

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -98,7 +98,7 @@ public final class ClientLoginValidator implements ILoginValidator {
 
     // check for version
     final Version clientVersion = new Version(versionString);
-    if (!ClientContext.engineVersion().equals(clientVersion, false)) {
+    if (!ClientContext.engineVersion().isCompatible(clientVersion)) {
       return "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion();
     }
 

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -185,11 +185,18 @@ public class Version implements Serializable, Comparable<Object> {
 
   private String toStringFull(final String separator, final boolean noMicro) {
     return m_major + separator + m_minor + separator + m_point
-      + (noMicro ? "" : (separator + (m_micro == Integer.MAX_VALUE ? "dev" : m_micro)));
+        + (noMicro ? "" : (separator + (m_micro == Integer.MAX_VALUE ? "dev" : m_micro)));
   }
 
   @Override
   public String toString() {
     return m_point == 0 && m_micro == 0 ? m_major + "." + m_minor : toStringFull(".", m_micro == 0);
+  }
+
+  public boolean isCompatible(final Version otherVersion) {
+    if (otherVersion == null) {
+      return false;
+    }
+    return otherVersion.m_major == m_major && otherVersion.m_minor == m_minor;
   }
 }

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -19,14 +19,23 @@ public class Version implements Serializable, Comparable<Object> {
   private final boolean microBlank;
   private final String exactVersion;
 
+  /**
+   * Constructs a Version object without the point and micro version, defaults those to 0.
+   */
   public Version(final int major, final int minor) {
     this(major, minor, 0);
   }
 
+  /**
+   * Constructs a Version object without the micro version, defaults to 0.
+   */
   public Version(final int major, final int minor, final int point) {
     this(major, minor, point, 0);
   }
 
+  /**
+   * Constructs a Version object with all version values set.
+   */
   public Version(final int major, final int minor, final int point, final int micro) {
     this.m_major = major;
     this.m_minor = minor;
@@ -89,18 +98,30 @@ public class Version implements Serializable, Comparable<Object> {
     return exactVersion != null ? exactVersion : toString();
   }
 
+  /**
+   * Returns the major version number.
+   */
   public int getMajor() {
     return m_major;
   }
 
+  /**
+   * Returns the minor version number.
+   */
   public int getMinor() {
     return m_minor;
   }
 
+  /**
+   * Returns the point version number.
+   */
   public int getPoint() {
     return m_point;
   }
 
+  /**
+   * Returns the micro version number.
+   */
   public int getMicro() {
     return m_micro;
   }
@@ -110,10 +131,6 @@ public class Version implements Serializable, Comparable<Object> {
     return compareTo(o) == 0;
   }
 
-  public boolean equals(final Object o, final boolean ignoreMicro) {
-    return compareTo(o, ignoreMicro) == 0;
-  }
-
   @Override
   public int hashCode() {
     return this.toString().hashCode();
@@ -121,22 +138,10 @@ public class Version implements Serializable, Comparable<Object> {
 
   @Override
   public int compareTo(final Object o) {
-    return compareTo(o, false);
-  }
-
-  public int compareTo(final Version other) {
-    return compareTo(other, false);
-  }
-
-  private int compareTo(final Object o, final boolean ignoreMicro) {
-    if (o == null) {
+    if (o == null || !(o instanceof Version)) {
       return -1;
     }
-    if (!(o instanceof Version)) {
-      return -1;
-    }
-    final Version other = (Version) o;
-    return compareTo(other, ignoreMicro);
+    return compareTo((Version) o, false);
   }
 
   private int compareTo(final Version other, final boolean ignoreMicro) {
@@ -167,32 +172,46 @@ public class Version implements Serializable, Comparable<Object> {
     return 0;
   }
 
+  /**
+   * Returns true, if the provided Version object is greater than this object.
+   */
   public boolean isGreaterThan(final Version other) {
     return isGreaterThan(other, false);
   }
 
+  /**
+   * Returns true, if the provided Version object is greater than this object.
+   * If ignoreMicro is set to true, the micro version number is ignored.
+   */
   public boolean isGreaterThan(final Version other, final boolean ignoreMicro) {
     return compareTo(other, ignoreMicro) < 0;
   }
 
+  /**
+   * Returns true, if the provided Version object is less than this object.
+   */
   public boolean isLessThan(final Version other) {
-    return compareTo(other, false) > 0;
+    return compareTo(other) > 0;
   }
 
-  public String toStringFull(final String separator) {
-    return toStringFull(separator, false);
-  }
-
-  private String toStringFull(final String separator, final boolean noMicro) {
+  /**
+   * Creates a complete version string, even if some version numbers are 0.
+   */
+  public String toStringFull() {
+    final String separator = ".";
     return m_major + separator + m_minor + separator + m_point
-        + (noMicro ? "" : (separator + (m_micro == Integer.MAX_VALUE ? "dev" : m_micro)));
+        + (separator + (m_micro == Integer.MAX_VALUE ? "dev" : m_micro));
   }
 
   @Override
   public String toString() {
-    return m_point == 0 && m_micro == 0 ? m_major + "." + m_minor : toStringFull(".", m_micro == 0);
+    return m_point == 0 && m_micro == 0 ? m_major + "." + m_minor : toStringFull();
   }
 
+  /**
+   * Checks if The major and minor version numbers are equal.
+   * Returns true if they are.
+   */
   public boolean isCompatible(final Version otherVersion) {
     if (otherVersion == null) {
       return false;

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -212,7 +212,7 @@ public class Version implements Serializable, Comparable<Object> {
    * Checks if The major and minor version numbers are equal.
    * Returns true if they are.
    */
-  public boolean isCompatible(final Version otherVersion) {
-    return otherVersion != null && otherVersion.m_major == m_major && otherVersion.m_minor == m_minor;
+  public boolean isCompatible(final Version other) {
+    return other != null && other.m_major == m_major && other.m_minor == m_minor && other.m_point == m_point;
   }
 }

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -140,7 +140,7 @@ public class Version implements Serializable, Comparable<Object> {
 
   @Override
   public int compareTo(final Object o) {
-    if (o == null || !(o instanceof Version)) {
+    if (!(o instanceof Version)) {
       return -1;
     }
     return compareTo((Version) o, false);

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -205,7 +205,7 @@ public class Version implements Serializable, Comparable<Object> {
 
   @Override
   public String toString() {
-    return m_point == 0 && m_micro == 0 ? m_major + "." + m_minor : toStringFull();
+    return m_micro != 0 ? toStringFull() : m_major + "." + m_minor + (m_point != 0 ? "." + m_point : "");
   }
 
   /**

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -3,6 +3,8 @@ package games.strategy.util;
 import java.io.Serializable;
 import java.util.StringTokenizer;
 
+import com.google.common.base.Joiner;
+
 /**
  * Represents a version string.
  * versions are of the form major.minor.point.micro
@@ -198,9 +200,7 @@ public class Version implements Serializable, Comparable<Object> {
    * Creates a complete version string, even if some version numbers are 0.
    */
   public String toStringFull() {
-    final String separator = ".";
-    return m_major + separator + m_minor + separator + m_point
-        + (separator + (m_micro == Integer.MAX_VALUE ? "dev" : m_micro));
+    return Joiner.on('.').join(m_major, m_minor, m_point, m_micro == Integer.MAX_VALUE ? "dev" : m_micro);
   }
 
   @Override
@@ -213,9 +213,6 @@ public class Version implements Serializable, Comparable<Object> {
    * Returns true if they are.
    */
   public boolean isCompatible(final Version otherVersion) {
-    if (otherVersion == null) {
-      return false;
-    }
-    return otherVersion.m_major == m_major && otherVersion.m_minor == m_minor;
+    return otherVersion != null && otherVersion.m_major == m_major && otherVersion.m_minor == m_minor;
   }
 }

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -69,6 +69,10 @@ public class VersionTest {
   @Test
   public void testCompatible() {
     assertTrue(new Version(1, 9).isCompatible(new Version(1, 9)));
+    assertTrue(new Version(1, 9).isCompatible(new Version(1, 9, 1, 2)));
+    assertTrue(new Version(1, 9, 1, 2).isCompatible(new Version(1, 9, 3, 4)));
+    assertTrue(new Version(1, 9, 1).isCompatible(new Version(1, 9, 2, 3)));
+    assertTrue(new Version(1, 9, 1, 2).isCompatible(new Version(1, 9, 3)));
     assertFalse(new Version(2, 9).isCompatible(new Version(1, 9)));
     assertFalse(new Version(1, 10).isCompatible(new Version(1, 9)));
     assertFalse(new Version(2, 10).isCompatible(new Version(1, 9)));

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -41,15 +41,6 @@ public class VersionTest {
   }
 
   @Test
-  public void testCompare5() {
-    // micro differences should have no difference
-    final Version v1 = new Version(0, 0, 0, 0);
-    final Version v2 = new Version(0, 0, 0, 1);
-    assertTrue(v1.equals(v2, true));
-    assertTrue(v2.equals(v1, true));
-  }
-
-  @Test
   public void testRead1() {
     assertTrue("1.2.3".equals(new Version("1.2.3").toString()));
   }

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -42,22 +42,22 @@ public class VersionTest {
 
   @Test
   public void testRead1() {
-    assertTrue("1.2.3".equals(new Version("1.2.3").toString()));
+    assertEquals("1.2.3", new Version("1.2.3").toString());
   }
 
   @Test
   public void testRead2() {
-    assertTrue("1.2".equals(new Version("1.2").toString()));
+    assertEquals("1.2", new Version("1.2").toString());
   }
 
   @Test
   public void testRead3() {
-    assertTrue("1.2".equals(new Version("1.2.0").toString()));
+    assertEquals("1.2", new Version("1.2.0").toString());
   }
 
   @Test
   public void testRead4() {
-    assertTrue("1.2.3.dev".equals(new Version("1.2.3.dev").toString()));
+    assertEquals("1.2.3.dev", new Version("1.2.3.dev").toString());
   }
 
   @Test

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -74,4 +74,12 @@ public class VersionTest {
     assertEquals("1.2.3.4", new Version(1, 2, 3, 4).getExactVersion());
     assertEquals("1.2.3.4.5", new Version("1.2.3.4.5").getExactVersion());
   }
+
+  @Test
+  public void testCompatible() {
+    assertTrue(new Version(1, 9).isCompatible(new Version(1, 9)));
+    assertFalse(new Version(2, 9).isCompatible(new Version(1, 9)));
+    assertFalse(new Version(1, 10).isCompatible(new Version(1, 9)));
+    assertFalse(new Version(2, 10).isCompatible(new Version(1, 9)));
+  }
 }

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -70,12 +70,13 @@ public class VersionTest {
   @Test
   public void testCompatible() {
     assertTrue(new Version(1, 9).isCompatible(new Version(1, 9)));
-    assertTrue(new Version(1, 9).isCompatible(new Version(1, 9, 1, 2)));
-    assertTrue(new Version(1, 9, 1, 2).isCompatible(new Version(1, 9, 3, 4)));
-    assertTrue(new Version(1, 9, 1).isCompatible(new Version(1, 9, 2, 3)));
-    assertTrue(new Version(1, 9, 1, 2).isCompatible(new Version(1, 9, 3)));
+    assertTrue(new Version(1, 9).isCompatible(new Version(1, 9, 0, 1)));
+    assertTrue(new Version(1, 9, 0, 1).isCompatible(new Version(1, 9, 0, 2)));
+    assertTrue(new Version(1, 9, 1).isCompatible(new Version(1, 9, 1, 3)));
+    assertTrue(new Version(1, 9, 1, 2).isCompatible(new Version(1, 9, 1)));
     assertFalse(new Version(2, 9).isCompatible(new Version(1, 9)));
     assertFalse(new Version(1, 10).isCompatible(new Version(1, 9)));
     assertFalse(new Version(2, 10).isCompatible(new Version(1, 9)));
+    assertFalse(new Version(1, 9, 1, 9).isCompatible(new Version(2, 0, 1, 9)));
   }
 }

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -2,6 +2,7 @@ package games.strategy.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -12,32 +13,32 @@ public class VersionTest {
   public void testCompare() {
     final Version v1 = new Version(0, 0, 0);
     final Version v2 = new Version(1, 0, 0);
-    assertFalse(v1.equals(v2));
-    assertFalse(v2.equals(v1));
+    assertNotEquals(v1, v2);
+    assertNotEquals(v2, v1);
   }
 
   @Test
   public void testCompare2() {
     final Version v1 = new Version(0, 0, 0);
     final Version v2 = new Version(1, 1, 0);
-    assertTrue(!v1.equals(v2));
-    assertTrue(!v2.equals(v1));
+    assertNotEquals(v1, v2);
+    assertNotEquals(v2, v1);
   }
 
   @Test
   public void testCompare3() {
     final Version v1 = new Version(0, 0, 0);
     final Version v2 = new Version(0, 1, 0);
-    assertTrue(!v1.equals(v2));
-    assertTrue(!v2.equals(v1));
+    assertNotEquals(v1, v2);
+    assertNotEquals(v2, v1);
   }
 
   @Test
   public void testCompare4() {
     final Version v1 = new Version(0, 0, 0);
     final Version v2 = new Version(0, 0, 1);
-    assertTrue(!v1.equals(v2));
-    assertTrue(!v2.equals(v1));
+    assertNotEquals(v1, v2);
+    assertNotEquals(v2, v1);
   }
 
   @Test


### PR DESCRIPTION
This fixes the last noteable regression.
Note that my assumption is that as long the major and minor version number are the same, a release is considered compatible.
I did some testing and it turns out this change works without requiring to update bots as long as the third (point) version number isn't changed.
If this version number is changed, the bots need to be updated to consider the client as compatible.

I also did a lot of cleanup, the core change is very small (just view the first 3 commits)