### PR TITLE
Update map thumbnail image links to use GitHub

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -86,7 +86,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/total_world_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_total_world_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/total_world_war/master/description/TripleA_total_world_war_mini.png
   description: |
     <br><em><b style="font-size: x-large;">Created by Rolf Larsson and Hepster</b></em>
     <br>
@@ -153,7 +153,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/270bc/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_270BC_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/270bc/master/description/TripleA_270BC_mini.png
   description: |
     <br> by Dr.Che
     <br>270BC is a beautifully made fun map. With its slow and few units, and no air, but a very dynamic income situation, as well as nicely interlinked theaters of war, it plays refreshingly different.
@@ -226,7 +226,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_at_war/archive/master.zip
   version: 3
-  img: http://tripleamaps.sourceforge.net/images/TripleA_world_at_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_at_war/master/description/TripleA_world_at_war_mini.png
   description: |
     <br> by Sieg
     <br>
@@ -237,7 +237,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/the_rising_sun/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_the_rising_sun_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/the_rising_sun/master/description/TripleA_the_rising_sun_mini.png
   description: |
     <br>
     <br>=THE RISING SUN=
@@ -253,7 +253,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/diplomacy/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/diplomacy/master/description/TripleA_diplomacy_mini.png
   description: |
     <br>An adaptation of the game "Diplomacy" for TripleA.
     <br>Includes 3 Free-For-All (ffa) games, and 1 normal
@@ -280,7 +280,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_classic/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v1_classic_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_classic/master/description/TripleA_ww2v1_classic_mini.png
   description: |
     <br>
     <br>A classic edition of World War II
@@ -293,7 +293,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_revised/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_revised_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised/master/description/TripleA_ww2v2_revised_mini.png
   description: |
     <br>
     <br>A revised edition of World War II, including artillery support, and destroyer capabilities.
@@ -306,21 +306,21 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_v3/archive/master.zip
   version: 3
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_1941_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_v3/master/description/TripleA_ww2v3_1941_mini.png
   description: |
     <br>
     <h2>1942</h2>
-    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_1942_mini.png" alt="Thumbnail">
+    <img src="https://raw.githubusercontent.com/triplea-maps/world_war_ii_v3/master/description/TripleA_ww2v3_1942_mini.png" alt="Thumbnail">
     <br>
     <br>A new edition of World War II with new tech and units. Includes the two starting scenarios 1941 and 1942.
 - mapName: World War II v4
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_v4/archive/master.zip
   version: 3
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v4_1942_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_v4/master/description/TripleA_ww2v4_1942_mini.png
   description: |
     <br>
-    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v4_ffa_mini.png" alt="Thumbnail">
+    <img src="https://raw.githubusercontent.com/triplea-maps/world_war_ii_v4/master/description/TripleA_ww2v4_ffa_mini.png" alt="Thumbnail">
     <br>
     <br>The latest edition of World War II. Starting in 1942 with the World War II v3 rule set and a map similar to World War II v2 Revised.
     <br>Includes two 6-Army-Free-For-All variants.
@@ -328,7 +328,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_pacific/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2_pacific_1940_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_pacific/master/description/TripleA_ww2_pacific_1940_mini.png
   description: |
     <br>
     <br>World War II Pacific 1940
@@ -348,7 +348,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_europe/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2_europe_1940_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_europe/master/description/TripleA_ww2_europe_1940_mini.png
   description: |
     <br>
     <br>World War II Europe 1940
@@ -366,7 +366,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_global/archive/master.zip
   version: 10
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2_global_1940_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_global/master/description/TripleA_ww2_global_1940_mini.png
   description: |
     <br>
     <br>World War II Global 1940
@@ -388,7 +388,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_v5_1942/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v5_1942_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_v5_1942/master/description/TripleA_ww2v5_1942_mini.png
   description: |
     <br>Second edition update of the popular "Spring 1942" game (ww2v4), which itself was an update of "Revised" (ww2v2).
     <br>
