### PR TITLE
Ensure TimespanDialog has consistent initial focus across all platforms

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
@@ -1,31 +1,113 @@
 package games.strategy.engine.lobby.client.ui;
 
-import java.awt.Component;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.awt.Frame;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
 import javax.swing.JComboBox;
-import javax.swing.JOptionPane;
+import javax.swing.JDialog;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.AncestorEvent;
-import javax.swing.event.AncestorListener;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import games.strategy.ui.SwingComponents;
+import swinglib.JButtonBuilder;
 import swinglib.JLabelBuilder;
 import swinglib.JPanelBuilder;
 
 /**
  * A UI-Utility class that can be used to prompt the user for a ban or mute time.
  */
-public class TimespanDialog {
+public final class TimespanDialog extends JDialog {
+  private static final long serialVersionUID = 1367343948352548021L;
+
+  @VisibleForTesting
+  static final int MAX_DURATION = 99_999_999;
+
+  private final JSpinner durationSpinner = new JSpinner(new SpinnerNumberModel(1, 1, MAX_DURATION, 1));
+  private final JComboBox<TimeUnit> timeUnitComboBox = new JComboBox<>(TimeUnit.values());
+  private Result result = Result.CANCEL;
+
+  private TimespanDialog(final Frame owner, final String title, final String message) {
+    super(owner, title, true);
+
+    add(JPanelBuilder.builder()
+        .borderEmpty(10)
+        .verticalBoxLayout()
+        .add(JPanelBuilder.builder()
+            .horizontalBoxLayout()
+            .add(JLabelBuilder.builder()
+                .text(message)
+                .build())
+            .addHorizontalGlue()
+            .build())
+        .addVerticalStrut(10)
+        .add(JPanelBuilder.builder()
+            .horizontalBoxLayout()
+            .add(durationSpinner)
+            .addHorizontalStrut(5)
+            .add(timeUnitComboBox)
+            .build())
+        .addVerticalStrut(20)
+        .add(JPanelBuilder.builder()
+            .horizontalBoxLayout()
+            .addHorizontalGlue()
+            .add(JButtonBuilder.builder()
+                .title("OK")
+                .actionListener(() -> close(Result.OK))
+                .build())
+            .addHorizontalStrut(5)
+            .add(JButtonBuilder.builder()
+                .title("Cancel")
+                .actionListener(() -> close(Result.CANCEL))
+                .build())
+            .build())
+        .build());
+    pack();
+    setLocationRelativeTo(owner);
+
+    SwingComponents.addEscapeKeyListener(this, () -> close(Result.CANCEL));
+    timeUnitComboBox.addActionListener(e -> updateComponents());
+  }
+
+  private void close(final Result result) {
+    setVisible(false);
+    dispose();
+    this.result = result;
+  }
+
+  private void updateComponents() {
+    durationSpinner.setEnabled(!TimeUnit.FOREVER.equals(timeUnitComboBox.getSelectedItem()));
+  }
+
+  Optional<Timespan> open() {
+    setVisible(true);
+
+    switch (result) {
+      case OK:
+        return Optional.of(new Timespan(
+            (Integer) durationSpinner.getValue(),
+            (TimeUnit) timeUnitComboBox.getSelectedItem()));
+      case CANCEL:
+        return Optional.empty();
+      default:
+        throw new AssertionError("unknown result: " + result);
+    }
+  }
+
+  private enum Result {
+    OK, CANCEL;
+  }
 
   /**
    * The possible time units and corresponding mappings.
@@ -49,8 +131,8 @@ public class TimespanDialog {
     private final String displayName;
     private final Function<Integer, Instant> function;
 
-    private TimeUnit(final String name, final Function<Integer, Instant> function) {
-      this.displayName = name;
+    private TimeUnit(final String displayName, final Function<Integer, Instant> function) {
+      this.displayName = displayName;
       this.function = function;
     }
 
@@ -60,8 +142,20 @@ public class TimespanDialog {
     }
 
     @VisibleForTesting
+    @Nullable
     Instant getInstant(final Integer integer) {
       return function.apply(integer);
+    }
+  }
+
+  @VisibleForTesting
+  static final class Timespan {
+    final Integer duration;
+    final TimeUnit timeUnit;
+
+    Timespan(final Integer duration, final TimeUnit timeUnit) {
+      this.duration = duration;
+      this.timeUnit = timeUnit;
     }
   }
 
@@ -70,45 +164,20 @@ public class TimespanDialog {
    * If the operation is not cancelled, the action Consumer is run.
    * Not that the Date passed to the consumer can be null if the user chose forever.
    */
-  public static void prompt(final Component parent, final String title, final String infoMessage,
-      final Consumer<Date> action) {
-    final JSpinner spinner = new JSpinner(new SpinnerNumberModel(1, 1, 99999999, 1));
-    spinner.addAncestorListener(new AncestorListener() {
+  public static void prompt(final Frame owner, final String title, final String message, final Consumer<Date> action) {
+    checkNotNull(owner);
+    checkNotNull(title);
+    checkNotNull(message);
+    checkNotNull(action);
 
-      @Override
-      public void ancestorAdded(final AncestorEvent e) {
-        e.getComponent().requestFocusInWindow();
-      }
-
-      @Override
-      public void ancestorMoved(final AncestorEvent e) {}
-
-      @Override
-      public void ancestorRemoved(final AncestorEvent e) {}
-    });
-    final JComboBox<TimeUnit> comboBox = new JComboBox<>(TimeUnit.values());
-    comboBox.addActionListener(e -> spinner.setEnabled(!comboBox.getSelectedItem().equals(TimeUnit.FOREVER)));
-    final int returnValue = JOptionPane.showConfirmDialog(parent, JPanelBuilder.builder()
-        .borderLayout()
-        .addNorth(JLabelBuilder.builder()
-            .text(infoMessage)
-            .border(new EmptyBorder(0, 0, 5, 0))
-            .build())
-        .addSouth(JPanelBuilder.builder()
-            .horizontalBoxLayout()
-            .add(spinner)
-            .add(comboBox)
-            .build())
-        .build(), title, JOptionPane.OK_CANCEL_OPTION);
-    runAction(action, returnValue, (TimeUnit) comboBox.getSelectedItem(), (Integer) spinner.getValue());
+    runAction(action, new TimespanDialog(owner, title, message).open());
   }
 
   @VisibleForTesting
-  static void runAction(final Consumer<Date> action, final int returnType, final TimeUnit timeUnit,
-      final Integer duration) {
-    if (returnType == JOptionPane.OK_OPTION) {
-      final Instant instant = timeUnit.getInstant(duration);
+  static void runAction(final Consumer<Date> action, final Optional<Timespan> timespan) {
+    timespan.ifPresent(it -> {
+      final @Nullable Instant instant = it.timeUnit.getInstant(it.duration);
       action.accept(instant == null ? null : Date.from(instant));
-    }
+    });
   }
 }

--- a/src/test/java/games/strategy/engine/lobby/client/ui/TimespanDialogTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/ui/TimespanDialogTest.java
@@ -5,13 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
-
-import javax.swing.JOptionPane;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.client.ui.TimespanDialog.TimeUnit;
+import games.strategy.engine.lobby.client.ui.TimespanDialog.Timespan;
 
 public class TimespanDialogTest {
 
@@ -45,29 +46,29 @@ public class TimespanDialogTest {
 
   @Test
   public void testCancelDoesExecuteNothing() {
-    TimespanDialog.runAction(d -> fail("Operation was not cancelled!"), JOptionPane.CANCEL_OPTION, TimeUnit.FOREVER, 0);
+    TimespanDialog.runAction(d -> fail("Operation was not cancelled!"), Optional.empty());
   }
 
   @Test
   public void testNonNullDateInTheFuture() {
     // We can't use Integer#MAX_VALUE for years, because this will result in a long-overflow
     // So we just limit the amount for every time unit
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.MINUTES, 99999999);
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.HOURS, 99999999);
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.DAYS, 99999999);
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.WEEKS, 99999999);
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.MONTHS, 99999999);
-    TimespanDialog.runAction(d -> assertTrue(d.after(new Date())),
-        JOptionPane.OK_OPTION, TimeUnit.YEARS, 99999999);
+    Arrays.asList(
+        TimeUnit.MINUTES,
+        TimeUnit.HOURS,
+        TimeUnit.DAYS,
+        TimeUnit.WEEKS,
+        TimeUnit.MONTHS,
+        TimeUnit.YEARS)
+        .forEach(timeUnit -> {
+          TimespanDialog.runAction(
+              d -> assertTrue(d.after(new Date())),
+              Optional.of(new Timespan(TimespanDialog.MAX_DURATION, timeUnit)));
+        });
   }
 
   @Test
   public void testForeverPassesNull() {
-    TimespanDialog.runAction(d -> assertNull(d), JOptionPane.OK_OPTION, TimeUnit.FOREVER, 0);
+    TimespanDialog.runAction(d -> assertNull(d), Optional.of(new Timespan(0, TimeUnit.FOREVER)));
   }
 }


### PR DESCRIPTION
Based on a [discussion](https://github.com/triplea-game/triplea/pull/2454#discussion_r142014549) from #2454.

On Linux, the initial focus of `TimespanDialog` is set to the OK button rather than the duration spinner, as it is on Windows.  As referenced in the above comment, this is apparently a limitation of `JOptionPane`.

This PR changes `TimespanDialog` to inherit directly from `JDialog` to avoid the `JOptionPane` plumbing which is causing the focus issues on Linux.

#### Functional changes

None.  However, due to the switch to `JDialog`, the layout changed slightly:

![timespan-dialog](https://user-images.githubusercontent.com/4826349/32479068-19c30890-c356-11e7-9fb1-38d6f0cad07c.png)

#### Refactoring changes

I changed the signature of the internal `runAction()` method to use the new `Timespan` value type to encapsulate the `TimespanDialog` implementation as much as possible.

#### Testing

Even though there are no functional changes, I tested banning a username using all time units just to be sure. :smile: