### PR TITLE
Add new BackgroundTaskRunner method for Runnables

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -274,7 +274,7 @@ public class GameRunner {
 
   private static void loadGame() {
     try {
-      BackgroundTaskRunner.runInBackgroundAndReturn("Loading game...", () -> {
+      BackgroundTaskRunner.runInBackground("Loading game...", () -> {
         gameSelectorModel.loadDefaultGame(false);
         final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
         if (fileName.length() > 0) {
@@ -285,8 +285,6 @@ public class GameRunner {
         if (!downloadableMap.isEmpty()) {
           SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(downloadableMap));
         }
-
-        return null;
       });
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -372,10 +372,9 @@ public class GameSelectorPanel extends JPanel implements Observer {
         return;
       }
       try {
-        BackgroundTaskRunner.runInBackgroundAndReturn("Loading savegame...", () -> {
+        BackgroundTaskRunner.runInBackground("Loading savegame...", () -> {
           model.load(file, this);
           setOriginalPropertiesMap(model.getGameData());
-          return null;
         });
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -385,18 +384,17 @@ public class GameSelectorPanel extends JPanel implements Observer {
         final GameChooserEntry entry =
             GameChooser.chooseGame(JOptionPane.getFrameForComponent(this), model.getGameName());
         if (entry != null) {
-          BackgroundTaskRunner.runInBackgroundAndReturn("Loading map...", () -> {
+          BackgroundTaskRunner.runInBackground("Loading map...", () -> {
             if (!entry.isGameDataLoaded()) {
               try {
                 entry.fullyParseGameData();
               } catch (final GameParseException e) {
                 entry.delayParseGameData();
                 // TODO remove bad entries from the underlying model
-                return null;
+                return;
               }
             }
             model.load(entry);
-            return null;
           });
           setOriginalPropertiesMap(model.getGameData());
           // only for new games, not saved games, we set the default options, and set them only once

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -22,6 +22,30 @@ public final class BackgroundTaskRunner {
   private BackgroundTaskRunner() {}
 
   /**
+   * Runs the specified action in the background without blocking the UI.
+   *
+   * <p>
+   * {@code backgroundAction} is run on a background (non-UI) thread. While the background action is running, a dialog
+   * is displayed with the specified message. When the background action is complete, the dialog is removed.
+   * </p>
+   *
+   * @param message The message displayed to the user while the background action is running.
+   * @param backgroundAction The action to run in the background.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
+   * @throws InterruptedException If the UI thread is interrupted while waiting for the background action to complete.
+   */
+  public static void runInBackground(
+      final String message,
+      final Runnable backgroundAction)
+      throws InterruptedException {
+    runInBackgroundAndReturn(message, () -> {
+      backgroundAction.run();
+      return null;
+    });
+  }
+
+  /**
    * Runs the specified action in the background without blocking the UI and returns the result of that action.
    *
    * <p>

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -68,7 +68,7 @@ public final class BackgroundTaskRunner {
       final String message,
       final Supplier<T> backgroundAction)
       throws InterruptedException {
-    return runInBackgroundAndReturnOrThrow(message, () -> backgroundAction.get(), RuntimeException.class);
+    return runInBackgroundAndReturn(message, () -> backgroundAction.get(), RuntimeException.class);
   }
 
   /**
@@ -95,7 +95,7 @@ public final class BackgroundTaskRunner {
    * @throws E If the background action fails.
    * @throws InterruptedException If the UI thread is interrupted while waiting for the background action to complete.
    */
-  public static <T, E extends Exception> T runInBackgroundAndReturnOrThrow(
+  public static <T, E extends Exception> T runInBackgroundAndReturn(
       final String message,
       final ThrowingSupplier<T, E> backgroundAction,
       final Class<E> exceptionType)

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -54,7 +54,7 @@ public class LobbyLogin {
 
   private @Nullable LobbyClient login(final LoginPanel panel) {
     try {
-      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturnOrThrow(
+      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturn(
           "Connecting to lobby...",
           () -> login(panel.getUserName(), panel.getPassword(), panel.isAnonymousLogin()),
           IOException.class);
@@ -132,7 +132,7 @@ public class LobbyLogin {
 
   private @Nullable LobbyClient createAccount(final CreateUpdateAccountPanel panel) {
     try {
-      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturnOrThrow(
+      final IMessenger messenger = BackgroundTaskRunner.runInBackgroundAndReturn(
           "Connecting to lobby...",
           () -> createAccount(panel.getUserName(), panel.getPassword(), panel.getEmail()),
           IOException.class);


### PR DESCRIPTION
This PR adds the new `BackgroundTaskRunner#runInBackground(String, Runnable)` method.  Callers that do not require a result from the background task can use this method instead of the method that accepts a `Supplier<T>` and having to return `null` (or some other artificial value).  All calls to `runInBackgroundAndReturn()` that did not use the return value were converted to call `runInBackground()` instead.

I also renamed the `runInBackgroundAndReturnOrThrow()` method.  The `OrThrow` suffix was not necessary to distinguish this overload from the version that does not throw because they have parameter lists of different lengths (this wasn't the case when I originally added these methods, but I forgot to rename them at that time).