### PR TITLE
Add additional SwingBuilder components

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -371,8 +371,7 @@ public class DownloadMapsWindow extends JFrame {
 
     final List<DownloadFileDescription> maps = MapDownloadListSort.sortByMapName(unsortedMaps);
     final JPanel main = JPanelBuilder.builder()
-        .borderWidth(30)
-        .border(JPanelBuilder.BorderType.EMPTY)
+        .borderEmpty(30)
         .build();
     final JEditorPane descriptionPane = SwingComponents.newHtmlJEditorPane();
     main.add(SwingComponents.newJScrollPane(descriptionPane), BorderLayout.CENTER);
@@ -507,8 +506,7 @@ public class DownloadMapsWindow extends JFrame {
 
     return JPanelBuilder.builder()
         .gridLayout(1, 5)
-        .border(JPanelBuilder.BorderType.EMPTY)
-        .borderWidth(20)
+        .borderEmpty(20)
         .add(buildMapActionButton(action, gamesList, maps, listModel))
         .add(Box.createGlue())
         .add(JButtonBuilder.builder()

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.settings;
 
 import java.io.File;
+
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
@@ -8,6 +9,7 @@ import javax.swing.UIManager;
 
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import games.strategy.debug.ClientLogger;
@@ -109,7 +111,11 @@ public enum ClientSetting implements GameSetting {
 
   WHEEL_SCROLL_AMOUNT(60),
 
-  PLAYER_NAME(System.getProperty("user.name"));
+  PLAYER_NAME(System.getProperty("user.name")),
+
+  /* for testing purposes, to be used in unit tests only */
+  @VisibleForTesting
+  TEST_SETTING;
 
   public final String defaultValue;
 
@@ -167,8 +173,27 @@ public enum ClientSetting implements GameSetting {
     Preferences.userNodeForPackage(ClientSetting.class).put(name(), newValue);
   }
 
+  public static void save(final String key, final String value) {
+    Preferences.userNodeForPackage(ClientSetting.class).put(key, value);
+  }
+
+  public static String load(final String key) {
+    return Preferences.userNodeForPackage(ClientSetting.class).get(key, "");
+  }
+
+  public void saveAndFlush(final String newValue) {
+    save(newValue);
+    ClientSetting.flush();
+  }
+
+
   @Override
   public String value() {
     return Strings.nullToEmpty(Preferences.userNodeForPackage(ClientSetting.class).get(name(), defaultValue));
+  }
+
+  @Override
+  public void resetAndFlush() {
+    saveAndFlush(defaultValue);
   }
 }

--- a/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -7,7 +7,7 @@ package games.strategy.triplea.settings;
  */
 public interface GameSetting {
   /**
-   * @return True if the setting has been specified by the user or updated from default.
+   * Return true if the setting has been specified by the user or updated from default.
    */
   boolean isSet();
 
@@ -36,4 +36,6 @@ public interface GameSetting {
   default boolean booleanValue() {
     return Boolean.valueOf(value());
   }
+
+  void resetAndFlush();
 }

--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -17,7 +17,6 @@ import javax.swing.SwingUtilities;
 import com.google.common.base.Preconditions;
 
 import games.strategy.ui.SwingComponents;
-import swinglib.GridBagHelper;
 import swinglib.JButtonBuilder;
 import swinglib.JLabelBuilder;
 import swinglib.JPanelBuilder;

--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -86,17 +86,14 @@ enum SettingsWindow {
   }
 
   private static JComponent tabMainContents(final Iterable<ClientSettingUiBinding> settings) {
-    final JPanel contents = JPanelBuilder.builder()
-        .gridBagLayout()
-        .build();
-
-    final GridBagHelper grid = new GridBagHelper(contents, 3);
+    final JPanelBuilder contents = JPanelBuilder.builder()
+        .gridBagLayout(3);
 
     // Add settings, one per row, columns of 3:
     // setting title (JLabel) | input component (eg: radio buttons) | description (JTextArea)}
 
     settings.forEach(setting -> {
-      grid.add(JPanelBuilder.builder()
+      contents.add(JPanelBuilder.builder()
           .horizontalBoxLayout()
           .add(
               JLabelBuilder.builder()
@@ -106,9 +103,9 @@ enum SettingsWindow {
                   .build())
           .build());
 
-      grid.add(setting.buildSelectionComponent());
+      contents.add(setting.buildSelectionComponent());
 
-      grid.add(JScrollPaneBuilder.builder()
+      contents.add(JScrollPaneBuilder.builder()
           .view(JTextAreaBuilder.builder()
               .text(setting.description)
               .rows(2)
@@ -117,7 +114,7 @@ enum SettingsWindow {
               .build())
           .build());
     });
-    return SwingComponents.newJScrollPane(contents);
+    return SwingComponents.newJScrollPane(contents.build());
   }
 
   private static JPanel buttonPanel(final List<ClientSettingUiBinding> settings, final Runnable closeListener) {

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -3,6 +3,9 @@ package games.strategy.ui;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.Consumer;
 
@@ -84,5 +87,20 @@ public class SwingAction {
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }
+  }
+
+  /**
+   * Creates a new KeyListener that is executed on key release event.
+   *
+   * @param eventConsumer We will pass a key event to this consumer whenever there is a key released event.
+   * @return A Swing KeyListener object, can be attached to swing component objects.
+   */
+  public static KeyListener keyReleaseListener(final Consumer<KeyEvent> eventConsumer) {
+    return new KeyAdapter() {
+      @Override
+      public void keyReleased(final KeyEvent e) {
+        eventConsumer.accept(e);
+      }
+    };
   }
 }

--- a/src/main/java/swinglib/JButtonBuilder.java
+++ b/src/main/java/swinglib/JButtonBuilder.java
@@ -2,13 +2,15 @@ package swinglib;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.awt.Font;
+
 import javax.swing.JButton;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 /**
- * Example usage:
+ * Example usage:.
  * <code><pre>
  *   JButton button = JButtonBuilder.builder()
  *     .text("button text")
@@ -21,31 +23,14 @@ public class JButtonBuilder {
   private String title;
   private String toolTip;
   private Runnable actionListener;
+  private boolean visible = true;
+  private boolean enabled = false;
+  private int biggerFont = 0;
 
   private JButtonBuilder() {}
 
   public static JButtonBuilder builder() {
     return new JButtonBuilder();
-  }
-
-  /** required - The text that will be on the button. */
-  public JButtonBuilder title(final String title) {
-    Preconditions.checkArgument(!Strings.nullToEmpty(title).trim().isEmpty());
-    this.title = title;
-    return this;
-  }
-
-  /** optional, but potentially required in the future. This is the hover text when hovering on the button. */
-  public JButtonBuilder toolTip(final String toolTip) {
-    Preconditions.checkArgument(!Strings.nullToEmpty(toolTip).trim().isEmpty());
-    this.toolTip = toolTip;
-    return this;
-  }
-
-  /** request, the event that occurs when the button is clicked. */
-  public JButtonBuilder actionListener(final Runnable actionListener) {
-    this.actionListener = checkNotNull(actionListener);
-    return this;
   }
 
   /**
@@ -54,14 +39,90 @@ public class JButtonBuilder {
    */
   public JButton build() {
     Preconditions.checkNotNull(title);
-    Preconditions.checkNotNull(actionListener);
+    Preconditions.checkState(!enabled || actionListener != null,
+        "Was enabled? " + enabled + ", action listener == null? " + (actionListener == null));
 
     final JButton button = new JButton(title);
     if (toolTip != null) {
       button.setToolTipText(toolTip);
     }
     button.addActionListener(e -> actionListener.run());
+    button.setVisible(visible);
+    button.setEnabled(enabled);
+
+    if (biggerFont > 0) {
+      button.setFont(
+          new Font(
+              button.getFont().getName(),
+              button.getFont().getStyle(),
+              button.getFont().getSize() + biggerFont));
+    }
+
     return button;
   }
 
+
+  /** required - The text that will be on the button. */
+  public JButtonBuilder title(final String title) {
+    Preconditions.checkArgument(!Strings.nullToEmpty(title).trim().isEmpty());
+    this.title = title;
+    return this;
+  }
+
+  /**
+   * Increases button text size by a default amount.
+   */
+  public JButtonBuilder biggerFont() {
+    return biggerFont(4);
+  }
+
+  /**
+   * Increases button text size.
+   * 
+   * @param plusAmount Text increase amount, typically somewhere around +2 to +4
+   */
+  public JButtonBuilder biggerFont(final int plusAmount) {
+    Preconditions.checkArgument(plusAmount > 0);
+    biggerFont = plusAmount;
+    return this;
+  }
+
+
+  /**
+   * Sets the text shown when hovering on the button.
+   */
+  public JButtonBuilder toolTip(final String toolTip) {
+    Preconditions.checkArgument(!Strings.nullToEmpty(toolTip).trim().isEmpty());
+    this.toolTip = toolTip;
+    return this;
+  }
+
+  /**
+   * Sets the event that occurs when the button is clicked.
+   * SIDE EFFECT: Enables the button
+   */
+  public JButtonBuilder actionListener(final Runnable actionListener) {
+    this.actionListener = checkNotNull(actionListener);
+    enabled = true;
+    return this;
+  }
+
+
+
+  /**
+   * Toggles whether the button is visible on screen or not.
+   * TODO: does an invisible component take up space?
+   */
+  public JButtonBuilder visible(final boolean visible) {
+    this.visible = visible;
+    return this;
+  }
+
+  /**
+   * Whether the button can be clicked on or not.
+   */
+  public JButtonBuilder enabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
 }

--- a/src/main/java/swinglib/JCheckBoxBuilder.java
+++ b/src/main/java/swinglib/JCheckBoxBuilder.java
@@ -1,0 +1,35 @@
+package swinglib;
+
+import javax.swing.JCheckBox;
+
+/**
+ * Relatively simple builder for a swing JCheckBox.
+ * By default check boxes are 'selected'.
+ */
+public class JCheckBoxBuilder {
+
+  private boolean isSelected = true;
+
+  private JCheckBoxBuilder() {
+
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JCheckBox build() {
+    final JCheckBox checkBox = new JCheckBox();
+    checkBox.setSelected(isSelected);
+    return checkBox;
+  }
+
+  public JCheckBoxBuilder selected(final boolean isSelected) {
+    this.isSelected = isSelected;
+    return this;
+  }
+
+  public static JCheckBoxBuilder builder() {
+    return new JCheckBoxBuilder();
+  }
+
+}

--- a/src/main/java/swinglib/JComboBoxBuilder.java
+++ b/src/main/java/swinglib/JComboBoxBuilder.java
@@ -1,0 +1,161 @@
+package swinglib;
+
+import java.awt.event.ItemEvent;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.swing.JComboBox;
+
+import com.google.common.base.Preconditions;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+/**
+ * Builds a swing JComboBox that supports String values only. This is a pull down
+ * box with menu options that can be selected.
+ * <br />
+ * Example usage:
+ * 
+ * <pre>
+ * <code>
+ *   JComboBox combBox = JComboBoxBuilder.builder()
+ *       .menuOptions("option 1", "option 2")
+ *       .itemListener(selection -> selection.equals("option 1") ? fooBar())
+ *       .build();
+ * </code>
+ * </pre>
+ */
+public final class JComboBoxBuilder {
+
+  private final List<String> options = new ArrayList<>();
+
+  private Consumer<String> selectionAction;
+
+  private String settingKeyName;
+
+  private ClientSetting clientSetting;
+
+
+  private JComboBoxBuilder() {
+
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JComboBox<String> build() {
+    Preconditions.checkState(options.size() > 0);
+    final Consumer<String> myAction = selectionAction;
+
+    final JComboBox<String> comboBox = new JComboBox<>(options.toArray(new String[options.size()]));
+
+    if (clientSetting != null) {
+      final String lastValue = clientSetting.value();
+
+      if (options.contains(lastValue)) {
+        comboBox.setSelectedItem(lastValue);
+      } else {
+        clientSetting.resetAndFlush();
+      }
+    }
+
+    if (settingKeyName != null) {
+      final String lastValue = ClientSetting.load(settingKeyName);
+
+      if (options.contains(lastValue)) {
+        // note: this will fire any item action listeners
+        comboBox.setSelectedItem(lastValue);
+      }
+    }
+
+    if (selectionAction != null) {
+      comboBox.addItemListener(e -> {
+
+        // combo box will fire two events when you change selection, first a 'ItemEvent.DESELECTED' event and then
+        // a 'ItemEvent.SELECTED' event. We keep it simple for now and ignore the deselected event
+        if (e.getStateChange() == ItemEvent.SELECTED) {
+          final String selectionValue = (e.getItem() == null) ? null : e.getItem().toString();
+
+          Preconditions.checkState(!(clientSetting != null && settingKeyName != null),
+              "Only one of ClientSetting or settingKey should be set at a type, they are"
+                  + "are redundant to each other. One is a type safe enum, the other is a free form String value."
+                  + " Client setting == null ? " + (clientSetting == null)
+                  + ", settingKeyName == null ? " + (settingKeyName == null));
+
+          if (clientSetting != null) {
+            clientSetting.saveAndFlush(selectionValue);
+          } else if (settingKeyName != null) {
+            ClientSetting.save(settingKeyName, selectionValue);
+            ClientSetting.flush();
+          }
+
+          myAction.accept(selectionValue);
+        }
+      });
+    }
+
+    return comboBox;
+  }
+
+  public static JComboBoxBuilder builder() {
+    return new JComboBoxBuilder();
+  }
+
+  /**
+   * Adds a set of options to be displayed in the combo box.
+   */
+  public JComboBoxBuilder menuOptions(final String... options) {
+    Preconditions.checkArgument(options.length > 0);
+    this.options.addAll(Arrays.asList(options));
+    return this;
+  }
+
+  /**
+   * Adds a listener that is fired when an item is selected. The input value
+   * to the passed in consumer is the value selected.
+   */
+  public JComboBoxBuilder itemListener(final Consumer<String> selectionAction) {
+    Preconditions.checkNotNull(selectionAction);
+    this.selectionAction = selectionAction;
+    return this;
+  }
+
+
+  public JComboBoxCompositeBuilder compositeBuilder() {
+    return new JComboBoxCompositeBuilder(this);
+  }
+
+
+  /**
+   * Toggles a behavior where the last selected value will be remembered as a default.
+   * This uses ClientSettings, so it would use the windows registry to store these values.
+   *
+   * @param settingKeyName A key name to be used for storage. Unique names will overwrite each other.
+   */
+  public JComboBoxBuilder useLastSelectionAsFutureDefault(final String settingKeyName) {
+    this.settingKeyName = settingKeyName;
+    if (selectionAction == null) {
+      selectionAction = value -> {
+      };
+    }
+    return this;
+  }
+
+  /**
+   * Toggles a behavior where last selected value is remembered. The ClientSetting passed in
+   * as a parameter is used to 'back' this behavior. The value of the ClientSetting will
+   * be read for a default value and will be saved back when the combo box selection has
+   * been updated.
+   */
+  public JComboBoxBuilder useLastSelectionAsFutureDefault(final ClientSetting clientSetting) {
+    this.clientSetting = clientSetting;
+    if (selectionAction == null) {
+      selectionAction = value -> {
+      };
+    }
+    return this;
+  }
+
+}

--- a/src/main/java/swinglib/JComboBoxCompositeBuilder.java
+++ b/src/main/java/swinglib/JComboBoxCompositeBuilder.java
@@ -1,0 +1,114 @@
+package swinglib;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+/**
+ * 'Composite' builder can be used to create a JComboBox plus an attached component that
+ * can be hidden or revealed depending on combo box selection. So for example you could
+ * use this composite builder to add an extra settings panel that is shown when a specific
+ * value is selected in the combo box.
+ */
+public class JComboBoxCompositeBuilder {
+
+  private final JComboBoxBuilder comboBoxBuilder;
+
+  private final Map<String, JComponent> componentRevealMap = new HashMap<>();
+
+
+  private String triggerValueForPanelHide;
+  private JComponent componentToHide;
+
+  private String label;
+
+  JComboBoxCompositeBuilder(final JComboBoxBuilder comboBoxBuilder) {
+    this.comboBoxBuilder = comboBoxBuilder;
+  }
+
+  public JComboBoxCompositeBuilder label(final String label) {
+    this.label = label;
+    return this;
+  }
+
+  public JComboBoxCompositeBuilder onSelectionShowPanel(final String triggerValue, final JComponent componentToReveal) {
+    componentRevealMap.put(triggerValue, componentToReveal);
+    return this;
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JComponent build() {
+
+    final JPanel parent = JPanelBuilder.builder()
+        .verticalBoxLayout()
+        .build();
+
+    final JComboBox<String> comboBox = comboBoxBuilder.build();
+
+    if (label != null) {
+      parent.add(JPanelBuilder.builder()
+          .horizontalBoxLayout()
+          .addHorizontalGlue()
+          .addLabel(label)
+          .addHorizontalStrut(5)
+          .add(comboBox)
+          .addHorizontalGlue()
+          .build());
+    } else {
+      parent.add(comboBox);
+    }
+
+
+    for (final Map.Entry<String, JComponent> entry : componentRevealMap.entrySet()) {
+      if (comboBox.getSelectedItem() != null && comboBox.getSelectedItem().toString().equals(entry.getKey())) {
+        parent.add(entry.getValue());
+      }
+    }
+
+
+    if (triggerValueForPanelHide != null && comboBox.getSelectedItem() != null
+        && !comboBox.getSelectedItem().toString().equals(triggerValueForPanelHide)) {
+      parent.add(componentToHide);
+    }
+    parent.revalidate();
+
+
+    comboBox.addItemListener(itemEvent -> {
+      for (final Map.Entry<String, JComponent> entry : componentRevealMap.entrySet()) {
+        if (comboBox.getSelectedItem() != null && comboBox.getSelectedItem().toString().equals(entry.getKey())) {
+          parent.add(entry.getValue());
+        } else {
+          parent.remove(entry.getValue());
+        }
+      }
+
+      if (triggerValueForPanelHide != null) {
+        if (itemEvent.getItem() != null && itemEvent.getItem().toString().equals(triggerValueForPanelHide)) {
+          parent.remove(componentToHide);
+        } else {
+          parent.add(componentToHide);
+        }
+      }
+      parent.revalidate();
+    });
+    return parent;
+  }
+
+
+  /**
+   * Convenience method to tie a specific selection to hiding another panel.
+   * For example, you could create a list with "none" or "custom" as options,
+   * when "none" is selected that could trigger a panel to be hidden.
+   */
+  public JComboBoxCompositeBuilder onSelectionHidePanel(final String triggerValueForPanelHide,
+      final JPanel componentToHide) {
+    this.triggerValueForPanelHide = triggerValueForPanelHide;
+    this.componentToHide = componentToHide;
+    return this;
+  }
+}

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -42,7 +42,7 @@ public class JLabelBuilder {
     Preconditions.checkNotNull(text);
     Preconditions.checkState(!text.trim().isEmpty());
 
-    final String truncated = maxTextLength > 0 && text.length() > maxTextLength ? text.substring(0, 25) + "..." : text;
+    final String truncated = (maxTextLength > 0 && text.length() > maxTextLength) ? text.substring(0, maxTextLength) + "..." : text;
 
     final JLabel label = new JLabel(truncated);
 

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -9,10 +9,13 @@ import javax.swing.border.Border;
 import com.google.common.base.Preconditions;
 
 /**
+ * Builds a swing JLabel.
+ * <br />
  * Example usage:
  * <code><pre>
  *   JLabel label = JLabelBuilder.builder()
  *     .text("label text")
+ *     .leftAlign()
  *     .build();
  * </pre></code>
  */
@@ -21,6 +24,8 @@ public class JLabelBuilder {
   private String text;
   private Alignment alignment;
   private Dimension maxSize;
+  private int maxTextLength;
+  private String tooltip;
   private Border border;
 
   private JLabelBuilder() {}
@@ -37,7 +42,9 @@ public class JLabelBuilder {
     Preconditions.checkNotNull(text);
     Preconditions.checkState(!text.trim().isEmpty());
 
-    final JLabel label = new JLabel(text);
+    final String truncated = maxTextLength > 0 && text.length() > maxTextLength ? text.substring(0, 25) + "..." : text;
+
+    final JLabel label = new JLabel(truncated);
 
     if (alignment != null) {
       switch (alignment) {
@@ -48,6 +55,9 @@ public class JLabelBuilder {
       }
     }
 
+    if (tooltip != null) {
+      label.setToolTipText(tooltip);
+    }
     if (maxSize != null) {
       label.setMaximumSize(maxSize);
     }
@@ -76,6 +86,22 @@ public class JLabelBuilder {
 
   public JLabelBuilder border(final Border border) {
     this.border = border;
+    return this;
+  }
+
+  public JLabelBuilder tooltip(final String tooltip) {
+    this.tooltip = tooltip;
+    return this;
+  }
+
+
+  /**
+   * Builds a label with a max length enforced for the printed text. Text is truncated if exceeds the max
+   * length and the full text is placed into a hover-over tooltip.
+   */
+  public JLabelBuilder textWithMaxLength(final String text, final int maxTextLength) {
+    this.maxTextLength = maxTextLength;
+    this.text = text;
     return this;
   }
 

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -42,7 +42,8 @@ public class JLabelBuilder {
     Preconditions.checkNotNull(text);
     Preconditions.checkState(!text.trim().isEmpty());
 
-    final String truncated = (maxTextLength > 0 && text.length() > maxTextLength) ? text.substring(0, maxTextLength) + "..." : text;
+    final String truncated = 
+        (maxTextLength > 0 && text.length() > maxTextLength) ? text.substring(0, maxTextLength) + "..." : text;
 
     final JLabel label = new JLabel(truncated);
 

--- a/src/main/java/swinglib/JPanelBuilder.java
+++ b/src/main/java/swinglib/JPanelBuilder.java
@@ -4,7 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.Graphics;
-import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.LayoutManager;
 import java.awt.image.BufferedImage;
@@ -13,8 +12,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.imageio.ImageIO;
@@ -273,7 +270,7 @@ public class JPanelBuilder {
     return this;
   }
 
-  public JPanelBuilder addEach(final List<? extends Component> components) {
+  public JPanelBuilder addEach(final Iterable<? extends Component> components) {
     components.forEach(this::add);
     return this;
   }

--- a/src/main/java/swinglib/JPanelBuilder.java
+++ b/src/main/java/swinglib/JPanelBuilder.java
@@ -2,20 +2,42 @@ package swinglib;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Graphics;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
+import java.awt.LayoutManager;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
+import javax.imageio.ImageIO;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.EtchedBorder;
+import javax.swing.border.TitledBorder;
 
 import org.apache.commons.math3.util.Pair;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import games.strategy.debug.ClientLogger;
+import games.strategy.triplea.ResourceLoader;
+
 /**
- * Example usage:
+ * Example usage:.
  * <code><pre>
  *   final JPanel panel = JPanelBuilder.builder()
  *       .gridLayout(2, 1)
@@ -26,15 +48,19 @@ import org.apache.commons.math3.util.Pair;
  */
 public class JPanelBuilder {
 
-  private final Collection<Pair<Component, BorderLayoutPosition>> components = new ArrayList<>();
-  private Layout layout = Layout.DEFAULT;
-  private int gridRows;
-  private int gridColumns;
-  private BorderType borderType;
-  private int borderWidth;
+  private final Collection<Pair<Component, PanelProperties>> components = new ArrayList<>();
   private Float horizontalAlignment;
+  private String backgroundImage;
+  private Border border;
+  private LayoutManager layout;
+  private BoxLayoutType boxLayoutType = null;
+  private boolean useGridBagHelper = false;
+  private int gridBagHelperColumns;
+  private boolean flowLayoutWrapper = false;
 
-  private JPanelBuilder() {}
+  private JPanelBuilder() {
+
+  }
 
   public static JPanelBuilder builder() {
     return new JPanelBuilder();
@@ -45,38 +71,64 @@ public class JPanelBuilder {
    * Values that must be set: (requires no values to be set)
    */
   public JPanel build() {
-    final JPanel panel = new JPanel();
-    if (borderType != null) {
-      switch (borderType) {
-        case EMPTY:
-        default:
-          panel.setBorder(new EmptyBorder(borderWidth, borderWidth, borderWidth, borderWidth));
-          break;
+
+    JPanel panel = new JPanel();
+
+    panel.setOpaque(false);
+
+    if (backgroundImage != null) {
+      final URL backgroundImageUrl = ResourceLoader.getGameEngineAssetLoader().getResource(backgroundImage);
+
+      try {
+        final BufferedImage bufferedImaged = ImageIO.read(backgroundImageUrl);
+        panel = new JPanel() {
+          private static final long serialVersionUID = -5926048824903223767L;
+
+          @Override
+          protected void paintComponent(final Graphics g) {
+            super.paintComponent(g);
+            g.drawImage(bufferedImaged, 50, 200, null);
+          }
+        };
+      } catch (final IOException e) {
+        ClientLogger.logError("Could not load image: " + backgroundImage, e);
       }
     }
-    switch (layout) {
-      case GRID:
-        panel.setLayout(new GridLayout(gridRows, gridColumns));
-        break;
-      case GRID_BAG:
-        panel.setLayout(new GridBagLayout());
-        break;
-      case BOX_LAYOUT_HORIZONTAL:
-        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
-        break;
-      case BOX_LAYOUT_VERTICAL:
-        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        break;
-      case DEFAULT:
-      default:
-        panel.setLayout(new BorderLayout());
-        break;
+
+
+    if (border != null) {
+      panel.setBorder(border);
     }
-    for (final Pair<Component, BorderLayoutPosition> child : components) {
-      if (child.getSecond() == BorderLayoutPosition.DEFAULT) {
-        panel.add(child.getFirst());
+
+    if (layout == null && boxLayoutType != null) {
+      final int boxDirection = boxLayoutType == BoxLayoutType.HORIZONTAL ? BoxLayout.X_AXIS : BoxLayout.Y_AXIS;
+      layout = new BoxLayout(panel, boxDirection);
+    } else if (layout == null) {
+      layout = new FlowLayout();
+    }
+
+    panel.setLayout(layout);
+
+    GridBagHelper gridBagHelper = null;
+    if (useGridBagHelper) {
+      gridBagHelper = new GridBagHelper(panel, gridBagHelperColumns);
+    }
+
+    for (final Pair<Component, PanelProperties> child : components) {
+      Preconditions.checkNotNull(child.getFirst());
+      Preconditions.checkNotNull(child.getSecond());
+
+
+      final PanelProperties panelProperties = child.getSecond();
+
+      if (panelProperties.borderLayoutPosition == BorderLayoutPosition.DEFAULT) {
+        if (gridBagHelper != null) {
+          gridBagHelper.add(child.getFirst(), panelProperties.columnSpan);
+        } else {
+          panel.add(child.getFirst());
+        }
       } else {
-        switch (child.getSecond()) {
+        switch (panelProperties.borderLayoutPosition) {
           case CENTER:
             panel.add(child.getFirst(), BorderLayout.CENTER);
             break;
@@ -93,6 +145,7 @@ public class JPanelBuilder {
             panel.add(child.getFirst(), BorderLayout.EAST);
             break;
           default:
+            Preconditions.checkState(layout != null);
             panel.add(child.getFirst());
             break;
         }
@@ -101,75 +154,107 @@ public class JPanelBuilder {
     if (horizontalAlignment != null) {
       panel.setAlignmentX(horizontalAlignment);
     }
+
+    if (flowLayoutWrapper) {
+      return JPanelBuilder.builder()
+          .flowLayout()
+          .add(panel)
+          .build();
+    }
     return panel;
   }
 
-  public JPanelBuilder gridBagLayout() {
-    layout = Layout.GRID_BAG;
+  /**
+   * Sets the current layout manager to a GridBag. This helper method will do most of the work
+   * of the gridbag for you, but the number of columns in the grid needs to be specified. After
+   * this components can be added as normal, rows will wrap as needed when enough components are
+   * added.
+   *
+   * @param gridBagHelperColumns The number of columns to be created before components will wrap
+   *        to a new row.
+   */
+  public JPanelBuilder gridBagLayout(final int gridBagHelperColumns) {
+    this.useGridBagHelper = true;
+    this.gridBagHelperColumns = gridBagHelperColumns;
     return this;
   }
 
   public JPanelBuilder horizontalBoxLayout() {
-    layout = Layout.BOX_LAYOUT_HORIZONTAL;
+    boxLayoutType = BoxLayoutType.HORIZONTAL;
     return this;
   }
 
   public JPanelBuilder verticalBoxLayout() {
-    layout = Layout.BOX_LAYOUT_VERTICAL;
+    boxLayoutType = BoxLayoutType.VERTICAL;
     return this;
   }
 
-  public JPanelBuilder addNorth(final Component child) {
-    components.add(new Pair<>(child, BorderLayoutPosition.NORTH));
+  /**
+   * Toggles a border layout, adds a given component to the 'north' portion of the border layout.
+   */
+  public JPanelBuilder addNorth(final JComponent child) {
+    layout = new BorderLayout();
+    Preconditions.checkNotNull(child);
+    components.add(new Pair<>(child, new PanelProperties(BorderLayoutPosition.NORTH)));
     return this;
   }
 
-  public JPanelBuilder addSouth(final Component child) {
-    components.add(new Pair<>(child, BorderLayoutPosition.SOUTH));
+  /**
+   * Toggles a border layout, adds a given component to the 'east' portion of the border layout.
+   */
+  public JPanelBuilder addEast(final JComponent child) {
+    layout = new BorderLayout();
+    Preconditions.checkNotNull(child);
+    components.add(new Pair<>(child, new PanelProperties(BorderLayoutPosition.EAST)));
     return this;
   }
 
-  public JPanelBuilder addEast(final Component child) {
-    components.add(new Pair<>(child, BorderLayoutPosition.EAST));
+  /**
+   * Toggles a border layout, adds a given component to the 'west' portion of the border layout.
+   */
+  public JPanelBuilder addWest(final JComponent child) {
+    layout = new BorderLayout();
+    Preconditions.checkNotNull(child);
+    components.add(new Pair<>(child, new PanelProperties(BorderLayoutPosition.WEST)));
     return this;
   }
 
-  public JPanelBuilder addWest(final Component child) {
-    components.add(new Pair<>(child, BorderLayoutPosition.WEST));
-    return this;
-  }
-
-  public JPanelBuilder addCenter(final Component child) {
-    components.add(new Pair<>(child, BorderLayoutPosition.CENTER));
-    return this;
-  }
-
-
-  public JPanelBuilder add(final Component component) {
-    components.add(new Pair<>(component, BorderLayoutPosition.DEFAULT));
+  /**
+   * Toggles a border layout, adds a given component to the 'center' portion of the border layout.
+   */
+  public JPanelBuilder addCenter(final JComponent child) {
+    layout = new BorderLayout();
+    components.add(new Pair<>(child, new PanelProperties(BorderLayoutPosition.CENTER)));
     return this;
   }
 
   /**
    * Specify a grid layout with a given number of rows and columns.
-   * 
+   *
    * @param rows First parameter for 'new GridLayout'
    * @param columns Second parameter for 'new GridLayout'
    */
   public JPanelBuilder gridLayout(final int rows, final int columns) {
-    layout = Layout.GRID;
-    this.gridRows = rows;
-    this.gridColumns = columns;
+    layout = new GridLayout(rows, columns);
     return this;
   }
 
-  public JPanelBuilder border(final BorderType borderType) {
-    this.borderType = borderType;
+  public JPanelBuilder borderEmpty(final int borderWidth) {
+    border = new EmptyBorder(borderWidth, borderWidth, borderWidth, borderWidth);
     return this;
   }
 
-  public JPanelBuilder borderWidth(final int borderWidth) {
-    this.borderWidth = borderWidth;
+  public JPanelBuilder borderEtched() {
+    border = new EtchedBorder();
+    return this;
+  }
+
+  /**
+   * Adds a 'titled' border to the current panel.
+   */
+  public JPanelBuilder borderTitled(final String title) {
+    Preconditions.checkArgument(!Strings.nullToEmpty(title).isEmpty());
+    border = new TitledBorder(title);
     return this;
   }
 
@@ -178,19 +263,151 @@ public class JPanelBuilder {
     return this;
   }
 
-  private enum Layout {
-    DEFAULT, GRID, GRID_BAG, BOX_LAYOUT_HORIZONTAL, BOX_LAYOUT_VERTICAL
+  public JPanelBuilder backgroundImage(final String imagePath) {
+    this.backgroundImage = imagePath;
+    return this;
   }
 
-  private enum BorderLayoutPosition {
+  public JPanelBuilder flowLayout() {
+    layout = new FlowLayout();
+    return this;
+  }
+
+  public JPanelBuilder addEach(final List<? extends Component> components) {
+    components.forEach(this::add);
+    return this;
+  }
+
+  /**
+   * For each component supplied as a parameter, adds each one.
+   */
+  public JPanelBuilder addEach(final Component... component) {
+    Preconditions.checkArgument(component.length > 0);
+    Arrays.asList(component).forEach(this::add);
+    return this;
+  }
+
+  public JPanelBuilder add(final Component component) {
+    components.add(new Pair<>(component, new PanelProperties(BorderLayoutPosition.DEFAULT)));
+    return this;
+  }
+
+  /**
+   * An 'add' method to be used with the grid bag layout, can specify how many columns the component should span.
+   */
+  public JPanelBuilder add(final Component component, final GridBagHelper.ColumnSpan columnSpan) {
+    components.add(new Pair<>(component, new PanelProperties(columnSpan)));
+    return this;
+  }
+
+  public JPanelBuilder flowLayoutWrapper() {
+    flowLayoutWrapper = true;
+    return this;
+  }
+
+  /**
+   * Assumes a border layout, adds a given component to the southern portion of the border layout
+   * if the boolean parameter is true.
+   */
+  public JPanelBuilder addSouthIf(final boolean condition, final Supplier<JComponent> builder) {
+    if (condition) {
+      addSouth(builder.get());
+    }
+    return this;
+  }
+
+  /**
+   * Adds a given component to the southern portion of a border layout.
+   */
+  public JPanelBuilder addSouth(final JComponent child) {
+    layout = new BorderLayout();
+    Preconditions.checkNotNull(child);
+    components.add(new Pair<>(child, new PanelProperties(BorderLayoutPosition.SOUTH)));
+    return this;
+  }
+
+  public JPanelBuilder addLabel(final String text) {
+    add(new JLabel(text));
+    return this;
+  }
+
+  /**
+   * Use this to fill up extra vertical space to avoid components stetching to fill up that space.
+   */
+  public JPanelBuilder addVerticalGlue() {
+    add(JPanelBuilder.builder()
+        .add(Box.createVerticalGlue())
+        .build());
+    return this;
+  }
+
+  /**
+   * use this when you want an empty space component that will take up extra space. For example, with a gridbag layout
+   * with 2 columns, if you have 2 components, the second will be stretched by default to fill all available space
+   * to the right. This right hand component would then resize with the window. If on the other hand a 3 column
+   * grid bag were used and the last element were a horizontal glue, then the 2nd component would then have a fixed
+   * size.
+   */
+  public JPanelBuilder addHorizontalGlue() {
+    add(Box.createHorizontalGlue());
+    return this;
+  }
+
+  public JPanelBuilder addVerticalStrut(final int strutSize) {
+    add(Box.createVerticalStrut(strutSize));
+    return this;
+  }
+
+  public JPanelBuilder addHorizontalStrut(final int strutSize) {
+    add(Box.createHorizontalStrut(strutSize));
+    return this;
+  }
+
+  public JPanelBuilder borderLayout() {
+    layout = new BorderLayout();
+    return this;
+  }
+
+  public JPanelBuilder addHtmlLabel(final String s) {
+    return addLabel("<html>" + s + "</html>");
+  }
+
+  public JPanelBuilder addEmptyLabel() {
+    return addLabel("");
+  }
+
+  /**
+   * BoxLayout needs a reference to the panel component that is using the layout, so we cannot create the layout
+   * until after we create the component. Thus we use a flag to create it, rather than creating and storing
+   * the layout manager directly as we do for the other layouts such as gridLayout.
+   */
+  private enum BoxLayoutType {
+    NONE, HORIZONTAL, VERTICAL
+  }
+
+  /**
+   * Swing border layout locations.
+   */
+  public enum BorderLayoutPosition {
     DEFAULT, CENTER, SOUTH, NORTH, WEST, EAST
   }
 
 
   /**
-   * Enumeration of the different types of borders that can be chosen.
+   * Struct-like class for the various properties and styles that can be applied to a panel.
    */
-  public enum BorderType {
-    EMPTY
+  private static final class PanelProperties {
+    BorderLayoutPosition borderLayoutPosition = BorderLayoutPosition.DEFAULT;
+    GridBagHelper.ColumnSpan columnSpan = GridBagHelper.ColumnSpan.of(1);
+
+    PanelProperties(final BorderLayoutPosition borderLayoutPosition) {
+      Preconditions.checkNotNull(borderLayoutPosition);
+      this.borderLayoutPosition = borderLayoutPosition;
+    }
+
+    public PanelProperties(final GridBagHelper.ColumnSpan columnSpan) {
+      Preconditions.checkNotNull(columnSpan);
+      this.columnSpan = columnSpan;
+    }
   }
 }

--- a/src/main/java/swinglib/JSplitPaneBuilder.java
+++ b/src/main/java/swinglib/JSplitPaneBuilder.java
@@ -1,0 +1,135 @@
+package swinglib;
+
+import java.awt.Component;
+
+import javax.swing.JComponent;
+import javax.swing.JSplitPane;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Relatively simple type-safe builder API for constructring a JTabbedPane.
+ * <br />
+ * Example usage:
+ * 
+ * <pre>
+ * <code>
+ *   JSplitPane splitPane = JSplitPaneBuilder.builder()
+ *      .addLeft(new JLabel("left component")
+ *      .addRight(new JLabel("right component");
+ *      .build();
+ * </code>
+ * </pre>
+ * 
+ * <br />
+ * Note the builder sets the 'horizontal' or 'vertical' configuration of the
+ * split panel automatically. To do the top/bottom version, eg:
+ *
+ * <pre>
+ * <code>
+ *   JSplitPane splitPane = JSplitPaneBuilder.builder()
+ *      .addTop(new JLabel("top component")
+ *      .addBottom(new JLabel("bottom component");
+ *      .build();
+ * </code>
+ * </pre>
+ * 
+ */
+public final class JSplitPaneBuilder {
+
+  private int dividerLocation = 150;
+
+
+  private boolean extraSpaceToTopAndLeft = false;
+  private Component left;
+  private Component right;
+
+  private Component top;
+  private Component bottom;
+
+
+  private JSplitPaneBuilder() {
+
+  }
+
+  public static JSplitPaneBuilder builder() {
+    return new JSplitPaneBuilder();
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JSplitPane build() {
+    final JSplitPane pane = new JSplitPane();
+    pane.setDividerLocation(dividerLocation);
+    pane.setResizeWeight(extraSpaceToTopAndLeft ? 1.0 : 0.0);
+
+
+    if (left != null) {
+      Preconditions.checkNotNull(right);
+      Preconditions.checkState(top == null);
+      Preconditions.checkState(bottom == null);
+
+      pane.setOrientation(JSplitPane.HORIZONTAL_SPLIT);
+      pane.setLeftComponent(left);
+      pane.setRightComponent(right);
+    } else {
+      Preconditions.checkNotNull(top);
+      Preconditions.checkNotNull(bottom);
+      Preconditions.checkState(right == null);
+
+      pane.setOrientation(JSplitPane.VERTICAL_SPLIT);
+      pane.setTopComponent(top);
+      pane.setBottomComponent(bottom);
+    }
+
+    return pane;
+  }
+
+  public JSplitPaneBuilder dividerLocation(final int dividerLocation) {
+    this.dividerLocation = dividerLocation;
+    return this;
+  }
+
+  public JSplitPaneBuilder addLeft(final Component component) {
+    this.left = component;
+    return this;
+  }
+
+  /**
+   * Adds a component to the right hand side of the split pane.
+   * TODO: maybe we may want a 'add-first' and 'add-second' method so that the client does not have to worry about
+   * calling addRight vs addBottom, they can call 'addSecond'
+   */
+  public JSplitPaneBuilder addRight(final Component component) {
+    this.right = component;
+    return this;
+  }
+
+  /**
+   * Overrides default behavior and allocates extra window space to the left or top panels in the split pane.
+   */
+  public JSplitPaneBuilder giveExtraSpaceToTopAndLeftPanes() {
+    this.extraSpaceToTopAndLeft = true;
+    return this;
+  }
+
+  /**
+   * Sets spacing flag back to default, extra window space will be given to the bottom or right panes.
+   */
+  public JSplitPaneBuilder giveExtraSpaceToBottomAndRightPanes() {
+    this.extraSpaceToTopAndLeft = false;
+    return this;
+  }
+
+  public JSplitPaneBuilder addTop(final JComponent top) {
+    this.top = top;
+    return this;
+  }
+
+  public JSplitPaneBuilder addBottom(final JComponent bottom) {
+    this.bottom = bottom;
+    return this;
+  }
+
+}

--- a/src/main/java/swinglib/JTabbedPaneBuilder.java
+++ b/src/main/java/swinglib/JTabbedPaneBuilder.java
@@ -1,0 +1,68 @@
+package swinglib;
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+
+import org.apache.commons.math3.util.Pair;
+
+import games.strategy.ui.SwingComponents;
+
+/**
+ * Builder for a JTabbedPane. Provides a convenient API for adding components
+ * to a JTabbedPane and starts off with reasonable defaults that can be configured
+ * further as needed.
+ * <br />
+ * Example usage:
+ * 
+ * <pre>
+ * <code>
+ * JTabbedPaneBuilder JTabbedPaneBuilder.builder()
+ *    .addTab(new JLabel("I will be tab one")
+ *    .addTab(new JLabel("And I will be tab two")
+ *    .build();
+ * </code>
+ * </pre>
+ */
+public class JTabbedPaneBuilder {
+
+  private static final int DEFAULT_TAB_WIDTH = 130;
+  private static final int DEFAULT_TAB_HEIGHT = 20;
+  private final List<Pair<String, Component>> components = new ArrayList<>();
+  private int tabIndex = 0;
+
+  private JTabbedPaneBuilder() {
+
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JTabbedPane build() {
+    final JTabbedPane tabbedPane = new JTabbedPane();
+
+    components.forEach(component -> {
+      final JLabel sizedLabel = new JLabel(component.getKey());
+      sizedLabel.setPreferredSize(new Dimension(DEFAULT_TAB_WIDTH, DEFAULT_TAB_HEIGHT));
+      tabbedPane.addTab(component.getKey(), SwingComponents.newJScrollPane(component.getValue()));
+      tabbedPane.setTabComponentAt(tabIndex, sizedLabel);
+      tabIndex++;
+    });
+
+    return tabbedPane;
+  }
+
+  public JTabbedPaneBuilder addTab(final String tabTitle, final Component tabContents) {
+    components.add(new Pair<>(tabTitle, tabContents));
+    return this;
+  }
+
+
+  public static JTabbedPaneBuilder builder() {
+    return new JTabbedPaneBuilder();
+  }
+}

--- a/src/main/java/swinglib/JTextFieldBuilder.java
+++ b/src/main/java/swinglib/JTextFieldBuilder.java
@@ -1,0 +1,168 @@
+package swinglib;
+
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import javax.swing.JTextField;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+/**
+ * Builder class for building swing text fields. Example usage:
+ * 
+ * <pre>
+ * <code>
+ *   JTextField field = JTextFieldBuilder.builder()
+ *      .columns(15)
+ *      .text("initial text")
+ *      .actionListener(textValue -> enterPressedWithTextInput(textValue)
+ *      .keyTypedListener(textValue -> processKeyTypedWithText(textValue)
+ *      .compositeBuilder()
+ *      .withButton("buttonText", textValue -> buttonPressedAction(textValue)
+ *      .build();
+ * </code>
+ * </pre>
+ */
+public class JTextFieldBuilder {
+
+  private String text;
+  private int columns;
+
+  private Consumer<String> textEnteredAction;
+  private boolean enabled = true;
+
+
+  private JTextFieldBuilder() {
+
+  }
+
+  /**
+   * Sets the initial value displayed on the text field.
+   */
+  public JTextFieldBuilder text(final String value) {
+    Preconditions.checkNotNull(value);
+    this.text = value;
+    return this;
+  }
+
+  /**
+   * Convenience method for setting the text value to a numeric value.
+   */
+  public JTextFieldBuilder text(final int value) {
+    this.text = String.valueOf(value);
+    return this;
+  }
+
+  /**
+   * Defines the width of the text field. Value is passed directly to swing.
+   * TODO: list some typical/reasonable value examples
+   */
+  public JTextFieldBuilder columns(final int columns) {
+    Preconditions.checkArgument(columns > 0);
+    this.columns = columns;
+    return this;
+  }
+
+  /**
+   * Builds the swing component.
+   */
+  public JTextField build() {
+    final JTextField textField = new JTextField(Strings.nullToEmpty(this.text));
+    if (columns > 0) {
+      textField.setColumns(columns);
+    }
+
+    if (textEnteredAction != null) {
+      textField.addActionListener(e -> textEnteredAction.accept(textField.getText()));
+    }
+
+    textField.setEnabled(enabled);
+    return textField;
+  }
+
+  public static JTextFieldBuilder builder() {
+    return new JTextFieldBuilder();
+  }
+
+  /**
+   * Returns a builder that creates a JComponent with a text field and jbutton.
+   *
+   * @param buttonText The 'title' or 'text' displayed on the button that will
+   *        appear next to the constructed JTextField.
+   * @param buttonAction Action to be fired when the button is clicked. The value
+   *        of the TextField will be passed as input to the Consumer function.
+   */
+  public JTextFieldButtonAttachmentBuilder attachButton(
+      final String buttonText,
+      final Consumer<String> buttonAction) {
+
+    return new JTextFieldButtonAttachmentBuilder(this)
+        .withButton(buttonText, buttonAction);
+  }
+
+
+  /**
+   * Adds an action listener that is fired when the user presses enter after entering text
+   * into the text field.
+   * 
+   * @param textEnteredAction Action to fire on 'enter', input value is the current value of the
+   *        text field.
+   */
+  public JTextFieldBuilder actionListener(final Consumer<String> textEnteredAction) {
+    Preconditions.checkNotNull(textEnteredAction);
+    this.textEnteredAction = textEnteredAction;
+    return this;
+  }
+
+  /**
+   * Adds a listener action to the text field that is fired whenever a key is typed.
+   */
+  public static void keyTypedListener(final Consumer<KeyEvent> listener, final JTextField... fields) {
+    Preconditions.checkNotNull(listener);
+    Preconditions.checkArgument(fields.length > 0);
+    Preconditions.checkNotNull(fields[0]);
+
+    for (final JTextField field : Arrays.asList(fields)) {
+
+      field.addKeyListener(new KeyListener() {
+        @Override
+        public void keyTyped(final KeyEvent e) {
+
+        }
+
+        @Override
+        public void keyPressed(final KeyEvent e) {
+
+        }
+
+        @Override
+        public void keyReleased(final KeyEvent e) {
+          listener.accept(e);
+        }
+      });
+    }
+
+  }
+
+  /**
+   * Toggles whether the text field is 'enabled', if 'disabled' then it is read only.
+   * By default text fields will be enabled.
+   */
+  public JTextFieldBuilder enabled(final boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  /**
+   * Disables a text field, sets it to 'read-only'.
+   * Same as calling 'builder().enabled(false)'
+   */
+  public JTextFieldBuilder disabled() {
+    this.enabled = false;
+    return this;
+  }
+
+}

--- a/src/main/java/swinglib/JTextFieldBuilder.java
+++ b/src/main/java/swinglib/JTextFieldBuilder.java
@@ -1,7 +1,6 @@
 package swinglib;
 
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
@@ -9,6 +8,8 @@ import javax.swing.JTextField;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+
+import games.strategy.ui.SwingAction;
 
 /**
  * Builder class for building swing text fields. Example usage:
@@ -125,26 +126,8 @@ public class JTextFieldBuilder {
     Preconditions.checkArgument(fields.length > 0);
     Preconditions.checkNotNull(fields[0]);
 
-    for (final JTextField field : Arrays.asList(fields)) {
-
-      field.addKeyListener(new KeyListener() {
-        @Override
-        public void keyTyped(final KeyEvent e) {
-
-        }
-
-        @Override
-        public void keyPressed(final KeyEvent e) {
-
-        }
-
-        @Override
-        public void keyReleased(final KeyEvent e) {
-          listener.accept(e);
-        }
-      });
-    }
-
+    Arrays.asList(fields).forEach(field ->
+        field.addKeyListener(SwingAction.keyReleaseListener(listener)));
   }
 
   /**

--- a/src/main/java/swinglib/JTextFieldButtonAttachmentBuilder.java
+++ b/src/main/java/swinglib/JTextFieldButtonAttachmentBuilder.java
@@ -1,0 +1,69 @@
+package swinglib;
+
+import java.util.function.Consumer;
+
+import javax.swing.JComponent;
+import javax.swing.JTextField;
+
+/**
+ * Composition of a text field and an 'attached' button that acts on the field value.
+ * For example, useful for input fields that have 'submit' button next to it.
+ * <br />
+ * Example usage:
+ * 
+ * <pre>
+ * <code>
+ *   JComponent textFieldButtonComposite = JTextFieldBuilder.builder()
+ *      .text("initial field value")
+ *      .attachButton("submit",
+ *         fieldText -> executeButtonAction(fieldText)
+ *      .build();
+ * </code>
+ * </pre>
+ */
+public final class JTextFieldButtonAttachmentBuilder {
+
+  private final JTextFieldBuilder textFieldBuilder;
+  /**
+   * When not null will cause builder to create a flow layout field + button, where the text value of the field
+   * will be set to the button when it is clicked.
+   */
+  private String actionButtonText;
+  private Consumer<String> actionButtonAction;
+
+
+
+  JTextFieldButtonAttachmentBuilder(final JTextFieldBuilder textFieldBuilder) {
+    this.textFieldBuilder = textFieldBuilder;
+
+  }
+
+  /**
+   * Builds a JComponent containing text field and button in a flow layout.
+   */
+  public JComponent build() {
+    final JTextField textField = textFieldBuilder.build();
+
+    return JPanelBuilder.builder()
+        .flowLayout()
+        .add(textField)
+        .add(JButtonBuilder.builder()
+            .title(actionButtonText)
+            .actionListener(() -> actionButtonAction.accept(textField.getText()))
+            .build())
+        .build();
+  }
+
+
+  /**
+   * Adds a JButtonn component with title and action that will be fired
+   * when the button is clicked. Input of the consumer function is the value
+   * of the associated JTextField.
+   */
+  public JTextFieldButtonAttachmentBuilder withButton(final String buttonText, final Consumer<String> buttonAction) {
+    this.actionButtonText = buttonText;
+    this.actionButtonAction = buttonAction;
+    return this;
+  }
+
+}

--- a/src/test/java/swinglib/JCheckBoxBuilderTest.java
+++ b/src/test/java/swinglib/JCheckBoxBuilderTest.java
@@ -1,0 +1,35 @@
+package swinglib;
+
+import javax.swing.JCheckBox;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+public class JCheckBoxBuilderTest {
+  @Test
+  public void build() {
+    final JCheckBox box = JCheckBoxBuilder.builder()
+        .build();
+
+    MatcherAssert.assertThat(box.isEnabled(), Is.is(true));
+    MatcherAssert.assertThat(box.isSelected(), Is.is(true));
+  }
+
+  @Test
+  public void selected() {
+    MatcherAssert.assertThat(
+        JCheckBoxBuilder.builder()
+            .selected(false)
+            .build()
+            .isSelected(),
+        Is.is(false));
+
+    MatcherAssert.assertThat(
+        JCheckBoxBuilder.builder()
+            .selected(true)
+            .build()
+            .isSelected(),
+        Is.is(true));
+  }
+}

--- a/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -8,9 +8,11 @@ import javax.swing.JComboBox;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -41,7 +43,7 @@ public class JComboBoxBuilderTest {
 
   @Test
   public void basicBuilderWithMenuOptions() {
-    final JComboBox box = JComboBoxBuilder.builder()
+    final JComboBox<String> box = JComboBoxBuilder.builder()
         .menuOptions("option 1", "option 2", "option 3")
         .build();
 
@@ -62,7 +64,7 @@ public class JComboBoxBuilderTest {
     final AtomicInteger triggerCount = new AtomicInteger(0);
 
     final String secondOption = "option 2";
-    final JComboBox box = JComboBoxBuilder.builder()
+    final JComboBox<String> box = JComboBoxBuilder.builder()
         .menuOptions("option 1", secondOption, "option 3")
         .itemListener(value -> {
           if (value.equals(secondOption)) {
@@ -86,7 +88,7 @@ public class JComboBoxBuilderTest {
     MatcherAssert.assertThat("establish a preconditions state to avoid pollution between runs",
         ClientSetting.load(settingKey), Is.is(""));
 
-    final JComboBox box = JComboBoxBuilder.builder()
+    final JComboBox<String> box = JComboBoxBuilder.builder()
         .menuOptions("option 1", "option 2")
         .useLastSelectionAsFutureDefault(settingKey)
         .build();
@@ -107,7 +109,7 @@ public class JComboBoxBuilderTest {
   public void useLastSelectionAsFutureDefaultWithClientKey() throws Exception {
     ClientSetting.TEST_SETTING.saveAndFlush("");
 
-    final JComboBox box = JComboBoxBuilder.builder()
+    final JComboBox<String> box = JComboBoxBuilder.builder()
         .menuOptions("option 1", "option 2")
         .useLastSelectionAsFutureDefault(ClientSetting.TEST_SETTING)
         .build();

--- a/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -1,0 +1,125 @@
+package swinglib;
+
+import java.awt.event.ItemEvent;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.JComboBox;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class JComboBoxBuilderTest {
+  @Mock
+  private ItemEvent mockItemEvent;
+
+  @Before
+  public void setUp() {}
+
+  @Test(expected = IllegalArgumentException.class)
+  public void buildInvalidEmptyOptionSet() {
+    JComboBoxBuilder.builder()
+        .menuOptions()
+        .build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void builderNoMenuOptionSpecified() {
+    JComboBoxBuilder.builder()
+        .build();
+  }
+
+  @Test
+  public void basicBuilderWithMenuOptions() {
+    final JComboBox box = JComboBoxBuilder.builder()
+        .menuOptions("option 1", "option 2", "option 3")
+        .build();
+
+    MatcherAssert.assertThat(box.getSelectedIndex(), Is.is(0));
+    MatcherAssert.assertThat(box.getItemCount(), Is.is(3));
+    MatcherAssert.assertThat(box.getItemAt(0), Is.is("option 1"));
+    MatcherAssert.assertThat(box.getItemAt(1), Is.is("option 2"));
+    MatcherAssert.assertThat(box.getItemAt(2), Is.is("option 3"));
+    MatcherAssert.assertThat(
+        // TODO: document which item listener is attached by default, why is this not zero?
+        box.getItemListeners().length, Is.is(1));
+    MatcherAssert.assertThat(box.getSelectedItem(), Is.is("option 1"));
+  }
+
+  @Test
+  public void itemListener() {
+
+    final AtomicInteger triggerCount = new AtomicInteger(0);
+
+    final String secondOption = "option 2";
+    final JComboBox box = JComboBoxBuilder.builder()
+        .menuOptions("option 1", secondOption, "option 3")
+        .itemListener(value -> {
+          if (value.equals(secondOption)) {
+            triggerCount.incrementAndGet();
+          }
+        }).build();
+
+    MatcherAssert.assertThat(
+        "There is an existing listener (TODO: learn more about this), and there"
+            + "is the one we added, so we expect 2 in total at this point",
+        box.getItemListeners().length, Is.is(2));
+
+    box.setSelectedIndex(1);
+    MatcherAssert.assertThat(triggerCount.get(), Is.is(1));
+  }
+
+  @Test
+  public void useLastSelectionAsFutureDefaultWithStringKey() throws Exception {
+    final String settingKey = "settingKey";
+    ClientSetting.save(settingKey, "");
+    MatcherAssert.assertThat("establish a preconditions state to avoid pollution between runs",
+        ClientSetting.load(settingKey), Is.is(""));
+
+    final JComboBox box = JComboBoxBuilder.builder()
+        .menuOptions("option 1", "option 2")
+        .useLastSelectionAsFutureDefault(settingKey)
+        .build();
+    Mockito.when(mockItemEvent.getStateChange()).thenReturn(ItemEvent.SELECTED);
+    Mockito.when(mockItemEvent.getSource()).thenReturn(box);
+    final String valueFromEvent = "test value";
+    Mockito.when(mockItemEvent.getItem()).thenReturn(valueFromEvent);
+    Arrays.stream(box.getItemListeners())
+        .forEach(listener -> listener.itemStateChanged(mockItemEvent));
+
+    MatcherAssert.assertThat(
+        "selecting the 1st index should be 'option 2', we expect that to "
+            + "have been flushed to client settings",
+        ClientSetting.load(settingKey), Is.is(valueFromEvent));
+  }
+
+  @Test
+  public void useLastSelectionAsFutureDefaultWithClientKey() throws Exception {
+    ClientSetting.TEST_SETTING.saveAndFlush("");
+
+    final JComboBox box = JComboBoxBuilder.builder()
+        .menuOptions("option 1", "option 2")
+        .useLastSelectionAsFutureDefault(ClientSetting.TEST_SETTING)
+        .build();
+
+    Mockito.when(mockItemEvent.getStateChange()).thenReturn(ItemEvent.SELECTED);
+    Mockito.when(mockItemEvent.getSource()).thenReturn(box);
+    final String valueFromEvent = "test value";
+    Mockito.when(mockItemEvent.getItem()).thenReturn(valueFromEvent);
+    Arrays.stream(box.getItemListeners())
+        .forEach(listener -> listener.itemStateChanged(mockItemEvent));
+
+    MatcherAssert.assertThat("We expect any selected value to have been bound to our test setting",
+        ClientSetting.TEST_SETTING.value(), Is.is(valueFromEvent));
+  }
+}

--- a/src/test/java/swinglib/JPanelBuilderTest.java
+++ b/src/test/java/swinglib/JPanelBuilderTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-import java.awt.BorderLayout;
+import java.awt.FlowLayout;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
@@ -30,8 +30,7 @@ public class JPanelBuilderTest {
   public void testBorder() {
     final int borderWidth = 3;
     final JPanel panel = JPanelBuilder.builder()
-        .border(JPanelBuilder.BorderType.EMPTY)
-        .borderWidth(borderWidth)
+        .borderEmpty(borderWidth)
         .build();
 
     assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
@@ -74,7 +73,7 @@ public class JPanelBuilderTest {
 
 
     assertThat(JPanelBuilder.builder()
-        .gridBagLayout()
+        .gridBagLayout(2)
         .build()
         .getLayout(),
         instanceOf(GridBagLayout.class));
@@ -82,6 +81,35 @@ public class JPanelBuilderTest {
     assertThat(JPanelBuilder.builder()
         .build()
         .getLayout(),
-        instanceOf(BorderLayout.class));
+        instanceOf(FlowLayout.class));
   }
+
+  @Test
+  public void emptyBorder() {
+    final int borderWidth = 100;
+    final JPanel panel = JPanelBuilder.builder()
+        .borderEmpty(borderWidth)
+        .build();
+    assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
+    final Insets insets = panel.getBorder().getBorderInsets(panel);
+    assertThat(insets.top, is(borderWidth));
+    assertThat(insets.bottom, is(borderWidth));
+    assertThat(insets.left, is(borderWidth));
+    assertThat(insets.right, is(borderWidth));
+  }
+
+
+  @Test
+  public void addLabel() {
+    final String labelText = "abc";
+
+    final JPanel panel = JPanelBuilder.builder()
+        .addLabel(labelText)
+        .build();
+
+    assertThat(panel.getComponents().length, is(1));
+    assertThat(panel.getComponents()[0], instanceOf(JLabel.class));
+    assertThat(((JLabel) panel.getComponents()[0]).getText(), is(labelText));
+  }
+
 }

--- a/src/test/java/swinglib/JTabbedPaneBuilderTest.java
+++ b/src/test/java/swinglib/JTabbedPaneBuilderTest.java
@@ -1,0 +1,32 @@
+package swinglib;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.IsSame;
+import org.junit.Test;
+import org.mockito.internal.matchers.InstanceOf;
+
+public class JTabbedPaneBuilderTest {
+  @Test
+  public void addTab() throws Exception {
+    final JLabel label = new JLabel("value");
+    final JComponent component = new JTextField("sample component");
+    final JTabbedPane pane = JTabbedPaneBuilder.builder()
+        .addTab("tab", label)
+        .addTab("second tab", component)
+        .build();
+
+    MatcherAssert.assertThat("we added two tabs",
+        pane.getTabCount(), Is.is(2));
+    MatcherAssert.assertThat("first tab we added was a label",
+        pane.getTabComponentAt(0), IsInstanceOf.instanceOf(JLabel.class));
+    MatcherAssert.assertThat("second tab had a component",
+        pane.getTabComponentAt(1), IsInstanceOf.instanceOf(JComponent.class));
+  }
+}

--- a/src/test/java/swinglib/JTabbedPaneBuilderTest.java
+++ b/src/test/java/swinglib/JTabbedPaneBuilderTest.java
@@ -8,9 +8,8 @@ import javax.swing.JTextField;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsInstanceOf;
-import org.hamcrest.core.IsSame;
+
 import org.junit.Test;
-import org.mockito.internal.matchers.InstanceOf;
 
 public class JTabbedPaneBuilderTest {
   @Test

--- a/src/test/java/swinglib/JTextFieldBuilderTest.java
+++ b/src/test/java/swinglib/JTextFieldBuilderTest.java
@@ -1,0 +1,100 @@
+package swinglib;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.JTextField;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.Is;
+import org.junit.Test;
+
+public class JTextFieldBuilderTest {
+
+
+  @Test
+  public void defaultValues() {
+    final JTextField field = JTextFieldBuilder.builder()
+        .build();
+
+    MatcherAssert.assertThat(
+        field.isEnabled(),
+        Is.is(true));
+
+    MatcherAssert.assertThat(
+        field.getText(),
+        Is.is(""));
+  }
+
+  @Test
+  public void text() {
+    final String testValue = "test value";
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .text(testValue)
+            .build()
+            .getText(),
+        Is.is(testValue));
+  }
+
+  @Test
+  public void textWithIntegerValue() {
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .text(2)
+            .build()
+            .getText(),
+        Is.is("2"));
+  }
+
+  @Test
+  public void columns() throws Exception {
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .columns(3)
+            .build()
+            .getColumns(),
+        Is.is(3));
+  }
+
+  @Test
+  public void actionListener() {
+    // we will know we fired an action event if this value is incremented to 1
+    final AtomicInteger value = new AtomicInteger(0);
+
+    JTextFieldBuilder.builder()
+        .actionListener(fieldValue -> value.incrementAndGet())
+        .build()
+        // and then fire the action!
+        .getActionListeners()[0].actionPerformed(null);
+    MatcherAssert.assertThat(
+        "action expected to have been called and incremented our value from 0 to 1",
+        value.get(), Is.is(1));
+  }
+
+  @Test
+  public void enabled() {
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .enabled(true)
+            .build()
+            .isEnabled(),
+        Is.is(true));
+
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .enabled(false)
+            .build()
+            .isEnabled(),
+        Is.is(false));
+  }
+
+  @Test
+  public void disabled() {
+    MatcherAssert.assertThat(
+        JTextFieldBuilder.builder()
+            .disabled()
+            .build()
+            .isEnabled(),
+        Is.is(false));
+  }
+}


### PR DESCRIPTION
These builders represent a subset of a larger branch. For now they are
independent of much of the existing code and with this update we add a number of
'for-now' unused methods.

NB: this is perhaps update 2 of 4 pulled from this work-in-progress branch https://github.com/DanVanAtta/triplea/tree/launch_screen_rewrite. The next update I suspect will be largely the refactored bits of existing code. The last part would add some new UI behind a 'beta' feature flag.


Recall, the Swing builders are useful for a few things:
- functional style declaration of UI components
- type safe interfaces
- simplified APIs

The usage of GridBagLayout helper has been simplified and hidden a bit.
Client code now instead specifies a grid bag layout and a fixed column
width, components added are then behind the scenes added to the grid bag
helper. You can pretty much use a GridBag as if it were a sane layout
now : )   just add compoonents and the row count will be variable. A key
advantage to a GridBag is it fits to the components added, as opposed to
a GridLayout that stretches components to git and requires a fix number
of rows.

Of note, the composite and button attachment builders are a bit interesting in
that it combines common components that are often together and work in
tandem. These builders are also only available when building existing
components, at that point you switch builders and the 'build()' function
switches from for example a JTextField to a JComponent.

These composite components were pulled from the early setting screens and
connect to host windows.  For example notably the proxy settings window
that reveals an additional settings panel when proxy settings are on, and
hides that panel when proxy settings are off. The composite or button
attachment builders are used in-line with the builder statements and
from there switches builder on you. The idea is you would first define
the build config and then define composite builders last, eg:
```
JComponent composite = JTextFieldBuilder.builder()
  .text("text")
  .attachButton("buttonText",
      textFieldValue -> buttonAction(textFieldValue))
  .build();
```

--------------

Testing notes:
- For the most part most existing components were rewritten. The builder
code is for the most simplified versions of existing UI code, added to
support the re-written UI. While doing that work most of this code was
developed and tested manually.
- Unit test coverage should be pretty high

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