@@ -404,7 +404,7 @@
   mapCategory: BEST
   url: https://github.com/triplea-maps/world_war_ii_v6_1941/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v6_1941_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_v6_1941/master/description/TripleA_ww2v6_1941_mini.png
   description: |
     <br>Simplified version of the WWIIv5 1942 scenario, with fewer territories, starting units and income.
     <br>Good for an easy game, and great for beginners.
@@ -438,7 +438,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/big_world_2/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_big_world2_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/big_world_2/master/description/TripleA_big_world2_mini.png
   description: |
     <br>Version 6.1.2, last update 2015.1.2 for engine 1.8.0.5
     <br>Mod done by Prussia.
@@ -473,7 +473,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/ultimate_world/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ultimate_world_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ultimate_world/master/description/TripleA_ultimate_world_mini.png
   description: |
     <br>
     Ultimate World
@@ -486,7 +486,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/battle_of_jutland/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_battle_of_jutland_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/battle_of_jutland/master/description/TripleA_battle_of_jutland_mini.png
   description: |
     <br> <b><em>by Veqryn</em></b>
     <br>
@@ -576,7 +576,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/red_sun_over_china/archive/master.zip
   version: 3
-  img: http://tripleamaps.sourceforge.net/images/TripleA_red_sun_over_china_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/red_sun_over_china/master/description/TripleA_red_sun_over_china_mini.png
   description: |
     <br>This is a mod based on the Second Sino-Japanese War, starting in January 1938.
     <br>Will the Japanese and their allies push into the interior of China or will the Nationalist and Communist Chinese and their allies resist the onslaught?
@@ -589,7 +589,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/feudal_japan/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_feudal_japan_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/feudal_japan/master/description/TripleA_feudal_japan_mini.png
   description: |
     <br>
     <div style="text-align: center;">
@@ -615,7 +615,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/battle_of_aventurica/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_battle_of_aventurica_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/battle_of_aventurica/master/description/TripleA_battle_of_aventurica_mini2.png
   description: |
     <br> by Nick Taylor
     <br>
@@ -625,7 +625,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/greyhawk_wars/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_greyhawk_wars_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/greyhawk_wars/master/description/TripleA_greyhawk_wars_mini.png
   description: |
     <br>by Panguitch
     <br>Version 1.0 for TripleA 1.8.0.5
@@ -644,7 +644,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/greyhawk/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_greyhawk_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/greyhawk/master/description/TripleA_greyhawk_mini.png
   description: |
     <br>by Panguitch
     <br>Version 0.9.9
@@ -674,7 +674,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/domination/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_domination_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/domination/master/description/TripleA_domination_mini.png
   description: |
     <br>
         An Anachronistic 20th century scenario based roughly on the years 1890-1914.
@@ -745,7 +745,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/twilight_imperium/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_twilight_imperium_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/twilight_imperium/master/description/TripleA_twilight_imperium_mini2.png
   description: |
     <br> by Geno33 (bpbull@shaw.ca)
     <br>
@@ -815,7 +815,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/pacific_challenge/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_pacific_challenge_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/pacific_challenge/master/description/TripleA_pacific_challenge_mini.png
   description: |
     <br>
     <br><b>Pacific_Theater_Solo_Challenge by Zim Xero </b>
@@ -825,7 +825,7 @@
 - mapName: Big World Variations
   url: https://github.com/triplea-maps/big_world_variations/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_big_world_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/big_world_variations/master/description/TripleA_big_world_mini.png
   description: |
     <br>Variations of BigWorld.
     <br>
@@ -839,7 +839,7 @@
 - mapName: NWO Variants
   url: https://github.com/triplea-maps/nwo_variants/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/nwo_variants/master/description/TripleA_new_world_order_mini.png
   description: |
     <br>
     <br>Includes 3 variants of New World Order
@@ -859,7 +859,7 @@
 - mapName: Pact of Steel Variations
   url: https://github.com/triplea-maps/pact_of_steel_variations/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_pact_of_steel_china_added_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/pact_of_steel_variations/master/description/TripleA_pact_of_steel_china_added_mini.png
   description: |
     <br>
     <br>1. adoy's version of PoS with China added.
