### PR TITLE
Checkstyle: Fix member name violations

### DIFF
--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -15,8 +15,8 @@ import games.strategy.util.Match;
 public class CompositeRouteFinder {
   private static final Logger logger = Logger.getLogger(CompositeRouteFinder.class.getName());
 
-  private final GameMap m_map;
-  private final Map<Match<Territory>, Integer> m_matches;
+  private final GameMap map;
+  private final Map<Match<Territory>, Integer> matches;
 
   /**
    * This class can find composite routes between two territories.
@@ -33,20 +33,20 @@ public class CompositeRouteFinder {
    *        - Set of matches and scores. The lower a match is scored, the more favorable it is.
    */
   public CompositeRouteFinder(final GameMap map, final Map<Match<Territory>, Integer> matches) {
-    m_map = map;
-    m_matches = matches;
+    this.map = map;
+    this.matches = matches;
     logger.finer("Initializing CompositeRouteFinderClass...");
   }
 
   Route findRoute(final Territory start, final Territory end) {
     final Set<Territory> allMatchingTers =
-        new HashSet<>(Matches.getMatches(m_map.getTerritories(), Match.anyOf(m_matches.keySet())));
+        new HashSet<>(Matches.getMatches(map.getTerritories(), Match.anyOf(matches.keySet())));
     final Map<Territory, Integer> terScoreMap = createScoreMap();
     final Map<Territory, Integer> routeScoreMap = new HashMap<>();
     int bestRouteToEndScore = Integer.MAX_VALUE;
     final Map<Territory, Territory> previous = new HashMap<>();
     List<Territory> routeLeadersToProcess = new ArrayList<>();
-    for (final Territory ter : m_map.getNeighbors(start, Matches.territoryIsInList(allMatchingTers))) {
+    for (final Territory ter : map.getNeighbors(start, Matches.territoryIsInList(allMatchingTers))) {
       final int routeScore = terScoreMap.get(start) + terScoreMap.get(ter);
       routeScoreMap.put(ter, routeScore);
       routeLeadersToProcess.add(ter);
@@ -55,7 +55,7 @@ public class CompositeRouteFinder {
     while (routeLeadersToProcess.size() > 0) {
       final List<Territory> newLeaders = new ArrayList<>();
       for (final Territory oldLeader : routeLeadersToProcess) {
-        for (final Territory ter : m_map.getNeighbors(oldLeader, Matches.territoryIsInList(allMatchingTers))) {
+        for (final Territory ter : map.getNeighbors(oldLeader, Matches.territoryIsInList(allMatchingTers))) {
           final int routeScore = routeScoreMap.get(oldLeader) + terScoreMap.get(ter);
           if (routeLeadersToProcess.contains(ter) || ter.equals(start)) {
             continue;
@@ -102,7 +102,7 @@ public class CompositeRouteFinder {
 
   private Map<Territory, Integer> createScoreMap() {
     final Map<Territory, Integer> result = new HashMap<>();
-    for (final Territory ter : m_map.getTerritories()) {
+    for (final Territory ter : map.getTerritories()) {
       result.put(ter, getTerScore(ter));
     }
     return result;
@@ -113,8 +113,8 @@ public class CompositeRouteFinder {
    */
   private int getTerScore(final Territory ter) {
     int bestMatchingScore = Integer.MAX_VALUE;
-    for (final Match<Territory> match : m_matches.keySet()) {
-      final int score = m_matches.get(match);
+    for (final Match<Territory> match : matches.keySet()) {
+      final int score = matches.get(match);
       if (score < bestMatchingScore) { // If this is a 'better' match
         if (match.match(ter)) {
           bestMatchingScore = score;

--- a/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -10,7 +10,7 @@ import games.strategy.engine.framework.GameObjectStreamFactory;
  * Please refer to the comments on GameObjectOutputStream.
  */
 public class GameObjectInputStream extends ObjectInputStream {
-  private final GameObjectStreamFactory m_dataSource;
+  private final GameObjectStreamFactory dataSource;
 
   /**
    * Creates new GameObjectReader.
@@ -22,12 +22,12 @@ public class GameObjectInputStream extends ObjectInputStream {
    */
   public GameObjectInputStream(final GameObjectStreamFactory dataSource, final InputStream input) throws IOException {
     super(input);
-    m_dataSource = dataSource;
+    this.dataSource = dataSource;
     enableResolveObject(true);
   }
 
   public GameData getData() {
-    return m_dataSource.getData();
+    return dataSource.getData();
   }
 
   @Override
@@ -39,7 +39,7 @@ public class GameObjectInputStream extends ObjectInputStream {
     // thus, in one vm you can add some units to a territory, and when you serialize the change
     // and look at the Territory object in another vm, the units have not been added
     if (obj instanceof GameData) {
-      return m_dataSource.getData();
+      return dataSource.getData();
     } else if ((obj instanceof GameObjectStreamData)) {
       return ((GameObjectStreamData) obj).getReference(getData());
     } else if (obj instanceof Unit) {
@@ -50,16 +50,16 @@ public class GameObjectInputStream extends ObjectInputStream {
   }
 
   private Object resolveUnit(final Unit unit) {
-    m_dataSource.getData().acquireReadLock();
+    dataSource.getData().acquireReadLock();
     try {
-      final Unit local = m_dataSource.getData().getUnits().get(unit.getId());
+      final Unit local = dataSource.getData().getUnits().get(unit.getId());
       if (local != null) {
         return local;
       }
       getData().getUnits().put(unit);
       return unit;
     } finally {
-      m_dataSource.getData().releaseReadLock();
+      dataSource.getData().releaseReadLock();
     }
   }
 }

--- a/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -12,30 +12,30 @@ import games.strategy.net.INode;
  * Tracks what Node in the networks is playing which roles in the game.
  */
 public class PlayerManager {
-  private final Map<String, INode> m_playerMapping;
+  private final Map<String, INode> playerMapping;
 
   public PlayerManager(final Map<String, INode> map) {
-    m_playerMapping = new HashMap<>(map);
+    playerMapping = new HashMap<>(map);
   }
 
   public Map<String, INode> getPlayerMapping() {
-    return new HashMap<>(m_playerMapping);
+    return new HashMap<>(playerMapping);
   }
 
   public boolean isEmpty() {
-    return m_playerMapping == null || m_playerMapping.isEmpty();
+    return playerMapping == null || playerMapping.isEmpty();
   }
 
   @Override
   public String toString() {
-    if (m_playerMapping == null || m_playerMapping.isEmpty()) {
+    if (playerMapping == null || playerMapping.isEmpty()) {
       return "empty";
     }
     final StringBuilder sb = new StringBuilder();
-    final Iterator<String> iter = m_playerMapping.keySet().iterator();
+    final Iterator<String> iter = playerMapping.keySet().iterator();
     while (iter.hasNext()) {
       final String key = iter.next();
-      final INode value = m_playerMapping.get(key);
+      final INode value = playerMapping.get(key);
       sb.append(key).append("=").append(value.getName());
       if (iter.hasNext()) {
         sb.append(", ");
@@ -45,11 +45,11 @@ public class PlayerManager {
   }
 
   public Set<INode> getNodes() {
-    return new HashSet<>(m_playerMapping.values());
+    return new HashSet<>(playerMapping.values());
   }
 
   public INode getNode(final String playerName) {
-    return m_playerMapping.get(playerName);
+    return playerMapping.get(playerName);
   }
 
   /**
@@ -58,17 +58,17 @@ public class PlayerManager {
    * @return whether the given node playing as anyone.
    */
   public boolean isPlaying(final INode node) {
-    return m_playerMapping.containsValue(node);
+    return playerMapping.containsValue(node);
   }
 
   public Set<String> getPlayers() {
-    return new HashSet<>(m_playerMapping.keySet());
+    return new HashSet<>(playerMapping.keySet());
   }
 
   public Set<String> getPlayedBy(final INode playerNode) {
     final Set<String> players = new HashSet<>();
-    for (final String player : m_playerMapping.keySet()) {
-      if (m_playerMapping.get(player).equals(playerNode)) {
+    for (final String player : playerMapping.keySet()) {
+      if (playerMapping.get(player).equals(playerNode)) {
         players.add(player);
       }
     }
@@ -88,20 +88,20 @@ public class PlayerManager {
   public PlayerID getRemoteOpponent(final INode localNode, final GameData data) {
     // find a local player
     PlayerID local = null;
-    for (final String player : m_playerMapping.keySet()) {
-      if (m_playerMapping.get(player).equals(localNode)) {
+    for (final String player : playerMapping.keySet()) {
+      if (playerMapping.get(player).equals(localNode)) {
         local = data.getPlayerList().getPlayerId(player);
         break;
       }
     }
     // we arent playing anyone, return any
     if (local == null) {
-      final String remote = m_playerMapping.keySet().iterator().next();
+      final String remote = playerMapping.keySet().iterator().next();
       return data.getPlayerList().getPlayerId(remote);
     }
     String any = null;
-    for (final String player : m_playerMapping.keySet()) {
-      if (!m_playerMapping.get(player).equals(localNode)) {
+    for (final String player : playerMapping.keySet()) {
+      if (!playerMapping.get(player).equals(localNode)) {
         any = player;
         final PlayerID remotePlayerId = data.getPlayerList().getPlayerId(player);
         if (!data.getRelationshipTracker().isAllied(local, remotePlayerId)) {

--- a/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -13,20 +13,20 @@ import games.strategy.util.Match;
 // TODO this class doesn't take movementcost into account... typically the shortest route is the fastest route, but not
 // always...
 class RouteFinder {
-  private final GameMap m_map;
-  private final Match<Territory> m_condition;
-  private final Map<Territory, Territory> m_previous;
+  private final GameMap map;
+  private final Match<Territory> condition;
+  private final Map<Territory, Territory> previous;
 
   RouteFinder(final GameMap map, final Match<Territory> condition) {
-    m_map = map;
-    m_condition = condition;
-    m_previous = new HashMap<>();
+    this.map = map;
+    this.condition = condition;
+    previous = new HashMap<>();
   }
 
   Route findRoute(final Territory start, final Territory end) {
-    final Set<Territory> startSet = m_map.getNeighbors(start, m_condition);
+    final Set<Territory> startSet = map.getNeighbors(start, condition);
     for (final Territory t : startSet) {
-      m_previous.put(t, start);
+      previous.put(t, start);
     }
     if (calculate(startSet, end)) {
       return getRoute(start, end);
@@ -37,10 +37,10 @@ class RouteFinder {
   private boolean calculate(final Set<Territory> startSet, final Territory end) {
     final Set<Territory> nextSet = new HashSet<>();
     for (final Territory t : startSet) {
-      final Set<Territory> neighbors = m_map.getNeighbors(t, m_condition);
+      final Set<Territory> neighbors = map.getNeighbors(t, condition);
       for (final Territory neighbor : neighbors) {
-        if (!m_previous.containsKey(neighbor)) {
-          m_previous.put(neighbor, t);
+        if (!previous.containsKey(neighbor)) {
+          previous.put(neighbor, t);
           if (neighbor.equals(end)) {
             return true;
           }
@@ -62,7 +62,7 @@ class RouteFinder {
         return null;
       }
       route.add(current);
-      current = m_previous.get(current);
+      current = previous.get(current);
     }
     route.add(start);
     Collections.reverse(route);

--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -23,35 +23,34 @@ import games.strategy.sound.ISound;
  * Default implementation of DelegateBridge.
  */
 public class DefaultDelegateBridge implements IDelegateBridge {
-  private final GameData m_data;
-  private final IGame m_game;
-  private final IDelegateHistoryWriter m_historyWriter;
-  private final RandomStats m_randomStats;
-  private final DelegateExecutionManager m_delegateExecutionManager;
-  private IRandomSource m_randomSource;
+  private final GameData gameData;
+  private final IGame game;
+  private final IDelegateHistoryWriter historyWriter;
+  private final RandomStats randomStats;
+  private final DelegateExecutionManager delegateExecutionManager;
+  private IRandomSource randomSource;
 
-  /** Creates new DefaultDelegateBridge. */
   public DefaultDelegateBridge(final GameData data, final IGame game, final IDelegateHistoryWriter historyWriter,
       final RandomStats randomStats, final DelegateExecutionManager delegateExecutionManager) {
-    m_data = data;
-    m_game = game;
-    m_historyWriter = historyWriter;
-    m_randomStats = randomStats;
-    m_delegateExecutionManager = delegateExecutionManager;
+    gameData = data;
+    this.game = game;
+    this.historyWriter = historyWriter;
+    this.randomStats = randomStats;
+    this.delegateExecutionManager = delegateExecutionManager;
   }
 
   @Override
   public GameData getData() {
-    return m_data;
+    return gameData;
   }
 
   @Override
   public PlayerID getPlayerId() {
-    return m_data.getSequence().getStep().getPlayerId();
+    return gameData.getSequence().getStep().getPlayerId();
   }
 
   public void setRandomSource(final IRandomSource randomSource) {
-    m_randomSource = randomSource;
+    this.randomSource = randomSource;
   }
 
   /**
@@ -61,16 +60,16 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public int getRandom(final int max, final PlayerID player, final DiceType diceType, final String annotation)
       throws IllegalArgumentException, IllegalStateException {
-    final int random = m_randomSource.getRandom(max, annotation);
-    m_randomStats.addRandom(random, player, diceType);
+    final int random = randomSource.getRandom(max, annotation);
+    randomStats.addRandom(random, player, diceType);
     return random;
   }
 
   @Override
   public int[] getRandom(final int max, final int count, final PlayerID player, final DiceType diceType,
       final String annotation) throws IllegalArgumentException, IllegalStateException {
-    final int[] randomValues = m_randomSource.getRandom(max, count, annotation);
-    m_randomStats.addRandom(randomValues, player, diceType);
+    final int[] randomValues = randomSource.getRandom(max, count, annotation);
+    randomStats.addRandom(randomValues, player, diceType);
     return randomValues;
   }
 
@@ -84,23 +83,23 @@ public class DefaultDelegateBridge implements IDelegateBridge {
       }
     }
     if (!change.isEmpty()) {
-      m_game.addChange(change);
+      game.addChange(change);
     }
   }
 
   @Override
   public String getStepName() {
-    return m_data.getSequence().getStep().getName();
+    return gameData.getSequence().getStep().getName();
   }
 
   @Override
   public IDelegateHistoryWriter getHistoryWriter() {
-    return m_historyWriter;
+    return historyWriter;
   }
 
   private Object getOutbound(final Object o) {
     final Class<?>[] interfaces = o.getClass().getInterfaces();
-    return m_delegateExecutionManager.createOutboundImplementation(o, interfaces);
+    return delegateExecutionManager.createOutboundImplementation(o, interfaces);
   }
 
   @Override
@@ -111,7 +110,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public IRemotePlayer getRemotePlayer(final PlayerID id) {
     try {
-      final Object implementor = m_game.getRemoteMessenger().getRemote(ServerGame.getRemoteName(id, m_data));
+      final Object implementor = game.getRemoteMessenger().getRemote(ServerGame.getRemoteName(id, gameData));
       return (IRemotePlayer) getOutbound(implementor);
     } catch (final MessengerException me) {
       throw new GameOverException("Game Over!");
@@ -121,33 +120,33 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public IDisplay getDisplayChannelBroadcaster() {
     final Object implementor =
-        m_game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getDisplayChannel(m_data));
+        game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getDisplayChannel(gameData));
     return (IDisplay) getOutbound(implementor);
   }
 
   @Override
   public ISound getSoundChannelBroadcaster() {
-    final Object implementor = m_game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getSoundChannel(m_data));
+    final Object implementor = game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getSoundChannel(gameData));
     return (ISound) getOutbound(implementor);
   }
 
   @Override
   public Properties getStepProperties() {
-    return m_data.getSequence().getStep().getProperties();
+    return gameData.getSequence().getStep().getProperties();
   }
 
   @Override
   public void leaveDelegateExecution() {
-    m_delegateExecutionManager.leaveDelegateExecution();
+    delegateExecutionManager.leaveDelegateExecution();
   }
 
   @Override
   public void enterDelegateExecution() {
-    m_delegateExecutionManager.enterDelegateExecution();
+    delegateExecutionManager.enterDelegateExecution();
   }
 
   @Override
   public void stopGameSequence() {
-    ((ServerGame) m_game).stopGameSequence();
+    ((ServerGame) game).stopGameSequence();
   }
 }

--- a/src/main/java/games/strategy/engine/display/DefaultDisplayBridge.java
+++ b/src/main/java/games/strategy/engine/display/DefaultDisplayBridge.java
@@ -3,18 +3,18 @@ package games.strategy.engine.display;
 import games.strategy.engine.data.GameData;
 
 public class DefaultDisplayBridge implements IDisplayBridge {
-  private final GameData m_gameData;
+  private final GameData gameData;
 
   /**
    * Constructs a DefaultDisplayBridge.
    */
   public DefaultDisplayBridge(final GameData gameData) {
     super();
-    m_gameData = gameData;
+    this.gameData = gameData;
   }
 
   @Override
   public GameData getGameData() {
-    return m_gameData;
+    return gameData;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -31,46 +31,46 @@ import games.strategy.sound.ISound;
 public abstract class AbstractGame implements IGame {
   protected static final String DISPLAY_CHANNEL = "games.strategy.engine.framework.AbstractGame.DISPLAY_CHANNEL";
   protected static final String SOUND_CHANNEL = "games.strategy.engine.framework.AbstractGame.SOUND_CHANNEL";
-  protected final GameData m_data;
-  protected final IMessenger m_messenger;
-  protected final IRemoteMessenger m_remoteMessenger;
-  protected final IChannelMessenger m_channelMessenger;
-  protected final Map<PlayerID, IGamePlayer> m_gamePlayers = new HashMap<>();
-  protected volatile boolean m_isGameOver = false;
-  protected final Vault m_vault;
-  protected IGameModifiedChannel m_gameModifiedChannel;
-  protected final PlayerManager m_playerManager;
-  protected boolean m_firstRun = true;
+  protected final GameData gameData;
+  protected final IMessenger messenger;
+  protected final IRemoteMessenger remoteMessenger;
+  protected final IChannelMessenger channelMessenger;
+  protected final Map<PlayerID, IGamePlayer> gamePlayers = new HashMap<>();
+  protected volatile boolean isGameOver = false;
+  protected final Vault vault;
+  protected IGameModifiedChannel gameModifiedChannel;
+  protected final PlayerManager playerManager;
+  protected boolean firstRun = true;
   protected final List<GameStepListener> gameStepListeners = new CopyOnWriteArrayList<>();
 
   protected AbstractGame(final GameData data, final Set<IGamePlayer> gamePlayers,
       final Map<String, INode> remotePlayerMapping, final Messengers messengers) {
-    m_data = data;
-    m_messenger = messengers.getMessenger();
-    m_remoteMessenger = messengers.getRemoteMessenger();
-    m_channelMessenger = messengers.getChannelMessenger();
-    m_vault = new Vault(m_channelMessenger);
+    gameData = data;
+    messenger = messengers.getMessenger();
+    remoteMessenger = messengers.getRemoteMessenger();
+    channelMessenger = messengers.getChannelMessenger();
+    vault = new Vault(channelMessenger);
     final Map<String, INode> allPlayers = new HashMap<>(remotePlayerMapping);
     for (final IGamePlayer player : gamePlayers) {
       // this is necessary for Server games, but not needed for client games.
-      allPlayers.put(player.getName(), m_messenger.getLocalNode());
+      allPlayers.put(player.getName(), messenger.getLocalNode());
     }
-    m_playerManager = new PlayerManager(allPlayers);
-    if (m_playerManager == null) {
+    playerManager = new PlayerManager(allPlayers);
+    if (playerManager == null) {
       throw new IllegalArgumentException("Player manager cant be null");
     }
     setupLocalPlayers(gamePlayers);
   }
 
   private void setupLocalPlayers(final Set<IGamePlayer> localPlayers) {
-    final PlayerList playerList = m_data.getPlayerList();
+    final PlayerList playerList = gameData.getPlayerList();
     for (final IGamePlayer gp : localPlayers) {
       final PlayerID player = playerList.getPlayerId(gp.getName());
-      m_gamePlayers.put(player, gp);
+      gamePlayers.put(player, gp);
       final IPlayerBridge bridge = new DefaultPlayerBridge(this);
       gp.initialize(bridge, player);
-      final RemoteName descriptor = ServerGame.getRemoteName(gp.getPlayerId(), m_data);
-      m_remoteMessenger.registerRemote(gp, descriptor);
+      final RemoteName descriptor = ServerGame.getRemoteName(gp.getPlayerId(), gameData);
+      remoteMessenger.registerRemote(gp, descriptor);
     }
   }
 
@@ -95,37 +95,37 @@ public abstract class AbstractGame implements IGame {
 
   @Override
   public GameData getData() {
-    return m_data;
+    return gameData;
   }
 
   @Override
   public Vault getVault() {
-    return m_vault;
+    return vault;
   }
 
   @Override
   public boolean isGameOver() {
-    return m_isGameOver;
+    return isGameOver;
   }
 
   @Override
   public IRemoteMessenger getRemoteMessenger() {
-    return m_remoteMessenger;
+    return remoteMessenger;
   }
 
   @Override
   public IChannelMessenger getChannelMessenger() {
-    return m_channelMessenger;
+    return channelMessenger;
   }
 
   @Override
   public IMessenger getMessenger() {
-    return m_messenger;
+    return messenger;
   }
 
   @Override
   public PlayerManager getPlayerManager() {
-    return m_playerManager;
+    return playerManager;
   }
 
   @Override
@@ -144,13 +144,13 @@ public abstract class AbstractGame implements IGame {
 
   @Override
   public void addDisplay(final IDisplay display) {
-    display.initialize(new DefaultDisplayBridge(m_data));
-    m_channelMessenger.registerChannelSubscriber(display, getDisplayChannel(getData()));
+    display.initialize(new DefaultDisplayBridge(gameData));
+    channelMessenger.registerChannelSubscriber(display, getDisplayChannel(getData()));
   }
 
   @Override
   public void removeDisplay(final IDisplay display) {
-    m_channelMessenger.unregisterChannelSubscriber(display, getDisplayChannel(getData()));
+    channelMessenger.unregisterChannelSubscriber(display, getDisplayChannel(getData()));
   }
 
   public static RemoteName getSoundChannel(final GameData data) {
@@ -159,11 +159,11 @@ public abstract class AbstractGame implements IGame {
 
   @Override
   public void addSoundChannel(final ISound soundChannel) {
-    m_channelMessenger.registerChannelSubscriber(soundChannel, getSoundChannel(getData()));
+    channelMessenger.registerChannelSubscriber(soundChannel, getSoundChannel(getData()));
   }
 
   @Override
   public void removeSoundChannel(final ISound soundChannel) {
-    m_channelMessenger.unregisterChannelSubscriber(soundChannel, getSoundChannel(getData()));
+    channelMessenger.unregisterChannelSubscriber(soundChannel, getSoundChannel(getData()));
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameObjectStreamFactory.java
+++ b/src/main/java/games/strategy/engine/framework/GameObjectStreamFactory.java
@@ -12,10 +12,10 @@ import games.strategy.engine.data.GameObjectOutputStream;
 import games.strategy.net.IObjectStreamFactory;
 
 public class GameObjectStreamFactory implements IObjectStreamFactory {
-  private GameData m_data;
+  private GameData gameData;
 
   public GameObjectStreamFactory(final GameData data) {
-    m_data = data;
+    gameData = data;
   }
 
   @Override
@@ -29,10 +29,10 @@ public class GameObjectStreamFactory implements IObjectStreamFactory {
   }
 
   public void setData(final GameData data) {
-    m_data = data;
+    gameData = data;
   }
 
   public GameData getData() {
-    return m_data;
+    return gameData;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/LocalPlayers.java
+++ b/src/main/java/games/strategy/engine/framework/LocalPlayers.java
@@ -8,21 +8,21 @@ import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.triplea.player.AbstractHumanPlayer;
 
 public class LocalPlayers {
-  protected final Set<IGamePlayer> m_localPlayers;
+  protected final Set<IGamePlayer> localPlayers;
 
   public LocalPlayers(final Set<IGamePlayer> localPlayers) {
-    m_localPlayers = localPlayers;
+    this.localPlayers = localPlayers;
   }
 
   public Set<IGamePlayer> getLocalPlayers() {
-    return Collections.unmodifiableSet(m_localPlayers);
+    return Collections.unmodifiableSet(localPlayers);
   }
 
   public boolean playing(final PlayerID id) {
     if (id == null) {
       return false;
     }
-    for (final IGamePlayer gamePlayer : m_localPlayers) {
+    for (final IGamePlayer gamePlayer : localPlayers) {
       if (gamePlayer.getPlayerId().equals(id) && AbstractHumanPlayer.class.isAssignableFrom(gamePlayer.getClass())) {
         return true;
       }

--- a/src/main/java/games/strategy/engine/framework/VerifiedRandomNumbers.java
+++ b/src/main/java/games/strategy/engine/framework/VerifiedRandomNumbers.java
@@ -3,30 +3,30 @@ package games.strategy.engine.framework;
 import games.strategy.triplea.formatter.MyFormatter;
 
 public class VerifiedRandomNumbers {
-  private final int[] m_values;
-  private final String m_annotation;
+  private final int[] values;
+  private final String annotation;
 
   public VerifiedRandomNumbers(final String annotation, final int[] values) {
-    m_values = values;
-    m_annotation = annotation;
+    this.values = values;
+    this.annotation = annotation;
   }
 
   @Override
   public String toString() {
-    return "Rolled :" + MyFormatter.asDice(m_values) + " for " + m_annotation;
+    return "Rolled :" + MyFormatter.asDice(values) + " for " + annotation;
   }
 
   /**
-   * @return Returns the m_annotation.
+   * @return Returns the annotation.
    */
   public String getAnnotation() {
-    return m_annotation;
+    return annotation;
   }
 
   /**
-   * @return Returns the m_values.
+   * @return Returns the values.
    */
   public int[] getValues() {
-    return m_values;
+    return values;
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in several non-serializable classes.  All changes simply remove the `m_` prefix from field names.