### PR TITLE
Fix NPE during TripleAFrame initialization

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -231,7 +231,15 @@ public class TripleAFrame extends MainGameFrame {
     this.setCursor(uiContext.getCursor());
     editModeButtonModel = new JToggleButton.ToggleButtonModel();
     editModeButtonModel.setEnabled(false);
-
+    showCommentLogButtonModel = new JToggleButton.ToggleButtonModel();
+    showCommentLogButtonModel.setSelected(false);
+    showCommentLogButtonModel.addActionListener(e -> {
+      if (showCommentLogButtonModel.isSelected()) {
+        showCommentLog();
+      } else {
+        hideCommentLog();
+      }
+    });
     menu = new TripleAMenuBar(this);
     this.setJMenuBar(menu);
     final ImageScrollModel model = new ImageScrollModel();
@@ -273,15 +281,6 @@ public class TripleAFrame extends MainGameFrame {
     } else {
       mapAndChatPanel.add(mapPanel, BorderLayout.CENTER);
     }
-    showCommentLogButtonModel = new JToggleButton.ToggleButtonModel();
-    showCommentLogButtonModel.setSelected(false);
-    showCommentLogButtonModel.addActionListener(e -> {
-      if (showCommentLogButtonModel.isSelected()) {
-        showCommentLog();
-      } else {
-        hideCommentLog();
-      }
-    });
     gameMainPanel.setLayout(new BorderLayout());
     this.getContentPane().setLayout(new BorderLayout());
     this.getContentPane().add(gameMainPanel, BorderLayout.CENTER);


### PR DESCRIPTION
Fixes #2575.

The `TripleAFrame#showCommentLogButtonModel` field must be initialized before the `TripleAMenuBar` is created.  Creating the `TripleAMenuBar` causes the `ViewMenu` to be created.  During `ViewMenu` creation, a call is made to obtain `TripleAFrame#showCommentLogButtonModel`.  If this field is `null`, the Substance L&F will throw an NPE when `JCheckBoxMenuItem#setModel()` is called.

#2570 changed the initialization order so that `TripleAFrame#showCommentLogButtonModel` was initialized after the `TripleAMenuBar` was created.  This change restores the initialization order prior to that PR such that `TripleAFrame#showCommentLogButtonModel` is initialized before the creation of the `TripleAMenuBar`.