### PR TITLE
Use HTTP as default dice server protocol

### DIFF
--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -144,8 +144,9 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       // rather than sending out email for each roll
       httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = m_props.getProperty("host");
-      final int port = Integer.parseInt(m_props.getProperty("port", "443"));
-      final HttpHost hostConfig = new HttpHost(host, port, "https");
+      final int port = Integer.parseInt(m_props.getProperty("port", "80"));
+      final String scheme = m_props.getProperty("scheme", "http");
+      final HttpHost hostConfig = new HttpHost(host, port, scheme);
       HttpProxy.addProxy(httpPost);
       try (CloseableHttpResponse response = httpClient.execute(hostConfig, httpPost)) {
         return EntityUtils.toString(response.getEntity());


### PR DESCRIPTION
Per [#2565](https://github.com/triplea-game/triplea/pull/2565#issuecomment-341726855).

#### Functional changes

* Reset default dice server port to 80 and protocol to HTTP.
* Add new `scheme` property so that the complete dice server endpoint can be overridden.  For example, to use HTTPS to connect to MARTI, specify the following in the _tripleawarclub.properties_ file:

```properties
host=dice.tripleawarclub.org
port=443
scheme=https
```

#### Testing

I tested the following scenarios:

* Existing _tripleawarclub.properties_ connects to MARTI on HTTP endpoint.  Test roll successful.
* Modified _tripleawarclub.properties_ as above to connect to MARTI on HTTPS endpoint.  Test roll successful.