### PR TITLE
Improved fix for #2584

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -294,33 +294,28 @@ public class GameSelectorModel extends Observable {
     }
     final String userPreferredDefaultGameName = ClientSetting.DEFAULT_GAME_NAME_PREF.value();
 
-    try {
-      final GameChooserModel model = GameChooserModel.newInstance();
-      GameChooserEntry selectedGame = model.findByName(userPreferredDefaultGameName);
-      if (selectedGame == null) {
-        selectedGame = model.findByName(userPreferredDefaultGameName);
-      }
-      if (selectedGame == null && model.size() > 0) {
-        selectedGame = model.get(0);
-      }
-      if (selectedGame == null) {
-        return null;
-      }
-      if (!selectedGame.isGameDataLoaded()) {
-        try {
-          selectedGame.fullyParseGameData();
-        } catch (final GameParseException e) {
-          // Load real default game...
-          selectedGame.delayParseGameData();
-          model.removeEntry(selectedGame);
-          loadDefaultGame(true);
-          return null;
-        }
-      }
-      return selectedGame;
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+    final GameChooserModel model = new GameChooserModel();
+    GameChooserEntry selectedGame = model.findByName(userPreferredDefaultGameName);
+    if (selectedGame == null) {
+      selectedGame = model.findByName(userPreferredDefaultGameName);
+    }
+    if (selectedGame == null && model.size() > 0) {
+      selectedGame = model.get(0);
+    }
+    if (selectedGame == null) {
       return null;
     }
+    if (!selectedGame.isGameDataLoaded()) {
+      try {
+        selectedGame.fullyParseGameData();
+      } catch (final GameParseException e) {
+        // Load real default game...
+        selectedGame.delayParseGameData();
+        model.removeEntry(selectedGame);
+        loadDefaultGame(true);
+        return null;
+      }
+    }
+    return selectedGame;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -24,6 +24,7 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.util.LocalizeHtml;
 
 public class GameChooser extends JDialog {
@@ -99,7 +100,10 @@ public class GameChooser extends JDialog {
 
   public static GameChooserEntry chooseGame(final Frame parent, final String defaultGameName)
       throws InterruptedException {
-    final GameChooser chooser = new GameChooser(parent, GameChooserModel.newInstance());
+    final GameChooserModel gameChooserModel = new GameChooserModel(BackgroundTaskRunner.runInBackgroundAndReturn(
+        "Loading all available games...",
+        GameChooserModel::parseMapFiles));
+    final GameChooser chooser = new GameChooser(parent, gameChooserModel);
     chooser.setSize(800, 600);
     chooser.setLocationRelativeTo(parent);
     chooser.selectGame(defaultGameName);


### PR DESCRIPTION
As discussed in #2584, this alternate fix removes the requirement to handle `InterruptedException` for callers that are not running on the EDT.

Reviewing with whitespace changes ignored (`?w=1`) will reduce the diff significantly.