### PR TITLE
Extract assertNotThrows() method

### DIFF
--- a/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.startup.login;
 
+import static games.strategy.test.Assertions.assertNotThrows;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
@@ -58,11 +59,7 @@ public final class ClientLoginIntegrationTest {
       }
     };
 
-    try {
-      newClientMessenger(connectionLogin).shutDown();
-    } catch (final Exception e) {
-      throw new AssertionError(e);
-    }
+    assertNotThrows(() -> newClientMessenger(connectionLogin).shutDown());
   }
 
   private static class TestConnectionLogin extends ClientLogin {
@@ -118,11 +115,7 @@ public final class ClientLoginIntegrationTest {
   public void login_ShouldSucceedUsingHmacSha512AuthenticatorWhenPasswordMatches() {
     final IConnectionLogin connectionLogin = new TestConnectionLogin();
 
-    try {
-      newClientMessenger(connectionLogin).shutDown();
-    } catch (final Exception e) {
-      throw new AssertionError(e);
-    }
+    assertNotThrows(() -> newClientMessenger(connectionLogin).shutDown());
   }
 
   @Test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -29,12 +29,12 @@ public class EmailLimitIntegrationTest {
   }
 
   @Test
-  public void testAllowsMaximumLentgh() {
+  public void testAllowsMaximumLentgh() throws Exception {
     createAccountWithEmail(getStringWithLength(60) + "@" + getStringWithLength(193));
   }
 
   @Test
-  public void testAllowsMaximumLocalLength() {
+  public void testAllowsMaximumLocalLength() throws Exception {
     createAccountWithEmail(getStringWithLength(64) + "@" + getStringWithLength(189));
   }
 
@@ -42,15 +42,13 @@ public class EmailLimitIntegrationTest {
     return Strings.padStart(Util.createUniqueTimeStamp(), length, 'a');
   }
 
-  private static void createAccountWithEmail(final String email) {
+  private static void createAccountWithEmail(final String email) throws SQLException {
     try (PreparedStatement ps =
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
       ps.setString(3, MD5Crypt.crypt("password"));
       ps.execute();
-    } catch (final SQLException e) {
-      throw new AssertionError(e);
     }
   }
 

--- a/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -1,6 +1,8 @@
 package games.strategy.engine.lobby.server.login;
 
 import static games.strategy.engine.lobby.server.login.RsaAuthenticator.hashPasswordWithSalt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -13,6 +15,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
@@ -137,15 +141,8 @@ public class LobbyLoginValidatorIntegrationTest {
     assertError(generateChallenge(null).apply(challenge -> response), "user");
   }
 
-  private static void assertError(final String errorMessage, final String... strings) {
-    assertNotNull(errorMessage);
-    final String simpleError = errorMessage.trim().toLowerCase();
-    try {
-      assertTrue(Arrays.stream(strings).map(String::toLowerCase).allMatch(simpleError::contains));
-    } catch (final AssertionError e) {
-      throw new AssertionError(String.format("Error message '%s' did not contain all of those keywords: %s",
-          errorMessage, Arrays.toString(strings)), e);
-    }
+  private static void assertError(final @Nullable String errorMessage, final String... strings) {
+    Arrays.stream(strings).forEach(string -> assertThat(errorMessage, containsStringIgnoringCase(string)));
   }
 
   private interface ChallengeResultFunction

--- a/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.startup.login;
 
+import static games.strategy.test.Assertions.assertNotThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -164,11 +165,7 @@ public final class HmacSha512AuthenticatorTest {
     final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
     final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
 
-    try {
-      HmacSha512Authenticator.authenticate(PASSWORD, challenge, response);
-    } catch (final Exception e) {
-      throw new AssertionError(e);
-    }
+    assertNotThrows(() -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.startup.login;
 
+import static games.strategy.test.Assertions.assertNotThrows;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -128,11 +129,7 @@ public final class Md5CryptAuthenticatorTest {
     final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
     final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 
-    try {
-      Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response);
-    } catch (final Exception e) {
-      throw new AssertionError(e);
-    }
+    assertNotThrows(() -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
   }
 
   @Test

--- a/src/test/java/games/strategy/test/Assertions.java
+++ b/src/test/java/games/strategy/test/Assertions.java
@@ -1,0 +1,46 @@
+package games.strategy.test;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.function.Executable;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * A collection of utility methods that support asserting conditions in tests.
+ *
+ * <p>
+ * Unless otherwise noted, a failed assertion will throw an {@link AssertionFailedError} or a subclass thereof.
+ * </p>
+ */
+public final class Assertions {
+  private Assertions() {}
+
+  /**
+   * Asserts that execution of the supplied executable does not throw an exception.
+   *
+   * <p>
+   * If an exception is thrown, this method will fail.
+   * </p>
+   */
+  public static void assertNotThrows(final Executable executable) {
+    checkNotNull(executable);
+
+    try {
+      executable.execute();
+    } catch (final Throwable t) {
+      throw new AssertionFailedError(
+          String.format("Expected no exception to be thrown, but %s was thrown", getCanonicalName(t.getClass())));
+    }
+  }
+
+  private static String getCanonicalName(final Class<?> type) {
+    try {
+      final @Nullable String canonicalName = type.getCanonicalName();
+      return canonicalName != null ? canonicalName : type.getName();
+    } catch (final Throwable t) {
+      return type.getName();
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces the `g.s.test.Assertions.assertNotThrows()` method to replace explicit try-catch blocks used to assert a block of code does not throw an exception.

There were also two other changes in order to get rid of explicit `throw new AssertionError()` calls within test code.