@@ -875,10 +875,10 @@
   version: 2
   description: |
     <br>6 army ffa
-    <br><img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_ffa_mini.png" alt="Thumbnail">
+    <br><img src="https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised_variations/master/description/TripleA_ww2v2_ffa_mini.png" alt="Thumbnail">
     <br>
     <br>7 power ww2v2
-    <br><img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_7power_mini.png" alt="Thumbnail">
+    <br><img src="https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised_variations/master/description/TripleA_ww2v2_7power_mini.png" alt="Thumbnail">
     <br>
     <br>
     <br>1. Free-For-All for 6 players
@@ -906,7 +906,7 @@
 - mapName: Classic Variations
   url: https://github.com/triplea-maps/classic_variations/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v1_classic_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/classic_variations/master/description/TripleA_ww2v1_classic_mini.png
   description: |
     <br>
     <br>The mod pack is for the "World War II Classic" map, and you must have that map already installed to be able to use these mods and variants.
@@ -945,7 +945,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/world_war_ii_global-battlemap_skin/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2_global_1940_battlemap_skin_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war_ii_global-battlemap_skin/master/description/TripleA_ww2_global_1940_battlemap_skin_mini.png
   description: |
     <br>An alternative skin based on the ABattleMap program.
     <br>
@@ -954,7 +954,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/new_world_order-skin_sieg_2/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_siegSkin2_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/new_world_order-skin_sieg_2/master/description/TripleA_new_world_order_siegSkin2_mini.png
   description: |
     <div style="text-align: left;">
     	<br>
@@ -968,7 +968,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/new_world_order-skin_pulicat_1/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_pulicatSkin_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/new_world_order-skin_pulicat_1/master/description/TripleA_new_world_order_pulicatSkin_mini.png
   description: |
     <div style="text-align: left;">
     	<br>
@@ -982,7 +982,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/new_world_order-skin_gudkarma_1/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_gudkarmaSkin_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/new_world_order-skin_gudkarma_1/master/description/TripleA_new_world_order_gudkarmaSkin_mini.png
   description: |
     <div style="text-align: left;">
     	<br>
@@ -996,7 +996,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/diplomacy-map_skin1/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin1_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/diplomacy-map_skin1/master/description/TripleA_diplomacy_mapskin1_mini.png
   description: |
     <br>This is a MAP SKIN for "Diplomacy"
     <br>The original relief tiles, in all their glory, made by Veqryn.
@@ -1004,7 +1004,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/diplomacy-map_skin2/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin2_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/diplomacy-map_skin2/master/description/TripleA_diplomacy_mapskin2_mini.png
   description: |
     <br>This is a MAP SKIN for "Diplomacy"
     <br>Similar style to ww2v3 relief tiles, made by Bung, Veqryn, TripleElk, and Imperious Leader
@@ -1012,7 +1012,7 @@
   mapType: MAP_SKIN
   url: https://github.com/triplea-maps/diplomacy-map_skin3/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin3_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/diplomacy-map_skin3/master/description/TripleA_diplomacy_mapskin3_mini.png
   description: |
     <br>This is a MAP SKIN for "Diplomacy"
     <br>A very basic style.  I made this one for people who hate the cursive writing of the other 3 skins.  It has a simple font, no textures, and no cursive.
@@ -1020,7 +1020,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/world_at_war_variants/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_world_at_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_at_war_variants/master/description/TripleA_world_at_war_mini.png
   description: |
     <br>
     <br>v3 Variants of World At War (original map by Sieg)
@@ -1073,7 +1073,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/world_war2010/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_world_war_2010_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/world_war2010/master/description/TripleA_world_war_2010_mini.png
   description: |
     <br>The year is 2010.
     <br>
@@ -1096,7 +1096,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_global_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/global_war/master/description/TripleA_global_war_mini.png
   description: |
     <br>Global War
     <br>Created by Dagon81
