### PR TITLE
Add isSuicideOnHit Unit Attribute

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -15,6 +15,9 @@ import games.strategy.triplea.ai.proAI.logging.ProLogger;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 
+/**
+ * Takes all available purchase options, filters out those which the AI can't handle, and sorts them into categories.
+ */
 public class ProPurchaseOptionMap {
 
   private final List<ProPurchaseOption> landFodderOptions;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -63,7 +63,8 @@ public class ProPurchaseOptionMap {
       // Add rule to appropriate purchase option list
       if ((UnitAttachment.get(unitType).getMovement(player) <= 0
           && !(UnitAttachment.get(unitType).getCanProduceUnits()))
-          || Matches.unitTypeConsumesUnitsOnCreation().match(unitType) || UnitAttachment.get(unitType).getIsSuicide()) {
+          || Matches.unitTypeConsumesUnitsOnCreation().match(unitType) || UnitAttachment.get(unitType).getIsSuicide()
+          || UnitAttachment.get(unitType).getIsSuicideOnHit()) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);
         ProLogger.debug("Special: " + ppo);

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -92,6 +92,7 @@ public class UnitAttachment extends DefaultAttachment {
   private int m_unitSupportCount = -1;
   private int m_isMarine = 0;
   private boolean m_isSuicide = false;
+  private boolean m_isSuicideOnHit = false;
   private Tuple<Integer, String> m_attackingLimit = null;
   private int m_attackRolls = 1;
   private int m_defenseRolls = 1;
@@ -1735,6 +1736,24 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setIsSuicideOnHit(final String s) {
+    m_isSuicideOnHit = getBool(s);
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setIsSuicideOnHit(final boolean s) {
+    m_isSuicideOnHit = s;
+  }
+
+  public boolean getIsSuicideOnHit() {
+    return m_isSuicideOnHit;
+  }
+
+  public void resetIsSuicideOnHit() {
+    m_isSuicideOnHit = false;
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setIsKamikaze(final String s) {
     m_isKamikaze = getBool(s);
   }
@@ -2891,8 +2910,10 @@ public class UnitAttachment extends DefaultAttachment {
             : "null")
         + "  canOnlyBePlacedInTerritoryValuedAtX:" + m_canOnlyBePlacedInTerritoryValuedAtX + "  maxBuiltPerPlayer:"
         + m_maxBuiltPerPlayer + "  special:"
-        + (m_special != null ? (m_special.size() == 0 ? "empty" : m_special.toString()) : "null") + "  isSuicide:"
-        + m_isSuicide + "  isSuicide:" + m_isSuicide + "  isCombatTransport:" + m_isCombatTransport
+        + (m_special != null ? (m_special.size() == 0 ? "empty" : m_special.toString()) : "null")
+        + "  isSuicide:" + m_isSuicide
+        + "  isSuicideOnHit:" + m_isSuicideOnHit
+        + "  isCombatTransport:" + m_isCombatTransport
         + "  canInvadeOnlyFrom:"
         + (m_canInvadeOnlyFrom != null
             ? (m_canInvadeOnlyFrom.length == 0 ? "empty" : Arrays.toString(m_canInvadeOnlyFrom))
@@ -3159,6 +3180,9 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (getIsSuicide()) {
       stats.append("Suicide/Munition Unit, ");
+    }
+    if (getIsSuicideOnHit()) {
+      stats.append("SuicideOnHit Unit, ");
     }
     if (getIsAir() && (getIsKamikaze() || Properties.getKamikaze_Airplanes(getData()))) {
       stats.append("can use All Movement To Attack Target, ");

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -231,6 +231,7 @@ public class Fire implements IExecutable {
           m_battle.markDamaged(m_damaged, bridge);
         }
         m_battle.removeCasualties(m_killed, m_canReturnFire, !m_defending, bridge);
+        m_battle.removeSuicideOnHitCasualties(m_firingUnits, m_dice.getHits(), m_defending, bridge);
       }
     };
     stack.push(notifyCasualties);

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -531,6 +531,10 @@ public final class Matches {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicide());
   }
 
+  static Match<Unit> unitIsSuicideOnHit() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicideOnHit());
+  }
+
   static Match<Unit> unitIsKamikaze() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsKamikaze());
   }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1924,11 +1924,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         returnFire, "Subs defend, ");
   }
 
