### PR TITLE
Update lobby text, remove DB wipeout mention

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -8,8 +8,4 @@
     
     TOC 11 signup has now started, $100 first place prize:
     https://forums.triplea-game.org/topic/69/revised-tournament-of-champions-11-toc-11
-    
-    *** Lobby Database was Wiped Out during Migration ***
-    Our legacy database died while we were migrating off of it. If you had a password
-    protected account, please re-create it to register in our brand new lobby database.
   error_message:  


### PR DESCRIPTION
When we migrated the lobby server code from Derby DB to postgres we wound up 'losing' the accounts from Derby and basically switched to a new clean database. We put up some lobby messaging to let people know they needed to recreate their account. It's been some time now, this messaging is not likely to be of help to many more people.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
