### PR TITLE
Inline Util#reorder()

### DIFF
--- a/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
+++ b/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
@@ -2,11 +2,11 @@ package games.strategy.engine.data;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
 import games.strategy.triplea.delegate.TechAdvance;
-import games.strategy.util.Util;
 
 public class TechnologyFrontier extends GameDataComponent implements Iterable<TechAdvance> {
   private static final long serialVersionUID = -5245743727479551766L;
@@ -38,7 +38,7 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   private void reorderTechsToMatchGameTechsOrder() {
     final GameData gameData = getData();
     if (gameData != null) {
-      Util.reorder(m_techs, gameData.getTechnologyFrontier().getTechs());
+      m_techs.sort(Comparator.comparing(gameData.getTechnologyFrontier().getTechs()::indexOf));
       m_cachedTechs = null;
     }
   }

--- a/src/main/java/games/strategy/util/Util.java
+++ b/src/main/java/games/strategy/util/Util.java
@@ -7,7 +7,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -103,27 +103,12 @@ public class Util {
   }
 
   public static <T> void reorder(final List<T> reorder, final List<T> order) {
-    final IntegerMap<T> map = new IntegerMap<>();
-    for (final T o : order) {
-      map.put(o, order.indexOf(o));
-    }
-    Collections.sort(reorder, (o1, o2) -> {
-      // get int returns 0 if no value
-      final int v1 = map.getInt(o1);
-      final int v2 = map.getInt(o2);
-      if (v1 > v2) {
-        return 1;
-      } else if (v1 == v2) {
-        return 0;
-      } else {
-        return -1;
-      }
-    });
+    reorder.sort(Comparator.comparing(order::indexOf));
   }
 
   /**
    * Creates a hash of the given String based on the SHA-512 algorithm.
-   * 
+   *
    * @param input The input String to hash.
    * @return A hashed hexadecimal String of the input.
    */

--- a/src/main/java/games/strategy/util/Util.java
+++ b/src/main/java/games/strategy/util/Util.java
@@ -7,7 +7,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -100,10 +99,6 @@ public class Util {
       ThreadUtil.sleep(1);
     }
     return "" + System.currentTimeMillis();
-  }
-
-  public static <T> void reorder(final List<T> reorder, final List<T> order) {
-    reorder.sort(Comparator.comparing(order::indexOf));
   }
 
   /**

--- a/src/test/java/games/strategy/util/UtilTest.java
+++ b/src/test/java/games/strategy/util/UtilTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -62,5 +63,15 @@ public class UtilTest {
 
     assertThat(Util.not(it -> false).test(t), is(true));
     assertThat(Util.not(it -> true).test(t), is(false));
+  }
+
+  @Test
+  public void reorder_ShouldSortFirstListAccordingToSecondList() {
+    final List<Integer> reorder = Arrays.asList(1, 2, 3, 4, 5);
+    final List<Integer> order = Arrays.asList(5, 3, 1, 4, 2);
+
+    Util.reorder(reorder, order);
+
+    assertThat(reorder, is(order));
   }
 }

--- a/src/test/java/games/strategy/util/UtilTest.java
+++ b/src/test/java/games/strategy/util/UtilTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Test;
 
@@ -63,15 +62,5 @@ public class UtilTest {
 
     assertThat(Util.not(it -> false).test(t), is(true));
     assertThat(Util.not(it -> true).test(t), is(false));
-  }
-
-  @Test
-  public void reorder_ShouldSortFirstListAccordingToSecondList() {
-    final List<Integer> reorder = Arrays.asList(1, 2, 3, 4, 5);
-    final List<Integer> order = Arrays.asList(5, 3, 1, 4, 2);
-
-    Util.reorder(reorder, order);
-
-    assertThat(reorder, is(order));
   }
 }


### PR DESCRIPTION
The `Util#reorder()` method has only a single caller.  This PR simply inlines the method at its one call site.

However, before inlining, I simplified the implementation using `Comparator#comparing()`.  I performed the following changes leading up to the inlining to ensure the existing behavior was preserved:

1. Write a characterization test for `Util#reorder()`.
1. Change `reorder()` implementation while ensuring tests continue to pass.
1. Inline `reorder()`.

This sequence of steps can be observed by reviewing the PR commits individually.

#### Notes

The new implementation is less efficient than the previous implementation because it is O(N) instead of O(1).  However, the usage in `TechnologyFrontier#reorderTechsToMatchGameTechsOrder()` sorts the list of game tech advances, and the size of this list will be limited to the number of tech advance implementations, which is currently less than 20.  Therefore, the speed of the new implementation should be comparable to the old implementation because of the list's small size.

I originally used Guava `Ordering#explicit()` in the new implementation, which does use maps internally.  However, it has the additional requirement that the list items must implement `Comparable`, which `TechAdvance` does not.