### PR TITLE
Remove uneccessary VM args

### DIFF
--- a/eclipse/launchers/GameRunner_run_game.launch
+++ b/eclipse/launchers/GameRunner_run_game.launch
@@ -10,5 +10,5 @@
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.GameRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10;-Dcom.sun.management.jmxremote=true &#13;&#10;-Dcom.sun.management.jmxremote.port=3614 &#13;&#10;-Dcom.sun.management.jmxremote.authenticate=false &#13;&#10;-Dcom.sun.management.jmxremote.ssl=false"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>


### PR DESCRIPTION
Seems to be no longer necessary.
From http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html : 
> ### Local Monitoring and Management
> Under previous releases of the Java SE platform, to allow the JMX client access to a local Java VM, you had to set the following system property when you started the Java VM or Java application.
> ```
>      com.sun.management.jmxremote
> ```
> Setting this property registered the Java VM platform's MBeans and published the Remote Method Invocation (RMI) connector via a private interface to allow JMX client applications to monitor a local Java platform, that is, a Java VM running on the same machine as the JMX client.
> 
> In the Java SE 6 platform, it is no longer necessary to set this system property. Any application that is started on the Java SE 6 platform will support the Attach API, and so will automatically be made available for local monitoring and management when needed.

Removing those args allows us to launch multiple instances of triplea simultaneously from within the IDE (eclipse)