### PR TITLE
Fix map blend rendering when zoom < 100%

### DIFF
--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -44,7 +45,7 @@ public final class TileImageFactory {
   private static final Logger logger = Logger.getLogger(TileImageFactory.class.getName());
   private double scale = 1.0;
   // maps image name to ImageRef
-  private HashMap<String, ImageRef> imageCache = new HashMap<>();
+  private Map<String, ImageRef> imageCache = new HashMap<>();
   private ResourceLoader resourceLoader;
 
   static {
@@ -77,7 +78,7 @@ public final class TileImageFactory {
     }
     synchronized (mutex) {
       scale = newScale;
-      getM_imageCache().clear();
+      imageCache.clear();
     }
   }
 
@@ -130,22 +131,22 @@ public final class TileImageFactory {
     synchronized (mutex) {
       // we manually want to clear each ref to allow the soft reference to
       // be removed
-      final Iterator<ImageRef> values = getM_imageCache().values().iterator();
+      final Iterator<ImageRef> values = imageCache.values().iterator();
       while (values.hasNext()) {
         final ImageRef imageRef = values.next();
         imageRef.clear();
       }
-      getM_imageCache().clear();
+      imageCache.clear();
     }
   }
 
   public TileImageFactory() {}
 
   private Image isImageLoaded(final String fileName) {
-    if (getM_imageCache().get(fileName) == null) {
+    if (imageCache.get(fileName) == null) {
       return null;
     }
-    return getM_imageCache().get(fileName).getImage();
+    return imageCache.get(fileName).getImage();
   }
 
   public Image getBaseTile(final int x, final int y) {
@@ -288,13 +289,13 @@ public final class TileImageFactory {
       g2.drawImage(baseFile, 0, 0, null);
       final ImageRef ref = new ImageRef(blendedImage);
       if (cache) {
-        getM_imageCache().put(fileName, ref);
+        imageCache.put(fileName, ref);
       }
       return blendedImage;
     } else {
       final ImageRef ref = new ImageRef(baseFile);
       if (cache) {
-        getM_imageCache().put(fileName, ref);
+        imageCache.put(fileName, ref);
       }
       return baseFile;
     }
@@ -331,7 +332,7 @@ public final class TileImageFactory {
     }
     final ImageRef ref = new ImageRef(image);
     if (cache) {
-      getM_imageCache().put(fileName, ref);
+      imageCache.put(fileName, ref);
     }
     return image;
   }
@@ -356,13 +357,5 @@ public final class TileImageFactory {
 
   public static BufferedImage createCompatibleImage(final int width, final int height) {
     return configuration.createCompatibleImage(width, height);
-  }
-
-  public void setM_imageCache(final HashMap<String, ImageRef> imageCache) {
-    this.imageCache = imageCache;
-  }
-
-  public HashMap<String, ImageRef> getM_imageCache() {
-    return imageCache;
   }
 }

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -277,24 +277,24 @@ public final class TileImageFactory {
     }
     /* reversing the to/from files leaves white underlays visible */
     if (reliefFile != null) {
-      final Graphics2D g2 = reliefFile.createGraphics();
+      final BufferedImage blendedImage =
+          new BufferedImage(reliefFile.getWidth(null), reliefFile.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+      final Graphics2D g2 = blendedImage.createGraphics();
       if (scale && m_scale != 1.0) {
         final AffineTransform transform = new AffineTransform();
         transform.scale(m_scale, m_scale);
         g2.setTransform(transform);
       }
       g2.drawImage(reliefFile, overX, overY, null);
-      // gets the blending mode from the map.properties file (sometimes)
       final BlendingMode blendMode = BlendComposite.BlendingMode.valueOf(getShowMapBlendMode());
       final BlendComposite blendComposite = BlendComposite.getInstance(blendMode).derive(alpha);
-      // g2.setComposite(BlendComposite.Overlay.derive(alpha));
       g2.setComposite(blendComposite);
       g2.drawImage(baseFile, overX, overY, null);
-      final ImageRef ref = new ImageRef(reliefFile);
+      final ImageRef ref = new ImageRef(blendedImage);
       if (cache) {
         getM_imageCache().put(fileName, ref);
       }
-      return reliefFile;
+      return blendedImage;
     } else {
       final ImageRef ref = new ImageRef(baseFile);
       if (cache) {

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -140,8 +140,6 @@ public final class TileImageFactory {
     }
   }
 
-  public TileImageFactory() {}
-
   private Image isImageLoaded(final String fileName) {
     if (imageCache.get(fileName) == null) {
       return null;

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -45,7 +45,7 @@ public final class TileImageFactory {
   private static final Logger logger = Logger.getLogger(TileImageFactory.class.getName());
   private double scale = 1.0;
   // maps image name to ImageRef
-  private Map<String, ImageRef> imageCache = new HashMap<>();
+  private final Map<String, ImageRef> imageCache = new HashMap<>();
   private ResourceLoader resourceLoader;
 
   static {

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -222,7 +222,6 @@ public final class TileImageFactory {
     return compatibleImage;
   }
 
-
   private Image loadImage(final URL imageLocation, final String fileName, final boolean transparent,
       final boolean cache, final boolean scale) {
     if (showMapBlends && showReliefImages && transparent) {
@@ -262,8 +261,6 @@ public final class TileImageFactory {
 
     // This does the blend
     final float alpha = getShowMapBlendAlpha();
-    final int overX = 0;
-    final int overY = 0;
     if (reliefFile == null) {
       try {
         reliefFile = loadCompatibleImage(urlBlankRelief);
@@ -285,11 +282,11 @@ public final class TileImageFactory {
         transform.scale(m_scale, m_scale);
         g2.setTransform(transform);
       }
-      g2.drawImage(reliefFile, overX, overY, null);
+      g2.drawImage(reliefFile, 0, 0, null);
       final BlendingMode blendMode = BlendComposite.BlendingMode.valueOf(getShowMapBlendMode());
       final BlendComposite blendComposite = BlendComposite.getInstance(blendMode).derive(alpha);
       g2.setComposite(blendComposite);
-      g2.drawImage(baseFile, overX, overY, null);
+      g2.drawImage(baseFile, 0, 0, null);
       final ImageRef ref = new ImageRef(blendedImage);
       if (cache) {
         getM_imageCache().put(fileName, ref);
@@ -370,5 +367,3 @@ public final class TileImageFactory {
     return m_imageCache;
   }
 }
-
-


### PR DESCRIPTION
This PR fixes the incorrect rendering of map blends when zoom < 100%, as reported in #2488.

When drawing a blended map tile, the renderer reuses the graphics context from the _unscaled_ relief image.  Using this graphics context, it first draws the _scaled_ relief image, and then draws the _scaled_ base image.  Thus, the resulting image is a composite of _three_ images:

* unscaled relief image
* scaled relief image
* scaled base image

The presence of the unscaled relief image is the root cause of the incorrect rendering artifacts observed when the zoom is less than 100%.

#### Functional changes

The fix is to create a new empty image on which to render the scaled relief and base images so that the unscaled relief image does not appear in the final composite image.  This fix is encapsulated in the first commit.

#### Refactoring changes

The second and subsequent commits contain a few minor refactorings.

#### Testing

##### Show Map Blends: Enabled; Zoom: 50%

![map-blends-zoom-50-fixed](https://user-images.githubusercontent.com/4826349/32017849-03021c6e-b996-11e7-8208-7a1633d08808.png)

####  Notes

It's probably easier to review the first commit in isolation to avoid the noise from the refactoring changes.  Then review the PR as a whole.