### PR TITLE
Rename enclosing test fixtures

### DIFF
--- a/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mock;
 
 import games.strategy.triplea.settings.GameSetting;
 
-public final class ClientFileSystemHelperTests {
+public final class ClientFileSystemHelperTest {
   @ExtendWith(MockitoExtension.class)
   @Nested
   public final class GetUserMapsFolderPathTest {

--- a/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.framework.GameDataFileUtils.SaveGameFormat;
 
-public final class GameDataFileUtilsTests {
+public final class GameDataFileUtilsTest {
   @Nested
-  public final class AddExtensionTests {
+  public final class AddExtensionTest {
     @Nested
     public final class WhenSaveGameFormatIsSerializationTest {
       private String addExtension(final String fileName) {
@@ -48,9 +48,9 @@ public final class GameDataFileUtilsTests {
   }
 
   @Nested
-  public final class AddExtensionIfAbsentTests {
+  public final class AddExtensionIfAbsentTest {
     @Nested
-    public final class WhenSaveGameFormatIsSerializationTests {
+    public final class WhenSaveGameFormatIsSerializationTest {
       @Nested
       public final class WhenFileSystemIsCaseSensitiveTest {
         private String addExtensionIfAbsent(final String fileName) {
@@ -97,7 +97,7 @@ public final class GameDataFileUtilsTests {
     }
 
     @Nested
-    public final class WhenSaveGameFormatIsProxySerializationTests {
+    public final class WhenSaveGameFormatIsProxySerializationTest {
       @Nested
       public final class WhenFileSystemIsCaseSensitiveTest {
         private String addExtensionIfAbsent(final String fileName) {
@@ -148,9 +148,9 @@ public final class GameDataFileUtilsTests {
   }
 
   @Nested
-  public final class IsCandidateFileNameTests {
+  public final class IsCandidateFileNameTest {
     @Nested
-    public final class WhenSaveGameFormatIsSerializationTests {
+    public final class WhenSaveGameFormatIsSerializationTest {
       @Nested
       public final class WhenFileSystemIsCaseSensitiveTest {
         private boolean isCandidateFileName(final String fileName) {
@@ -237,7 +237,7 @@ public final class GameDataFileUtilsTests {
     }
 
     @Nested
-    public final class WhenSaveGameFormatIsProxySerializationTests {
+    public final class WhenSaveGameFormatIsProxySerializationTest {
       @Nested
       public final class WhenFileSystemIsCaseSensitiveTest {
         private boolean isCandidateFileName(final String fileName) {

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 
 import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
 
-public final class DownloadUtilsTests {
+public final class DownloadUtilsTest {
   private static final String URI = "some://uri";
 
   @ExtendWith(MockitoExtension.class)

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
@@ -27,7 +27,7 @@ import games.strategy.engine.framework.map.download.MapDownloadController.Tutori
 import games.strategy.engine.framework.map.download.MapDownloadController.UserMaps;
 import games.strategy.util.Version;
 
-public final class MapDownloadControllerTests {
+public final class MapDownloadControllerTest {
 
   @Nested
   @ExtendWith(MockitoExtension.class)

--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-public final class ClientLoginTests {
+public final class ClientLoginTest {
   private static final String PASSWORD = "password";
 
   @Nested

--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.framework.startup.login.ClientLoginValidator.ErrorMessages;
 
-public final class ClientLoginValidatorTests {
+public final class ClientLoginValidatorTest {
   private static final String PASSWORD = "password";
   private static final String OTHER_PASSWORD = "otherPassword";
 
@@ -47,10 +47,8 @@ public final class ClientLoginValidatorTests {
     }
   }
 
-
   @Nested
-  public final class GetChallengePropertiesTests {
-    @Nested
+  public final class GetChallengePropertiesTest {
     public abstract class AbstractTestCase {
       final ClientLoginValidator clientLoginValidator = new ClientLoginValidator(null);
 

--- a/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -40,13 +40,11 @@ import games.strategy.security.TestSecurityUtils;
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;
 
-public final class LobbyLoginValidatorTests {
+public final class LobbyLoginValidatorTest {
 
   interface ResponseGenerator extends Function<Map<String, String>, Map<String, String>> {
   }
 
-  @Nested
-  @ExtendWith(MockitoExtension.class)
   abstract class AbstractTestCase {
     static final String EMAIL = "n@n.com";
     static final String PASSWORD = "password";
@@ -217,7 +215,7 @@ public final class LobbyLoginValidatorTests {
   }
 
   @Nested
-  public final class WhenUserDoesNotExistTests {
+  public final class WhenUserDoesNotExistTest {
     @ExtendWith(MockitoExtension.class)
     @Nested
     public final class WhenUsingLegacyClientTest extends AbstractTestCase {
@@ -268,7 +266,7 @@ public final class LobbyLoginValidatorTests {
   }
 
   @Nested
-  public final class WhenUserExistsTests {
+  public final class WhenUserExistsTest {
     @ExtendWith(MockitoExtension.class)
     @Nested
     public final class WhenUsingLegacyClientTest extends AbstractTestCase {

--- a/src/test/java/games/strategy/test/EqualsPredicateTest.java
+++ b/src/test/java/games/strategy/test/EqualsPredicateTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class EqualsPredicateTests {
+public final class EqualsPredicateTest {
   private static EqualsPredicate newEqualsPredicate(final EqualityComparator... equalityComparators) {
     return new EqualsPredicate(EqualityComparatorRegistry.newInstance(equalityComparators));
   }

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -29,7 +29,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.Match;
 
-public final class MatchesTests {
+public final class MatchesTest {
 
   private static final Match<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
   private static final Object VALUE = new Object();

--- a/src/test/java/games/strategy/util/CoreEqualityComparatorsTest.java
+++ b/src/test/java/games/strategy/util/CoreEqualityComparatorsTest.java
@@ -16,7 +16,7 @@ import games.strategy.test.EqualityComparator;
 import games.strategy.test.EqualityComparatorRegistry;
 import games.strategy.test.TestUtil;
 
-public final class CoreEqualityComparatorsTests {
+public final class CoreEqualityComparatorsTest {
   private static EqualityComparatorRegistry newEqualityComparatorRegistryOf(
       final EqualityComparator primaryEqualityComparator,
       final EqualityComparator... secondaryEqualityComparators) {


### PR DESCRIPTION
The convention to use the `Tests` suffix for enclosing test fixtures is no longer necessary due to proper support for nested test fixtures in JUnit 5.

I also removed some unnecessary annotations.  For example, `@Nested` does not need to appear on an abstract test fixture class; it only needs to appear on the concrete test fixture classes.