### PR TITLE
Log ExecutionException cause

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -92,7 +92,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        ClientLogger.logError(e);
+        ClientLogger.logError(e.getCause());
       }
     }
     return parsedMapSet;


### PR DESCRIPTION
The `ExecutionException` itself contains no useful information, so log the cause directly.