### PR TITLE
Remove explicit call to close() on auto-closeable resource

### DIFF
--- a/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -76,7 +76,6 @@ class CountryChart {
         }
         countryFileWriter.write("\r\n");
       }
-      countryFileWriter.close();
     } catch (final IOException e) {
       ClientLogger.logError("Failed Saving to File " + outFile.toString(), e);
     }


### PR DESCRIPTION
This PR fixes the following warning reported by `javac`:

```
src/main/java/games/strategy/triplea/printgenerator/CountryChart.java:79: warning: [try] explicit call to close() on an auto-closeable resource
      countryFileWriter.close();
                       ^
```