### PR TITLE
Remove redundant Unit#getUnitType() method

### DIFF
--- a/src/main/java/games/strategy/engine/data/Unit.java
+++ b/src/main/java/games/strategy/engine/data/Unit.java
@@ -51,10 +51,6 @@ public class Unit extends GameDataComponent {
     return m_type;
   }
 
-  public UnitType getUnitType() {
-    return m_type;
-  }
-
   public PlayerID getOwner() {
     return m_owner;
   }

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -144,7 +144,7 @@ public class AIUtils {
     // Loop through all units, starting from the right, and rearrange units
     for (int i = result.size() - 1; i >= 0; i--) {
       final Unit unit = result.get(i);
-      final UnitAttachment ua = UnitAttachment.get(unit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
       // If this is a plane
       if (ua.getCarrierCost() > 0) {
         // If we haven't ignored enough trailing planes
@@ -165,7 +165,7 @@ public class AIUtils {
           seekedCarrier = result.get(seekedCarrierIndex);
           // Tell the code to insert carrier to the right of this plane
           indexToPlaceCarrierAt = i + 1;
-          spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+          spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
         }
         spaceLeftOnSeekedCarrier -= ua.getCarrierCost();
         // If the carrier has been filled or overflowed
@@ -193,7 +193,7 @@ public class AIUtils {
             }
             // Place next carrier right before this plane (which just filled the old carrier that was just moved)
             indexToPlaceCarrierAt = i;
-            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
           } else { // If it's later in the list
             final int oldIndex = result.indexOf(seekedCarrier);
             int carrierPlaceLocation = indexToPlaceCarrierAt;
@@ -208,7 +208,7 @@ public class AIUtils {
             final List<Unit> planesBetweenHereAndCarrier = new ArrayList<>();
             for (int i2 = i; i2 < carrierPlaceLocation; i2++) {
               final Unit unit2 = result.get(i2);
-              final UnitAttachment ua2 = UnitAttachment.get(unit2.getUnitType());
+              final UnitAttachment ua2 = UnitAttachment.get(unit2.getType());
               if (ua2.getCarrierCost() > 0) {
                 planesBetweenHereAndCarrier.add(unit2);
               }
@@ -231,7 +231,7 @@ public class AIUtils {
             }
             // Since we only moved planes up, just reduce next carrier place index by plane move count
             indexToPlaceCarrierAt = carrierPlaceLocation - planeMoveCount;
-            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -325,7 +325,7 @@ class ProPurchaseAI {
             final List<Unit> unitsToPlace = new ArrayList<>();
             for (final Unit placeUnit : ppt.getPlaceUnits()) {
               for (final Unit myUnit : myUnits) {
-                if (myUnit.getUnitType().equals(placeUnit.getUnitType()) && !unitsToPlace.contains(myUnit)) {
+                if (myUnit.getType().equals(placeUnit.getType()) && !unitsToPlace.contains(myUnit)) {
                   unitsToPlace.add(myUnit);
                   break;
                 }
@@ -343,7 +343,7 @@ class ProPurchaseAI {
             final List<Unit> unitsToPlace = new ArrayList<>();
             for (final Unit placeUnit : ppt.getPlaceUnits()) {
               for (final Unit myUnit : myUnits) {
-                if (myUnit.getUnitType().equals(placeUnit.getUnitType()) && !unitsToPlace.contains(myUnit)) {
+                if (myUnit.getType().equals(placeUnit.getType()) && !unitsToPlace.contains(myUnit)) {
                   unitsToPlace.add(myUnit);
                   break;
                 }
@@ -1785,7 +1785,7 @@ class ProPurchaseAI {
       for (final Territory t : purchaseTerritories.keySet()) {
         for (final ProPlaceTerritory ppt : purchaseTerritories.get(t).getCanPlaceTerritories()) {
           for (final Unit u : ppt.getPlaceUnits()) {
-            if (u.getUnitType().equals(ppo.getUnitType()) && !unplacedUnits.contains(u)) {
+            if (u.getType().equals(ppo.getUnitType()) && !unplacedUnits.contains(u)) {
               numUnits++;
             }
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -247,7 +247,7 @@ public class ProTransportUtils {
     // Loop through all units, starting from the right, and rearrange units
     for (int i = result.size() - 1; i >= 0; i--) {
       final Unit unit = result.get(i);
-      final UnitAttachment ua = UnitAttachment.get(unit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (ua.getCarrierCost() > 0 || i == 0) { // If this is a plane or last unit
         // If we haven't ignored enough trailing planes and not last unit
         if (processedPlaneCount < planesThatDontNeedToLand && i > 0) {
@@ -264,7 +264,7 @@ public class ProTransportUtils {
           }
           seekedCarrier = result.get(seekedCarrierIndex);
           indexToPlaceCarrierAt = i + 1; // Tell the code to insert carrier to the right of this plane
-          spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+          spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
         }
         if (ua.getCarrierCost() > 0) {
           spaceLeftOnSeekedCarrier -= ua.getCarrierCost();
@@ -295,7 +295,7 @@ public class ProTransportUtils {
 
             // Place next carrier right before this plane (which just filled the old carrier that was just moved)
             indexToPlaceCarrierAt = i;
-            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
           } else {
 
             // If it's later in the list
@@ -314,7 +314,7 @@ public class ProTransportUtils {
             final List<Unit> planesBetweenHereAndCarrier = new ArrayList<>();
             for (int i2 = i; i2 < carrierPlaceLocation; i2++) {
               final Unit unit2 = result.get(i2);
-              final UnitAttachment ua2 = UnitAttachment.get(unit2.getUnitType());
+              final UnitAttachment ua2 = UnitAttachment.get(unit2.getType());
               if (ua2.getCarrierCost() > 0) {
                 planesBetweenHereAndCarrier.add(unit2);
               }
@@ -338,7 +338,7 @@ public class ProTransportUtils {
 
             // Since we only moved planes up, just reduce next carrier place index by plane move count
             indexToPlaceCarrierAt = carrierPlaceLocation - planeMoveCount;
-            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
+            spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getType()).getCarrierCapacity();
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -834,7 +834,7 @@ public class WeakAI extends AbstractAI {
       int maxUnits = (totalPu - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || repairFactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : repairRules) {
-          if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {
+          if (!capUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;
           }
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())

--- a/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -303,7 +303,7 @@ public abstract class AbstractBattle implements IBattle {
   static int getMaxHits(final Collection<Unit> units) {
     int count = 0;
     for (final Unit unit : units) {
-      count += UnitAttachment.get(unit.getUnitType()).getHitPoints();
+      count += UnitAttachment.get(unit.getType()).getHitPoints();
       count -= unit.getHits();
     }
     return count;

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -751,7 +751,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     final IntegerMap<String> constructionMap = howManyOfEachConstructionCanPlace(to, to, units, player);
     for (final Unit currentUnit : Matches.getMatches(units, Matches.unitIsConstruction())) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       /*
        * if (ua.getIsFactory() && !ua.getIsConstruction())
        * constructionMap.add("factory", -1);
@@ -818,7 +818,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     // account for any unit placement restrictions by territory
     for (final Unit currentUnit : units) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       // Can be null!
       final TerritoryAttachment ta = TerritoryAttachment.get(to);
       if (ua.getCanOnlyBePlacedInTerritoryValuedAtX() != -1
@@ -937,7 +937,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     final Collection<Unit> placeableUnits3 = new ArrayList<>();
     for (final Unit currentUnit : placeableUnits2) {
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       // Can be null!
       final TerritoryAttachment ta = TerritoryAttachment.get(to);
       if (ua.getCanOnlyBePlacedInTerritoryValuedAtX() != -1
@@ -1258,7 +1258,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     while (unitHeldIter.hasNext()) {
       final Unit currentUnit = unitHeldIter.next();
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       // account for any unit placement restrictions by territory
       if (isUnitPlacementRestrictions()) {
         final String[] terrs = ua.getUnitPlacementRestrictions();
@@ -1296,7 +1296,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final IntegerMap<String> unitMapTo = new IntegerMap<>();
     if (Match.anyMatch(unitsInTo, Matches.unitIsConstruction())) {
       for (final Unit currentUnit : Matches.getMatches(unitsInTo, Matches.unitIsConstruction())) {
-        final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+        final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
         /*
          * if (Matches.UnitIsFactory.match(currentUnit) && !ua.getIsConstruction())
          * unitMapTO.add("factory", 1);
@@ -1327,7 +1327,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final Iterator<Unit> unitAlready = Matches.getMatches(unitsPlacedAlready, Matches.unitIsConstruction()).iterator();
     while (unitAlready.hasNext()) {
       final Unit currentUnit = unitAlready.next();
-      final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
+      final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       unitMapTypePerTurn.add(ua.getConstructionType(), -1);
     }
     // modify this list based on how many we can place per turn
@@ -1346,7 +1346,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   int howManyOfConstructionUnit(final Unit unit, final IntegerMap<String> constructionsMap) {
-    final UnitAttachment ua = UnitAttachment.get(unit.getUnitType());
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
     if (/* !ua.getIsFactory() && */(!ua.getIsConstruction() || ua.getConstructionsPerTerrPerTypePerTurn() < 1
         || ua.getMaxConstructionsPerTypePerTerr() < 1)) {
       return 0;

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -60,10 +60,10 @@ public class BattleCalculator {
   // units with least movement
   static void sortPreBattle(final List<Unit> units) {
     final Comparator<Unit> comparator = (u1, u2) -> {
-      if (u1.getUnitType().equals(u2.getUnitType())) {
+      if (u1.getType().equals(u2.getType())) {
         return UnitComparator.getLowestToHighestMovementComparator().compare(u1, u2);
       }
-      return u1.getUnitType().getName().compareTo(u2.getUnitType().getName());
+      return u1.getType().getName().compareTo(u2.getType().getName());
     };
     Collections.sort(units, comparator);
   }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -613,11 +613,11 @@ public final class Matches {
   }
 
   static Match<Unit> unitHasMovementLimit() {
-    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getMovementLimit() != null);
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getMovementLimit() != null);
   }
 
   static final Match<Unit> unitHasAttackingLimit() {
-    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getAttackingLimit() != null);
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getAttackingLimit() != null);
   }
 
   private static Match<UnitType> unitTypeCanNotMoveDuringCombatMove() {
@@ -762,7 +762,7 @@ public final class Matches {
   }
 
   public static Match<Unit> unitIsInfantry() {
-    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getIsInfantry());
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getIsInfantry());
   }
 
   public static Match<Unit> unitIsNotInfantry() {
@@ -778,7 +778,7 @@ public final class Matches {
       if (ta == null || !ta.getParatroopers()) {
         return false;
       }
-      final UnitType type = obj.getUnitType();
+      final UnitType type = obj.getType();
       final UnitAttachment ua = UnitAttachment.get(type);
       return ua.getIsAirTransportable();
     });
@@ -797,18 +797,18 @@ public final class Matches {
       if (ta == null || !ta.getParatroopers()) {
         return false;
       }
-      final UnitType type = obj.getUnitType();
+      final UnitType type = obj.getType();
       final UnitAttachment ua = UnitAttachment.get(type);
       return ua.getIsAirTransport();
     });
   }
 
   public static Match<Unit> unitIsArtillery() {
-    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getArtillery());
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getArtillery());
   }
 
   public static Match<Unit> unitIsArtillerySupportable() {
-    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getArtillerySupportable());
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getArtillerySupportable());
   }
 
   // TODO: CHECK whether this makes any sense
@@ -1804,7 +1804,7 @@ public final class Matches {
       if (unitIsDisabled().match(unitWhichCanGiveBonusMovement)) {
         return false;
       }
-      final UnitType type = unitWhichCanGiveBonusMovement.getUnitType();
+      final UnitType type = unitWhichCanGiveBonusMovement.getType();
       final UnitAttachment ua = UnitAttachment.get(type);
       // TODO: make sure the unit is operational
       return unitCanGiveBonusMovement().match(unitWhichCanGiveBonusMovement)
@@ -2032,7 +2032,7 @@ public final class Matches {
         return true;
       }
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.canInvadeFrom(transport.getUnitType().getName());
+      return ua.canInvadeFrom(transport.getType().getName());
     });
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -393,8 +393,8 @@ public class MoveValidator {
     // See if we are doing invasions in combat phase, with units or transports that can't do invasion.
     if (route.isUnload() && Matches.isTerritoryEnemy(player, data).match(route.getEnd())) {
       for (final Unit unit : Matches.getMatches(units, Matches.unitCanInvade().invert())) {
-        result.addDisallowedUnit(unit.getUnitType().getName() + " can't invade from "
-            + TripleAUnit.get(unit).getTransportedBy().getUnitType().getName(), unit);
+        result.addDisallowedUnit(unit.getType().getName() + " can't invade from "
+            + TripleAUnit.get(unit).getTransportedBy().getType().getName(), unit);
       }
     }
     return result;
@@ -1453,7 +1453,7 @@ public class MoveValidator {
 
   private static Collection<Unit> getCanCarry(final Unit carrier, final Collection<Unit> selectFrom,
       final PlayerID playerWhoIsDoingTheMovement, final GameData data) {
-    final UnitAttachment ua = UnitAttachment.get(carrier.getUnitType());
+    final UnitAttachment ua = UnitAttachment.get(carrier.getType());
     final Collection<Unit> canCarry = new ArrayList<>();
     int available = ua.getCarrierCapacity();
     final Iterator<Unit> iter = selectFrom.iterator();
@@ -1461,7 +1461,7 @@ public class MoveValidator {
     while (iter.hasNext()) {
       final Unit plane = iter.next();
       final TripleAUnit taPlane = (TripleAUnit) plane;
-      final UnitAttachment planeAttachment = UnitAttachment.get(plane.getUnitType());
+      final UnitAttachment planeAttachment = UnitAttachment.get(plane.getType());
       final int cost = planeAttachment.getCarrierCost();
       if (available >= cost) {
         // this is to test if they started in the same sea zone or not, and its not a very good way of testing it.

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -198,7 +198,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!isAlliedAirIndependent()) {
       dependencies.putAll(MoveValidator.carrierMustMoveWith(units, units, m_data, m_attacker));
       for (final Unit carrier : dependencies.keySet()) {
-        final UnitAttachment ua = UnitAttachment.get(carrier.getUnitType());
+        final UnitAttachment ua = UnitAttachment.get(carrier.getType());
         if (ua.getCarrierCapacity() == -1) {
           continue;
         }
@@ -2605,7 +2605,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Comparator<Unit> decreasingMovement = UnitComparator.getLowestToHighestMovementComparator();
     final Comparator<Unit> comparator = (u1, u2) -> {
       int amphibComp = 0;
-      if (u1.getUnitType().equals(u2.getUnitType())) {
+      if (u1.getType().equals(u2.getType())) {
         final UnitAttachment ua = UnitAttachment.get(u1.getType());
         final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
         if (ua.getIsMarine() != 0 && ua2.getIsMarine() != 0) {
@@ -2616,7 +2616,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
         return amphibComp;
       }
-      return u1.getUnitType().getName().compareTo(u2.getUnitType().getName());
+      return u1.getType().getName().compareTo(u2.getType().getName());
     };
     Collections.sort(units, comparator);
   }

--- a/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -47,7 +47,7 @@ public class MyFormatter {
     while (iter.hasNext()) {
       final Unit unit = iter.next();
       if (owner == null || owner.equals(unit.getOwner())) {
-        map.add(unit.getUnitType(), 1);
+        map.add(unit.getType(), 1);
       }
     }
     final StringBuilder buf = new StringBuilder();

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -532,7 +532,7 @@ public class BattlePanel extends ActionPanel {
     BombardComponent(final Unit unit, final Territory unitTerritory, final Collection<Territory> territories,
         final boolean noneAvailable) {
       this.setLayout(new BorderLayout());
-      final String unitName = unit.getUnitType().getName() + " in " + unitTerritory;
+      final String unitName = unit.getType().getName() + " in " + unitTerritory;
       final JLabel label = new JLabel("Which territory should " + unitName + " bombard?");
       this.add(label, BorderLayout.NORTH);
       final Vector<Object> listElements = new Vector<>(territories);

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -199,8 +199,8 @@ public class TransportUtils {
 
   private static List<Unit> sortByTransportCostDescending(final Collection<Unit> units) {
     final Comparator<Unit> transportCostComparator = (o1, o2) -> {
-      final int cost1 = UnitAttachment.get((o1).getUnitType()).getTransportCost();
-      final int cost2 = UnitAttachment.get((o2).getUnitType()).getTransportCost();
+      final int cost1 = UnitAttachment.get((o1).getType()).getTransportCost();
+      final int cost2 = UnitAttachment.get((o2).getType()).getTransportCost();
       return Integer.compare(cost2, cost1);
     };
     final List<Unit> canBeTransported = Matches.getMatches(units, Matches.unitCanBeTransported());

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -63,7 +63,7 @@ public class UnitSeperator {
       }
       int unitTransportCost = -1;
       if (categorizeTransportCost) {
-        unitTransportCost = UnitAttachment.get((current).getUnitType()).getTransportCost();
+        unitTransportCost = UnitAttachment.get((current).getType()).getTransportCost();
       }
       Collection<Unit> currentDependents = null;
       if (dependent != null) {

--- a/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -38,6 +38,6 @@ public class AiUtilsTest {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final List<Unit> sorted = new ArrayList<>(germany.getUnits().getUnits());
     Collections.sort(sorted, AIUtils.getCostComparator());
-    assertEquals(sorted.get(0).getUnitType().getName(), Constants.UNIT_TYPE_INFANTRY);
+    assertEquals(sorted.get(0).getType().getName(), Constants.UNIT_TYPE_INFANTRY);
   }
 }


### PR DESCRIPTION
The `Unit#getUnitType()` method is identical to `Unit#getType()`.  `getType()` has 372 references, while `getUnitType()` has 52 references.  Therefore, `getUnitType()` was removed, and all references to `getUnitType()` were replaced with references to `getType()`.

I couldn't find any reflective uses of `Unit#getUnitType()`.