### PR TITLE
Add bug warning notice to lobby text

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -2,6 +2,11 @@
   host: 45.79.144.53
   port: 3304
   message: |
+    Bug in v7062 warning!  
+    The TripleA team is working on a next latest version of TripleA!
+    If you downloaded and installed TripleA between Oct 10th and Oct 19th,
+    please re-install to the latest to get a bug fix: github.com/triplea-game/triplea/releases/latest
+    
     Welcome to TripleA 1.9 - For help: http://www.triplea-game.org/help/
     No talking politics in the lobby! Take your political comments to a private game!
     Lobby Rules: https://forums.triplea-game.org/topic/4


### PR DESCRIPTION
Prepping a text update for lobby asking users to download a bug fix latest. Please do not merge for a day, let's see if we can get v7175 with a bug fix for #2511 marked as latest beforehand. I think the best case here is anyone would upgrade just once this way rather than rolling back first.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
