### PR TITLE
Ensure tests do not permanently modify ClientSettings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,6 @@ repositories {
 
 dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
-    compile 'commons-io:commons-io:2.5'
     compile 'org.postgresql:postgresql:42.1.4'
     compile 'com.github.insubstantial:substance:7.3'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
@@ -106,9 +105,11 @@ dependencies {
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.1'
     testCompile 'org.mockito:mockito-core:2.11.0'
+    testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
 
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.1'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.1'
+    testRuntime 'org.slf4j:slf4j-nop:1.7.25'
 }
 
 task integTest(type: JavaExec, dependsOn: [compileIntegTestJava]) {

--- a/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -6,7 +6,9 @@ import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.Test;
 
-public class ClientContextIntegrationTest {
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+
+public class ClientContextIntegrationTest extends AbstractClientSettingTestCase {
 
   @Test
   public void verifyClientContext() {

--- a/src/integ_test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.Test;
 
-public class LobbyServerPropertiesFetcherIntegrationTest {
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+
+public class LobbyServerPropertiesFetcherIntegrationTest extends AbstractClientSettingTestCase {
   @Test
   public void remoteLobbyUrlReaderWorks() {
 

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -119,6 +119,7 @@ public class GameRunner {
    */
   public static void main(final String[] args) {
     LoggingConfiguration.initialize();
+    ClientSetting.initialize();
 
     if (!ClientContext.gameEnginePropertyReader().useJavaFxUi()) {
       ErrorConsole.getConsole();

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -647,6 +647,8 @@ public class HeadlessGameServer {
   }
 
   public static void main(final String[] args) {
+    ClientSetting.initialize();
+
     System.getProperties().setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
     if (!ArgParser.handleCommandLineArgs(args, getProperties())) {
       usage();

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -24,13 +24,14 @@ import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.data.ResourceCollection;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PropertyUtil;
 
 /**
  * A test that validates that all attachment classes have properties with valid setters and getters.
  */
-public class ValidateAttachmentsTest {
+public class ValidateAttachmentsTest extends AbstractClientSettingTestCase {
   /**
    * Test that the Example Attachment is valid.
    */

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -10,9 +10,10 @@ import java.util.Arrays;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 
-public class ArgParserTest {
+public class ArgParserTest extends AbstractClientSettingTestCase {
 
 
   @AfterEach

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -21,8 +21,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.io.IoUtils;
 import games.strategy.persistence.serializable.ProxyRegistry;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
-public class GameDataManagerTest {
+public class GameDataManagerTest extends AbstractClientSettingTestCase {
   @Test
   public void testLoadStoreKeepsGameUuid() throws IOException {
     final GameData data = new GameData();

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -8,9 +8,10 @@ import java.io.File;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
 
-public class DownloadFileDescriptionTest {
+public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
 
   @Test
   public void testIsMap() {

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
@@ -36,8 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
 import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
-public final class DownloadUtilsTest {
+public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
   private static final String URI = "some://uri";
 
   @ExtendWith(MockitoExtension.class)

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -16,10 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
 
 @ExtendWith(MockitoExtension.class)
-public class MapDownloadListTest {
+public class MapDownloadListTest extends AbstractClientSettingTestCase {
   private static final String MAP_NAME = "new_test_order";
   private static final Version MAP_VERSION = new Version(10, 10);
   private static final Version lowVersion = new Version(0, 0);

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -25,10 +25,11 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.ui.GameChooserEntry;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
 
 @ExtendWith(MockitoExtension.class)
-public class GameSelectorModelTest {
+public class GameSelectorModelTest extends AbstractClientSettingTestCase {
 
   private static void assertHasEmptyData(final GameSelectorModel objectToCheck) {
     assertThat(objectToCheck.getGameData(), nullValue());

--- a/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Maps;
 
-public class ResourceLoaderTest {
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+
+public class ResourceLoaderTest extends AbstractClientSettingTestCase {
   @Test
   public void testGetMapZipFileCandidates_ShouldIncludeDefaultZipFile() {
     final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");

--- a/src/test/java/games/strategy/triplea/settings/AbstractClientSettingTestCase.java
+++ b/src/test/java/games/strategy/triplea/settings/AbstractClientSettingTestCase.java
@@ -1,0 +1,27 @@
+package games.strategy.triplea.settings;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+/**
+ * Superclass for test fixtures that directly or indirectly interact with instances of {@link ClientSetting}.
+ *
+ * <p>
+ * This fixture ensures the {@link ClientSetting} preferences are properly initialized before each test and
+ * uninitialized after each test.
+ * </p>
+ */
+public abstract class AbstractClientSettingTestCase {
+  protected AbstractClientSettingTestCase() {}
+
+  @BeforeEach
+  public final void initializeClientSettingPreferences() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  @AfterEach
+  public final void uninitializeClientSettingPreferences() {
+    ClientSetting.resetPreferences();
+  }
+}

--- a/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -16,11 +16,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 
 
 @ExtendWith(MockitoExtension.class)
-public class JComboBoxBuilderTest {
+public class JComboBoxBuilderTest extends AbstractClientSettingTestCase {
   @Mock
   private ItemEvent mockItemEvent;
 


### PR DESCRIPTION
Fixes #2588.

Several unit tests indirectly modify one or more `ClientSetting`s.  This has the side effect of permanently modifying the developer's preferences.  This can be annoying as those changes then affect the production operation of TripleA on the developer's machine.  It also makes the tests susceptible to changes in the developer's preferences (e.g. enabling beta features).

#### Functional changes

This change forces all such tests to use an in-memory `Preferences` implementation so that no permanent changes are made.  In order to help developers detect indirect usage of `ClientSetting` within tests in the future, the default `Preferences` implementation is not initialized.  If an attempt is made to access a `ClientSetting` before the `ClientSetting` framework has been initialized, an exception will be thrown with a message describing this scenario.

There are two mechanisms for initializing the `ClientSetting` framework:

1. For production code, a call to `ClientSetting#initialize()` should be made early in the application lifecycle.  This call will utilize the default persistent `Preferences` implementation appropriate for the OS.
1. For test code, a call to `ClientSetting#setPreferences()` with an appropriate `Preferences` implementation should be made before running each test, and a call to `ClientSetting#resetPreferences()` should be made after running each test.  A test fixture superclass that performs these operations using an in-memory `Preferences` implementation is provided in this change for the convenience of test authors (`AbstractClientSettingTestCase`).

#### Functional issues for review

I didn't expect this fix to be so invasive, but I felt it was important to guard against future tests unknowingly causing the same issues described in #2588 because they didn't realize a code path they were using changes a `ClientSetting`.  I'm open to any alternative ideas for how to do this other than the solution proposed in this PR that requires explicit initialization of the `ClientSetting` framework.

The only production code that was affected were the `main()` methods in `GameRunner` and `HeadlessGameServer`.  `LobbyServer` does not (and should not) use the `ClientSetting` framework.  None of the Map Maker utilities that are launched as separate processes appear to use the `ClientSetting` framework either.