### PR TITLE
General refactoring of g.s.debug package

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -13,9 +13,11 @@ import javax.annotation.Nullable;
  * the {@code logQuietly()} methods will send their output to the developer output (standard output) stream.
  * </p>
  */
-public class ClientLogger {
+public final class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
   private static final PrintStream userOutputStream = System.err;
+
+  private ClientLogger() {}
 
   private static void log(final PrintStream stream, final Throwable e) {
     e.printStackTrace(stream);

--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -3,6 +3,8 @@ package games.strategy.debug;
 import java.io.PrintStream;
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 /**
  * Provides methods for the client to write log messages.
  *
@@ -23,11 +25,11 @@ public class ClientLogger {
     log(developerOutputStream, e);
   }
 
-  public static void logQuietly(final String msg) {
+  public static void logQuietly(final @Nullable String msg) {
     developerOutputStream.println(msg);
   }
 
-  public static void logQuietly(final String msg, final Throwable e) {
+  public static void logQuietly(final @Nullable String msg, final Throwable e) {
     logQuietly(msg);
     logQuietly(e);
   }
@@ -36,11 +38,11 @@ public class ClientLogger {
     log(userOutputStream, e);
   }
 
-  public static void logError(final String msg) {
+  public static void logError(final @Nullable String msg) {
     userOutputStream.println(msg);
   }
 
-  public static void logError(final String msg, final Throwable e) {
+  public static void logError(final @Nullable String msg, final Throwable e) {
     logError(msg);
     logError(e);
   }
@@ -48,10 +50,10 @@ public class ClientLogger {
   /**
    * Logs the specified message and collection of errors to the user output stream.
    *
-   * @param msg The error message; may be {@code null}.
-   * @param throwables The collection of errors; must not be {@code null}.
+   * @param msg The error message.
+   * @param throwables The collection of errors.
    */
-  public static void logError(final String msg, final Collection<? extends Throwable> throwables) {
+  public static void logError(final @Nullable String msg, final Collection<? extends Throwable> throwables) {
     logError(msg);
     throwables.forEach(ClientLogger::logError);
   }

--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -3,6 +3,14 @@ package games.strategy.debug;
 import java.io.PrintStream;
 import java.util.Collection;
 
+/**
+ * Provides methods for the client to write log messages.
+ *
+ * <p>
+ * In general, the {@code logError()} methods will send their output to the user output (standard error) stream, while
+ * the {@code logQuietly()} methods will send their output to the developer output (standard output) stream.
+ * </p>
+ */
 public class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
   private static final PrintStream userOutputStream = System.err;

--- a/src/main/java/games/strategy/debug/DebugUtils.java
+++ b/src/main/java/games/strategy/debug/DebugUtils.java
@@ -9,11 +9,15 @@ import java.util.List;
 import java.util.Properties;
 
 /**
- * Moved out of Console class, so that we don't need swing.
+ * A collection of methods that provide information about the JVM state that may be useful for debugging.
  */
 public class DebugUtils {
   private static final ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
 
+  /**
+   * Returns a message containing the stack trace of each active thread, as well as a listing of possibly-deadlocked
+   * threads.
+   */
   public static String getThreadDumps() {
     final StringBuilder result = new StringBuilder();
     result.append("THREAD DUMP\n");
@@ -48,6 +52,9 @@ public class DebugUtils {
     return result.toString();
   }
 
+  /**
+   * Returns a message containing information about current memory usage.
+   */
   public static String getMemory() {
     System.gc();
     System.runFinalization();

--- a/src/main/java/games/strategy/debug/DebugUtils.java
+++ b/src/main/java/games/strategy/debug/DebugUtils.java
@@ -11,8 +11,10 @@ import java.util.Properties;
 /**
  * A collection of methods that provide information about the JVM state that may be useful for debugging.
  */
-public class DebugUtils {
+public final class DebugUtils {
   private static final ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+
+  private DebugUtils() {}
 
   /**
    * Returns a message containing the stack trace of each active thread, as well as a listing of possibly-deadlocked
@@ -69,7 +71,7 @@ public class DebugUtils {
     return buf.toString();
   }
 
-  public static String getProperties() {
+  static String getProperties() {
     final StringBuilder buf = new StringBuilder("SYSTEM PROPERTIES\n");
     final Properties props = System.getProperties();
     final List<String> keys = new ArrayList<>(props.stringPropertyNames());

--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -6,9 +6,13 @@ import games.strategy.ui.SwingAction;
 /**
  * A debug console window that displays the standard output and standard error streams.
  */
-public class ErrorConsole extends GenericConsole {
+public final class ErrorConsole extends GenericConsole {
   private static final long serialVersionUID = -3489030525309243438L;
   private static ErrorConsole console;
+
+  private ErrorConsole() {
+    super("TripleA Console");
+  }
 
   /**
    * Gets the singleton instance of the {@code ErrorConsole} class.
@@ -30,10 +34,5 @@ public class ErrorConsole extends GenericConsole {
   @Override
   public GenericConsole getConsoleInstance() {
     return getConsole();
-  }
-
-  /** Creates a new instance of ErrorConsole. */
-  public ErrorConsole() {
-    super("TripleA Console");
   }
 }

--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -3,10 +3,18 @@ package games.strategy.debug;
 import games.strategy.triplea.ui.ErrorHandler;
 import games.strategy.ui.SwingAction;
 
+/**
+ * A debug console window that displays the standard output and standard error streams.
+ */
 public class ErrorConsole extends GenericConsole {
   private static final long serialVersionUID = -3489030525309243438L;
   private static ErrorConsole console;
 
+  /**
+   * Gets the singleton instance of the {@code ErrorConsole} class.
+   *
+   * @return An {@code ErrorConsole}.
+   */
   public static ErrorConsole getConsole() {
     if (console == null) {
       SwingAction.invokeAndWait(() -> {

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -17,6 +17,9 @@ import javax.swing.WindowConstants;
 
 import games.strategy.ui.SwingAction;
 
+/**
+ * Superclass for all debug console windows.
+ */
 public abstract class GenericConsole extends JFrame {
   private static final long serialVersionUID = 5754914217052820386L;
 

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -49,7 +49,7 @@ public abstract class GenericConsole extends JFrame {
       Toolkit.getDefaultToolkit().getSystemClipboard().setContents(select, select);
     });
     actions.add(copyAction);
-    final AbstractAction clearAction = SwingAction.of("Clear", e -> clear());
+    final AbstractAction clearAction = SwingAction.of("Clear", e -> textArea.setText(""));
     actions.add(clearAction);
     SwingUtilities.invokeLater(() -> pack());
   }
@@ -60,16 +60,8 @@ public abstract class GenericConsole extends JFrame {
     textArea.append(s);
   }
 
-  public void clear() {
-    textArea.setText("");
-  }
-
   public void dumpStacks() {
     threadDiagnoseAction.actionPerformed(null);
-  }
-
-  public String getText() {
-    return textArea.getText();
   }
 
   /**

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -27,7 +27,7 @@ public abstract class GenericConsole extends JFrame {
   private final AbstractAction threadDiagnoseAction =
       SwingAction.of("Enumerate Threads", e -> System.out.println(DebugUtils.getThreadDumps()));
 
-  public GenericConsole(final String title) {
+  protected GenericConsole(final String title) {
     super(title);
     setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -20,26 +20,28 @@ import games.strategy.ui.SwingAction;
 public abstract class GenericConsole extends JFrame {
   private static final long serialVersionUID = 5754914217052820386L;
 
-  private final JTextArea m_text = new JTextArea(20, 50);
+  private final JTextArea textArea = new JTextArea(20, 50);
+  private final AbstractAction threadDiagnoseAction =
+      SwingAction.of("Enumerate Threads", e -> System.out.println(DebugUtils.getThreadDumps()));
 
   public GenericConsole(final String title) {
     super(title);
     setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     getContentPane().setLayout(new BorderLayout());
-    m_text.setLineWrap(true);
-    m_text.setWrapStyleWord(true);
-    final JScrollPane scroll = new JScrollPane(m_text);
+    textArea.setLineWrap(true);
+    textArea.setWrapStyleWord(true);
+    final JScrollPane scroll = new JScrollPane(textArea);
     getContentPane().add(scroll, BorderLayout.CENTER);
     final JToolBar actions = new JToolBar(SwingConstants.HORIZONTAL);
     getContentPane().add(actions, BorderLayout.SOUTH);
     actions.setFloatable(false);
-    actions.add(m_threadDiagnoseAction);
+    actions.add(threadDiagnoseAction);
     final AbstractAction memoryAction = SwingAction.of("Memory", e -> append(DebugUtils.getMemory()));
     actions.add(memoryAction);
     final AbstractAction propertiesAction = SwingAction.of("Properties", e -> append(DebugUtils.getProperties()));
     actions.add(propertiesAction);
     final Action copyAction = SwingAction.of("Copy to clipboard", e -> {
-      final String text = m_text.getText();
+      final String text = textArea.getText();
       final StringSelection select = new StringSelection(text);
       Toolkit.getDefaultToolkit().getSystemClipboard().setContents(select, select);
     });
@@ -52,19 +54,19 @@ public abstract class GenericConsole extends JFrame {
   public abstract GenericConsole getConsoleInstance();
 
   public void append(final String s) {
-    m_text.append(s);
+    textArea.append(s);
   }
 
   public void clear() {
-    m_text.setText("");
+    textArea.setText("");
   }
 
   public void dumpStacks() {
-    m_threadDiagnoseAction.actionPerformed(null);
+    threadDiagnoseAction.actionPerformed(null);
   }
 
   public String getText() {
-    return m_text.getText();
+    return textArea.getText();
   }
 
   /**
@@ -72,7 +74,7 @@ public abstract class GenericConsole extends JFrame {
    */
   protected void displayStandardError() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.err);
-    final ThreadReader reader = new ThreadReader(out, m_text, true, getConsoleInstance());
+    final ThreadReader reader = new ThreadReader(out, textArea, true, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std err reader");
     thread.setDaemon(true);
     thread.start();
@@ -82,16 +84,11 @@ public abstract class GenericConsole extends JFrame {
 
   protected void displayStandardOutput() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.out);
-    final ThreadReader reader = new ThreadReader(out, m_text, false, getConsoleInstance());
+    final ThreadReader reader = new ThreadReader(out, textArea, false, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std out reader");
     thread.setDaemon(true);
     thread.start();
     final PrintStream print = new PrintStream(out);
     System.setOut(print);
   }
-
-  private final AbstractAction m_threadDiagnoseAction =
-      SwingAction.of("Enumerate Threads", e -> System.out.println(DebugUtils.getThreadDumps()));
 }
-
-

--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -10,15 +10,15 @@ import java.io.PrintStream;
  */
 class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
   private final Object lock = new Object();
-  private final PrintStream m_mirror;
+  private final PrintStream mirror;
 
   SynchedByteArrayOutputStream(final PrintStream mirror) {
-    m_mirror = mirror;
+    this.mirror = mirror;
   }
 
   public void write(final byte b) {
     synchronized (lock) {
-      m_mirror.write(b);
+      mirror.write(b);
       super.write(b);
       lock.notifyAll();
     }
@@ -28,7 +28,7 @@ class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
   public void write(final byte[] b, final int off, final int len) {
     synchronized (lock) {
       super.write(b, off, len);
-      m_mirror.write(b, off, len);
+      mirror.write(b, off, len);
       lock.notifyAll();
     }
   }

--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -4,11 +4,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 /**
- * Allows data written to a byte output stream to be read
- * safely friom a seperate thread.
- * Only readFully() is currently threadSafe for reading.
+ * Allows data written to a byte output stream to be read safely from a separate thread.
+ * Only readFully() is currently thread safe for reading.
  */
-class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
+final class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
   private final Object lock = new Object();
   private final PrintStream mirror;
 
@@ -36,9 +35,9 @@ class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
   /**
    * Read all data written to the stream.
    * Blocks until data is available.
-   * This is currently the only threadsafe method for reading.
+   * This is currently the only thread safe method for reading.
    */
-  public String readFully() {
+  String readFully() {
     synchronized (lock) {
       if (super.size() == 0) {
         try {

--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -15,7 +15,8 @@ final class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
     this.mirror = mirror;
   }
 
-  public void write(final byte b) {
+  @Override
+  public void write(final int b) {
     synchronized (lock) {
       mirror.write(b);
       super.write(b);

--- a/src/main/java/games/strategy/debug/ThreadReader.java
+++ b/src/main/java/games/strategy/debug/ThreadReader.java
@@ -6,24 +6,24 @@ import games.strategy.util.ThreadUtil;
 
 class ThreadReader implements Runnable {
   private static final int CONSOLE_UPDATE_INTERVAL_MS = 100;
-  private final JTextArea m_text;
-  private final SynchedByteArrayOutputStream m_in;
-  private final boolean m_displayConsoleOnWrite;
+  private final JTextArea text;
+  private final SynchedByteArrayOutputStream in;
+  private final boolean displayConsoleOnWrite;
   private final GenericConsole parentConsole;
 
   ThreadReader(final SynchedByteArrayOutputStream in, final JTextArea text, final boolean displayConsoleOnWrite,
       final GenericConsole parentConsole) {
-    m_in = in;
-    m_text = text;
-    m_displayConsoleOnWrite = displayConsoleOnWrite;
+    this.in = in;
+    this.text = text;
+    this.displayConsoleOnWrite = displayConsoleOnWrite;
     this.parentConsole = parentConsole;
   }
 
   @Override
   public void run() {
     while (true) {
-      m_text.append(m_in.readFully());
-      if (m_displayConsoleOnWrite && !parentConsole.isVisible()) {
+      text.append(in.readFully());
+      if (displayConsoleOnWrite && !parentConsole.isVisible()) {
         parentConsole.setVisible(true);
       }
       if (!ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS)) {

--- a/src/main/java/games/strategy/debug/ThreadReader.java
+++ b/src/main/java/games/strategy/debug/ThreadReader.java
@@ -4,7 +4,7 @@ import javax.swing.JTextArea;
 
 import games.strategy.util.ThreadUtil;
 
-class ThreadReader implements Runnable {
+final class ThreadReader implements Runnable {
   private static final int CONSOLE_UPDATE_INTERVAL_MS = 100;
   private final JTextArea text;
   private final SynchedByteArrayOutputStream in;


### PR DESCRIPTION
This started out as just trying to fix some Checkstyle violations in the `g.s.debug` package, but then I saw some other low-hanging fruit that could be pruned.  Changes include:

* Fix violations of the Checkstyle MemberName, JavadocType, and JavadocMethod rules.
* Replace nullity constraints in some Javadocs with annotations.
* Make classes `final` if possible.
* Reduce member accessibility as much as possible.
* Remove unused methods.
* Fix a possible bug in `SynchedByteArrayOutputStream`: the `write(byte)` overload seems to have been mistakenly added when the author probably meant to override `write(int)` (especially since `write(byte)` calls the superclass implementation of `write(int)`).