### PR TITLE
[Do not merge] Intoduce Parallel Attachment parsing

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -306,8 +306,7 @@ public class GameParser {
    *
    * @return a RelationshipType from the relationshipTypeList, at this point all relationshipTypes should have been
    *         declared
-   * @throws GameParseException
-   *         when
+   * @throws GameParseException when
    */
   private RelationshipType getRelationshipType(final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
@@ -1212,7 +1211,7 @@ public class GameParser {
     service.shutdown();
     while (!service.isTerminated()) {
       try {
-        if(executor.take().get() == null) {
+        if (executor.take().get() == null) {
           return;
         }
       } catch (InterruptedException e) {

--- a/src/main/java/games/strategy/engine/data/NamedAttachable.java
+++ b/src/main/java/games/strategy/engine/data/NamedAttachable.java
@@ -1,12 +1,12 @@
 package games.strategy.engine.data;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NamedAttachable extends DefaultNamed implements Attachable {
   private static final long serialVersionUID = 8597712929519099255L;
-  private final Map<String, IAttachment> m_attachments = new HashMap<>();
+  private final Map<String, IAttachment> m_attachments = new ConcurrentHashMap<>();
 
   /** Creates new NamedAttachable. */
   public NamedAttachable(final String name, final GameData data) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -387,8 +387,8 @@ public class GameSelectorPanel extends JPanel implements Observer {
         }
         model.load(entry);
         setOriginalPropertiesMap(model.getGameData());
-        // only for new games, not saved games, we set the default options, and set them only once (the first time it is
-        // loaded)
+        // only for new games, not saved games, we set the default options, and set them only once
+        // (the first time it is loaded)
         gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
       }
     }

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -62,16 +62,13 @@ public class PlayerAttachment extends DefaultAttachment {
   // what can be hit by suicide attacks
   private HashSet<UnitType> m_suicideAttackTargets = null;
   // placement limits on a flexible per player basis
-  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_placementLimit =
-      new HashSet<>();
+  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_placementLimit = new HashSet<>();
 
   // movement limits on a flexible per player basis
-  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_movementLimit =
-      new HashSet<>();
+  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_movementLimit = new HashSet<>();
 
   // attacking limits on a flexible per player basis
-  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_attackingLimit =
-      new HashSet<>();
+  private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_attackingLimit = new HashSet<>();
 
   /** Creates new PlayerAttachment. */
   public PlayerAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import games.strategy.debug.ClientLogger;
@@ -70,7 +69,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   // List of relationshipChanges that should be executed when this trigger hits.
   private ArrayList<String> m_relationshipChange = new ArrayList<>();
   private String m_victory = null;
-  private ArrayList<Tuple<String, String>> m_activateTrigger = new ArrayList<>();
+  private List<Tuple<String, String>> m_activateTrigger = Collections.synchronizedList(new ArrayList<>());
   private ArrayList<String> m_changeOwnership = new ArrayList<>();
   // raw property changes below:
   //
@@ -137,10 +136,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    */
   static Set<TriggerAttachment> getTriggers(final PlayerID player, final Match<TriggerAttachment> cond) {
     final Set<TriggerAttachment> trigs = new HashSet<>();
-    final Map<String, IAttachment> map = player.getAttachments();
-    final Iterator<String> iter = map.keySet().iterator();
-    while (iter.hasNext()) {
-      final IAttachment a = map.get(iter.next());
+    for (final IAttachment a : player.getAttachments().values()) {
       if (a instanceof TriggerAttachment) {
         if (cond == null || cond.match((TriggerAttachment) a)) {
           trigs.add((TriggerAttachment) a);
@@ -328,7 +324,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_activateTrigger = value;
   }
 
-  public ArrayList<Tuple<String, String>> getActivateTrigger() {
+  public List<Tuple<String, String>> getActivateTrigger() {
     return m_activateTrigger;
   }
 
@@ -1365,10 +1361,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
     }
     for (final Territory t : territories) {
-      if (m_removeUnits.containsKey(t)) {
-        map.add(m_removeUnits.get(t));
+      synchronized (m_removeUnits) {
+        if (m_removeUnits.containsKey(t)) {
+          map.add(m_removeUnits.get(t));
+        }
+        m_removeUnits.put(t, map);
       }
-      m_removeUnits.put(t, map);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -921,7 +921,7 @@ public class UnitAttachment extends DefaultAttachment {
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setRequiresUnits(final String value) {
-    synchronized(m_requiresUnits) {
+    synchronized (m_requiresUnits) {
       m_requiresUnits.add(value.split(":"));
     }
   }

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -921,7 +921,9 @@ public class UnitAttachment extends DefaultAttachment {
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setRequiresUnits(final String value) {
-    m_requiresUnits.add(value.split(":"));
+    synchronized(m_requiresUnits) {
+      m_requiresUnits.add(value.split(":"));
+    }
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -392,7 +392,9 @@ public class UnitSupportAttachment extends DefaultAttachment {
     if (m_unitType == null) {
       m_unitType = new HashSet<>();
     }
-    m_unitType.addAll(types);
+    synchronized (m_unitType) {
+      m_unitType.addAll(types);
+    }
   }
 
   @InternalDoNotExport

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -393,7 +393,9 @@ public class UnitSupportAttachment extends DefaultAttachment {
       m_unitType = new HashSet<>();
     }
     synchronized (m_unitType) {
-      m_unitType.addAll(types);
+      synchronized (types) {
+        m_unitType.addAll(types);
+      }
     }
   }
 

--- a/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -115,15 +115,15 @@ public class ParserTest {
   public void testAttachments() {
     TestAttachment att = (TestAttachment) gameData.getResourceList().getResource("gold")
         .getAttachment(Constants.RESOURCE_ATTACHMENT_NAME);
-    assertEquals(att.getValue(), "gold");
+    assertEquals("gold", att.getValue());
     att = (TestAttachment) gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF)
         .getAttachment(Constants.INF_ATTACHMENT_NAME);
-    assertEquals(att.getValue(), "inf");
+    assertEquals("inf", att.getValue());
     att = (TestAttachment) gameData.getMap().getTerritory("us").getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
-    assertEquals(att.getValue(), "us of a");
+    assertEquals("us of a", att.getValue());
     att = (TestAttachment) gameData.getPlayerList().getPlayerId("chretian")
         .getAttachment(Constants.PLAYER_ATTACHMENT_NAME);
-    assertEquals(att.getValue(), "liberal");
+    assertEquals("liberal", att.getValue());
   }
 
   @Test


### PR DESCRIPTION
#2555 and #2540 reminded me of #986
~This PR unfortunately has similar issues like #986:
Flaky tests, which means at some point the new asynchronous execution causes stuff to happen in the wrong order, sometimes.~

The current NPEs are probably due to some concurrent access to non-final fields, we'll need to investigate that...

Goal before being able to merge this PR is to find code that needs to ~be synchronized~ made thread safe to keep everything working.
~Addtitionally, I'd appreciate some general feedback on this PR, if it goes in the right direction.~
This PR is almost complete now, it can already be reviewed.

EDIT: I found an issue with my implementation, which fixed the severe issues when I changed it.
Now there are just some NPEs left and the synchronized blocks are not really pretty and could probably made better.


What I noticed during writing the code is, that a lot of the game parsing code is invoked on the EDT, which causes the UI to freeze a couple of seconds if not more.
Goal for a future PR would be to have game parsing and UI actions strictly seperated from each other, it's not going to be very easy, because there are some UI types that do some blocking operations (during initialization) before displaying themselves.

EDIT2:
Worth noting, perhaps that I can notice speedups up to ~20 seconds of parsing time for all maps (from 1 minute to 40 seconds).
I'll do some accurate benchmarks, once no NPEs are being thrown, I still want to encourage you to try this branch on your machine to see if it has a greater or smaller impact!