### PR TITLE
Return serializable collection from AvailableGames#getGameNames()

### DIFF
--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -48,7 +48,7 @@ public class AvailableGames {
   }
 
   Set<String> getGameNames() {
-    return Collections.unmodifiableSet(availableGames.keySet());
+    return new HashSet<>(availableGames.keySet());
   }
 
   Set<String> getAvailableMapFolderOrZipNames() {


### PR DESCRIPTION
Fixes #2609.

`AvailableGames#getGameNames()` is called by `HeadlessGameServer#getAvailableGames()`, which is called by `getAvailableGames()` in the anonymous implementation of `IServerStartupRemote` stored in `ServerModel#m_serverStartupRemote`.  It appears the return value of that method is then serialized during RMI.

`TreeMap$KeySet` is not serializable, so we create a copy that is serializable and return that from `AvailableGames#getGameNames()`.