@@ -1112,7 +1112,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_war2/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_global_war_2_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/global_war2/master/description/TripleA_global_war_2_mini.png
   description: |
     <br>Global War 2
     <br>Created by Dagon81
@@ -1122,7 +1122,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/new_world_order_lebowski_edition/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_nwo_1939_lebowski_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/new_world_order_lebowski_edition/master/description/TripleA_nwo_1939_lebowski_mini.png
   description: |
     <br>
     <br>A version of NWO by Lebowski.
@@ -1131,7 +1131,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ww2v3_11n/archive/master.zip
   version: 3
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_11nation_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ww2v3_11n/master/description/TripleA_ww2v3_11nation_mini.png
   description: |
     <br>World War II v3 11 Nation Mod
     <br>A mod of ww2v3 by Furyisback
@@ -1144,7 +1144,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ww2v3_variants/archive/master.zip
   version: 4
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_11nation_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ww2v3_variants/master/description/TripleA_ww2v3_11nation_mini.png
   description: |
     <br>10 Variants of World War II v3
     <br>
@@ -1183,7 +1183,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/atari/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_atari_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/atari/master/description/TripleA_atari_mini2.png
   description: |
     <br>
     <br>Atari - War in the Pacific
@@ -1194,7 +1194,7 @@
 - url: https://github.com/triplea-maps/ww2_phillipines/archive/master.zip
   mapCategory: EXPERIMENTAL
   mapName: WW2 Phillipines
-  img: http://tripleamaps.sourceforge.net/images/TripleA_atari_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/ww2_phillipines/master/description/TripleA_atari_mini2.png
   description: |
     <br>Created by Marshal
     <br>
@@ -1206,7 +1206,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/eastern_front/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_eastern_front_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/eastern_front/master/description/TripleA_eastern_front_mini.png
   description: |
     <br>Eastern Front by RODTHEGOD
     <br>with some help by Veqryn
@@ -1215,7 +1215,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/d-day/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_d-day_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/d-day/master/description/TripleA_d-day_mini.png
   description: |
     <br>A map of Normandy on D-Day.
     <br>D-Day Created by Dagon81
@@ -1229,7 +1229,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/d-day2/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_d-day_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/d-day2/master/description/TripleA_d-day_mini.png
   description: |
     <br>A map of Normandy on D-Day.
     <br>D-Day 2 created by Dagon81 and ZjelcoP
@@ -1240,7 +1240,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/arnhem/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_arnhem_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/arnhem/master/description/TripleA_arnhem_mini2.png
   description: |
     <br>Created by Dagon81
     <br>
@@ -1249,11 +1249,11 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/tactics_campaign/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_tactics_campaign_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/tactics_campaign/master/description/TripleA_tactics_campaign_mini2.png
   description: |
     <br> by sieg
     <br>
-    <img src="http://tripleamaps.sourceforge.net/images/TripleA_tactics_campaign_alt_mini2.png" alt="Thumbnail">
+    <img src="https://raw.githubusercontent.com/triplea-maps/tactics_campaign/master/description/TripleA_tactics_campaign_alt_mini2.png" alt="Thumbnail">
     <br>
     <br>
     <br>Very flexible package of small tactical hex-maps. Both good for fast games as well as well suited for modding. Only needs better adaption to the new TripleA to be
@@ -1263,7 +1263,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/neuschwabenland/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_neuschwabenland_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/neuschwabenland/master/description/TripleA_neuschwabenland_mini.png
   description: |
     <br>A simple map created by Sieg.
     <br>Comes with 4 games, (including 1 mod by DH).
@@ -1274,7 +1274,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/cold_war_asia1948/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_cold_war_asia_1948_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/cold_war_asia1948/master/description/TripleA_cold_war_asia_1948_mini.png
   description: |
     <br>created by demagogue
     <br>
@@ -1285,7 +1285,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/camp_david/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_camp_david_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/camp_david/master/description/TripleA_camp_david_mini2.png
   description: |
     <br>By Bas71
     <br>
