### PR TITLE
Enable validateYamls task in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - python3-yaml
 install: ./.travis/setup_lobby_database
 before_script: ./.travis/setup_gpg
-script: ./gradlew check jacocoJunit5TestReport -x validateYamls
+script: ./gradlew check jacocoJunit5TestReport
 after_success:
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle


### PR DESCRIPTION
Per #2426, this PR re-enables the `validateYamls` task in the Travis build now that all SourceForge links checked by this task have been replaced with GitHub links.