### PR TITLE
Checkstyle: Fix abbreviation violations in UiContext types

### DIFF
--- a/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -19,17 +19,17 @@ import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.PlayerManager;
 import games.strategy.engine.framework.IGame;
 import games.strategy.net.INode;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 
 public class PlayerChatRenderer extends DefaultListCellRenderer {
   private static final long serialVersionUID = -8195565028281374498L;
   private final IGame game;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   int maxIconCounter = 0;
   HashMap<String, List<Icon>> iconMap = new HashMap<>();
   HashMap<String, Set<String>> playerMap = new HashMap<>();
 
-  public PlayerChatRenderer(final IGame game, final IUIContext uiContext) {
+  public PlayerChatRenderer(final IGame game, final UiContext uiContext) {
     this.game = game;
     this.uiContext = uiContext;
     setIconMap();

--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -14,8 +14,8 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.image.UnitImageFactory;
-import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.TooltipProperties;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.util.LocalizeHtml;
 
 /**
@@ -91,7 +91,7 @@ public class UnitType extends NamedAttachable {
    * Will return a key of NULL for any units which we do not have art for.
    */
   public static Map<PlayerID, List<UnitType>> getAllPlayerUnitsWithImages(final GameData data,
-      final IUIContext uiContext, final boolean forceIncludeNeutralPlayer) {
+      final UiContext uiContext, final boolean forceIncludeNeutralPlayer) {
     final LinkedHashMap<PlayerID, List<UnitType>> unitTypes = new LinkedHashMap<>();
     data.acquireReadLock();
     try {
@@ -119,7 +119,7 @@ public class UnitType extends NamedAttachable {
   }
 
   private static List<UnitType> getPlayerUnitsWithImages(final PlayerID player, final GameData data,
-      final IUIContext uiContext) {
+      final UiContext uiContext) {
     final ArrayList<UnitType> unitTypes = new ArrayList<>();
     data.acquireReadLock();
     try {

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
@@ -135,7 +135,7 @@ public class NewGameChooser extends JDialog {
       notes.append("<p></p>");
       final String notesProperty = data.getProperties().get("notes", "");
       if (notesProperty != null && notesProperty.trim().length() != 0) {
-        // UIContext resource loader should be null (or potentially is still the last game we played's loader),
+        // AbstractUiContext resource loader should be null (or potentially is still the last game we played's loader),
         // so we send the map dir name so that our localizing of image links can get a new resource loader if needed
         notes.append(LocalizeHtml.localizeImgLinksInHtml(notesProperty.trim(), null, mapNameDir));
       }

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -32,9 +32,9 @@ import games.strategy.triplea.ai.weakAI.DoesNothingAI;
 import games.strategy.triplea.ai.weakAI.WeakAI;
 import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.triplea.ui.HeadlessUIContext;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.HeadlessUiContext;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.ui.display.TripleADisplay;
@@ -107,7 +107,7 @@ public class TripleA implements IGameLoader {
     }
     final LocalPlayers localPlayers = new LocalPlayers(players);
     if (headless) {
-      final IUIContext uiContext = new HeadlessUIContext();
+      final UiContext uiContext = new HeadlessUiContext();
       uiContext.setDefaultMapDir(game.getData());
       uiContext.setLocalPlayers(localPlayers);
       display = new HeadlessDisplay();

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
@@ -12,8 +12,8 @@ import javax.swing.WindowConstants;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
-import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.ui.SwingComponents;
 
 public class OddsCalculatorDialog extends JDialog {
@@ -55,7 +55,7 @@ public class OddsCalculatorDialog extends JDialog {
     taFrame.getUiContext().addShutdownWindow(dialog);
   }
 
-  OddsCalculatorDialog(final GameData data, final IUIContext context, final JFrame parent, final Territory location) {
+  OddsCalculatorDialog(final GameData data, final UiContext context, final JFrame parent, final Territory location) {
     super(parent, "Odds Calculator");
     panel = new OddsCalculatorPanel(data, context, location, this);
     getContentPane().setLayout(new BorderLayout());

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
@@ -55,9 +55,9 @@ public class OddsCalculatorDialog extends JDialog {
     taFrame.getUiContext().addShutdownWindow(dialog);
   }
 
-  OddsCalculatorDialog(final GameData data, final UiContext context, final JFrame parent, final Territory location) {
+  OddsCalculatorDialog(final GameData data, final UiContext uiContext, final JFrame parent, final Territory location) {
     super(parent, "Odds Calculator");
-    panel = new OddsCalculatorPanel(data, context, location, this);
+    panel = new OddsCalculatorPanel(data, uiContext, location, this);
     getContentPane().setLayout(new BorderLayout());
     getContentPane().add(panel, BorderLayout.CENTER);
     pack();

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -107,7 +107,7 @@ class OddsCalculatorPanel extends JPanel {
   private final JCheckBox amphibiousCheckBox = new JCheckBox("Battle is Amphibious");
   private final JCheckBox landBattleCheckBox = new JCheckBox("Land Battle");
   private final JCheckBox retreatWhenOnlyAirLeftCheckBox = new JCheckBox("Retreat when only air left");
-  private final UiContext context;
+  private final UiContext uiContext;
   private final GameData data;
   private final IOddsCalculator calculator;
   private PlayerUnitsPanel attackingUnitsPanel;
@@ -129,10 +129,10 @@ class OddsCalculatorPanel extends JPanel {
   private JList<String> territoryEffectsJList;
   private final WidgetChangedListener listenerPlayerUnitsPanel = () -> setWidgetActivation();
 
-  OddsCalculatorPanel(final GameData data, final UiContext context, final Territory location,
+  OddsCalculatorPanel(final GameData data, final UiContext uiContext, final Territory location,
       final Window parent) {
     this.data = data;
-    this.context = context;
+    this.uiContext = uiContext;
     this.location = location;
     this.parent = parent;
     calculateButton.setEnabled(false);
@@ -303,7 +303,7 @@ class OddsCalculatorPanel extends JPanel {
     orderOfLossesButton.addActionListener(e -> {
       final OrderOfLossesInputPanel oolPanel = new OrderOfLossesInputPanel(attackerOrderOfLosses,
           defenderOrderOfLosses, attackingUnitsPanel.getCategories(), defendingUnitsPanel.getCategories(),
-          landBattleCheckBox.isSelected(), context, data);
+          landBattleCheckBox.isSelected(), uiContext, data);
       if (JOptionPane.OK_OPTION == JOptionPane.showConfirmDialog(OddsCalculatorPanel.this, oolPanel,
           "Create Order Of Losses for each side", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE)) {
         if (OddsCalculator.isValidOrderOfLoss(oolPanel.getAttackerOrder(), data)) {
@@ -690,8 +690,8 @@ class OddsCalculatorPanel extends JPanel {
     defenderCombo.setRenderer(new PlayerRenderer());
     attackerCombo.setRenderer(new PlayerRenderer());
     swapSidesCombo.setRenderer(new PlayerRenderer());
-    defendingUnitsPanel = new PlayerUnitsPanel(data, context, true);
-    attackingUnitsPanel = new PlayerUnitsPanel(data, context, false);
+    defendingUnitsPanel = new PlayerUnitsPanel(data, uiContext, true);
+    attackingUnitsPanel = new PlayerUnitsPanel(data, uiContext, false);
     numRuns.setColumns(4);
     numRuns.setMin(1);
     numRuns.setMax(20000);
@@ -797,7 +797,7 @@ class OddsCalculatorPanel extends JPanel {
       super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
       final PlayerID id = (PlayerID) value;
       setText(id.getName());
-      setIcon(new ImageIcon(context.getFlagImageFactory().getSmallFlag(id)));
+      setIcon(new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(id)));
       return this;
     }
   }
@@ -820,16 +820,16 @@ class OddsCalculatorPanel extends JPanel {
   private static final class PlayerUnitsPanel extends JPanel {
     private static final long serialVersionUID = -1206338960403314681L;
     private final GameData data;
-    private final UiContext context;
+    private final UiContext uiContext;
     private final boolean defender;
     private boolean isLand = true;
     private List<UnitCategory> categories = null;
     private final List<WidgetChangedListener> listeners = new ArrayList<>();
     private final WidgetChangedListener listenerUnitPanel = () -> notifyListeners();
 
-    PlayerUnitsPanel(final GameData data, final UiContext context, final boolean defender) {
+    PlayerUnitsPanel(final GameData data, final UiContext uiContext, final boolean defender) {
       this.data = data;
-      this.context = context;
+      this.uiContext = uiContext;
       this.defender = defender;
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     }
@@ -900,7 +900,7 @@ class OddsCalculatorPanel extends JPanel {
       }
       for (final UnitCategory category : categories) {
         if (predicate.match(category.getType())) {
-          final UnitPanel upanel = new UnitPanel(context, category, costs);
+          final UnitPanel upanel = new UnitPanel(uiContext, category, costs);
           upanel.addChangeListener(listenerUnitPanel);
           add(upanel);
         }
@@ -965,15 +965,15 @@ class OddsCalculatorPanel extends JPanel {
 
   private static final class UnitPanel extends JPanel {
     private static final long serialVersionUID = 1509643150038705671L;
-    private final UiContext context;
+    private final UiContext uiContext;
     private final UnitCategory category;
     private final ScrollableTextField textField;
     private final List<WidgetChangedListener> listeners = new CopyOnWriteArrayList<>();
     private final ScrollableTextFieldListener listenerTextField = field -> notifyListeners();
 
-    UnitPanel(final UiContext context, final UnitCategory category, final IntegerMap<UnitType> costs) {
+    UnitPanel(final UiContext uiContext, final UnitCategory category, final IntegerMap<UnitType> costs) {
       this.category = category;
-      this.context = context;
+      this.uiContext = uiContext;
       textField = new ScrollableTextField(0, 512);
       textField.setShowMaxAndMin(false);
       textField.addChangeListener(listenerTextField);
@@ -986,7 +986,7 @@ class OddsCalculatorPanel extends JPanel {
 
 
       final Optional<Image> img =
-          this.context.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
+          this.uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
               category.hasDamageOrBombingUnitDamage(), category.getDisabled());
 
       final JLabel label = img.isPresent() ? new JLabel(new ImageIcon(img.get())) : new JLabel();
@@ -1038,7 +1038,7 @@ class OddsCalculatorPanel extends JPanel {
   private static final class OrderOfLossesInputPanel extends JPanel {
     private static final long serialVersionUID = 8815617685388156219L;
     private final GameData data;
-    private final UiContext context;
+    private final UiContext uiContext;
     private final List<UnitCategory> attackerCategories;
     private final List<UnitCategory> defenderCategories;
     private final JTextField attackerTextField;
@@ -1050,9 +1050,9 @@ class OddsCalculatorPanel extends JPanel {
 
     OrderOfLossesInputPanel(final String attackerOrder, final String defenderOrder,
         final List<UnitCategory> attackerCategories, final List<UnitCategory> defenderCategories, final boolean land,
-        final UiContext context, final GameData data) {
+        final UiContext uiContext, final GameData data) {
       this.data = data;
-      this.context = context;
+      this.uiContext = uiContext;
       this.land = land;
       this.attackerCategories = attackerCategories;
       this.defenderCategories = defenderCategories;
@@ -1186,7 +1186,7 @@ class OddsCalculatorPanel extends JPanel {
           final String toolTipText = "<html>" + category.getType().getName() + ":  "
               + category.getType().getTooltip(category.getOwner()) + "</html>";
           final Optional<Image> img =
-              context.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
+              uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
                   category.hasDamageOrBombingUnitDamage(), category.getDisabled());
           if (img.isPresent()) {
             final JButton button = new JButton(new ImageIcon(img.get()));

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -68,7 +68,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.UnitBattleComparator;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
@@ -107,7 +107,7 @@ class OddsCalculatorPanel extends JPanel {
   private final JCheckBox amphibiousCheckBox = new JCheckBox("Battle is Amphibious");
   private final JCheckBox landBattleCheckBox = new JCheckBox("Land Battle");
   private final JCheckBox retreatWhenOnlyAirLeftCheckBox = new JCheckBox("Retreat when only air left");
-  private final IUIContext context;
+  private final UiContext context;
   private final GameData data;
   private final IOddsCalculator calculator;
   private PlayerUnitsPanel attackingUnitsPanel;
@@ -129,7 +129,7 @@ class OddsCalculatorPanel extends JPanel {
   private JList<String> territoryEffectsJList;
   private final WidgetChangedListener listenerPlayerUnitsPanel = () -> setWidgetActivation();
 
-  OddsCalculatorPanel(final GameData data, final IUIContext context, final Territory location,
+  OddsCalculatorPanel(final GameData data, final UiContext context, final Territory location,
       final Window parent) {
     this.data = data;
     this.context = context;
@@ -820,14 +820,14 @@ class OddsCalculatorPanel extends JPanel {
   private static final class PlayerUnitsPanel extends JPanel {
     private static final long serialVersionUID = -1206338960403314681L;
     private final GameData data;
-    private final IUIContext context;
+    private final UiContext context;
     private final boolean defender;
     private boolean isLand = true;
     private List<UnitCategory> categories = null;
     private final List<WidgetChangedListener> listeners = new ArrayList<>();
     private final WidgetChangedListener listenerUnitPanel = () -> notifyListeners();
 
-    PlayerUnitsPanel(final GameData data, final IUIContext context, final boolean defender) {
+    PlayerUnitsPanel(final GameData data, final UiContext context, final boolean defender) {
       this.data = data;
       this.context = context;
       this.defender = defender;
@@ -965,13 +965,13 @@ class OddsCalculatorPanel extends JPanel {
 
   private static final class UnitPanel extends JPanel {
     private static final long serialVersionUID = 1509643150038705671L;
-    private final IUIContext context;
+    private final UiContext context;
     private final UnitCategory category;
     private final ScrollableTextField textField;
     private final List<WidgetChangedListener> listeners = new CopyOnWriteArrayList<>();
     private final ScrollableTextFieldListener listenerTextField = field -> notifyListeners();
 
-    UnitPanel(final IUIContext context, final UnitCategory category, final IntegerMap<UnitType> costs) {
+    UnitPanel(final UiContext context, final UnitCategory category, final IntegerMap<UnitType> costs) {
       this.category = category;
       this.context = context;
       textField = new ScrollableTextField(0, 512);
@@ -1038,7 +1038,7 @@ class OddsCalculatorPanel extends JPanel {
   private static final class OrderOfLossesInputPanel extends JPanel {
     private static final long serialVersionUID = 8815617685388156219L;
     private final GameData data;
-    private final IUIContext context;
+    private final UiContext context;
     private final List<UnitCategory> attackerCategories;
     private final List<UnitCategory> defenderCategories;
     private final JTextField attackerTextField;
@@ -1050,7 +1050,7 @@ class OddsCalculatorPanel extends JPanel {
 
     OrderOfLossesInputPanel(final String attackerOrder, final String defenderOrder,
         final List<UnitCategory> attackerCategories, final List<UnitCategory> defenderCategories, final boolean land,
-        final IUIContext context, final GameData data) {
+        final UiContext context, final GameData data) {
       this.data = data;
       this.context = context;
       this.land = land;

--- a/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -23,12 +23,12 @@ import games.strategy.triplea.ResourceLoader;
 import games.strategy.util.CountDownLatchHandler;
 
 
-public abstract class AbstractUIContext implements IUIContext {
+public abstract class AbstractUiContext implements UiContext {
 
   protected static final String UNIT_SCALE_PREF = "UnitScale";
   protected static final String MAP_SKIN_PREF = "MapSkin";
   protected static final String MAP_SCALE_PREF = "MapScale";
-  protected static final Logger logger = Logger.getLogger(AbstractUIContext.class.getName());
+  protected static final Logger logger = Logger.getLogger(AbstractUiContext.class.getName());
   protected static String mapDir;
   protected static final String LOCK_MAP = "LockMap";
   protected static final String SHOW_END_OF_TURN_REPORT = "ShowEndOfTurnReport";
@@ -70,14 +70,14 @@ public abstract class AbstractUIContext implements IUIContext {
    * Get the preferences for the map.
    */
   protected static Preferences getPreferencesForMap(final String mapName) {
-    return Preferences.userNodeForPackage(AbstractUIContext.class).node(mapName);
+    return Preferences.userNodeForPackage(AbstractUiContext.class).node(mapName);
   }
 
   /**
    * Get the preferences for the map or map skin.
    */
   protected static Preferences getPreferencesMapOrSkin(final String mapDir) {
-    return Preferences.userNodeForPackage(AbstractUIContext.class).node(mapDir);
+    return Preferences.userNodeForPackage(AbstractUiContext.class).node(mapDir);
   }
 
   protected static String getDefaultMapDir(final GameData data) {
@@ -193,8 +193,8 @@ public abstract class AbstractUIContext implements IUIContext {
     // If you are calling this method while holding a lock on an object, while the EDT is separately
     // waiting for that lock, then you have a deadlock.
     // A real life example: player disconnects while you have the battle calc open.
-    // Non-EDT thread does shutdown on IGame and UIContext, causing btl calc to shutdown, which calls the
-    // window closed event on the EDT, and waits for the lock on UIContext to removeShutdownWindow, meanwhile
+    // Non-EDT thread does shutdown on IGame and HeadedUiContext, causing btl calc to shutdown, which calls the
+    // window closed event on the EDT, and waits for the lock on HeadedUiContext to removeShutdownWindow, meanwhile
     // our non-EDT tries to dispose the battle panel, which requires the EDT with a invokeAndWait, resulting in a
     // deadlock.
     SwingUtilities.invokeLater(window::dispose);
@@ -276,13 +276,13 @@ public abstract class AbstractUIContext implements IUIContext {
 
   @Override
   public boolean getLockMap() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(LOCK_MAP, false);
   }
 
   @Override
   public void setLockMap(final boolean lockMap) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     prefs.putBoolean(LOCK_MAP, lockMap);
     try {
       prefs.flush();
@@ -293,13 +293,13 @@ public abstract class AbstractUIContext implements IUIContext {
 
   @Override
   public boolean getShowEndOfTurnReport() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(SHOW_END_OF_TURN_REPORT, true);
   }
 
   @Override
   public void setShowEndOfTurnReport(final boolean value) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     prefs.putBoolean(SHOW_END_OF_TURN_REPORT, value);
     try {
       prefs.flush();
@@ -310,13 +310,13 @@ public abstract class AbstractUIContext implements IUIContext {
 
   @Override
   public boolean getShowTriggeredNotifications() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(SHOW_TRIGGERED_NOTIFICATIONS, true);
   }
 
   @Override
   public void setShowTriggeredNotifications(final boolean value) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_NOTIFICATIONS, value);
     try {
       prefs.flush();
@@ -327,13 +327,13 @@ public abstract class AbstractUIContext implements IUIContext {
 
   @Override
   public boolean getShowTriggerChanceSuccessful() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(SHOW_TRIGGERED_CHANCE_SUCCESSFUL, true);
   }
 
   @Override
   public void setShowTriggerChanceSuccessful(final boolean value) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_CHANCE_SUCCESSFUL, value);
     try {
       prefs.flush();
@@ -344,13 +344,13 @@ public abstract class AbstractUIContext implements IUIContext {
 
   @Override
   public boolean getShowTriggerChanceFailure() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(SHOW_TRIGGERED_CHANCE_FAILURE, true);
   }
 
   @Override
   public void setShowTriggerChanceFailure(final boolean value) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUIContext.class);
+    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     prefs.putBoolean(SHOW_TRIGGERED_CHANCE_FAILURE, value);
     try {
       prefs.flush();

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -104,7 +104,7 @@ public class BattleDisplay extends JPanel {
   private final JPanel casualtiesInstantPanelAttacker = new JPanel();
   private final JLabel labelNoneAttacker = new JLabel("None");
   private final JLabel labelNoneDefender = new JLabel("None");
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final JLabel messageLabel = new JLabel();
   private final Action nullAction = SwingAction.of(" ", e -> {
   });
@@ -717,7 +717,7 @@ public class BattleDisplay extends JPanel {
 
   private static final class BattleModel extends DefaultTableModel {
     private static final long serialVersionUID = 6913324191512043963L;
-    private final IUIContext uiContext;
+    private final UiContext uiContext;
     private final GameData gameData;
     // is the player the aggressor?
     private final boolean attack;
@@ -746,7 +746,7 @@ public class BattleDisplay extends JPanel {
 
     BattleModel(final Collection<Unit> units, final boolean attack, final BattleType battleType,
         final GameData data, final Territory battleLocation, final Collection<TerritoryEffect> territoryEffects,
-        final boolean isAmphibious, final Collection<Unit> amphibiousLandAttackers, final IUIContext uiContext) {
+        final boolean isAmphibious, final Collection<Unit> amphibiousLandAttackers, final UiContext uiContext) {
       super(new Object[0][0], varDiceArray(data));
       this.uiContext = uiContext;
       gameData = data;
@@ -881,7 +881,7 @@ public class BattleDisplay extends JPanel {
     private TableData() {}
 
     TableData(final PlayerID player, final int count, final UnitType type, final boolean damaged,
-        final boolean disabled, final IUIContext uiContext) {
+        final boolean disabled, final UiContext uiContext) {
       this.count = count;
       icon = uiContext.getUnitImageFactory().getIcon(type, player, damaged, disabled);
     }
@@ -905,9 +905,9 @@ public class BattleDisplay extends JPanel {
     private final JPanel killed = new JPanel();
     private final JPanel damaged = new JPanel();
     private final GameData data;
-    private final IUIContext uiContext;
+    private final UiContext uiContext;
 
-    CasualtyNotificationPanel(final GameData data, final IUIContext uiContext) {
+    CasualtyNotificationPanel(final GameData data, final UiContext uiContext) {
       this.data = data;
       this.uiContext = uiContext;
       dice = new DicePanel(uiContext, data);

--- a/src/main/java/games/strategy/triplea/ui/DiceChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/DiceChooser.java
@@ -20,7 +20,7 @@ import games.strategy.ui.SwingAction;
 
 class DiceChooser extends JPanel {
   private static final long serialVersionUID = -3658408802544268998L;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private JPanel dicePanel;
   private final int[] random;
   private int diceCount = 0;
@@ -33,7 +33,7 @@ class DiceChooser extends JPanel {
   // private final GameData m_data;
   private int diceSides = 6;
 
-  DiceChooser(final IUIContext uiContext, final int numRolls, final int hitAt, final boolean hitOnlyIfEquals,
+  DiceChooser(final UiContext uiContext, final int numRolls, final int hitAt, final boolean hitOnlyIfEquals,
       final int diceSides) {
     this.uiContext = uiContext;
     this.numRolls = numRolls;

--- a/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -18,10 +18,10 @@ import games.strategy.triplea.delegate.Die;
 
 public class DicePanel extends JPanel {
   private static final long serialVersionUID = -7544999867518263506L;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final GameData data;
 
-  public DicePanel(final IUIContext uiContext, final GameData data) {
+  public DicePanel(final UiContext uiContext, final GameData data) {
     this.uiContext = uiContext;
     this.data = data;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -24,12 +24,12 @@ public class EditProductionPanel extends ProductionPanel {
   private static final long serialVersionUID = 5826523459539469173L;
 
   public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
-      final IUIContext uiContext) {
+      final UiContext uiContext) {
     return new EditProductionPanel(uiContext).show(id, parent, data, false, new IntegerMap<>());
   }
 
   /** Creates new EditProductionPanel. */
-  private EditProductionPanel(final IUIContext uiContext) {
+  private EditProductionPanel(final UiContext uiContext) {
     super(uiContext);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -24,7 +24,7 @@ public class ExtendedStats extends StatPanel {
   private static final long serialVersionUID = 2502397606419491543L;
   private IStat[] statsExtended = new IStat[] {};
 
-  public ExtendedStats(final GameData data, final IUIContext uiContext) {
+  public ExtendedStats(final GameData data, final UiContext uiContext) {
     super(data, uiContext);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -34,7 +34,7 @@ import games.strategy.triplea.util.Stopwatch;
 /**
  * A place to find images and map data for a ui.
  */
-public class UIContext extends AbstractUIContext {
+public class HeadedUiContext extends AbstractUiContext {
   protected MapData mapData;
   protected final TileImageFactory tileImageFactory = new TileImageFactory();
   protected final UnitImageFactory unitImageFactory = new UnitImageFactory();
@@ -49,7 +49,7 @@ public class UIContext extends AbstractUIContext {
   protected OptionalExtraBorderLevel extraTerritoryBorderLevel = OptionalExtraBorderLevel.LOW;
   protected Cursor cursor = Cursor.getDefaultCursor();
 
-  UIContext() {
+  HeadedUiContext() {
     super();
     mapImage = new MapImage();
   }

--- a/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
@@ -23,8 +23,8 @@ import games.strategy.triplea.util.Stopwatch;
 /**
  * Headless version, so that we don't get error in linux when the system has no graphics configuration.
  */
-public class HeadlessUIContext extends AbstractUIContext {
-  public HeadlessUIContext() {
+public class HeadlessUiContext extends AbstractUiContext {
+  public HeadlessUiContext() {
     super();
   }
 

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -41,7 +41,7 @@ public class IndividualUnitPanel extends JPanel {
   private int max = -1;
   private final JLabel leftToSelect = new JLabel();
   private final GameData gameData;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private ScrollableTextField textFieldPurelyForListening;
   private final ScrollableTextFieldListener countOptionalTextFieldListener;
   private final boolean showSelectAll;
@@ -56,7 +56,7 @@ public class IndividualUnitPanel extends JPanel {
    * unit.
    */
   IndividualUnitPanel(final Collection<Unit> units, final String title, final GameData data,
-      final IUIContext uiContext, final int max, final boolean showMinAndMax, final boolean showSelectAll,
+      final UiContext uiContext, final int max, final boolean showMinAndMax, final boolean showSelectAll,
       final ScrollableTextFieldListener optionalListener) {
     gameData = data;
     this.uiContext = uiContext;
@@ -83,7 +83,7 @@ public class IndividualUnitPanel extends JPanel {
    *        mapped to their individual max, then min, then current values
    */
   public IndividualUnitPanel(final HashMap<Unit, Triple<Integer, Integer, Integer>> unitsAndTheirMaxMinAndCurrent,
-      final String title, final GameData data, final IUIContext context, final int max, final boolean showMinAndMax,
+      final String title, final GameData data, final UiContext context, final int max, final boolean showMinAndMax,
       final boolean showSelectAll, final ScrollableTextFieldListener optionalListener) {
     gameData = data;
     uiContext = context;
@@ -228,13 +228,13 @@ public class IndividualUnitPanel extends JPanel {
     private static final Insets nullInsets = new Insets(0, 0, 0, 0);
     private final ScrollableTextFieldListener countTextFieldListener;
 
-    SingleUnitPanel(final Unit unit, final GameData data, final IUIContext uiContext,
+    SingleUnitPanel(final Unit unit, final GameData data, final UiContext uiContext,
         final ScrollableTextFieldListener textFieldListener, final int max, final int min,
         final boolean showMaxAndMin) {
       this(unit, data, uiContext, textFieldListener, max, min, 0, showMaxAndMin);
     }
 
-    SingleUnitPanel(final Unit unit, final GameData data, final IUIContext context,
+    SingleUnitPanel(final Unit unit, final GameData data, final UiContext context,
         final ScrollableTextFieldListener textFieldListener, final int max, final int min, final int currentValue,
         final boolean showMaxAndMin) {
       this.unit = unit;
@@ -253,8 +253,8 @@ public class IndividualUnitPanel extends JPanel {
 
       final boolean isDamaged = taUnit.getUnitDamage() > 0 || taUnit.getHits() > 0;
       final JLabel label = context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), data,
-          isDamaged ? IUIContext.UnitDamage.DAMAGED : IUIContext.UnitDamage.NOT_DAMAGED,
-          taUnit.getDisabled() ? IUIContext.UnitEnable.DISABLED : IUIContext.UnitEnable.ENABLED);
+          isDamaged ? UiContext.UnitDamage.DAMAGED : UiContext.UnitDamage.NOT_DAMAGED,
+          taUnit.getDisabled() ? UiContext.UnitEnable.DISABLED : UiContext.UnitEnable.ENABLED);
 
       add(label, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
           new Insets(0, 0, 0, 10), 0, 0));

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -83,10 +83,10 @@ public class IndividualUnitPanel extends JPanel {
    *        mapped to their individual max, then min, then current values
    */
   public IndividualUnitPanel(final HashMap<Unit, Triple<Integer, Integer, Integer>> unitsAndTheirMaxMinAndCurrent,
-      final String title, final GameData data, final UiContext context, final int max, final boolean showMinAndMax,
+      final String title, final GameData data, final UiContext uiContext, final int max, final boolean showMinAndMax,
       final boolean showSelectAll, final ScrollableTextFieldListener optionalListener) {
     gameData = data;
-    uiContext = context;
+    this.uiContext = uiContext;
     this.title = new JTextArea(title);
     this.title.setBackground(this.getBackground());
     this.title.setEditable(false);
@@ -108,7 +108,7 @@ public class IndividualUnitPanel extends JPanel {
       }
       final int thisMin = Math.max(0, entry.getValue().getSecond());
       final int thisCurrent = Math.max(thisMin, Math.min(thisMax, entry.getValue().getThird()));
-      entries.add(new SingleUnitPanel(entry.getKey(), gameData, uiContext, textFieldListener, thisMax, thisMin,
+      entries.add(new SingleUnitPanel(entry.getKey(), gameData, this.uiContext, textFieldListener, thisMax, thisMin,
           thisCurrent, showMinAndMax));
     }
     layoutEntries();
@@ -234,7 +234,7 @@ public class IndividualUnitPanel extends JPanel {
       this(unit, data, uiContext, textFieldListener, max, min, 0, showMaxAndMin);
     }
 
-    SingleUnitPanel(final Unit unit, final GameData data, final UiContext context,
+    SingleUnitPanel(final Unit unit, final GameData data, final UiContext uiContext,
         final ScrollableTextFieldListener textFieldListener, final int max, final int min, final int currentValue,
         final boolean showMaxAndMin) {
       this.unit = unit;
@@ -252,7 +252,7 @@ public class IndividualUnitPanel extends JPanel {
       setLayout(new GridBagLayout());
 
       final boolean isDamaged = taUnit.getUnitDamage() > 0 || taUnit.getHits() > 0;
-      final JLabel label = context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), data,
+      final JLabel label = uiContext.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), data,
           isDamaged ? UiContext.UnitDamage.DAMAGED : UiContext.UnitDamage.NOT_DAMAGED,
           taUnit.getDisabled() ? UiContext.UnitEnable.DISABLED : UiContext.UnitEnable.ENABLED);
 

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
@@ -41,7 +41,7 @@ public class IndividualUnitPanelGrouped extends JPanel {
   private final boolean showMinAndMax;
   private final JTextArea title;
   private final GameData gameData;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final Map<String, Collection<Unit>> unitsToChooseFrom;
   private final Collection<Tuple<String, IndividualUnitPanel>> entries =
       new ArrayList<>();
@@ -57,7 +57,7 @@ public class IndividualUnitPanelGrouped extends JPanel {
    * unit.
    */
   public IndividualUnitPanelGrouped(final Map<String, Collection<Unit>> unitsToChooseFrom, final GameData data,
-      final IUIContext uiContext, final String title, final int maxTotal, final boolean showMinAndMax,
+      final UiContext uiContext, final String title, final int maxTotal, final boolean showMinAndMax,
       final boolean showSelectAll) {
     gameData = data;
     this.uiContext = uiContext;

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -89,7 +89,7 @@ public class MapPanel extends ImageScrollerLargeView {
   private final BackgroundDrawer backgroundDrawer;
   private BufferedImage mouseShadowImage = null;
   private String movementLeftForCurrentUnits = "";
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final LinkedBlockingQueue<Tile> undrawnTiles = new LinkedBlockingQueue<>();
   private Map<Territory, List<Unit>> highlightedUnits;
   private Cursor hiddenCursor = null;
@@ -97,7 +97,7 @@ public class MapPanel extends ImageScrollerLargeView {
 
 
   /** Creates new MapPanel. */
-  public MapPanel(final GameData data, final MapPanelSmallView smallView, final IUIContext uiContext,
+  public MapPanel(final GameData data, final MapPanelSmallView smallView, final UiContext uiContext,
       final ImageScrollModel model, final Supplier<Integer> computeScrollSpeed) {
     super(uiContext.getMapData().getMapDimensions(), model);
     this.uiContext = uiContext;
@@ -226,7 +226,7 @@ public class MapPanel extends ImageScrollerLargeView {
     return undrawnTiles;
   }
 
-  private void recreateTiles(final GameData data, final IUIContext uiContext) {
+  private void recreateTiles(final GameData data, final UiContext uiContext) {
     this.tileManager.createTiles(new Rectangle(this.uiContext.getMapData().getMapDimensions()));
     this.tileManager.resetTiles(data, uiContext.getMapData());
   }
@@ -798,7 +798,7 @@ public class MapPanel extends ImageScrollerLargeView {
     tileManager.clearTerritoryOverlay(territory, gameData, uiContext.getMapData());
   }
 
-  public IUIContext getUiContext() {
+  public UiContext getUiContext() {
     return uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
+++ b/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
@@ -21,7 +21,7 @@ public class NotificationMessages {
   private final Properties properties = new Properties();
 
   protected NotificationMessages() {
-    final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
     if (url != null) {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -580,7 +580,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     private final Properties properties = new Properties();
 
     protected ObjectiveProperties() {
-      final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+      final ResourceLoader loader = AbstractUiContext.getResourceLoader();
       final URL url = loader.getResource(PROPERTY_FILE);
       if (url != null) {
         final Optional<InputStream> inputStream = UrlStreams.openStream(url);

--- a/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -23,17 +23,17 @@ public class PlayerChooser extends JOptionPane {
   private JList<PlayerID> list;
   private final PlayerList players;
   private final PlayerID defaultPlayer;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final boolean allowNeutral;
 
   // private JOptionPane m_pane;
   /** Creates new PlayerChooser. */
-  public PlayerChooser(final PlayerList players, final IUIContext uiContext, final boolean allowNeutral) {
+  public PlayerChooser(final PlayerList players, final UiContext uiContext, final boolean allowNeutral) {
     this(players, null, uiContext, allowNeutral);
   }
 
   /** Creates new PlayerChooser. */
-  public PlayerChooser(final PlayerList players, final PlayerID defaultPlayer, final IUIContext uiContext,
+  public PlayerChooser(final PlayerList players, final PlayerID defaultPlayer, final UiContext uiContext,
       final boolean allowNeutral) {
     setMessageType(JOptionPane.PLAIN_MESSAGE);
     setOptionType(JOptionPane.OK_CANCEL_OPTION);
@@ -87,9 +87,9 @@ public class PlayerChooser extends JOptionPane {
 
   private static final class PlayerChooserRenderer extends DefaultListCellRenderer {
     private static final long serialVersionUID = -2185921124436293304L;
-    private final IUIContext uiContext;
+    private final UiContext uiContext;
 
-    PlayerChooserRenderer(final IUIContext uiContext) {
+    PlayerChooserRenderer(final UiContext uiContext) {
       this.uiContext = uiContext;
     }
 

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -34,7 +34,7 @@ import games.strategy.util.Triple;
 public class PoliticalStateOverview extends JPanel {
   private static final long serialVersionUID = -8445782272897831080L;
   public static final String LABEL_SELF = "----";
-  private final UiContext uic;
+  private final UiContext uiContext;
   private final GameData data;
   private final boolean editable;
   private final Set<Triple<PlayerID, PlayerID, RelationshipType>> editChanges = new HashSet<>();
@@ -48,7 +48,7 @@ public class PoliticalStateOverview extends JPanel {
    *        uicontext to use to show this panel.
    */
   public PoliticalStateOverview(final GameData data, final UiContext uiContext, final boolean editable) {
-    this.uic = uiContext;
+    this.uiContext = uiContext;
     this.data = data;
     this.editable = editable;
     drawPoliticsUi();
@@ -201,7 +201,7 @@ public class PoliticalStateOverview extends JPanel {
    * @return the label representing this player
    */
   protected JLabel getPlayerLabel(final PlayerID player) {
-    return new JLabel(player.getName(), new ImageIcon(uic.getFlagImageFactory().getFlag(player)), JLabel.LEFT);
+    return new JLabel(player.getName(), new ImageIcon(uiContext.getFlagImageFactory().getFlag(player)), JLabel.LEFT);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -34,7 +34,7 @@ import games.strategy.util.Triple;
 public class PoliticalStateOverview extends JPanel {
   private static final long serialVersionUID = -8445782272897831080L;
   public static final String LABEL_SELF = "----";
-  private final IUIContext uic;
+  private final UiContext uic;
   private final GameData data;
   private final boolean editable;
   private final Set<Triple<PlayerID, PlayerID, RelationshipType>> editChanges = new HashSet<>();
@@ -47,7 +47,7 @@ public class PoliticalStateOverview extends JPanel {
    * @param uiContext
    *        uicontext to use to show this panel.
    */
-  public PoliticalStateOverview(final GameData data, final IUIContext uiContext, final boolean editable) {
+  public PoliticalStateOverview(final GameData data, final UiContext uiContext, final boolean editable) {
     this.uic = uiContext;
     this.data = data;
     this.editable = editable;

--- a/src/main/java/games/strategy/triplea/ui/PoliticsText.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsText.java
@@ -29,7 +29,7 @@ public class PoliticsText {
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
 
   protected PoliticsText() {
-    final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
 
     if (url != null) {

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -45,7 +45,7 @@ import swinglib.JDialogBuilder;
 public class ProductionPanel extends JPanel {
   private static final long serialVersionUID = -1539053979479586609L;
 
-  protected final IUIContext uiContext;
+  protected final UiContext uiContext;
   protected List<Rule> rules = new ArrayList<>();
   protected JLabel left = new JLabel();
   protected JButton done;
@@ -57,7 +57,7 @@ public class ProductionPanel extends JPanel {
 
 
   public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
-      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final IUIContext context) {
+      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext context) {
     return new ProductionPanel(context).show(id, parent, data, bid, initialPurchase);
   }
 
@@ -72,7 +72,7 @@ public class ProductionPanel extends JPanel {
     return prod;
   }
 
-  protected ProductionPanel(final IUIContext uiContext) {
+  protected ProductionPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -57,8 +57,8 @@ public class ProductionPanel extends JPanel {
 
 
   public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
-      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext context) {
-    return new ProductionPanel(context).show(id, parent, data, bid, initialPurchase);
+      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext uiContext) {
+    return new ProductionPanel(uiContext).show(id, parent, data, bid, initialPurchase);
   }
 
   private IntegerMap<ProductionRule> getProduction() {

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -44,7 +44,7 @@ public class ProductionRepairPanel extends JPanel {
   private static final long serialVersionUID = -6344711064699083729L;
   private final JFrame owner = null;
   private JDialog dialog;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final List<Rule> rules = new ArrayList<>();
   private final JLabel left = new JLabel();
   private JButton done;
@@ -55,7 +55,7 @@ public class ProductionRepairPanel extends JPanel {
 
   public static HashMap<Unit, IntegerMap<RepairRule>> getProduction(final PlayerID id,
       final Collection<PlayerID> allowedPlayersToRepair, final JFrame parent, final GameData data, final boolean bid,
-      final HashMap<Unit, IntegerMap<RepairRule>> initialPurchase, final IUIContext uiContext) {
+      final HashMap<Unit, IntegerMap<RepairRule>> initialPurchase, final UiContext uiContext) {
     return new ProductionRepairPanel(uiContext).show(id, allowedPlayersToRepair, parent, data, bid, initialPurchase);
   }
 
@@ -111,7 +111,7 @@ public class ProductionRepairPanel extends JPanel {
 
   /** Creates new ProductionRepairPanel. */
   // the constructor can be accessed by subclasses
-  public ProductionRepairPanel(final IUIContext uiContext) {
+  public ProductionRepairPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -42,7 +42,7 @@ public class ProductionTabsProperties {
 
   protected ProductionTabsProperties(final PlayerID playerId, final List<Rule> rules) {
     this.rules = rules;
-    final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
     String propertyFile = PROPERTY_FILE + "." + playerId.getName() + ".properties";
     URL url = loader.getResource(propertyFile);
     if (url == null) {

--- a/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -31,9 +31,9 @@ import games.strategy.util.IntegerMap;
  */
 public class SimpleUnitPanel extends JPanel {
   private static final long serialVersionUID = -3768796793775300770L;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public SimpleUnitPanel(final IUIContext uiContext) {
+  public SimpleUnitPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
   }

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -51,10 +51,10 @@ public class StatPanel extends AbstractStatPanel {
   private JTable statsTable;
   private Image statsImage = null;
   protected final Map<PlayerID, ImageIcon> mapPlayerImage = new HashMap<>();
-  protected IUIContext uiContext;
+  protected UiContext uiContext;
 
   /** Creates a new instance of StatPanel. */
-  public StatPanel(final GameData data, final IUIContext uiContext) {
+  public StatPanel(final GameData data, final UiContext uiContext) {
     super(data);
     this.uiContext = uiContext;
     dataModel = new StatTableModel();

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -33,12 +33,12 @@ public class TabbedProductionPanel extends ProductionPanel {
   private int rows;
   private int columns;
 
-  protected TabbedProductionPanel(final IUIContext uiContext) {
+  protected TabbedProductionPanel(final UiContext uiContext) {
     super(uiContext);
   }
 
   public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
-      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final IUIContext uiContext) {
+      final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext uiContext) {
     return new TabbedProductionPanel(uiContext).show(id, parent, data, bid, initialPurchase);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -20,7 +20,7 @@ import games.strategy.triplea.delegate.dataObjects.TechResults;
 public class TechResultsDisplay extends JPanel {
   private static final long serialVersionUID = -8303376983862918107L;
 
-  TechResultsDisplay(final TechResults msg, final IUIContext uiContext, final GameData data) {
+  TechResultsDisplay(final TechResults msg, final UiContext uiContext, final GameData data) {
     setLayout(new GridBagLayout());
     add(new JLabel("You got " + msg.getHits() + " hit" + (msg.getHits() != 1 ? "s" : "") + "."), new GridBagConstraints(
         0, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 5, 0), 0, 0));

--- a/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -30,7 +30,7 @@ import games.strategy.ui.SwingComponents;
 
 public class TerritoryDetailPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 1377022163587438988L;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final JButton showOdds = new JButton("Battle Calculator (Ctrl-B)");
   private Territory currentTerritory;
   private final TripleAFrame frame;
@@ -39,7 +39,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     return "Hover over or drag and drop from a territory to list those units in this panel";
   }
 
-  TerritoryDetailPanel(final MapPanel mapPanel, final GameData data, final IUIContext uiContext,
+  TerritoryDetailPanel(final MapPanel mapPanel, final GameData data, final UiContext uiContext,
       final TripleAFrame frame) {
     super(data);
     this.frame = frame;
@@ -99,7 +99,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     refresh();
   }
 
-  private static JPanel unitsInTerritoryPanel(final Collection<Unit> unitsInTerritory, final IUIContext uiContext) {
+  private static JPanel unitsInTerritoryPanel(final Collection<Unit> unitsInTerritory, final UiContext uiContext) {
     final JPanel panel = new JPanel();
     panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));

--- a/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -23,7 +23,7 @@ public class TooltipProperties {
   private final Properties properties = new Properties();
 
   protected TooltipProperties() {
-    final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
     if (url != null) {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1386,8 +1386,7 @@ public class TripleAFrame extends MainGameFrame {
   GameStepListener stepListener = (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
 
   private void updateStep() {
-    final UiContext context = uiContext;
-    if (context == null || context.isShutDown()) {
+    if (uiContext == null || uiContext.isShutDown()) {
       return;
     }
     data.acquireReadLock();

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -189,7 +189,7 @@ public class TripleAFrame extends MainGameFrame {
   private boolean inHistory = false;
   private boolean inGame = true;
   private HistorySynchronizer historySyncher;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final JPanel mapAndChatPanel;
   private ChatPanel chatPanel;
   private final CommentPanel commentPanel;
@@ -224,7 +224,7 @@ public class TripleAFrame extends MainGameFrame {
       }
     };
     this.addWindowListener(windowListener);
-    uiContext = new UIContext();
+    uiContext = new HeadedUiContext();
     uiContext.setDefaultMapDir(game.getData());
     uiContext.getMapData().verify(data);
     uiContext.setLocalPlayers(players);
@@ -1386,7 +1386,7 @@ public class TripleAFrame extends MainGameFrame {
   GameStepListener stepListener = (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
 
   private void updateStep() {
-    final IUIContext context = uiContext;
+    final UiContext context = uiContext;
     if (context == null || context.isShutDown()) {
       return;
     }
@@ -2019,7 +2019,7 @@ public class TripleAFrame extends MainGameFrame {
     return showMapOnlyAction;
   }
 
-  public IUIContext getUiContext() {
+  public UiContext getUiContext() {
     return uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -21,7 +21,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable.OptionalExtraBorderLevel;
 import games.strategy.util.CountDownLatchHandler;
 
-public interface IUIContext {
+public interface UiContext {
   Cursor getCursor();
 
   double getScale();

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -40,21 +40,21 @@ final class UnitChooser extends JPanel {
   private boolean allowMultipleHits = false;
   private JButton autoSelectButton;
   private JButton selectNoneButton;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private final Match<Collection<Unit>> match;
 
   UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent,
-      final boolean allowTwoHit, final IUIContext uiContext) {
+      final boolean allowTwoHit, final UiContext uiContext) {
     this(units, Collections.emptyList(), dependent, allowTwoHit, uiContext);
   }
 
   private UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
-      final Map<Unit, Collection<Unit>> dependent, final boolean allowTwoHit, final IUIContext uiContext) {
+      final Map<Unit, Collection<Unit>> dependent, final boolean allowTwoHit, final UiContext uiContext) {
     this(units, defaultSelections, dependent, false, false, allowTwoHit, uiContext);
   }
 
   private UnitChooser(final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits,
-      final IUIContext uiContext, final Match<Collection<Unit>> match) {
+      final UiContext uiContext, final Match<Collection<Unit>> match) {
     dependents = dependent;
     this.allowMultipleHits = allowMultipleHits;
     this.uiContext = uiContext;
@@ -62,7 +62,7 @@ final class UnitChooser extends JPanel {
   }
 
   UnitChooser(final Collection<Unit> units, final CasualtyList defaultSelections,
-      final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits, final IUIContext uiContext) {
+      final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits, final UiContext uiContext) {
     this(dependent, allowMultipleHits, uiContext, null);
     final List<Unit> combinedList = defaultSelections.getDamaged();
     // TODO: this adds it to the default selections list, is this intended?
@@ -73,7 +73,7 @@ final class UnitChooser extends JPanel {
 
   UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
-      final boolean categorizeTransportCost, final boolean allowMultipleHits, final IUIContext uiContext) {
+      final boolean categorizeTransportCost, final boolean allowMultipleHits, final UiContext uiContext) {
     this(dependent, allowMultipleHits, uiContext, null);
     createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
     layoutEntries();
@@ -82,7 +82,7 @@ final class UnitChooser extends JPanel {
   UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
       final boolean categorizeTransportCost, final boolean allowMultipleHits,
-      final IUIContext uiContext, final Match<Collection<Unit>> match) {
+      final UiContext uiContext, final Match<Collection<Unit>> match) {
     this(dependent, allowMultipleHits, uiContext, match);
     createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
     layoutEntries();
@@ -327,10 +327,10 @@ final class UnitChooser extends JPanel {
     private final List<JLabel> hitLabel = new ArrayList<>();
     private int leftToSelect = 0;
     private static final Insets nullInsets = new Insets(0, 0, 0, 0);
-    private final IUIContext uiContext;
+    private final UiContext uiContext;
 
     ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,
-        final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
+        final boolean allowTwoHit, final int defaultValue, final UiContext uiContext) {
       hitTextFieldListener = listener;
       this.category = category;
       this.leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
@@ -458,9 +458,9 @@ final class UnitChooser extends JPanel {
     private class UnitChooserEntryIcon extends JComponent {
       private static final long serialVersionUID = 591598594559651745L;
       private final boolean forceDamaged;
-      private final IUIContext uiContext;
+      private final UiContext uiContext;
 
-      UnitChooserEntryIcon(final boolean forceDamaged, final IUIContext uiContext) {
+      UnitChooserEntryIcon(final boolean forceDamaged, final UiContext uiContext) {
         this.forceDamaged = forceDamaged;
         this.uiContext = uiContext;
       }

--- a/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -28,7 +28,7 @@ public class UserActionText {
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
 
   protected UserActionText() {
-    final ResourceLoader loader = AbstractUIContext.getResourceLoader();
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
     if (url != null) {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);

--- a/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -79,8 +79,8 @@ public final class ScreenshotExporter {
         round = ((Round) curNode).getRoundNo();
       }
     }
-    final UiContext iuiContext = frame.getUiContext();
-    final double scale = iuiContext.getScale();
+    final UiContext uiContext = frame.getUiContext();
+    final double scale = uiContext.getScale();
     // print map panel to image
     final MapPanel mapPanel = frame.getMapPanel();
     final BufferedImage mapImage =
@@ -95,13 +95,13 @@ public final class ScreenshotExporter {
       mapPanel.drawMapImage(mapGraphics);
       mapPanel.setTopLeft(offsetX, offsetY);
       // overlay title
-      Color titleColor = iuiContext.getMapData().getColorProperty(MapData.PROPERTY_SCREENSHOT_TITLE_COLOR);
+      Color titleColor = uiContext.getMapData().getColorProperty(MapData.PROPERTY_SCREENSHOT_TITLE_COLOR);
       if (titleColor == null) {
         titleColor = Color.BLACK;
       }
-      final String encodedTitleX = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_X);
-      final String encodedTitleY = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_Y);
-      final String encodedTitleSize = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_FONT_SIZE);
+      final String encodedTitleX = uiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_X);
+      final String encodedTitleY = uiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_Y);
+      final String encodedTitleSize = uiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_FONT_SIZE);
       int titleX;
       int titleY;
       int titleSize;
@@ -121,7 +121,7 @@ public final class ScreenshotExporter {
       mapGraphics.setTransform(transform);
       mapGraphics.setFont(new Font("Ariel", Font.BOLD, titleSize));
       mapGraphics.setColor(titleColor);
-      if (iuiContext.getMapData().getBooleanProperty(MapData.PROPERTY_SCREENSHOT_TITLE_ENABLED)) {
+      if (uiContext.getMapData().getBooleanProperty(MapData.PROPERTY_SCREENSHOT_TITLE_ENABLED)) {
         mapGraphics.drawString(gameData.getGameName() + " Round " + round, titleX, titleY);
       }
 

--- a/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -18,9 +18,9 @@ import javax.swing.SwingUtilities;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
-import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.MapPanel;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
@@ -79,7 +79,7 @@ public final class ScreenshotExporter {
         round = ((Round) curNode).getRoundNo();
       }
     }
-    final IUIContext iuiContext = frame.getUiContext();
+    final UiContext iuiContext = frame.getUiContext();
     final double scale = iuiContext.getScale();
     // print map panel to image
     final MapPanel mapPanel = frame.getMapPanel();

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -32,7 +32,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Step;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 
 /**
  * Shows the history as a tree.
@@ -45,11 +45,9 @@ public class HistoryPanel extends JPanel {
   private HistoryNode currentPopupNode;
   private final JPopupMenu popup;
 
-  // private final UIContext m_uiContext;
   // private boolean m_lockBefore;
   public HistoryPanel(final GameData data, final IHistoryDetailsPanel details, final JPopupMenu popup,
-      final IUIContext uiContext) {
-    // m_uiContext = uiContext;
+      final UiContext uiContext) {
     mouseOverPanel = false;
     mouseWasOverPanel = false;
     final MouseListener mouseFocusListener = new MouseListener() {
@@ -400,9 +398,9 @@ public class HistoryPanel extends JPanel {
   private static final class HistoryTreeCellRenderer extends DefaultTreeCellRenderer {
     private static final long serialVersionUID = -72258573320689596L;
     private final ImageIcon icon = new ImageIcon();
-    private final IUIContext uiContext;
+    private final UiContext uiContext;
 
-    HistoryTreeCellRenderer(final IUIContext uiContext) {
+    HistoryTreeCellRenderer(final UiContext uiContext) {
       this.uiContext = uiContext;
     }
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -57,13 +57,13 @@ class ExportMenu {
 
   private final TripleAFrame frame;
   private final GameData gameData;
-  private final UiContext iuiContext;
+  private final UiContext uiContext;
   private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd");
 
   ExportMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {
     this.frame = frame;
     gameData = frame.getGame().getData();
-    iuiContext = frame.getUiContext();
+    uiContext = frame.getUiContext();
 
     final JMenu menuGame = new JMenu("Export");
     menuGame.setMnemonic(KeyEvent.VK_E);
@@ -140,7 +140,7 @@ class ExportMenu {
   }
 
   private void createAndSaveStats(final boolean showPhaseStats) {
-    final ExtendedStats statPanel = new ExtendedStats(gameData, iuiContext);
+    final ExtendedStats statPanel = new ExtendedStats(gameData, uiContext);
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
     final File rootDir = new File(System.getProperties().getProperty("user.dir"));
@@ -398,7 +398,7 @@ class ExportMenu {
       }
       try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
         writer.write(
-            HelpMenu.getUnitStatsTable(gameData, iuiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
+            HelpMenu.getUnitStatsTable(gameData, uiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
       } catch (final IOException e1) {
         ClientLogger.logQuietly(e1);
@@ -429,7 +429,7 @@ class ExportMenu {
       frame.pack();
       frame.setLocationRelativeTo(frame);
       frame.setVisible(true);
-      iuiContext.addShutdownWindow(frame);
+      uiContext.addShutdownWindow(frame);
 
     }));
     menuFileExport.setMnemonic(KeyEvent.VK_C);

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -44,8 +44,8 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.printgenerator.SetupFrame;
 import games.strategy.triplea.ui.ExtendedStats;
-import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.export.ScreenshotExporter;
 import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.triplea.util.PlayerOrderComparator;
@@ -57,7 +57,7 @@ class ExportMenu {
 
   private final TripleAFrame frame;
   private final GameData gameData;
-  private final IUIContext iuiContext;
+  private final UiContext iuiContext;
   private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd");
 
   ExportMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -43,7 +43,7 @@ import games.strategy.ui.SwingComponents;
 class GameMenu {
 
   private final TripleAFrame frame;
-  private final UiContext iuiContext;
+  private final UiContext uiContext;
   private final GameData gameData;
   private final IGame game;
 
@@ -51,7 +51,7 @@ class GameMenu {
     this.frame = frame;
     game = frame.getGame();
     gameData = frame.getGame().getData();
-    iuiContext = frame.getUiContext();
+    uiContext = frame.getUiContext();
 
     menuBar.add(createGameMenu());
   }
@@ -112,7 +112,7 @@ class GameMenu {
    */
   private void addPoliticsMenu(final JMenu menuGame) {
     final AbstractAction politicsAction = SwingAction.of("Show Politics Panel", e -> {
-      final PoliticalStateOverview ui = new PoliticalStateOverview(gameData, iuiContext, false);
+      final PoliticalStateOverview ui = new PoliticalStateOverview(gameData, uiContext, false);
       final JScrollPane scroll = new JScrollPane(ui);
       scroll.setBorder(BorderFactory.createEmptyBorder());
       final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
@@ -148,10 +148,10 @@ class GameMenu {
     notificationMenu.addMenuListener(new MenuListener() {
       @Override
       public void menuSelected(final MenuEvent e) {
-        showEndOfTurnReport.setSelected(iuiContext.getShowEndOfTurnReport());
-        showTriggeredNotifications.setSelected(iuiContext.getShowTriggeredNotifications());
-        showTriggerChanceSuccessful.setSelected(iuiContext.getShowTriggerChanceSuccessful());
-        showTriggerChanceFailure.setSelected(iuiContext.getShowTriggerChanceFailure());
+        showEndOfTurnReport.setSelected(uiContext.getShowEndOfTurnReport());
+        showTriggeredNotifications.setSelected(uiContext.getShowTriggeredNotifications());
+        showTriggerChanceSuccessful.setSelected(uiContext.getShowTriggerChanceSuccessful());
+        showTriggerChanceFailure.setSelected(uiContext.getShowTriggerChanceFailure());
       }
 
       @Override
@@ -160,13 +160,13 @@ class GameMenu {
       @Override
       public void menuCanceled(final MenuEvent e) {}
     });
-    showEndOfTurnReport.addActionListener(e -> iuiContext.setShowEndOfTurnReport(showEndOfTurnReport.isSelected()));
+    showEndOfTurnReport.addActionListener(e -> uiContext.setShowEndOfTurnReport(showEndOfTurnReport.isSelected()));
     showTriggeredNotifications.addActionListener(
-        e -> iuiContext.setShowTriggeredNotifications(showTriggeredNotifications.isSelected()));
+        e -> uiContext.setShowTriggeredNotifications(showTriggeredNotifications.isSelected()));
     showTriggerChanceSuccessful.addActionListener(
-        e -> iuiContext.setShowTriggerChanceSuccessful(showTriggerChanceSuccessful.isSelected()));
+        e -> uiContext.setShowTriggerChanceSuccessful(showTriggerChanceSuccessful.isSelected()));
     showTriggerChanceFailure.addActionListener(
-        e -> iuiContext.setShowTriggerChanceFailure(showTriggerChanceFailure.isSelected()));
+        e -> uiContext.setShowTriggerChanceFailure(showTriggerChanceFailure.isSelected()));
     notificationMenu.add(showEndOfTurnReport);
     notificationMenu.add(showTriggeredNotifications);
     notificationMenu.add(showTriggerChanceSuccessful);

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -32,9 +32,9 @@ import games.strategy.engine.random.RandomStatsDetails;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.oddsCalculator.ta.OddsCalculatorDialog;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.PoliticalStateOverview;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.VerifiedRandomNumbersDialog;
 import games.strategy.ui.IntTextField;
 import games.strategy.ui.SwingAction;
@@ -43,7 +43,7 @@ import games.strategy.ui.SwingComponents;
 class GameMenu {
 
   private final TripleAFrame frame;
-  private final IUIContext iuiContext;
+  private final UiContext iuiContext;
   private final GameData gameData;
   private final IGame game;
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -34,7 +34,7 @@ import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
@@ -42,10 +42,10 @@ import games.strategy.util.LocalizeHtml;
 
 public class HelpMenu {
 
-  private final IUIContext iuiContext;
+  private final UiContext iuiContext;
   private final GameData gameData;
 
-  HelpMenu(final JMenuBar menuBar, final IUIContext iuiContext, final GameData gameData, final Color backgroundColor) {
+  HelpMenu(final JMenuBar menuBar, final UiContext iuiContext, final GameData gameData, final Color backgroundColor) {
     this.iuiContext = iuiContext;
     this.gameData = gameData;
 
@@ -115,7 +115,7 @@ public class HelpMenu {
     })).setMnemonic(KeyEvent.VK_M);
   }
 
-  static String getUnitStatsTable(final GameData gameData, final IUIContext iuiContext) {
+  static String getUnitStatsTable(final GameData gameData, final UiContext iuiContext) {
     // html formatted string
     int i = 0;
     final String color1 = "ABABAB";
@@ -154,7 +154,7 @@ public class HelpMenu {
     return hints.toString();
   }
 
-  private static String getUnitImageUrl(final UnitType unitType, final PlayerID player, final IUIContext iuiContext) {
+  private static String getUnitImageUrl(final UnitType unitType, final PlayerID player, final UiContext iuiContext) {
     final UnitImageFactory unitImageFactory = iuiContext.getUnitImageFactory();
     if (player == null || unitImageFactory == null) {
       return "no image";

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -42,11 +42,11 @@ import games.strategy.util.LocalizeHtml;
 
 public class HelpMenu {
 
-  private final UiContext iuiContext;
+  private final UiContext uiContext;
   private final GameData gameData;
 
-  HelpMenu(final JMenuBar menuBar, final UiContext iuiContext, final GameData gameData, final Color backgroundColor) {
-    this.iuiContext = iuiContext;
+  HelpMenu(final JMenuBar menuBar, final UiContext uiContext, final GameData gameData, final Color backgroundColor) {
+    this.uiContext = uiContext;
     this.gameData = gameData;
 
     final JMenu helpMenu = new JMenu("Help");
@@ -115,7 +115,7 @@ public class HelpMenu {
     })).setMnemonic(KeyEvent.VK_M);
   }
 
-  static String getUnitStatsTable(final GameData gameData, final UiContext iuiContext) {
+  static String getUnitStatsTable(final GameData gameData, final UiContext uiContext) {
     // html formatted string
     int i = 0;
     final String color1 = "ABABAB";
@@ -128,7 +128,7 @@ public class HelpMenu {
       final Map<PlayerID, Map<UnitType, ResourceCollection>> costs =
           TuvUtils.getResourceCostsForTuv(gameData, true);
       final Map<PlayerID, List<UnitType>> playerUnitTypes =
-          UnitType.getAllPlayerUnitsWithImages(gameData, iuiContext, true);
+          UnitType.getAllPlayerUnitsWithImages(gameData, uiContext, true);
       for (final Map.Entry<PlayerID, List<UnitType>> entry : playerUnitTypes.entrySet()) {
         final PlayerID player = entry.getKey();
         hints.append("<p><table border=\"1\" bgcolor=\"" + color1 + "\">");
@@ -139,7 +139,7 @@ public class HelpMenu {
         for (final UnitType ut : entry.getValue()) {
           i++;
           hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
-              .append(">").append("<td>").append(getUnitImageUrl(ut, player, iuiContext)).append("</td>").append("<td>")
+              .append(">").append("<td>").append(getUnitImageUrl(ut, player, uiContext)).append("</td>").append("<td>")
               .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHtml())
               .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
         }
@@ -154,8 +154,8 @@ public class HelpMenu {
     return hints.toString();
   }
 
-  private static String getUnitImageUrl(final UnitType unitType, final PlayerID player, final UiContext iuiContext) {
-    final UnitImageFactory unitImageFactory = iuiContext.getUnitImageFactory();
+  private static String getUnitImageUrl(final UnitType unitType, final PlayerID player, final UiContext uiContext) {
+    final UnitImageFactory unitImageFactory = uiContext.getUnitImageFactory();
     if (player == null || unitImageFactory == null) {
       return "no image";
     }
@@ -173,7 +173,7 @@ public class HelpMenu {
       final JEditorPane editorPane = new JEditorPane();
       editorPane.setEditable(false);
       editorPane.setContentType("text/html");
-      editorPane.setText(getUnitStatsTable(gameData, iuiContext));
+      editorPane.setText(getUnitStatsTable(gameData, uiContext));
       editorPane.setCaretPosition(0);
       final JScrollPane scroll = new JScrollPane(editorPane);
       scroll.setBorder(BorderFactory.createEmptyBorder());

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -45,10 +45,10 @@ import games.strategy.engine.data.properties.PropertiesUI;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.TileImageFactory;
-import games.strategy.triplea.ui.AbstractUIContext;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.AbstractUiContext;
 import games.strategy.triplea.ui.PurchasePanel;
 import games.strategy.triplea.ui.TripleAFrame;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.screen.UnitsDrawer;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
 import games.strategy.ui.SwingAction;
@@ -59,7 +59,7 @@ class ViewMenu {
 
   private final GameData gameData;
   private final TripleAFrame frame;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
   ViewMenu(final JMenuBar menuBar, final TripleAFrame frame) {
     this.frame = frame;
@@ -247,13 +247,13 @@ class ViewMenu {
     mapSubMenu.setMnemonic(KeyEvent.VK_K);
     menuGame.add(mapSubMenu);
     final ButtonGroup mapButtonGroup = new ButtonGroup();
-    final Map<String, String> skins = AbstractUIContext.getSkins(frame.getGame().getData());
+    final Map<String, String> skins = AbstractUiContext.getSkins(frame.getGame().getData());
     mapSubMenu.setEnabled(skins.size() > 1);
     for (final String key : skins.keySet()) {
       final JMenuItem mapMenuItem = new JRadioButtonMenuItem(key);
       mapButtonGroup.add(mapMenuItem);
       mapSubMenu.add(mapMenuItem);
-      if (skins.get(key).equals(AbstractUIContext.getMapDir())) {
+      if (skins.get(key).equals(AbstractUiContext.getMapDir())) {
         mapMenuItem.setSelected(true);
       }
       mapMenuItem.addActionListener(e -> {

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -31,7 +31,7 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TerritoryOverLayDrawable.Operation;
 import games.strategy.triplea.ui.screen.drawable.BaseMapDrawable;
@@ -67,9 +67,9 @@ public class TileManager {
   private final Map<String, Set<IDrawable>> territoryDrawables = new HashMap<>();
   private final Map<String, Set<Tile>> territoryTiles = new HashMap<>();
   private final Collection<UnitsDrawer> allUnitDrawables = new ArrayList<>();
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public TileManager(final IUIContext uiContext) {
+  public TileManager(final UiContext uiContext) {
     this.uiContext = uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.image.MapImage;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
 import games.strategy.util.Match;
@@ -38,7 +38,7 @@ public class UnitsDrawer implements IDrawable {
   private final boolean disabled;
   private final boolean overflow;
   private final String territoryName;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
   private static UnitFlagDrawMode drawUnitNationMode = UnitFlagDrawMode.NEXT_TO;
 
   public enum PreferenceKeys {
@@ -53,7 +53,7 @@ public class UnitsDrawer implements IDrawable {
 
   public UnitsDrawer(final int count, final String unitType, final String playerName, final Point placementPoint,
       final int damaged, final int bombingUnitDamage, final boolean disabled, final boolean overflow,
-      final String territoryName, final IUIContext uiContext2) {
+      final String territoryName, final UiContext uiContext2) {
     this.count = count;
     this.unitType = unitType;
     this.playerName = playerName;

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -53,7 +53,7 @@ public class UnitsDrawer implements IDrawable {
 
   public UnitsDrawer(final int count, final String unitType, final String playerName, final Point placementPoint,
       final int damaged, final int bombingUnitDamage, final boolean disabled, final boolean overflow,
-      final String territoryName, final UiContext uiContext2) {
+      final String territoryName, final UiContext uiContext) {
     this.count = count;
     this.unitType = unitType;
     this.playerName = playerName;
@@ -63,7 +63,7 @@ public class UnitsDrawer implements IDrawable {
     this.disabled = disabled;
     this.overflow = overflow;
     this.territoryName = territoryName;
-    this.uiContext = uiContext2;
+    this.uiContext = uiContext;
   }
 
   public Point getPlacementPoint() {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
@@ -2,10 +2,10 @@ package games.strategy.triplea.ui.screen.drawable;
 
 import java.awt.Image;
 
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 
 public class BaseMapDrawable extends MapTileDrawable {
-  public BaseMapDrawable(final int x, final int y, final IUIContext uiContext) {
+  public BaseMapDrawable(final int x, final int y, final UiContext uiContext) {
     super(x, y, uiContext);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -9,15 +9,15 @@ import java.awt.geom.AffineTransform;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class CapitolMarkerDrawable implements IDrawable {
   private final String player;
   private final String location;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public CapitolMarkerDrawable(final PlayerID player, final Territory location, final IUIContext uiContext) {
+  public CapitolMarkerDrawable(final PlayerID player, final Territory location, final UiContext uiContext) {
     super();
     if (player == null) {
       throw new IllegalStateException("no player for capitol:" + location);

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -9,16 +9,16 @@ import java.awt.geom.AffineTransform;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 // Rewritten class to use country markers rather than shading for Convoy Centers/Routes.
 public class ConvoyZoneDrawable implements IDrawable {
   private final String player;
   private final String location;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public ConvoyZoneDrawable(final PlayerID player, final Territory location, final IUIContext uiContext) {
+  public ConvoyZoneDrawable(final PlayerID player, final Territory location, final UiContext uiContext) {
     super();
     this.player = player.getName();
     this.location = location.getName();

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -11,15 +11,15 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 // Class to use 'Faded' country markers for Kamikaze Zones.
 public class KamikazeZoneDrawable implements IDrawable {
   private final String location;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public KamikazeZoneDrawable(final Territory location, final IUIContext uiContext) {
+  public KamikazeZoneDrawable(final Territory location, final UiContext uiContext) {
     super();
     this.location = location.getName();
     this.uiContext = uiContext;

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -7,7 +7,7 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TileManager;
 
@@ -15,10 +15,10 @@ public abstract class MapTileDrawable implements IDrawable {
   protected boolean noImage = false;
   protected final int x;
   protected final int y;
-  protected final IUIContext uiContext;
+  protected final UiContext uiContext;
   protected boolean unscaled;
 
-  protected MapTileDrawable(final int x, final int y, final IUIContext uiContext) {
+  protected MapTileDrawable(final int x, final int y, final UiContext uiContext) {
     this.x = x;
     this.y = y;
     this.uiContext = uiContext;

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
@@ -6,8 +6,8 @@ import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.ui.UiContext;
 
 public class ReliefMapDrawable extends MapTileDrawable {
-  public ReliefMapDrawable(final int x, final int y, final UiContext context) {
-    super(x, y, context);
+  public ReliefMapDrawable(final int x, final int y, final UiContext uiContext) {
+    super(x, y, uiContext);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
@@ -3,10 +3,10 @@ package games.strategy.triplea.ui.screen.drawable;
 import java.awt.Image;
 
 import games.strategy.triplea.image.TileImageFactory;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 
 public class ReliefMapDrawable extends MapTileDrawable {
-  public ReliefMapDrawable(final int x, final int y, final IUIContext context) {
+  public ReliefMapDrawable(final int x, final int y, final UiContext context) {
     super(x, y, context);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -16,14 +16,14 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.image.MapImage;
-import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class TerritoryNameDrawable implements IDrawable {
   private final String territoryName;
-  private final IUIContext uiContext;
+  private final UiContext uiContext;
 
-  public TerritoryNameDrawable(final String territoryName, final IUIContext uiContext) {
+  public TerritoryNameDrawable(final String territoryName, final UiContext uiContext) {
     this.territoryName = territoryName;
     this.uiContext = uiContext;
   }

--- a/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -5,7 +5,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import games.strategy.triplea.ResourceLoader;
-import games.strategy.triplea.ui.AbstractUIContext;
+import games.strategy.triplea.ui.AbstractUiContext;
 
 public class LocalizeHtml {
   public static final String ASSET_IMAGE_FOLDER = "doc/images/";
@@ -58,7 +58,7 @@ public class LocalizeHtml {
    * resource loader.
    */
   public static String localizeImgLinksInHtml(final String htmlText) {
-    return localizeImgLinksInHtml(htmlText, AbstractUIContext.getResourceLoader(), null);
+    return localizeImgLinksInHtml(htmlText, AbstractUiContext.getResourceLoader(), null);
   }
 
   public static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader resourceLoader,


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in `IUIContext` and its subtypes by renaming them appropriately:

* `IUIContext` -> `UiContext`
* `AbstractUIContext` -> `AbstractUiContext`
* `HeadlessUIContext` -> `HeadlessUiContext`
* `UIContext` -> `HeadedUiContext`

I also standardized the names of variables of type `UiContext` to be `uiContext`.  Previously, there were inconsistent names used for variables of this type (e.g. `uiContext`, `iuiContext`, `context`, etc.).

These two changes were done in separate commits.  It might be easier to review them separately.

#### Testing

I don't think `UiContext` is used for anything related to RMI, but just to be safe, I tested a network game with a 3635 client.  No issues were observed.