### PR TITLE
Ensure placement error message is displayed to correct user

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -31,7 +31,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.ui.SwingComponents;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -261,7 +260,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
 
     if (!unitsLeftToPlace.isEmpty()) {
-      SwingComponents.showDialog("Unit Placement Canceled", "Not enough unit production territories available");
+      getDisplay().reportMessageToPlayers(
+          Collections.singletonList(m_player),
+          Collections.emptyList(),
+          "Not enough unit production territories available",
+          "Unit Placement Canceled");
     }
 
     // play a sound


### PR DESCRIPTION
This PR addresses the problem reported in #2158.  Please see that issue for a complete description of the problem and the proposed fix.

#### Testing

I was unable to figure out how to trigger the correct code path to pass the `if` check that triggers the error message.  So I simply commented out the `if` check during development.  The test procedure I followed was

* Start a network game.
* From the client, place at least one unit during the placement phase.

Prior to this change, the error message would be displayed on the server node (and since it's modal, it blocks the UI on the server).  After this change, I confirmed that the error message is now displayed on the client node.