### PR TITLE
Fix missing apiguardian-api type warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,9 +104,11 @@ dependencies {
 
     testCompile 'eu.codearte.catch-exception:catch-exception:2.0.0-ALPHA-1'
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
+    testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testCompile 'org.mockito:mockito-core:2.11.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
+    testCompile 'org.mockito:mockito-core:2.11.0'
+
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.1'
 }


### PR DESCRIPTION
After JUnit 5 was merged, I noticed numerous warnings similar to the following appear in the console:

```
junit-jupiter-api-5.0.1.jar(org/junit/jupiter/api/extension/ExtensionContext.class): warning: Cannot find annotation method 'status()' in type 'API': class file for org.apiguardian.api.API not found
warning: unknown enum constant Status.STABLE
  reason: class file for org.apiguardian.api.API$Status not found
```

JUnit 5 depends on apiguardian, but for some reason, the dependency doesn't seem to be transitive.

This PR simply adds an explicit dependency on apiguardian-api to get rid of the warnings.  I'm not sure if there is a better solution.