### PR TITLE
Map WaitDialog system close button to cancel action

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
@@ -2,8 +2,8 @@ package games.strategy.engine.framework.ui.background;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.util.Optional;
 
-import javax.annotation.Nullable;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
@@ -18,24 +18,28 @@ public final class WaitDialog extends JDialog {
   private static final long serialVersionUID = 7433959812027467868L;
 
   public WaitDialog(final Component parent, final String message) {
-    this(parent, message, null);
+    this(parent, message, Optional.empty());
   }
 
-  public WaitDialog(final Component parent, final String message, final @Nullable Runnable cancelAction) {
+  public WaitDialog(final Component parent, final String message, final Runnable cancelAction) {
+    this(parent, message, Optional.of(cancelAction));
+  }
+
+  private WaitDialog(final Component parent, final String message, final Optional<Runnable> cancelAction) {
     super(JOptionPane.getFrameForComponent(parent), "Please Wait", true);
 
     setLayout(new BorderLayout());
     add(new WaitPanel(message), BorderLayout.CENTER);
 
     setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-    if (cancelAction != null) {
+    cancelAction.ifPresent(it -> {
       final JButton cancelButton = new JButton("Cancel");
-      cancelButton.addActionListener(e -> cancelAction.run());
+      cancelButton.addActionListener(e -> it.run());
       add(cancelButton, BorderLayout.SOUTH);
 
-      SwingComponents.addEscapeKeyListener(this, cancelAction);
-      SwingComponents.addWindowClosingListener(this, cancelAction);
-    }
+      SwingComponents.addEscapeKeyListener(this, it);
+      SwingComponents.addWindowClosingListener(this, it);
+    });
 
     pack();
     setLocationRelativeTo(parent);

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
@@ -2,11 +2,13 @@ package games.strategy.engine.framework.ui.background;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.event.ActionListener;
 
+import javax.annotation.Nullable;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+
+import games.strategy.ui.SwingComponents;
 
 /**
  * A dialog that can be displayed during a long-running operation that optionally provides the user with the ability to
@@ -15,19 +17,24 @@ import javax.swing.JOptionPane;
 public final class WaitDialog extends JDialog {
   private static final long serialVersionUID = 7433959812027467868L;
 
-  public WaitDialog(final Component parent, final String waitMessage) {
-    this(parent, waitMessage, null);
+  public WaitDialog(final Component parent, final String message) {
+    this(parent, message, null);
   }
 
-  public WaitDialog(final Component parent, final String waitMessage, final ActionListener cancelAction) {
+  public WaitDialog(final Component parent, final String message, final @Nullable Runnable cancelAction) {
     super(JOptionPane.getFrameForComponent(parent), "Please Wait", true);
-    final WaitPanel panel = new WaitPanel(waitMessage);
-    getContentPane().setLayout(new BorderLayout());
-    getContentPane().add(panel, BorderLayout.CENTER);
+
+    setLayout(new BorderLayout());
+    add(new WaitPanel(message), BorderLayout.CENTER);
+
+    setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
     if (cancelAction != null) {
       final JButton cancelButton = new JButton("Cancel");
-      cancelButton.addActionListener(cancelAction);
-      getContentPane().add(cancelButton, BorderLayout.SOUTH);
+      cancelButton.addActionListener(e -> cancelAction.run());
+      add(cancelButton, BorderLayout.SOUTH);
+
+      SwingComponents.addEscapeKeyListener(this, cancelAction);
+      SwingComponents.addWindowClosingListener(this, cancelAction);
     }
 
     pack();

--- a/src/main/java/games/strategy/triplea/oddscalc/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddscalc/OddsCalculatorPanel.java
@@ -311,7 +311,10 @@ class OddsCalculatorPanel extends JPanel {
       throw new IllegalStateException("Wrong thread");
     }
     final AtomicReference<AggregateResults> results = new AtomicReference<>();
-    final WaitDialog dialog = new WaitDialog(this, "Calculating Odds", e -> calculator.cancel());
+    // NB: Do not replace the lambda below with the method reference "calculator::cancel". "calculator" is null
+    // at this point and will be bound to the method reference as the call site, which will raise an NPE when the
+    // method reference is invoked. The form below defers evaluation of "calculator" until the lambda is invoked.
+    final WaitDialog dialog = new WaitDialog(this, "Calculating Odds", () -> calculator.cancel());
     new Thread(() -> {
       try {
         // find a territory to fight in


### PR DESCRIPTION
#### Functional changes

The `WaitDialog` system close button (i.e. the "X" in the upper left/right corner) previously would simply hide the dialog without doing anything else.  Now, if a cancel action is provided, clicking the system close button will trigger the cancel action.  Otherwise, clicking the button does nothing.

I also added an <kbd>Esc</kbd> key handler that invokes the cancel action if one was provided.  Otherwise, pressing <kbd>Esc</kbd> does nothing.

#### Testing

For a `WaitDialog` without a cancel action, I tested the game loading wait dialog displayed during startup.  I confirmed clicking the system close button no longer closes the dialog.

For a `WaitDialog` with a cancel action, I tested the Odds Calculator progress dialog.  I confirmed clicking the system close button cancels the simulation and closes the dialog.  I also confirmed there was no change in behavior when clicking the Cancel button in the dialog content pane.