### PR TITLE
Fix IllegalStateException when parsing maps

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -23,6 +23,7 @@ import java.util.zip.ZipFile;
 
 import javax.swing.DefaultListModel;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -51,21 +52,21 @@ public class GameChooserModel extends DefaultListModel<GameChooserEntry> {
 
   /**
    * Creates a new Instance of a GameChooserModel.
-   * Must be called on the EDT, will not return until all
+   * If called on the EDT, will not return until all
    * map files have been scanned, but is not going to
    * effectively block the EDT.
    *
    * @return The newly created instance.
    *
-   * @throws InterruptedException If this Thread is being interrupted
+   * @throws InterruptedException If called on the EDT and this thread is interrupted
    *         while waiting for the SwingWorker to complete.
-   * @throws IllegalStateException If this method is called on any other
-   *         Thread than the Swing Event Dispatch Thread.
    */
   public static GameChooserModel newInstance() throws InterruptedException {
-    return new GameChooserModel(BackgroundTaskRunner.runInBackgroundAndReturn(
-        "Loading all available games...",
-        GameChooserModel::parseMapFiles));
+    return new GameChooserModel(SwingUtilities.isEventDispatchThread()
+        ? BackgroundTaskRunner.runInBackgroundAndReturn(
+            "Loading all available games...",
+            GameChooserModel::parseMapFiles)
+        : parseMapFiles());
   }
 
   @Override


### PR DESCRIPTION
This is a temporary fix for #2584.  It may be superseded by a follow-up PR based on the discussion in #2584.

<hr>

Certain code paths may call `GameChooserModel#newInstance()` from a thread other than the EDT.  In such a case, an `IllegalStateException` is thrown because this method assumes it will always be called from the EDT.

The fix is to determine if the current thread is the EDT.  If so, use `BackgroundTaskRunner` to parse all maps.  Otherwise, parse all maps on the current thread.