-  void removeSuicideOnHitCasualties(final Collection<Unit> killed, final int hits, final boolean defender,
+  void removeSuicideOnHitCasualties(final Collection<Unit> firingUnits, final int hits, final boolean defender,
       final IDelegateBridge bridge) {
-    if (Match.anyMatch(killed, Matches.unitIsSuicideOnHit()) && hits > 0) {
-      final List<Unit> units = killed.stream().limit(hits).collect(Collectors.toList());
-      removeCasualties(units, ReturnFire.NONE, defender, bridge);
+    if (Match.anyMatch(firingUnits, Matches.unitIsSuicideOnHit()) && hits > 0) {
+      final List<Unit> units = firingUnits.stream().limit(hits).collect(Collectors.toList());
+      getDisplay(bridge).deadUnitNotification(m_battleID, defender ? m_defender : m_attacker, units, m_dependentUnits);
+      remove(units, bridge, m_battleSite, defender);
     }
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -41,9 +41,9 @@ public class GameDataTestUtil {
   }
 
   /**
-   * Get the german PlayerID for the given GameData object.
+   * Get the germany PlayerID for the given GameData object.
    *
-   * @return A german PlayerID.
+   * @return A germany PlayerID.
    */
   public static PlayerID germany(final GameData data) {
     return data.getPlayerList().getPlayerId("Germany");
@@ -74,6 +74,15 @@ public class GameDataTestUtil {
    */
   public static PlayerID americans(final GameData data) {
     return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_AMERICANS);
+  }
+
+  /**
+   * Get the USA PlayerID for the given GameData object.
+   *
+   * @return A USA PlayerID.
+   */
+  public static PlayerID usa(final GameData data) {
+    return data.getPlayerList().getPlayerId("Usa");
   }
 
   /**
@@ -242,6 +251,20 @@ public class GameDataTestUtil {
    */
   public static UnitType germanRail(final GameData data) {
     return unitType("germanRail", data);
+  }
+
+  /**
+   * Returns a germanMine UnitType object for the specified GameData object.
+   */
+  public static UnitType germanMine(final GameData data) {
+    return unitType("germanMine", data);
+  }
+
+  /**
+   * Returns a americanCruiser UnitType object for the specified GameData object.
+   */
+  public static UnitType americanCruiser(final GameData data) {
+    return unitType("americanCruiser", data);
   }
 
   /**

--- a/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -1,0 +1,55 @@
+package games.strategy.triplea.delegate;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.move;
+import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.ITestDelegateBridge;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.random.ScriptedRandomSource;
+import games.strategy.triplea.player.ITripleAPlayer;
+import games.strategy.triplea.xml.TestMapGameData;
+
+public class MustFightBattleTest extends DelegateTest {
+
+  private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
+
+  @Test
+  public void testFightWithIsSuicideOnHit() throws Exception {
+
+    final GameData twwGameData = TestMapGameData.TWW.getGameData();
+
+    // Create battle with 1 cruiser attacking 1 mine
+    final PlayerID usa = GameDataTestUtil.usa(twwGameData);
+    final PlayerID germany = GameDataTestUtil.germany(twwGameData);
+    final Territory sz33 = territory("33 Sea Zone", twwGameData);
+    addTo(sz33, GameDataTestUtil.americanCruiser(twwGameData).create(1, usa));
+    final Territory sz40 = territory("40 Sea Zone", twwGameData);
+    addTo(sz40, GameDataTestUtil.germanMine(twwGameData).create(1, germany));
+    final ITestDelegateBridge bridge = GameDataTestUtil.getDelegateBridge(usa, twwGameData);
+    bridge.setStepName("CombatMove");
+    moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(twwGameData).start();
+    move(sz33.getUnits().getUnits(), new Route(sz33, sz40));
+    moveDelegate(twwGameData).end();
+    final MustFightBattle battle =
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40, false, null);
+    bridge.setRemote(dummyPlayer);
+
+    // Set first roll to hit (mine AA) and check that both units are killed
+    final ScriptedRandomSource randomSource = new ScriptedRandomSource(0, ScriptedRandomSource.ERROR);
+    bridge.setRandomSource(randomSource);
+    battle.fight(bridge);
+    assertEquals(1, randomSource.getTotalRolled());
+    assertEquals(0, sz40.getUnits().size());
+  }
+
+}

--- a/src/test/resources/Total_World_War_Dec1941.xml
+++ b/src/test/resources/Total_World_War_Dec1941.xml
@@ -1893,6 +1893,7 @@
   <unitList>
     <unit name="germanTrain"/>
     <unit name="germanRail"/>
+    <unit name="germanMine"/>
     <unit name="germanInfantry"/>
     <unit name="germanAlpineInfantry"/>
     <unit name="germanCombatEngineer"/>
@@ -7678,6 +7679,23 @@
       <option name="whenCapturedChangesInto" value="any:India:true:Material:1"/>
     </attachment>
     <!-- German Units -->
+    <attachment name="unitAttachment" attachTo="germanMine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="attack" value="0"/>
+      <option name="defense" value="0"/>
+      <option name="isSea" value="true"/>
+      <option name="isSub" value="true"/>
+      <option name="isAAforCombatOnly" value="true"/>
+      <option name="mayOverStackAA" value="true"/>
+      <option name="typeAA" value="navalmine"/>
+      <option name="targetsAA" value="americanCruiser"/>
+      <option name="maxAAattacks" value="1"/>
+      <option name="maxRoundsAA" value="1"/>
+      <option name="movement" value="0"/>
+      <option name="attackAA" value="2"/>
+      <option name="damageableAA" value="true"/>
+      <option name="canInvadeOnlyFrom" value="none"/>
+      <option name="isSuicideOnHit" value="true"/>
+    </attachment>        
     <attachment name="unitAttachment" attachTo="germanTrain" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
       <option name="movement" value="5"/>
       <option name="attack" value="0"/>


### PR DESCRIPTION
Addresses: https://forums.triplea-game.org/topic/323/unit-option-which-suicides-only-when-it-registers-a-hit-mines

Recommend reviewing without whitespace changes (?w=1).

**Functional Changes**
- Add new isSuicideOnHit unit attribute
- Implement logic to roll isSuicideOnHit unit types separately so the engine knows if they roll hits
- Implement logic to remove any isSuicideOnHit units that roll hits

**Testing**
- Added unit test to test basic functionality of "mine" unit using isSuicideOnHit attribute
- Did some actual manual gameplay testing with an edited version of TWW
- Save game compatibility seems fine

Example XML:
```
<attachment name="unitAttachment" attachTo="germanNavalMine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
<option name="attack" value="0"/>
<option name="defense" value="0"/>
<option name="isSea" value="true"/>
<option name="isSub" value="true"/>
<option name="isAAforCombatOnly" value="true"/>
<option name="mayOverStackAA" value="true"/>
<option name="typeAA" value="navalmine"/>
<option name="targetsAA" value="Battleship:Cruiser:Destroyer:Submarine:Transport"/>
<option name="maxAAattacks" value="1"/>
<option name="maxRoundsAA" value="1"/>	
<option name="movement" value="0"/>
<option name="attackAA" value="2"/>
<option name="damageableAA" value="true"/>
<option name="canInvadeOnlyFrom" value="none"/>
<option name="isSuicideOnHit" value="true"/>
</attachment>
```