### PR TITLE
Remove redundant final modifiers

### DIFF
--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -35,8 +35,8 @@ public class BadWordControllerIntegrationTest {
   }
 
   private static void removeBadWord(final String word) throws Exception {
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?")) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?")) {
       ps.setString(1, word);
       ps.execute();
       con.commit();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -43,7 +43,7 @@ public class EmailLimitIntegrationTest {
   }
 
   private static void createAccountWithEmail(final String email) {
-    try (final PreparedStatement ps =
+    try (PreparedStatement ps =
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -82,7 +82,7 @@ public class UserControllerIntegrationTest {
     controller.updateUser(
         new DBUser(new DBUser.UserName(user.getName()), new DBUser.UserEmail(email2)),
         new HashedPassword(password2));
-    try (final Connection con = connectionSupplier.get()) {
+    try (Connection con = connectionSupplier.get()) {
       final String sql = " select * from ta_users where username = '" + user.getName() + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
@@ -110,7 +110,7 @@ public class UserControllerIntegrationTest {
   }
 
   private static int getUserCount() throws Exception {
-    try (final Connection dbConnection = connectionSupplier.get()) {
+    try (Connection dbConnection = connectionSupplier.get()) {
       final String sql = "select count(*) from TA_USERS";
       final ResultSet rs = dbConnection.createStatement().executeQuery(sql);
       assertTrue(rs.next());

--- a/src/main/java/games/strategy/debug/LoggingConfiguration.java
+++ b/src/main/java/games/strategy/debug/LoggingConfiguration.java
@@ -33,7 +33,7 @@ public final class LoggingConfiguration {
       return;
     }
 
-    try (final InputStream is = LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
+    try (InputStream is = LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
       logManager.readConfiguration(is);
     } catch (final IOException e) {
       System.err.println("unable to set custom logging configuration using logging.properties");

--- a/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -163,8 +164,8 @@ public class GameProperties extends GameDataComponent {
    */
   public static byte[] writeEditableProperties(final List<IEditableProperty> editableProperties) throws IOException {
     return IoUtils.writeToMemory(os -> {
-      try (final GZIPOutputStream gzipos = new GZIPOutputStream(os);
-          final ObjectOutputStream oos = new ObjectOutputStream(gzipos)) {
+      try (OutputStream gzipos = new GZIPOutputStream(os);
+          ObjectOutputStream oos = new ObjectOutputStream(gzipos)) {
         oos.writeObject(editableProperties);
       }
     });
@@ -184,9 +185,9 @@ public class GameProperties extends GameDataComponent {
   public static List<IEditableProperty> readEditableProperties(final byte[] bytes)
       throws IOException, ClassCastException {
     return IoUtils.readFromMemory(bytes, is -> {
-      try (final InputStream bis = new BufferedInputStream(is);
-          final GZIPInputStream gzipis = new GZIPInputStream(bis);
-          final ObjectInputStream ois = new ObjectInputStream(gzipis)) {
+      try (InputStream bis = new BufferedInputStream(is);
+          InputStream gzipis = new GZIPInputStream(bis);
+          ObjectInputStream ois = new ObjectInputStream(gzipis)) {
         return (List<IEditableProperty>) ois.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -64,8 +64,8 @@ public final class GameDataManager {
   public static GameData loadGame(final File file) throws IOException {
     checkNotNull(file);
 
-    try (final InputStream fis = new FileInputStream(file);
-        final InputStream is = new BufferedInputStream(fis)) {
+    try (InputStream fis = new FileInputStream(file);
+        InputStream is = new BufferedInputStream(fis)) {
       return loadGame(is);
     }
   }
@@ -94,8 +94,8 @@ public final class GameDataManager {
   }
 
   private static Memento loadMemento(final InputStream is) throws IOException {
-    try (final InputStream gzipis = new GZIPInputStream(is);
-        final ObjectInputStream ois = new ObjectInputStream(gzipis)) {
+    try (InputStream gzipis = new GZIPInputStream(is);
+        ObjectInputStream ois = new ObjectInputStream(gzipis)) {
       return (Memento) ois.readObject();
     } catch (final ClassNotFoundException e) {
       throw new IOException(e);
@@ -249,8 +249,8 @@ public final class GameDataManager {
       final Memento memento,
       final ProxyRegistry proxyRegistry)
       throws IOException {
-    try (final GZIPOutputStream gzipos = new GZIPOutputStream(os);
-        final ObjectOutputStream oos = new ProxyableObjectOutputStream(gzipos, proxyRegistry)) {
+    try (OutputStream gzipos = new GZIPOutputStream(os);
+        ObjectOutputStream oos = new ProxyableObjectOutputStream(gzipos, proxyRegistry)) {
       oos.writeObject(memento);
     }
   }
@@ -262,7 +262,7 @@ public final class GameDataManager {
       throws IOException {
     // write internally first in case of error
     final byte[] bytes = IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream outStream = new ObjectOutputStream(os)) {
+      try (ObjectOutputStream outStream = new ObjectOutputStream(os)) {
         outStream.writeObject(ClientContext.engineVersion());
         data.acquireReadLock();
         try {
@@ -279,7 +279,7 @@ public final class GameDataManager {
     });
 
     // now write to file
-    try (final GZIPOutputStream zippedOut = new GZIPOutputStream(sink)) {
+    try (OutputStream zippedOut = new GZIPOutputStream(sink)) {
       zippedOut.write(bytes);
     }
   }

--- a/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
@@ -40,13 +41,13 @@ public final class GameDataUtils {
   public static <T> T translateIntoOtherGameData(final T object, final GameData translateInto) {
     try {
       final byte[] bytes = IoUtils.writeToMemory(os -> {
-        try (final GameObjectOutputStream out = new GameObjectOutputStream(os)) {
+        try (ObjectOutputStream out = new GameObjectOutputStream(os)) {
           out.writeObject(object);
         }
       });
       return IoUtils.readFromMemory(bytes, is -> {
         final GameObjectStreamFactory factory = new GameObjectStreamFactory(translateInto);
-        try (final ObjectInputStream in = factory.create(is)) {
+        try (ObjectInputStream in = factory.create(is)) {
           return (T) in.readObject();
         } catch (final ClassNotFoundException e) {
           throw new IOException(e);

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -123,10 +123,9 @@ public class AvailableGames {
 
   private static void populateFromZip(final File map, final Map<String, URI> availableGames,
       final Set<String> availableMapFolderOrZipNames, final Set<String> mapNamePropertyList) {
-    try (
-        final FileInputStream fis = new FileInputStream(map);
-        final ZipInputStream zis = new ZipInputStream(fis);
-        final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
+    try (InputStream fis = new FileInputStream(map);
+        ZipInputStream zis = new ZipInputStream(fis);
+        URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
       ZipEntry entry = zis.getNextEntry();
       while (entry != null) {
         if (entry.getName().contains("games/") && entry.getName().toLowerCase().endsWith(".xml")) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.LocalDateTime;
 import java.util.Properties;
 
@@ -22,7 +24,7 @@ class DownloadFileProperties {
       return new DownloadFileProperties();
     }
     final DownloadFileProperties downloadFileProperties = new DownloadFileProperties();
-    try (final FileInputStream fis = new FileInputStream(fromZip(zipFile))) {
+    try (InputStream fis = new FileInputStream(fromZip(zipFile))) {
       downloadFileProperties.props.load(fis);
     } catch (final IOException e) {
       ClientLogger.logError("Failed to read property file: " + fromZip(zipFile).getAbsolutePath(), e);
@@ -31,7 +33,7 @@ class DownloadFileProperties {
   }
 
   static void saveForZip(final File zipFile, final DownloadFileProperties props) {
-    try (final FileOutputStream fos = new FileOutputStream(fromZip(zipFile))) {
+    try (OutputStream fos = new FileOutputStream(fromZip(zipFile))) {
       props.props.store(fos, null);
     } catch (final IOException e) {
       ClientLogger.logError("Failed to write property file to: " + fromZip(zipFile).getAbsolutePath(), e);

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -60,7 +60,7 @@ public final class DownloadUtils {
   }
 
   private static Optional<Long> getDownloadLengthFromHost(final String uri) {
-    try (final CloseableHttpClient client = newHttpClient()) {
+    try (CloseableHttpClient client = newHttpClient()) {
       return getDownloadLengthFromHost(uri, client);
     } catch (final IOException e) {
       ClientLogger.logQuietly(String.format("failed to get download length for '%s'", uri), e);
@@ -72,7 +72,7 @@ public final class DownloadUtils {
   static Optional<Long> getDownloadLengthFromHost(
       final String uri,
       final CloseableHttpClient client) throws IOException {
-    try (final CloseableHttpResponse response = client.execute(newHttpHeadRequest(uri))) {
+    try (CloseableHttpResponse response = client.execute(newHttpHeadRequest(uri))) {
       final int statusCode = response.getStatusLine().getStatusCode();
       if (statusCode != HttpStatus.SC_OK) {
         throw new IOException(String.format("unexpected status code (%d)", statusCode));
@@ -162,8 +162,8 @@ public final class DownloadUtils {
     checkNotNull(uri);
     checkNotNull(file);
 
-    try (final FileOutputStream os = new FileOutputStream(file);
-        final CloseableHttpClient client = newHttpClient()) {
+    try (FileOutputStream os = new FileOutputStream(file);
+        CloseableHttpClient client = newHttpClient()) {
       downloadToFile(uri, os, client);
     }
   }
@@ -175,7 +175,7 @@ public final class DownloadUtils {
       final String uri,
       final FileOutputStream os,
       final CloseableHttpClient client) throws IOException {
-    try (final CloseableHttpResponse response = client.execute(newHttpGetRequest(uri))) {
+    try (CloseableHttpResponse response = client.execute(newHttpGetRequest(uri))) {
       final int statusCode = response.getStatusLine().getStatusCode();
       if (statusCode != HttpStatus.SC_OK) {
         throw new IOException(String.format("unexpected status code (%d)", statusCode));

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -4,8 +4,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -46,7 +48,8 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
       if (!cache.getParentFile().exists()) {
         cache.getParentFile().mkdirs();
       }
-      try (final ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(cache))) {
+      try (OutputStream os = new FileOutputStream(cache);
+          ObjectOutputStream out = new ObjectOutputStream(os)) {
         out.writeObject(serializableMap);
       }
     } catch (final IOException e) {
@@ -61,7 +64,8 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
     final File cache = getCacheFile(gameData);
     try {
       if (cache.exists()) {
-        try (final ObjectInputStream in = new ObjectInputStream(new FileInputStream(cache))) {
+        try (InputStream is = new FileInputStream(cache);
+            ObjectInputStream in = new ObjectInputStream(is)) {
           final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
           for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
             final Serializable ser = serializedMap.get(property.getName());

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -6,6 +6,7 @@ import java.awt.Insets;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -157,7 +158,7 @@ public class EmailSenderEditor extends EditorPanel {
         final String html = "<html><body><h1>Success</h1><p>This was a test email sent by TripleA<p></body></html>";
         final File dummy = new File(ClientFileSystemHelper.getUserRootFolder(), "dummySave.txt");
         dummy.deleteOnExit();
-        try (final FileOutputStream fout = new FileOutputStream(dummy)) {
+        try (OutputStream fout = new FileOutputStream(dummy)) {
           fout.write("This file would normally be a save game".getBytes());
         }
         ((IEmailSender) getBean()).sendEmail("TripleA Test", html, dummy, "dummy.txt");

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLoginPreferences.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLoginPreferences.java
@@ -70,7 +70,7 @@ public final class LobbyLoginPreferences {
       return credentials;
     }
 
-    try (final CredentialManager credentialManager = credentialManagerFactory.create()) {
+    try (CredentialManager credentialManager = credentialManagerFactory.create()) {
       return new Credentials(
           credentials.userName.isEmpty() ? "" : credentialManager.unprotectToString(credentials.userName),
           credentials.password.isEmpty() ? "" : credentialManager.unprotectToString(credentials.password),
@@ -118,7 +118,7 @@ public final class LobbyLoginPreferences {
       final CredentialManagerFactory credentialManagerFactory) {
     assert !credentials.isProtected;
 
-    try (final CredentialManager credentialManager = credentialManagerFactory.create()) {
+    try (CredentialManager credentialManager = credentialManagerFactory.create()) {
       return new Credentials(
           credentialManager.protect(credentials.userName),
           credentialManager.protect(credentials.password),

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -122,7 +122,7 @@ class LobbyGameController implements ILobbyGameController {
     final int port = description.getPort();
     final String host = description.getHostedBy().getAddress().getHostAddress();
     logger.fine("Testing game connection on host:" + host + " port:" + port);
-    try (final Socket s = new Socket()) {
+    try (Socket s = new Socket()) {
       s.connect(new InetSocketAddress(host, port), 10 * 1000);
       logger.fine("Connection test passed for host:" + host + " port:" + port);
       return null;

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -13,10 +13,9 @@ import java.util.List;
 public final class BadWordController implements BadWordDao {
   @Override
   public void addBadWord(final String word) {
-    try (final Connection con = Database.getPostgresConnection();
+    try (Connection con = Database.getPostgresConnection();
         // If the word already is present we don't need to add it twice.
-        final PreparedStatement ps =
-            con.prepareStatement("insert into bad_words (word) values (?) on conflict do nothing")) {
+        PreparedStatement ps = con.prepareStatement("insert into bad_words (word) values (?) on conflict do nothing")) {
       ps.setString(1, word);
       ps.execute();
       con.commit();
@@ -29,9 +28,9 @@ public final class BadWordController implements BadWordDao {
   public List<String> list() {
     final String sql = "select word from bad_words";
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(sql);
-        final ResultSet rs = ps.executeQuery()) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql);
+        ResultSet rs = ps.executeQuery()) {
       final List<String> badWords = new ArrayList<>();
       while (rs.next()) {
         badWords.add(rs.getString(1));

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -21,8 +21,8 @@ public class BannedMacController extends TimedController implements BannedMacDao
   @Override
   public void addBannedMac(final String mac, final @Nullable Instant banTill) {
     if (banTill == null || banTill.isAfter(now())) {
-      try (final Connection con = Database.getPostgresConnection();
-          final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)"
+      try (Connection con = Database.getPostgresConnection();
+          PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)"
               + " on conflict (mac) do update set ban_till=excluded.ban_till")) {
         ps.setString(1, mac);
         ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
@@ -37,8 +37,8 @@ public class BannedMacController extends TimedController implements BannedMacDao
   }
 
   private static void removeBannedMac(final String mac) {
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from banned_macs where mac=?")) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement("delete from banned_macs where mac=?")) {
       ps.setString(1, mac);
       ps.execute();
       con.commit();
@@ -54,10 +54,10 @@ public class BannedMacController extends TimedController implements BannedMacDao
   public Tuple<Boolean, /* @Nullable */ Timestamp> isMacBanned(final String mac) {
     final String sql = "select mac, ban_till from banned_macs where mac=?";
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, mac);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         // If the ban has expired, allow the mac
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -21,10 +21,9 @@ public class BannedUsernameController extends TimedController implements BannedU
     if (banTill == null || banTill.isAfter(now())) {
       logger.fine("Banning username:" + username);
 
-      try (final Connection con = Database.getPostgresConnection();
-          final PreparedStatement ps =
-              con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
-                  + " on conflict (username) do update set ban_till=excluded.ban_till")) {
+      try (Connection con = Database.getPostgresConnection();
+          PreparedStatement ps = con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
+              + " on conflict (username) do update set ban_till=excluded.ban_till")) {
         ps.setString(1, username);
         ps.setTimestamp(2, banTill != null ? Timestamp.from(banTill) : null);
         ps.execute();
@@ -40,8 +39,8 @@ public class BannedUsernameController extends TimedController implements BannedU
   private static void removeBannedUsername(final String username) {
     logger.fine("Removing banned username:" + username);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?")) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?")) {
       ps.setString(1, username);
       ps.execute();
       con.commit();
@@ -57,10 +56,10 @@ public class BannedUsernameController extends TimedController implements BannedU
   public Tuple<Boolean, Timestamp> isUsernameBanned(final String username) {
     final String sql = "select username, ban_till from banned_usernames where username = ?";
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         // If the ban has expired, allow the username
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -25,8 +25,8 @@ public class MutedMacController extends TimedController {
     if (muteTill == null || muteTill.isAfter(now())) {
       logger.fine("Muting mac:" + mac);
 
-      try (final Connection con = Database.getPostgresConnection();
-          final PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
+      try (Connection con = Database.getPostgresConnection();
+          PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
               + " on conflict (mac) do update set mute_till=excluded.mute_till")) {
         ps.setString(1, mac);
         ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
@@ -43,8 +43,8 @@ public class MutedMacController extends TimedController {
   private static void removeMutedMac(final String mac) {
     logger.fine("Removing muted mac:" + mac);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from muted_macs where mac=?")) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement("delete from muted_macs where mac=?")) {
       ps.setString(1, mac);
       ps.execute();
       con.commit();
@@ -68,10 +68,10 @@ public class MutedMacController extends TimedController {
   public long getMacUnmuteTime(final String mac) {
     final String sql = "select mac, mute_till from muted_macs where mac=?";
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, mac);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         final boolean found = rs.next();
         if (found) {
           final Timestamp muteTill = rs.getTimestamp(2);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -25,9 +25,8 @@ public class MutedUsernameController extends TimedController {
     if (muteTill == null || muteTill.isAfter(now())) {
       logger.fine("Muting username:" + username);
 
-      try (final Connection con = Database.getPostgresConnection();
-          final PreparedStatement ps =
-              con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
+      try (Connection con = Database.getPostgresConnection();
+          PreparedStatement ps = con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
                   + " on conflict (username) do update set mute_till=excluded.mute_till")) {
         ps.setString(1, username);
         ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
@@ -44,8 +43,8 @@ public class MutedUsernameController extends TimedController {
   private static void removeMutedUsername(final String username) {
     logger.fine("Removing muted username:" + username);
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement("delete from muted_usernames where username = ?")) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement("delete from muted_usernames where username = ?")) {
       ps.setString(1, username);
       ps.execute();
       con.commit();
@@ -69,10 +68,10 @@ public class MutedUsernameController extends TimedController {
   public long getUsernameUnmuteTime(final String username) {
     final String sql = "select username, mute_till from muted_usernames where username = ?";
 
-    try (final Connection con = Database.getPostgresConnection();
-        final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         final boolean found = rs.next();
         if (found) {
           final Timestamp muteTill = rs.getTimestamp(2);

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -39,11 +39,11 @@ public class UserController implements UserDao {
   }
 
   private HashedPassword getPassword(final String username, final boolean legacy) {
-    try (final Connection con = connectionSupplier.get();
-        final PreparedStatement ps = con
+    try (Connection con = connectionSupplier.get();
+        PreparedStatement ps = con
             .prepareStatement("select password, coalesce(bcrypt_password, password) from ta_users where username=?")) {
       ps.setString(1, username);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
           return new HashedPassword(rs.getString(legacy ? 1 : 2));
         }
@@ -57,9 +57,9 @@ public class UserController implements UserDao {
   @Override
   public boolean doesUserExist(final String username) {
     final String sql = "select username from ta_users where upper(username) = upper(?)";
-    try (final Connection con = connectionSupplier.get(); final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = connectionSupplier.get(); final PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         return rs.next();
       }
     } catch (final SQLException sqle) {
@@ -71,15 +71,15 @@ public class UserController implements UserDao {
   public void updateUser(final DBUser user, final HashedPassword hashedPassword) {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 
-    try (final Connection con = connectionSupplier.get();
-        final PreparedStatement ps = con.prepareStatement(
+    try (Connection con = connectionSupplier.get();
+        PreparedStatement ps = con.prepareStatement(
             String.format("update ta_users set %s=?, email=? where username=?", getPasswordColumn(hashedPassword)))) {
       ps.setString(1, hashedPassword.value);
       ps.setString(2, user.getEmail());
       ps.setString(3, user.getName());
       ps.execute();
       if (!hashedPassword.isBcrypted()) {
-        try (final PreparedStatement ps2 =
+        try (PreparedStatement ps2 =
             con.prepareStatement("update ta_users set bcrypt_password=null where username=?")) {
           ps2.setString(1, user.getName());
           ps2.execute();
@@ -109,8 +109,8 @@ public class UserController implements UserDao {
   public void makeAdmin(final DBUser user) {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 
-    try (final Connection con = connectionSupplier.get();
-        final PreparedStatement ps = con.prepareStatement("update ta_users set admin=? where username = ?")) {
+    try (Connection con = connectionSupplier.get();
+        PreparedStatement ps = con.prepareStatement("update ta_users set admin=? where username = ?")) {
       ps.setBoolean(1, user.isAdmin());
       ps.setString(2, user.getName());
       ps.execute();
@@ -125,8 +125,8 @@ public class UserController implements UserDao {
     Preconditions.checkState(hashedPassword.isHashedWithSalt());
     Preconditions.checkState(user.isValid(), user.getValidationErrorMessage());
 
-    try (final Connection con = connectionSupplier.get();
-        final PreparedStatement ps = con.prepareStatement(
+    try (Connection con = connectionSupplier.get();
+        PreparedStatement ps = con.prepareStatement(
             "insert into ta_users (username, password, bcrypt_password, email) values (?, ?, ?, ?)")) {
       ps.setString(1, user.getName());
       ps.setString(2, hashedPassword.isBcrypted() ? null : hashedPassword.value);
@@ -142,13 +142,13 @@ public class UserController implements UserDao {
 
   @Override
   public boolean login(final String username, final HashedPassword hashedPassword) {
-    try (final Connection con = connectionSupplier.get()) {
+    try (Connection con = connectionSupplier.get()) {
       if (hashedPassword.isHashedWithSalt()) {
-        try (final PreparedStatement ps =
+        try (PreparedStatement ps =
             con.prepareStatement("select username from  ta_users where username = ? and password = ?")) {
           ps.setString(1, username);
           ps.setString(2, hashedPassword.value);
-          try (final ResultSet rs = ps.executeQuery()) {
+          try (ResultSet rs = ps.executeQuery()) {
             if (!rs.next()) {
               return false;
             }
@@ -165,7 +165,7 @@ public class UserController implements UserDao {
         }
       }
       // update last login time
-      try (final PreparedStatement ps = con.prepareStatement("update ta_users set lastLogin = ? where username = ?")) {
+      try (PreparedStatement ps = con.prepareStatement("update ta_users set lastLogin = ? where username = ?")) {
         ps.setTimestamp(1, Timestamp.from(Instant.now()));
         ps.setString(2, username);
         ps.execute();
@@ -181,9 +181,10 @@ public class UserController implements UserDao {
   @Override
   public DBUser getUserByName(final String username) {
     final String sql = "select * from ta_users where username = ?";
-    try (final Connection con = connectionSupplier.get(); final PreparedStatement ps = con.prepareStatement(sql)) {
+    try (Connection con = connectionSupplier.get();
+        PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);
-      try (final ResultSet rs = ps.executeQuery()) {
+      try (ResultSet rs = ps.executeQuery()) {
         if (!rs.next()) {
           return null;
         }

--- a/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -61,7 +61,7 @@ public abstract class AbstractForumPoster implements IForumPoster {
   private void protectCredentials() {
     if (credentialsSaved) {
       credentialsProtected = true;
-      try (final CredentialManager credentialManager = CredentialManager.newInstance()) {
+      try (CredentialManager credentialManager = CredentialManager.newInstance()) {
         m_username = credentialManager.protect(m_username);
         m_password = credentialManager.protect(m_password);
       } catch (final CredentialManagerException e) {
@@ -81,7 +81,7 @@ public abstract class AbstractForumPoster implements IForumPoster {
 
   private void unprotectCredentials() {
     if (credentialsProtected) {
-      try (final CredentialManager credentialManager = CredentialManager.newInstance()) {
+      try (CredentialManager credentialManager = CredentialManager.newInstance()) {
         m_username = credentialManager.unprotectToString(m_username);
         m_password = credentialManager.unprotectToString(m_password);
       } catch (final CredentialManagerException e) {

--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -91,7 +91,7 @@ public class GenericEmailSender implements IEmailSender {
   private void protectCredentials() {
     if (credentialsSaved) {
       credentialsProtected = true;
-      try (final CredentialManager credentialManager = CredentialManager.newInstance()) {
+      try (CredentialManager credentialManager = CredentialManager.newInstance()) {
         m_userName = credentialManager.protect(m_userName);
         m_password = credentialManager.protect(m_password);
       } catch (final CredentialManagerException e) {
@@ -111,7 +111,7 @@ public class GenericEmailSender implements IEmailSender {
 
   private void unprotectCredentials() {
     if (credentialsProtected) {
-      try (final CredentialManager credentialManager = CredentialManager.newInstance()) {
+      try (CredentialManager credentialManager = CredentialManager.newInstance()) {
         m_userName = credentialManager.unprotectToString(m_userName);
         m_password = credentialManager.unprotectToString(m_password);
       } catch (final CredentialManagerException e) {

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -3,6 +3,7 @@ package games.strategy.engine.random;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -64,7 +65,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       if (!file.isDirectory() && file.getName().endsWith(".properties")) {
         try {
           final Properties props = new Properties();
-          try (final FileInputStream fin = new FileInputStream(file)) {
+          try (InputStream fin = new FileInputStream(file)) {
             props.load(fin);
             propFiles.add(props);
           }

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -130,14 +130,14 @@ public class ResourceLoader implements Closeable {
     final List<String> paths = new ArrayList<>();
     paths.add(match.get().getAbsolutePath());
     // find dependencies
-    try (final URLClassLoader url = new URLClassLoader(new URL[] {match.get().toURI().toURL()})) {
+    try (URLClassLoader url = new URLClassLoader(new URL[] {match.get().toURI().toURL()})) {
       final URL dependencesUrl = url.getResource("dependencies.txt");
       if (dependencesUrl != null) {
         final java.util.Properties dependenciesFile = new java.util.Properties();
 
         final Optional<InputStream> inputStream = UrlStreams.openStream(dependencesUrl);
         if (inputStream.isPresent()) {
-          try (final InputStream stream = inputStream.get()) {
+          try (InputStream stream = inputStream.get()) {
             dependenciesFile.load(stream);
             final String dependencies = dependenciesFile.getProperty("dependencies");
             final StringTokenizer tokens = new StringTokenizer(dependencies, ",", false);

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -31,7 +31,7 @@ public class ProLogSettings implements Serializable {
         final byte[] pool = Preferences.userNodeForPackage(ProAI.class).getByteArray(PROGRAM_SETTINGS, null);
         if (pool != null) {
           result = IoUtils.readFromMemory(pool, is -> {
-            try (final ObjectInputStream ois = new ObjectInputStream(is)) {
+            try (ObjectInputStream ois = new ObjectInputStream(is)) {
               return (ProLogSettings) ois.readObject();
             } catch (final ClassNotFoundException e) {
               throw new IOException(e);
@@ -55,7 +55,7 @@ public class ProLogSettings implements Serializable {
     lastSettings = settings;
     try {
       final byte[] bytes = IoUtils.writeToMemory(os -> {
-        try (final ObjectOutputStream outputStream = new ObjectOutputStream(os)) {
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(os)) {
           outputStream.writeObject(settings);
         }
       });

--- a/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.printgenerator;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -47,7 +48,7 @@ class PlayerOrder {
     }
     printData.getOutDir().mkdir();
     final File outFile = new File(printData.getOutDir(), "General Information.csv");
-    try (final FileWriter turnWriter = new FileWriter(outFile, true)) {
+    try (Writer turnWriter = new FileWriter(outFile, true)) {
       turnWriter.write("Turn Order\r\n");
       final Set<PlayerID> noDuplicates = removeDups(playerSet);
       final Iterator<PlayerID> playerIterator = noDuplicates.iterator();

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -4,6 +4,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ class ExportMenu {
       gameData.releaseReadLock();
     }
     try {
-      try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
+      try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
         writer.write(xmlFile);
       }
     } catch (final IOException e1) {
@@ -376,7 +377,7 @@ class ExportMenu {
     } finally {
       gameData.releaseReadLock();
     }
-    try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
+    try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
       writer.write(text.toString());
     } catch (final IOException e1) {
       ClientLogger.logQuietly(e1);
@@ -395,7 +396,7 @@ class ExportMenu {
       if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
         return;
       }
-      try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
+      try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
         writer.write(
             HelpMenu.getUnitStatsTable(gameData, iuiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -97,7 +97,7 @@ public class AutoPlacementFinder {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          try (final Scanner scanner = new Scanner(file)) {
+          try (Scanner scanner = new Scanner(file)) {
             while (scanner.hasNextLine()) {
               final String line = scanner.nextLine();
               if (line.contains(scaleProperty)) {

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -236,7 +237,7 @@ public class CenterPicker extends JFrame {
       if (fileName == null) {
         return;
       }
-      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+      try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToOne(out, centers);
       }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -462,7 +463,7 @@ public class DecorationPlacer extends JFrame {
       if (fileName == null) {
         return;
       }
-      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+      try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
       }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -375,7 +376,7 @@ public class PolygonGrabber extends JFrame {
       if (polyName == null) {
         return;
       }
-      try (final FileOutputStream out = new FileOutputStream(polyName)) {
+      try (OutputStream out = new FileOutputStream(polyName)) {
         PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
       }
       System.out.println("Data written to :" + new File(polyName).getCanonicalPath());

--- a/src/main/java/tools/image/XmlUpdater.java
+++ b/src/main/java/tools/image/XmlUpdater.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -39,9 +40,8 @@ public class XmlUpdater {
     final Transformer trans = TransformerFactory.newInstance().newTransformer(new StreamSource(source));
 
     final byte[] resultBytes = IoUtils.writeToMemory(os -> {
-      try (
-          final FileInputStream fileInputStream = new FileInputStream(gameXmlFile);
-          final InputStream gameXmlStream = new BufferedInputStream(fileInputStream)) {
+      try (InputStream fileInputStream = new FileInputStream(gameXmlFile);
+          InputStream gameXmlStream = new BufferedInputStream(fileInputStream)) {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setValidating(true);
         // use a dummy game.dtd, this prevents the xml parser from adding default values
@@ -54,7 +54,7 @@ public class XmlUpdater {
       }
     });
     gameXmlFile.renameTo(new File(gameXmlFile.getAbsolutePath() + ".backup"));
-    try (final FileOutputStream outStream = new FileOutputStream(gameXmlFile)) {
+    try (OutputStream outStream = new FileOutputStream(gameXmlFile)) {
       outStream.write(resultBytes);
     }
     System.out.println("Successfully updated:" + gameXmlFile);

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -185,7 +186,7 @@ public class ConnectionFinder {
         }
         System.out.println(connectionsString.toString());
       } else {
-        try (final FileOutputStream out = new FileOutputStream(fileName)) {
+        try (OutputStream out = new FileOutputStream(fileName)) {
           if (territoryDefinitions != null) {
             out.write(String.valueOf(territoryDefinitions).getBytes());
           }

--- a/src/main/java/tools/map/making/ImageShrinker.java
+++ b/src/main/java/tools/map/making/ImageShrinker.java
@@ -12,6 +12,7 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.FileImageOutputStream;
+import javax.imageio.stream.ImageOutputStream;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
@@ -55,7 +56,7 @@ public class ImageShrinker {
     graphics2D.drawImage(baseImg, 0, 0, thumbWidth, thumbHeight, null);
     // save thumbnail image to OUTFILE
     final File file = new File(new File(mapFile.getPath()).getParent() + File.separatorChar + "smallMap.jpeg");
-    try (final FileImageOutputStream out = new FileImageOutputStream(file)) {
+    try (ImageOutputStream out = new FileImageOutputStream(file)) {
       final ImageWriter encoder = ImageIO.getImageWritersByFormatName("JPEG").next();
       final JPEGImageWriteParam param = new JPEGImageWriteParam(null);
       param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
@@ -341,9 +343,9 @@ public class MapPropertiesMaker extends JFrame {
       if (fileName == null) {
         return;
       }
-      final FileOutputStream sink = new FileOutputStream(fileName);
       final String stringToWrite = getOutPutString();
-      try (final OutputStreamWriter out = new OutputStreamWriter(sink)) {
+      try (OutputStream sink = new FileOutputStream(fileName);
+          Writer out = new OutputStreamWriter(sink)) {
         out.write(stringToWrite);
       }
       System.out.println("");

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -163,7 +164,7 @@ public class PlacementPicker extends JFrame {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          try (final Scanner scanner = new Scanner(file)) {
+          try (Scanner scanner = new Scanner(file)) {
             while (scanner.hasNextLine()) {
               final String line = scanner.nextLine();
               if (line.contains(scaleProperty)) {
@@ -482,7 +483,7 @@ public class PlacementPicker extends JFrame {
       if (fileName == null) {
         return;
       }
-      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+      try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
       }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());

--- a/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.Writer;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +24,7 @@ public class PropertyFileReaderTest {
     final File tempFile = File.createTempFile("test", "tmp");
     tempFile.deleteOnExit();
 
-    try (final FileWriter writer = new FileWriter(tempFile)) {
+    try (Writer writer = new FileWriter(tempFile)) {
       writer.write("a=b\n");
       writer.write(" 1 = 2 \n");
       writer.write("whitespace =      \n");

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -30,12 +30,12 @@ public class ChangeTest {
 
   private Change serialize(final Change change) throws Exception {
     final byte[] bytes = IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream output = new GameObjectOutputStream(os)) {
+      try (ObjectOutputStream output = new GameObjectOutputStream(os)) {
         output.writeObject(change);
       }
     });
     return IoUtils.readFromMemory(bytes, is -> {
-      try (final ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameData), is)) {
+      try (ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameData), is)) {
         return (Change) input.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);

--- a/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -31,12 +31,12 @@ public class ChangeTripleATest {
 
   private Change serialize(final Change change) throws Exception {
     final byte[] bytes = IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream output = new GameObjectOutputStream(os)) {
+      try (ObjectOutputStream output = new GameObjectOutputStream(os)) {
         output.writeObject(change);
       }
     });
     return IoUtils.readFromMemory(bytes, is -> {
-      try (final ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameData), is)) {
+      try (ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameData), is)) {
         return (Change) input.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -26,12 +26,12 @@ public class SerializationTest {
 
   private Object serialize(final Object anObject) throws Exception {
     final byte[] bytes = IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream output = new GameObjectOutputStream(os)) {
+      try (ObjectOutputStream output = new GameObjectOutputStream(os)) {
         output.writeObject(anObject);
       }
     });
     return IoUtils.readFromMemory(bytes, is -> {
-      try (final ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameDataSource), is)) {
+      try (ObjectInputStream input = new GameObjectInputStream(new GameObjectStreamFactory(gameDataSource), is)) {
         return input.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -204,7 +204,7 @@ public class ValidateAttachmentsTest {
 
   private static String formatStackTrace(final Throwable t) {
     final StringWriter stringWriter = new StringWriter();
-    try (final PrintWriter printWriter = new PrintWriter(stringWriter)) {
+    try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
       t.printStackTrace(printWriter);
     }
     return stringWriter.toString();

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -59,7 +59,7 @@ public class GameDataManagerTest {
 
   @Test
   public void loadGameInProxySerializationFormat_ShouldNotCloseInputStream() throws Exception {
-    try (final InputStream is = spy(newInputStreamWithGameInProxySerializationFormat())) {
+    try (InputStream is = spy(newInputStreamWithGameInProxySerializationFormat())) {
       GameDataManager.loadGameInProxySerializationFormat(is);
 
       verify(is, never()).close();

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
@@ -91,7 +91,7 @@ public final class DownloadUtilsTests {
     }
 
     private void downloadToFile() throws Exception {
-      try (final FileOutputStream os = new FileOutputStream(file)) {
+      try (FileOutputStream os = new FileOutputStream(file)) {
         DownloadUtils.downloadToFile(URI, os, client);
       }
     }

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -107,7 +107,7 @@ public abstract class AbstractProxyTestCase<T> {
 
   private static Object readObject(final byte[] bytes) throws Exception {
     return IoUtils.readFromMemory(bytes, is -> {
-      try (final ObjectInputStream ois = new ObjectInputStream(is)) {
+      try (ObjectInputStream ois = new ObjectInputStream(is)) {
         return ois.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);
@@ -117,7 +117,7 @@ public abstract class AbstractProxyTestCase<T> {
 
   private byte[] writeObject(final T obj) throws Exception {
     return IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
+      try (ObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
         oos.writeObject(obj);
       }
     });

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
@@ -32,7 +32,7 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
   private Object[] readObjects(final int count) throws Exception {
     final Object[] objs = new Object[count];
     IoUtils.consumeFromMemory(bytes, is -> {
-      try (final ObjectInputStream ois = new ObjectInputStream(is)) {
+      try (ObjectInputStream ois = new ObjectInputStream(is)) {
         for (int i = 0; i < count; ++i) {
           objs[i] = ois.readObject();
         }
@@ -49,7 +49,7 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
 
   private void writeObjects(final ProxyRegistry proxyRegistry, final Object... objs) throws Exception {
     bytes = IoUtils.writeToMemory(os -> {
-      try (final ObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
+      try (ObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
         for (final Object obj : objs) {
           oos.writeObject(obj);
         }

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectOutputStreamTest.java
@@ -21,7 +21,7 @@ public final class ProxyableObjectOutputStreamTest {
     final Object expectedReplacedObj = "42";
     final ProxyRegistry proxyRegistry = givenProxyRegistryFor(obj, expectedReplacedObj);
     IoUtils.writeToMemory(os -> {
-      try (final ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
+      try (ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, proxyRegistry)) {
         final Object actualReplacedObj = oos.replaceObject(obj);
 
         verify(proxyRegistry).getProxyFor(obj);
@@ -39,7 +39,7 @@ public final class ProxyableObjectOutputStreamTest {
   @Test
   public void replaceObject_ShouldReturnNullWhenObjectIsNull() throws Exception {
     IoUtils.writeToMemory(os -> {
-      try (final ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, ProxyRegistry.newInstance())) {
+      try (ProxyableObjectOutputStream oos = new ProxyableObjectOutputStream(os, ProxyRegistry.newInstance())) {
         final Object replacedObj = oos.replaceObject(null);
 
         assertThat(replacedObj, is(nullValue()));

--- a/src/test/java/games/strategy/security/TestSecurityUtils.java
+++ b/src/test/java/games/strategy/security/TestSecurityUtils.java
@@ -70,13 +70,13 @@ public final class TestSecurityUtils {
     final KeyFactory keyFactory = KeyFactory.getInstance(RSA_ALGORITHM);
 
     final X509EncodedKeySpec publicKeySpec;
-    try (final InputStream is = type.getResourceAsStream(getPublicKeyFileName(type))) {
+    try (InputStream is = type.getResourceAsStream(getPublicKeyFileName(type))) {
       publicKeySpec = new X509EncodedKeySpec(ByteStreams.toByteArray(is));
     }
     final PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
 
     final PKCS8EncodedKeySpec privateKeySpec;
-    try (final InputStream is = type.getResourceAsStream(getPrivateKeyFileName(type))) {
+    try (InputStream is = type.getResourceAsStream(getPrivateKeyFileName(type))) {
       privateKeySpec = new PKCS8EncodedKeySpec(ByteStreams.toByteArray(is));
     }
     final PrivateKey privateKey = keyFactory.generatePrivate(privateKeySpec);


### PR DESCRIPTION
I learned recently that variables declared in a try-with-resources statement are implicitly `final`, and thus any `final` modifier is redundant.  (This explains why I never see the Eclipse Clean Up tool add `final` to a variable declared in a try-with-resources statement.)  This PR removes all such redundant `final` modifiers.

I also changed the type of each variable to the least-specific type, where possible (e.g. `FileOutputStream` -> `OutputStream`).