@@ -1305,7 +1305,7 @@
   mapCategory: GOOD
   url: https://github.com/triplea-maps/cold_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_cold_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/cold_war/master/description/TripleA_cold_war_mini.png
   description: |
     <br>October 1962: Cuban Missle Crisis
     <br>
@@ -1319,7 +1319,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/the_great_northern_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_the_great_northern_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/the_great_northern_war/master/description/TripleA_the_great_northern_war_mini.png
   description: |
     <br>Created by Doctor Che
     <br>
@@ -1334,7 +1334,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/age_of_the_sturlungs/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_age_of_the_sturlungs_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/age_of_the_sturlungs/master/description/TripleA_age_of_the_sturlungs_mini.png
   description: |
     <br>
         this scenario loosely based somewhere around  the year 1226.
@@ -1344,7 +1344,7 @@
 - mapName: First Punic War
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/first_punic_war/archive/master.zip
-  img: http://tripleamaps.sourceforge.net/images/TripleA_first_punic_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/first_punic_war/master/description/TripleA_first_punic_war_mini.png
   description: |
     <br>
         A map of the First Punic War between Rome and Carthage.
@@ -1353,7 +1353,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ancient_times/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ancient_times_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ancient_times/master/description/TripleA_ancient_times_mini.png
   description: |
     <br>
     Make War to control ancient europe.
@@ -1361,7 +1361,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/war_of_the_lance/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_lance_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/war_of_the_lance/master/description/TripleA_war_of_the_lance_mini.png
   description: |
     <br>
     <br>War of the Lance
@@ -1373,7 +1373,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/rome_total_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_rome_total_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/rome_total_war/master/description/TripleA_rome_total_war_mini.png
   description: |
     <br>
     <br>Rome Total War
@@ -1405,7 +1405,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/1914-cow-empires/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_1914_cow_empires_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/1914-cow-empires/master/description/TripleA_1914_cow_empires_mini.png
   description: |
     <br>Version 1.0, last update 2014.12.07 for engine 1.8.0.3
     <br>Game done by RogerCooper
@@ -1425,7 +1425,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/blue_vs_gray/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_blue_vs_gray_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/blue_vs_gray/master/description/TripleA_blue_vs_gray_mini.png
   description: |
     <br>Version 1.0.4, last update 2015.01.03 for engine 1.8.0.5
     <br>Game done by humbabba
@@ -1459,7 +1459,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ur_quan_war_masters_edition/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ur-quan_slave_war_masters_edition_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ur_quan_war_masters_edition/master/description/TripleA_ur-quan_slave_war_masters_edition_mini.png
   description: |
     <br>
     <br>Ur-Quan Slave War: Masters Edition
@@ -1486,7 +1486,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/steampunk/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_Steampunk_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/steampunk/master/description/TripleA_Steampunk_mini.png
   description: |
     <br>
     <br>Large Map of 1915 Earth with some fictional locations.
@@ -1511,7 +1511,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/domination_1914_blood_and_steel/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_domination_1914_blood_and_steel_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/domination_1914_blood_and_steel/master/description/TripleA_domination_1914_blood_and_steel_mini.png
   description: |
     <br>by Navalland
     <br>Version 1.0 for TripleA 1.8.0.5
@@ -1545,7 +1545,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/feudal_japan_warlords/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_feudal_japan_warlords_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/feudal_japan_warlords/master/description/TripleA_feudal_japan_warlords_mini.png
   description: |
     <br>
     <br><b style="font-size: xx-large;"> Feudal Japan Warlords </b>
@@ -1573,7 +1573,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/war_of_the_relics/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_relics_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/war_of_the_relics/master/description/TripleA_war_of_the_relics_mini.png
   description: |
     <br>
     <br>Warning: This slow to load (can be ~30seconds per player)
@@ -1589,7 +1589,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/empire/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_empire_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/empire/master/description/TripleA_empire_mini.png
   description: |
     <br>
     <br>Empire
