### PR TITLE
Display wait indicator during lobby login

### DIFF
--- a/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -76,9 +76,6 @@ public final class ClientLoginIntegrationTest {
     }
 
     @Override
-    public void notifyFailedLogin(final String message) {}
-
-    @Override
     protected String promptForPassword() {
       return password;
     }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -151,10 +151,14 @@ public class DownloadMapsWindow extends JFrame {
       assert state == State.UNINITIALIZED;
 
       state = State.INITIALIZING;
-      BackgroundTaskRunner.runInBackground(
-          "Downloading list of available maps...",
-          ClientContext::getMapDownloadList,
-          downloads -> createAndShow(mapNames, downloads));
+      try {
+        final List<DownloadFileDescription> downloads = BackgroundTaskRunner.runInBackgroundAndReturn(
+            "Downloading list of available maps...",
+            ClientContext::getMapDownloadList);
+        createAndShow(mapNames, downloads);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
     }
 
     private void createAndShow(final Collection<String> mapNames, final List<DownloadFileDescription> downloads) {

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -11,7 +11,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.net.IConnectionLogin;
-import games.strategy.util.EventThreadJOptionPane;
 
 /**
  * The client side of the peer-to-peer network game authentication protocol.
@@ -69,10 +68,5 @@ public class ClientLogin implements IConnectionLogin {
         "Enter a password to join the game",
         JOptionPane.QUESTION_MESSAGE);
     return new String(passwordField.getPassword());
-  }
-
-  @Override
-  public void notifyFailedLogin(final String message) {
-    EventThreadJOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parentComponent), message);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -150,8 +150,8 @@ public class ClientModel implements IMessengerErrorListener {
     try {
       final String mac = MacFinder.getHashedMacAddress();
       m_messenger = new ClientMessenger(address, port, name, mac, m_objectStreamFactory, new ClientLogin(m_ui));
-    } catch (final CouldNotLogInException ioe) {
-      // an error message should have already been reported
+    } catch (final CouldNotLogInException e) {
+      EventThreadJOptionPane.showMessageDialog(ui, e.getMessage());
       return false;
     } catch (final Exception ioe) {
       ioe.printStackTrace(System.out);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -94,9 +94,6 @@ public class InGameLobbyWatcher {
     System.getProperties().setProperty(GameRunner.LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override
-      public void notifyFailedLogin(final String message) {}
-
-      @Override
       public Map<String, String> getProperties(final Map<String, String> challengeProperties) {
         final Map<String, String> properties = new HashMap<>();
         properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -81,9 +81,6 @@ public class LobbyLogin {
         MacFinder.getHashedMacAddress(),
         new IConnectionLogin() {
           @Override
-          public void notifyFailedLogin(final String message) {}
-
-          @Override
           public Map<String, String> getProperties(final Map<String, String> challenge) {
             final Map<String, String> response = new HashMap<>();
             if (anonymousLogin) {
@@ -161,9 +158,6 @@ public class LobbyLogin {
         userName,
         MacFinder.getHashedMacAddress(),
         new IConnectionLogin() {
-          @Override
-          public void notifyFailedLogin(final String message) {}
-
           @Override
           public Map<String, String> getProperties(final Map<String, String> challenge) {
             final Map<String, String> response = new HashMap<>();

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -37,7 +37,7 @@ public class LobbyLogin {
    * If we could not login, return null.
    * </p>
    */
-  public LobbyClient login() {
+  public @Nullable LobbyClient login() {
     if (!lobbyServerProperties.isServerAvailable()) {
       showError("Could not connect to server", lobbyServerProperties.serverErrorMessage);
       return null;
@@ -91,7 +91,6 @@ public class LobbyLogin {
             } else {
               final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, MD5Crypt.newSalt());
               response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(password, salt));
-
               if (RsaAuthenticator.canProcessChallenge(challenge)) {
                 response.putAll(RsaAuthenticator.newResponse(challenge, password));
               }
@@ -106,7 +105,7 @@ public class LobbyLogin {
     JOptionPane.showMessageDialog(parentWindow, message, title, JOptionPane.ERROR_MESSAGE);
   }
 
-  private LobbyClient loginToServer() {
+  private @Nullable LobbyClient loginToServer() {
     final LoginPanel loginPanel = new LoginPanel(LobbyLoginPreferences.load());
     final LoginPanel.ReturnValue returnValue = loginPanel.show(parentWindow);
     switch (returnValue) {
@@ -121,7 +120,7 @@ public class LobbyLogin {
     }
   }
 
-  private LobbyClient createAccount() {
+  private @Nullable LobbyClient createAccount() {
     final CreateUpdateAccountPanel createAccountPanel = CreateUpdateAccountPanel.newCreatePanel();
     final CreateUpdateAccountPanel.ReturnValue returnValue = createAccountPanel.show(parentWindow);
     switch (returnValue) {
@@ -134,41 +133,51 @@ public class LobbyLogin {
     }
   }
 
-  private LobbyClient createAccount(final CreateUpdateAccountPanel createAccount) {
+  private @Nullable LobbyClient createAccount(final CreateUpdateAccountPanel panel) {
     try {
-      final String mac = MacFinder.getHashedMacAddress();
-      final ClientMessenger messenger = new ClientMessenger(lobbyServerProperties.host, lobbyServerProperties.port,
-          createAccount.getUserName(), mac, new IConnectionLogin() {
-            @Override
-            public void notifyFailedLogin(final String message) {
-              showError("Login Failed", message);
-            }
-
-            @Override
-            public Map<String, String> getProperties(final Map<String, String> challengeProperties) {
-              final Map<String, String> props = new HashMap<>();
-              props.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
-              props.put(LobbyLoginValidator.EMAIL_KEY, createAccount.getEmail());
-              // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
-              // backwards-compatibility
-              props.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(createAccount.getPassword()));
-              if (RsaAuthenticator.canProcessChallenge(challengeProperties)) {
-                props.putAll(RsaAuthenticator.newResponse(challengeProperties, createAccount.getPassword()));
-              }
-              props.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-              return props;
-            }
-          });
-
-      // lobby login was successful if we reach this point
-      createAccount.getLobbyLoginPreferences().save();
+      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturnOrThrow(
+          "Connecting to lobby...",
+          () -> createAccount(panel.getUserName(), panel.getPassword(), panel.getEmail()),
+          IOException.class);
+      panel.getLobbyLoginPreferences().save();
       return new LobbyClient(messenger, false);
-    } catch (final CouldNotLogInException clne) {
-      // this has already been dealt with
-      return createAccount();
+    } catch (final CouldNotLogInException e) {
+      showError("Account Creation Failed", e.getMessage());
+      return createAccount(); // NB: potential stack overflow due to recursive call
     } catch (final IOException e) {
-      showError("Account creation failed", e.getMessage());
+      showError("Could Not Connect", "Could not connect to lobby: " + e.getMessage());
+      return null;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       return null;
     }
+  }
+
+  private IMessenger createAccount(final String userName, final String password, final String email)
+      throws IOException {
+    return new ClientMessenger(
+        lobbyServerProperties.host,
+        lobbyServerProperties.port,
+        userName,
+        MacFinder.getHashedMacAddress(),
+        new IConnectionLogin() {
+          @Override
+          public void notifyFailedLogin(final String message) {}
+
+          @Override
+          public Map<String, String> getProperties(final Map<String, String> challenge) {
+            final Map<String, String> response = new HashMap<>();
+            response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
+            response.put(LobbyLoginValidator.EMAIL_KEY, email);
+            // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
+            // backwards-compatibility
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(password));
+            if (RsaAuthenticator.canProcessChallenge(challenge)) {
+              response.putAll(RsaAuthenticator.newResponse(challenge, password));
+            }
+            response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+            return response;
+          }
+        });
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -4,10 +4,11 @@ import java.awt.Window;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.server.LobbyServer;
 import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
@@ -15,6 +16,7 @@ import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.IConnectionLogin;
+import games.strategy.net.IMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.util.MD5Crypt;
@@ -37,80 +39,71 @@ public class LobbyLogin {
    */
   public LobbyClient login() {
     if (!lobbyServerProperties.isServerAvailable()) {
-      JOptionPane.showMessageDialog(
-          parentWindow,
-          lobbyServerProperties.serverErrorMessage,
-          "Could not connect to server",
-          JOptionPane.ERROR_MESSAGE);
+      showError("Could not connect to server", lobbyServerProperties.serverErrorMessage);
       return null;
     }
     if (lobbyServerProperties.port == -1) {
-      JOptionPane.showMessageDialog(parentWindow,
+      showError("Could not connect to server",
           "<html>Could not find lobby server for this version of TripleA, <br>"
               + "Please make sure you are using the latest version: " + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE
-              + "</html>",
-          "Could not connect to server", JOptionPane.ERROR_MESSAGE);
+              + "</html>");
       return null;
     }
     return loginToServer();
   }
 
-  private LobbyClient login(final LoginPanel panel) {
+  private @Nullable LobbyClient login(final LoginPanel panel) {
     try {
-      final String mac = MacFinder.getHashedMacAddress();
-      final ClientMessenger messenger = new ClientMessenger(lobbyServerProperties.host, lobbyServerProperties.port,
-          panel.getUserName(), mac, new IConnectionLogin() {
-            private final AtomicReference<String> internalError = new AtomicReference<>();
-
-            @Override
-            public void notifyFailedLogin(String message) {
-              if (internalError.get() != null) {
-                message = internalError.get();
-              }
-              JOptionPane.showMessageDialog(parentWindow, message, "Login Failed", JOptionPane.ERROR_MESSAGE);
-            }
-
-            @Override
-            public Map<String, String> getProperties(final Map<String, String> challengeProperties) {
-              final Map<String, String> props = new HashMap<>();
-              if (panel.isAnonymousLogin()) {
-                props.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-              } else {
-                final boolean isUpdatedLobby = RsaAuthenticator.canProcessChallenge(challengeProperties);
-                String salt = challengeProperties.get(LobbyLoginValidator.SALT_KEY);
-                if (salt == null) {
-                  if (!isUpdatedLobby) {
-                    // the server does not have a salt value
-                    // so there is no user with our name,
-                    // continue as before
-                    internalError.set("No account with that name exists");
-                  }
-                  salt = MD5Crypt.newSalt();
-                }
-                props.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(panel.getPassword(), salt));
-                if (isUpdatedLobby) {
-                  props.putAll(RsaAuthenticator.newResponse(challengeProperties, panel.getPassword()));
-                }
-              }
-              props.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-              return props;
-            }
-          });
-
-      // lobby login was successful if we reach this point
+      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturnOrThrow(
+          "Connecting to lobby...",
+          () -> login(panel.getUserName(), panel.getPassword(), panel.isAnonymousLogin()),
+          IOException.class);
       panel.getLobbyLoginPreferences().save();
       return new LobbyClient(messenger, panel.isAnonymousLogin());
     } catch (final CouldNotLogInException e) {
-      // this has already been dealt with
-      return loginToServer();
+      showError("Login Failed", e.getMessage());
+      return loginToServer(); // NB: potential stack overflow due to recursive call
     } catch (final IOException e) {
-      JOptionPane.showMessageDialog(
-          parentWindow,
-          "Could Not Connect to Lobby : " + e.getMessage(),
-          "Could not connect",
-          JOptionPane.ERROR_MESSAGE);
+      showError("Could Not Connect", "Could not connect to lobby: " + e.getMessage());
+      return null;
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       return null;
     }
+  }
+
+  private IMessenger login(final String userName, final String password, final boolean anonymousLogin)
+      throws IOException {
+    return new ClientMessenger(
+        lobbyServerProperties.host,
+        lobbyServerProperties.port,
+        userName,
+        MacFinder.getHashedMacAddress(),
+        new IConnectionLogin() {
+          @Override
+          public void notifyFailedLogin(final String message) {}
+
+          @Override
+          public Map<String, String> getProperties(final Map<String, String> challenge) {
+            final Map<String, String> response = new HashMap<>();
+            if (anonymousLogin) {
+              response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+            } else {
+              final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, MD5Crypt.newSalt());
+              response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(password, salt));
+
+              if (RsaAuthenticator.canProcessChallenge(challenge)) {
+                response.putAll(RsaAuthenticator.newResponse(challenge, password));
+              }
+            }
+            response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+            return response;
+          }
+        });
+  }
+
+  private void showError(final String title, final String message) {
+    JOptionPane.showMessageDialog(parentWindow, message, title, JOptionPane.ERROR_MESSAGE);
   }
 
   private LobbyClient loginToServer() {
@@ -148,7 +141,7 @@ public class LobbyLogin {
           createAccount.getUserName(), mac, new IConnectionLogin() {
             @Override
             public void notifyFailedLogin(final String message) {
-              JOptionPane.showMessageDialog(parentWindow, message, "Login Failed", JOptionPane.ERROR_MESSAGE);
+              showError("Login Failed", message);
             }
 
             @Override
@@ -174,11 +167,7 @@ public class LobbyLogin {
       // this has already been dealt with
       return createAccount();
     } catch (final IOException e) {
-      JOptionPane.showMessageDialog(
-          parentWindow,
-          e.getMessage(),
-          "Account creation failed",
-          JOptionPane.ERROR_MESSAGE);
+      showError("Account creation failed", e.getMessage());
       return null;
     }
   }

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -119,7 +119,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
         if (m_connectionRefusedError != null) {
           msg += ", " + m_connectionRefusedError;
         }
-        login.notifyFailedLogin(msg);
         throw new CouldNotLogInException(msg);
       } else if (m_connectionRefusedError instanceof CouldNotLogInException) {
         throw (CouldNotLogInException) m_connectionRefusedError;

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -120,7 +120,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
           msg += ", " + m_connectionRefusedError;
         }
         login.notifyFailedLogin(msg);
-        throw new CouldNotLogInException();
+        throw new CouldNotLogInException(msg);
       } else if (m_connectionRefusedError instanceof CouldNotLogInException) {
         throw (CouldNotLogInException) m_connectionRefusedError;
       } else if (m_connectionRefusedError != null) {

--- a/src/main/java/games/strategy/net/CouldNotLogInException.java
+++ b/src/main/java/games/strategy/net/CouldNotLogInException.java
@@ -5,6 +5,12 @@ import java.io.IOException;
 /**
  * Thrown when a ClientMessenger could not log in to a ServerMessenger.
  */
-public class CouldNotLogInException extends IOException {
+public final class CouldNotLogInException extends IOException {
   private static final long serialVersionUID = -7266754722803615270L;
+
+  public CouldNotLogInException() {}
+
+  public CouldNotLogInException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/games/strategy/net/IConnectionLogin.java
+++ b/src/main/java/games/strategy/net/IConnectionLogin.java
@@ -7,9 +7,8 @@ import java.util.Map;
  *
  * <p>
  * An IConnectionLogin is generally paired with an ILoginValidator. The validator will send a challenge string, to which
- * the
- * IConnectionLogin will respond with a key/value map of credentials. The validator will then allow the login, or return
- * an error message.
+ * the IConnectionLogin will respond with a key/value map of credentials. The validator will then allow the login or
+ * return an error message.
  * </p>
  */
 public interface IConnectionLogin {
@@ -17,9 +16,4 @@ public interface IConnectionLogin {
    * Get the properties to log in given the challenge Properties.
    */
   Map<String, String> getProperties(Map<String, String> challengeProperties);
-
-  /**
-   * A notification that the login failed. The error message supplied should be shown to the user.
-   */
-  void notifyFailedLogin(String message);
 }


### PR DESCRIPTION
This PR addresses #2473 by displaying a wait indicator when the user attempts to login to the lobby (either when authenticating with an existing account or when creating a new account).

#### Functional changes

* A standard wait dialog is now displayed after the user presses **Login** on the Login dialog or **OK** on the Create Account dialog.  The dialog is closed upon a successful authentication or any kind of failure.
![lobby-login-wait-indicator](https://user-images.githubusercontent.com/4826349/32122679-343234c8-bb2f-11e7-9e16-24f2c905ed78.png)
* Prior to this PR, the lobby authentication process ran on the UI thread.  In order to display the wait dialog, this process needed to be moved to a background thread.  This was accomplished using the existing `BackgroundTaskRunner` class.

#### Refactoring changes

* `BackgroundTaskRunner` was modified to return the result of the background action or throw the exception raised by the background action (previously it used a `Consumer` to forward the result and only logged exceptions).  Since the methods of this class are blocking, it made sense to allow it to throw `InterruptedException` instead of swallowing it (this was also necessary because it's not clear what value to return when an `InterruptedException` is raised).
* `IConnectionLogin#notifyFailedLogin()` was removed.  Three of four implementations of this method were no-ops.  For consistency, all callers now display the failed login message to the user from the `CouldNotLogInException` handler.  This has the benefit of co-locating all error handling instead of it being spread out across multiple methods.
* I extracted the `LobbyLogin#showError()` method to avoid duplicating a lot of the boilerplate required to display an error dialog.

#### Testing

I tested several scenarios to ensure the wait indicator is displayed correctly and the correct error message is displayed upon a failure.  Note that the non-lobby scenarios were tested because the `IConnectionLogin` refactoring affected them.

* Lobby
    * Successful authentication of existing user
    * Failed authentication of existing user
    * Successfully create new user
    * Duplicate username when creating new user
    * Network failure (e.g. no lobby at specified host/port)
* Password-protected network game
    * Successful authentication
    * Failed authentication
    * Network failure (e.g. no game server at specified host/port)

#### Notes

During testing, I observed the following error two times out of the probably 100+ times I tested the affected code:

```
Oct 27, 2017 12:59:21 AM games.strategy.net.nio.NioWriter loop
WARNING: error in writer
java.nio.channels.ClosedSelectorException
	at sun.nio.ch.SelectorImpl.selectedKeys(SelectorImpl.java:74)
	at games.strategy.net.nio.NioWriter.loop(NioWriter.java:93)
	at java.lang.Thread.run(Thread.java:748)
```

There appears to be a race condition in `NioWriter` where the NIO Writer thread may be in the middle of something when `NioWriter#shutDown()` is called.  Both of the two occurrences of this error were triggered when I was testing the "Network failure" scenario.  I don't ever remember seeing this error before (although I don't think I regularly test network failures; the only time it would happen for me is when I was trying to connect to my local lobby but forgot to start it).  I suspect moving the `ClientMessenger` creation in `LobbyLogin` from the UI thread to a background thread is exacerbating the race condition.

I think the easiest way to fix this issue is to handle `ClosedSelectorException` explicitly in the NIO Writer thread and ignore it if `running` is `false`.  However, because I can't reproduce this failure easily, and I'm just theorizing on the root cause, I'd prefer to wait to fix it until we get a few more repros.  I'd be interested to hear if someone else can more easily reproduce the error when testing the "Network failure" scenario.