### PR TITLE
Cli overhaul

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.install4j.gradle' version '7.0.1'
     id 'de.undercouch.download' version '3.2.0'
-    id "net.ltgt.errorprone" version "0.0.11"
+    id 'net.ltgt.errorprone' version '0.0.11'
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
@@ -100,6 +100,7 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'org.json:json:20170516'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
+    compile 'commons-cli:commons-cli:1.4'
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -8,7 +8,7 @@
 <listEntry value="1"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game=triplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3300&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game= -Ptriplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3300&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -8,7 +8,7 @@
 <listEntry value="1"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="triplea.game.host.console=true &#13;&#10;triplea.game= triplea.server=true &#13;&#10;triplea.port=3300&#13;&#10;triplea.lobby.host=127.0.0.1&#13;&#10;triplea.lobby.port=3300&#13;&#10;triplea.name=Bot1_TestServer &#13;&#10;triplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;triplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;triplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game=triplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3300&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -12,7 +13,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import games.strategy.debug.ClientLogger;
+import com.google.common.base.Joiner;
+
 import games.strategy.triplea.settings.ClientSetting;
 
 /**
@@ -21,59 +23,65 @@ import games.strategy.triplea.settings.ClientSetting;
 public final class ArgParser {
   private static final String TRIPLEA_PROTOCOL = "triplea:";
   private static final String TRIPLEA_PROPERTY_PREFIX = "P";
+  private final Set<String> availableProperties;
 
-  private ArgParser() {}
+  public ArgParser(final Set<String> availableProperties) {
+    this.availableProperties = availableProperties;
+  }
 
   /**
    * Move command line arguments to system properties or client settings.
    *
    * @return Return true if all args were valid and accepted, false otherwise.
    */
-  public static boolean handleCommandLineArgs(final String[] args, final String[] availableProperties) {
+  public boolean handleCommandLineArgs(final String[] args) {
     resetTransientClientSettings();
     final Options options = getOptions();
     final CommandLineParser parser = new DefaultParser();
     try {
       final CommandLine cli = parser.parse(options, args);
       if (!cli.getOptionProperties(TRIPLEA_PROPERTY_PREFIX).entrySet().stream().allMatch(
-          entry -> setSystemPropertyOrClientSetting((String) entry.getKey(), (String) entry.getValue(),
-              availableProperties))) {
+          entry -> setSystemPropertyOrClientSetting((String) entry.getKey(), (String) entry.getValue()))) {
+        return false;
       }
 
       // Parse remaining options
-      parseRemaining(cli.getArgs(), availableProperties);
+      parseRemaining(cli.getArgs());
 
     } catch (final ParseException e) {
-      ClientLogger.logError(e);
+      throw new IllegalArgumentException(e);
     }
     ClientSetting.flush();
     return true;
   }
 
