### PR TITLE
Error Prone: Fix WaitNotInLoop violations in production code

### DIFF
--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -40,10 +40,10 @@ final class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
    */
   String readFully() {
     synchronized (lock) {
-      if (super.size() == 0) {
+      while (super.size() == 0) {
         try {
           lock.wait();
-        } catch (final InterruptedException ie) {
+        } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       }

--- a/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
+++ b/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
@@ -1,0 +1,72 @@
+package games.strategy.debug;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public final class SynchedByteArrayOutputStreamTest {
+  @Rule
+  public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+
+  @Mock
+  private PrintStream mirror;
+
+  @InjectMocks
+  private SynchedByteArrayOutputStream os;
+
+  @Test
+  public void writeByte_ShouldTriggerReadFromDifferentThread() throws Exception {
+    final String expected = "X";
+    final AtomicReference<String> actualRef = new AtomicReference<>();
+    final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
+
+    final Thread readerThread = new Thread(() -> {
+      readerThreadReadyLatch.countDown();
+      actualRef.set(os.readFully());
+    }, "Reader");
+    readerThread.start();
+    readerThreadReadyLatch.await();
+    new Thread(() -> {
+      final byte[] bytes = expected.getBytes();
+      assert bytes.length == 1;
+      os.write(bytes[0]);
+    }, "Writer").start();
+    readerThread.join();
+
+    assertThat(actualRef.get(), is(expected));
+  }
+
+  @Test
+  public void writeBytes_ShouldTriggerReadFromDifferentThread() throws Exception {
+    final String expected = "the quick brown fox";
+    final AtomicReference<String> actualRef = new AtomicReference<>();
+    final CountDownLatch readerThreadReadyLatch = new CountDownLatch(1);
+
+    final Thread readerThread = new Thread(() -> {
+      readerThreadReadyLatch.countDown();
+      actualRef.set(os.readFully());
+    }, "Reader");
+    readerThread.start();
+    readerThreadReadyLatch.await();
+    new Thread(() -> {
+      final byte[] bytes = expected.getBytes();
+      os.write(bytes, 0, bytes.length);
+    }, "Writer").start();
+    readerThread.join();
+
+    assertThat(actualRef.get(), is(expected));
+  }
+}


### PR DESCRIPTION
This PR fixes the remaining occurrences of the Error Prone WaitNotInLoop violations within production code.

The fix for `SynchedByteArrayOutputStream` was straightforward with the `if` check replaced with a `while` loop.  Before making changes, I added characterization tests to ensure I didn't break the inter-thread communication.

The fix for `PBEMDiceRoller$HttpDiceRollerDialog` is a bit more interesting.  Since the `wait`/`notify` usage was in UI code, I spent some time reviewing the code to determine how I could manually test it.  After looking it over a bit, I came to the conclusion that the entire `wait`/`notify` construct was unnecessary and could be removed entirely.

The `wait`/`notify` was used to handle the case when the `HttpDiceRollerDialog$roll()` method was invoked off of the EDT.  However, this method has only two callers, and both of them guarantee that `roll()` will always be called on the EDT:

1. `PBEMDiceRoller#test()` is always called on the EDT, thus when it calls `roll()`, it too will be run on the EDT.
1. `PBEMDiceRoller#getRandom(int, int, String)` may be called on or off the EDT.  However, this method checks to see if it is called off the EDT, and in such a case, re-invokes itself on the EDT.  Thus, again, `roll()` will be run on the EDT.

I tested both code paths manually and no exceptions were thrown indicating the `roll()` code was invoked off of the EDT.