### PR TITLE
Restore combat client settings

### DIFF
--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -151,8 +151,6 @@ public interface Constants {
   String LARGE_MAP_FILENAME = "largeMap.gif";
   String SMALL_MAP_FILENAME = "smallMap.jpeg";
   String MAP_NAME = "mapName";
-  String SHOW_ENEMY_CASUALTIES_USER_PREF = "ShowEnemyCasualties";
-  String FOCUS_ON_OWN_CASUALTIES_USER_PREF = "FocusOnOwnCasualties";
   // new scramble property names
   String SCRAMBLE_RULES_IN_EFFECT = "Scramble Rules In Effect";
   String SCRAMBLED_UNITS_RETURN_TO_BASE = "Scrambled Units Return To Base";
@@ -253,7 +251,6 @@ public interface Constants {
   String PROPERTY_FALSE = "false";
   String PROPERTY_DEFAULT = "default";
 
-  String CONFIRM_DEFENSIVE_ROLLS = "confirm_defensive_rolls";
   String CONSTRUCTION_TYPE_FACTORY = "factory";
 
   static String getIncomePercentageFor(final PlayerID playerId) {

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -51,7 +51,7 @@ import games.strategy.triplea.delegate.remote.IUserActionDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.AbstractHumanPlayer;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.triplea.ui.BattleDisplay;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.PlaceData;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.util.IntegerMap;
@@ -669,7 +669,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       return;
     }
     // we dont want to confirm enemy casualties
-    if (!BattleDisplay.getShowEnemyCasualtyNotification()) {
+    if (!ClientSetting.CONFIRM_ENEMY_CASUALTIES.booleanValue()) {
       return;
     }
     ui.getBattlePanel().confirmCasualties(battleId, message);

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -27,7 +27,6 @@ import java.util.TimerTask;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.prefs.Preferences;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -59,7 +58,6 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.system.SystemProperties;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -70,6 +68,7 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.triplea.delegate.dataObjects.CasualtyList;
 import games.strategy.triplea.image.UnitImageFactory;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitOwner;
 import games.strategy.triplea.util.UnitSeperator;
@@ -167,37 +166,6 @@ public class BattleDisplay extends JPanel {
     dicePanel.setDiceRollForBombing(dice, cost);
     actionLayout.show(actionPanel, DICE_KEY);
   }
-
-  public static boolean getShowEnemyCasualtyNotification() {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    return prefs.getBoolean(Constants.SHOW_ENEMY_CASUALTIES_USER_PREF, true);
-  }
-
-  public static void setShowEnemyCasualtyNotification(final boolean showEnemyCasualtyNotification) {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    prefs.putBoolean(Constants.SHOW_ENEMY_CASUALTIES_USER_PREF, showEnemyCasualtyNotification);
-  }
-
-  public static boolean getFocusOnOwnCasualtiesNotification() {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    return prefs.getBoolean(Constants.FOCUS_ON_OWN_CASUALTIES_USER_PREF, false);
-  }
-
-  public static void setFocusOnOwnCasualtiesNotification(final boolean focusOnOwnCasualtiesNotification) {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    prefs.putBoolean(Constants.FOCUS_ON_OWN_CASUALTIES_USER_PREF, focusOnOwnCasualtiesNotification);
-  }
-
-  public static void setConfirmDefensiveRolls(final boolean confirmDefensiveRolls) {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    prefs.putBoolean(Constants.CONFIRM_DEFENSIVE_ROLLS, confirmDefensiveRolls);
-  }
-
-  public static boolean getConfirmDefensiveRolls() {
-    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
-    return prefs.getBoolean(Constants.CONFIRM_DEFENSIVE_ROLLS, false);
-  }
-
 
   /**
    * updates the panel content according to killed units for the player.
@@ -298,7 +266,7 @@ public class BattleDisplay extends JPanel {
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.
-    if (!getConfirmDefensiveRolls()) {
+    if (!ClientSetting.CONFIRM_DEFENSIVE_ROLLS.booleanValue()) {
       final int maxWaitTime = 1500;
       final Timer t = new Timer();
       t.schedule(new TimerTask() {
@@ -539,7 +507,7 @@ public class BattleDisplay extends JPanel {
             chooserScrollPane.setBorder(new LineBorder(chooserScrollPane.getBackground()));
           }
           final String[] options = {"Ok", "Cancel"};
-          final String focus = BattleDisplay.getFocusOnOwnCasualtiesNotification() ? options[0] : null;
+          final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;
           final int option = JOptionPane.showOptionDialog(BattleDisplay.this, chooserScrollPane,
               hit.getName() + " select casualties", JOptionPane.OK_OPTION, JOptionPane.PLAIN_MESSAGE, null, options,
               focus);


### PR DESCRIPTION
Fixes #2597.

#### Functional changes

The three Combat client settings are now consulted instead of always using the default values specified in `BattleDisplay`.  The link between the settings and their respective functional area was broken during the client settings framework overhaul in #2137.

#### Testing

I tested each setting with a value of both `true` and `false`.

For `CONFIRM_DEFENSIVE_ROLLS` and `SPACE_BAR_CONFIRMS_CASUALTIES`, `BattleDisplay` behaved as expected in a local game with no AI players.

To test `CONFIRM_ENEMY_CASUALTIES`, I had to start a network game with no AI players.  I also noticed that `CONFIRM_ENEMY_CASUALTIES` == `true` only takes effect when `CONFIRM_DEFENSIVE_ROLLS` == `true`.  I'm not sure if that's intended.  Regardless, when both are `true`,  `BattleDisplay` behaved as expected.

There's a possibility that my interpretation of "as expected" is incorrect.  If anyone wants to take this branch for a spin to confirm the behavior, please feel free.