### PR TITLE
Update dice properties to use https instead of http.

### DIFF
--- a/dice_servers/tripleawarclub.properties
+++ b/dice_servers/tripleawarclub.properties
@@ -4,6 +4,7 @@ order=10
 name=dice.tripleawarclub.org
 #dice server host
 host=dice.tripleawarclub.org
+port=443
 #path in dice server post to post too
 path=/MARTI.php
 roll.single.start=your dice are: 

--- a/dice_servers/tripleawarclub.properties
+++ b/dice_servers/tripleawarclub.properties
@@ -4,7 +4,6 @@ order=10
 name=dice.tripleawarclub.org
 #dice server host
 host=dice.tripleawarclub.org
-port=443
 #path in dice server post to post too
 path=/MARTI.php
 roll.single.start=your dice are: 

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -145,7 +145,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = m_props.getProperty("host");
       final int port = Integer.parseInt(m_props.getProperty("port", "80"));
-      final HttpHost hostConfig = new HttpHost(host, port);
+      final HttpHost hostConfig = new HttpHost(host, port, "https");
       HttpProxy.addProxy(httpPost);
       try (CloseableHttpResponse response = httpClient.execute(hostConfig, httpPost)) {
         return EntityUtils.toString(response.getEntity());

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -144,7 +144,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       // rather than sending out email for each roll
       httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = m_props.getProperty("host");
-      final int port = Integer.parseInt(m_props.getProperty("port", "80"));
+      final int port = Integer.parseInt(m_props.getProperty("port", "443"));
       final HttpHost hostConfig = new HttpHost(host, port, "https");
       HttpProxy.addProxy(httpPost);
       try (CloseableHttpResponse response = httpClient.execute(hostConfig, httpPost)) {


### PR DESCRIPTION
dice.tripleawarclub.org redirects to https, with these updates we would request dice rolls from the https endpoint directly. These updates are based on @ssoloff's comment in: https://github.com/triplea-game/triplea/issues/2564#issuecomment-341616422

```
curl -L -v http://dice.tripleawarclub.org/MARTI.php
*   Trying 2600:3c03::f03c:91ff:fef1:be1b...
* Connected to dice.tripleawarclub.org (2600:3c03::f03c:91ff:fef1:be1b) port 80 (#0)
> GET /MARTI.php HTTP/1.1
> Host: dice.tripleawarclub.org
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
```

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
