### PR TITLE
Introduce JUnit5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - python3-yaml
 install: ./.travis/setup_lobby_database
 before_script: ./.travis/setup_gpg
-script: ./gradlew check jacocoTestReport -x validateYamls
+script: ./gradlew check jacocoJunit5TestReport -x validateYamls
 after_success:
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     testCompile 'eu.codearte.catch-exception:catch-exception:2.0.0-ALPHA-1'
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testCompile 'org.mockito:mockito-core:2.8.47'
+    testCompile 'org.mockito:mockito-core:2.11.0'
     testCompile 'org.junit.platform:junit-platform-launcher:1.0.1'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -113,11 +113,6 @@ dependencies {
     testRuntime 'org.junit.vintage:junit-vintage-engine:4.12.1'
 }
 
-test {
-    exclude '**/*Tests.class'
-}
-
-
 task integTest(type: Test) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = 'Runs the integration tests.'
@@ -325,6 +320,12 @@ jacocoTestReport {
     reports {
         xml.enabled true
         html.enabled true
+    }
+}
+
+junitPlatform {
+    filters {
+        includeClassNamePattern '.*Test'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ sourceSets {
         java.srcDir 'src/integ_test/java'
         resources.srcDir 'src/integ_test/resources'
 
-        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime + configurations.junitPlatform
-        runtimeClasspath = output + compileClasspath
+        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
+        runtimeClasspath = output + compileClasspath + configurations.junitPlatform
     }
 }
 
@@ -111,7 +111,7 @@ dependencies {
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
 }
 
-task integTest(type: JavaExec) {
+task integTest(type: JavaExec, dependsOn: [compileIntegTestJava]) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = 'Runs the integration tests.'
 
@@ -121,8 +121,6 @@ task integTest(type: JavaExec) {
     args "--reports-dir=$project.buildDir/integ-test-results/junit-platform"
     args '--scan-classpath'
     args '--include-classname', '^.*IntegrationTests?$'
-
-    mustRunAfter tasks.test
 }
 
 task jacocoRootReport(type: JacocoReport) {
@@ -281,14 +279,8 @@ gradle.taskGraph.whenReady { graph ->
     })
 }
 
-tasks.withType(Test) {
-    testLogging {
-        exceptionFormat = 'full'
-    }
-}
-
 check {
-    dependsOn 'integTest', 'validateYamls'
+    dependsOn 'junitPlatformTest', 'integTest', 'validateYamls'
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+	repositories {
+		mavenCentral()
+	}
+	dependencies {
+		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+	}
+}
+
 plugins {
     id 'java'
     id 'application'
@@ -11,6 +20,7 @@ plugins {
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
+apply plugin: 'org.junit.platform.gradle.plugin'
 
 group = 'triplea'
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
@@ -96,7 +106,11 @@ dependencies {
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.10.0'
+    testCompile 'org.junit.platform:junit-platform-launcher:1.0.1'
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
     testCompile 'junit:junit:4.12'
+    testRuntime 'org.junit.vintage:junit-vintage-engine:4.12.1'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ sourceSets {
         java.srcDir 'src/integ_test/java'
         resources.srcDir 'src/integ_test/resources'
 
-        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
+        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime + configurations.junitPlatform
         runtimeClasspath = output + compileClasspath
     }
 }
@@ -106,24 +106,21 @@ dependencies {
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.11.0'
-    testCompile 'org.junit.platform:junit-platform-launcher:1.0.1'
+    testRuntime 'org.junit.platform:junit-platform-launcher:1.0.1'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
 }
 
-task integTest(type: Test) {
+task integTest(type: JavaExec) {
     group = LifecycleBasePlugin.VERIFICATION_GROUP
     description = 'Runs the integration tests.'
 
-    testClassesDirs = sourceSets.integTest.output.classesDirs
     classpath = sourceSets.integTest.runtimeClasspath
-
-    binResultsDir = file("$buildDir/integration_test_results/binary/integTest")
-
-    reports {
-        reports.html.destination = file("${reports.html.destination}/$name")
-        reports.junitXml.destination = file("${reports.junitXml.destination}/$name")
-    }
+    main = 'org.junit.platform.console.ConsoleLauncher'
+    args '--details', 'none'
+    args "--reports-dir=$project.buildDir/integ-test-results/junit-platform"
+    args '--scan-classpath'
+    args '--include-classname', '^.*IntegrationTests?$'
 
     mustRunAfter tasks.test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
-	repositories {
-		mavenCentral()
-	}
-	dependencies {
-		classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
-	}
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.1'
+    }
 }
 
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -105,12 +105,10 @@ dependencies {
     testCompile 'eu.codearte.catch-exception:catch-exception:2.0.0-ALPHA-1'
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testCompile 'org.mockito:mockito-core:2.10.0'
+    testCompile 'org.mockito:mockito-core:2.8.47'
     testCompile 'org.junit.platform:junit-platform-launcher:1.0.1'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
-    testCompile 'junit:junit:4.12'
-    testRuntime 'org.junit.vintage:junit-vintage-engine:4.12.1'
 }
 
 task integTest(type: Test) {
@@ -320,12 +318,6 @@ jacocoTestReport {
     reports {
         xml.enabled true
         html.enabled true
-    }
-}
-
-junitPlatform {
-    filters {
-        includeClassNamePattern '.*Test'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -327,3 +327,23 @@ jacocoTestReport {
         html.enabled true
     }
 }
+
+afterEvaluate {
+    def junitPlatformTest = tasks.junitPlatformTest
+
+    jacoco {
+        applyTo(junitPlatformTest)
+    }
+
+    task jacocoJunit5TestReport(type: JacocoReport) {
+        executionData junitPlatformTest
+        sourceSets sourceSets.main
+        sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+        classDirectories = files(sourceSets.main.output)
+
+        reports {
+            xml.enabled true
+            html.enabled true
+        }
+    }
+}

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -227,7 +227,7 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test, BeforeClass, AfterClass, Before, After"/>
+            <property name="allowedAnnotations" value="Override, Test, BeforeAll, AfterAll, BeforeEach, AfterEach"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>
         </module>

--- a/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import static org.hamcrest.core.Is.is;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClientContextIntegrationTest {
 

--- a/src/integ_test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -2,7 +2,7 @@ package games.strategy.engine.chat;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -83,7 +83,7 @@ public final class ChatIntegrationTest {
 
   @Test
   public void shouldBeAbleToChatAcrossMultipleNodes() {
-    assertTimeout(Duration.ofSeconds(15), () -> {
+    assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
       final ChatController controller = newChatController();
       final Chat server = newChat(serverMessenger, serverChannelMessenger, serverRemoteMessenger);
       server.addChatListener(serverChatListener);

--- a/src/integ_test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
@@ -3,7 +3,7 @@ package games.strategy.engine.config.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LobbyServerPropertiesFetcherIntegrationTest {
   @Test

--- a/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -2,16 +2,16 @@ package games.strategy.engine.framework.startup.login;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
@@ -31,7 +31,7 @@ public final class ClientLoginIntegrationTest {
   private IServerMessenger serverMessenger;
   private final int serverPort = TestUtil.getUniquePort();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     serverMessenger = newServerMessenger();
   }
@@ -49,7 +49,7 @@ public final class ClientLoginIntegrationTest {
     return clientLoginValidator;
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     serverMessenger.shutDown();
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.lobby.server;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -11,8 +11,8 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -33,7 +33,7 @@ public class ModeratorControllerIntegrationTest {
   private ConnectionChangeListener connectionChangeListener;
   private INode adminNode;
 
-  @Before
+  @BeforeEach
   public void setUp() throws UnknownHostException {
     moderatorController = new ModeratorController(serverMessenger, null);
     final String adminName = Util.createUniqueTimeStamp();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.lobby.server.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.Util;
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
@@ -1,16 +1,16 @@
 package games.strategy.engine.lobby.server.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
@@ -1,16 +1,16 @@
 package games.strategy.engine.lobby.server.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -4,9 +4,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Strings;
 
@@ -22,7 +22,7 @@ public class EmailLimitIntegrationTest {
 
   private static Connection connection;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws SQLException {
     connection = Database.getPostgresConnection();
     connection.setAutoCommit(true);
@@ -54,7 +54,7 @@ public class EmailLimitIntegrationTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws SQLException {
     connection.close();
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.lobby.server.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.lobby.server.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.Util;
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -2,13 +2,13 @@ package games.strategy.engine.lobby.server.db;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -18,7 +18,7 @@ import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
 
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -1,10 +1,11 @@
 package games.strategy.engine.lobby.server.login;
 
 import static games.strategy.engine.lobby.server.login.RsaAuthenticator.hashPasswordWithSalt;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -14,7 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import org.mindrot.jbcrypt.BCrypt;
 
 import games.strategy.engine.lobby.server.LobbyServer;

--- a/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -1,8 +1,8 @@
 package games.strategy.net;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -13,9 +13,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.concurrent.GuardedBy;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.test.TestUtil;
@@ -30,7 +30,7 @@ public class MessengerIntegrationTest {
   private final MessageListener client1MessageListener = new MessageListener();
   private final MessageListener client2MessageListener = new MessageListener();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     serverPort = TestUtil.getUniquePort();
     serverMessenger = new ServerMessenger("Server", serverPort);
@@ -54,7 +54,7 @@ public class MessengerIntegrationTest {
     assertEquals(serverMessenger.getNodes().size(), 3);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       if (serverMessenger != null) {
@@ -216,7 +216,7 @@ public class MessengerIntegrationTest {
 
       @Override
       public void connectionAdded(final INode to) {
-        fail();
+        fail("A connection should not be added.");
       }
     });
     client1Messenger.shutDown();

--- a/src/test/java/games/strategy/debug/ConsoleHandlerTest.java
+++ b/src/test/java/games/strategy/debug/ConsoleHandlerTest.java
@@ -1,7 +1,7 @@
 package games.strategy.debug;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -19,13 +19,13 @@ import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class ConsoleHandlerTest {
   private ConsoleHandler consoleHandler;
 
@@ -41,7 +41,7 @@ public final class ConsoleHandlerTest {
   @Mock
   private PrintStream out;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     consoleHandler = new ConsoleHandler(() -> out, () -> err);
     consoleHandler.setErrorManager(errorManager);

--- a/src/test/java/games/strategy/debug/LoggingConfigurationTest.java
+++ b/src/test/java/games/strategy/debug/LoggingConfigurationTest.java
@@ -7,12 +7,12 @@ import static org.mockito.Mockito.verify;
 import java.util.Properties;
 import java.util.logging.LogManager;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class LoggingConfigurationTest {
   @Spy
   private final LogManager logManager = LogManager.getLogManager();

--- a/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
+++ b/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
@@ -2,7 +2,7 @@ package games.strategy.debug;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.io.PrintStream;
 import java.time.Duration;
@@ -28,7 +28,7 @@ public final class SynchedByteArrayOutputStreamTest {
 
   @Test
   public void writeByte_ShouldTriggerReadFromDifferentThread() throws Exception {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final String expected = "X";
       final AtomicReference<String> actualRef = new AtomicReference<>();
       final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
@@ -52,7 +52,7 @@ public final class SynchedByteArrayOutputStreamTest {
 
   @Test
   public void writeBytes_ShouldTriggerReadFromDifferentThread() throws Exception {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final String expected = "the quick brown fox";
       final AtomicReference<String> actualRef = new AtomicReference<>();
       final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);

--- a/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
+++ b/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
@@ -1,25 +1,24 @@
 package games.strategy.debug;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class SynchedByteArrayOutputStreamTest {
-  @Rule
-  public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+
+  private static final Duration timeout = Duration.ofSeconds(5);
 
   @Mock
   private PrintStream mirror;
@@ -29,44 +28,48 @@ public final class SynchedByteArrayOutputStreamTest {
 
   @Test
   public void writeByte_ShouldTriggerReadFromDifferentThread() throws Exception {
-    final String expected = "X";
-    final AtomicReference<String> actualRef = new AtomicReference<>();
-    final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
+    assertTimeout(timeout, () -> {
+      final String expected = "X";
+      final AtomicReference<String> actualRef = new AtomicReference<>();
+      final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
 
-    final Thread readerThread = new Thread(() -> {
-      readerThreadReadyLatch.countDown();
-      actualRef.set(os.readFully());
-    }, "Reader");
-    readerThread.start();
-    readerThreadReadyLatch.await();
-    new Thread(() -> {
-      final byte[] bytes = expected.getBytes();
-      assert bytes.length == 1;
-      os.write(bytes[0]);
-    }, "Writer").start();
-    readerThread.join();
+      final Thread readerThread = new Thread(() -> {
+        readerThreadReadyLatch.countDown();
+        actualRef.set(os.readFully());
+      }, "Reader");
+      readerThread.start();
+      readerThreadReadyLatch.await();
+      new Thread(() -> {
+        final byte[] bytes = expected.getBytes();
+        assert bytes.length == 1;
+        os.write(bytes[0]);
+      }, "Writer").start();
+      readerThread.join();
 
-    assertThat(actualRef.get(), is(expected));
+      assertThat(actualRef.get(), is(expected));
+    });
   }
 
   @Test
   public void writeBytes_ShouldTriggerReadFromDifferentThread() throws Exception {
-    final String expected = "the quick brown fox";
-    final AtomicReference<String> actualRef = new AtomicReference<>();
-    final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
+    assertTimeout(timeout, () -> {
+      final String expected = "the quick brown fox";
+      final AtomicReference<String> actualRef = new AtomicReference<>();
+      final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
 
-    final Thread readerThread = new Thread(() -> {
-      readerThreadReadyLatch.countDown();
-      actualRef.set(os.readFully());
-    }, "Reader");
-    readerThread.start();
-    readerThreadReadyLatch.await();
-    new Thread(() -> {
-      final byte[] bytes = expected.getBytes();
-      os.write(bytes, 0, bytes.length);
-    }, "Writer").start();
-    readerThread.join();
+      final Thread readerThread = new Thread(() -> {
+        readerThreadReadyLatch.countDown();
+        actualRef.set(os.readFully());
+      }, "Reader");
+      readerThread.start();
+      readerThreadReadyLatch.await();
+      new Thread(() -> {
+        final byte[] bytes = expected.getBytes();
+        os.write(bytes, 0, bytes.length);
+      }, "Writer").start();
+      readerThread.join();
 
-    assertThat(actualRef.get(), is(expected));
+      assertThat(actualRef.get(), is(expected));
+    });
   }
 }

--- a/src/test/java/games/strategy/engine/ClientFileSystemHelperTests.java
+++ b/src/test/java/games/strategy/engine/ClientFileSystemHelperTests.java
@@ -1,21 +1,21 @@
 package games.strategy.engine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.triplea.settings.GameSetting;
 
-@RunWith(Enclosed.class)
 public final class ClientFileSystemHelperTests {
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class GetUserMapsFolderPathTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class GetUserMapsFolderPathTest {
     @Mock
     private GameSetting currentSetting;
 

--- a/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
+++ b/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.chat;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChatFloodControlTest {
   private static final long INITIAL_CLEAR_TIME = 100;

--- a/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
+++ b/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
@@ -1,23 +1,23 @@
 package games.strategy.engine.chat;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ChatIgnoreListTest {
-  @Before
+  @BeforeEach
   public void setUp() throws BackingStoreException {
     // clear this
     clearStore();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws BackingStoreException {
     clearStore();
   }

--- a/src/test/java/games/strategy/engine/chat/ChatPanelTest.java
+++ b/src/test/java/games/strategy/engine/chat/ChatPanelTest.java
@@ -1,11 +1,11 @@
 package games.strategy.engine.chat;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.swing.text.DefaultStyledDocument;
 import javax.swing.text.StyledDocument;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChatPanelTest {
 
@@ -18,12 +18,12 @@ public class ChatPanelTest {
     }
     doc.insertString(0, buffer.toString(), null);
     ChatMessagePanel.trimLines(doc, 20);
-    assertEquals(doc.getLength(), 10);
+    assertEquals(10, doc.getLength());
     ChatMessagePanel.trimLines(doc, 10);
-    assertEquals(doc.getLength(), 10);
+    assertEquals(10, doc.getLength());
     ChatMessagePanel.trimLines(doc, 5);
-    assertEquals(doc.getLength(), 5);
+    assertEquals(5, doc.getLength());
     ChatMessagePanel.trimLines(doc, 1);
-    assertEquals(doc.getLength(), 1);
+    assertEquals(1, doc.getLength());
   }
 }

--- a/src/test/java/games/strategy/engine/chat/StatusTest.java
+++ b/src/test/java/games/strategy/engine/chat/StatusTest.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.chat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;

--- a/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
@@ -2,13 +2,14 @@ package games.strategy.engine.config;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PropertyFileReaderTest {
 
@@ -19,7 +20,7 @@ public class PropertyFileReaderTest {
    * test data written to it. Subsequent tests will verify parsing
    * based on this data.
    */
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     final File tempFile = File.createTempFile("test", "tmp");
     tempFile.deleteOnExit();
@@ -52,17 +53,17 @@ public class PropertyFileReaderTest {
   }
 
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void throwsNullPointerOnNullInput() {
-    testObj.readProperty(null);
+    assertThrows(NullPointerException.class, () -> testObj.readProperty(null));
   }
 
   /**
    * Empty input parameter would be a mistake from the client, throw an error rather than continuing.
    */
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void throwIfInputIsEmpty() {
-    testObj.readProperty("  ");
+    assertThrows(IllegalArgumentException.class, () -> testObj.readProperty("  "));
   }
 
 }

--- a/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
@@ -4,16 +4,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.config.PropertyFileReader;
 import games.strategy.util.Version;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class GameEnginePropertyReaderTest {
 
   @Mock

--- a/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
@@ -7,7 +7,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.util.Version;

--- a/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
@@ -2,24 +2,23 @@ package games.strategy.engine.config.client;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.framework.map.download.DownloadUtils;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.util.Version;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class LobbyServerPropertiesFetcherTest {
 
   private static final Version fakeVersion = new Version("0.0.0.0");
@@ -32,7 +31,7 @@ public class LobbyServerPropertiesFetcherTest {
   /**
    * Sets up a test object with mocked dependencies. We will primarily verify control flow.
    */
-  @Before
+  @BeforeEach
   public void setup() {
     testObj = new LobbyServerPropertiesFetcher(mockFileDownloader);
   }
@@ -56,13 +55,15 @@ public class LobbyServerPropertiesFetcherTest {
     when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.success(temp));
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void throwsOnDownloadFailure() throws Exception {
-    final File temp = File.createTempFile("temp", "tmp");
-    temp.deleteOnExit();
-    when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.FAILURE);
+    assertThrows(IOException.class, () -> {
+      final File temp = File.createTempFile("temp", "tmp");
+      temp.deleteOnExit();
+      when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.FAILURE);
 
-    testObj.downloadAndParseRemoteFile(TestData.url, fakeVersion, (a, b) -> TestData.lobbyServerProperties);
+      testObj.downloadAndParseRemoteFile(TestData.url, fakeVersion, (a, b) -> TestData.lobbyServerProperties);
+    });
   }
 
 

--- a/src/test/java/games/strategy/engine/config/client/MaxMemorySettingTest.java
+++ b/src/test/java/games/strategy/engine/config/client/MaxMemorySettingTest.java
@@ -3,11 +3,11 @@ package games.strategy.engine.config.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MaxMemorySettingTest {
   @Test

--- a/src/test/java/games/strategy/engine/config/client/MaxMemorySettingTest.java
+++ b/src/test/java/games/strategy/engine/config/client/MaxMemorySettingTest.java
@@ -2,7 +2,6 @@ package games.strategy.engine.config.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;

--- a/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -24,7 +24,7 @@ public class LobbyPropertyReaderTest {
    */
   @BeforeEach
   public void setup() throws IOException {
-    final File testFile = tempFolderRule.newFile("testname");
+    final File testFile = tempFolderRule.newFile(getClass().getName());
 
     try (FileWriter writer = new FileWriter(testFile)) {
       writer.write(keyValuePair(LobbyPropertyReader.PropertyKeys.port, String.valueOf(TestData.fakePort)));

--- a/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -16,13 +16,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(TemporaryFolderExtension.class)
 public class LobbyPropertyReaderTest {
   private LobbyPropertyReader testObj;
+  private TemporaryFolder tempFolderRule;
 
   /**
    * Sets up an example lobby property file with some fake values, then sets up a property reader test object
    * pointed at this file.
    */
   @BeforeEach
-  public void setup(TemporaryFolder tempFolderRule) throws IOException {
+  public void setup() throws IOException {
     final File testFile = tempFolderRule.newFile("testname");
 
     try (FileWriter writer = new FileWriter(testFile)) {

--- a/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -7,24 +7,23 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.experimental.extensions.TemporaryFolder;
+import org.junit.experimental.extensions.TemporaryFolderExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(TemporaryFolderExtension.class)
 public class LobbyPropertyReaderTest {
   private LobbyPropertyReader testObj;
-
-  @Rule
-  public TemporaryFolder tempFolderRule = new TemporaryFolder();
 
   /**
    * Sets up an example lobby property file with some fake values, then sets up a property reader test object
    * pointed at this file.
    */
-  @Before
-  public void setup() throws IOException {
-    final File testFile = tempFolderRule.newFile();
+  @BeforeEach
+  public void setup(TemporaryFolder tempFolderRule) throws IOException {
+    final File testFile = tempFolderRule.newFile("testname");
 
     try (FileWriter writer = new FileWriter(testFile)) {
       writer.write(keyValuePair(LobbyPropertyReader.PropertyKeys.port, String.valueOf(TestData.fakePort)));

--- a/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -7,9 +7,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.experimental.extensions.TemporaryFolder;
 import org.junit.experimental.extensions.TemporaryFolderExtension;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -1,10 +1,10 @@
 package games.strategy.engine.data;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -12,7 +12,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class AllianceTrackerTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.TEST.getGameData();
   }

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -11,8 +11,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.framework.GameObjectStreamFactory;
@@ -23,7 +23,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class ChangeTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.TEST.getGameData();
   }
@@ -71,8 +71,7 @@ public class ChangeTest {
 
     assertEquals(2, can.getUnits().getUnitCount());
     gameData.performChange(change.invert());
-    assertEquals("last change inverted, should have gained units.", 5,
-        can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnits().getUnitCount(), "last change inverted, should have gained units.");
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.data;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.changefactory.ChangeFactory;
@@ -21,7 +21,7 @@ public class ChangeTripleATest {
   private GameData gameData;
   private Territory can;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     ClientContext.gameEnginePropertyReader();
     gameData = TestMapGameData.BIG_WORLD_1942.getGameData();

--- a/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -2,20 +2,20 @@ package games.strategy.engine.data;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class DefaultAttachmentTest {
   @Mock
   private NamedAttachable namedAttachable;

--- a/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
+++ b/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
+++ b/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
@@ -8,9 +8,9 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.memento.Memento;
 import games.strategy.util.memento.MementoExporter;

--- a/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
+++ b/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
@@ -4,11 +4,11 @@ import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
 import static games.strategy.engine.data.Matchers.equalToGameData;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/src/test/java/games/strategy/engine/data/MapTest.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.delegate.Matches;
 
@@ -32,7 +32,7 @@ public class MapTest {
   Territory nowhere;
   GameMap map;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     // map, l is land, w is water
     // each territory is connected to
@@ -103,7 +103,7 @@ public class MapTest {
 
   @Test
   public void testNowhere() {
-    assertTrue(-1 == map.getDistance(aa, nowhere));
+    assertEquals(-1, map.getDistance(aa, nowhere));
   }
 
   @Test
@@ -118,7 +118,7 @@ public class MapTest {
 
   @Test
   public void testSame() {
-    assertTrue(0 == map.getDistance(aa, aa));
+    assertEquals(0, map.getDistance(aa, aa));
   }
 
   @Test
@@ -128,57 +128,55 @@ public class MapTest {
 
   @Test
   public void testOne() {
-    final int distance = map.getDistance(aa, ab);
-    assertTrue("" + distance, 1 == distance);
+    assertEquals(1, map.getDistance(aa, ab));
   }
 
   @Test
   public void testTwo() {
-    final int distance = map.getDistance(aa, ac);
-    assertTrue("" + distance, 2 == distance);
+    assertEquals(2, map.getDistance(aa, ac));
   }
 
   @Test
   public void testOverWater() {
-    assertTrue(map.getDistance(ca, cd) == 3);
+    assertEquals(3, map.getDistance(ca, cd));
   }
 
   @Test
   public void testOverWaterCantReach() {
-    assertTrue(map.getLandDistance(ca, cd) == -1);
+    assertEquals(-1, map.getLandDistance(ca, cd));
   }
 
   @Test
   public void testLong() {
-    assertTrue(map.getLandDistance(ad, da) == 6);
+    assertEquals(6, map.getLandDistance(ad, da));
   }
 
   @Test
   public void testLongRoute() {
     final Route route = map.getLandRoute(ad, da);
-    assertEquals(route.numberOfSteps(), 6);
+    assertEquals(6, route.numberOfSteps());
   }
 
   @Test
   public void testNeighborLandNoSeaConnect() {
-    assertTrue(-1 == map.getWaterDistance(aa, ab));
+    assertEquals(-1, map.getWaterDistance(aa, ab));
   }
 
   @Test
   public void testNeighborSeaNoLandConnect() {
-    assertTrue(-1 == map.getLandDistance(bc, bd));
+    assertEquals(-1, map.getLandDistance(bc, bd));
   }
 
   @Test
   public void testRouteToSelf() {
     final Route rt = map.getRoute(aa, aa);
-    assertTrue(rt.numberOfSteps() == 0);
+    assertEquals(0, rt.numberOfSteps());
   }
 
   @Test
   public void testRouteSizeOne() {
     final Route rt = map.getRoute(aa, ab);
-    assertTrue(rt.numberOfSteps() == 1);
+    assertEquals(1, rt.numberOfSteps());
   }
 
   @Test
@@ -190,36 +188,36 @@ public class MapTest {
   @Test
   public void testImpossibleLandRoute() {
     final Route rt = map.getLandRoute(aa, cd);
-    assertTrue(rt == null);
+    assertNull(rt);
   }
 
   @Test
   public void testImpossibleLandDistance() {
     final int distance = map.getLandDistance(aa, cd);
-    assertTrue("wrongDistance exp -1, got:" + distance, distance == -1);
+    assertEquals(-1, distance, "wrong distance");
   }
 
   @Test
   public void testWaterRout() {
     final Route rt = map.getWaterRoute(bd, dd);
-    assertTrue("bc:" + rt, rt.getTerritoryAtStep(0).equals(bc));
-    assertTrue("cc", rt.getTerritoryAtStep(1).equals(cc));
-    assertTrue("dc", rt.getTerritoryAtStep(2).equals(dc));
-    assertTrue("dd", rt.getTerritoryAtStep(3).equals(dd));
+    assertEquals(bc, rt.getTerritoryAtStep(0), "bc:" + rt);
+    assertEquals(cc, rt.getTerritoryAtStep(1), "cc");
+    assertEquals(dc, rt.getTerritoryAtStep(2), "dc");
+    assertEquals(dd, rt.getTerritoryAtStep(3), "dd");
   }
 
   @Test
   public void testMultiplePossible() {
     final Route rt = map.getRoute(aa, dd);
-    assertEquals(rt.getStart(), aa);
-    assertEquals(rt.getEnd(), dd);
-    assertEquals(rt.numberOfSteps(), 6);
+    assertEquals(aa, rt.getStart());
+    assertEquals(dd, rt.getEnd());
+    assertEquals(6, rt.numberOfSteps());
   }
 
   @Test
   public void testNeighbors() {
     final Set<Territory> neighbors = map.getNeighbors(aa);
-    assertTrue(neighbors.size() == 2);
+    assertEquals(2, neighbors.size());
     assertTrue(neighbors.contains(ab));
     assertTrue(neighbors.contains(ba));
   }
@@ -227,13 +225,13 @@ public class MapTest {
   @Test
   public void testNeighborsWithDistance() {
     Set<Territory> neighbors = map.getNeighbors(aa, 0);
-    assertTrue(neighbors.size() == 0);
+    assertEquals(0, neighbors.size());
     neighbors = map.getNeighbors(aa, 1);
-    assertTrue(neighbors.size() == 2);
+    assertEquals(2, neighbors.size());
     assertTrue(neighbors.contains(ab));
     assertTrue(neighbors.contains(ba));
     neighbors = map.getNeighbors(aa, 2);
-    assertTrue(neighbors.size() == 5);
+    assertEquals(5, neighbors.size());
     assertTrue(neighbors.contains(ab));
     assertTrue(neighbors.contains(ac));
     assertTrue(neighbors.contains(ba));

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.data;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.io.IoUtils;
@@ -18,7 +18,7 @@ public class SerializationTest {
   private GameData gameDataSource;
   private GameData gameDataSink;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameDataSource = TestMapGameData.TEST.getGameData();
     gameDataSink = TestMapGameData.TEST.getGameData();

--- a/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -2,7 +2,7 @@ package games.strategy.engine.data;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
@@ -10,17 +10,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.IntegerMap;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class UnitCollectionTest {
 
   @Mock
@@ -54,7 +54,7 @@ public class UnitCollectionTest {
   private int unitCountUnitTypeOne;
   private int unitCountUnitTypeTwo;
 
-  @Before
+  @BeforeEach
   public void setup() {
     unitTypeOne = new UnitType("Unit Type 1", mockGameData);
     unitTypeTwo = new UnitType("Unit Type 2", mockGameData);

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.data.annotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.awt.GraphicsEnvironment;
 import java.io.File;
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.data.ResourceCollection;
@@ -140,7 +140,7 @@ public class ValidateAttachmentsTest {
    */
   @Test
   public void testAllAttachments() throws Exception {
-    assumeFalse("cannot scan for attachments in a headless environment", GraphicsEnvironment.isHeadless());
+    assumeFalse(GraphicsEnvironment.isHeadless(), "cannot scan for attachments in a headless environment");
 
     final File root = getRootClassesFolder();
     final String errors = findAttachmentsAndValidate(root, root);

--- a/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
+++ b/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
@@ -6,8 +6,8 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.delegate.IDelegate;
@@ -23,7 +23,7 @@ public class XmlGameElementMapperTest {
 
   private XmlGameElementMapper testObj;
 
-  @Before
+  @BeforeEach
   public void setup() {
     testObj = new XmlGameElementMapper();
   }

--- a/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
+++ b/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
@@ -1,12 +1,12 @@
 package games.strategy.engine.data.properties;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class GamePropertiesTest {
   @Test

--- a/src/test/java/games/strategy/engine/data/util/ResourceCollectionUtilsTest.java
+++ b/src/test/java/games/strategy/engine/data/util/ResourceCollectionUtilsTest.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.data.util;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -10,11 +10,11 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
@@ -23,7 +23,7 @@ import games.strategy.engine.data.ResourceList;
 import games.strategy.triplea.Constants;
 import games.strategy.util.IntegerMap;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class ResourceCollectionUtilsTest {
   @Mock
   private GameData data;
@@ -34,7 +34,7 @@ public final class ResourceCollectionUtilsTest {
 
   private Resource vps;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     pus = createResource(Constants.PUS);
     techTokens = createResource(Constants.TECH_TOKENS);

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -3,19 +3,19 @@ package games.strategy.engine.framework;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.settings.ClientSetting;
 
 public class ArgParserTest {
 
 
-  @After
+  @AfterEach
   public void teardown() {
     System.clearProperty(GameRunner.TRIPLEA_GAME_PROPERTY);
   }

--- a/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
@@ -1,21 +1,20 @@
 package games.strategy.engine.framework;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.io.IOCase;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.framework.GameDataFileUtils.SaveGameFormat;
 
-@RunWith(Enclosed.class)
 public final class GameDataFileUtilsTests {
-  @RunWith(Enclosed.class)
-  public static final class AddExtensionTests {
-    public static final class WhenSaveGameFormatIsSerializationTest {
-      private static String addExtension(final String fileName) {
+  @Nested
+  public final class AddExtensionTests {
+    @Nested
+    public final class WhenSaveGameFormatIsSerializationTest {
+      private String addExtension(final String fileName) {
         return GameDataFileUtils.addExtension(fileName, SaveGameFormat.SERIALIZATION);
       }
 
@@ -30,8 +29,9 @@ public final class GameDataFileUtilsTests {
       }
     }
 
-    public static final class WhenSaveGameFormatIsProxySerializationTest {
-      private static String addExtension(final String fileName) {
+    @Nested
+    public final class WhenSaveGameFormatIsProxySerializationTest {
+      private String addExtension(final String fileName) {
         return GameDataFileUtils.addExtension(fileName, SaveGameFormat.PROXY_SERIALIZATION);
       }
 
@@ -47,12 +47,13 @@ public final class GameDataFileUtilsTests {
     }
   }
 
-  @RunWith(Enclosed.class)
-  public static final class AddExtensionIfAbsentTests {
-    @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsSerializationTests {
-      public static final class WhenFileSystemIsCaseSensitiveTest {
-        private static String addExtensionIfAbsent(final String fileName) {
+  @Nested
+  public final class AddExtensionIfAbsentTests {
+    @Nested
+    public final class WhenSaveGameFormatIsSerializationTests {
+      @Nested
+      public final class WhenFileSystemIsCaseSensitiveTest {
+        private String addExtensionIfAbsent(final String fileName) {
           return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.SERIALIZATION, IOCase.SENSITIVE);
         }
 
@@ -72,8 +73,9 @@ public final class GameDataFileUtilsTests {
         }
       }
 
-      public static final class WhenFileSystemIsCaseInsensitiveTest {
-        private static String addExtensionIfAbsent(final String fileName) {
+      @Nested
+      public final class WhenFileSystemIsCaseInsensitiveTest {
+        private String addExtensionIfAbsent(final String fileName) {
           return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.SERIALIZATION, IOCase.INSENSITIVE);
         }
 
@@ -94,10 +96,11 @@ public final class GameDataFileUtilsTests {
       }
     }
 
-    @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsProxySerializationTests {
-      public static final class WhenFileSystemIsCaseSensitiveTest {
-        private static String addExtensionIfAbsent(final String fileName) {
+    @Nested
+    public final class WhenSaveGameFormatIsProxySerializationTests {
+      @Nested
+      public final class WhenFileSystemIsCaseSensitiveTest {
+        private String addExtensionIfAbsent(final String fileName) {
           return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.PROXY_SERIALIZATION, IOCase.SENSITIVE);
         }
 
@@ -117,8 +120,9 @@ public final class GameDataFileUtilsTests {
         }
       }
 
-      public static final class WhenFileSystemIsCaseInsensitiveTest {
-        private static String addExtensionIfAbsent(final String fileName) {
+      @Nested
+      public final class WhenFileSystemIsCaseInsensitiveTest {
+        private String addExtensionIfAbsent(final String fileName) {
           return GameDataFileUtils.addExtensionIfAbsent(
               fileName,
               SaveGameFormat.PROXY_SERIALIZATION,
@@ -143,12 +147,13 @@ public final class GameDataFileUtilsTests {
     }
   }
 
-  @RunWith(Enclosed.class)
-  public static final class IsCandidateFileNameTests {
-    @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsSerializationTests {
-      public static final class WhenFileSystemIsCaseSensitiveTest {
-        private static boolean isCandidateFileName(final String fileName) {
+  @Nested
+  public final class IsCandidateFileNameTests {
+    @Nested
+    public final class WhenSaveGameFormatIsSerializationTests {
+      @Nested
+      public final class WhenFileSystemIsCaseSensitiveTest {
+        private boolean isCandidateFileName(final String fileName) {
           return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.SERIALIZATION, IOCase.SENSITIVE);
         }
 
@@ -188,8 +193,9 @@ public final class GameDataFileUtilsTests {
         }
       }
 
-      public static final class WhenFileSystemIsCaseInsensitiveTest {
-        private static boolean isCandidateFileName(final String fileName) {
+      @Nested
+      public final class WhenFileSystemIsCaseInsensitiveTest {
+        private boolean isCandidateFileName(final String fileName) {
           return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.SERIALIZATION, IOCase.INSENSITIVE);
         }
 
@@ -230,10 +236,11 @@ public final class GameDataFileUtilsTests {
       }
     }
 
-    @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsProxySerializationTests {
-      public static final class WhenFileSystemIsCaseSensitiveTest {
-        private static boolean isCandidateFileName(final String fileName) {
+    @Nested
+    public final class WhenSaveGameFormatIsProxySerializationTests {
+      @Nested
+      public final class WhenFileSystemIsCaseSensitiveTest {
+        private boolean isCandidateFileName(final String fileName) {
           return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.PROXY_SERIALIZATION, IOCase.SENSITIVE);
         }
 
@@ -253,8 +260,9 @@ public final class GameDataFileUtilsTests {
         }
       }
 
-      public static final class WhenFileSystemIsCaseInsensitiveTest {
-        private static boolean isCandidateFileName(final String fileName) {
+      @Nested
+      public final class WhenFileSystemIsCaseInsensitiveTest {
+        private boolean isCandidateFileName(final String fileName) {
           return GameDataFileUtils.isCandidateFileName(
               fileName,
               SaveGameFormat.PROXY_SERIALIZATION,

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.framework;
 
 import static games.strategy.engine.data.Matchers.equalToGameData;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -2,8 +2,8 @@ package games.strategy.engine.framework;
 
 import static games.strategy.engine.data.Matchers.equalToGameData;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -15,7 +15,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TestGameDataFactory;

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -2,11 +2,11 @@ package games.strategy.engine.framework.map.download;
 
 import static org.hamcrest.Matchers.is;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.util.Version;

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -1,8 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
-import static org.hamcrest.Matchers.is;
-
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -1,12 +1,12 @@
 package games.strategy.engine.framework.map.download;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.io.IoUtils;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
@@ -3,12 +3,12 @@ package games.strategy.engine.framework.map.download;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,26 +28,27 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.experimental.extensions.TemporaryFolder;
+import org.junit.experimental.extensions.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
 
-@RunWith(Enclosed.class)
 public final class DownloadUtilsTests {
   private static final String URI = "some://uri";
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class DownloadToFileTest {
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @ExtendWith(MockitoExtension.class)
+  @ExtendWith(TemporaryFolderExtension.class)
+  @Nested
+  public final class DownloadToFileTest {
+    
+    private TemporaryFolder temporaryFolder;
 
     @Mock
     private CloseableHttpClient client;
@@ -66,9 +67,9 @@ public final class DownloadUtilsTests {
     /**
      * Sets up the test fixture.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-      file = temporaryFolder.newFile();
+      file = temporaryFolder.newFile("filename1123");
 
       when(client.execute(any())).thenReturn(response);
       when(response.getEntity()).thenReturn(entity);
@@ -123,17 +124,18 @@ public final class DownloadUtilsTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class GetDownloadLengthFromCacheTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class GetDownloadLengthFromCacheTest {
     @Mock
     private DownloadLengthSupplier downloadLengthSupplier;
 
-    @Before
+    @BeforeEach
     public void setUp() {
       DownloadUtils.downloadLengthsByUri.clear();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
       DownloadUtils.downloadLengthsByUri.clear();
     }
@@ -173,8 +175,9 @@ public final class DownloadUtilsTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class GetDownloadLengthFromHostTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class GetDownloadLengthFromHostTest {
     @Mock
     private CloseableHttpClient client;
 
@@ -190,7 +193,7 @@ public final class DownloadUtilsTests {
     /**
      * Sets up the test fixture.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       when(client.execute(any())).thenReturn(response);
       when(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH)).thenReturn(contentLengthHeader);

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
@@ -47,7 +47,7 @@ public final class DownloadUtilsTests {
   @ExtendWith(TemporaryFolderExtension.class)
   @Nested
   public final class DownloadToFileTest {
-    
+
     private TemporaryFolder temporaryFolder;
 
     @Mock
@@ -69,7 +69,7 @@ public final class DownloadUtilsTests {
      */
     @BeforeEach
     public void setUp() throws Exception {
-      file = temporaryFolder.newFile("filename1123");
+      file = temporaryFolder.newFile(getClass().getName());
 
       when(client.execute(any())).thenReturn(response);
       when(response.getEntity()).thenReturn(entity);

--- a/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -1,17 +1,17 @@
 package games.strategy.engine.framework.map.download;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class FileDownloadTest {
   @Mock
   private DownloadFileDescription mockDownload;

--- a/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
@@ -1,15 +1,16 @@
 package games.strategy.engine.framework.map.download;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.experimental.extensions.TemporaryFolder;
+import org.junit.experimental.extensions.TemporaryFolderExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.google.common.io.Files;
 
@@ -20,19 +21,20 @@ import games.strategy.util.Version;
  * a properties file for each map that we download. Reading XMLs in Zips is can be
  * fast, so one day we should just read the versions directly from the map zip files.
  */
+@ExtendWith(TemporaryFolderExtension.class)
 public class FileSystemStrategyTest {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private TemporaryFolder temporaryFolder;
 
   private FileSystemAccessStrategy testObj;
 
   private File mapFile;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     testObj = new FileSystemAccessStrategy();
     final String text = DownloadFileProperties.VERSION_PROPERTY + " = 1.2";
-    mapFile = temporaryFolder.newFile();
+    mapFile = temporaryFolder.newFile("someothertestname");
     final File propFile = temporaryFolder.newFile(mapFile.getName() + ".properties");
     Files.write(text.getBytes(), propFile);
   }

--- a/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
@@ -34,7 +34,7 @@ public class FileSystemStrategyTest {
   public void setUp() throws Exception {
     testObj = new FileSystemAccessStrategy();
     final String text = DownloadFileProperties.VERSION_PROPERTY + " = 1.2";
-    mapFile = temporaryFolder.newFile("someothertestname");
+    mapFile = temporaryFolder.newFile(getClass().getName());
     final File propFile = temporaryFolder.newFile(mapFile.getName() + ".properties");
     Files.write(text.getBytes(), propFile);
   }

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
@@ -32,29 +32,29 @@ public final class MapDownloadControllerTests {
   @Nested
   @ExtendWith(MockitoExtension.class)
   public final class GetOutOfDateMapNamesTest {
-    private final String MAP_NAME = "myMap";
+    private final String mapName = "myMap";
 
-    private final File MAP_ZIP_FILE_1 = new File("file1.zip");
+    private final File mapZipFile1 = new File("file1.zip");
 
-    private final File MAP_ZIP_FILE_2 = new File("file2.zip");
+    private final File mapZipFile2 = new File("file2.zip");
 
-    private final Version VERSION_1 = new Version(1, 0);
+    private final Version version1 = new Version(1, 0);
 
-    private final Version VERSION_2 = new Version(2, 0);
+    private final Version version2 = new Version(2, 0);
 
-    private final Version VERSION_UNKNOWN = null;
+    private final Version versionUnknown = null;
 
     @Mock
     private DownloadedMaps downloadedMaps;
 
     @Test
     public void shouldIncludeMapWhenMapIsOutOfDate() {
-      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_2);
-      givenDownloadedMapVersionIs(VERSION_1);
+      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(version2);
+      givenDownloadedMapVersionIs(version1);
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
-      assertThat(outOfDateMapNames, contains(MAP_NAME));
+      assertThat(outOfDateMapNames, contains(mapName));
     }
 
     private Collection<DownloadFileDescription> givenLatestMapVersionIs(final Version version) {
@@ -69,16 +69,16 @@ public final class MapDownloadControllerTests {
       return new DownloadFileDescription(
           "url",
           "description",
-          MAP_NAME,
+          mapName,
           version,
           DownloadFileDescription.DownloadType.MAP,
           DownloadFileDescription.MapCategory.BEST);
     }
 
     private void givenDownloadedMapVersionIs(final Version version) {
-      when(downloadedMaps.getZipFileCandidates(MAP_NAME)).thenReturn(Arrays.asList(MAP_ZIP_FILE_1, MAP_ZIP_FILE_2));
-      doReturn(Optional.empty()).when(downloadedMaps).getVersionForZipFile(MAP_ZIP_FILE_1);
-      doReturn(Optional.of(version)).when(downloadedMaps).getVersionForZipFile(MAP_ZIP_FILE_2);
+      when(downloadedMaps.getZipFileCandidates(mapName)).thenReturn(Arrays.asList(mapZipFile1, mapZipFile2));
+      doReturn(Optional.empty()).when(downloadedMaps).getVersionForZipFile(mapZipFile1);
+      doReturn(Optional.of(version)).when(downloadedMaps).getVersionForZipFile(mapZipFile2);
     }
 
     private Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloads) {
@@ -87,43 +87,43 @@ public final class MapDownloadControllerTests {
 
     @Test
     public void shouldExcludeMapWhenMapIsUpToDate() {
-      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_1);
-      givenDownloadedMapVersionIs(VERSION_1);
+      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(version1);
+      givenDownloadedMapVersionIs(version1);
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
-      assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+      assertThat(outOfDateMapNames, not(contains(mapName)));
     }
 
     @Test
     public void shouldExcludeMapWhenDownloadedVersionIsUnknown() {
-      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_1);
+      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(version1);
       givenDownloadedMapVersionIsUnknown();
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
-      assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+      assertThat(outOfDateMapNames, not(contains(mapName)));
     }
 
     private void givenDownloadedMapVersionIsUnknown() {
-      when(downloadedMaps.getZipFileCandidates(MAP_NAME)).thenReturn(Arrays.asList(MAP_ZIP_FILE_1, MAP_ZIP_FILE_2));
+      when(downloadedMaps.getZipFileCandidates(mapName)).thenReturn(Arrays.asList(mapZipFile1, mapZipFile2));
       when(downloadedMaps.getVersionForZipFile(any())).thenReturn(Optional.empty());
     }
 
     @Test
     public void shouldExcludeMapWhenLatestVersionIsUnknown() {
-      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_UNKNOWN);
-      givenDownloadedMapVersionIs(VERSION_1);
+      final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(versionUnknown);
+      givenDownloadedMapVersionIs(version1);
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
-      assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+      assertThat(outOfDateMapNames, not(contains(mapName)));
     }
 
     @Test
     public void shouldExcludeMapWhenDownloadIsNull() {
       final Collection<DownloadFileDescription> downloads = givenDownload(null);
-      givenDownloadedMapVersionIs(VERSION_1);
+      givenDownloadedMapVersionIs(version1);
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
@@ -1,10 +1,10 @@
 package games.strategy.engine.framework.map.download;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -16,32 +16,33 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.framework.map.download.MapDownloadController.DownloadedMaps;
 import games.strategy.engine.framework.map.download.MapDownloadController.TutorialMapPreferences;
 import games.strategy.engine.framework.map.download.MapDownloadController.UserMaps;
 import games.strategy.util.Version;
 
-@RunWith(Enclosed.class)
 public final class MapDownloadControllerTests {
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class GetOutOfDateMapNamesTest {
-    private static final String MAP_NAME = "myMap";
+  
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  public final class GetOutOfDateMapNamesTest {
+    private final String MAP_NAME = "myMap";
 
-    private static final File MAP_ZIP_FILE_1 = new File("file1.zip");
+    private final File MAP_ZIP_FILE_1 = new File("file1.zip");
 
-    private static final File MAP_ZIP_FILE_2 = new File("file2.zip");
+    private final File MAP_ZIP_FILE_2 = new File("file2.zip");
 
-    private static final Version VERSION_1 = new Version(1, 0);
+    private final Version VERSION_1 = new Version(1, 0);
 
-    private static final Version VERSION_2 = new Version(2, 0);
+    private final Version VERSION_2 = new Version(2, 0);
 
-    private static final Version VERSION_UNKNOWN = null;
+    private final Version VERSION_UNKNOWN = null;
 
     @Mock
     private DownloadedMaps downloadedMaps;
@@ -56,15 +57,15 @@ public final class MapDownloadControllerTests {
       assertThat(outOfDateMapNames, contains(MAP_NAME));
     }
 
-    private static Collection<DownloadFileDescription> givenLatestMapVersionIs(final Version version) {
+    private Collection<DownloadFileDescription> givenLatestMapVersionIs(final Version version) {
       return givenDownload(newDownloadWithVersion(version));
     }
 
-    private static Collection<DownloadFileDescription> givenDownload(final DownloadFileDescription download) {
+    private Collection<DownloadFileDescription> givenDownload(final DownloadFileDescription download) {
       return Collections.singletonList(download);
     }
 
-    private static DownloadFileDescription newDownloadWithVersion(final Version version) {
+    private DownloadFileDescription newDownloadWithVersion(final Version version) {
       return new DownloadFileDescription(
           "url",
           "description",
@@ -130,8 +131,9 @@ public final class MapDownloadControllerTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class PreventPromptToDownloadTutorialMapTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class PreventPromptToDownloadTutorialMapTest {
     @Mock
     private TutorialMapPreferences tutorialMapPreferences;
 
@@ -147,8 +149,9 @@ public final class MapDownloadControllerTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class ShouldPromptToDownloadTutorialMapTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class ShouldPromptToDownloadTutorialMapTest {
     @Mock
     private TutorialMapPreferences tutorialMapPreferences;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -1,11 +1,11 @@
 package games.strategy.engine.framework.map.download;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
 

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -10,15 +10,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.util.Version;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class MapDownloadListTest {
   private static final String MAP_NAME = "new_test_order";
   private static final Version MAP_VERSION = new Version(10, 10);
@@ -32,7 +32,7 @@ public class MapDownloadListTest {
 
   private final List<DownloadFileDescription> descriptions = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     descriptions.add(TEST_MAP);
   }

--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginTests.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginTests.java
@@ -1,22 +1,21 @@
 package games.strategy.engine.framework.startup.login;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-@RunWith(Enclosed.class)
 public final class ClientLoginTests {
   private static final String PASSWORD = "password";
 
-  public static final class AddAuthenticationResponsePropertiesTest {
+  @Nested
+  public final class AddAuthenticationResponsePropertiesTest {
     @Test
     public void shouldCreateResponseProcessableByMd5CryptAuthenticatorWhenMd5CryptChallengePresent() {
       final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();

--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTests.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTests.java
@@ -1,32 +1,31 @@
 package games.strategy.engine.framework.startup.login;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.framework.startup.login.ClientLoginValidator.ErrorMessages;
 
-
-@RunWith(Enclosed.class)
 public final class ClientLoginValidatorTests {
   private static final String PASSWORD = "password";
   private static final String OTHER_PASSWORD = "otherPassword";
 
-  public static final class MacValidationTest {
+  @Nested
+  public final class MacValidationTest {
     private static final String MAGIC_MAC_START = ClientLoginValidator.MAC_MAGIC_STRING_PREFIX;
 
     @Test
@@ -48,9 +47,11 @@ public final class ClientLoginValidatorTests {
     }
   }
 
-  @RunWith(Enclosed.class)
-  public static final class GetChallengePropertiesTests {
-    public abstract static class AbstractTestCase {
+
+  @Nested
+  public final class GetChallengePropertiesTests {
+    @Nested
+    public abstract class AbstractTestCase {
       final ClientLoginValidator clientLoginValidator = new ClientLoginValidator(null);
 
       @Mock
@@ -61,9 +62,10 @@ public final class ClientLoginValidatorTests {
       }
     }
 
-    @RunWith(MockitoJUnitRunner.StrictStubs.class)
-    public static final class WhenPasswordSetTest extends AbstractTestCase {
-      @Before
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    public final class WhenPasswordSetTest extends AbstractTestCase {
+      @BeforeEach
       public void givenPasswordSet() {
         clientLoginValidator.setGamePassword(PASSWORD);
       }
@@ -83,9 +85,10 @@ public final class ClientLoginValidatorTests {
       }
     }
 
-    @RunWith(MockitoJUnitRunner.StrictStubs.class)
-    public static final class WhenPasswordNotSetTest extends AbstractTestCase {
-      @Before
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    public final class WhenPasswordNotSetTest extends AbstractTestCase {
+      @BeforeEach
       public void givenPasswordNotSet() {
         clientLoginValidator.setGamePassword(null);
       }
@@ -106,11 +109,12 @@ public final class ClientLoginValidatorTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.StrictStubs.class)
-  public static final class AuthenticateTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class AuthenticateTest {
     private final ClientLoginValidator clientLoginValidator = new ClientLoginValidator(null);
 
-    @Before
+    @BeforeEach
     public void givenPasswordSet() {
       clientLoginValidator.setGamePassword(PASSWORD);
     }

--- a/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
@@ -12,13 +12,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;

--- a/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.startup.login;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
@@ -12,7 +13,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Base64;

--- a/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -11,11 +11,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;

--- a/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.startup.login;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
@@ -11,7 +12,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -1,11 +1,9 @@
 package games.strategy.engine.framework.startup.mc;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-
-import static org.junit.Assert.assertThat;
-
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,14 +13,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Observer;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
@@ -31,7 +28,7 @@ import games.strategy.engine.framework.ui.NewGameChooserEntry;
 import games.strategy.util.Version;
 
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class GameSelectorModelTest {
 
   private static void assertHasEmptyData(final GameSelectorModel objectToCheck) {
@@ -76,14 +73,14 @@ public class GameSelectorModelTest {
   @Mock
   private ClientModel mockClientModel;
 
-  @Before
+  @BeforeEach
   public void setup() {
     testObj = new GameSelectorModel();
     assertHasEmptyData(testObj);
     testObj.addObserver(mockObserver);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     testObj.deleteObservers();
   }

--- a/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
+++ b/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.systemcheck;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
+++ b/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.framework.systemcheck;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 

--- a/src/test/java/games/strategy/engine/framework/systemcheck/SystemCheckTest.java
+++ b/src/test/java/games/strategy/engine/framework/systemcheck/SystemCheckTest.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.framework.systemcheck;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SystemCheckTest {
 

--- a/src/test/java/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.framework.ui;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NewGameChooserModelTest {
 

--- a/src/test/java/games/strategy/engine/lobby/client/login/LobbyLoginPreferencesTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/login/LobbyLoginPreferencesTest.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.lobby.client.login;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.AdditionalAnswers.returnsSecondArg;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -14,11 +14,11 @@ import static org.mockito.Mockito.verify;
 import java.util.Optional;
 import java.util.prefs.Preferences;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Stubber;
 
 import games.strategy.engine.lobby.client.login.LobbyLoginPreferences.PreferenceKeys;
@@ -26,7 +26,7 @@ import games.strategy.security.CredentialManager;
 import games.strategy.security.CredentialManagerException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class LobbyLoginPreferencesTest {
   private static final String PASSWORD = "password";
   private static final String PROTECTED_PASSWORD = String.format("PROTECTED(%s)", PASSWORD);

--- a/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -1,18 +1,18 @@
 package games.strategy.engine.lobby.client.ui;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.ILobbyGameController;
@@ -25,7 +25,7 @@ import games.strategy.net.INode;
 import games.strategy.test.TestUtil;
 import games.strategy.util.Tuple;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class LobbyGameTableModelTest {
 
   private LobbyGameTableModel testObj;
@@ -48,7 +48,7 @@ public class LobbyGameTableModelTest {
   @Mock
   private INode serverNode;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     fakeGameMap = new HashMap<>();
     fakeGame = Tuple.of(new GUID(), mockGameDescription);

--- a/src/test/java/games/strategy/engine/lobby/client/ui/TimespanDialogTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/ui/TimespanDialogTest.java
@@ -1,15 +1,15 @@
 package games.strategy.engine.lobby.client.ui;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Instant;
 import java.util.Date;
 
 import javax.swing.JOptionPane;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.client.ui.TimespanDialog.TimeUnit;
 

--- a/src/test/java/games/strategy/engine/lobby/server/db/HashedPasswordTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/db/HashedPasswordTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.core.Is.is;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.MD5Crypt;
 import nl.jqno.equalsverifier.EqualsVerifier;

--- a/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTests.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTests.java
@@ -50,7 +50,7 @@ public final class LobbyLoginValidatorTests {
   abstract class AbstractTestCase {
     static final String EMAIL = "n@n.com";
     static final String PASSWORD = "password";
-    private final SocketAddress REMOTE_ADDRESS = new InetSocketAddress(9999);
+    private final SocketAddress remoteAddress = new InetSocketAddress(9999);
     private static final String USERNAME = "username";
 
     @Mock
@@ -147,13 +147,13 @@ public final class LobbyLoginValidatorTests {
 
     final void whenAuthenticating(final ResponseGenerator responseGenerator) {
       final String hashedMac = "$1$MH$lW2b9Tx3VIpD4llOnivrP1";
-      final Map<String, String> challenge = lobbyLoginValidator.getChallengeProperties(USERNAME, REMOTE_ADDRESS);
+      final Map<String, String> challenge = lobbyLoginValidator.getChallengeProperties(USERNAME, remoteAddress);
       authenticationErrorMessage = lobbyLoginValidator.verifyConnection(
           challenge,
           responseGenerator.apply(challenge),
           USERNAME,
           hashedMac,
-          REMOTE_ADDRESS);
+          remoteAddress);
     }
 
     final void thenAuthenticationShouldFailWithMessage(final String errorMessage) {

--- a/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.lobby.server.login;
 
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -10,15 +10,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.security.TestSecurityUtils;
 
 public final class RsaAuthenticatorTest {
   private RsaAuthenticator rsaAuthenticator;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     rsaAuthenticator = new RsaAuthenticator(TestSecurityUtils.loadRsaKeyPair());
   }

--- a/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
@@ -4,11 +4,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
@@ -2,9 +2,9 @@ package games.strategy.engine.lobby.server.userDB;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
@@ -1,11 +1,11 @@
 package games.strategy.engine.message;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collection;
 import java.util.Comparator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.test.TestUtil;
 

--- a/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
@@ -2,9 +2,9 @@ package games.strategy.engine.message;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
@@ -4,9 +4,9 @@ import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class RemoteMethodCallTest {
   @Test

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.message.unifiedmessenger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.ChannelMessenger;
@@ -30,7 +30,7 @@ public class ChannelMessengerTest {
   private ChannelMessenger clientChannelMessenger;
   private UnifiedMessengerHub unifiedMessengerHub;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     serverPort = TestUtil.getUniquePort();
     serverMessenger = new ServerMessenger("Server", serverPort);
@@ -43,7 +43,7 @@ public class ChannelMessengerTest {
     clientChannelMessenger = new ChannelMessenger(new UnifiedMessenger(clientMessenger));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       if (serverMessenger != null) {

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
@@ -1,11 +1,11 @@
 package games.strategy.engine.message.unifiedmessenger;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Comparator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteMethodCallResults;

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -1,11 +1,10 @@
 package games.strategy.engine.message.unifiedmessenger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -19,10 +18,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -50,7 +48,7 @@ public class RemoteMessengerTest {
   private RemoteMessenger remoteMessenger;
   private UnifiedMessengerHub unifiedMessengerHub;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     // simple set up for non networked testing
     final List<IConnectionChangeListener> connectionListeners = new CopyOnWriteArrayList<>();
@@ -84,7 +82,7 @@ public class RemoteMessengerTest {
     serverPort = TestUtil.getUniquePort();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     serverMessenger = null;
     remoteMessenger = null;

--- a/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
@@ -1,16 +1,16 @@
 package games.strategy.engine.random;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CryptoRandomSourceTest {
 
   @Test
   public void testIntsToBytes() {
-    final byte[] bytes = CryptoRandomSource.intsToBytes(new int[] { 0xD1C2B3A4, 0x1A2B3C4D });
+    final byte[] bytes = CryptoRandomSource.intsToBytes(new int[] {0xD1C2B3A4, 0x1A2B3C4D});
     assertEquals(8, bytes.length);
     assertEquals((byte) 0xA4, bytes[0]);
     assertEquals((byte) 0xB3, bytes[1]);
@@ -26,7 +26,7 @@ public class CryptoRandomSourceTest {
   public void testBytesToInts() {
     final int[] ints = CryptoRandomSource.bytesToInts(new byte[] {
         (byte) 0xA4, (byte) 0xB3, (byte) 0xC2, (byte) 0xD1,
-        (byte) 0x4D, (byte) 0x3C, (byte) 0x2B, (byte) 0x1A });
+        (byte) 0x4D, (byte) 0x3C, (byte) 0x2B, (byte) 0x1A});
     assertEquals(2, ints.length);
     assertEquals(0xD1C2B3A4, ints[0]);
     assertEquals(0x1A2B3C4D, ints[1]);
@@ -49,7 +49,7 @@ public class CryptoRandomSourceTest {
         Integer.MAX_VALUE, Integer.MIN_VALUE};
     final int[] thereAndBack = CryptoRandomSource.bytesToInts(CryptoRandomSource.intsToBytes(ints));
     for (int i = 0; i < ints.length; i++) {
-      assertEquals("at " + i, ints[i], thereAndBack[i]);
+      assertEquals(ints[i], thereAndBack[i], "at " + i);
     }
   }
 }

--- a/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/CryptoRandomSourceTest.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.random;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/engine/random/PlainRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/PlainRandomSourceTest.java
@@ -3,13 +3,13 @@ package games.strategy.engine.random;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;

--- a/src/test/java/games/strategy/engine/random/PlainRandomSourceTest.java
+++ b/src/test/java/games/strategy/engine/random/PlainRandomSourceTest.java
@@ -9,12 +9,12 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class PlainRandomSourceTest {
   private static final String ANNOTATION = "annotation";

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.vault;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,9 +10,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.ChannelMessenger;
@@ -38,7 +38,7 @@ public class VaultTest {
   private Vault clientVault;
   private Vault serverVault;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     serverPort = TestUtil.getUniquePort();
     serverMessenger = new ServerMessenger("Server", serverPort);
@@ -52,7 +52,7 @@ public class VaultTest {
     Thread.yield();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     try {
       if (serverMessenger != null) {

--- a/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -1,12 +1,12 @@
 package games.strategy.engine.xml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.DelegateList;
 import games.strategy.engine.data.GameData;
@@ -25,7 +25,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class ParserTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.GAME_EXAMPLE.getGameData();
   }
@@ -129,8 +129,8 @@ public class ParserTest {
   @Test
   public void testOwnerInitialze() {
     final Territory can = gameData.getMap().getTerritory("canada");
-    assertNotNull("couldnt find country", can);
-    assertNotNull("owner null", can.getOwner());
+    assertNotNull(can, "couldnt find country");
+    assertNotNull(can.getOwner(), "owner null");
     assertEquals(can.getOwner().getName(), "chretian");
     final Territory us = gameData.getMap().getTerritory("us");
     assertEquals(us.getOwner().getName(), "bush");

--- a/src/test/java/games/strategy/internal/persistence/serializable/AbstractGameDataComponentProxyTestCase.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/AbstractGameDataComponentProxyTestCase.java
@@ -3,7 +3,7 @@ package games.strategy.internal.persistence.serializable;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameDataComponent;
@@ -94,7 +94,7 @@ public abstract class AbstractGameDataComponentProxyTestCase<T extends GameDataC
   /**
    * Subclasses may override and are required to call the superclass implementation first.
    */
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     super.setUp();

--- a/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
@@ -1,6 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -16,7 +16,7 @@ public final class TripleAProxyAsProxyTest extends AbstractProxyTestCase<TripleA
 
   @Override
   protected void assertPrincipalEquals(final TripleA expected, final TripleA actual) {
-    assertTrue("no persistent state; all non-null instances are considered equal", true);
+    assertTrue(true, "no persistent state; all non-null instances are considered equal");
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/UnitProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/UnitProxyAsProxyTest.java
@@ -6,7 +6,7 @@ import static games.strategy.engine.data.TestGameDataComponentFactory.newUnit;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Unit;
@@ -30,7 +30,7 @@ public final class UnitProxyAsProxyTest extends AbstractGameDataComponentProxyTe
     actual.setOwner(playerId);
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     super.setUp();

--- a/src/test/java/games/strategy/io/IoUtilsTest.java
+++ b/src/test/java/games/strategy/io/IoUtilsTest.java
@@ -1,7 +1,7 @@
 package games.strategy.io;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/games/strategy/io/IoUtilsTest.java
+++ b/src/test/java/games/strategy/io/IoUtilsTest.java
@@ -1,13 +1,13 @@
 package games.strategy.io;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.InputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import games.strategy.io.IoUtils.InputStreamConsumer;

--- a/src/test/java/games/strategy/net/GuidTest.java
+++ b/src/test/java/games/strategy/net/GuidTest.java
@@ -1,6 +1,6 @@
 package games.strategy.net;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyRegistryTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyRegistryTestCase.java
@@ -1,8 +1,8 @@
 package games.strategy.persistence.serializable;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -10,14 +10,14 @@ import static org.mockito.Mockito.verify;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * A fixture for testing the basic aspects of classes that implement the {@link ProxyRegistry} interface.
  */
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractProxyRegistryTestCase {
   protected AbstractProxyRegistryTestCase() {}
 

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -15,8 +15,8 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.io.IoUtils;
 import games.strategy.test.EqualityComparator;
@@ -126,7 +126,7 @@ public abstract class AbstractProxyTestCase<T> {
   /**
    * Subclasses may override and are required to call the superclass implementation first.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     equalityComparatorRegistry = EqualityComparatorRegistry.newInstance(getEqualityComparators());
     proxyRegistry = ProxyRegistry.newInstance(getProxyFactories());

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -2,12 +2,12 @@ package games.strategy.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static games.strategy.test.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
@@ -14,7 +14,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Date;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.io.IoUtils;
 

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
@@ -2,11 +2,11 @@ package games.strategy.persistence.serializable;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.io.NotSerializableException;

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
@@ -1,19 +1,19 @@
 package games.strategy.persistence.serializable;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import games.strategy.io.IoUtils;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class ProxyableObjectOutputStreamTest {
   @Test
   public void replaceObject_ShouldDelegateToProxyRegistryWhenObjectIsNotNull() throws Exception {

--- a/src/test/java/games/strategy/security/DefaultCredentialManagerTest.java
+++ b/src/test/java/games/strategy/security/DefaultCredentialManagerTest.java
@@ -3,11 +3,11 @@ package games.strategy.security;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.AdditionalAnswers.returnsSecondArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,14 +16,14 @@ import static org.mockito.Mockito.when;
 
 import java.util.prefs.Preferences;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class DefaultCredentialManagerTest {
   private static final char[] MASTER_PASSWORD = "MASTER←PASSWORD↑WITH→UNICODE↓CHARS".toCharArray();
 
@@ -32,12 +32,12 @@ public final class DefaultCredentialManagerTest {
 
   private DefaultCredentialManager credentialManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     credentialManager = DefaultCredentialManager.newInstance(MASTER_PASSWORD);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     credentialManager.close();
   }

--- a/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
+++ b/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
@@ -1,9 +1,9 @@
 package games.strategy.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
+++ b/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
@@ -3,12 +3,12 @@ package games.strategy.test;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class EqualityComparatorRegistryTest {
   @Test

--- a/src/test/java/games/strategy/test/EqualsPredicateTests.java
+++ b/src/test/java/games/strategy/test/EqualsPredicateTests.java
@@ -1,19 +1,18 @@
 package games.strategy.test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-@RunWith(Enclosed.class)
 public final class EqualsPredicateTests {
   private static EqualsPredicate newEqualsPredicate(final EqualityComparator... equalityComparators) {
     return new EqualsPredicate(EqualityComparatorRegistry.newInstance(equalityComparators));
   }
 
-  public static final class NullAndReferenceEqualityTest {
+  @Nested
+  public final class NullAndReferenceEqualityTest {
     private final EqualsPredicate equalsPredicate = newEqualsPredicate();
 
     @Test
@@ -39,7 +38,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  public static final class EquatableObjectWithoutCustomComparatorTest {
+  @Nested
+  public final class EquatableObjectWithoutCustomComparatorTest {
     private final EqualsPredicate equalsPredicate = newEqualsPredicate();
 
     @Test
@@ -53,7 +53,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  public static final class EquatableObjectWithCustomComparatorTest {
+  @Nested
+  public final class EquatableObjectWithCustomComparatorTest {
     @Test
     public void shouldReturnTrueWhenObjectsAreEqual() {
       final EqualsPredicate equalsPredicate = newEqualsPredicate(
@@ -71,7 +72,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  public static final class NonEquatableObjectTest {
+  @Nested
+  public final class NonEquatableObjectTest {
     private final EqualsPredicate equalsPredicate = newEqualsPredicate(
         EqualityComparator.newInstance(FakeClass.class, (context, o1, o2) -> o1.value == o2.value));
 
@@ -86,7 +88,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  public static final class NonEquatableNestedObjectTest {
+  @Nested
+  public final class NonEquatableNestedObjectTest {
     private final EqualsPredicate equalsPredicate = newEqualsPredicate(
         EqualityComparator.newInstance(FakeClass.class, (context, o1, o2) -> o1.value == o2.value),
         EqualityComparator.newInstance(FakeNestedClass.class, (context, o1, o2) -> context.equals(o1.value, o2.value)));
@@ -105,7 +108,8 @@ public final class EqualsPredicateTests {
           new FakeNestedClass(new FakeClass(-42))));
     }
 
-    private static final class FakeNestedClass {
+    @Nested
+    private final class FakeNestedClass {
       final FakeClass value;
 
       FakeNestedClass(final FakeClass value) {
@@ -114,7 +118,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  public static final class NonEquatableCircularReferenceTest {
+  @Nested
+  public final class NonEquatableCircularReferenceTest {
     final EqualsPredicate equalsPredicate = newEqualsPredicate(
         EqualityComparator.newInstance(
             FakeOwnerClass.class,
@@ -159,7 +164,8 @@ public final class EqualsPredicateTests {
       assertFalse(equalsPredicate.test(owner1, owner2));
     }
 
-    private static final class FakeOwnerClass {
+    @Nested
+    private final class FakeOwnerClass {
       FakeOwneeClass ownee;
       final int value;
 
@@ -168,7 +174,8 @@ public final class EqualsPredicateTests {
       }
     }
 
-    private static final class FakeOwneeClass {
+    @Nested
+    private final class FakeOwneeClass {
       final FakeOwnerClass owner;
       final int value;
 
@@ -179,7 +186,8 @@ public final class EqualsPredicateTests {
     }
   }
 
-  private static final class FakeClass {
+  @Nested
+  private final class FakeClass {
     final int value;
 
     FakeClass(final int value) {

--- a/src/test/java/games/strategy/test/EqualsPredicateTests.java
+++ b/src/test/java/games/strategy/test/EqualsPredicateTests.java
@@ -108,7 +108,6 @@ public final class EqualsPredicateTests {
           new FakeNestedClass(new FakeClass(-42))));
     }
 
-    @Nested
     private final class FakeNestedClass {
       final FakeClass value;
 
@@ -164,7 +163,6 @@ public final class EqualsPredicateTests {
       assertFalse(equalsPredicate.test(owner1, owner2));
     }
 
-    @Nested
     private final class FakeOwnerClass {
       FakeOwneeClass ownee;
       final int value;
@@ -174,7 +172,6 @@ public final class EqualsPredicateTests {
       }
     }
 
-    @Nested
     private final class FakeOwneeClass {
       final FakeOwnerClass owner;
       final int value;
@@ -186,8 +183,7 @@ public final class EqualsPredicateTests {
     }
   }
 
-  @Nested
-  private final class FakeClass {
+  private static final class FakeClass {
     final int value;
 
     FakeClass(final int value) {

--- a/src/test/java/games/strategy/thread/LockUtilTest.java
+++ b/src/test/java/games/strategy/thread/LockUtilTest.java
@@ -1,8 +1,8 @@
 package games.strategy.thread;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,14 +12,14 @@ import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class LockUtilTest {
   private final LockUtil lockUtil = LockUtil.INSTANCE;
 
@@ -28,12 +28,12 @@ public final class LockUtilTest {
 
   private LockUtil.ErrorReporter oldErrorReporter;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     oldErrorReporter = lockUtil.setErrorReporter(errorReporter);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     lockUtil.setErrorReporter(oldErrorReporter);
   }

--- a/src/test/java/games/strategy/thread/ThreadPoolTest.java
+++ b/src/test/java/games/strategy/thread/ThreadPoolTest.java
@@ -1,11 +1,11 @@
 package games.strategy.thread;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.util.ThreadUtil;
 

--- a/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.util.List;

--- a/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.stream.StreamSupport;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
 

--- a/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.is;
 
 import java.net.URL;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ResourceLocationTrackerTest {

--- a/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -1,13 +1,13 @@
 package games.strategy.triplea.ai;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -21,7 +21,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class AiUtilsTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.REVISED.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -9,8 +9,8 @@ import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Map.Entry;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -30,7 +30,7 @@ public class AirThatCantLandUtilTest {
   private PlayerID americansPlayer;
   private UnitType fighterType;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.REVISED.getGameData();
     americansPlayer = GameDataTestUtil.americans(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -8,7 +8,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge
 import static games.strategy.triplea.delegate.GameDataTestUtil.makeGameLowLuck;
 import static games.strategy.triplea.delegate.GameDataTestUtil.setSelectAaCasualties;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -38,7 +38,7 @@ public class BattleCalculatorTest {
   private ITestDelegateBridge bridge;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final GameData data = TestMapGameData.REVISED.getGameData();
     bridge = getDelegateBridge(british(data), data);

--- a/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -8,10 +8,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -25,7 +25,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class BattleTrackerTest {
 
   @Mock

--- a/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -6,8 +6,8 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -18,7 +18,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class BigWorldTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.BIG_WORLD_1942.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
@@ -1,9 +1,9 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;

--- a/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
@@ -78,7 +79,7 @@ public class DelegateTest {
   protected UnitType carrier;
   protected Resource pus;
 
-  @Test
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.DELEGATE_TEST.getGameData();
     british = GameDataTestUtil.british(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -3,14 +3,14 @@ package games.strategy.triplea.delegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -30,7 +30,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class DiceRollTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.LHTR.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -2,8 +2,8 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -407,7 +407,7 @@ public class GameDataTestUtil {
    * Helper method to check if a String is null and otherwise print the String.
    */
   static void assertValid(final String string) {
-    Assert.assertNull(string, string);
+    Assertions.assertNull(string, string);
   }
 
   /**
@@ -415,7 +415,7 @@ public class GameDataTestUtil {
    * In this scenario used to verify an error message exists.
    */
   static void assertError(final String string) {
-    Assert.assertNotNull(string);
+    Assertions.assertNotNull(string);
   }
 
   /**

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -1,10 +1,10 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -12,8 +12,8 @@ import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -35,7 +35,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class LhtrTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.LHTR.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
@@ -1,12 +1,13 @@
 package games.strategy.triplea.delegate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -16,10 +17,9 @@ import javax.annotation.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -29,7 +29,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.Match;
 
-@RunWith(Enclosed.class)
 public final class MatchesTests {
 
   private static final Match<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
@@ -96,45 +95,41 @@ public final class MatchesTests {
   public void testGetMatches() {
     final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-    assertEquals("empty collection", Arrays.asList(), Matches.getMatches(Arrays.asList(), Matches.always()));
-    assertEquals("none match", Arrays.asList(), Matches.getMatches(input, Matches.never()));
-    assertEquals("some match", Arrays.asList(-1, 1), Matches.getMatches(input, IS_ZERO_MATCH.invert()));
-    assertEquals("all match", Arrays.asList(-1, 0, 1), Matches.getMatches(input, Matches.always()));
+    assertEquals(Arrays.asList(), Matches.getMatches(Arrays.asList(), Matches.always()), "empty collection");
+    assertEquals(Arrays.asList(), Matches.getMatches(input, Matches.never()), "none match");
+    assertEquals(Arrays.asList(-1, 1), Matches.getMatches(input, IS_ZERO_MATCH.invert()), "some match");
+    assertEquals(Arrays.asList(-1, 0, 1), Matches.getMatches(input, Matches.always()), "all match");
   }
 
   @Test
   public void testGetNMatches() {
     final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-    assertEquals("empty collection", Arrays.asList(), Matches.getNMatches(Arrays.asList(), 999, Matches.always()));
-    assertEquals("max = 0", Arrays.asList(), Matches.getNMatches(input, 0, Matches.never()));
-    assertEquals("none match", Arrays.asList(), Matches.getNMatches(input, input.size(), Matches.never()));
-    assertEquals("some match; max < count",
-        Arrays.asList(0),
-        Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO_MATCH));
-    assertEquals("some match; max = count",
-        Arrays.asList(0, 0),
-        Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO_MATCH));
-    assertEquals("some match; max > count",
-        Arrays.asList(0, 0),
-        Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO_MATCH));
-    assertEquals("all match; max < count",
-        Arrays.asList(-1, 0),
-        Matches.getNMatches(input, input.size() - 1, Matches.always()));
-    assertEquals("all match; max = count",
-        Arrays.asList(-1, 0, 1),
-        Matches.getNMatches(input, input.size(), Matches.always()));
-    assertEquals("all match; max > count",
-        Arrays.asList(-1, 0, 1),
-        Matches.getNMatches(input, input.size() + 1, Matches.always()));
+    assertEquals(Arrays.asList(), Matches.getNMatches(Arrays.asList(), 999, Matches.always()), "empty collection");
+    assertEquals(Arrays.asList(), Matches.getNMatches(input, 0, Matches.never()), "max = 0");
+    assertEquals(Arrays.asList(), Matches.getNMatches(input, input.size(), Matches.never()), "none match");
+    assertEquals(Arrays.asList(0), Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO_MATCH),
+        "some match; max < count");
+    assertEquals(Arrays.asList(0, 0), Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO_MATCH),
+        "some match; max = count");
+    assertEquals(Arrays.asList(0, 0), Matches.getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO_MATCH),
+        "some match; max > count");
+    assertEquals(Arrays.asList(-1, 0), Matches.getNMatches(input, input.size() - 1, Matches.always()),
+        "all match; max < count");
+    assertEquals(Arrays.asList(-1, 0, 1), Matches.getNMatches(input, input.size(), Matches.always()),
+        "all match; max = count");
+    assertEquals(Arrays.asList(-1, 0, 1), Matches.getNMatches(input, input.size() + 1, Matches.always()),
+        "all match; max > count");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testGetNMatches_ShouldThrowExceptionWhenMaxIsNegative() {
-    Matches.getNMatches(Arrays.asList(-1, 0, 1), -1, Matches.always());
+    assertThrows(IllegalArgumentException.class,
+        () -> Matches.getNMatches(Arrays.asList(-1, 0, 1), -1, Matches.always()));
   }
 
-  public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyTest {
+  @Nested
+  public final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyTest {
     private GameData gameData;
     private PlayerID player;
     private PlayerID alliedPlayer;
@@ -161,7 +156,7 @@ public final class MatchesTests {
       return GameDataTestUtil.battleship(gameData).create(player);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       gameData = TestMapGameData.DELEGATE_TEST.getGameData();
 
@@ -220,17 +215,18 @@ public final class MatchesTests {
     }
   }
 
-  public static final class TerritoryIsNotUnownedWaterTest {
+  @Nested
+  public final class TerritoryIsNotUnownedWaterTest {
     private GameData gameData;
     private PlayerID player;
     private Territory landTerritory;
     private Territory seaTerritory;
 
-    private static Match<Territory> newMatch() {
+    private Match<Territory> newMatch() {
       return Matches.territoryIsNotUnownedWater();
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
       gameData = TestMapGameData.DELEGATE_TEST.getGameData();
 

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -1,17 +1,17 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -30,7 +30,7 @@ public class MoveDelegateTest extends DelegateTest {
   ITestDelegateBridge bridge;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     bridge = super.getDelegateBridge(british);

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -29,10 +29,8 @@ public class MoveDelegateTest extends DelegateTest {
   MoveDelegate delegate;
   ITestDelegateBridge bridge;
 
-  @Override
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setupMoveDelegate() {
     bridge = super.getDelegateBridge(british);
     bridge.setStepName("britishCombatMove");
     final InitializationDelegate initDel =

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -2,10 +2,10 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,8 +13,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -29,7 +29,7 @@ import games.strategy.util.Match;
 public class MoveValidatorTest extends DelegateTest {
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
   }

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -28,12 +28,6 @@ import games.strategy.util.Match;
 
 public class MoveValidatorTest extends DelegateTest {
 
-  @Override
-  @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
-  }
-
   @Test
   public void testEnemyUnitsInPath() {
     // japanese unit in congo

--- a/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -1,12 +1,12 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.ITestDelegateBridge;
 import games.strategy.engine.data.PlayerID;
@@ -53,7 +53,7 @@ public class PacificTest extends DelegateTest {
   MoveDelegate delegate;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     gameData = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();

--- a/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -52,10 +52,8 @@ public class PacificTest extends DelegateTest {
   ITestDelegateBridge bridge;
   MoveDelegate delegate;
 
-  @Override
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setupPacificTest() throws Exception {
     gameData = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();
     // Define units
     infantry = GameDataTestUtil.infantry(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -1,14 +1,14 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -20,7 +20,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class PactOfSteel2Test {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -28,10 +28,8 @@ public class PlaceDelegateTest extends DelegateTest {
     return gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INFANTRY).create(count, player);
   }
 
-  @Override
   @BeforeEach
-  public void setUp() throws Exception {
-    super.setUp();
+  public void setupPlaceDelegate() {
     bridge = super.getDelegateBridge(british);
     delegate = new PlaceDelegate();
     delegate.initialize("place");

--- a/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -1,14 +1,14 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.ITestDelegateBridge;
 import games.strategy.engine.data.PlayerID;
@@ -29,7 +29,7 @@ public class PlaceDelegateTest extends DelegateTest {
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     super.setUp();
     bridge = super.getDelegateBridge(british);

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -34,11 +34,11 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -54,8 +54,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -90,7 +90,7 @@ public class RevisedTest {
   /**
    * Sets up a GameData object for testing..
    */
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(),
         anyBoolean(), any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {

--- a/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
@@ -9,8 +9,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -30,7 +30,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class StratBombTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.GLOBAL1940.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
@@ -4,11 +4,11 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;

--- a/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -1,11 +1,11 @@
 package games.strategy.triplea.delegate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -41,7 +41,7 @@ public class VictoryTest {
   private Territory libya;
   private MoveDelegate moveDelegate;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.VICTORY_TEST.getGameData();
     italians = GameDataTestUtil.italians(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -37,12 +37,12 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -58,8 +58,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -98,7 +98,7 @@ public class WW2V3Year41Test {
   private GameData gameData;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(),
         anyBoolean(), any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
@@ -359,7 +359,7 @@ public class WW2V3Year41Test {
     battleDelegate.start();
     // battle already fought
     // make sure the infantry die with the transport
-    assertTrue(sz7.getUnits().toString(), sz7.getUnits().getMatches(Matches.unitOwnedBy(british)).isEmpty());
+    assertTrue(sz7.getUnits().getMatches(Matches.unitOwnedBy(british)).isEmpty(), sz7.getUnits().toString());
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -12,16 +12,16 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -35,7 +35,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class WW2V3Year42Test {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.WW2V3_1942.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
@@ -5,16 +5,16 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -27,7 +27,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public class OddsCalculatorTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.REVISED.getGameData();
   }
@@ -81,8 +81,8 @@ public class OddsCalculatorTest {
     final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(gameData), germans(gameData),
         sz1, attacking, defending, Collections.emptyList(), TerritoryEffectHelper.getEffects(sz1), 1);
     calculator.shutdown();
-    assertEquals(results.getAttackerWinPercent(), 0.0, 0.0);
-    assertEquals(results.getDefenderWinPercent(), 1.0, 0.0);
+    assertEquals(results.getAttackerWinPercent(), 0.0);
+    assertEquals(results.getDefenderWinPercent(), 1.0);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class OddsCalculatorTest {
     final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(gameData), germans(gameData),
         sz1, attacking, defending, Collections.emptyList(), TerritoryEffectHelper.getEffects(sz1), 1);
     calculator.shutdown();
-    assertEquals(results.getAttackerWinPercent(), 1.0, 0.0);
-    assertEquals(results.getDefenderWinPercent(), 0.0, 0.0);
+    assertEquals(results.getAttackerWinPercent(), 1.0);
+    assertEquals(results.getDefenderWinPercent(), 0.0);
   }
 }

--- a/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -9,17 +9,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.JOptionPane;
 
 import org.hamcrest.MatcherAssert;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableMap;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class SaveFunctionTest {
 
   @Mock

--- a/src/test/java/games/strategy/triplea/ui/RouteTest.java
+++ b/src/test/java/games/strategy/triplea/ui/RouteTest.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.ui;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -18,8 +18,8 @@ import java.awt.geom.Point2D;
 
 import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
 import org.apache.commons.math3.analysis.polynomials.PolynomialSplineFunction;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
@@ -35,7 +35,7 @@ public class RouteTest {
   private final RouteDescription dummyRouteDescription =
       spy(new RouteDescription(dummyRoute, dummyPoints[0].toPoint(), dummyPoints[2].toPoint(), null));
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1].toPoint());
     when(dummyMapData.getMapDimensions()).thenReturn(new Dimension(1000, 1000));
@@ -43,7 +43,7 @@ public class RouteTest {
 
   @Test
   public void testIndex() {
-    assertArrayEquals(spyRouteDrawer.createParameterizedIndex(new Point[] {}), new double[] {}, 0);
+    assertArrayEquals(spyRouteDrawer.createParameterizedIndex(new Point[] {}), new double[] {});
     assertEquals(dummyIndex.length, dummyPoints.length);
     // Not sure whether it makes sense to include a Test for specific values
     // The way the index is being calculated may change to a better System
@@ -67,8 +67,8 @@ public class RouteTest {
   public void testPointSplitting() {
     final double[] expectedXCoords = new double[] {0, 100, 0};
     final double[] expectedYCoords = new double[] {0, 0, 100};
-    assertArrayEquals(expectedXCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getX()), 0);
-    assertArrayEquals(expectedYCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getY()), 0);
+    assertArrayEquals(expectedXCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getX()));
+    assertArrayEquals(expectedYCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getY()));
   }
 
 

--- a/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.ui;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,11 +9,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -23,14 +23,14 @@ import games.strategy.engine.data.ResourceList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class UserActionPanelTest {
   @Mock
   private GameData data;
 
   private Resource pus;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     pus = new Resource(Constants.PUS, data);
   }

--- a/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
@@ -1,18 +1,17 @@
 package games.strategy.triplea.ui.logic;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import org.mockito.junit.MockitoJUnitRunner;
-
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class RouteCalculatorTest {
 
   @Test

--- a/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
@@ -1,9 +1,9 @@
 package games.strategy.triplea.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -15,7 +15,7 @@ import games.strategy.util.IntegerMap;
 public class TuvUtilsTest {
   private GameData gameData;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     gameData = TestMapGameData.TWW.getGameData();
   }

--- a/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
+++ b/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
@@ -1,13 +1,15 @@
 package games.strategy.triplea.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.test.TestUtil;
 

--- a/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
+++ b/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.util;
 
-
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/games/strategy/ui/SwingComponentsTest.java
+++ b/src/test/java/games/strategy/ui/SwingComponentsTest.java
@@ -4,11 +4,11 @@ import static games.strategy.ui.SwingComponents.appendExtensionIfAbsent;
 import static games.strategy.ui.SwingComponents.extensionWithLeadingPeriod;
 import static games.strategy.ui.SwingComponents.extensionWithoutLeadingPeriod;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class SwingComponentsTest {
   @Test

--- a/src/test/java/games/strategy/ui/SwingComponentsTest.java
+++ b/src/test/java/games/strategy/ui/SwingComponentsTest.java
@@ -3,8 +3,8 @@ package games.strategy.ui;
 import static games.strategy.ui.SwingComponents.appendExtensionIfAbsent;
 import static games.strategy.ui.SwingComponents.extensionWithLeadingPeriod;
 import static games.strategy.ui.SwingComponents.extensionWithoutLeadingPeriod;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 

--- a/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
+++ b/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
@@ -6,13 +6,13 @@ import java.beans.PropertyChangeEvent;
 
 import javax.swing.SwingWorker;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class SwingWorkerCompletionWaiterTest {
 
   private SwingWorkerCompletionWaiter waiter;
@@ -20,7 +20,7 @@ public final class SwingWorkerCompletionWaiterTest {
   @Mock
   private SwingWorkerCompletionWaiter.ProgressWindow progressWindow;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     waiter = new SwingWorkerCompletionWaiter(progressWindow);
   }

--- a/src/test/java/games/strategy/util/CoreEqualityComparatorsTests.java
+++ b/src/test/java/games/strategy/util/CoreEqualityComparatorsTests.java
@@ -1,15 +1,14 @@
 package games.strategy.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -17,7 +16,6 @@ import games.strategy.test.EqualityComparator;
 import games.strategy.test.EqualityComparatorRegistry;
 import games.strategy.test.TestUtil;
 
-@RunWith(Enclosed.class)
 public final class CoreEqualityComparatorsTests {
   private static EqualityComparatorRegistry newEqualityComparatorRegistryOf(
       final EqualityComparator primaryEqualityComparator,
@@ -28,10 +26,11 @@ public final class CoreEqualityComparatorsTests {
     return EqualityComparatorRegistry.newInstance(equalityComparators);
   }
 
-  public static final class CollectionTest {
+  @Nested
+  public final class CollectionTest {
     private final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry();
 
-    private static EqualityComparatorRegistry newEqualityComparatorRegistry(
+    private EqualityComparatorRegistry newEqualityComparatorRegistry(
         final EqualityComparator... equalityComparators) {
       return newEqualityComparatorRegistryOf(CoreEqualityComparators.COLLECTION, equalityComparators);
     }
@@ -72,10 +71,11 @@ public final class CoreEqualityComparatorsTests {
     }
   }
 
-  public static final class MapTest {
+  @Nested
+  public final class MapTest {
     private final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry();
 
-    private static EqualityComparatorRegistry newEqualityComparatorRegistry(
+    private EqualityComparatorRegistry newEqualityComparatorRegistry(
         final EqualityComparator... equalityComparators) {
       return newEqualityComparatorRegistryOf(CoreEqualityComparators.MAP, equalityComparators);
     }

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -2,7 +2,7 @@ package games.strategy.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,7 +29,7 @@ public final class EventThreadJOptionPaneTest {
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread()
       throws Exception {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicBoolean runOnEventDispatchThread = new AtomicBoolean(false);
 
@@ -48,7 +48,7 @@ public final class EventThreadJOptionPaneTest {
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEventDispatchThread() throws Exception {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicBoolean run = new AtomicBoolean(false);
 
@@ -67,7 +67,7 @@ public final class EventThreadJOptionPaneTest {
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldReturnSupplierResult() {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final Object expectedResult = new Object();
 
       final Object actualResult =
@@ -79,7 +79,7 @@ public final class EventThreadJOptionPaneTest {
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
 
       verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
@@ -89,7 +89,7 @@ public final class EventThreadJOptionPaneTest {
 
   @Test
   public void testInvokeAndWaitWithIntSupplier_ShouldReturnIntSupplierResult() {
-    assertTimeout(timeout, () -> {
+    assertTimeoutPreemptively(timeout, () -> {
       final int expectedResult = 42;
 
       final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -1,29 +1,27 @@
 package games.strategy.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.SwingUtilities;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class EventThreadJOptionPaneTest {
-  @Rule
-  public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+  private static final Duration timeout = Duration.ofSeconds(5);
 
   @Spy
   private final CountDownLatchHandler latchHandler = new CountDownLatchHandler();
@@ -31,62 +29,72 @@ public final class EventThreadJOptionPaneTest {
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread()
       throws Exception {
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicBoolean runOnEventDispatchThread = new AtomicBoolean(false);
+    assertTimeout(timeout, () -> {
+      final CountDownLatch latch = new CountDownLatch(1);
+      final AtomicBoolean runOnEventDispatchThread = new AtomicBoolean(false);
 
-    new Thread(() -> {
-      EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
-        runOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread());
-        return Optional.empty();
-      });
-      latch.countDown();
-    }).start();
-    latch.await();
+      new Thread(() -> {
+        EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
+          runOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread());
+          return Optional.empty();
+        });
+        latch.countDown();
+      }).start();
+      latch.await();
 
-    assertThat(runOnEventDispatchThread.get(), is(true));
+      assertThat(runOnEventDispatchThread.get(), is(true));
+    });
   }
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEventDispatchThread() throws Exception {
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicBoolean run = new AtomicBoolean(false);
+    assertTimeout(timeout, () -> {
+      final CountDownLatch latch = new CountDownLatch(1);
+      final AtomicBoolean run = new AtomicBoolean(false);
 
-    SwingUtilities.invokeLater(() -> {
-      EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
-        run.set(true);
-        return Optional.empty();
+      SwingUtilities.invokeLater(() -> {
+        EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
+          run.set(true);
+          return Optional.empty();
+        });
+        latch.countDown();
       });
-      latch.countDown();
-    });
-    latch.await();
+      latch.await();
 
-    assertThat(run.get(), is(true));
+      assertThat(run.get(), is(true));
+    });
   }
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldReturnSupplierResult() {
-    final Object expectedResult = new Object();
+    assertTimeout(timeout, () -> {
+      final Object expectedResult = new Object();
 
-    final Object actualResult =
-        EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.of(expectedResult)).get();
+      final Object actualResult =
+          EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.of(expectedResult)).get();
 
-    assertThat(actualResult, is(expectedResult));
+      assertThat(actualResult, is(expectedResult));
+    });
   }
 
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
-    EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
+    assertTimeout(timeout, () -> {
+      EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
 
-    verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
-    verify(latchHandler, times(1)).removeShutdownLatch(any(CountDownLatch.class));
+      verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
+      verify(latchHandler, times(1)).removeShutdownLatch(any(CountDownLatch.class));
+    });
   }
 
   @Test
   public void testInvokeAndWaitWithIntSupplier_ShouldReturnIntSupplierResult() {
-    final int expectedResult = 42;
+    assertTimeout(timeout, () -> {
+      final int expectedResult = 42;
 
-    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);
+      final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);
 
-    assertThat(actualResult, is(expectedResult));
+      assertThat(actualResult, is(expectedResult));
+    });
   }
 }

--- a/src/test/java/games/strategy/util/FileNameUtilsTest.java
+++ b/src/test/java/games/strategy/util/FileNameUtilsTest.java
@@ -1,11 +1,11 @@
 package games.strategy.util;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class FileNameUtilsTest {
   @Test

--- a/src/test/java/games/strategy/util/FileNameUtilsTest.java
+++ b/src/test/java/games/strategy/util/FileNameUtilsTest.java
@@ -1,7 +1,7 @@
 package games.strategy.util;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.util.Collections;
 

--- a/src/test/java/games/strategy/util/IntegerMapTest.java
+++ b/src/test/java/games/strategy/util/IntegerMapTest.java
@@ -1,9 +1,9 @@
 package games.strategy.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/games/strategy/util/IntegerMapTest.java
+++ b/src/test/java/games/strategy/util/IntegerMapTest.java
@@ -2,11 +2,11 @@ package games.strategy.util;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
+++ b/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
@@ -1,8 +1,8 @@
 package games.strategy.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
+++ b/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
@@ -2,9 +2,9 @@ package games.strategy.util;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -1,11 +1,11 @@
 package games.strategy.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.delegate.Matches;
 
@@ -55,30 +55,30 @@ public class MatchTest {
 
   @Test
   public void testAllMatch() {
-    assertTrue("empty collection", Match.allMatch(Arrays.asList(), IS_ZERO_MATCH));
-    assertFalse("none match", Match.allMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
-    assertFalse("some match", Match.allMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
-    assertTrue("all match (one element)", Match.allMatch(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("all match (multiple elements)", Match.allMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+    assertTrue(Match.allMatch(Arrays.asList(), IS_ZERO_MATCH), "empty collection");
+    assertFalse(Match.allMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH), "none match");
+    assertFalse(Match.allMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH), "some match");
+    assertTrue(Match.allMatch(Arrays.asList(0), IS_ZERO_MATCH), "all match (one element)");
+    assertTrue(Match.allMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH), "all match (multiple elements)");
   }
 
   @Test
   public void testAnyMatch() {
-    assertFalse("empty collection", Match.anyMatch(Arrays.asList(), IS_ZERO_MATCH));
-    assertFalse("none match", Match.anyMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
-    assertTrue("some match (one element)", Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("some match (multiple elements)", Match.anyMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
-    assertTrue("all match (one element)", Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("all match (multiple elements)", Match.anyMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+    assertFalse(Match.anyMatch(Arrays.asList(), IS_ZERO_MATCH), "empty collection");
+    assertFalse(Match.anyMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH), "none match");
+    assertTrue(Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH), "some match (one element)");
+    assertTrue(Match.anyMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH), "some match (multiple elements)");
+    assertTrue(Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH), "all match (one element)");
+    assertTrue(Match.anyMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH), "all match (multiple elements)");
   }
 
   @Test
   public void testNoneMatch() {
-    assertTrue("empty collection", Match.noneMatch(Arrays.asList(), IS_ZERO_MATCH));
-    assertTrue("none match (one element)", Match.noneMatch(Arrays.asList(-1), IS_ZERO_MATCH));
-    assertTrue("none match (multiple elements)", Match.noneMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
-    assertFalse("some match", Match.noneMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
-    assertFalse("all match", Match.noneMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+    assertTrue(Match.noneMatch(Arrays.asList(), IS_ZERO_MATCH), "empty collection");
+    assertTrue(Match.noneMatch(Arrays.asList(-1), IS_ZERO_MATCH), "none match (one element)");
+    assertTrue(Match.noneMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH), "none match (multiple elements)");
+    assertFalse(Match.noneMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH), "some match");
+    assertFalse(Match.noneMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH), "all match");
   }
 
   @Test

--- a/src/test/java/games/strategy/util/OptionalUtilsTest.java
+++ b/src/test/java/games/strategy/util/OptionalUtilsTest.java
@@ -1,13 +1,13 @@
 package games.strategy.util;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class OptionalUtilsTest {
   @Test

--- a/src/test/java/games/strategy/util/OptionalUtilsTest.java
+++ b/src/test/java/games/strategy/util/OptionalUtilsTest.java
@@ -1,7 +1,7 @@
 package games.strategy.util;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -1,9 +1,10 @@
 package games.strategy.util;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.attachments.RulesAttachment;
 
@@ -59,14 +60,14 @@ public class PropertyUtilTest {
 
 
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testErrorCaseWithNoSetterMethod() {
-    PropertyUtil.set(BAR, NEW_VALUE, new NoSetterClass());
+    assertThrows(IllegalStateException.class, () -> PropertyUtil.set(BAR, NEW_VALUE, new NoSetterClass()));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testErrorCaseWithInvalidSetterMethod() {
-    PropertyUtil.set(BAR, NEW_VALUE, new InvalidSetterClass());
+    assertThrows(IllegalStateException.class, () ->PropertyUtil.set(BAR, NEW_VALUE, new InvalidSetterClass()));
   }
 
   @Test

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -1,7 +1,7 @@
 package games.strategy.util;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -67,7 +67,7 @@ public class PropertyUtilTest {
 
   @Test
   public void testErrorCaseWithInvalidSetterMethod() {
-    assertThrows(IllegalStateException.class, () ->PropertyUtil.set(BAR, NEW_VALUE, new InvalidSetterClass()));
+    assertThrows(IllegalStateException.class, () -> PropertyUtil.set(BAR, NEW_VALUE, new InvalidSetterClass()));
   }
 
   @Test
@@ -81,30 +81,30 @@ public class PropertyUtilTest {
   }
 
   private static class NoSetterClass {
-    
+
     @SuppressWarnings("unused")
     private final String bar = PropertyUtilTest.DEFAULT;
   }
 
   private static class InvalidSetterClass {
-    
+
     @SuppressWarnings("unused")
     private final String bar = PropertyUtilTest.DEFAULT;
-    
+
     @SuppressWarnings("unused")
     public void setBar() {}
   }
 
   private static class NoOpSetterClass {
     protected String bar = PropertyUtilTest.DEFAULT;
-    
+
     @SuppressWarnings("unused")
     public void setBar(final String value) {}
   }
 
   private static class PropertyClass {
     protected String bar = PropertyUtilTest.DEFAULT;
-    
+
     @SuppressWarnings("unused")
     public void setBar(final String newValue) {
       bar = newValue;
@@ -112,10 +112,10 @@ public class PropertyUtilTest {
   }
 
   private static class UnderBarClass {
-    
+
     @SuppressWarnings("unused")
     private String m_bar = PropertyUtilTest.DEFAULT;
-    
+
     @SuppressWarnings("unused")
     public void setBar(final String newValue) {
       m_bar = newValue;

--- a/src/test/java/games/strategy/util/TupleTest.java
+++ b/src/test/java/games/strategy/util/TupleTest.java
@@ -1,12 +1,11 @@
 package games.strategy.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;

--- a/src/test/java/games/strategy/util/TupleTest.java
+++ b/src/test/java/games/strategy/util/TupleTest.java
@@ -5,13 +5,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
 

--- a/src/test/java/games/strategy/util/UrlStreamsTest.java
+++ b/src/test/java/games/strategy/util/UrlStreamsTest.java
@@ -12,13 +12,13 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class UrlStreamsTest {
 
   private UrlStreams testObj;
@@ -31,7 +31,7 @@ public class UrlStreamsTest {
   private InputStream mockInputStream;
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     // set up the test object with a function that will return a mocked url connection
     testObj = new UrlStreams(url -> mockUrlConnection);

--- a/src/test/java/games/strategy/util/UtilTest.java
+++ b/src/test/java/games/strategy/util/UtilTest.java
@@ -4,12 +4,12 @@ import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UtilTest {
 

--- a/src/test/java/games/strategy/util/UtilTest.java
+++ b/src/test/java/games/strategy/util/UtilTest.java
@@ -2,10 +2,10 @@ package games.strategy.util;
 
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -1,11 +1,11 @@
 package games.strategy.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VersionTest {
 

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoExporterTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoExporterTest.java
@@ -1,7 +1,7 @@
 package games.strategy.util.memento;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoExporterTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoExporterTest.java
@@ -1,9 +1,9 @@
 package games.strategy.util.memento;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoImportExportIntegrationTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoImportExportIntegrationTest.java
@@ -1,7 +1,7 @@
 package games.strategy.util.memento;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoImportExportIntegrationTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoImportExportIntegrationTest.java
@@ -1,9 +1,9 @@
 package games.strategy.util.memento;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class PropertyBagMementoImportExportIntegrationTest {
   private static final String SCHEMA_ID = "schema-id";

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoImporterTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoImporterTest.java
@@ -7,10 +7,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoImporterTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoImporterTest.java
@@ -3,11 +3,11 @@ package games.strategy.util.memento;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/games/strategy/util/memento/PropertyBagMementoTest.java
+++ b/src/test/java/games/strategy/util/memento/PropertyBagMementoTest.java
@@ -1,6 +1,6 @@
 package games.strategy.util.memento;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;

--- a/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
+++ b/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
@@ -33,44 +33,42 @@ import org.mockito.MockitoAnnotations;
  */
 public class MockitoExtension implements TestInstancePostProcessor, ParameterResolver {
 
-    @Override
-    public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
-        MockitoAnnotations.initMocks(testInstance);
-    }
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+    MockitoAnnotations.initMocks(testInstance);
+  }
 
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-        return parameterContext.getParameter().isAnnotationPresent(Mock.class);
-    }
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return parameterContext.getParameter().isAnnotationPresent(Mock.class);
+  }
 
-    @Override
-    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-        return getMock(parameterContext.getParameter(), extensionContext);
-    }
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return getMock(parameterContext.getParameter(), extensionContext);
+  }
 
-    private Object getMock(Parameter parameter, ExtensionContext extensionContext) {
-        Class<?> mockType = parameter.getType();
-        Store mocks = extensionContext.getStore(Namespace.create(MockitoExtension.class, mockType));
-        String mockName = getMockName(parameter);
+  private Object getMock(Parameter parameter, ExtensionContext extensionContext) {
+    Class<?> mockType = parameter.getType();
+    Store mocks = extensionContext.getStore(Namespace.create(MockitoExtension.class, mockType));
+    String mockName = getMockName(parameter);
 
-        if (mockName != null) {
-            return mocks.getOrComputeIfAbsent(mockName, key -> mock(mockType, mockName));
-        }
-        else {
-            return mocks.getOrComputeIfAbsent(mockType.getCanonicalName(), key -> mock(mockType));
-        }
+    if (mockName != null) {
+      return mocks.getOrComputeIfAbsent(mockName, key -> mock(mockType, mockName));
+    } else {
+      return mocks.getOrComputeIfAbsent(mockType.getCanonicalName(), key -> mock(mockType));
     }
+  }
 
-    private String getMockName(Parameter parameter) {
-        String explicitMockName = parameter.getAnnotation(Mock.class).name().trim();
-        if (!explicitMockName.isEmpty()) {
-            return explicitMockName;
-        }
-        else if (parameter.isNamePresent()) {
-            return parameter.getName();
-        }
-        return null;
+  private String getMockName(Parameter parameter) {
+    String explicitMockName = parameter.getAnnotation(Mock.class).name().trim();
+    if (!explicitMockName.isEmpty()) {
+      return explicitMockName;
+    } else if (parameter.isNamePresent()) {
+      return parameter.getName();
     }
+    return null;
+  }
 
 }
 

--- a/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
+++ b/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
@@ -1,0 +1,76 @@
+package org.junit.experimental.extensions;
+
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Parameter;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * {@code MockitoExtension} showcases the {@link TestInstancePostProcessor}
+ * and {@link ParameterResolver} extension APIs of JUnit 5 by providing
+ * dependency injection support at the field level and at the method parameter
+ * level via Mockito 2.x's {@link Mock @Mock} annotation.
+ *
+ * @since 5.0
+ */
+public class MockitoExtension implements TestInstancePostProcessor, ParameterResolver {
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+        MockitoAnnotations.initMocks(testInstance);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().isAnnotationPresent(Mock.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return getMock(parameterContext.getParameter(), extensionContext);
+    }
+
+    private Object getMock(Parameter parameter, ExtensionContext extensionContext) {
+        Class<?> mockType = parameter.getType();
+        Store mocks = extensionContext.getStore(Namespace.create(MockitoExtension.class, mockType));
+        String mockName = getMockName(parameter);
+
+        if (mockName != null) {
+            return mocks.getOrComputeIfAbsent(mockName, key -> mock(mockType, mockName));
+        }
+        else {
+            return mocks.getOrComputeIfAbsent(mockType.getCanonicalName(), key -> mock(mockType));
+        }
+    }
+
+    private String getMockName(Parameter parameter) {
+        String explicitMockName = parameter.getAnnotation(Mock.class).name().trim();
+        if (!explicitMockName.isEmpty()) {
+            return explicitMockName;
+        }
+        else if (parameter.isNamePresent()) {
+            return parameter.getName();
+        }
+        return null;
+    }
+
+}
+

--- a/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
+++ b/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
@@ -1,0 +1,29 @@
+package org.junit.experimental.extensions;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Based off
+ * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolder.java
+ */
+public class TemporaryFolder {
+  private File rootFolder;
+
+  public File newFile(String name) throws IOException {
+    File result = new File(rootFolder, name);
+    result.createNewFile();
+    return result;
+  }
+
+  void prepare() {
+    try {
+      rootFolder = File.createTempFile("junit5-", ".tmp");
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+    rootFolder.delete();
+    rootFolder.mkdirs();
+    rootFolder.deleteOnExit();
+  }
+}

--- a/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
+++ b/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
@@ -6,10 +6,14 @@ import java.io.IOException;
 /**
  * Based off
  * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolder.java
+ * Replacement for the JUnit 4 TemporaryFolder.
  */
 public class TemporaryFolder {
   private File rootFolder;
 
+  /**
+   * Creates and returns a new temporary file which gets deleted when the Virtual Machine Terminates.
+   */
   public File newFile(String name) throws IOException {
     File result = new File(rootFolder, name);
     result.createNewFile();

--- a/src/test/java/org/junit/experimental/extensions/TemporaryFolderExtension.java
+++ b/src/test/java/org/junit/experimental/extensions/TemporaryFolderExtension.java
@@ -1,0 +1,60 @@
+package org.junit.experimental.extensions;
+
+import static java.util.Arrays.stream;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+/**
+ * Based off
+ * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolderExtension.java
+ */
+public class TemporaryFolderExtension implements TestInstancePostProcessor, ParameterResolver {
+
+  private final Collection<TemporaryFolder> tempFolders;
+
+  public TemporaryFolderExtension() {
+    tempFolders = new ArrayList<>();
+  }
+
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+    stream(testInstance.getClass().getDeclaredFields())
+        .filter(field -> field.getType() == TemporaryFolder.class)
+        .forEach(field -> injectTemporaryFolder(testInstance, field));
+  }
+
+  private void injectTemporaryFolder(Object instance, Field field) {
+    field.setAccessible(true);
+    try {
+      field.set(instance, createTempFolder());
+    } catch (IllegalAccessException iae) {
+      throw new RuntimeException(iae);
+    }
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return parameterContext.getParameter().getType() == TemporaryFolder.class;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+    return createTempFolder();
+  }
+
+  private TemporaryFolder createTempFolder() {
+    TemporaryFolder result = new TemporaryFolder();
+    result.prepare();
+    tempFolders.add(result);
+    return result;
+  }
+
+}
+

--- a/src/test/java/org/junit/experimental/extensions/TemporaryFolderExtension.java
+++ b/src/test/java/org/junit/experimental/extensions/TemporaryFolderExtension.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 /**
  * Based off
  * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolderExtension.java
+ * Replacement for the JUnit4 TemporaryFolder Rule.
  */
 public class TemporaryFolderExtension implements TestInstancePostProcessor, ParameterResolver {
 

--- a/src/test/java/swinglib/GridBagHelperTest.java
+++ b/src/test/java/swinglib/GridBagHelperTest.java
@@ -7,7 +7,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GridBagHelperTest {
 

--- a/src/test/java/swinglib/JButtonBuilderTest.java
+++ b/src/test/java/swinglib/JButtonBuilderTest.java
@@ -2,6 +2,7 @@ package swinglib;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.event.ActionEvent;
 import java.util.Arrays;
@@ -9,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JButton;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JButtonBuilderTest {
 
@@ -41,26 +42,26 @@ public class JButtonBuilderTest {
     assertThat(button.getToolTipText(), is("toolTip"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void titleCannotBeEmpty() {
-    JButtonBuilder.builder().title("");
+    assertThrows(IllegalArgumentException.class, () -> JButtonBuilder.builder().title(""));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void titleIsRequired() {
-    JButtonBuilder.builder()
+    assertThrows(NullPointerException.class, () -> JButtonBuilder.builder()
         .actionListener(() -> {
         })
-        .build();
+        .build());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void actionListenerIsRequired() {
-    JButtonBuilder.builder().actionListener(null);
+    assertThrows(NullPointerException.class, () -> JButtonBuilder.builder().actionListener(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void toolTipCanNotBeEmptyIfSpecified() {
-    JButtonBuilder.builder().toolTip("");
+    assertThrows(IllegalArgumentException.class, () -> JButtonBuilder.builder().toolTip(""));
   }
 }

--- a/src/test/java/swinglib/JCheckBoxBuilderTest.java
+++ b/src/test/java/swinglib/JCheckBoxBuilderTest.java
@@ -4,7 +4,7 @@ import javax.swing.JCheckBox;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JCheckBoxBuilderTest {
   @Test

--- a/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -1,5 +1,7 @@
 package swinglib;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.awt.event.ItemEvent;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -8,37 +10,30 @@ import javax.swing.JComboBox;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.triplea.settings.ClientSetting;
 
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class JComboBoxBuilderTest {
   @Mock
   private ItemEvent mockItemEvent;
 
-  @Before
-  public void setUp() {}
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void buildInvalidEmptyOptionSet() {
-    JComboBoxBuilder.builder()
+    assertThrows(IllegalArgumentException.class, () -> JComboBoxBuilder.builder()
         .menuOptions()
-        .build();
+        .build());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void builderNoMenuOptionSpecified() {
-    JComboBoxBuilder.builder()
-        .build();
+    assertThrows(IllegalStateException.class, JComboBoxBuilder.builder()::build);
   }
 
   @Test

--- a/src/test/java/swinglib/JDialogBuilderTest.java
+++ b/src/test/java/swinglib/JDialogBuilderTest.java
@@ -1,10 +1,10 @@
 package swinglib;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 

--- a/src/test/java/swinglib/JDialogBuilderTest.java
+++ b/src/test/java/swinglib/JDialogBuilderTest.java
@@ -4,8 +4,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.awt.GraphicsEnvironment;
 
@@ -13,7 +14,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JDialogBuilderTest {
 
@@ -29,7 +30,7 @@ public class JDialogBuilderTest {
   }
 
   private static void assumeHeadedGraphicsEnvironment() {
-    assumeFalse("requires headed graphics environment", GraphicsEnvironment.isHeadless());
+    assumeFalse(GraphicsEnvironment.isHeadless(), "requires headed graphics environment");
   }
 
   @Test
@@ -47,11 +48,11 @@ public class JDialogBuilderTest {
     assertThat(dialog.getParent(), is(sameInstance(parentFrame)));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void contentsIsRequired() {
-    JDialogBuilder.builder()
+    assertThrows(NullPointerException.class, () -> JDialogBuilder.builder()
         .title("title")
-        .build();
+        .build());
   }
 
   @Test
@@ -66,25 +67,25 @@ public class JDialogBuilderTest {
     assertThat(dialog.getParent(), is(not(nullValue())));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void titleIsRequired() {
-    JDialogBuilder.builder()
+    assertThrows(NullPointerException.class, () -> JDialogBuilder.builder()
         .contents(new JPanel())
-        .build();
+        .build());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void contentsCanNotBeNull() {
-    JDialogBuilder.builder().contents(null);
+    assertThrows(NullPointerException.class, () -> JDialogBuilder.builder().contents(null));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void parentFrameCanNotBeNull() {
-    JDialogBuilder.builder().parentFrame(null);
+    assertThrows(NullPointerException.class, () -> JDialogBuilder.builder().parentFrame(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void titleCanNotBeEmpty() {
-    JDialogBuilder.builder().title(" ");
+    assertThrows(IllegalArgumentException.class, () -> JDialogBuilder.builder().title(" "));
   }
 }

--- a/src/test/java/swinglib/JLabelBuilderTest.java
+++ b/src/test/java/swinglib/JLabelBuilderTest.java
@@ -1,13 +1,14 @@
 package swinglib;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 
 import org.hamcrest.MatcherAssert;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JLabelBuilderTest {
 
@@ -29,9 +30,9 @@ public class JLabelBuilderTest {
     MatcherAssert.assertThat(label.getAlignmentX(), is(JComponent.LEFT_ALIGNMENT));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void textIsRequired() {
-    JLabelBuilder.builder().build();
+    assertThrows(NullPointerException.class, JLabelBuilder.builder()::build);
   }
 
   @Test

--- a/src/test/java/swinglib/JLabelBuilderTest.java
+++ b/src/test/java/swinglib/JLabelBuilderTest.java
@@ -7,7 +7,6 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 
 import org.hamcrest.MatcherAssert;
-
 import org.junit.jupiter.api.Test;
 
 public class JLabelBuilderTest {

--- a/src/test/java/swinglib/JPanelBuilderTest.java
+++ b/src/test/java/swinglib/JPanelBuilderTest.java
@@ -17,7 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JPanelBuilderTest {
 

--- a/src/test/java/swinglib/JScrollPaneBuilderTest.java
+++ b/src/test/java/swinglib/JScrollPaneBuilderTest.java
@@ -3,12 +3,12 @@ package swinglib;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.awt.Component;
 

--- a/src/test/java/swinglib/JScrollPaneBuilderTest.java
+++ b/src/test/java/swinglib/JScrollPaneBuilderTest.java
@@ -8,14 +8,14 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.awt.Component;
 
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public final class JScrollPaneBuilderTest {
   private final JScrollPaneBuilder builder = JScrollPaneBuilder.builder();

--- a/src/test/java/swinglib/JTabbedPaneBuilderTest.java
+++ b/src/test/java/swinglib/JTabbedPaneBuilderTest.java
@@ -8,8 +8,7 @@ import javax.swing.JTextField;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsInstanceOf;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JTabbedPaneBuilderTest {
   @Test

--- a/src/test/java/swinglib/JTextAreaBuilderTest.java
+++ b/src/test/java/swinglib/JTextAreaBuilderTest.java
@@ -2,10 +2,11 @@ package swinglib;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.swing.JTextArea;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JTextAreaBuilderTest {
 
@@ -36,9 +37,9 @@ public class JTextAreaBuilderTest {
     assertThat(area.getRows(), is(5));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void rowsNonZero() {
-    JTextAreaBuilder.builder().rows(0);
+    assertThrows(IllegalArgumentException.class, () -> JTextAreaBuilder.builder().rows(0));
   }
 
   @Test
@@ -50,9 +51,9 @@ public class JTextAreaBuilderTest {
     assertThat(area.getColumns(), is(20));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void columnsNonZero() {
-    JTextAreaBuilder.builder().columns(0);
+    assertThrows(IllegalArgumentException.class, () -> JTextAreaBuilder.builder().columns(0));
   }
 
   @Test

--- a/src/test/java/swinglib/JTextFieldBuilderTest.java
+++ b/src/test/java/swinglib/JTextFieldBuilderTest.java
@@ -6,7 +6,7 @@ import javax.swing.JTextField;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JTextFieldBuilderTest {
 


### PR DESCRIPTION
See #935 and #951 for more information.

This PR introduces the JUnit5 Runner now that eclipse officially supports JUnit5 in the latest 4.7.1a build.
This means you are highly encouraged to write new tests using the new namespace (importing the test annotation from junit5), and migrate the junit 4 test cases every now and then.

This is still experimental, it is working for me, but I really want to hear some feedback...