### PR TITLE
Fix broken Hotmail PBEM

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -16,6 +16,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.editors.validators.EmailValidator;
@@ -166,7 +167,8 @@ public class EmailSenderEditor extends EditorPanel {
         message = "Email sent, it should arrive shortly, otherwise check your spam folder";
         messageType = JOptionPane.INFORMATION_MESSAGE;
       } catch (final IOException ioe) {
-        message = "Unable to send email: " + ioe.getMessage();
+        message = "Unable to send email; see TripleA Console for details.";
+        ClientLogger.logError(ioe);
       } finally {
         // now that we have a result, marshall it back unto the swing thread
         final String finalMessage = message;

--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -142,7 +142,7 @@ public class GenericEmailSender implements IEmailSender {
     props.put("mail.smtp.connectiontimeout", m_timeout);
     props.put("mail.smtp.timeout", m_timeout);
     final String to = m_toAddress;
-    final String from = "noreply@triplea-game.org";
+    final String from = getUserName();
     // todo get the turn and player number from the game data
     try {
       final Session session = Session.getInstance(props, null);
@@ -191,7 +191,7 @@ public class GenericEmailSender implements IEmailSender {
         transport.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
       }
     } catch (final MessagingException e) {
-      throw new IOException(e.getMessage());
+      throw new IOException(e);
     }
   }
 


### PR DESCRIPTION
Fixes #2595.

As of [July 2017](https://answers.microsoft.com/en-us/msoffice/forum/mso_win10/i-cannot-send-out-email-anymore-from-outlook/eb21d415-883f-4ad1-b69d-5f05007064b3?auth=1), Hotmail changed their SMTP interface to require the email address in the From field be a verified address associated with the authenticated sender's account.  TripleA always uses a From address of `noreply@triplea-game.org`, which is unlikely to ever be a verified address for a PBEM user.

This PR changes all PBEM providers to use the sender's email address in the From field.  Note that Gmail itself automatically does this regardless of what we specify as the From address.  Thus, this change simply brings the Hotmail and generic SMTP PBEM providers to parity with the Gmail PBEM provider.

<hr>

There is also an additional commit that fixes an issue I observed while testing the Hotmail PBEM issue.
    
Hotmail may return an excessively-long error messages (e.g. thousands of characters).  Such a message causes the resulting `JOptionPane` that is displayed to be several screens wide and effectively unusable.  On some window managers, such an excessive width for a window causes the window manager to crash (I observed this using GNOME on Fedora 26).

This PR changes the error reporting such that the full exception is logged to the error console and only a brief, fixed-size message is displayed in the `JOptionPane` informing the user that an error occurred.

<hr>

#### Testing

I verified that I could send a test email using the Hotmail PBEM provider.