### PR TITLE
Ignore command-line switches

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -20,9 +20,8 @@ public final class ArgParser {
    *
    * @return Return true if all args were valid and accepted, false otherwise.
    */
-  public static boolean handleCommandLineArgs(
-      final String[] args, final String[] availableProperties) {
-    if (args.length == 1 && !args[0].contains("=")) {
+  public static boolean handleCommandLineArgs(final String[] args, final String[] availableProperties) {
+    if (args.length == 1 && !args[0].contains("=") && !isSwitch(args[0])) {
       // assume a default single arg, convert the format so we can process as normally.
       if (args[0].startsWith(TRIPLEA_PROTOCOL)) {
         final String encoding = StandardCharsets.UTF_8.displayName();
@@ -40,6 +39,11 @@ public final class ArgParser {
     resetTransientClientSettings();
 
     for (final String arg : args) {
+      // ignore command-line switches forwarded by launchers
+      if (isSwitch(arg)) {
+        continue;
+      }
+
       final String key;
       final int indexOf = arg.indexOf('=');
       if (indexOf > 0) {
@@ -57,6 +61,10 @@ public final class ArgParser {
     ClientSetting.flush();
 
     return true;
+  }
+
+  private static boolean isSwitch(final String arg) {
+    return arg.startsWith("-");
   }
 
   /**

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -84,6 +84,11 @@ public class ArgParserTest {
   }
 
   @Test
+  public void commandLineSwitchesAreIgnored() {
+    assertThat(ArgParser.handleCommandLineArgs(new String[] {"-console"}, new String[] {}), is(true));
+  }
+
+  @Test
   public void returnFalseIfWeCannotMapKeysToAvailableSet() {
     final String[] validKeys = {"a", "b"};
     Arrays.asList(


### PR DESCRIPTION
While debugging #2554, I learned that one can redirect stdout and stderr to a console window when using the _TripleA.exe_ launcher on Windows by passing the `-console` command-line switch (see [here](https://resources.ej-technologies.com/install4j/help/doc/steps/launcher/wizard/executable.html) for details).  However, install4j does not strip off the `-console` switch from the list of command-line arguments and forwards it to the TripleA Java process.  TripleA thinks this switch is a file name and attempts to load it, which results in the following error message being displayed:

![console-switch-interpreted-as-file](https://user-images.githubusercontent.com/4826349/32426504-d2c56348-c288-11e7-8351-16b823eaa734.png)

This PR modifies the command-line argument parser to simply ignore all switches (i.e. arguments that begin with a dash) since all relevant arguments to be processed are always of the form `key=value`.

The only possible improvement I can think of is to write a message to stdout stating the switch is being ignored.  Opinions welcome.