### PR TITLE
Fix minimum bombing damage to be 0 instead of 1

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -281,7 +281,7 @@ public class RocketsFireHelper {
           final int[] rolls = bridge.getRandom(highestMaxDice, numberOfAttacks, player, DiceType.BOMBING,
               "Rocket fired by " + player.getName() + " at " + attacked.getName());
           for (int i = 0; i < rolls.length; i++) {
-            final int r = rolls[i] + highestBonus;
+            final int r = Math.max(-1, rolls[i] + highestBonus);
             rolls[i] = r;
             // we are zero based
             cost += r + 1;
@@ -343,7 +343,7 @@ public class RocketsFireHelper {
           final int[] rolls = bridge.getRandom(highestMaxDice, numberOfAttacks, player, DiceType.BOMBING,
               "Rocket fired by " + player.getName() + " at " + attacked.getName());
           for (int i = 0; i < rolls.length; i++) {
-            final int r = rolls[i] + highestBonus;
+            final int r = Math.max(-1, rolls[i] + highestBonus);
             rolls[i] = r;
             // we are zero based
             cost += r + 1;

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -616,12 +616,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               if (maxDice > 0) {
                 final int[] dicerolls = bridge.getRandom(maxDice, rolls, m_attacker, DiceType.BOMBING, annotation);
                 for (final int die : dicerolls) {
-                  m_dice[i] = Math.max(0, die + bonus);
+                  // min value is -1 as we add 1 when setting damage since dice are 0 instead of 1 based
+                  m_dice[i] = Math.max(-1, die + bonus);
                   i++;
                 }
               } else {
                 for (int j = 0; j < rolls; j++) {
-                  m_dice[i] = Math.max(0, bonus);
+                  // min value is -1 as we add 1 when setting damage since dice are 0 instead of 1 based
+                  m_dice[i] = Math.max(-1, bonus);
                   i++;
                 }
               }
@@ -658,12 +660,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             if (maxDice > 0) {
               final int[] dicerolls = bridge.getRandom(maxDice, rolls, m_attacker, DiceType.BOMBING, annotation);
               for (final int die : dicerolls) {
-                m_dice[i] = Math.max(0, die + bonus);
+                // min value is -1 as we add 1 when setting damage since dice are 0 instead of 1 based
+                m_dice[i] = Math.max(-1, die + bonus);
                 i++;
               }
             } else {
               for (int j = 0; j < rolls; j++) {
-                m_dice[i] = Math.max(0, bonus);
+                // min value is -1 as we add 1 when setting damage since dice are 0 instead of 1 based
+                m_dice[i] = Math.max(-1, bonus);
                 i++;
               }
             }


### PR DESCRIPTION
Follow up of: #2371 and #2551 

The minimum bombing damage should be 0 instead of 1 when using negative bombing bonus.

The code is kind of funky as the dice rolls are 0 based rather than 1 based. Then 1 is added when calculating bombing damage so the minimum of (dice + bonus) should be -1 so that min damage is 0.