### PR TITLE
Remove unnecessary JaCoCo configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,13 +302,6 @@ checkstyleTest {
     source sourceSets.test.output.resourcesDir
 }
 
-jacocoTestReport {
-    reports {
-        xml.enabled true
-        html.enabled true
-    }
-}
-
 afterEvaluate {
     def junitPlatformTest = tasks.junitPlatformTest
 


### PR DESCRIPTION
The `jacocoTestReport` task is no longer used; we now use the `jacocoJunit5TestReport` task.