### PR TITLE
Checkstyle: Fix member name violations

### DIFF
--- a/src/main/java/games/strategy/engine/history/DelegateHistoryWriter.java
+++ b/src/main/java/games/strategy/engine/history/DelegateHistoryWriter.java
@@ -11,18 +11,18 @@ import games.strategy.engine.message.IChannelMessenger;
  * be used by the GameData
  */
 public class DelegateHistoryWriter implements IDelegateHistoryWriter {
-  private final IGameModifiedChannel m_channel;
+  private final IGameModifiedChannel channel;
 
   public DelegateHistoryWriter(final IChannelMessenger messenger) {
-    m_channel = (IGameModifiedChannel) messenger.getChannelBroadcastor(IGame.GAME_MODIFICATION_CHANNEL);
+    channel = (IGameModifiedChannel) messenger.getChannelBroadcastor(IGame.GAME_MODIFICATION_CHANNEL);
   }
 
   public DelegateHistoryWriter(final IGameModifiedChannel channel) {
-    m_channel = channel;
+    this.channel = channel;
   }
 
   private IGameModifiedChannel getGameModifiedChannel() {
-    return m_channel;
+    return channel;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/history/IndexedHistoryNode.java
+++ b/src/main/java/games/strategy/engine/history/IndexedHistoryNode.java
@@ -3,24 +3,24 @@ package games.strategy.engine.history;
 public abstract class IndexedHistoryNode extends HistoryNode {
   private static final long serialVersionUID = 607716179473453685L;
   // points to the first change we are responsible for
-  private final int m_changeStartIndex;
+  private final int changeStartIndex;
   // points after the last change we are responsible for
-  private int m_changeStopIndex = -1;
+  private int changeStopIndex = -1;
 
   public IndexedHistoryNode(final String value, final int changeStartIndex) {
     super(value);
-    m_changeStartIndex = changeStartIndex;
+    this.changeStartIndex = changeStartIndex;
   }
 
   int getChangeStartIndex() {
-    return m_changeStartIndex;
+    return changeStartIndex;
   }
 
   int getChangeEndIndex() {
-    return m_changeStopIndex;
+    return changeStopIndex;
   }
 
   void setChangeEndIndex(final int index) {
-    m_changeStopIndex = index;
+    changeStopIndex = index;
   }
 }

--- a/src/main/java/games/strategy/engine/history/Round.java
+++ b/src/main/java/games/strategy/engine/history/Round.java
@@ -2,19 +2,19 @@ package games.strategy.engine.history;
 
 public class Round extends IndexedHistoryNode {
   private static final long serialVersionUID = 7645058269791039043L;
-  private final int m_RoundNo;
+  private final int roundNo;
 
   Round(final int round, final int changeStartIndex) {
     super("Round: " + round, changeStartIndex);
-    m_RoundNo = round;
+    roundNo = round;
   }
 
   public int getRoundNo() {
-    return m_RoundNo;
+    return roundNo;
   }
 
   @Override
   public SerializationWriter getWriter() {
-    return new RoundHistorySerializer(m_RoundNo);
+    return new RoundHistorySerializer(roundNo);
   }
 }

--- a/src/main/java/games/strategy/engine/history/Step.java
+++ b/src/main/java/games/strategy/engine/history/Step.java
@@ -4,33 +4,33 @@ import games.strategy.engine.data.PlayerID;
 
 public class Step extends IndexedHistoryNode {
   private static final long serialVersionUID = 1015799886178275645L;
-  private final PlayerID m_player;
-  private final String m_stepName;
-  private final String m_delegateName;
+  private final PlayerID player;
+  private final String stepName;
+  private final String delegateName;
 
   /** Creates a new instance of Step. */
   Step(final String stepName, final String delegateName, final PlayerID player, final int changeStartIndex,
       final String displayName) {
     super(displayName, changeStartIndex);
-    m_stepName = stepName;
-    m_delegateName = delegateName;
-    m_player = player;
+    this.stepName = stepName;
+    this.delegateName = delegateName;
+    this.player = player;
   }
 
   public PlayerID getPlayerId() {
-    return m_player;
+    return player;
   }
 
   @Override
   public SerializationWriter getWriter() {
-    return new StepHistorySerializer(m_stepName, m_delegateName, m_player, super.getTitle());
+    return new StepHistorySerializer(stepName, delegateName, player, super.getTitle());
   }
 
   public String getDelegateName() {
-    return m_delegateName;
+    return delegateName;
   }
 
   public String getStepName() {
-    return m_stepName;
+    return stepName;
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -47,42 +47,42 @@ public class LobbyFrame extends JFrame {
       "Name and Mac",
       "Cancel");
 
-  private final LobbyClient m_client;
-  private final ChatMessagePanel m_chatMessagePanel;
+  private final LobbyClient client;
+  private final ChatMessagePanel chatMessagePanel;
 
   public LobbyFrame(final LobbyClient client, final LobbyServerProperties lobbyServerProperties) {
     super("TripleA Lobby");
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     setIconImage(GameRunner.getGameIcon(this));
-    m_client = client;
+    this.client = client;
     setJMenuBar(new LobbyMenu(this));
-    final Chat chat = new Chat(m_client.getMessenger(), LobbyServer.LOBBY_CHAT, m_client.getChannelMessenger(),
-        m_client.getRemoteMessenger(), Chat.ChatSoundProfile.LOBBY_CHATROOM);
-    m_chatMessagePanel = new ChatMessagePanel(chat);
+    final Chat chat = new Chat(this.client.getMessenger(), LobbyServer.LOBBY_CHAT,
+        this.client.getChannelMessenger(), this.client.getRemoteMessenger(), Chat.ChatSoundProfile.LOBBY_CHATROOM);
+    chatMessagePanel = new ChatMessagePanel(chat);
     showServerMessage(lobbyServerProperties);
-    m_chatMessagePanel.setShowTime(true);
+    chatMessagePanel.setShowTime(true);
     final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(null);
     chatPlayers.addHiddenPlayerName(LobbyServer.ADMIN_USERNAME);
     chatPlayers.setChat(chat);
     chatPlayers.setPreferredSize(new Dimension(200, 600));
     chatPlayers.addActionFactory(clickedOn -> createAdminActions(clickedOn));
-    final LobbyGamePanel gamePanel = new LobbyGamePanel(m_client.getMessengers());
+    final LobbyGamePanel gamePanel = new LobbyGamePanel(this.client.getMessengers());
     final JSplitPane leftSplit = new JSplitPane();
     leftSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);
     leftSplit.setTopComponent(gamePanel);
-    leftSplit.setBottomComponent(m_chatMessagePanel);
+    leftSplit.setBottomComponent(chatMessagePanel);
     leftSplit.setResizeWeight(0.8);
     gamePanel.setPreferredSize(new Dimension(700, 200));
-    m_chatMessagePanel.setPreferredSize(new Dimension(700, 400));
+    chatMessagePanel.setPreferredSize(new Dimension(700, 400));
     final JSplitPane mainSplit = new JSplitPane();
     mainSplit.setOrientation(JSplitPane.HORIZONTAL_SPLIT);
     mainSplit.setLeftComponent(leftSplit);
     mainSplit.setRightComponent(chatPlayers);
     add(mainSplit, BorderLayout.CENTER);
     pack();
-    m_chatMessagePanel.requestFocusInWindow();
+    chatMessagePanel.requestFocusInWindow();
     setLocationRelativeTo(null);
-    m_client.getMessenger().addErrorListener((messenger, reason) -> connectionToServerLost());
+    this.client.getMessenger().addErrorListener((messenger, reason) -> connectionToServerLost());
     addWindowListener(new WindowAdapter() {
       @Override
       public void windowClosing(final WindowEvent e) {
@@ -92,23 +92,23 @@ public class LobbyFrame extends JFrame {
   }
 
   public ChatMessagePanel getChatMessagePanel() {
-    return m_chatMessagePanel;
+    return chatMessagePanel;
   }
 
   private void showServerMessage(final LobbyServerProperties props) {
     if (!props.serverMessage.isEmpty()) {
-      m_chatMessagePanel.addServerMessage(props.serverMessage);
+      chatMessagePanel.addServerMessage(props.serverMessage);
     }
   }
 
   private List<Action> createAdminActions(final INode clickedOn) {
-    if (!m_client.isAdmin()) {
+    if (!client.isAdmin()) {
       return Collections.emptyList();
     }
-    if (clickedOn.equals(m_client.getMessenger().getLocalNode())) {
+    if (clickedOn.equals(client.getMessenger().getLocalNode())) {
       return Collections.emptyList();
     }
-    final IModeratorController controller = (IModeratorController) m_client.getRemoteMessenger()
+    final IModeratorController controller = (IModeratorController) client.getRemoteMessenger()
         .getRemote(ModeratorController.getModeratorControllerName());
     final List<Action> actions = new ArrayList<>();
     actions.add(SwingAction.of("Boot " + clickedOn.getName(), e -> {
@@ -208,12 +208,12 @@ public class LobbyFrame extends JFrame {
   }
 
   public LobbyClient getLobbyClient() {
-    return m_client;
+    return client;
   }
 
   public void setShowChatTime(final boolean showTime) {
-    if (m_chatMessagePanel != null) {
-      m_chatMessagePanel.setShowTime(showTime);
+    if (chatMessagePanel != null) {
+      chatMessagePanel.setShowTime(showTime);
     }
   }
 
@@ -221,7 +221,7 @@ public class LobbyFrame extends JFrame {
     setVisible(false);
     dispose();
     GameRunner.showMainFrame();
-    m_client.getMessenger().shutDown();
+    client.getMessenger().shutDown();
     GameRunner.exitGameIfFinished();
   }
 

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -25,7 +25,7 @@ class LobbyGameTableModel extends AbstractTableModel {
     Host, Name, GV, Round, Players, P, B, EV, Started, Status, Comments, GUID
   }
 
-  private final IMessenger m_messenger;
+  private final IMessenger messenger;
 
   // these must only be accessed in the swing event thread
   private final List<Tuple<GUID, GameDescription>> gameList;
@@ -36,7 +36,7 @@ class LobbyGameTableModel extends AbstractTableModel {
 
     gameList = new ArrayList<>();
 
-    m_messenger = messenger;
+    this.messenger = messenger;
     lobbyGameBroadcaster = new ILobbyGameBroadcaster() {
       @Override
       public void gameUpdated(final GUID gameId, final GameDescription description) {
@@ -101,7 +101,7 @@ class LobbyGameTableModel extends AbstractTableModel {
   }
 
   private void assertSentFromServer() {
-    if (!MessageContext.getSender().equals(m_messenger.getServerNode())) {
+    if (!MessageContext.getSender().equals(messenger.getServerNode())) {
       throw new IllegalStateException("Invalid sender");
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
@@ -10,27 +10,27 @@ import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 
 public class EditGameCommentAction extends AbstractAction {
   private static final long serialVersionUID = 1723950003185387843L;
-  private final InGameLobbyWatcherWrapper m_lobbyWatcher;
-  private final Component m_parent;
+  private final InGameLobbyWatcherWrapper lobbyWatcher;
+  private final Component parent;
 
   public EditGameCommentAction(final InGameLobbyWatcherWrapper watcher, final Component parent) {
     super("Set Lobby Comment...");
-    m_parent = parent;
-    m_lobbyWatcher = watcher;
+    this.parent = parent;
+    lobbyWatcher = watcher;
   }
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    if (!m_lobbyWatcher.isActive()) {
+    if (!lobbyWatcher.isActive()) {
       setEnabled(false);
-      JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(m_parent), "Not connected to Lobby");
+      JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(parent), "Not connected to Lobby");
       return;
     }
-    final String current = m_lobbyWatcher.getComments();
-    final String gameComments = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(m_parent),
+    final String current = lobbyWatcher.getComments();
+    final String gameComments = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(parent),
         "Edit the comments for the game", current);
     if (gameComments != null) {
-      m_lobbyWatcher.setGameComments(gameComments);
+      lobbyWatcher.setGameComments(gameComments);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/action/RemoveGameFromLobbyAction.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/action/RemoveGameFromLobbyAction.java
@@ -8,16 +8,16 @@ import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 
 public class RemoveGameFromLobbyAction extends AbstractAction {
   private static final long serialVersionUID = 8802420945692279375L;
-  private final InGameLobbyWatcherWrapper m_lobbyWatcher;
+  private final InGameLobbyWatcherWrapper lobbyWatcher;
 
   public RemoveGameFromLobbyAction(final InGameLobbyWatcherWrapper watcher) {
     super("Remove Game From Lobby");
-    m_lobbyWatcher = watcher;
+    lobbyWatcher = watcher;
   }
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    m_lobbyWatcher.shutDown();
+    lobbyWatcher.shutDown();
     setEnabled(false);
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/AbstractModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/AbstractModeratorController.java
@@ -10,12 +10,12 @@ import games.strategy.net.Messengers;
 
 public abstract class AbstractModeratorController implements IModeratorController {
   protected static final Logger logger = Logger.getLogger(ModeratorController.class.getName());
-  protected final IServerMessenger m_serverMessenger;
-  protected final Messengers m_allMessengers;
+  protected final IServerMessenger serverMessenger;
+  protected final Messengers allMessengers;
 
   public AbstractModeratorController(final IServerMessenger serverMessenger, final Messengers messengers) {
-    m_serverMessenger = serverMessenger;
-    m_allMessengers = messengers;
+    this.serverMessenger = serverMessenger;
+    allMessengers = messengers;
   }
 
   public static RemoteName getModeratorControllerName() {
@@ -27,7 +27,7 @@ public abstract class AbstractModeratorController implements IModeratorControlle
   }
 
   protected String getNodeMacAddress(final INode node) {
-    return m_serverMessenger.getPlayerMac(node.getName());
+    return serverMessenger.getPlayerMac(node.getName());
   }
 
   protected String getRealName(final INode node) {
@@ -38,7 +38,7 @@ public abstract class AbstractModeratorController implements IModeratorControlle
   protected String getAliasesFor(final INode node) {
     final StringBuilder builder = new StringBuilder();
     final String nodeMac = getNodeMacAddress(node);
-    for (final INode cur : m_serverMessenger.getNodes()) {
+    for (final INode cur : serverMessenger.getNodes()) {
       if (cur.equals(node) || cur.getName().equals("Admin")) {
         continue;
       }

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -19,7 +19,7 @@ public class LobbyServer {
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
   private static final Logger logger = Logger.getLogger(LobbyServer.class.getName());
-  private final Messengers m_messengers;
+  private final Messengers messengers;
 
   private LobbyServer(final int port) {
     final IServerMessenger server;
@@ -29,20 +29,20 @@ public class LobbyServer {
       logger.log(Level.SEVERE, ex.toString());
       throw new IllegalStateException(ex.getMessage());
     }
-    m_messengers = new Messengers(server);
+    messengers = new Messengers(server);
     server.setLoginValidator(new LobbyLoginValidator());
     // setup common objects
-    new UserManager().register(m_messengers.getRemoteMessenger());
-    final ModeratorController moderatorController = new ModeratorController(server, m_messengers);
-    moderatorController.register(m_messengers.getRemoteMessenger());
-    new ChatController(LOBBY_CHAT, m_messengers, moderatorController);
+    new UserManager().register(messengers.getRemoteMessenger());
+    final ModeratorController moderatorController = new ModeratorController(server, messengers);
+    moderatorController.register(messengers.getRemoteMessenger());
+    new ChatController(LOBBY_CHAT, messengers, moderatorController);
 
     // register the status controller
-    new StatusManager(m_messengers).shutDown();
+    new StatusManager(messengers).shutDown();
 
-    final LobbyGameController controller = new LobbyGameController((ILobbyGameBroadcaster) m_messengers
+    final LobbyGameController controller = new LobbyGameController((ILobbyGameBroadcaster) messengers
         .getChannelMessenger().getChannelBroadcastor(ILobbyGameBroadcaster.GAME_BROADCASTER_CHANNEL), server);
-    controller.register(m_messengers.getRemoteMessenger());
+    controller.register(messengers.getRemoteMessenger());
 
     // now we are open for business
     server.setAcceptNewConnections(true);
@@ -69,10 +69,10 @@ public class LobbyServer {
   }
 
   public IServerMessenger getMessenger() {
-    return (IServerMessenger) m_messengers.getMessenger();
+    return (IServerMessenger) messengers.getMessenger();
   }
 
   public Messengers getMessengers() {
-    return m_messengers;
+    return messengers;
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -116,7 +116,7 @@ public class ModeratorController extends AbstractModeratorController {
     final String mac = getNodeMacAddress(node);
     final String realName = getRealName(node);
     new MutedUsernameController().addMutedUsername(realName, muteExpires);
-    m_serverMessenger.notifyUsernameMutingOfPlayer(realName, muteExpires);
+    serverMessenger.notifyUsernameMutingOfPlayer(realName, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
     logger.info(String.format(
         "User was muted on the lobby(Username mute). "
@@ -138,7 +138,7 @@ public class ModeratorController extends AbstractModeratorController {
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     new MutedMacController().addMutedMac(mac, muteExpires);
-    m_serverMessenger.notifyMacMutingOfPlayer(mac, muteExpires);
+    serverMessenger.notifyMacMutingOfPlayer(mac, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
     logger.info(String.format(
         "User was muted on the lobby(Mac mute). "
@@ -151,12 +151,12 @@ public class ModeratorController extends AbstractModeratorController {
   public void boot(final INode node) {
     assertUserIsAdmin();
     // You can't boot the server node
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot boot server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    m_serverMessenger.removeConnection(node);
+    serverMessenger.removeConnection(node);
     logger.info(String.format(
         "User was booted from the lobby. Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -166,7 +166,7 @@ public class ModeratorController extends AbstractModeratorController {
   @Override
   public String getHeadlessHostBotSalt(final INode node) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
@@ -177,21 +177,21 @@ public class ModeratorController extends AbstractModeratorController {
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     return remoteHostUtils.getSalt();
   }
 
   @Override
   public String getChatLogHeadlessHostBot(final INode node, final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.getChatLogHeadlessHostBot(hashedPassword, salt);
     logger.info(String.format(
         ((response == null || response.equals("Invalid password!")) ? "Failed" : "Successful")
@@ -206,14 +206,14 @@ public class ModeratorController extends AbstractModeratorController {
   public String mutePlayerHeadlessHostBot(final INode node, final String playerNameToBeMuted, final int minutes,
       final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response =
         remoteHostUtils.mutePlayerHeadlessHostBot(playerNameToBeMuted, minutes, hashedPassword, salt);
     logger.info(String.format(
@@ -229,14 +229,14 @@ public class ModeratorController extends AbstractModeratorController {
   public String bootPlayerHeadlessHostBot(final INode node, final String playerNameToBeBooted,
       final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.bootPlayerHeadlessHostBot(playerNameToBeBooted, hashedPassword, salt);
     logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Boot of " + playerNameToBeBooted
@@ -250,14 +250,14 @@ public class ModeratorController extends AbstractModeratorController {
   public String banPlayerHeadlessHostBot(final INode node, final String playerNameToBeBanned, final int hours,
       final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hours, hashedPassword, salt);
     logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Ban of " + playerNameToBeBanned
@@ -271,14 +271,14 @@ public class ModeratorController extends AbstractModeratorController {
   @Override
   public String stopGameHeadlessHostBot(final INode node, final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.stopGameHeadlessHostBot(hashedPassword, salt);
     logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
@@ -291,7 +291,7 @@ public class ModeratorController extends AbstractModeratorController {
   @Override
   public String shutDownHeadlessHostBot(final INode node, final String hashedPassword, final String salt) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot shutdown server node");
     }
     final INode modNode = MessageContext.getSender();
@@ -302,7 +302,7 @@ public class ModeratorController extends AbstractModeratorController {
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.shutDownHeadlessHostBot(hashedPassword, salt);
     logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
@@ -331,12 +331,12 @@ public class ModeratorController extends AbstractModeratorController {
   @Override
   public String getHostConnections(final INode node) {
     assertUserIsAdmin();
-    if (m_serverMessenger.getServerNode().equals(node)) {
+    if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
     final RemoteName remoteName = RemoteHostUtils.getRemoteHostUtilsName(node);
     final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
+        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     return remoteHostUtils.getConnections();
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/RemoteHostUtils.java
+++ b/src/main/java/games/strategy/engine/lobby/server/RemoteHostUtils.java
@@ -9,8 +9,8 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 
 public class RemoteHostUtils implements IRemoteHostUtils {
-  private final INode m_serverNode;
-  private final IServerMessenger m_serverMessenger;
+  private final INode serverNode;
+  private final IServerMessenger serverMessenger;
 
   public static RemoteName getRemoteHostUtilsName(final INode node) {
     return new RemoteName(IRemoteHostUtils.class,
@@ -18,18 +18,18 @@ public class RemoteHostUtils implements IRemoteHostUtils {
   }
 
   public RemoteHostUtils(final INode serverNode, final IServerMessenger gameServerMessenger) {
-    m_serverNode = serverNode;
-    m_serverMessenger = gameServerMessenger;
+    this.serverNode = serverNode;
+    serverMessenger = gameServerMessenger;
   }
 
   @Override
   public String getConnections() {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
-    if (m_serverMessenger != null) {
-      final StringBuilder sb = new StringBuilder("Connected: " + m_serverMessenger.isConnected() + "\n" + "Nodes: \n");
-      final Set<INode> nodes = m_serverMessenger.getNodes();
+    if (serverMessenger != null) {
+      final StringBuilder sb = new StringBuilder("Connected: " + serverMessenger.isConnected() + "\n" + "Nodes: \n");
+      final Set<INode> nodes = serverMessenger.getNodes();
       if (nodes == null) {
         sb.append("  null\n");
       } else {
@@ -44,7 +44,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
 
   @Override
   public String getChatLogHeadlessHostBot(final String hashedPassword, final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -57,7 +57,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
   @Override
   public String mutePlayerHeadlessHostBot(final String playerNameToBeMuted, final int minutes,
       final String hashedPassword, final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -70,7 +70,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
   @Override
   public String bootPlayerHeadlessHostBot(final String playerNameToBeBooted, final String hashedPassword,
       final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -83,7 +83,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
   @Override
   public String banPlayerHeadlessHostBot(final String playerNameToBeBanned, final int hours,
       final String hashedPassword, final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -95,7 +95,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
 
   @Override
   public String stopGameHeadlessHostBot(final String hashedPassword, final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -107,7 +107,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
 
   @Override
   public String shutDownHeadlessHostBot(final String hashedPassword, final String salt) {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();
@@ -119,7 +119,7 @@ public class RemoteHostUtils implements IRemoteHostUtils {
 
   @Override
   public String getSalt() {
-    if (!MessageContext.getSender().equals(m_serverNode)) {
+    if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
     final HeadlessGameServer instance = HeadlessGameServer.getInstance();


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in UI and non-serializable classes under the `g.s.engine.gamePlayer`, `g.s.engine.history`, and `g.s.engine.lobby` packages.

Note that the modified types under `g.s.engine.history` are UI classes that are not serialized (they have `Serializable` peers).  I verified I could still load an old save game with several rounds of history to check this assertion.