### PR TITLE
Use try-with-resources for auto-closeable resources

### DIFF
--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -180,15 +180,16 @@ public class GenericEmailSender implements IEmailSender {
       } catch (final Exception e) {
         // NoOp - the Date field is simply ignored in this case
       }
-      final Transport transport = session.getTransport("smtp");
-      if (getUserName() != null) {
-        transport.connect(getHost(), getPort(), getUserName(), getPassword());
-      } else {
-        transport.connect();
+
+      try (Transport transport = session.getTransport("smtp")) {
+        if (getUserName() != null) {
+          transport.connect(getHost(), getPort(), getUserName(), getPassword());
+        } else {
+          transport.connect();
+        }
+        mimeMessage.saveChanges();
+        transport.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
       }
-      mimeMessage.saveChanges();
-      transport.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
-      transport.close();
     } catch (final MessagingException e) {
       throw new IOException(e.getMessage());
     }


### PR DESCRIPTION
This PR fixes a static analysis warning that detected an auto-closeable resource not being managed by a try-with-resources statement.

This PR is more easily reviewed with whitespace changes ignored (`?w=1`).