-  private static void parseRemaining(final String[] remainingArgs, final String[] availableProperties) {
-    if (remainingArgs.length >= 1) {
+  private void parseRemaining(final String[] remainingArgs) {
+    if (remainingArgs.length == 1) {
       if (remainingArgs[0].startsWith(TRIPLEA_PROTOCOL)) {
         final String encoding = StandardCharsets.UTF_8.displayName();
         try {
           setSystemPropertyOrClientSetting(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY,
-              URLDecoder.decode(remainingArgs[0].substring(TRIPLEA_PROTOCOL.length()), encoding), availableProperties);
+              URLDecoder.decode(remainingArgs[0].substring(TRIPLEA_PROTOCOL.length()), encoding));
         } catch (final UnsupportedEncodingException e) {
           throw new AssertionError(encoding + " is not a supported encoding!", e);
         }
       } else {
-        setSystemPropertyOrClientSetting(GameRunner.TRIPLEA_GAME_PROPERTY, remainingArgs[0], availableProperties);
+        setSystemPropertyOrClientSetting(GameRunner.TRIPLEA_GAME_PROPERTY, remainingArgs[0]);
       }
+    } else if (remainingArgs.length > 1) {
+      throw new IllegalArgumentException("Too much arguments: " + Arrays.toString(remainingArgs));
     }
   }
 
-  private static Options getOptions() {
+  private Options getOptions() {
     final Options options = new Options();
     options.addOption(Option.builder(TRIPLEA_PROPERTY_PREFIX)
-        .argName("property=value")
+        .argName("key=value")
         .hasArgs()
         .numberOfArgs(2)
         .valueSeparator()
-        .desc("Assign the given value to the given property key.")
+        .desc("Assign the given value to the given property key.\nValid keys are : "
+            + Joiner.on(",\n").join(availableProperties))
         .build());
     // See https://github.com/triplea-game/triplea/pull/2574 for more information
     options.addOption(Option.builder("console").build());
@@ -95,11 +103,10 @@ public final class ArgParser {
         .forEach(setting -> setting.save(setting.defaultValue));
   }
 
-  private static boolean setSystemPropertyOrClientSetting(
+  private boolean setSystemPropertyOrClientSetting(
       final String key,
-      final String value,
-      final String[] availableProperties) {
-    if (!Arrays.stream(availableProperties).anyMatch(key::equals)) {
+      final String value) {
+    if (!availableProperties.contains(key)) {
       System.out.println(String.format("Key %s is unknown", key));
       return false;
     }
@@ -117,7 +124,6 @@ public final class ArgParser {
       ClientSetting.MAP_FOLDER_OVERRIDE.save(value);
       return true;
     }
-
     return false;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -14,9 +14,12 @@ import java.io.File;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.swing.JFileChooser;
@@ -105,11 +108,11 @@ public class GameRunner {
   private static final SetupPanelModel setupPanelModel = new SetupPanelModel(gameSelectorModel);
   private static JFrame mainFrame;
 
-  private static final String[] COMMAND_LINE_ARGS =
-      {TRIPLEA_GAME_PROPERTY, TRIPLEA_MAP_DOWNLOAD_PROPERTY, TRIPLEA_SERVER_PROPERTY, TRIPLEA_CLIENT_PROPERTY,
-          TRIPLEA_HOST_PROPERTY, TRIPLEA_PORT_PROPERTY, TRIPLEA_NAME_PROPERTY, TRIPLEA_SERVER_PASSWORD_PROPERTY,
-          TRIPLEA_STARTED, TRIPLEA_LOBBY_PORT_PROPERTY, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
-          TRIPLEA_ENGINE_VERSION_BIN, TRIPLEA_DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER};
+  private static final Set<String> COMMAND_LINE_ARGS = new HashSet<>(Arrays.asList(
+      TRIPLEA_GAME_PROPERTY, TRIPLEA_MAP_DOWNLOAD_PROPERTY, TRIPLEA_SERVER_PROPERTY, TRIPLEA_CLIENT_PROPERTY,
+      TRIPLEA_HOST_PROPERTY, TRIPLEA_PORT_PROPERTY, TRIPLEA_NAME_PROPERTY, TRIPLEA_SERVER_PASSWORD_PROPERTY,
+      TRIPLEA_STARTED, TRIPLEA_LOBBY_PORT_PROPERTY, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
+      TRIPLEA_ENGINE_VERSION_BIN, TRIPLEA_DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER));
 
 
   /**
@@ -123,7 +126,7 @@ public class GameRunner {
     if (!ClientContext.gameEnginePropertyReader().useJavaFxUi()) {
       ErrorConsole.getConsole();
     }
-    if (!ArgParser.handleCommandLineArgs(args, COMMAND_LINE_ARGS)) {
+    if (!new ArgParser(COMMAND_LINE_ARGS).handleCommandLineArgs(args)) {
       usage();
       return;
     }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -665,6 +665,7 @@ public class HeadlessGameServer {
   }
 
   private static void usage() {
+    // TODO replace this method with the generated usage of commons-cli
     System.out.println("\nUsage and Valid Arguments:\n"
         + "   " + GameRunner.TRIPLEA_GAME_PROPERTY + "=<FILE_NAME>\n"
         + "   " + GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY + "=<true/false>\n"

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -469,14 +471,14 @@ public class HeadlessGameServer {
     }
   }
 
-  private static String[] getProperties() {
-    return new String[] {GameRunner.TRIPLEA_GAME_PROPERTY, GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY,
+  private static Set<String> getProperties() {
+    return new HashSet<>(Arrays.asList(GameRunner.TRIPLEA_GAME_PROPERTY, GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY,
         GameRunner.TRIPLEA_SERVER_PROPERTY, GameRunner.TRIPLEA_PORT_PROPERTY,
         GameRunner.TRIPLEA_NAME_PROPERTY, GameRunner.LOBBY_HOST, GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY,
         GameRunner.LOBBY_GAME_COMMENTS, GameRunner.LOBBY_GAME_HOSTED_BY, GameRunner.LOBBY_GAME_SUPPORT_EMAIL,
         GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, GameRunner.LOBBY_GAME_RECONNECTION,
         GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME, GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
-        GameRunner.MAP_FOLDER};
+        GameRunner.MAP_FOLDER));
   }
 
   String getStatus() {
@@ -648,7 +650,7 @@ public class HeadlessGameServer {
 
   public static void main(final String[] args) {
     System.getProperties().setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
-    if (!ArgParser.handleCommandLineArgs(args, getProperties())) {
+    if (!new ArgParser(getProperties()).handleCommandLineArgs(args)) {
       usage();
       return;
     }

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -73,7 +73,7 @@ public class ArgParserTest {
   }
 
   @Test
-  public void commandLineSwitchesAreIgnored() {
+  public void install4jSwitchesAreIgnored() {
     assertThat(new ArgParser(Collections.emptySet()).handleCommandLineArgs(new String[] {"-console"}), is(true));
   }
 


### PR DESCRIPTION
This Pr makes TripleA use the commons-cli library.
Breaking Changes:
No every engine property must be prefixed with `-P`, so `mapFolder=/home/triplea/maps` needs to be replaced with `-PmapFolder=/home/triplea/maps`.
In order not to make too break too much there are no other functional changes.
https://github.com/triplea-game/lobby/pull/46 should be merged after this PR

In the future we should probably aim to replace those properties with normal flags