### PR TITLE
AI: Add support for CanInvadeOnlyFrom

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -1176,9 +1176,8 @@ class ProNonCombatMoveAI {
         for (final Territory t : moveMap.keySet()) {
 
           // Check if land with adjacent sea that can be reached and that I'm not already adjacent to
-          final boolean territoryHasTransportableUnits =
-              Matches.territoryHasUnitsThatMatch(ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, false))
-                  .match(t);
+          final boolean territoryHasTransportableUnits = Matches.territoryHasUnitsThatMatch(
+              ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, false)).match(t);
           final int distance = data.getMap().getDistance_IgnoreEndForCondition(currentTerritory, t,
               ProMatches.territoryCanMoveSeaUnits(player, data, true));
           final boolean hasSeaNeighbor =

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -909,8 +909,8 @@ public class ProTerritoryManager {
             } else if (Matches.territoryHasEnemySeaUnits(player, data).invert().match(currentTerritory)) {
               final Set<Territory> possibleLoadTerritories = data.getMap().getNeighbors(currentTerritory);
               for (final Territory possibleLoadTerritory : possibleLoadTerritories) {
-                List<Unit> possibleUnits = possibleLoadTerritory.getUnits()
-                    .getMatches(ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, isCombatMove));
+                List<Unit> possibleUnits = possibleLoadTerritory.getUnits().getMatches(
+                    ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, myTransportUnit, isCombatMove));
                 if (isCheckingEnemyAttacks) {
                   possibleUnits = possibleLoadTerritory.getUnits()
                       .getMatches(ProMatches.unitIsOwnedCombatTransportableUnit(player));

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -501,10 +501,12 @@ public class ProMatches {
         Matches.unitCanNotMoveDuringCombatMove().invert(), Matches.unitCanMove());
   }
 
-  public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player,
+  public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player, final Unit transport,
       final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
+      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      if (isCombatMove
+          && (Matches.unitCanNotMoveDuringCombatMove().match(u) || !ua.canInvadeFrom(transport.getType().getName()))) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -506,7 +506,7 @@ public class ProMatches {
     return Match.of(u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
       if (isCombatMove
-          && (Matches.unitCanNotMoveDuringCombatMove().match(u) || !ua.canInvadeFrom(transport.getType().getName()))) {
+          && (Matches.unitCanNotMoveDuringCombatMove().match(u) || !ua.canInvadeFrom(transport))) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -48,8 +48,8 @@ public class ProTransportUtils {
       // Get all units that can be transported
       final List<Unit> units = new ArrayList<>();
       for (final Territory loadFrom : territoriesToLoadFrom) {
-        units.addAll(
-            loadFrom.getUnits().getMatches(ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, true)));
+        units.addAll(loadFrom.getUnits()
+            .getMatches(ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, true)));
       }
       units.removeAll(unitsToIgnore);
 
@@ -72,7 +72,7 @@ public class ProTransportUtils {
   public static List<Unit> getUnitsToTransportFromTerritories(final PlayerID player, final Unit transport,
       final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore) {
     return getUnitsToTransportFromTerritories(player, transport, territoriesToLoadFrom, unitsToIgnore,
-        ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, true));
+        ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, true));
   }
 
   // TODO: this needs fixed to consider whether a valid route exists to load all units

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -908,7 +908,7 @@ public class UnitAttachment extends DefaultAttachment {
         || m_canInvadeOnlyFrom[0].equals("all")) {
       return true;
     }
-    return Arrays.asList(m_canInvadeOnlyFrom).contains(transport);
+    return Arrays.asList(m_canInvadeOnlyFrom).contains(transport.getType().getName());
   }
 
   public void resetCanInvadeOnlyFrom() {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -903,16 +903,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canInvadeOnlyFrom;
   }
 
-  public boolean canInvadeFrom(final String transport) {
-    final UnitType ut = getData().getUnitTypeList().getUnitType(transport);
-    if (ut == null) {
-      throw new IllegalStateException("No unit called:" + transport + thisErrorMsg());
-    }
-    // (UnitAttachment) ut.getAttachments().values().iterator().next();
-    // UnitAttachment ua = UnitAttachment.get(ut);
-    // Units may be considered transported if they are on a carrier, or if they are paratroopers, or if they are mech
-    // infantry. The
-    // "transporter" may not be an actual transport, so we should not check for that here.
+  public boolean canInvadeFrom(final Unit transport) {
     if (m_canInvadeOnlyFrom == null || Arrays.asList(m_canInvadeOnlyFrom).isEmpty() || m_canInvadeOnlyFrom[0].equals("")
         || m_canInvadeOnlyFrom[0].equals("all")) {
       return true;

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2032,7 +2032,7 @@ public final class Matches {
         return true;
       }
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.canInvadeFrom(transport.getType().getName());
+      return ua.canInvadeFrom(transport);
     });
   }
 


### PR DESCRIPTION
Addresses AI issues mentioned here: https://forums.triplea-game.org/topic/349/non-amphibious-transports-confuse-ai

**Changes**
The AI now checks whether units that it is considering amphib assaulting with meet the CanInvadeOnlyFrom attribute.

**Testing**
Here is a save game with an edited German starting units. It has a bunch of transports that don't allow units to amphib. Before this change, the AI tries to invade UK but only attacks with planes as transports sit off the coast. After this change, the AI doesn't try to invade the UK since it can't amphib assault with any units.
[test.zip](https://github.com/triplea-game/triplea/files/1400788/test.zip)
