### PR TITLE
Fix Download Maps window layout (#2511)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -371,6 +371,7 @@ public class DownloadMapsWindow extends JFrame {
 
     final List<DownloadFileDescription> maps = MapDownloadListSort.sortByMapName(unsortedMaps);
     final JPanel main = JPanelBuilder.builder()
+        .borderLayout()
         .borderEmpty(30)
         .build();
     final JEditorPane descriptionPane = SwingComponents.newHtmlJEditorPane();

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -94,6 +94,7 @@ final class MapDownloadProgressPanel extends JPanel implements DownloadListener 
     final int itemCount = downloadList.size();
     this.removeAll();
     add(JPanelBuilder.builder()
+        .borderLayout()
         .addWest(labelGrid)
         .addEast(progressGrid)
         .build());

--- a/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
@@ -83,6 +83,7 @@ public class TimespanDialog {
     final JComboBox<TimeUnit> comboBox = new JComboBox<>(TimeUnit.values());
     comboBox.addActionListener(e -> spinner.setEnabled(!comboBox.getSelectedItem().equals(TimeUnit.FOREVER)));
     final int returnValue = JOptionPane.showConfirmDialog(parent, JPanelBuilder.builder()
+        .borderLayout()
         .addNorth(JLabelBuilder.builder()
             .text(infoMessage)
             .border(new EmptyBorder(0, 0, 5, 0))

--- a/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
@@ -84,6 +84,7 @@ public class SetupFrame extends JPanel {
 
 
     final JPanel textButtonRadioPanel = JPanelBuilder.builder()
+        .borderLayout()
         .addWest(outField)
         .addEast(outDirButton)
         .addSouth(JPanelBuilder.builder()

--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -79,6 +79,7 @@ enum SettingsWindow {
 
   private static JComponent buildTab(final List<ClientSettingUiBinding> settings, final Runnable closeListener) {
     return JPanelBuilder.builder()
+        .borderLayout()
         .addCenter(tabMainContents(settings))
         .addSouth(buttonPanel(settings, closeListener))
         .build();

--- a/src/test/java/swinglib/JPanelBuilderTest.java
+++ b/src/test/java/swinglib/JPanelBuilderTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
+import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
@@ -63,6 +64,11 @@ public class JPanelBuilderTest {
   }
 
   @Test
+  public void defaultLayoutIsFlowLayout() {
+    assertThat(JPanelBuilder.builder().build().getLayout(), instanceOf(FlowLayout.class));
+  }
+
+  @Test
   public void testLayouts() {
     final GridLayout result = (GridLayout) JPanelBuilder.builder()
         .gridLayout(1, 2)
@@ -71,7 +77,6 @@ public class JPanelBuilderTest {
     assertThat(result.getRows(), is(1));
     assertThat(result.getColumns(), is(2));
 
-
     assertThat(JPanelBuilder.builder()
         .gridBagLayout(2)
         .build()
@@ -79,9 +84,16 @@ public class JPanelBuilderTest {
         instanceOf(GridBagLayout.class));
 
     assertThat(JPanelBuilder.builder()
+        .flowLayout()
         .build()
         .getLayout(),
         instanceOf(FlowLayout.class));
+
+    assertThat(JPanelBuilder.builder()
+        .borderLayout()
+        .build()
+        .getLayout(),
+        instanceOf(BorderLayout.class));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the layout issue described in #2511.

9acfd00 (#2478) changed the default layout used by `JPanelBuilder` from `BorderLayout` to `FlowLayout`.  (This is actually a good change because the default layout used by `JPanel` is `FlowLayout`.)  This caused a few layout issues for callers that didn't explicitly specify their desired layout but relied on the default.

This PR adds an explicit call to `borderLayout()` to all `JPanelBuilder` instances where it is obvious the original author intended to use a `BorderLayout`.