### PR TITLE
Only check non-transported units for requiresUnitToMove

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -659,7 +659,7 @@ public class MoveValidator {
       }
       // Check requiresUnitsToMove conditions
       for (final Territory t : route.getAllTerritories()) {
-        if (!Match.allMatch(units, Matches.unitHasRequiredUnitsToMove(t, data))) {
+        if (!Match.allMatch(moveTest, Matches.unitHasRequiredUnitsToMove(t, data))) {
           return result.setErrorReturnResult(
               t.getName() + " doesn't have the required units to allow moving the selected units into it");
         }


### PR DESCRIPTION
Change requiresUnitToMove logic to only check non-transported units. This allows units such as trains to be transported.