### PR TITLE
Fix IllegalStateException during combat when player is neutral

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -22,6 +22,8 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.TripleA;
+import games.strategy.triplea.ai.weakAI.WeakAI;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
@@ -461,8 +463,9 @@ public class BattleCalculator {
     }
     final GameData data = bridge.getData();
     final boolean isEditMode = BaseEditDelegate.getEditMode(data);
-    final ITripleAPlayer tripleaPlayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
-
+    final ITripleAPlayer tripleaPlayer = player.isNull()
+        ? new WeakAI(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE)
+        : (ITripleAPlayer) bridge.getRemotePlayer(player);
     final Map<Unit, Collection<Unit>> dependents = headLess ? Collections.emptyMap() : getDependents(targetsToPickFrom);
     if (isEditMode && !headLess) {
       final CasualtyDetails editSelection = tripleaPlayer.selectCasualties(targetsToPickFrom, dependents, 0, text, dice,


### PR DESCRIPTION
Fixes #2594 by partially reverting #2557 (the portion that initializes the `ITripleAPlayer` reference).

#### Testing

I verified playing the save game attached to #2594 no longer throws `IllegalStateException` and combat proceeds as expected.