### PR TITLE
Clean up TestMapGameData

### DIFF
--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.xml;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicReference;
 
 import games.strategy.engine.data.GameData;
@@ -26,8 +27,6 @@ public enum TestMapGameData {
   GAME_EXAMPLE("GameExample.xml"),
   TWW("Total_World_War_Dec1941.xml");
 
-  private static final String TEST_MAP_XML_PATH = "src/test/resources/";
-
   private final String fileName;
 
   TestMapGameData(final String value) {
@@ -47,7 +46,7 @@ public enum TestMapGameData {
    * @throws Exception If an error occurs while loading the map.
    */
   public GameData getGameData() throws Exception {
-    try (InputStream is = new FileInputStream(TEST_MAP_XML_PATH + fileName)) {
+    try (InputStream is = new FileInputStream(Paths.get("src", "test", "resources", fileName).toFile())) {
       return new GameParser("game name").parse(is, new AtomicReference<>(), false);
     }
   }

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -28,15 +28,15 @@ public enum TestMapGameData {
 
   private static final String TEST_MAP_XML_PATH = "src/test/resources/";
 
-  private final String value;
+  private final String fileName;
 
   TestMapGameData(final String value) {
-    this.value = value;
+    this.fileName = value;
   }
 
   @Override
   public String toString() {
-    return value;
+    return fileName;
   }
 
   /**
@@ -47,7 +47,7 @@ public enum TestMapGameData {
    * @throws Exception If an error occurs while loading the map.
    */
   public GameData getGameData() throws Exception {
-    try (InputStream is = new FileInputStream(TEST_MAP_XML_PATH + value)) {
+    try (InputStream is = new FileInputStream(TEST_MAP_XML_PATH + fileName)) {
       return new GameParser("game name").parse(is, new AtomicReference<>(), false);
     }
   }

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.xml;
 
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -9,7 +8,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 
 /**
- * Enum providing all the constants to be used by other tests.
+ * The available maps for use during testing.
  */
 public enum TestMapGameData {
   BIG_WORLD_1942("big_world_1942_test.xml"),
@@ -40,11 +39,16 @@ public enum TestMapGameData {
     return value;
   }
 
-  private InputStream getInputStream() throws IOException {
-    return new FileInputStream(TEST_MAP_XML_PATH + value);
-  }
-
+  /**
+   * Gets the game data for the associated map.
+   *
+   * @return The game data for the associated map.
+   *
+   * @throws Exception If an error occurs while loading the map.
+   */
   public GameData getGameData() throws Exception {
-    return (new GameParser("game name")).parse(getInputStream(), new AtomicReference<>(), false);
+    try (InputStream is = new FileInputStream(TEST_MAP_XML_PATH + value)) {
+      return new GameParser("game name").parse(is, new AtomicReference<>(), false);
+    }
   }
 }

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.xml;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,9 +41,7 @@ public enum TestMapGameData {
   }
 
   private InputStream getInputStream() throws IOException {
-    final File f = new File(TEST_MAP_XML_PATH + value);
-    System.out.println("f .... => " + f.getAbsolutePath());
-    return new FileInputStream(f);
+    return new FileInputStream(TEST_MAP_XML_PATH + value);
   }
 
   public GameData getGameData() throws Exception {

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -13,18 +13,31 @@ import games.strategy.engine.data.GameParser;
  */
 public enum TestMapGameData {
   BIG_WORLD_1942("big_world_1942_test.xml"),
+
   IRON_BLITZ("iron_blitz_test.xml"),
+
   LHTR("lhtr_test.xml"),
+
   PACIFIC_INCOMPLETE("pacific_incomplete_test.xml"),
+
   PACT_OF_STEEL_2("pact_of_steel_2_test.xml"),
+
   REVISED("revised_test.xml"),
+
   VICTORY_TEST("victory_test.xml"),
+
   WW2V3_1941("ww2v3_1941_test.xml"),
+
   WW2V3_1942("ww2v3_1942_test.xml"),
+
   GLOBAL1940("ww2_g40_balanced.xml"),
+
   TEST("Test.xml"),
+
   DELEGATE_TEST("DelegateTest.xml"),
+
   GAME_EXAMPLE("GameExample.xml"),
+
   TWW("Total_World_War_Dec1941.xml");
 
   private final String fileName;


### PR DESCRIPTION
Just a bit of clean-up in `TestMapGameData`:

* Remove a debug trace statement that is responsible for about 100 lines of console output (specifically to reduce Travis log size in light of the fact that the JUnit 5 Gradle plugin does not currently redirect stdout/stderr).
* Fix a leaked input stream.
* A few other minor changes (see the commit list).