@@ -1605,7 +1605,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/total_ancient_war/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_total_ancient_war_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/total_ancient_war/master/description/TripleA_total_ancient_war_mini.png
   description: |
     <br>
     <br>Make yourself an empire around the Mediterranean Ocean (the known world), in the era when hellenes, romans and phoenicians ruled.
@@ -1629,7 +1629,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/elemental_forces/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_elemental_forces_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/elemental_forces/master/description/TripleA_elemental_forces_mini.png
   description: |
     <br>
     <br>An FFA map with a lot of features, like: terrain, unit classes, regional elements etc.
@@ -1648,7 +1648,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/game_of_thrones/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_game_of_thrones_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/game_of_thrones/master/description/TripleA_game_of_thrones_mini.png
   description: |
     <br>
     <br>An FFA map with the background of George R. R. Martins novel: A Song of Ice and Fire.
@@ -1661,7 +1661,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/new_world_order1915lebowski/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_nwo_1915_lebowski_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/new_world_order1915lebowski/master/description/TripleA_nwo_1915_lebowski_mini.png
   description: |
     <br>
     <br>WW1 map by Lebowski, based on Siegs New World Order map.
@@ -1672,7 +1672,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/stellar_forces/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_stellar_forces_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/stellar_forces/master/description/TripleA_stellar_forces_mini.png
   description: |
     <br>
     <br>A 4 Player FFA map about populating the Galaxy by Zim Xero.
@@ -1684,7 +1684,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/pacific/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_pacific_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/pacific/master/description/TripleA_pacific_mini.png
   description: |
     <br>
     <br>WW2 Pacific (WW2 Revised era)
@@ -1696,7 +1696,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/europe/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_europe_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/europe/master/description/TripleA_europe_mini.png
   description: |
     <br>
     <br>Original Europe Edition.
@@ -1709,7 +1709,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/zombieland/archive/master.zip
   version: 2
-  img: http://tripleamaps.sourceforge.net/images/TripleA_zombieland_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/zombieland/master/description/TripleA_zombieland_mini.png
   description: |
     <br>Created by Pulicat
     <br>The zombie apocalypse has arrived!
@@ -1721,7 +1721,7 @@
 - mapName: Hex Globe10
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/hex_globe10/archive/master.zip
-  img: http://tripleamaps.sourceforge.net/images/TripleA_hexglobe_mini2.png
+  img: https://raw.githubusercontent.com/triplea-maps/hex_globe10/master/description/TripleA_hexglobe_mini2.png
   description: |
     <br>HexGlobe10 is a 4 player game with no alliances.
     <br>
@@ -1748,7 +1748,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/jurassic/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_jurassic_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/jurassic/master/description/TripleA_jurassic_mini.png
   description: |
     <br>
     <p><b>Welcome to the world of dead reptiles and avian ancestors.</b></p>
@@ -1778,7 +1778,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ultimate_world_variants/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ultimate_world_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/ultimate_world_variants/master/description/TripleA_ultimate_world_mini.png
   description: |
     <br>
     Ultimate World Variants
@@ -1802,7 +1802,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_1940_redesign_house_rules/archive/master.zip
   version: 1
-  img: http://tripleamaps.sourceforge.net/images/TripleA_ww2_global_1940_mini.png
+  img: https://raw.githubusercontent.com/triplea-maps/global_1940_redesign_house_rules/master/description/TripleA_ww2_global_1940_mini.png
   description: |
     <br>
     <br>World War II Global 1940 Redesign Maps. Imagine your own combination of house rules for Global!


### PR DESCRIPTION
As reported in #2426, the intermittent loss of connectivity to SourceForge sometimes causes our builds to fail when running the `validateYamls` task.  All map thumbnail images hosted on SourceForge were moved to the appropriate GitHub repos in a previous set of PRs.  This PR updates the links in _triplea_maps.yaml_ to point to the GitHub resources instead of the SourceForge resources.

#### Testing

I ran the `validateYamls` task locally, and it reported no errors.

I selected each map in the Download Maps window to ensure the thumbnails were displayed correctly.