### PR TITLE
Ensure JUnit temporary folders are deleted

### DIFF
--- a/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
+++ b/src/test/java/org/junit/experimental/extensions/TemporaryFolder.java
@@ -17,6 +17,7 @@ public class TemporaryFolder {
   public File newFile(String name) throws IOException {
     File result = new File(rootFolder, name);
     result.createNewFile();
+    result.deleteOnExit();
     return result;
   }
 


### PR DESCRIPTION
I don't know if this only affects Linux, but I noticed my `/tmp` folder was filling up with directories named `junit5-*.tmp`.  Even though the `TemporaryFolder` class invokes `File#deleteOnExit()` on the temporary folder, the folders aren't being removed.  I believe this is because the folders still contain files, and `File#delete()` won't remove a non-empty directory.

The fix proposed in this PR is to ensure all files created within the temporary folder are also deleted upon JVM exit so the temporary folder will be empty when the JVM attempts to delete it.  This works because files are deleted in the reverse order in which they are registered.