### PR TITLE
Use Predicate Interface type instead of explicit match

### DIFF
--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import games.strategy.triplea.delegate.Matches;
@@ -16,7 +17,7 @@ public class CompositeRouteFinder {
   private static final Logger logger = Logger.getLogger(CompositeRouteFinder.class.getName());
 
   private final GameMap map;
-  private final Map<Match<Territory>, Integer> matches;
+  private final Map<Predicate<Territory>, Integer> matches;
 
   /**
    * This class can find composite routes between two territories.
@@ -32,7 +33,7 @@ public class CompositeRouteFinder {
    * @param matches
    *        - Set of matches and scores. The lower a match is scored, the more favorable it is.
    */
-  public CompositeRouteFinder(final GameMap map, final Map<Match<Territory>, Integer> matches) {
+  public CompositeRouteFinder(final GameMap map, final Map<Predicate<Territory>, Integer> matches) {
     this.map = map;
     this.matches = matches;
     logger.finer("Initializing CompositeRouteFinderClass...");
@@ -113,7 +114,7 @@ public class CompositeRouteFinder {
    */
   private int getTerScore(final Territory ter) {
     int bestMatchingScore = Integer.MAX_VALUE;
-    for (final Match<Territory> match : matches.keySet()) {
+    for (final Predicate<Territory> match : matches.keySet()) {
       final int score = matches.get(match);
       if (score < bestMatchingScore) { // If this is a 'better' match
         if (match.test(ter)) {

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.IntegerMap;
@@ -221,7 +222,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return All adjacent neighbors of the starting territory that match the condition.
    *         Does NOT include the original/starting territory in the returned Set.
    */
-  public Set<Territory> getNeighbors(final Territory t, final Match<Territory> cond) {
+  public Set<Territory> getNeighbors(final Territory t, final Predicate<Territory> cond) {
     if (cond == null) {
       return getNeighbors(t);
     }
@@ -268,7 +269,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         Does NOT include the original/starting territory in the returned Set.
    */
   @SuppressWarnings("unchecked")
-  public Set<Territory> getNeighbors(final Territory territory, int distance, final Match<Territory> cond) {
+  public Set<Territory> getNeighbors(final Territory territory, int distance, final Predicate<Territory> cond) {
     if (distance < 0) {
       throw new IllegalArgumentException("Distance must be positive not:" + distance);
     }
@@ -289,7 +290,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
    *         other.
    */
-  public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance, final Match<Territory> cond) {
+  public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance, final Predicate<Territory> cond) {
     final Set<Territory> neighbors = getNeighbors(frontier, new HashSet<>(frontier), distance, cond);
     neighbors.removeAll(frontier);
     return neighbors;
@@ -307,7 +308,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   private Set<Territory> getNeighbors(final Set<Territory> frontier, final Set<Territory> searched, int distance,
-      final Match<Territory> cond) {
+      final Predicate<Territory> cond) {
     if (distance == 0) {
       return searched;
     }
@@ -358,7 +359,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the shortest route between two territories so that covered territories match the condition
    *         or null if no route exists.
    */
-  public Route getRoute(final Territory t1, final Territory t2, final Match<Territory> cond) {
+  public Route getRoute(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
     if (t1 == t2) {
       return new Route(t1);
     }
@@ -391,7 +392,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     return getRoute(t1, t2, Matches.territoryIsWater());
   }
 
-  public Route getRoute_IgnoreEnd(final Territory t1, final Territory t2, final Match<Territory> match) {
+  public Route getRoute_IgnoreEnd(final Territory t1, final Territory t2, final Predicate<Territory> match) {
     return getRoute(t1, t2, Match.anyOf(Matches.territoryIs(t2), match));
   }
 
@@ -415,11 +416,11 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return a composite route between two territories
    */
   public Route getCompositeRoute(final Territory t1, final Territory t2,
-      final HashMap<Match<Territory>, Integer> matches) {
+      final HashMap<Predicate<Territory>, Integer> matches) {
     if (t1 == t2) {
       return new Route(t1);
     }
-    final Match<Territory> allCond = Match.anyOf(matches.keySet());
+    final Predicate<Territory> allCond = Match.anyOf(matches.keySet());
     if (getNeighbors(t1, allCond).contains(t2)) {
       return new Route(t1, t2);
     }
@@ -428,7 +429,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   public Route getCompositeRoute_IgnoreEnd(final Territory t1, final Territory t2,
-      final HashMap<Match<Territory>, Integer> matches) {
+      final HashMap<Predicate<Territory>, Integer> matches) {
     matches.put(Matches.territoryIs(t2), 0);
     return getCompositeRoute(t1, t2, matches);
   }
@@ -454,7 +455,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the distance between two territories where the covered territories of the route satisfy the condition
    *         or -1 if they are not connected.
    */
-  public int getDistance(final Territory t1, final Territory t2, final Match<Territory> cond) {
+  public int getDistance(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
     if (t1.equals(t2)) {
       return 0;
     }
@@ -469,7 +470,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * Territories in searched have already been on the frontier.
    */
   private int getDistance(final int distance, final Set<Territory> searched, final Set<Territory> frontier,
-      final Territory target, final Match<Territory> cond) {
+      final Territory target, final Predicate<Territory> cond) {
     // add the frontier to the searched
     searched.addAll(frontier);
     // find the new frontier
@@ -497,7 +498,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   public IntegerMap<Territory> getDistance(final Territory target, final Collection<Territory> territories,
-      final Match<Territory> condition) {
+      final Predicate<Territory> condition) {
     final IntegerMap<Territory> distances = new IntegerMap<>();
     if (target == null || territories == null || territories.isEmpty()) {
       return distances;
@@ -541,7 +542,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         the condition
    *         or -1 if they are not connected. (Distance includes to the end)
    */
-  public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2, final Match<Territory> cond) {
+  public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
     return getDistance(t1, t2, Match.anyOf(Matches.territoryIs(t2), cond));
   }
 

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -290,7 +290,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
    *         other.
    */
-  public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance, final Predicate<Territory> cond) {
+  public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance,
+      final Predicate<Territory> cond) {
     final Set<Territory> neighbors = getNeighbors(frontier, new HashSet<>(frontier), distance, cond);
     neighbors.removeAll(frontier);
     return neighbors;
@@ -542,7 +543,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         the condition
    *         or -1 if they are not connected. (Distance includes to the end)
    */
-  public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
+  public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2,
+      final Predicate<Territory> cond) {
     return getDistance(t1, t2, Match.anyOf(Matches.territoryIs(t2), cond));
   }
 

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -9,11 +9,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.Match;
 import games.strategy.util.Util;
 
 /**
@@ -218,7 +218,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @param match referring match
    * @return whether all territories in this route match the given match (start territory is not tested).
    */
-  public boolean allMatch(final Match<Territory> match) {
+  public boolean allMatch(final Predicate<Territory> match) {
     return m_steps.stream().allMatch(match);
   }
 
@@ -228,7 +228,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @param match referring match
    * @return whether any territories in this route match the given match (start territory is not tested).
    */
-  public boolean anyMatch(final Match<Territory> match) {
+  public boolean anyMatch(final Predicate<Territory> match) {
     return m_steps.stream().anyMatch(match);
   }
 
@@ -236,7 +236,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @param match referring match
    * @return whether all territories in this route match the given match (start and end territories are not tested).
    */
-  public boolean allMatchMiddleSteps(final Match<Territory> match, final boolean defaultWhenNoMiddleSteps) {
+  public boolean allMatchMiddleSteps(final Predicate<Territory> match, final boolean defaultWhenNoMiddleSteps) {
     final List<Territory> middle = getMiddleSteps();
     if (middle.isEmpty()) {
       return defaultWhenNoMiddleSteps;
@@ -254,7 +254,7 @@ public class Route implements Serializable, Iterable<Territory> {
    *        referring match
    * @return all territories in this route match the given match (start territory is not tested).
    */
-  public Collection<Territory> getMatches(final Match<Territory> match) {
+  public Collection<Territory> getMatches(final Predicate<Territory> match) {
     return Matches.getMatches(m_steps, match);
   }
 

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -204,8 +204,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @param i
-   *        step number
+   * @param i step number
    * @return territory we will be in after the i'th step for this route has
    *         been made.
    */
@@ -214,36 +213,27 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @param match
-   *        referring match
+   * Checking if all of the steps match the given Predicate.
+   * 
+   * @param match referring match
    * @return whether all territories in this route match the given match (start territory is not tested).
    */
   public boolean allMatch(final Match<Territory> match) {
-    for (final Territory t : m_steps) {
-      if (!match.test(t)) {
-        return false;
-      }
-    }
-    return true;
+    return m_steps.stream().allMatch(match);
   }
 
   /**
-   * @param match
-   *        referring match
+   * Checking if any of the steps match the given Predicate.
+   * 
+   * @param match referring match
    * @return whether any territories in this route match the given match (start territory is not tested).
    */
   public boolean anyMatch(final Match<Territory> match) {
-    for (final Territory t : m_steps) {
-      if (match.test(t)) {
-        return true;
-      }
-    }
-    return false;
+    return m_steps.stream().anyMatch(match);
   }
 
   /**
-   * @param match
-   *        referring match
+   * @param match referring match
    * @return whether all territories in this route match the given match (start and end territories are not tested).
    */
   public boolean allMatchMiddleSteps(final Match<Territory> match, final boolean defaultWhenNoMiddleSteps) {

--- a/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -7,17 +7,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import games.strategy.util.Match;
+import java.util.function.Predicate;
 
 // TODO this class doesn't take movementcost into account... typically the shortest route is the fastest route, but not
 // always...
 class RouteFinder {
   private final GameMap map;
-  private final Match<Territory> condition;
+  private final Predicate<Territory> condition;
   private final Map<Territory, Territory> previous;
 
-  RouteFinder(final GameMap map, final Match<Territory> condition) {
+  RouteFinder(final GameMap map, final Predicate<Territory> condition) {
     this.map = map;
     this.condition = condition;
     previous = new HashMap<>();

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.swing.ButtonModel;
 import javax.swing.SwingUtilities;
@@ -385,7 +386,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
         && !id.getRepairFrontier().getRules().isEmpty()) {
       final GameData data = getGameData();
       if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
-        final Match<Unit> myDamaged = Match.allOf(
+        final Predicate<Unit> myDamaged = Match.allOf(
             Matches.unitIsOwnedBy(id),
             Matches.unitHasTakenSomeBombingUnitDamage());
         final Collection<Unit> damagedUnits = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -402,10 +402,10 @@ public class TripleAUnit extends Unit {
   public static Unit getBiggestProducer(final Collection<Unit> units, final Territory producer, final PlayerID player,
       final GameData data, final boolean accountForDamage) {
     final Predicate<Unit> factoryMatch = Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player)
-        .and(Matches.unitIsBeingTransported().invert())
+        .and(Matches.unitIsBeingTransported().negate())
         .and(producer.isWater()
-            ? Matches.unitIsLand().invert()
-            : Matches.unitIsSea().invert());
+            ? Matches.unitIsLand().negate()
+            : Matches.unitIsSea().negate());
     final Collection<Unit> factories = Matches.getMatches(units, factoryMatch);
     if (factories.isEmpty()) {
       return null;

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -112,7 +113,7 @@ public class AIUtils {
     return strength;
   }
 
-  public static Unit getLastUnitMatching(final List<Unit> units, final Match<Unit> match, final int endIndex) {
+  public static Unit getLastUnitMatching(final List<Unit> units, final Predicate<Unit> match, final int endIndex) {
     final int index = getIndexOfLastUnitMatching(units, match, endIndex);
     if (index == -1) {
       return null;
@@ -120,7 +121,7 @@ public class AIUtils {
     return units.get(index);
   }
 
-  public static int getIndexOfLastUnitMatching(final List<Unit> units, final Match<Unit> match, final int endIndex) {
+  public static int getIndexOfLastUnitMatching(final List<Unit> units, final Predicate<Unit> match, final int endIndex) {
     for (int i = endIndex; i >= 0; i--) {
       final Unit unit = units.get(i);
       if (match.test(unit)) {

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -121,7 +121,8 @@ public class AIUtils {
     return units.get(index);
   }
 
-  public static int getIndexOfLastUnitMatching(final List<Unit> units, final Predicate<Unit> match, final int endIndex) {
+  public static int getIndexOfLastUnitMatching(final List<Unit> units, final Predicate<Unit> match,
+      final int endIndex) {
     for (int i = endIndex; i >= 0; i--) {
       final Unit unit = units.get(i);
       if (match.test(unit)) {

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import games.strategy.engine.data.GameData;
@@ -310,18 +311,18 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       picked = territoryChoices.get(0);
     } else {
       Collections.shuffle(territoryChoices);
-      final List<Territory> notOwned = Matches.getMatches(territoryChoices, Matches.isTerritoryOwnedBy(me).invert());
+      final List<Territory> notOwned = Matches.getMatches(territoryChoices, Matches.isTerritoryOwnedBy(me).negate());
       if (notOwned.isEmpty()) {
         // only owned territories left
-        final boolean nonFactoryUnitsLeft = unitChoices.stream().anyMatch(Matches.unitCanProduceUnits().invert());
-        final Match<Unit> ownedFactories = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsOwnedBy(me));
+        final boolean nonFactoryUnitsLeft = unitChoices.stream().anyMatch(Matches.unitCanProduceUnits().negate());
+        final Predicate<Unit> ownedFactories = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsOwnedBy(me));
         final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(territoryChoices);
         final List<Territory> territoriesWithFactories =
             Matches.getMatches(territoryChoices, Matches.territoryHasUnitsThatMatch(ownedFactories));
         if (!nonFactoryUnitsLeft) {
-          test.retainAll(Matches.getMatches(test, Matches.territoryHasUnitsThatMatch(ownedFactories).invert()));
+          test.retainAll(Matches.getMatches(test, Matches.territoryHasUnitsThatMatch(ownedFactories).negate()));
           if (!test.isEmpty()) {
             picked = test.get(0);
           } else {
@@ -330,7 +331,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
                   Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.territoryIsLand())));
             }
             final List<Territory> doesNotHaveFactoryYet =
-                Matches.getMatches(territoryChoices, Matches.territoryHasUnitsThatMatch(ownedFactories).invert());
+                Matches.getMatches(territoryChoices, Matches.territoryHasUnitsThatMatch(ownedFactories).negate());
             if (capitals.isEmpty() || doesNotHaveFactoryYet.isEmpty()) {
               picked = territoryChoices.get(0);
             } else {
@@ -404,7 +405,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
     final Set<Unit> unitsToPlace = new HashSet<>();
     if (unitChoices != null && !unitChoices.isEmpty() && unitsPerPick > 0) {
       Collections.shuffle(unitChoices);
-      final List<Unit> nonFactory = Matches.getMatches(unitChoices, Matches.unitCanProduceUnits().invert());
+      final List<Unit> nonFactory = Matches.getMatches(unitChoices, Matches.unitCanProduceUnits().negate());
       if (nonFactory.isEmpty()) {
         for (int i = 0; i < unitsPerPick && !unitChoices.isEmpty(); i++) {
           unitsToPlace.add(unitChoices.get(0));

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -427,7 +427,7 @@ class ProCombatMoveAI {
         final ProBattleResult result = calc.estimateAttackBattleResults(t, new ArrayList<>(attackingUnits),
             patd.getMaxEnemyDefenders(player, data), patd.getMaxBombardUnits());
         final List<Unit> remainingUnitsToDefendWith =
-            Matches.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().invert());
+            Matches.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().negate());
         ProLogger.debug(t + ", value=" + territoryValueMap.get(t) + ", averageAttackFromValue=" + averageValue
             + ", MyAttackers=" + attackingUnits.size() + ", RemainingUnits=" + remainingUnitsToDefendWith.size());
 
@@ -879,7 +879,7 @@ class ProCombatMoveAI {
         if (enemyAttackOptions.getMax(t) != null
             && !ProMatches.territoryIsWaterAndAdjacentToOwnedFactory(player, data).test(t)) {
           List<Unit> remainingUnitsToDefendWith =
-              Matches.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().invert());
+              Matches.getMatches(result.getAverageAttackersRemaining(), Matches.unitIsAir().negate());
           ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
               remainingUnitsToDefendWith, patd.getMaxBombardUnits());
           if (patd.isCanHold() && result2.getTuvSwing() > 0) {
@@ -1382,7 +1382,7 @@ class ProCombatMoveAI {
       final Set<Territory> canBombardTerritories = new HashSet<>();
       for (final ProTerritory patd : prioritizedTerritories) {
         final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
-        final boolean hasDefenders = defendingUnits.stream().anyMatch(Matches.unitIsInfrastructure().invert());
+        final boolean hasDefenders = defendingUnits.stream().anyMatch(Matches.unitIsInfrastructure().negate());
         if (bombardMap.get(u).contains(patd.getTerritory()) && !patd.getTransportTerritoryMap().isEmpty()
             && hasDefenders && !TransportTracker.isTransporting(u)) {
           canBombardTerritories.add(patd.getTerritory());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -150,7 +151,7 @@ class ProNonCombatMoveAI {
 
     // Log a warning if any units not assigned to a territory (skip infrastructure for now)
     for (final Unit u : territoryManager.getDefendOptions().getUnitMoveMap().keySet()) {
-      if (Matches.unitIsInfrastructure().invert().test(u)) {
+      if (Matches.unitIsInfrastructure().negate().test(u)) {
         ProLogger.warn(player + ": " + unitTerritoryMap.get(u) + " has unmoved unit: " + u + " with options: "
             + territoryManager.getDefendOptions().getUnitMoveMap().get(u));
       }
@@ -359,7 +360,7 @@ class ProNonCombatMoveAI {
       patd.setMaxEnemyUnits(new ArrayList<>(enemyAttackingUnits));
       patd.setMaxEnemyBombardUnits(enemyAttackOptions.getMax(t).getMaxBombardUnits());
       final List<Unit> minDefendingUnitsAndNotAa =
-          Matches.getMatches(patd.getCantMoveUnits(), Matches.unitIsAaForAnything().invert());
+          Matches.getMatches(patd.getCantMoveUnits(), Matches.unitIsAaForAnything().negate());
       final ProBattleResult minResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
           minDefendingUnitsAndNotAa, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       patd.setMinBattleResult(minResult);
@@ -376,7 +377,7 @@ class ProNonCombatMoveAI {
       defendingUnits.addAll(patd.getMaxAmphibUnits());
       defendingUnits.addAll(patd.getCantMoveUnits());
       final List<Unit> defendingUnitsAndNotAa =
-          Matches.getMatches(defendingUnits, Matches.unitIsAaForAnything().invert());
+          Matches.getMatches(defendingUnits, Matches.unitIsAaForAnything().negate());
       final ProBattleResult result = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
           defendingUnitsAndNotAa, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       int isFactory = 0;
@@ -618,7 +619,7 @@ class ProNonCombatMoveAI {
         final TreeMap<Double, Territory> estimatesMap = new TreeMap<>();
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
           List<Unit> defendingUnits = Matches.getMatches(moveMap.get(t).getAllDefenders(),
-              ProMatches.unitIsAlliedNotOwnedAir(player, data).invert());
+              ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
           if (t.isWater()) {
             defendingUnits = moveMap.get(t).getAllDefenders();
           }
@@ -643,7 +644,7 @@ class ProNonCombatMoveAI {
         double maxWinPercentage = -1;
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
           List<Unit> defendingUnits = Matches.getMatches(moveMap.get(t).getAllDefenders(),
-              ProMatches.unitIsAlliedNotOwnedAir(player, data).invert());
+              ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
           if (t.isWater()) {
             defendingUnits = moveMap.get(t).getAllDefenders();
           }
@@ -695,7 +696,7 @@ class ProNonCombatMoveAI {
             continue; // skip moving air units to allied land without a factory
           }
           List<Unit> defendingUnits = Matches.getMatches(moveMap.get(t).getAllDefenders(),
-              ProMatches.unitIsAlliedNotOwnedAir(player, data).invert());
+              ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
           if (t.isWater()) {
             defendingUnits = moveMap.get(t).getAllDefenders();
           }
@@ -984,7 +985,7 @@ class ProNonCombatMoveAI {
 
       // Handle allied units such as fighters on carriers
       final List<Unit> alliedUnits =
-          Matches.getMatches(moveMap.get(t).getTempUnits(), Matches.unitIsOwnedBy(player).invert());
+          Matches.getMatches(moveMap.get(t).getTempUnits(), Matches.unitIsOwnedBy(player).negate());
       for (final Unit alliedUnit : alliedUnits) {
         moveMap.get(t).addCantMoveUnit(alliedUnit);
         moveMap.get(t).getTempUnits().remove(alliedUnit);
@@ -1218,9 +1219,9 @@ class ProNonCombatMoveAI {
           boolean movedTransport = false;
           final Set<Territory> cantHoldTerritories = new HashSet<>();
           while (true) {
-            final Match<Territory> match =
+            final Predicate<Territory> match =
                 Match.allOf(ProMatches.territoryCanMoveSeaUnitsThrough(player, data, false),
-                    Matches.territoryIsInList(cantHoldTerritories).invert());
+                    Matches.territoryIsInList(cantHoldTerritories).negate());
             final Route route = data.getMap().getRoute_IgnoreEnd(currentTerritory, patd.getTerritory(), match);
             if (route == null
                 || MoveValidator.validateCanal(route, Collections.singletonList(transport), player, data) != null) {
@@ -1547,7 +1548,7 @@ class ProNonCombatMoveAI {
 
       // Handle allied units such as fighters on carriers
       final List<Unit> alliedUnits =
-          Matches.getMatches(moveMap.get(t).getTempUnits(), Matches.unitIsOwnedBy(player).invert());
+          Matches.getMatches(moveMap.get(t).getTempUnits(), Matches.unitIsOwnedBy(player).negate());
       for (final Unit alliedUnit : alliedUnits) {
         moveMap.get(t).addCantMoveUnit(alliedUnit);
         moveMap.get(t).getTempUnits().remove(alliedUnit);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -73,7 +74,7 @@ class ProPurchaseAI {
     // Current data at the start of combat move
     this.data = data;
     this.player = player;
-    final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player),
+    final Predicate<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player),
         Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     final List<Territory> rfactories = Matches.getMatches(data.getMap().getTerritories(),
         ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
@@ -1875,7 +1876,7 @@ class ProPurchaseAI {
 
     ProLogger.info("Place land with isConstruction=" + isConstruction + ", units=" + player.getUnits().getUnits());
 
-    Match<Unit> unitMatch = Matches.unitIsNotConstruction();
+    Predicate<Unit> unitMatch = Matches.unitIsNotConstruction();
     if (isConstruction) {
       unitMatch = Matches.unitIsConstruction();
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -118,7 +118,8 @@ final class ProTechAI {
           Matches.unitCanMove());
       final Predicate<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
           Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.unitCanMove());
-      final Predicate<Unit> transport = Match.allOf(Matches.unitIsSea(), Matches.unitIsTransport(), Matches.unitCanMove());
+      final Predicate<Unit> transport =
+          Match.allOf(Matches.unitIsSea(), Matches.unitIsTransport(), Matches.unitCanMove());
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       // should change this to read production frontier and tech

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -132,7 +132,7 @@ public class ProTerritory {
     if (Properties.getProduceNewFightersOnOldCarriers(data)) {
       return getAllDefenders();
     } else {
-      final List<Unit> defenders = Matches.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).invert());
+      final List<Unit> defenders = Matches.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate());
       defenders.addAll(units);
       defenders.addAll(tempUnits);
       return defenders;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -309,8 +309,8 @@ public class ProTerritoryManager {
         maxScrambleDistance = ua.getMaxScrambleDistance();
       }
     }
-    final Match<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, player),
-        Matches.unitIsAirBase(), Matches.unitIsNotDisabled(), Matches.unitIsBeingTransported().invert());
+    final Predicate<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, player),
+        Matches.unitIsAirBase(), Matches.unitIsNotDisabled(), Matches.unitIsBeingTransported().negate());
     final Predicate<Territory> canScramble = PredicateBuilder.of(Match.anyOf(
         Matches.territoryIsWater(),
         Matches.isTerritoryEnemy(player, data)))
@@ -347,7 +347,7 @@ public class ProTerritoryManager {
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
         List<Unit> canScrambleAir = from.getUnits()
             .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.unitCanScramble(),
-                Matches.unitIsNotDisabled(), Matches.unitWasScrambled().invert(),
+                Matches.unitIsNotDisabled(), Matches.unitWasScrambled().negate(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
 
         // Add max scramble units
@@ -542,7 +542,7 @@ public class ProTerritoryManager {
 
   private static void findNavalMoveOptions(final PlayerID player, final List<Territory> myUnitTerritories,
       final Map<Territory, ProTerritory> moveMap, final Map<Unit, Set<Territory>> unitMoveMap,
-      final Map<Unit, Set<Territory>> transportMoveMap, final Match<Territory> moveToTerritoryMatch,
+      final Map<Unit, Set<Territory>> transportMoveMap, final Predicate<Territory> moveToTerritoryMatch,
       final List<Territory> clearedTerritories, final boolean isCombatMove, final boolean isCheckingEnemyAttacks) {
     final GameData data = ProData.getData();
 
@@ -652,7 +652,7 @@ public class ProTerritoryManager {
 
   private static void findLandMoveOptions(final PlayerID player, final List<Territory> myUnitTerritories,
       final Map<Territory, ProTerritory> moveMap, final Map<Unit, Set<Territory>> unitMoveMap,
-      final Map<Territory, Set<Territory>> landRoutesMap, final Match<Territory> moveToTerritoryMatch,
+      final Map<Territory, Set<Territory>> landRoutesMap, final Predicate<Territory> moveToTerritoryMatch,
       final List<Territory> enemyTerritories, final List<Territory> clearedTerritories, final boolean isCombatMove,
       final boolean isCheckingEnemyAttacks, final boolean isIgnoringRelationships) {
     final GameData data = ProData.getData();
@@ -737,7 +737,7 @@ public class ProTerritoryManager {
 
   private static void findAirMoveOptions(final PlayerID player, final List<Territory> myUnitTerritories,
       final Map<Territory, ProTerritory> moveMap, final Map<Unit, Set<Territory>> unitMoveMap,
-      final Match<Territory> moveToTerritoryMatch, final List<Territory> enemyTerritories,
+      final Predicate<Territory> moveToTerritoryMatch, final List<Territory> enemyTerritories,
       final List<Territory> alliedTerritories, final boolean isCombatMove, final boolean isCheckingEnemyAttacks,
       final boolean isIgnoringRelationships) {
     final GameData data = ProData.getData();
@@ -799,7 +799,7 @@ public class ProTerritoryManager {
         for (final Territory potentialTerritory : potentialTerritories) {
 
           // Find route ignoring impassable and territories with AA
-          Match<Territory> canFlyOverMatch = ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, isCombatMove);
+          Predicate<Territory> canFlyOverMatch = ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, isCombatMove);
           if (isCheckingEnemyAttacks) {
             canFlyOverMatch = ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove);
           }
@@ -853,7 +853,7 @@ public class ProTerritoryManager {
 
   private static void findAmphibMoveOptions(final PlayerID player, final List<Territory> myUnitTerritories,
       final Map<Territory, ProTerritory> moveMap, final List<ProTransport> transportMapList,
-      final Map<Territory, Set<Territory>> landRoutesMap, final Match<Territory> moveAmphibToTerritoryMatch,
+      final Map<Territory, Set<Territory>> landRoutesMap, final Predicate<Territory> moveAmphibToTerritoryMatch,
       final boolean isCombatMove, final boolean isCheckingEnemyAttacks, final boolean isIgnoringRelationships) {
     final GameData data = ProData.getData();
 
@@ -862,7 +862,7 @@ public class ProTerritoryManager {
       // Find my transports and amphibious units that have movement left
       final List<Unit> myTransportUnits =
           myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedTransport(player, isCombatMove));
-      Match<Territory> unloadAmphibTerritoryMatch = Match.allOf(
+      Predicate<Territory> unloadAmphibTerritoryMatch = Match.allOf(
           ProMatches.territoryCanMoveLandUnits(player, data, isCombatMove), moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
         unloadAmphibTerritoryMatch = Match.allOf(
@@ -906,7 +906,7 @@ public class ProTerritoryManager {
             final Set<Territory> myUnitsToLoadTerritories = new HashSet<>();
             if (TransportTracker.isTransporting(myTransportUnit)) {
               units.addAll(TransportTracker.transporting(myTransportUnit));
-            } else if (Matches.territoryHasEnemySeaUnits(player, data).invert().test(currentTerritory)) {
+            } else if (Matches.territoryHasEnemySeaUnits(player, data).negate().test(currentTerritory)) {
               final Set<Territory> possibleLoadTerritories = data.getMap().getNeighbors(currentTerritory);
               for (final Territory possibleLoadTerritory : possibleLoadTerritories) {
                 List<Unit> possibleUnits = possibleLoadTerritory.getUnits().getMatches(

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
@@ -65,7 +65,7 @@ public class ProSimulateTurnUtils {
         // Make updates to data
         final List<Unit> attackersToRemove = new ArrayList<>(attackers);
         attackersToRemove.removeAll(remainingUnits);
-        final List<Unit> defendersToRemove = Matches.getMatches(defenders, Matches.unitIsInfrastructure().invert());
+        final List<Unit> defendersToRemove = Matches.getMatches(defenders, Matches.unitIsInfrastructure().negate());
         final List<Unit> infrastructureToChangeOwner = Matches.getMatches(defenders, Matches.unitIsInfrastructure());
         ProLogger.debug("attackersToRemove=" + attackersToRemove);
         ProLogger.debug("defendersToRemove=" + defendersToRemove);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -55,7 +55,7 @@ public class ProBattleUtils {
     final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
         defendingUnits, false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     final List<Unit> defendersWithHitPoints =
-        Matches.getMatches(defendingUnits, Matches.unitIsInfrastructure().invert());
+        Matches.getMatches(defendingUnits, Matches.unitIsInfrastructure().negate());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
     return ((attackPower / data.getDiceSides()) >= totalDefenderHitPoints);
   }
@@ -66,7 +66,7 @@ public class ProBattleUtils {
     if (attackingUnits.size() == 0) {
       return 0;
     }
-    final List<Unit> actualDefenders = Matches.getMatches(defendingUnits, Matches.unitIsInfrastructure().invert());
+    final List<Unit> actualDefenders = Matches.getMatches(defendingUnits, Matches.unitIsInfrastructure().negate());
     if (actualDefenders.size() == 0) {
       return 100;
     }
@@ -83,7 +83,7 @@ public class ProBattleUtils {
         Matches.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     if (Properties.getTransportCasualtiesRestricted(data)) {
       unitsThatCanFight =
-          Matches.getMatches(unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().invert());
+          Matches.getMatches(unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().negate());
     }
     final int myHitPoints = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -60,7 +60,8 @@ public class ProMatches {
     });
   }
 
-  public static Predicate<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player,
+      final GameData data,
       final Unit u) {
     return Match.of(t -> {
       final Predicate<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
@@ -189,18 +190,21 @@ public class ProMatches {
     return Match.anyOf(Matches.territoryHasNoEnemyUnits(player, data), Matches.territoryIsInList(clearedTerritories));
   }
 
-  public static Predicate<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player,
+      final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
     return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
         Matches.territoryHasEnemyUnits(player, data), Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Predicate<Territory> territoryHasInfraFactoryAndIsLand() {
-    final Predicate<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
+    final Predicate<Unit> infraFactoryMatch =
+        Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
-  public static Predicate<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player,
+      final GameData data) {
     return Match.allOf(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
   }
 
@@ -238,8 +242,10 @@ public class ProMatches {
         Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
-  public static Predicate<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
-    final Predicate<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player,
+      final GameData data) {
+    final Predicate<Unit> infraFactoryMatch =
+        Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryAllied(player, data),
         Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
@@ -290,7 +296,8 @@ public class ProMatches {
   }
 
   public static Predicate<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    final Predicate<Territory> alliedLand = Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
+    final Predicate<Territory> alliedLand =
+        Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
     return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
   }
 
@@ -326,7 +333,8 @@ public class ProMatches {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Predicate<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.territoryIsLand());
+      final Predicate<Territory> match =
+          Match.allOf(Matches.isTerritoryAllied(player, data), Matches.territoryIsLand());
       return match.test(t);
     });
   }
@@ -341,7 +349,8 @@ public class ProMatches {
     });
   }
 
-  public static Predicate<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player,
+      final GameData data) {
     final Predicate<Territory> hasOwnedFactoryNeighbor =
         Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
     return Match.allOf(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
@@ -418,7 +427,8 @@ public class ProMatches {
     return Match.anyOf(myUnitHasNoMovementMatch, alliedUnitMatch);
   }
 
-  public static Predicate<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
+  public static Predicate<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player,
+      final GameData data,
       final Territory t) {
     return Match.allOf(unitCantBeMovedAndIsAlliedDefender(player, data, t),
         Matches.unitIsNotInfrastructure());
@@ -469,7 +479,8 @@ public class ProMatches {
     return Match.allOf(Matches.unitOwnedBy(player), Matches.unitIsAir());
   }
 
-  public static Predicate<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {
+  public static Predicate<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player,
+      final UnitType unitType) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
         Matches.unitIsTransporting());
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ai.proAI.util;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -20,112 +21,112 @@ import games.strategy.util.Match;
  */
 public class ProMatches {
 
-  public static Match<Territory> territoryCanLandAirUnits(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanLandAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> enemyTerritories, final List<Territory> alliedTerritories) {
     return Match.anyOf(Matches.territoryIsInList(alliedTerritories),
         Match.allOf(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
                 false, true, true),
-            Matches.territoryIsInList(enemyTerritories).invert()));
+            Matches.territoryIsInList(enemyTerritories).negate()));
   }
 
-  public static Match<Territory> territoryCanMoveAirUnits(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
             true, false));
   }
 
-  public static Match<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
-  public static Match<Territory> territoryCanMoveAirUnitsAndNoAa(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveAirUnitsAndNoAa(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.allOf(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
-        Matches.territoryHasEnemyAaForAnything(player, data).invert());
+        Matches.territoryHasEnemyAaForAnything(player, data).negate());
   }
 
-  public static Match<Territory> territoryCanMoveSpecificLandUnit(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final boolean isCombatMove, final Unit u) {
     return Match.of(t -> {
-      final Match<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Predicate<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
               false, false));
-      final Match<Unit> unitMatch =
-          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
+      final Predicate<Unit> unitMatch =
+          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).negate();
       return territoryMatch.test(t) && unitMatch.test(u);
     });
   }
 
-  public static Match<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final Unit u) {
     return Match.of(t -> {
-      final Match<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Predicate<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestricted(player, data));
-      final Match<Unit> unitMatch =
-          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
+      final Predicate<Unit> unitMatch =
+          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).negate();
       return territoryMatch.test(t) && unitMatch.test(u);
     });
   }
 
-  public static Match<Territory> territoryCanMoveLandUnits(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveLandUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
             false, false));
   }
 
-  public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.territoryIsLand(),
         Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
-  public static Match<Territory> territoryCanMoveLandUnitsAndIsAllied(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryCanMoveLandUnitsAndIsAllied(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.isTerritoryAllied(player, data),
         territoryCanMoveLandUnits(player, data, false));
   }
 
-  public static Match<Territory> territoryCanMoveLandUnitsThrough(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveLandUnitsThrough(final PlayerID player, final GameData data,
       final Unit u, final Territory startTerritory, final boolean isCombatMove,
       final List<Territory> enemyTerritories) {
     return Match.of(t -> {
-      Match<Territory> match =
+      Predicate<Territory> match =
           Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
               Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
-              Matches.territoryIsInList(enemyTerritories).invert());
+              Matches.territoryIsInList(enemyTerritories).negate());
       if (isCombatMove && Matches.unitCanBlitz().test(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-        final Match<Territory> alliedWithNoEnemiesMatch = Match.allOf(
+        final Predicate<Territory> alliedWithNoEnemiesMatch = Match.allOf(
             Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
-        final Match<Territory> alliedOrBlitzableMatch =
+        final Predicate<Territory> alliedOrBlitzableMatch =
             Match.anyOf(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
         match = Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
-            alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).invert());
+            alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).negate());
       }
       return match.test(t);
     });
   }
 
-  public static Match<Territory> territoryCanMoveLandUnitsThroughIgnoreEnemyUnits(final PlayerID player,
+  public static Predicate<Territory> territoryCanMoveLandUnitsThroughIgnoreEnemyUnits(final PlayerID player,
       final GameData data, final Unit u, final Territory startTerritory, final boolean isCombatMove,
       final List<Territory> blockedTerritories, final List<Territory> clearedTerritories) {
-    Match<Territory> alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
+    Predicate<Territory> alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
         Matches.territoryIsInList(clearedTerritories));
     if (isCombatMove && Matches.unitCanBlitz().test(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
       alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
           Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
     }
     return Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
-        alliedMatch, Matches.territoryIsInList(blockedTerritories).invert());
+        alliedMatch, Matches.territoryIsInList(blockedTerritories).negate());
   }
 
-  private static Match<Territory> territoryIsBlitzable(final PlayerID player, final GameData data, final Unit u) {
+  private static Predicate<Territory> territoryIsBlitzable(final PlayerID player, final GameData data, final Unit u) {
     return Match.of(t -> Matches.territoryIsBlitzable(player, data).test(t)
         && TerritoryEffectHelper.unitKeepsBlitz(u, t));
   }
 
-  public static Match<Territory> territoryCanMoveSeaUnits(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveSeaUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.of(t -> {
       final boolean navalMayNotNonComIntoControlled =
@@ -134,374 +135,374 @@ public class ProMatches {
           && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)) {
         return false;
       }
-      final Match<Territory> match = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Predicate<Territory> match = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
               false, false));
       return match.test(t);
     });
   }
 
-  public static Match<Territory> territoryCanMoveSeaUnitsThrough(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveSeaUnitsThrough(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
     return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         territoryHasOnlyIgnoredUnits(player, data));
   }
 
-  public static Match<Territory> territoryCanMoveSeaUnitsAndNotInList(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryCanMoveSeaUnitsAndNotInList(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> notTerritories) {
     return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         Matches.territoryIsNotInList(notTerritories));
   }
 
-  public static Match<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(final PlayerID player,
+  public static Predicate<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(final PlayerID player,
       final GameData data, final boolean isCombatMove, final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
-    final Match<Territory> onlyIgnoredOrClearedMatch = Match.anyOf(
+    final Predicate<Territory> onlyIgnoredOrClearedMatch = Match.anyOf(
         territoryHasOnlyIgnoredUnits(player, data), Matches.territoryIsInList(clearedTerritories));
     return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         onlyIgnoredOrClearedMatch, Matches.territoryIsNotInList(notTerritories));
   }
 
-  private static Match<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
+  private static Predicate<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> {
-      final Match<Unit> subOnly = Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsSub(),
-          Matches.enemyUnit(player, data).invert());
+      final Predicate<Unit> subOnly = Match.anyOf(Matches.unitIsInfrastructure(), Matches.unitIsSub(),
+          Matches.enemyUnit(player, data).negate());
       return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
           || Matches.territoryHasNoEnemyUnits(player, data).test(t);
     });
   }
 
-  public static Match<Territory> territoryHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
     return Match.anyOf(Matches.territoryHasEnemyUnits(player, data),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
-  public static Match<Territory> territoryHasPotentialEnemyUnits(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryHasPotentialEnemyUnits(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
     return Match.anyOf(Matches.territoryHasEnemyUnits(player, data),
         Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
   }
 
-  public static Match<Territory> territoryHasNoEnemyUnitsOrCleared(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryHasNoEnemyUnitsOrCleared(final PlayerID player, final GameData data,
       final List<Territory> clearedTerritories) {
     return Match.anyOf(Matches.territoryHasNoEnemyUnits(player, data), Matches.territoryIsInList(clearedTerritories));
   }
 
-  public static Match<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
     return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
         Matches.territoryHasEnemyUnits(player, data), Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
-    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsLand() {
+    final Predicate<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
     return Match.allOf(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
   }
 
-  static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
+  static Predicate<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
       final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
-    final Match<Territory> ownedAndCantBeHeld = Match.allOf(Matches.isTerritoryOwnedBy(player),
+    final Predicate<Territory> ownedAndCantBeHeld = Match.allOf(Matches.isTerritoryOwnedBy(player),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
-    final Match<Territory> enemyOrOwnedCantBeHeld =
+    final Predicate<Territory> enemyOrOwnedCantBeHeld =
         Match.anyOf(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
     return Match.allOf(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
     return Match.allOf(territoryIsNotConqueredOwnedLand(player, data),
         territoryHasInfraFactoryAndIsOwnedLand(player));
   }
 
-  public static Match<Territory> territoryHasNonMobileInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
+  public static Predicate<Territory> territoryHasNonMobileInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
     return Match.allOf(territoryHasNonMobileInfraFactory(),
         territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
   }
 
-  private static Match<Territory> territoryHasNonMobileInfraFactory() {
-    final Match<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(),
-        Matches.unitIsInfrastructure(), Matches.unitHasMovementLeft().invert());
+  private static Predicate<Territory> territoryHasNonMobileInfraFactory() {
+    final Predicate<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(),
+        Matches.unitIsInfrastructure(), Matches.unitHasMovementLeft().negate());
     return Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLand(final PlayerID player) {
-    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitIsOwnedBy(player),
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsOwnedLand(final PlayerID player) {
+    final Predicate<Unit> infraFactoryMatch = Match.allOf(Matches.unitIsOwnedBy(player),
         Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryOwnedBy(player),
         Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
-    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
+    final Predicate<Unit> infraFactoryMatch = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
     return Match.allOf(Matches.isTerritoryAllied(player, data),
         Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(final PlayerID player,
+  public static Predicate<Territory> territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(final PlayerID player,
       final GameData data) {
     return Match.allOf(territoryHasInfraFactoryAndIsOwnedLand(player),
         Matches.territoryHasNeighborMatching(data, Matches.territoryIsWater()));
   }
 
-  public static Match<Territory> territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
+  public static Predicate<Territory> territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
     return Match.allOf(territoryIsNotConqueredOwnedLand(player, data),
-        territoryHasInfraFactoryAndIsOwnedLand(player).invert());
+        territoryHasInfraFactoryAndIsOwnedLand(player).negate());
   }
 
-  public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
+  public static Predicate<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
       final List<PlayerID> players) {
-    final Match<Territory> territoryMatch = Match.allOf(Matches.isTerritoryOwnedBy(players),
+    final Predicate<Territory> territoryMatch = Match.allOf(Matches.isTerritoryOwnedBy(players),
         Matches.territoryHasUnitsThatMatch(Matches.unitIsLand()));
     return Matches.territoryHasNeighborMatching(data, territoryMatch);
   }
 
-  static Match<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player, final GameData data) {
-    final Match<Territory> alliedLand = Match.allOf(territoryCanMoveLandUnits(player, data, false),
+  static Predicate<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player, final GameData data) {
+    final Predicate<Territory> alliedLand = Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.isTerritoryAllied(player, data));
-    final Match<Territory> hasNoEnemyNeighbors = Matches
-        .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).invert();
+    final Predicate<Territory> hasNoEnemyNeighbors = Matches
+        .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).negate();
     return Match.allOf(alliedLand, hasNoEnemyNeighbors);
   }
 
-  public static Match<Territory> territoryIsEnemyLand(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsEnemyLand(final PlayerID player, final GameData data) {
     return Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.isTerritoryEnemy(player, data));
   }
 
-  public static Match<Territory> territoryIsEnemyNotNeutralLand(final PlayerID player, final GameData data) {
-    return Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().invert());
+  public static Predicate<Territory> territoryIsEnemyNotNeutralLand(final PlayerID player, final GameData data) {
+    return Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().negate());
   }
 
-  public static Match<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(final PlayerID player,
+  public static Predicate<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(final PlayerID player,
       final GameData data) {
-    final Match<Territory> isMatch =
-        Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().invert());
-    final Match<Territory> adjacentMatch = Match.allOf(territoryCanMoveLandUnits(player, data, false),
+    final Predicate<Territory> isMatch =
+        Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().negate());
+    final Predicate<Territory> adjacentMatch = Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.territoryHasNeighborMatching(data, isMatch));
     return Match.anyOf(isMatch, adjacentMatch);
   }
 
-  public static Match<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    final Match<Territory> alliedLand = Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
+  public static Predicate<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
+    final Predicate<Territory> alliedLand = Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
     return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
   }
 
-  public static Match<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
     return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
-  public static Match<Territory> territoryIsPotentialEnemy(final PlayerID player, final GameData data,
+  public static Predicate<Territory> territoryIsPotentialEnemy(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
     return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data), Matches.isTerritoryOwnedBy(players));
   }
 
-  public static Match<Territory> territoryIsPotentialEnemyOrHasPotentialEnemyUnits(final PlayerID player,
+  public static Predicate<Territory> territoryIsPotentialEnemyOrHasPotentialEnemyUnits(final PlayerID player,
       final GameData data, final List<PlayerID> players) {
     return Match.anyOf(territoryIsPotentialEnemy(player, data, players),
         territoryHasPotentialEnemyUnits(player, data, players));
   }
 
-  public static Match<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
+  public static Predicate<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
       final GameData data, final List<Territory> territoriesThatCantBeHeld) {
-    final Match<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsLand());
-    final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
+    final Predicate<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsLand());
+    final Predicate<Territory> territoryIsLandAndAdjacentToMyLandUnits =
         Match.allOf(Matches.territoryIsLand(),
             Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
     return Match.allOf(territoryIsLandAndAdjacentToMyLandUnits,
         territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
   }
 
-  public static Match<Territory> territoryIsNotConqueredAlliedLand(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsNotConqueredAlliedLand(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.territoryIsLand());
+      final Predicate<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.territoryIsLand());
       return match.test(t);
     });
   }
 
-  public static Match<Territory> territoryIsNotConqueredOwnedLand(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsNotConqueredOwnedLand(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
+      final Predicate<Territory> match = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
       return match.test(t);
     });
   }
 
-  public static Match<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player, final GameData data) {
-    final Match<Territory> hasOwnedFactoryNeighbor =
+  public static Predicate<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player, final GameData data) {
+    final Predicate<Territory> hasOwnedFactoryNeighbor =
         Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
     return Match.allOf(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
   }
 
-  private static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
+  private static Predicate<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft());
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().test(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsAir());
+      final Predicate<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsAir());
       return match.test(u);
     });
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedLand(final PlayerID player, final boolean isCombatMove) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedLand(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().test(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsLand(),
-          Matches.unitIsBeingTransported().invert());
+      final Predicate<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsLand(),
+          Matches.unitIsBeingTransported().negate());
       return match.test(u);
     });
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedSea(final PlayerID player, final boolean isCombatMove) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedSea(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().test(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsSea());
+      final Predicate<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsSea());
       return match.test(u);
     });
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedTransport(final PlayerID player, final boolean isCombatMove) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedTransport(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
       if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().test(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsTransport());
+      final Predicate<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitIsTransport());
       return match.test(u);
     });
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedBombard(final PlayerID player) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedBombard(final PlayerID player) {
     return Match.of(u -> {
       if (Matches.unitCanNotMoveDuringCombatMove().test(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
+      final Predicate<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
       return match.test(u);
     });
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
+  public static Predicate<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
     return Match.allOf(unitCanBeMovedAndIsOwned(player),
         Matches.unitCanNotMoveDuringCombatMove(), Matches.unitIsInfrastructure());
   }
 
-  public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
+  public static Predicate<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
       final Territory t) {
-    final Match<Unit> myUnitHasNoMovementMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft().invert());
-    final Match<Unit> alliedUnitMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
+    final Predicate<Unit> myUnitHasNoMovementMatch =
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft().negate());
+    final Predicate<Unit> alliedUnitMatch =
+        Match.allOf(Matches.unitIsOwnedBy(player).negate(), Matches.isUnitAllied(player, data),
             Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
-                data, false).invert());
+                data, false).negate());
     return Match.anyOf(myUnitHasNoMovementMatch, alliedUnitMatch);
   }
 
-  public static Match<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
+  public static Predicate<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
       final Territory t) {
     return Match.allOf(unitCantBeMovedAndIsAlliedDefender(player, data, t),
         Matches.unitIsNotInfrastructure());
   }
 
-  public static Match<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.unitIsLand(), Matches.isUnitAllied(player, data),
         Matches.unitIsNotInfrastructure());
   }
 
-  public static Match<Unit> unitIsAlliedNotOwned(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
+  public static Predicate<Unit> unitIsAlliedNotOwned(final PlayerID player, final GameData data) {
+    return Match.allOf(Matches.unitIsOwnedBy(player).negate(), Matches.isUnitAllied(player, data));
   }
 
-  public static Match<Unit> unitIsAlliedNotOwnedAir(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsAlliedNotOwnedAir(final PlayerID player, final GameData data) {
     return Match.allOf(unitIsAlliedNotOwned(player, data), Matches.unitIsAir());
   }
 
-  static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
+  static Predicate<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.isUnitAllied(player, data), Matches.unitIsAir());
   }
 
-  public static Match<Unit> unitIsEnemyAir(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsEnemyAir(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAir());
   }
 
-  public static Match<Unit> unitIsEnemyAndNotAa(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAaForAnything().invert());
+  public static Predicate<Unit> unitIsEnemyAndNotAa(final PlayerID player, final GameData data) {
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAaForAnything().negate());
   }
 
-  public static Match<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsNotInfrastructure());
   }
 
-  public static Match<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsNotLand());
   }
 
-  static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), unitIsNeutral().invert());
+  static Predicate<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
+    return Match.allOf(Matches.enemyUnit(player, data), unitIsNeutral().negate());
   }
 
-  private static Match<Unit> unitIsNeutral() {
+  private static Predicate<Unit> unitIsNeutral() {
     return Match.of(u -> u.getOwner().isNull());
   }
 
-  static Match<Unit> unitIsOwnedAir(final PlayerID player) {
+  static Predicate<Unit> unitIsOwnedAir(final PlayerID player) {
     return Match.allOf(Matches.unitOwnedBy(player), Matches.unitIsAir());
   }
 
-  public static Match<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {
+  public static Predicate<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
         Matches.unitIsTransporting());
   }
 
-  public static Match<Unit> unitIsOwnedAndMatchesTypeAndNotTransporting(final PlayerID player,
+  public static Predicate<Unit> unitIsOwnedAndMatchesTypeAndNotTransporting(final PlayerID player,
       final UnitType unitType) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
-        Matches.unitIsTransporting().invert());
+        Matches.unitIsTransporting().negate());
   }
 
-  public static Match<Unit> unitIsOwnedCarrier(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedCarrier(final PlayerID player) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1
         && Matches.unitIsOwnedBy(player).test(unit));
   }
 
-  public static Match<Unit> unitIsOwnedNotLand(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedNotLand(final PlayerID player) {
     return Match.allOf(Matches.unitIsNotLand(), Matches.unitIsOwnedBy(player));
   }
 
-  public static Match<Unit> unitIsOwnedTransport(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedTransport(final PlayerID player) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsTransport());
   }
 
-  public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(), Matches.unitCanMove());
   }
 
-  public static Match<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(),
-        Matches.unitCanNotMoveDuringCombatMove().invert(), Matches.unitCanMove());
+        Matches.unitCanNotMoveDuringCombatMove().negate(), Matches.unitCanMove());
   }
 
-  public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player, final Unit transport,
+  public static Predicate<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player, final Unit transport,
       final boolean isCombatMove) {
     return Match.of(u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
@@ -509,8 +510,8 @@ public class ProMatches {
           && (Matches.unitCanNotMoveDuringCombatMove().test(u) || !ua.canInvadeFrom(transport))) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),
-          Matches.unitHasMovementLeft(), Matches.unitIsBeingTransported().invert());
+      final Predicate<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),
+          Matches.unitHasMovementLeft(), Matches.unitIsBeingTransported().negate());
       return match.test(u);
     });
   }
@@ -522,7 +523,7 @@ public class ProMatches {
    *        territory we are testing for required units
    * @return whether the territory contains one of the required combos of units
    */
-  public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory t) {
+  public static Predicate<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory t) {
     return Match.of(unitWhichRequiresUnits -> {
       if (!Matches.unitRequiresUnitsOnCreation().test(unitWhichRequiresUnits)) {
         return true;

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -198,9 +198,8 @@ public class ProMatches {
   }
 
   public static Predicate<Territory> territoryHasInfraFactoryAndIsLand() {
-    final Predicate<Unit> infraFactoryMatch =
-        Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
-    return Match.allOf(Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+    final Predicate<Unit> infraFactory = Match.allOf(Matches.unitCanProduceUnits(), Matches.unitIsInfrastructure());
+    return Match.allOf(Matches.territoryIsLand(), Matches.territoryHasUnitsThatMatch(infraFactory));
   }
 
   public static Predicate<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player,
@@ -296,9 +295,8 @@ public class ProMatches {
   }
 
   public static Predicate<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    final Predicate<Territory> alliedLand =
-        Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data));
-    return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
+    return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data),
+        Match.allOf(Matches.territoryIsLand(), Matches.isTerritoryAllied(player, data)));
   }
 
   public static Predicate<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -127,7 +127,7 @@ public class ProMoveUtils {
         while (movesLeft >= 0) {
 
           // Load adjacent units if no enemies present in transport territory
-          if (Matches.territoryHasEnemyUnits(player, data).invert().test(transportTerritory)) {
+          if (Matches.territoryHasEnemyUnits(player, data).negate().test(transportTerritory)) {
             final List<Unit> unitsToRemove = new ArrayList<>();
             for (final Unit amphibUnit : remainingUnitsToLoad) {
               if (data.getMap().getDistance(transportTerritory, ProData.unitTerritoryMap.get(amphibUnit)) == 1) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -101,7 +101,7 @@ public class ProPurchaseUtils {
 
         // Find number of unit type that are already built and about to be placed
         int currentlyBuilt = 0;
-        final Match<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
+        final Predicate<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
         final List<Territory> allTerritories = data.getMap().getTerritories();
         for (final Territory t : allTerritories) {
           currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);
@@ -258,8 +258,8 @@ public class ProPurchaseUtils {
 
   private static int getUnitProduction(final Territory territory, final GameData data, final PlayerID player) {
     final Predicate<Unit> factoryMatch = Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player)
-        .and(Matches.unitIsBeingTransported().invert())
-        .and((territory.isWater() ? Matches.unitIsLand() : Matches.unitIsSea()).invert());
+        .and(Matches.unitIsBeingTransported().negate())
+        .and((territory.isWater() ? Matches.unitIsLand() : Matches.unitIsSea()).negate());
     final Collection<Unit> factoryUnits = territory.getUnits().getMatches(factoryMatch);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -77,7 +78,8 @@ public class ProTransportUtils {
 
   // TODO: this needs fixed to consider whether a valid route exists to load all units
   public static List<Unit> getUnitsToTransportFromTerritories(final PlayerID player, final Unit transport,
-      final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore, final Match<Unit> validUnitMatch) {
+      final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore,
+      final Predicate<Unit> validUnitMatch) {
     final List<Unit> selectedUnits = new ArrayList<>();
 
     // Get units if transport already loaded

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -56,12 +57,12 @@ class Utils {
     return strength;
   }
 
-  static Route findNearest(final Territory start, final Match<Territory> endCondition,
-      final Match<Territory> routeCondition, final GameData data) {
+  static Route findNearest(final Territory start, final Predicate<Territory> endCondition,
+      final Predicate<Territory> routeCondition, final GameData data) {
     Route shortestRoute = null;
     for (final Territory t : data.getMap().getTerritories()) {
       if (endCondition.test(t)) {
-        final Match<Territory> routeOrEnd = Match.anyOf(routeCondition, Matches.territoryIs(t));
+        final Predicate<Territory> routeOrEnd = Match.anyOf(routeCondition, Matches.territoryIs(t));
         final Route r = data.getMap().getRoute(start, t, routeOrEnd);
         if (r != null) {
           if (shortestRoute == null || r.numberOfSteps() < shortestRoute.numberOfSteps()) {
@@ -101,9 +102,9 @@ class Utils {
    * Return Territories containing any unit depending on unitCondition
    * Differs from findCertainShips because it doesn't require the units be owned.
    */
-  static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
+  static List<Territory> findUnitTerr(final GameData data, final Predicate<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
-    final Match<Unit> limitShips = Match.allOf(unitCondition);
+    final Predicate<Unit> limitShips = Match.allOf(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> neighbors = data.getMap().getTerritories();
     for (final Territory t2 : neighbors) {

--- a/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.attachments;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.CompositeChange;
@@ -224,7 +225,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     return testChance;
   }
 
-  public static Match<TriggerAttachment> isSatisfiedMatch(final HashMap<ICondition, Boolean> testedConditions) {
+  public static Predicate<TriggerAttachment> isSatisfiedMatch(final HashMap<ICondition, Boolean> testedConditions) {
     return Match.of(t -> t.isSatisfied(testedConditions));
   }
 
@@ -239,7 +240,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    * @return true if when and both args are null, and true if all are not null and when matches the args, otherwise
    *         false
    */
-  public static Match<TriggerAttachment> whenOrDefaultMatch(final String beforeOrAfter, final String stepName) {
+  public static Predicate<TriggerAttachment> whenOrDefaultMatch(final String beforeOrAfter, final String stepName) {
     return Match.of(t -> {
       if (beforeOrAfter == null && stepName == null && t.getWhen().isEmpty()) {
         return true;
@@ -254,9 +255,9 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     });
   }
 
-  public static final Match<TriggerAttachment> availableUses = Match.of(t -> t.getUses() != 0);
+  public static final Predicate<TriggerAttachment> availableUses = Match.of(t -> t.getUses() != 0);
 
-  public static Match<TriggerAttachment> notificationMatch() {
+  public static Predicate<TriggerAttachment> notificationMatch() {
     return Match.of(t -> t.getNotification() != null);
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -253,11 +253,11 @@ public class PlayerAttachment extends DefaultAttachment {
       final Collection<Unit> currentInTerritory = toMoveInto.getUnits().getUnits();
       // first remove units that do not apply to our current type
       if (type.equals("owned")) {
-        currentInTerritory.removeAll(Matches.getMatches(currentInTerritory, Matches.unitIsOwnedBy(owner).invert()));
-        copyUnitsMoving.removeAll(Matches.getMatches(copyUnitsMoving, Matches.unitIsOwnedBy(owner).invert()));
+        currentInTerritory.removeAll(Matches.getMatches(currentInTerritory, Matches.unitIsOwnedBy(owner).negate()));
+        copyUnitsMoving.removeAll(Matches.getMatches(copyUnitsMoving, Matches.unitIsOwnedBy(owner).negate()));
       } else if (type.equals("allied")) {
-        currentInTerritory.removeAll(Matches.getMatches(currentInTerritory, Matches.alliedUnit(owner, data).invert()));
-        copyUnitsMoving.removeAll(Matches.getMatches(copyUnitsMoving, Matches.alliedUnit(owner, data).invert()));
+        currentInTerritory.removeAll(Matches.getMatches(currentInTerritory, Matches.alliedUnit(owner, data).negate()));
+        copyUnitsMoving.removeAll(Matches.getMatches(copyUnitsMoving, Matches.alliedUnit(owner, data).negate()));
       }
       // else if (type.equals("total"))
       // now remove units that are not part of our list

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -936,7 +936,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     for (final Territory terr : territories) {
       final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());
       if (exclType.equals("direct")) {
-        allUnits.removeAll(Matches.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).invert()));
+        allUnits.removeAll(Matches.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).negate()));
       } else if (exclType.equals("allied")) {
         allUnits.retainAll(Matches.getMatches(allUnits, Matches.alliedUnitOfAnyOfThesePlayers(players, data)));
       } else if (exclType.equals("enemy")) {
@@ -1009,7 +1009,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         allUnits.removeAll(Matches.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players)));
         allUnits.retainAll(Matches.getMatches(allUnits, Matches.alliedUnitOfAnyOfThesePlayers(players, data)));
       } else if (exclType.equals("direct")) {
-        allUnits.removeAll(Matches.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).invert()));
+        allUnits.removeAll(Matches.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).negate()));
       } else if (exclType.equals("enemy")) { // any enemy units in the territory
         allUnits.retainAll(Matches.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)));
       } else if (exclType.equals("enemy_surface")) { // any enemy units (not trn/sub) in the territory

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1262,7 +1262,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allJets = Matches.getMatches(data.getUnitTypeList().getAllUnitTypes(),
-              Match.allOf(Matches.unitTypeIsAir(), Matches.unitTypeIsStrategicBomber().invert()));
+              Match.allOf(Matches.unitTypeIsAir(), Matches.unitTypeIsStrategicBomber().negate()));
           final boolean ww2v3TechModel = Properties.getWW2V3TechModel(data);
           for (final UnitType jet : allJets) {
             if (ww2v3TechModel) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.Attachable;
@@ -134,7 +135,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * @return set of trigger attachments (If you use null for the match condition, you will get all triggers for this
    *         player)
    */
-  static Set<TriggerAttachment> getTriggers(final PlayerID player, final Match<TriggerAttachment> cond) {
+  static Set<TriggerAttachment> getTriggers(final PlayerID player, final Predicate<TriggerAttachment> cond) {
     final Set<TriggerAttachment> trigs = new HashSet<>();
     for (final IAttachment a : player.getAttachments().values()) {
       if (a instanceof TriggerAttachment) {
@@ -152,7 +153,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * and then it will fire all the conditions which are satisfied.
    */
   public static void collectAndFireTriggers(final HashSet<PlayerID> players,
-      final Match<TriggerAttachment> triggerMatch, final IDelegateBridge bridge, final String beforeOrAfter,
+      final Predicate<TriggerAttachment> triggerMatch, final IDelegateBridge bridge, final String beforeOrAfter,
       final String stepName) {
     final HashSet<TriggerAttachment> toFirePossible = collectForAllTriggersMatching(players, triggerMatch);
     if (toFirePossible.isEmpty()) {
@@ -169,7 +170,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   public static HashSet<TriggerAttachment> collectForAllTriggersMatching(final HashSet<PlayerID> players,
-      final Match<TriggerAttachment> triggerMatch) {
+      final Predicate<TriggerAttachment> triggerMatch) {
     final HashSet<TriggerAttachment> toFirePossible = new HashSet<>();
     for (final PlayerID player : players) {
       toFirePossible.addAll(TriggerAttachment.getTriggers(player, triggerMatch));
@@ -631,7 +632,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[2] + " unknown " + thisErrorMsg());
     }
-    if (Matches.isValidRelationshipName(getData()).invert().test(s[3])) {
+    if (Matches.isValidRelationshipName(getData()).negate().test(s[3])) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[3] + " unknown " + thisErrorMsg());
     }
@@ -2533,75 +2534,75 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
-  public static Match<TriggerAttachment> prodMatch() {
+  public static Predicate<TriggerAttachment> prodMatch() {
     return Match.of(t -> t.getFrontier() != null);
   }
 
-  public static Match<TriggerAttachment> prodFrontierEditMatch() {
+  public static Predicate<TriggerAttachment> prodFrontierEditMatch() {
     return Match.of(t -> t.getProductionRule() != null && t.getProductionRule().size() > 0);
   }
 
-  public static Match<TriggerAttachment> techMatch() {
+  public static Predicate<TriggerAttachment> techMatch() {
     return Match.of(t -> !t.getTech().isEmpty());
   }
 
-  public static Match<TriggerAttachment> techAvailableMatch() {
+  public static Predicate<TriggerAttachment> techAvailableMatch() {
     return Match.of(t -> t.getAvailableTech() != null);
   }
 
-  public static Match<TriggerAttachment> removeUnitsMatch() {
+  public static Predicate<TriggerAttachment> removeUnitsMatch() {
     return Match.of(t -> t.getRemoveUnits() != null);
   }
 
-  public static Match<TriggerAttachment> placeMatch() {
+  public static Predicate<TriggerAttachment> placeMatch() {
     return Match.of(t -> t.getPlacement() != null);
   }
 
-  public static Match<TriggerAttachment> purchaseMatch() {
+  public static Predicate<TriggerAttachment> purchaseMatch() {
     return Match.of(t -> t.getPurchase() != null);
   }
 
-  public static Match<TriggerAttachment> resourceMatch() {
+  public static Predicate<TriggerAttachment> resourceMatch() {
     return Match.of(t -> t.getResource() != null && t.getResourceCount() != 0);
   }
 
-  public static Match<TriggerAttachment> supportMatch() {
+  public static Predicate<TriggerAttachment> supportMatch() {
     return Match.of(t -> t.getSupport() != null);
   }
 
-  public static Match<TriggerAttachment> changeOwnershipMatch() {
+  public static Predicate<TriggerAttachment> changeOwnershipMatch() {
     return Match.of(t -> !t.getChangeOwnership().isEmpty());
   }
 
-  public static Match<TriggerAttachment> unitPropertyMatch() {
+  public static Predicate<TriggerAttachment> unitPropertyMatch() {
     return Match.of(t -> !t.getUnitType().isEmpty() && t.getUnitProperty() != null);
   }
 
-  public static Match<TriggerAttachment> territoryPropertyMatch() {
+  public static Predicate<TriggerAttachment> territoryPropertyMatch() {
     return Match.of(t -> !t.getTerritories().isEmpty() && t.getTerritoryProperty() != null);
   }
 
-  public static Match<TriggerAttachment> playerPropertyMatch() {
+  public static Predicate<TriggerAttachment> playerPropertyMatch() {
     return Match.of(t -> t.getPlayerProperty() != null);
   }
 
-  public static Match<TriggerAttachment> relationshipTypePropertyMatch() {
+  public static Predicate<TriggerAttachment> relationshipTypePropertyMatch() {
     return Match.of(t -> !t.getRelationshipTypes().isEmpty() && t.getRelationshipTypeProperty() != null);
   }
 
-  public static Match<TriggerAttachment> territoryEffectPropertyMatch() {
+  public static Predicate<TriggerAttachment> territoryEffectPropertyMatch() {
     return Match.of(t -> !t.getTerritoryEffects().isEmpty() && t.getTerritoryEffectProperty() != null);
   }
 
-  public static Match<TriggerAttachment> relationshipChangeMatch() {
+  public static Predicate<TriggerAttachment> relationshipChangeMatch() {
     return Match.of(t -> !t.getRelationshipChange().isEmpty());
   }
 
-  public static Match<TriggerAttachment> victoryMatch() {
+  public static Predicate<TriggerAttachment> victoryMatch() {
     return Match.of(t -> t.getVictory() != null && t.getVictory().length() > 0);
   }
 
-  public static Match<TriggerAttachment> activateTriggerMatch() {
+  public static Predicate<TriggerAttachment> activateTriggerMatch() {
     return Match.of(t -> !t.getActivateTrigger().isEmpty());
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -196,7 +197,7 @@ class AAInMoveUtil implements Serializable {
     // don't iterate over the end
     // that will be a battle
     // and handled else where in this tangled mess
-    final Match<Unit> hasAa = Matches.unitIsAaThatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
+    final Predicate<Unit> hasAa = Matches.unitIsAaThatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
         Matches.unitIsAaForFlyOverOnly(), 1, true, data);
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -360,7 +361,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     if (blockable.isEmpty()) {
       return 0;
     }
-    final Match<Unit> enemyUnits = Match.allOf(Matches.enemyUnit(player, data));
+    final Predicate<Unit> enemyUnits = Match.allOf(Matches.enemyUnit(player, data));
     int totalLoss = 0;
     final boolean rollDiceForBlockadeDamage = Properties.getConvoyBlockadesRollDiceForCost(data);
     final Collection<String> transcripts = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -305,7 +305,7 @@ public class AirBattle extends AbstractBattle {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
             .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerId(), m_data),
-                Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
+                Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().negate()));
         for (final Unit unit : bombers) {
           final Collection<Unit> enemyTargets =
               Matches.getMatches(enemyTargetsTotal, Matches.unitIsLegalBombingTargetBy(unit));
@@ -628,40 +628,40 @@ public class AirBattle extends AbstractBattle {
     }
   }
 
-  private static Match<Unit> unitHasAirDefenseGreaterThanZero() {
+  private static Predicate<Unit> unitHasAirDefenseGreaterThanZero() {
     return Match.of(u -> UnitAttachment.get(u.getType()).getAirDefense(u.getOwner()) > 0);
   }
 
-  private static Match<Unit> unitHasAirAttackGreaterThanZero() {
+  private static Predicate<Unit> unitHasAirAttackGreaterThanZero() {
     return Match.of(u -> UnitAttachment.get(u.getType()).getAirAttack(u.getOwner()) > 0);
   }
 
-  static Match<Unit> attackingGroundSeaBattleEscorts() {
+  static Predicate<Unit> attackingGroundSeaBattleEscorts() {
     return Matches.unitCanAirBattle();
   }
 
-  private static Match<Unit> defendingGroundSeaBattleInterceptors(final PlayerID attacker, final GameData data) {
+  private static Predicate<Unit> defendingGroundSeaBattleInterceptors(final PlayerID attacker, final GameData data) {
     return Match.of(PredicateBuilder
         .of(Matches.unitCanAirBattle())
         .and(Matches.unitIsEnemyOf(data, attacker))
-        .and(Matches.unitWasInAirBattle().invert())
-        .andIf(!Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().invert())
+        .and(Matches.unitWasInAirBattle().negate())
+        .andIf(!Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().negate())
         .build());
   }
 
-  private static Match<Unit> defendingBombingRaidInterceptors(final PlayerID attacker, final GameData data) {
+  private static Predicate<Unit> defendingBombingRaidInterceptors(final PlayerID attacker, final GameData data) {
     return Match.of(PredicateBuilder
         .of(Matches.unitCanIntercept())
         .and(Matches.unitIsEnemyOf(data, attacker))
-        .and(Matches.unitWasInAirBattle().invert())
-        .andIf(!Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().invert())
+        .and(Matches.unitWasInAirBattle().negate())
+        .andIf(!Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().negate())
         .build());
   }
 
   static boolean territoryCouldPossiblyHaveAirBattleDefenders(final Territory territory, final PlayerID attacker,
       final GameData data, final boolean bombing) {
     final boolean canScrambleToAirBattle = Properties.getCanScrambleIntoAirBattles(data);
-    final Match<Unit> defendingAirMatch = bombing ? defendingBombingRaidInterceptors(attacker, data)
+    final Predicate<Unit> defendingAirMatch = bombing ? defendingBombingRaidInterceptors(attacker, data)
         : defendingGroundSeaBattleInterceptors(attacker, data);
     int maxScrambleDistance = 0;
     if (canScrambleToAirBattle) {

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -41,7 +42,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = data.getMap().getTerritories().iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.unitIsOwnedBy(player));
+      final Predicate<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.unitIsOwnedBy(player));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
@@ -56,7 +57,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = getTerritoriesWhereAirCantLand(player).iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
+      final Predicate<Unit> ownedAir = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player)).size() > 0;

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.delegate;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -85,7 +86,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     if (Properties.getTriggers(data)) {
       final String stepName = data.getSequence().getStep().getName();
       // we use AND in order to make sure there are uses and when is set correctly.
-      final Match<TriggerAttachment> baseDelegateWhenTriggerMatch = Match.allOf(
+      final Predicate<TriggerAttachment> baseDelegateWhenTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(beforeOrAfter, stepName));
       TriggerAttachment.collectAndFireTriggers(new HashSet<>(data.getPlayerList().getPlayers()),
           baseDelegateWhenTriggerMatch, m_bridge, beforeOrAfter, stepName);

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -576,7 +577,7 @@ public class BattleCalculator {
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
     final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
-    final Match<Unit> match = Match.allOf(Matches.unitIsLand(), Matches.unitWasNotAmphibious());
+    final Predicate<Unit> match = Match.allOf(Matches.unitIsLand(), Matches.unitWasNotAmphibious());
     killedNonAmphibUnits.addAll(Matches.getMatches(killed, match));
     // If all killed units are amphibious, just return them
     if (killedNonAmphibUnits.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -108,10 +109,10 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final PlayerID player) {
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> placeableUnits = new ArrayList<>();
-    final Match<Unit> groundUnits =
+    final Predicate<Unit> groundUnits =
         // we add factories and constructions later
         Match.allOf(Matches.unitIsLand(), Matches.unitIsNotConstruction());
-    final Match<Unit> airUnits = Match.allOf(Matches.unitIsAir(), Matches.unitIsNotConstruction());
+    final Predicate<Unit> airUnits = Match.allOf(Matches.unitIsAir(), Matches.unitIsNotConstruction());
     placeableUnits.addAll(Matches.getMatches(units, groundUnits));
     placeableUnits.addAll(Matches.getMatches(units, airUnits));
     if (units.stream().anyMatch(Matches.unitIsConstruction())) {
@@ -136,7 +137,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final Collection<Unit> unitsWhichConsume =
           Matches.getMatches(placeableUnits, Matches.unitConsumesUnitsOnCreation());
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().test(unit)) {
+        if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).negate().test(unit)) {
           placeableUnits.remove(unit);
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -646,7 +647,7 @@ public class DiceRoll implements Externalizable {
       if (!((allies && rule.getAllied()) || (!allies && rule.getEnemy()))) {
         continue;
       }
-      final Match<Unit> canSupport = Match.allOf(
+      final Predicate<Unit> canSupport = Match.allOf(
           Matches.unitIsOfType((UnitType) rule.getAttachedTo()), Matches.unitOwnedBy(rule.getPlayers()));
       final List<Unit> supporters = Matches.getMatches(unitsGivingTheSupport, canSupport);
       int numSupport = supporters.size();

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -90,7 +91,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
           if (units.isEmpty() || !units.stream().allMatch(Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
-          final Match<Unit> friendlySeaTransports =
+          final Predicate<Unit> friendlySeaTransports =
               Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Matches.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Matches.getMatches(units, Matches.unitIsLand());
@@ -155,7 +156,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
-      final Match<Unit> enemyNonCom = Match.allOf(Matches.unitIsInfrastructure(), Matches.enemyUnit(player, data));
+      final Predicate<Unit> enemyNonCom = Match.allOf(Matches.unitIsInfrastructure(), Matches.enemyUnit(player, data));
       final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
       // mark no movement for enemy units
       m_bridge.addChange(ChangeFactory.markNoMovementChange(units));

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -69,7 +70,7 @@ class EditValidator {
           if (units.isEmpty() || !units.stream().allMatch(Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
-          final Match<Unit> friendlySeaTransports =
+          final Predicate<Unit> friendlySeaTransports =
               Match.allOf(Matches.unitIsTransport(), Matches.unitIsSea(), Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Matches.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Matches.getMatches(units, Matches.unitIsLand());
@@ -86,12 +87,12 @@ class EditValidator {
           }
         }
         if (units.stream().anyMatch(Matches.unitIsAir())) {
-          if (units.stream().anyMatch(Match.allOf(Matches.unitIsAir(), Matches.unitCanLandOnCarrier().invert()))) {
+          if (units.stream().anyMatch(Match.allOf(Matches.unitIsAir(), Matches.unitCanLandOnCarrier().negate()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
-          final Match<Unit> friendlyCarriers = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
-          final Match<Unit> friendlyAirUnits = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
+          final Predicate<Unit> friendlyCarriers = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
+          final Predicate<Unit> friendlyAirUnits = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =
               AirMovementValidator.carrierCapacity(territory.getUnits().getMatches(friendlyCarriers), territory)

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -91,7 +91,8 @@ class EditValidator {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
-          final Predicate<Unit> friendlyCarriers = Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
+          final Predicate<Unit> friendlyCarriers =
+              Match.allOf(Matches.unitIsCarrier(), Matches.alliedUnit(player, data));
           final Predicate<Unit> friendlyAirUnits = Match.allOf(Matches.unitIsAir(), Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.swing.JOptionPane;
 
@@ -99,7 +100,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> endRoundDelegateTriggerMatch =
+      final Predicate<TriggerAttachment> endRoundDelegateTriggerMatch =
           Match.allOf(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null), Match.anyOf(
                   TriggerAttachment.activateTriggerMatch(), TriggerAttachment.victoryMatch()));

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -74,7 +75,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerId();
-    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesUnits());
+    final Predicate<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesUnits());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Matches.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -106,7 +107,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           change.add(place);
         }
         if (!toAddSea.isEmpty()) {
-          final Match<Territory> myTerrs = Match.allOf(Matches.territoryIsWater());
+          final Predicate<Territory> myTerrs = Match.allOf(Matches.territoryIsWater());
           final Collection<Territory> waterNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (waterNeighbors != null && !waterNeighbors.isEmpty()) {
             final Territory tw = getRandomTerritory(waterNeighbors, bridge);
@@ -119,7 +120,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAddLand.isEmpty()) {
-          final Match<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
+          final Predicate<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (landNeighbors != null && !landNeighbors.isEmpty()) {
             final Territory tl = getRandomTerritory(landNeighbors, bridge);
@@ -165,7 +166,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // Find total unit generated resources for all owned units
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerId();
-    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesResources());
+    final Predicate<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesResources());
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Matches.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -217,7 +218,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final boolean useTriggers = Properties.getTriggers(data);
     if (useTriggers) {
       // add conditions required for triggers
-      final Match<TriggerAttachment> endTurnDelegateTriggerMatch = Match.allOf(
+      final Predicate<TriggerAttachment> endTurnDelegateTriggerMatch = Match.allOf(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
           Match.anyOf(TriggerAttachment.resourceMatch()));
       toFirePossible.addAll(TriggerAttachment.collectForAllTriggersMatching(
@@ -283,7 +284,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     return Properties.getNationalObjectives(getData());
   }
 
-  private static final Match<RulesAttachment> availableUses = Match.of(ra -> ra.getUses() != 0);
+  private static final Predicate<RulesAttachment> availableUses = Match.of(ra -> ra.getUses() != 0);
 
   @Override
   protected String addOtherResources(final IDelegateBridge bridge) {

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -120,7 +120,8 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAddLand.isEmpty()) {
-          final Predicate<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
+          final Predicate<Territory> myTerrs =
+              Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.territoryIsLand());
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (landNeighbors != null && !landNeighbors.isEmpty()) {
             final Territory tl = getRandomTerritory(landNeighbors, bridge);

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -116,7 +117,7 @@ public class Fire implements IExecutable {
         // Leave enough transports for each defender for overflows so they can select who loses them.
         while (playerIter.hasNext()) {
           final PlayerID player = playerIter.next();
-          final Match<Unit> match = Match.allOf(
+          final Predicate<Unit> match = Match.allOf(
               Matches.unitIsTransportButNotCombatTransport(),
               Matches.unitIsOwnedBy(player));
           final Collection<Unit> playerTransports = Matches.getMatches(transportsOnly, match);

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -26,7 +27,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.BonusIncomeUtils;
 import games.strategy.util.IntegerMap;
-import games.strategy.util.Match;
 
 /**
  * This delegate is only supposed to be run once, per game, at the start of the game.
@@ -191,7 +191,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
       if (!heldUnits.isEmpty()) {
         change.add(ChangeFactory.removeUnits(player, heldUnits));
       }
-      final Match<Unit> owned = Matches.unitIsOwnedBy(player);
+      final Predicate<Unit> owned = Matches.unitIsOwnedBy(player);
       for (final Territory t : data.getMap().getTerritories()) {
         final Collection<Unit> terrUnits = t.getUnits().getMatches(owned);
         if (!terrUnits.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -84,7 +84,7 @@ public final class Matches {
    *
    * @return A match; never {@code null}.
    */
-  public static <T> Match<T> always() {
+  public static <T> Predicate<T> always() {
     return Match.of(it -> true);
   }
 
@@ -93,7 +93,7 @@ public final class Matches {
    *
    * @return A match; never {@code null}.
    */
-  public static <T> Match<T> never() {
+  public static <T> Predicate<T> never() {
     return Match.of(it -> false);
   }
 
@@ -120,49 +120,49 @@ public final class Matches {
     return collection.stream().filter(match).limit(max).collect(Collectors.toList());
   }
 
-  public static Match<UnitType> unitTypeHasMoreThanOneHitPointTotal() {
+  public static Predicate<UnitType> unitTypeHasMoreThanOneHitPointTotal() {
     return Match.of(ut -> UnitAttachment.get(ut).getHitPoints() > 1);
   }
 
-  public static Match<Unit> unitHasMoreThanOneHitPointTotal() {
+  public static Predicate<Unit> unitHasMoreThanOneHitPointTotal() {
     return Match.of(unit -> unitTypeHasMoreThanOneHitPointTotal().test(unit.getType()));
   }
 
-  public static Match<Unit> unitHasTakenSomeDamage() {
+  public static Predicate<Unit> unitHasTakenSomeDamage() {
     return Match.of(unit -> unit.getHits() > 0);
   }
 
-  public static Match<Unit> unitHasNotTakenAnyDamage() {
-    return unitHasTakenSomeDamage().invert();
+  public static Predicate<Unit> unitHasNotTakenAnyDamage() {
+    return unitHasTakenSomeDamage().negate();
   }
 
-  public static Match<Unit> unitIsSea() {
+  public static Predicate<Unit> unitIsSea() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSea());
   }
 
-  public static Match<Unit> unitIsSub() {
+  public static Predicate<Unit> unitIsSub() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSub());
   }
 
-  public static Match<Unit> unitIsNotSub() {
-    return unitIsSub().invert();
+  public static Predicate<Unit> unitIsNotSub() {
+    return unitIsSub().negate();
   }
 
-  private static Match<Unit> unitIsCombatTransport() {
+  private static Predicate<Unit> unitIsCombatTransport() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua.getIsCombatTransport() && ua.getIsSea();
     });
   }
 
-  static Match<Unit> unitIsNotCombatTransport() {
-    return unitIsCombatTransport().invert();
+  static Predicate<Unit> unitIsNotCombatTransport() {
+    return unitIsCombatTransport().negate();
   }
 
   /**
    * Returns a match indicating the specified unit is a transport but not a combat transport.
    */
-  public static Match<Unit> unitIsTransportButNotCombatTransport() {
+  public static Predicate<Unit> unitIsTransportButNotCombatTransport() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport();
@@ -172,7 +172,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified unit is not a transport but may be a combat transport.
    */
-  public static Match<Unit> unitIsNotTransportButCouldBeCombatTransport() {
+  public static Predicate<Unit> unitIsNotTransportButCouldBeCombatTransport() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (ua.getTransportCapacity() == -1) {
@@ -182,29 +182,29 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsDestroyer() {
+  public static Predicate<Unit> unitIsDestroyer() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
   }
 
-  public static Match<UnitType> unitTypeIsDestroyer() {
+  public static Predicate<UnitType> unitTypeIsDestroyer() {
     return Match.of(type -> UnitAttachment.get(type).getIsDestroyer());
   }
 
   /**
    * Returns a match indicating the specified unit can transport other units by sea.
    */
-  public static Match<Unit> unitIsTransport() {
+  public static Predicate<Unit> unitIsTransport() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua.getTransportCapacity() != -1 && ua.getIsSea();
     });
   }
 
-  public static Match<Unit> unitIsNotTransport() {
-    return unitIsTransport().invert();
+  public static Predicate<Unit> unitIsNotTransport() {
+    return unitIsTransport().negate();
   }
 
-  static Match<Unit> unitIsTransportAndNotDestroyer() {
+  static Predicate<Unit> unitIsTransportAndNotDestroyer() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return !unitIsDestroyer().test(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
@@ -214,7 +214,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified unit type is a strategic bomber.
    */
-  public static Match<UnitType> unitTypeIsStrategicBomber() {
+  public static Predicate<UnitType> unitTypeIsStrategicBomber() {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj);
       if (ua == null) {
@@ -224,15 +224,15 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsStrategicBomber() {
+  public static Predicate<Unit> unitIsStrategicBomber() {
     return Match.of(obj -> unitTypeIsStrategicBomber().test(obj.getType()));
   }
 
-  static Match<Unit> unitIsNotStrategicBomber() {
-    return unitIsStrategicBomber().invert();
+  static Predicate<Unit> unitIsNotStrategicBomber() {
+    return unitIsStrategicBomber().negate();
   }
 
-  static final Match<UnitType> unitTypeCanLandOnCarrier() {
+  static final Predicate<UnitType> unitTypeCanLandOnCarrier() {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj);
       if (ua == null) {
@@ -242,15 +242,15 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitHasMoved() {
+  static Predicate<Unit> unitHasMoved() {
     return Match.of(unit -> TripleAUnit.get(unit).getAlreadyMoved() > 0);
   }
 
-  public static Match<Unit> unitHasNotMoved() {
-    return unitHasMoved().invert();
+  public static Predicate<Unit> unitHasNotMoved() {
+    return unitHasMoved().negate();
   }
 
-  static Match<Unit> unitCanAttack(final PlayerID id) {
+  static Predicate<Unit> unitCanAttack(final PlayerID id) {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (ua.getMovement(id) <= 0) {
@@ -260,57 +260,57 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitHasAttackValueOfAtLeast(final int attackValue) {
+  public static Predicate<Unit> unitHasAttackValueOfAtLeast(final int attackValue) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getAttack(unit.getOwner()) >= attackValue);
   }
 
-  public static Match<Unit> unitHasDefendValueOfAtLeast(final int defendValue) {
+  public static Predicate<Unit> unitHasDefendValueOfAtLeast(final int defendValue) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getDefense(unit.getOwner()) >= defendValue);
   }
 
-  public static Match<Unit> unitIsEnemyOf(final GameData data, final PlayerID player) {
+  public static Predicate<Unit> unitIsEnemyOf(final GameData data, final PlayerID player) {
     return Match.of(unit -> data.getRelationshipTracker().isAtWar(unit.getOwner(), player));
   }
 
-  public static Match<Unit> unitIsNotSea() {
+  public static Predicate<Unit> unitIsNotSea() {
     return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsSea());
   }
 
-  public static Match<UnitType> unitTypeIsSea() {
+  public static Predicate<UnitType> unitTypeIsSea() {
     return Match.of(type -> UnitAttachment.get(type).getIsSea());
   }
 
-  public static Match<UnitType> unitTypeIsNotSea() {
+  public static Predicate<UnitType> unitTypeIsNotSea() {
     return Match.of(type -> !UnitAttachment.get(type).getIsSea());
   }
 
   /**
    * Returns a match indicating the specified unit type is for sea or air units.
    */
-  public static Match<UnitType> unitTypeIsSeaOrAir() {
+  public static Predicate<UnitType> unitTypeIsSeaOrAir() {
     return Match.of(type -> {
       final UnitAttachment ua = UnitAttachment.get(type);
       return ua.getIsSea() || ua.getIsAir();
     });
   }
 
-  public static Match<Unit> unitIsAir() {
+  public static Predicate<Unit> unitIsAir() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
   }
 
-  public static Match<Unit> unitIsNotAir() {
+  public static Predicate<Unit> unitIsNotAir() {
     return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsAir());
   }
 
-  public static Match<UnitType> unitTypeCanBombard(final PlayerID id) {
+  public static Predicate<UnitType> unitTypeCanBombard(final PlayerID id) {
     return Match.of(type -> UnitAttachment.get(type).getCanBombard(id));
   }
 
-  static Match<Unit> unitCanBeGivenByTerritoryTo(final PlayerID player) {
+  static Predicate<Unit> unitCanBeGivenByTerritoryTo(final PlayerID player) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBeGivenByTerritoryTo().contains(player));
   }
 
-  static Match<Unit> unitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
+  static Predicate<Unit> unitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
       final GameData data) {
     return Match.of(unit -> {
       if (!Properties.getCaptureUnitsOnEnteringTerritory(data)) {
@@ -340,11 +340,11 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
+  static Predicate<Unit> unitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
     return Match.anyOf(unitDestroyedWhenCapturedBy(playerBy), unitDestroyedWhenCapturedFrom());
   }
 
-  private static Match<Unit> unitDestroyedWhenCapturedBy(final PlayerID playerBy) {
+  private static Predicate<Unit> unitDestroyedWhenCapturedBy(final PlayerID playerBy) {
     return Match.of(u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
       if (ua.getDestroyedWhenCapturedBy().isEmpty()) {
@@ -359,7 +359,7 @@ public final class Matches {
     });
   }
 
-  private static Match<Unit> unitDestroyedWhenCapturedFrom() {
+  private static Predicate<Unit> unitDestroyedWhenCapturedFrom() {
     return Match.of(u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
       if (ua.getDestroyedWhenCapturedBy().isEmpty()) {
@@ -374,19 +374,19 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsAirBase() {
+  public static Predicate<Unit> unitIsAirBase() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAirBase());
   }
 
-  public static Match<UnitType> unitTypeCanBeDamaged() {
+  public static Predicate<UnitType> unitTypeCanBeDamaged() {
     return Match.of(ut -> UnitAttachment.get(ut).getCanBeDamaged());
   }
 
-  public static Match<Unit> unitCanBeDamaged() {
+  public static Predicate<Unit> unitCanBeDamaged() {
     return Match.of(unit -> unitTypeCanBeDamaged().test(unit.getType()));
   }
 
-  static Match<Unit> unitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
+  static Predicate<Unit> unitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (!ua.getCanBeDamaged()) {
@@ -401,7 +401,7 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
+  static Predicate<Unit> unitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(bomberOrRocket.getType());
       final Set<UnitType> allowedTargets = ua.getBombingTargets(bomberOrRocket.getData());
@@ -409,18 +409,18 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitHasTakenSomeBombingUnitDamage() {
+  public static Predicate<Unit> unitHasTakenSomeBombingUnitDamage() {
     return Match.of(unit -> ((TripleAUnit) unit).getUnitDamage() > 0);
   }
 
-  public static Match<Unit> unitHasNotTakenAnyBombingUnitDamage() {
-    return unitHasTakenSomeBombingUnitDamage().invert();
+  public static Predicate<Unit> unitHasNotTakenAnyBombingUnitDamage() {
+    return unitHasTakenSomeBombingUnitDamage().negate();
   }
 
   /**
    * Returns a match indicating the specified unit is disabled.
    */
-  public static Match<Unit> unitIsDisabled() {
+  public static Predicate<Unit> unitIsDisabled() {
     return Match.of(unit -> {
       if (!unitCanBeDamaged().test(unit)) {
         return false;
@@ -444,11 +444,11 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsNotDisabled() {
-    return unitIsDisabled().invert();
+  public static Predicate<Unit> unitIsNotDisabled() {
+    return unitIsDisabled().negate();
   }
 
-  static Match<Unit> unitCanDieFromReachingMaxDamage() {
+  static Predicate<Unit> unitCanDieFromReachingMaxDamage() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (!ua.getCanBeDamaged()) {
@@ -458,29 +458,30 @@ public final class Matches {
     });
   }
 
-  public static Match<UnitType> unitTypeIsInfrastructure() {
+  public static Predicate<UnitType> unitTypeIsInfrastructure() {
     return Match.of(ut -> UnitAttachment.get(ut).getIsInfrastructure());
   }
 
-  public static Match<Unit> unitIsInfrastructure() {
+  public static Predicate<Unit> unitIsInfrastructure() {
     return Match.of(unit -> unitTypeIsInfrastructure().test(unit.getType()));
   }
 
-  public static Match<Unit> unitIsNotInfrastructure() {
-    return unitIsInfrastructure().invert();
+  public static Predicate<Unit> unitIsNotInfrastructure() {
+    return unitIsInfrastructure().negate();
   }
 
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  public static Match<Unit> unitIsSupporterOrHasCombatAbility(final boolean attack) {
+  public static Predicate<Unit> unitIsSupporterOrHasCombatAbility(final boolean attack) {
     return Match.of(unit -> unitTypeIsSupporterOrHasCombatAbility(attack, unit.getOwner()).test(unit.getType()));
   }
 
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  private static Match<UnitType> unitTypeIsSupporterOrHasCombatAbility(final boolean attack, final PlayerID player) {
+  private static Predicate<UnitType> unitTypeIsSupporterOrHasCombatAbility(final boolean attack,
+      final PlayerID player) {
     return Match.of(ut -> {
       // if unit has attack or defense, return true
       final UnitAttachment ua = UnitAttachment.get(ut);
@@ -495,147 +496,147 @@ public final class Matches {
     });
   }
 
-  public static Match<UnitSupportAttachment> unitSupportAttachmentCanBeUsedByPlayer(final PlayerID player) {
+  public static Predicate<UnitSupportAttachment> unitSupportAttachmentCanBeUsedByPlayer(final PlayerID player) {
     return Match.of(usa -> usa.getPlayers().contains(player));
   }
 
-  public static Match<Unit> unitCanScramble() {
+  public static Predicate<Unit> unitCanScramble() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanScramble());
   }
 
-  public static Match<Unit> unitWasScrambled() {
+  public static Predicate<Unit> unitWasScrambled() {
     return Match.of(obj -> ((TripleAUnit) obj).getWasScrambled());
   }
 
-  static Match<Unit> unitWasInAirBattle() {
+  static Predicate<Unit> unitWasInAirBattle() {
     return Match.of(obj -> ((TripleAUnit) obj).getWasInAirBattle());
   }
 
-  public static Match<Unit> unitCanBombard(final PlayerID id) {
+  public static Predicate<Unit> unitCanBombard(final PlayerID id) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBombard(id));
   }
 
-  public static Match<Unit> unitCanBlitz() {
+  public static Predicate<Unit> unitCanBlitz() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner()));
   }
 
-  static Match<Unit> unitIsLandTransport() {
+  static Predicate<Unit> unitIsLandTransport() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsLandTransport());
   }
 
-  static Match<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
+  static Predicate<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
       final Territory terr, final GameData data) {
     return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsInfrastructure()
         && !unitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).test(unit));
   }
 
-  static Match<Unit> unitIsSuicide() {
+  static Predicate<Unit> unitIsSuicide() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicide());
   }
 
-  static Match<Unit> unitIsSuicideOnHit() {
+  static Predicate<Unit> unitIsSuicideOnHit() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicideOnHit());
   }
 
-  static Match<Unit> unitIsKamikaze() {
+  static Predicate<Unit> unitIsKamikaze() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsKamikaze());
   }
 
-  public static Match<UnitType> unitTypeIsAir() {
+  public static Predicate<UnitType> unitTypeIsAir() {
     return Match.of(type -> UnitAttachment.get(type).getIsAir());
   }
 
-  private static Match<UnitType> unitTypeIsNotAir() {
+  private static Predicate<UnitType> unitTypeIsNotAir() {
     return Match.of(type -> !UnitAttachment.get(type).getIsAir());
   }
 
-  public static Match<Unit> unitCanLandOnCarrier() {
+  public static Predicate<Unit> unitCanLandOnCarrier() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCost() != -1);
   }
 
-  public static Match<Unit> unitIsCarrier() {
+  public static Predicate<Unit> unitIsCarrier() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1);
   }
 
-  static Match<Territory> territoryHasOwnedCarrier(final PlayerID player) {
+  static Predicate<Territory> territoryHasOwnedCarrier(final PlayerID player) {
     return Match.of(t -> t.getUnits().anyMatch(Match.allOf(unitIsOwnedBy(player), unitIsCarrier())));
   }
 
-  public static Match<Unit> unitIsAlliedCarrier(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> unitIsAlliedCarrier(final PlayerID player, final GameData data) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1
         && data.getRelationshipTracker().isAllied(player, unit.getOwner()));
   }
 
-  public static Match<Unit> unitCanBeTransported() {
+  public static Predicate<Unit> unitCanBeTransported() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCost() != -1);
   }
 
-  static Match<Unit> unitWasAmphibious() {
+  static Predicate<Unit> unitWasAmphibious() {
     return Match.of(obj -> ((TripleAUnit) obj).getWasAmphibious());
   }
 
-  static Match<Unit> unitWasNotAmphibious() {
-    return unitWasAmphibious().invert();
+  static Predicate<Unit> unitWasNotAmphibious() {
+    return unitWasAmphibious().negate();
   }
 
-  static Match<Unit> unitWasInCombat() {
+  static Predicate<Unit> unitWasInCombat() {
     return Match.of(obj -> ((TripleAUnit) obj).getWasInCombat());
   }
 
-  static Match<Unit> unitWasUnloadedThisTurn() {
+  static Predicate<Unit> unitWasUnloadedThisTurn() {
     return Match.of(obj -> ((TripleAUnit) obj).getUnloadedTo() != null);
   }
 
-  private static Match<Unit> unitWasLoadedThisTurn() {
+  private static Predicate<Unit> unitWasLoadedThisTurn() {
     return Match.of(obj -> ((TripleAUnit) obj).getWasLoadedThisTurn());
   }
 
-  static Match<Unit> unitWasNotLoadedThisTurn() {
-    return unitWasLoadedThisTurn().invert();
+  static Predicate<Unit> unitWasNotLoadedThisTurn() {
+    return unitWasLoadedThisTurn().negate();
   }
 
-  public static Match<Unit> unitCanTransport() {
+  public static Predicate<Unit> unitCanTransport() {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCapacity() != -1);
   }
 
-  public static Match<UnitType> unitTypeCanProduceUnits() {
+  public static Predicate<UnitType> unitTypeCanProduceUnits() {
     return Match.of(obj -> UnitAttachment.get(obj).getCanProduceUnits());
   }
 
-  public static Match<Unit> unitCanProduceUnits() {
+  public static Predicate<Unit> unitCanProduceUnits() {
     return Match.of(obj -> unitTypeCanProduceUnits().test(obj.getType()));
   }
 
-  public static Match<UnitType> unitTypeHasMaxBuildRestrictions() {
+  public static Predicate<UnitType> unitTypeHasMaxBuildRestrictions() {
     return Match.of(type -> UnitAttachment.get(type).getMaxBuiltPerPlayer() >= 0);
   }
 
-  public static Match<UnitType> unitTypeIsRocket() {
+  public static Predicate<UnitType> unitTypeIsRocket() {
     return Match.of(obj -> UnitAttachment.get(obj).getIsRocket());
   }
 
-  static Match<Unit> unitIsRocket() {
+  static Predicate<Unit> unitIsRocket() {
     return Match.of(obj -> unitTypeIsRocket().test(obj.getType()));
   }
 
-  static Match<Unit> unitHasMovementLimit() {
+  static Predicate<Unit> unitHasMovementLimit() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getMovementLimit() != null);
   }
 
-  static final Match<Unit> unitHasAttackingLimit() {
+  static final Predicate<Unit> unitHasAttackingLimit() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getAttackingLimit() != null);
   }
 
-  private static Match<UnitType> unitTypeCanNotMoveDuringCombatMove() {
+  private static Predicate<UnitType> unitTypeCanNotMoveDuringCombatMove() {
     return Match.of(type -> UnitAttachment.get(type).getCanNotMoveDuringCombatMove());
   }
 
-  public static Match<Unit> unitCanNotMoveDuringCombatMove() {
+  public static Predicate<Unit> unitCanNotMoveDuringCombatMove() {
     return Match.of(obj -> unitTypeCanNotMoveDuringCombatMove().test(obj.getType()));
   }
 
-  private static Match<Unit> unitIsAaThatCanHitTheseUnits(final Collection<Unit> targets,
-      final Match<Unit> typeOfAa, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
+  private static Predicate<Unit> unitIsAaThatCanHitTheseUnits(final Collection<Unit> targets,
+      final Predicate<Unit> typeOfAa, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
     return Match.of(obj -> {
       if (!typeOfAa.test(obj)) {
         return false;
@@ -652,15 +653,15 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitIsAaOfTypeAa(final String typeAa) {
+  static Predicate<Unit> unitIsAaOfTypeAa(final String typeAa) {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAa));
   }
 
-  static Match<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {
+  static Predicate<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getDamageableAA());
   }
 
-  private static Match<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
+  private static Predicate<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
       for (final Unit u : enemyUnitsPresent) {
@@ -672,113 +673,113 @@ public final class Matches {
     });
   }
 
-  private static Match<UnitType> unitTypeIsAaThatCanFireOnRound(final int battleRoundNumber) {
+  private static Predicate<UnitType> unitTypeIsAaThatCanFireOnRound(final int battleRoundNumber) {
     return Match.of(obj -> {
       final int maxRoundsAa = UnitAttachment.get(obj).getMaxRoundsAA();
       return maxRoundsAa < 0 || maxRoundsAa >= battleRoundNumber;
     });
   }
 
-  private static Match<Unit> unitIsAaThatCanFireOnRound(final int battleRoundNumber) {
+  private static Predicate<Unit> unitIsAaThatCanFireOnRound(final int battleRoundNumber) {
     return Match.of(obj -> unitTypeIsAaThatCanFireOnRound(battleRoundNumber).test(obj.getType()));
   }
 
-  static Match<Unit> unitIsAaThatCanFire(final Collection<Unit> unitsMovingOrAttacking,
+  static Predicate<Unit> unitIsAaThatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
-      final Match<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
+      final Predicate<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
     return Match.allOf(enemyUnit(playerMovingOrAttacking, data),
-        unitIsBeingTransported().invert(),
+        unitIsBeingTransported().negate(),
         unitIsAaThatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
-        unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
+        unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).negate(),
         unitIsAaThatCanFireOnRound(battleRoundNumber),
         (defending ? unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()
             : unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()));
   }
 
-  private static Match<UnitType> unitTypeIsAaForCombatOnly() {
+  private static Predicate<UnitType> unitTypeIsAaForCombatOnly() {
     return Match.of(obj -> UnitAttachment.get(obj).getIsAAforCombatOnly());
   }
 
-  static Match<Unit> unitIsAaForCombatOnly() {
+  static Predicate<Unit> unitIsAaForCombatOnly() {
     return Match.of(obj -> unitTypeIsAaForCombatOnly().test(obj.getType()));
   }
 
-  public static Match<UnitType> unitTypeIsAaForBombingThisUnitOnly() {
+  public static Predicate<UnitType> unitTypeIsAaForBombingThisUnitOnly() {
     return Match.of(obj -> UnitAttachment.get(obj).getIsAAforBombingThisUnitOnly());
   }
 
-  public static Match<Unit> unitIsAaForBombingThisUnitOnly() {
+  public static Predicate<Unit> unitIsAaForBombingThisUnitOnly() {
     return Match.of(obj -> unitTypeIsAaForBombingThisUnitOnly().test(obj.getType()));
   }
 
-  private static Match<UnitType> unitTypeIsAaForFlyOverOnly() {
+  private static Predicate<UnitType> unitTypeIsAaForFlyOverOnly() {
     return Match.of(obj -> UnitAttachment.get(obj).getIsAAforFlyOverOnly());
   }
 
-  static Match<Unit> unitIsAaForFlyOverOnly() {
+  static Predicate<Unit> unitIsAaForFlyOverOnly() {
     return Match.of(obj -> unitTypeIsAaForFlyOverOnly().test(obj.getType()));
   }
 
   /**
    * Returns a match indicating the specified unit type is anti-aircraft for any condition.
    */
-  public static Match<UnitType> unitTypeIsAaForAnything() {
+  public static Predicate<UnitType> unitTypeIsAaForAnything() {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj);
       return ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly() || ua.getIsAAforFlyOverOnly();
     });
   }
 
-  public static Match<Unit> unitIsAaForAnything() {
+  public static Predicate<Unit> unitIsAaForAnything() {
     return Match.of(obj -> unitTypeIsAaForAnything().test(obj.getType()));
   }
 
-  public static Match<Unit> unitIsNotAa() {
-    return unitIsAaForAnything().invert();
+  public static Predicate<Unit> unitIsNotAa() {
+    return unitIsAaForAnything().negate();
   }
 
-  private static Match<UnitType> unitTypeMaxAaAttacksIsInfinite() {
+  private static Predicate<UnitType> unitTypeMaxAaAttacksIsInfinite() {
     return Match.of(obj -> UnitAttachment.get(obj).getMaxAAattacks() == -1);
   }
 
-  static Match<Unit> unitMaxAaAttacksIsInfinite() {
+  static Predicate<Unit> unitMaxAaAttacksIsInfinite() {
     return Match.of(obj -> unitTypeMaxAaAttacksIsInfinite().test(obj.getType()));
   }
 
-  private static Match<UnitType> unitTypeMayOverStackAa() {
+  private static Predicate<UnitType> unitTypeMayOverStackAa() {
     return Match.of(obj -> UnitAttachment.get(obj).getMayOverStackAA());
   }
 
-  static Match<Unit> unitMayOverStackAa() {
+  static Predicate<Unit> unitMayOverStackAa() {
     return Match.of(obj -> unitTypeMayOverStackAa().test(obj.getType()));
   }
 
-  static Match<Unit> unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
+  static Predicate<Unit> unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
       return ua.getAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
     });
   }
 
-  static Match<Unit> unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
+  static Predicate<Unit> unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return Match.of(obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
       return ua.getOffensiveAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
     });
   }
 
-  public static Match<Unit> unitIsInfantry() {
+  public static Predicate<Unit> unitIsInfantry() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getIsInfantry());
   }
 
-  public static Match<Unit> unitIsNotInfantry() {
-    return unitIsInfantry().invert();
+  public static Predicate<Unit> unitIsNotInfantry() {
+    return unitIsInfantry().negate();
   }
 
   /**
    * Returns a match indicating the specified unit can be transported by air.
    */
-  public static Match<Unit> unitIsAirTransportable() {
+  public static Predicate<Unit> unitIsAirTransportable() {
     return Match.of(obj -> {
       final TechAttachment ta = TechAttachment.get(obj.getOwner());
       if (ta == null || !ta.getParatroopers()) {
@@ -790,14 +791,14 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitIsNotAirTransportable() {
-    return unitIsAirTransportable().invert();
+  static Predicate<Unit> unitIsNotAirTransportable() {
+    return unitIsAirTransportable().negate();
   }
 
   /**
    * Returns a match indicating the specified unit can transport other units by air.
    */
-  public static Match<Unit> unitIsAirTransport() {
+  public static Predicate<Unit> unitIsAirTransport() {
     return Match.of(obj -> {
       final TechAttachment ta = TechAttachment.get(obj.getOwner());
       if (ta == null || !ta.getParatroopers()) {
@@ -809,27 +810,27 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsArtillery() {
+  public static Predicate<Unit> unitIsArtillery() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getArtillery());
   }
 
-  public static Match<Unit> unitIsArtillerySupportable() {
+  public static Predicate<Unit> unitIsArtillerySupportable() {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getArtillerySupportable());
   }
 
   // TODO: CHECK whether this makes any sense
-  public static Match<Territory> territoryIsLandOrWater() {
+  public static Predicate<Territory> territoryIsLandOrWater() {
     return Match.of(Objects::nonNull);
   }
 
-  public static Match<Territory> territoryIsWater() {
+  public static Predicate<Territory> territoryIsWater() {
     return Match.of(Territory::isWater);
   }
 
   /**
    * Returns a match indicating the specified territory is an island.
    */
-  public static Match<Territory> territoryIsIsland() {
+  public static Predicate<Territory> territoryIsIsland() {
     return Match.of(t -> {
       final Collection<Territory> neighbors = t.getData().getMap().getNeighbors(t);
       return neighbors.size() == 1 && territoryIsWater().test(neighbors.iterator().next());
@@ -839,7 +840,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified territory is a victory city.
    */
-  public static Match<Territory> territoryIsVictoryCity() {
+  public static Predicate<Territory> territoryIsVictoryCity() {
     return Match.of(t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (ta == null) {
@@ -849,11 +850,11 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsLand() {
-    return territoryIsWater().invert();
+  public static Predicate<Territory> territoryIsLand() {
+    return territoryIsWater().negate();
   }
 
-  public static Match<Territory> territoryIsEmpty() {
+  public static Predicate<Territory> territoryIsEmpty() {
     return Match.of(t -> t.getUnits().size() == 0);
   }
 
@@ -863,7 +864,7 @@ public final class Matches {
    * test ownership).
    * If the game option for contested territories not producing is on, then will also remove any contested territories.
    */
-  public static Match<Territory> territoryCanCollectIncomeFrom(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryCanCollectIncomeFrom(final PlayerID player, final GameData data) {
     final boolean contestedDoNotProduce =
         Properties.getContestedTerritoriesProduceNoIncome(data);
     return Match.of(t -> {
@@ -896,21 +897,22 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryHasNeighborMatching(final GameData data, final Match<Territory> match) {
+  public static Predicate<Territory> territoryHasNeighborMatching(final GameData data,
+      final Predicate<Territory> match) {
     return Match.of(t -> data.getMap().getNeighbors(t, match).size() > 0);
   }
 
-  public static Match<Territory> territoryHasAlliedNeighborWithAlliedUnitMatching(final GameData data,
-      final PlayerID player, final Match<Unit> unitMatch) {
+  public static Predicate<Territory> territoryHasAlliedNeighborWithAlliedUnitMatching(final GameData data,
+      final PlayerID player, final Predicate<Unit> unitMatch) {
     return Match.of(t -> data.getMap()
         .getNeighbors(t, territoryIsAlliedAndHasAlliedUnitMatching(data, player, unitMatch)).size() > 0);
   }
 
-  public static Match<Territory> territoryIsInList(final Collection<Territory> list) {
+  public static Predicate<Territory> territoryIsInList(final Collection<Territory> list) {
     return Match.of(list::contains);
   }
 
-  public static Match<Territory> territoryIsNotInList(final Collection<Territory> list) {
+  public static Predicate<Territory> territoryIsNotInList(final Collection<Territory> list) {
     return Match.of(not(list::contains));
   }
 
@@ -919,7 +921,7 @@ public final class Matches {
    *        game data
    * @return Match&lt;Territory> that tests if there is a route to an enemy capital from the given territory.
    */
-  public static Match<Territory> territoryHasRouteToEnemyCapital(final GameData data, final PlayerID player) {
+  public static Predicate<Territory> territoryHasRouteToEnemyCapital(final GameData data, final PlayerID player) {
     return Match.of(t -> {
       for (final PlayerID otherPlayer : data.getPlayerList().getPlayers()) {
         final List<Territory> capitalsListOwned =
@@ -942,7 +944,7 @@ public final class Matches {
    *        game data.
    * @return true only if the route is land
    */
-  public static Match<Territory> territoryHasLandRouteToEnemyCapital(final GameData data, final PlayerID player) {
+  public static Predicate<Territory> territoryHasLandRouteToEnemyCapital(final GameData data, final PlayerID player) {
     return Match.of(t -> {
       for (final PlayerID otherPlayer : data.getPlayerList().getPlayers()) {
         final List<Territory> capitalsListOwned =
@@ -960,30 +962,31 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryHasEnemyNonNeutralNeighborWithEnemyUnitMatching(final GameData data,
-      final PlayerID player, final Match<Unit> unitMatch) {
+  public static Predicate<Territory> territoryHasEnemyNonNeutralNeighborWithEnemyUnitMatching(final GameData data,
+      final PlayerID player, final Predicate<Unit> unitMatch) {
     return Match.of(t -> data.getMap()
         .getNeighbors(t, territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, unitMatch)).size() > 0);
   }
 
-  public static Match<Territory> territoryHasOwnedNeighborWithOwnedUnitMatching(final GameData data,
-      final PlayerID player, final Match<Unit> unitMatch) {
+  public static Predicate<Territory> territoryHasOwnedNeighborWithOwnedUnitMatching(final GameData data,
+      final PlayerID player, final Predicate<Unit> unitMatch) {
     return Match.of(t -> data.getMap()
         .getNeighbors(t, territoryIsOwnedAndHasOwnedUnitMatching(player, unitMatch)).size() > 0);
   }
 
-  static Match<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnitsNeighbor(
+  static Predicate<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnitsNeighbor(
       final GameData data, final PlayerID player) {
     return Match.of(t -> data.getMap()
         .getNeighbors(t, territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnits(data, player)).size() > 0);
   }
 
-  public static Match<Territory> territoryHasWaterNeighbor(final GameData data) {
+  public static Predicate<Territory> territoryHasWaterNeighbor(final GameData data) {
     return Match.of(t -> data.getMap().getNeighbors(t, territoryIsWater()).size() > 0);
   }
 
-  private static Match<Territory> territoryIsAlliedAndHasAlliedUnitMatching(final GameData data, final PlayerID player,
-      final Match<Unit> unitMatch) {
+  private static Predicate<Territory> territoryIsAlliedAndHasAlliedUnitMatching(final GameData data,
+      final PlayerID player,
+      final Predicate<Unit> unitMatch) {
     return Match.of(t -> {
       if (!data.getRelationshipTracker().isAllied(t.getOwner(), player)) {
         return false;
@@ -992,8 +995,8 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsOwnedAndHasOwnedUnitMatching(final PlayerID player,
-      final Match<Unit> unitMatch) {
+  public static Predicate<Territory> territoryIsOwnedAndHasOwnedUnitMatching(final PlayerID player,
+      final Predicate<Unit> unitMatch) {
     return Match.of(t -> {
       if (!t.getOwner().equals(player)) {
         return false;
@@ -1002,7 +1005,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryHasOwnedIsFactoryOrCanProduceUnits(final PlayerID player) {
+  public static Predicate<Territory> territoryHasOwnedIsFactoryOrCanProduceUnits(final PlayerID player) {
     return Match.of(t -> {
       if (!t.getOwner().equals(player)) {
         return false;
@@ -1011,7 +1014,7 @@ public final class Matches {
     });
   }
 
-  private static Match<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnits(final GameData data,
+  private static Predicate<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnits(final GameData data,
       final PlayerID player) {
     return Match.of(t -> {
       if (!t.getOwner().equals(player)) {
@@ -1025,7 +1028,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(final GameData data, final PlayerID player) {
+  static Predicate<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(final GameData data, final PlayerID player) {
     return Match.of(t -> {
       if (!isTerritoryAllied(player, data).test(t)) {
         return false;
@@ -1034,8 +1037,8 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(final GameData data,
-      final PlayerID player, final Match<Unit> unitMatch) {
+  public static Predicate<Territory> territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(final GameData data,
+      final PlayerID player, final Predicate<Unit> unitMatch) {
     return Match.of(t -> {
       if (!data.getRelationshipTracker().isAtWar(player, t.getOwner())) {
         return false;
@@ -1047,9 +1050,9 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerID player) {
+  static Predicate<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerID player) {
     return Match.of(t -> {
-      final Match<Unit> nonCom = Match.anyOf(unitIsInfrastructure(), enemyUnit(player, data).invert());
+      final Predicate<Unit> nonCom = Match.anyOf(unitIsInfrastructure(), enemyUnit(player, data).negate());
       return t.getUnits().allMatch(nonCom);
     });
   }
@@ -1057,7 +1060,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified territory is neutral and not water.
    */
-  public static Match<Territory> territoryIsNeutralButNotWater() {
+  public static Predicate<Territory> territoryIsNeutralButNotWater() {
     return Match.of(t -> {
       if (t.isWater()) {
         return false;
@@ -1069,7 +1072,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified territory is impassable.
    */
-  public static Match<Territory> territoryIsImpassable() {
+  public static Predicate<Territory> territoryIsImpassable() {
     return Match.of(t -> {
       if (t.isWater()) {
         return false;
@@ -1079,11 +1082,11 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsNotImpassable() {
-    return territoryIsImpassable().invert();
+  public static Predicate<Territory> territoryIsNotImpassable() {
+    return territoryIsImpassable().negate();
   }
 
-  static Match<Territory> seaCanMoveOver(final PlayerID player, final GameData data) {
+  static Predicate<Territory> seaCanMoveOver(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (!territoryIsWater().test(t)) {
         return false;
@@ -1092,7 +1095,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> airCanFlyOver(final PlayerID player, final GameData data,
+  static Predicate<Territory> airCanFlyOver(final PlayerID player, final GameData data,
       final boolean areNeutralsPassableByAir) {
     return Match.of(t -> {
       if (!areNeutralsPassableByAir && territoryIsNeutralButNotWater().test(t)) {
@@ -1106,7 +1109,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsPassableAndNotRestricted(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsPassableAndNotRestricted(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (territoryIsImpassable().test(t)) {
         return false;
@@ -1125,19 +1128,19 @@ public final class Matches {
     });
   }
 
-  private static Match<Territory> territoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
+  private static Predicate<Territory> territoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (t.isWater()) {
         return true;
-      } else if (territoryIsPassableAndNotRestricted(player, data).invert().test(t)) {
+      } else if (territoryIsPassableAndNotRestricted(player, data).negate().test(t)) {
         return true;
       }
       return false;
     });
   }
 
-  public static Match<Territory> territoryIsNotImpassableToLandUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> territoryIsImpassableToLandUnits(player, data).invert().test(t));
+  public static Predicate<Territory> territoryIsNotImpassableToLandUnits(final PlayerID player, final GameData data) {
+    return Match.of(t -> territoryIsImpassableToLandUnits(player, data).negate().test(t));
   }
 
   /**
@@ -1150,7 +1153,7 @@ public final class Matches {
    * attachment (canMoveLandUnitsOverOwnedLand, canMoveAirUnitsOverOwnedLand, canLandAirUnitsOnOwnedLand,
    * canMoveIntoDuringCombatMove, etc).
    */
-  public static Match<Territory> territoryIsPassableAndNotRestrictedAndOkByRelationships(
+  public static Predicate<Territory> territoryIsPassableAndNotRestrictedAndOkByRelationships(
       final PlayerID playerWhoOwnsAllTheUnitsMoving, final GameData data, final boolean isCombatMovePhase,
       final boolean hasLandUnitsNotBeingTransportedOrBeingLoaded, final boolean hasSeaUnitsNotBeingTransported,
       final boolean hasAirUnitsNotBeingTransported, final boolean isLandingZoneOnLandForAirUnits) {
@@ -1204,23 +1207,23 @@ public final class Matches {
     });
   }
 
-  static Match<IBattle> battleIsEmpty() {
+  static Predicate<IBattle> battleIsEmpty() {
     return Match.of(IBattle::isEmpty);
   }
 
-  static Match<IBattle> battleIsAmphibious() {
+  static Predicate<IBattle> battleIsAmphibious() {
     return Match.of(IBattle::isAmphibious);
   }
 
-  public static Match<Unit> unitHasEnoughMovementForRoutes(final List<Route> route) {
+  public static Predicate<Unit> unitHasEnoughMovementForRoutes(final List<Route> route) {
     return unitHasEnoughMovementForRoute(Route.create(route));
   }
 
-  public static Match<Unit> unitHasEnoughMovementForRoute(final List<Territory> territories) {
+  public static Predicate<Unit> unitHasEnoughMovementForRoute(final List<Territory> territories) {
     return unitHasEnoughMovementForRoute(new Route(territories));
   }
 
-  public static Match<Unit> unitHasEnoughMovementForRoute(final Route route) {
+  public static Predicate<Unit> unitHasEnoughMovementForRoute(final Route route) {
     return Match.of(unit -> {
       int left = TripleAUnit.get(unit).getMovementLeft();
       int movementcost = route.getMovementCost(unit);
@@ -1272,45 +1275,45 @@ public final class Matches {
   /**
    * Match units that have at least 1 movement left.
    */
-  public static Match<Unit> unitHasMovementLeft() {
+  public static Predicate<Unit> unitHasMovementLeft() {
     return Match.of(o -> TripleAUnit.get(o).getMovementLeft() >= 1);
   }
 
-  public static Match<Unit> unitCanMove() {
+  public static Predicate<Unit> unitCanMove() {
     return Match.of(u -> unitTypeCanMove(u.getOwner()).test(u.getType()));
   }
 
-  private static Match<UnitType> unitTypeCanMove(final PlayerID player) {
+  private static Predicate<UnitType> unitTypeCanMove(final PlayerID player) {
     return Match.of(obj -> UnitAttachment.get(obj).getMovement(player) > 0);
   }
 
-  public static Match<UnitType> unitTypeIsStatic(final PlayerID id) {
+  public static Predicate<UnitType> unitTypeIsStatic(final PlayerID id) {
     return Match.of(unitType -> !unitTypeCanMove(id).test(unitType));
   }
 
-  public static Match<Unit> unitIsLandAndOwnedBy(final PlayerID player) {
+  public static Predicate<Unit> unitIsLandAndOwnedBy(final PlayerID player) {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return !ua.getIsSea() && !ua.getIsAir() && unit.getOwner().equals(player);
     });
   }
 
-  public static Match<Unit> unitIsOwnedBy(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedBy(final PlayerID player) {
     return Match.of(unit -> unit.getOwner().equals(player));
   }
 
-  public static Match<Unit> unitIsOwnedByOfAnyOfThesePlayers(final Collection<PlayerID> players) {
+  public static Predicate<Unit> unitIsOwnedByOfAnyOfThesePlayers(final Collection<PlayerID> players) {
     return Match.of(unit -> players.contains(unit.getOwner()));
   }
 
-  public static Match<Unit> unitIsTransporting() {
+  public static Predicate<Unit> unitIsTransporting() {
     return Match.of(unit -> {
       final Collection<Unit> transporting = TripleAUnit.get(unit).getTransporting();
       return !(transporting == null || transporting.isEmpty());
     });
   }
 
-  public static Match<Unit> unitIsTransportingSomeCategories(final Collection<Unit> units) {
+  public static Predicate<Unit> unitIsTransportingSomeCategories(final Collection<Unit> units) {
     final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(units);
     return Match.of(unit -> {
       final Collection<Unit> transporting = TripleAUnit.get(unit).getTransporting();
@@ -1321,15 +1324,15 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> isTerritoryAllied(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> isTerritoryAllied(final PlayerID player, final GameData data) {
     return Match.of(t -> data.getRelationshipTracker().isAllied(player, t.getOwner()));
   }
 
-  public static Match<Territory> isTerritoryOwnedBy(final PlayerID player) {
+  public static Predicate<Territory> isTerritoryOwnedBy(final PlayerID player) {
     return Match.of(t -> t.getOwner().equals(player));
   }
 
-  public static Match<Territory> isTerritoryOwnedBy(final Collection<PlayerID> players) {
+  public static Predicate<Territory> isTerritoryOwnedBy(final Collection<PlayerID> players) {
     return Match.of(t -> {
       for (final PlayerID player : players) {
         if (t.getOwner().equals(player)) {
@@ -1340,11 +1343,11 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> isUnitAllied(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> isUnitAllied(final PlayerID player, final GameData data) {
     return Match.of(t -> data.getRelationshipTracker().isAllied(player, t.getOwner()));
   }
 
-  public static Match<Territory> isTerritoryFriendly(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> isTerritoryFriendly(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (t.isWater()) {
         return true;
@@ -1356,19 +1359,19 @@ public final class Matches {
     });
   }
 
-  private static Match<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
+  private static Predicate<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
     return Match.allOf(unitIsAaForAnything(), enemyUnit(player, data));
   }
 
-  private static Match<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
+  private static Predicate<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
     return Match.allOf(unitIsAaForCombatOnly(), enemyUnit(player, data));
   }
 
-  static Match<Unit> unitIsInTerritory(final Territory territory) {
+  static Predicate<Unit> unitIsInTerritory(final Territory territory) {
     return Match.of(o -> territory.getUnits().getUnits().contains(o));
   }
 
-  public static Match<Territory> isTerritoryEnemy(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> isTerritoryEnemy(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (t.getOwner().equals(player)) {
         return false;
@@ -1377,7 +1380,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> isTerritoryEnemyAndNotUnownedWater(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> isTerritoryEnemyAndNotUnownedWater(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (t.getOwner().equals(player)) {
         return false;
@@ -1394,7 +1397,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(final PlayerID player,
+  public static Predicate<Territory> isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(final PlayerID player,
       final GameData data) {
     return Match.of(t -> {
       if (t.getOwner().equals(player)) {
@@ -1415,7 +1418,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIsBlitzable(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryIsBlitzable(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       // cant blitz water
       if (t.isWater()) {
@@ -1433,7 +1436,7 @@ public final class Matches {
       }
       // we ignore neutral units
       final Predicate<Unit> blitzableUnits = PredicateBuilder
-          .of(enemyUnit(player, data).invert())
+          .of(enemyUnit(player, data).negate())
           // WW2V2, cant blitz through factories and aa guns
           // WW2V1, you can
           .orIf(!Properties.getWW2V2(data) && !Properties.getBlitzThroughFactoriesAndAARestricted(data),
@@ -1443,28 +1446,28 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> isTerritoryFreeNeutral(final GameData data) {
+  public static Predicate<Territory> isTerritoryFreeNeutral(final GameData data) {
     return Match.of(t -> t.getOwner().equals(PlayerID.NULL_PLAYERID) && Properties.getNeutralCharge(data) <= 0);
   }
 
-  public static Match<Territory> territoryDoesNotCostMoneyToEnter(final GameData data) {
-    return Match.of(t -> territoryIsLand().invert().test(t) || !t.getOwner().equals(PlayerID.NULL_PLAYERID)
+  public static Predicate<Territory> territoryDoesNotCostMoneyToEnter(final GameData data) {
+    return Match.of(t -> territoryIsLand().negate().test(t) || !t.getOwner().equals(PlayerID.NULL_PLAYERID)
         || Properties.getNeutralCharge(data) <= 0);
   }
 
-  public static Match<Unit> enemyUnit(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> enemyUnit(final PlayerID player, final GameData data) {
     return Match.of(unit -> data.getRelationshipTracker().isAtWar(player, unit.getOwner()));
   }
 
-  public static Match<Unit> enemyUnitOfAnyOfThesePlayers(final Collection<PlayerID> players, final GameData data) {
+  public static Predicate<Unit> enemyUnitOfAnyOfThesePlayers(final Collection<PlayerID> players, final GameData data) {
     return Match.of(unit -> data.getRelationshipTracker().isAtWarWithAnyOfThesePlayers(unit.getOwner(), players));
   }
 
-  public static Match<Unit> unitOwnedBy(final PlayerID player) {
+  public static Predicate<Unit> unitOwnedBy(final PlayerID player) {
     return Match.of(unit -> unit.getOwner().equals(player));
   }
 
-  public static Match<Unit> unitOwnedBy(final List<PlayerID> players) {
+  public static Predicate<Unit> unitOwnedBy(final List<PlayerID> players) {
     return Match.of(o -> {
       for (final PlayerID p : players) {
         if (o.getOwner().equals(p)) {
@@ -1475,7 +1478,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> alliedUnit(final PlayerID player, final GameData data) {
+  public static Predicate<Unit> alliedUnit(final PlayerID player, final GameData data) {
     return Match.of(unit -> {
       if (unit.getOwner().equals(player)) {
         return true;
@@ -1484,7 +1487,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> alliedUnitOfAnyOfThesePlayers(final Collection<PlayerID> players, final GameData data) {
+  public static Predicate<Unit> alliedUnitOfAnyOfThesePlayers(final Collection<PlayerID> players, final GameData data) {
     return Match.of(unit -> {
       if (unitIsOwnedByOfAnyOfThesePlayers(players).test(unit)) {
         return true;
@@ -1493,57 +1496,57 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> territoryIs(final Territory test) {
+  public static Predicate<Territory> territoryIs(final Territory test) {
     return Match.of(t -> t.equals(test));
   }
 
-  public static Match<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
+  public static Predicate<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
     return Match.of(t -> t.getUnits().anyMatch(Match.allOf(unitIsOwnedBy(player), unitIsLand())));
   }
 
-  public static Match<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
-    final Match<Unit> unitOwnedBy = unitIsOwnedBy(player);
+  public static Predicate<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
+    final Predicate<Unit> unitOwnedBy = unitIsOwnedBy(player);
     return Match.of(t -> t.getUnits().anyMatch(unitOwnedBy));
   }
 
-  public static Match<Territory> territoryHasUnitsThatMatch(final Match<Unit> cond) {
+  public static Predicate<Territory> territoryHasUnitsThatMatch(final Predicate<Unit> cond) {
     return Match.of(t -> t.getUnits().anyMatch(cond));
   }
 
-  public static Match<Territory> territoryHasEnemyAaForAnything(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasEnemyAaForAnything(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(unitIsEnemyAaForAnything(player, data)));
   }
 
-  public static Match<Territory> territoryHasEnemyAaForCombatOnly(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasEnemyAaForCombatOnly(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(unitIsEnemyAaForCombat(player, data)));
   }
 
-  public static Match<Territory> territoryHasNoEnemyUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasNoEnemyUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> !t.getUnits().anyMatch(enemyUnit(player, data)));
   }
 
-  public static Match<Territory> territoryHasAlliedUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasAlliedUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(alliedUnit(player, data)));
   }
 
-  static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
-    final Match<Unit> match = Match.allOf(enemyUnit(player, data), unitIsSubmerged().invert());
+  static Predicate<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
+    final Predicate<Unit> match = Match.allOf(enemyUnit(player, data), unitIsSubmerged().negate());
     return Match.of(t -> t.getUnits().anyMatch(match));
   }
 
-  public static Match<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), unitIsLand())));
   }
 
-  public static Match<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), unitIsSea())));
   }
 
-  public static Match<Territory> territoryHasEnemyUnits(final PlayerID player, final GameData data) {
+  public static Predicate<Territory> territoryHasEnemyUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> t.getUnits().anyMatch(enemyUnit(player, data)));
   }
 
-  static Match<Territory> territoryIsNotUnownedWater() {
+  static Predicate<Territory> territoryIsNotUnownedWater() {
     return Match.of(t -> !(t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull()));
   }
 
@@ -1551,7 +1554,7 @@ public final class Matches {
    * The territory is owned by the enemy of those enemy units (i.e. probably owned by you or your ally, but not
    * necessarily so in an FFA type game).
    */
-  static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(
+  static Predicate<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(
       final PlayerID player, final GameData gameData) {
     return Match.of(t -> {
       final List<Unit> enemyUnits = t.getUnits().getMatches(Match.allOf(
@@ -1565,7 +1568,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> transportCannotUnload(final Territory territory) {
+  public static Predicate<Unit> transportCannotUnload(final Territory territory) {
     return Match.of(transport -> {
       if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
         return true;
@@ -1577,11 +1580,11 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> transportIsNotTransporting() {
+  public static Predicate<Unit> transportIsNotTransporting() {
     return Match.of(transport -> !TransportTracker.isTransporting(transport));
   }
 
-  static Match<Unit> transportIsTransporting() {
+  static Predicate<Unit> transportIsTransporting() {
     return Match.of(transport -> TransportTracker.isTransporting(transport));
   }
 
@@ -1592,7 +1595,7 @@ public final class Matches {
    *         ship. (not sure if
    *         set for mech inf or not)
    */
-  public static Match<Unit> unitIsBeingTransported() {
+  public static Predicate<Unit> unitIsBeingTransported() {
     return Match.of(dependent -> ((TripleAUnit) dependent).getTransportedBy() != null);
   }
 
@@ -1610,7 +1613,7 @@ public final class Matches {
    * @return Match that tests the TripleAUnit getTransportedBy value
    *         (also tests for para-troopers, and for dependent allied fighters sitting as cargo on a ship)
    */
-  public static Match<Unit> unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(final Collection<Unit> units,
+  public static Predicate<Unit> unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(final Collection<Unit> units,
       final Route route, final PlayerID currentPlayer, final GameData data,
       final boolean forceLoadParatroopersIfPossible) {
     return Match.of(dependent -> {
@@ -1644,23 +1647,23 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitIsLand() {
+  public static Predicate<Unit> unitIsLand() {
     return Match.allOf(unitIsNotSea(), unitIsNotAir());
   }
 
-  public static Match<UnitType> unitTypeIsLand() {
+  public static Predicate<UnitType> unitTypeIsLand() {
     return Match.allOf(unitTypeIsNotSea(), unitTypeIsNotAir());
   }
 
-  public static Match<Unit> unitIsNotLand() {
-    return unitIsLand().invert();
+  public static Predicate<Unit> unitIsNotLand() {
+    return unitIsLand().negate();
   }
 
-  public static Match<Unit> unitIsOfType(final UnitType type) {
+  public static Predicate<Unit> unitIsOfType(final UnitType type) {
     return Match.of(unit -> unit.getType().equals(type));
   }
 
-  public static Match<Unit> unitIsOfTypes(final Set<UnitType> types) {
+  public static Predicate<Unit> unitIsOfTypes(final Set<UnitType> types) {
     return Match.of(unit -> {
       if (types == null || types.isEmpty()) {
         return false;
@@ -1669,40 +1672,42 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryWasFoughOver(final BattleTracker tracker) {
+  static Predicate<Territory> territoryWasFoughOver(final BattleTracker tracker) {
     return Match.of(t -> tracker.wasBattleFought(t) || tracker.wasBlitzed(t));
   }
 
-  static Match<Unit> unitIsSubmerged() {
+  static Predicate<Unit> unitIsSubmerged() {
     return Match.of(u -> TripleAUnit.get(u).getSubmerged());
   }
 
-  public static Match<UnitType> unitTypeIsSub() {
+  public static Predicate<UnitType> unitTypeIsSub() {
     return Match.of(type -> UnitAttachment.get(type).getIsSub());
   }
 
-  static Match<Unit> unitOwnerHasImprovedArtillerySupportTech() {
+  static Predicate<Unit> unitOwnerHasImprovedArtillerySupportTech() {
     return Match.of(u -> TechTracker.hasImprovedArtillerySupport(u.getOwner()));
   }
 
-  public static Match<Territory> territoryHasNonAllowedCanal(final PlayerID player, final Collection<Unit> unitsMoving,
+  public static Predicate<Territory> territoryHasNonAllowedCanal(final PlayerID player,
+      final Collection<Unit> unitsMoving,
       final GameData data) {
     return Match.of(t -> MoveValidator.validateCanal(t, null, unitsMoving, player, data).isPresent());
   }
 
-  public static Match<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
-    final Match<Unit> sub = Match.allOf(unitIsSub().invert());
-    final Match<Unit> transport = Match.allOf(unitIsTransportButNotCombatTransport().invert(), unitIsLand().invert());
-    final Match<Unit> unitCond = Match.of(PredicateBuilder
-        .of(unitIsInfrastructure().invert())
-        .and(alliedUnit(player, data).invert())
+  public static Predicate<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
+    final Predicate<Unit> sub = Match.allOf(unitIsSub().negate());
+    final Predicate<Unit> transport =
+        Match.allOf(unitIsTransportButNotCombatTransport().negate(), unitIsLand().negate());
+    final Predicate<Unit> unitCond = Match.of(PredicateBuilder
+        .of(unitIsInfrastructure().negate())
+        .and(alliedUnit(player, data).negate())
         .andIf(Properties.getIgnoreTransportInMovement(data), transport)
         .andIf(Properties.getIgnoreSubInMovement(data), sub)
         .build());
-    return Match.allOf(territoryHasUnitsThatMatch(unitCond).invert(), territoryIsWater());
+    return Match.allOf(territoryHasUnitsThatMatch(unitCond).negate(), territoryIsWater());
   }
 
-  static Match<Unit> unitCanRepairOthers() {
+  static Predicate<Unit> unitCanRepairOthers() {
     return Match.of(unit -> {
       if (unitIsDisabled().test(unit) || unitIsBeingTransported().test(unit)) {
         return false;
@@ -1715,7 +1720,7 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitCanRepairThisUnit(final Unit damagedUnit, final Territory territoryOfRepairUnit) {
+  static Predicate<Unit> unitCanRepairThisUnit(final Unit damagedUnit, final Territory territoryOfRepairUnit) {
     return Match.of(unitCanRepair -> {
       final Set<PlayerID> players =
           GameStepPropertiesHelper.getCombinedTurns(damagedUnit.getData(), damagedUnit.getOwner());
@@ -1758,14 +1763,14 @@ public final class Matches {
    *         (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can
    *         repair this unit.)
    */
-  public static Match<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
+  public static Predicate<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return Match.of(damagedUnit -> {
-      final Match<Unit> damaged = Match.allOf(unitHasMoreThanOneHitPointTotal(), unitHasTakenSomeDamage());
+      final Predicate<Unit> damaged = Match.allOf(unitHasMoreThanOneHitPointTotal(), unitHasTakenSomeDamage());
       if (!damaged.test(damagedUnit)) {
         return false;
       }
-      final Match<Unit> repairUnit = Match.allOf(alliedUnit(player, data),
+      final Predicate<Unit> repairUnit = Match.allOf(alliedUnit(player, data),
           unitCanRepairOthers(), unitCanRepairThisUnit(damagedUnit, territory));
       if (territory.getUnits().anyMatch(repairUnit)) {
         return true;
@@ -1774,7 +1779,7 @@ public final class Matches {
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, territoryIsLand()));
         for (final Territory current : neighbors) {
-          final Match<Unit> repairUnitLand = Match.allOf(alliedUnit(player, data),
+          final Predicate<Unit> repairUnitLand = Match.allOf(alliedUnit(player, data),
               unitCanRepairOthers(), unitCanRepairThisUnit(damagedUnit, current), unitIsLand());
           if (current.getUnits().anyMatch(repairUnitLand)) {
             return true;
@@ -1783,7 +1788,7 @@ public final class Matches {
       } else if (unitIsLand().test(damagedUnit)) {
         final List<Territory> neighbors = new ArrayList<>(data.getMap().getNeighbors(territory, territoryIsWater()));
         for (final Territory current : neighbors) {
-          final Match<Unit> repairUnitSea = Match.allOf(alliedUnit(player, data),
+          final Predicate<Unit> repairUnitSea = Match.allOf(alliedUnit(player, data),
               unitCanRepairOthers(), unitCanRepairThisUnit(damagedUnit, current), unitIsSea());
           if (current.getUnits().anyMatch(repairUnitSea)) {
             return true;
@@ -1794,14 +1799,14 @@ public final class Matches {
     });
   }
 
-  private static Match<Unit> unitCanGiveBonusMovement() {
+  private static Predicate<Unit> unitCanGiveBonusMovement() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua != null && ua.getGivesMovement().size() > 0 && unitIsBeingTransported().invert().test(unit);
+      return ua != null && ua.getGivesMovement().size() > 0 && unitIsBeingTransported().negate().test(unit);
     });
   }
 
-  static Match<Unit> unitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
+  static Predicate<Unit> unitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
     return Match.of(unitWhichCanGiveBonusMovement -> {
       if (unitIsDisabled().test(unitWhichCanGiveBonusMovement)) {
         return false;
@@ -1826,16 +1831,16 @@ public final class Matches {
    *         bonus movement to
    *         this unit.)
    */
-  public static Match<Unit> unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
+  public static Predicate<Unit> unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return Match.of(unitWhichWillGetBonus -> {
-      final Match<Unit> givesBonusUnit = Match.allOf(alliedUnit(player, data),
+      final Predicate<Unit> givesBonusUnit = Match.allOf(alliedUnit(player, data),
           unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
       if (territory.getUnits().anyMatch(givesBonusUnit)) {
         return true;
       }
       if (unitIsSea().test(unitWhichWillGetBonus)) {
-        final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, unitIsLand());
+        final Predicate<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, unitIsLand());
         final List<Territory> neighbors = new ArrayList<>(data.getMap().getNeighbors(territory, territoryIsLand()));
         for (final Territory current : neighbors) {
           if (current.getUnits().anyMatch(givesBonusUnitLand)) {
@@ -1847,14 +1852,14 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitCreatesUnits() {
+  static Predicate<Unit> unitCreatesUnits() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null && ua.getCreatesUnitsList() != null && ua.getCreatesUnitsList().size() > 0;
     });
   }
 
-  static Match<Unit> unitCreatesResources() {
+  static Predicate<Unit> unitCreatesResources() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null && ua.getCreatesResourcesList() != null && ua.getCreatesResourcesList().size() > 0;
@@ -1864,21 +1869,21 @@ public final class Matches {
   /**
    * Returns a match indicating the specified unit type consumes at least one type of unit upon creation.
    */
-  public static Match<UnitType> unitTypeConsumesUnitsOnCreation() {
+  public static Predicate<UnitType> unitTypeConsumesUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit);
       return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
     });
   }
 
-  static Match<Unit> unitConsumesUnitsOnCreation() {
+  static Predicate<Unit> unitConsumesUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
     });
   }
 
-  static Match<Unit> unitWhichConsumesUnitsHasRequiredUnits(final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
+  static Predicate<Unit> unitWhichConsumesUnitsHasRequiredUnits(final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return Match.of(unitWhichRequiresUnits -> {
       if (!unitConsumesUnitsOnCreation().test(unitWhichRequiresUnits)) {
         return true;
@@ -1888,7 +1893,7 @@ public final class Matches {
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       boolean canBuild = true;
       for (final UnitType ut : requiredUnits) {
-        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
+        final Predicate<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
             unitIsOwnedBy(unitWhichRequiresUnits.getOwner()),
             unitIsOfType(ut),
             unitHasNotTakenAnyBombingUnitDamage(),
@@ -1910,7 +1915,7 @@ public final class Matches {
   /**
    * Returns a match indicating the specified unit requires at least one type of unit upon creation.
    */
-  public static Match<Unit> unitRequiresUnitsOnCreation() {
+  public static Predicate<Unit> unitRequiresUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null && ua.getRequiresUnits() != null && ua.getRequiresUnits().size() > 0;
@@ -1920,13 +1925,13 @@ public final class Matches {
   /**
    * Checks if requiresUnits criteria allows placement in territory based on units there at the start of turn.
    */
-  public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnitsInList(
+  public static Predicate<Unit> unitWhichRequiresUnitsHasRequiredUnitsInList(
       final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return Match.of(unitWhichRequiresUnits -> {
       if (!unitRequiresUnitsOnCreation().test(unitWhichRequiresUnits)) {
         return true;
       }
-      final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
+      final Predicate<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
           unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), unitIsNotDisabled());
       unitsInTerritoryAtStartOfTurn.retainAll(getMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndNotDisabled));
       boolean canBuild = false;
@@ -1959,7 +1964,7 @@ public final class Matches {
   /**
    * Check if unit meets requiredUnitsToMove criteria and can move into territory.
    */
-  public static Match<Unit> unitHasRequiredUnitsToMove(final Territory t, final GameData data) {
+  public static Predicate<Unit> unitHasRequiredUnitsToMove(final Territory t, final GameData data) {
     return Match.of(unit -> {
 
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
@@ -1967,7 +1972,7 @@ public final class Matches {
         return true;
       }
 
-      final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
+      final Predicate<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
           isUnitAllied(unit.getOwner(), data), unitIsNotDisabled());
       final List<Unit> units = getMatches(t.getUnits().getUnits(), unitIsOwnedByAndNotDisabled);
 
@@ -1988,7 +1993,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryIsBlockadeZone() {
+  static Predicate<Territory> territoryIsBlockadeZone() {
     return Match.of(t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       return ta != null && ta.getBlockadeZone();
@@ -1998,26 +2003,26 @@ public final class Matches {
   /**
    * Returns a match indicating the specified unit type is a construction unit type.
    */
-  public static Match<UnitType> unitTypeIsConstruction() {
+  public static Predicate<UnitType> unitTypeIsConstruction() {
     return Match.of(type -> {
       final UnitAttachment ua = UnitAttachment.get(type);
       return ua != null && ua.getIsConstruction();
     });
   }
 
-  public static Match<Unit> unitIsConstruction() {
+  public static Predicate<Unit> unitIsConstruction() {
     return Match.of(obj -> unitTypeIsConstruction().test(obj.getType()));
   }
 
-  public static Match<Unit> unitIsNotConstruction() {
-    return unitIsConstruction().invert();
+  public static Predicate<Unit> unitIsNotConstruction() {
+    return unitIsConstruction().negate();
   }
 
-  public static Match<Unit> unitCanProduceUnitsAndIsInfrastructure() {
+  public static Predicate<Unit> unitCanProduceUnitsAndIsInfrastructure() {
     return Match.allOf(unitCanProduceUnits(), unitIsInfrastructure());
   }
 
-  public static Match<Unit> unitCanProduceUnitsAndCanBeDamaged() {
+  public static Predicate<Unit> unitCanProduceUnitsAndCanBeDamaged() {
     return Match.allOf(unitCanProduceUnits(), unitCanBeDamaged());
   }
 
@@ -2025,7 +2030,7 @@ public final class Matches {
    * See if a unit can invade. Units with canInvadeFrom not set, or set to "all", can invade from any other unit.
    * Otherwise, units must have a specific unit in this list to be able to invade from that unit.
    */
-  public static Match<Unit> unitCanInvade() {
+  public static Predicate<Unit> unitCanInvade() {
     return Match.of(unit -> {
       // is the unit being transported?
       final Unit transport = TripleAUnit.get(unit).getTransportedBy();
@@ -2038,30 +2043,30 @@ public final class Matches {
     });
   }
 
-  public static Match<RelationshipType> relationshipTypeIsAllied() {
+  public static Predicate<RelationshipType> relationshipTypeIsAllied() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isAllied());
   }
 
-  public static Match<RelationshipType> relationshipTypeIsNeutral() {
+  public static Predicate<RelationshipType> relationshipTypeIsNeutral() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isNeutral());
   }
 
-  public static Match<RelationshipType> relationshipTypeIsAtWar() {
+  public static Predicate<RelationshipType> relationshipTypeIsAtWar() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isWar());
   }
 
-  public static Match<Relationship> relationshipIsAtWar() {
+  public static Predicate<Relationship> relationshipIsAtWar() {
     return Match.of(relationship -> relationship.getRelationshipType().getRelationshipTypeAttachment().isWar());
   }
 
-  public static Match<RelationshipType> relationshipTypeCanMoveLandUnitsOverOwnedLand() {
+  public static Predicate<RelationshipType> relationshipTypeCanMoveLandUnitsOverOwnedLand() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveLandUnitsOverOwnedLand());
   }
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
    */
-  public static Match<Territory> territoryAllowsCanMoveLandUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
+  public static Predicate<Territory> territoryAllowsCanMoveLandUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
       final GameData data) {
     return Match.of(t -> {
       if (!territoryIsLand().test(t)) {
@@ -2075,14 +2080,14 @@ public final class Matches {
     });
   }
 
-  public static Match<RelationshipType> relationshipTypeCanMoveAirUnitsOverOwnedLand() {
+  public static Predicate<RelationshipType> relationshipTypeCanMoveAirUnitsOverOwnedLand() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveAirUnitsOverOwnedLand());
   }
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
    */
-  public static Match<Territory> territoryAllowsCanMoveAirUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
+  public static Predicate<Territory> territoryAllowsCanMoveAirUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
       final GameData data) {
     return Match.of(t -> {
       if (!territoryIsLand().test(t)) {
@@ -2096,63 +2101,63 @@ public final class Matches {
     });
   }
 
-  public static Match<RelationshipType> relationshipTypeCanLandAirUnitsOnOwnedLand() {
+  public static Predicate<RelationshipType> relationshipTypeCanLandAirUnitsOnOwnedLand() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canLandAirUnitsOnOwnedLand());
   }
 
-  public static Match<RelationshipType> relationshipTypeCanTakeOverOwnedTerritory() {
+  public static Predicate<RelationshipType> relationshipTypeCanTakeOverOwnedTerritory() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canTakeOverOwnedTerritory());
   }
 
-  public static Match<RelationshipType> relationshipTypeGivesBackOriginalTerritories() {
+  public static Predicate<RelationshipType> relationshipTypeGivesBackOriginalTerritories() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().givesBackOriginalTerritories());
   }
 
-  public static Match<RelationshipType> relationshipTypeCanMoveIntoDuringCombatMove() {
+  public static Predicate<RelationshipType> relationshipTypeCanMoveIntoDuringCombatMove() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveIntoDuringCombatMove());
   }
 
-  public static Match<RelationshipType> relationshipTypeCanMoveThroughCanals() {
+  public static Predicate<RelationshipType> relationshipTypeCanMoveThroughCanals() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveThroughCanals());
   }
 
-  public static Match<RelationshipType> relationshipTypeRocketsCanFlyOver() {
+  public static Predicate<RelationshipType> relationshipTypeRocketsCanFlyOver() {
     return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canRocketsFlyOver());
   }
 
-  public static Match<String> isValidRelationshipName(final GameData data) {
+  public static Predicate<String> isValidRelationshipName(final GameData data) {
     return Match.of(relationshipName -> data.getRelationshipTypeList().getRelationshipType(relationshipName) != null);
   }
 
-  public static Match<PlayerID> isAtWar(final PlayerID player, final GameData data) {
+  public static Predicate<PlayerID> isAtWar(final PlayerID player, final GameData data) {
     return Match.of(player2 -> relationshipTypeIsAtWar()
         .test(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
-  public static Match<PlayerID> isAtWarWithAnyOfThesePlayers(final Collection<PlayerID> players,
+  public static Predicate<PlayerID> isAtWarWithAnyOfThesePlayers(final Collection<PlayerID> players,
       final GameData data) {
     return Match.of(player2 -> data.getRelationshipTracker().isAtWarWithAnyOfThesePlayers(player2, players));
   }
 
-  public static Match<PlayerID> isAllied(final PlayerID player, final GameData data) {
+  public static Predicate<PlayerID> isAllied(final PlayerID player, final GameData data) {
     return Match.of(player2 -> relationshipTypeIsAllied()
         .test(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
-  public static Match<PlayerID> isAlliedWithAnyOfThesePlayers(final Collection<PlayerID> players,
+  public static Predicate<PlayerID> isAlliedWithAnyOfThesePlayers(final Collection<PlayerID> players,
       final GameData data) {
     return Match.of(player2 -> data.getRelationshipTracker().isAlliedWithAnyOfThesePlayers(player2, players));
   }
 
-  public static Match<Unit> unitIsOwnedAndIsFactoryOrCanProduceUnits(final PlayerID player) {
+  public static Predicate<Unit> unitIsOwnedAndIsFactoryOrCanProduceUnits(final PlayerID player) {
     return Match.of(unit -> unitCanProduceUnits().test(unit) && unitIsOwnedBy(player).test(unit));
   }
 
-  public static Match<Unit> unitCanReceiveAbilityWhenWith() {
+  public static Predicate<Unit> unitCanReceiveAbilityWhenWith() {
     return Match.of(unit -> !UnitAttachment.get(unit.getType()).getReceivesAbilityWhenWith().isEmpty());
   }
 
-  public static Match<Unit> unitCanReceiveAbilityWhenWith(final String filterForAbility,
+  public static Predicate<Unit> unitCanReceiveAbilityWhenWith(final String filterForAbility,
       final String filterForUnitType) {
     return Match.of(u -> {
       for (final String receives : UnitAttachment.get(u.getType()).getReceivesAbilityWhenWith()) {
@@ -2165,11 +2170,11 @@ public final class Matches {
     });
   }
 
-  private static Match<Unit> unitHasWhenCombatDamagedEffect() {
+  private static Predicate<Unit> unitHasWhenCombatDamagedEffect() {
     return Match.of(u -> !UnitAttachment.get(u.getType()).getWhenCombatDamaged().isEmpty());
   }
 
-  static Match<Unit> unitHasWhenCombatDamagedEffect(final String filterForEffect) {
+  static Predicate<Unit> unitHasWhenCombatDamagedEffect(final String filterForEffect) {
     return Match.of(u -> {
       if (!unitHasWhenCombatDamagedEffect().test(u)) {
         return false;
@@ -2193,7 +2198,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryHasWhenCapturedByGoesTo() {
+  static Predicate<Territory> territoryHasWhenCapturedByGoesTo() {
     return Match.of(t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (ta == null) {
@@ -2203,21 +2208,21 @@ public final class Matches {
     });
   }
 
-  static Match<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {
+  static Predicate<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {
     return Match.of(u -> !UnitAttachment.get(u.getType()).getWhenCapturedChangesInto().isEmpty());
   }
 
-  public static <T extends AbstractUserActionAttachment> Match<T> abstractUserActionAttachmentCanBeAttempted(
+  public static <T extends AbstractUserActionAttachment> Predicate<T> abstractUserActionAttachmentCanBeAttempted(
       final HashMap<ICondition, Boolean> testedConditions) {
     return Match.of(uaa -> uaa.hasAttemptsLeft() && uaa.canPerform(testedConditions));
   }
 
-  public static Match<PoliticalActionAttachment> politicalActionHasCostBetween(final int greaterThanEqualTo,
+  public static Predicate<PoliticalActionAttachment> politicalActionHasCostBetween(final int greaterThanEqualTo,
       final int lessThanEqualTo) {
     return Match.of(paa -> paa.getCostPU() >= greaterThanEqualTo && paa.getCostPU() <= lessThanEqualTo);
   }
 
-  static Match<Unit> unitCanOnlyPlaceInOriginalTerritories() {
+  static Predicate<Unit> unitCanOnlyPlaceInOriginalTerritories() {
     return Match.of(u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
       final Set<String> specialOptions = ua.getSpecial();
@@ -2233,7 +2238,7 @@ public final class Matches {
   /**
    * Accounts for OccupiedTerrOf. Returns false if there is no territory attachment (like if it is water).
    */
-  public static Match<Territory> territoryIsOriginallyOwnedBy(final PlayerID player) {
+  public static Predicate<Territory> territoryIsOriginallyOwnedBy(final PlayerID player) {
     return Match.of(t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (ta == null) {
@@ -2247,17 +2252,17 @@ public final class Matches {
     });
   }
 
-  static Match<PlayerID> isAlliedAndAlliancesCanChainTogether(final PlayerID player, final GameData data) {
+  static Predicate<PlayerID> isAlliedAndAlliancesCanChainTogether(final PlayerID player, final GameData data) {
     return Match.of(player2 -> relationshipTypeIsAlliedAndAlliancesCanChainTogether()
         .test(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
-  public static Match<RelationshipType> relationshipTypeIsAlliedAndAlliancesCanChainTogether() {
+  public static Predicate<RelationshipType> relationshipTypeIsAlliedAndAlliancesCanChainTogether() {
     return Match.of(rt -> relationshipTypeIsAllied().test(rt)
         && rt.getRelationshipTypeAttachment().canAlliancesChainTogether());
   }
 
-  public static Match<RelationshipType> relationshipTypeIsDefaultWarPosition() {
+  public static Predicate<RelationshipType> relationshipTypeIsDefaultWarPosition() {
     return Match.of(rt -> rt.getRelationshipTypeAttachment().isDefaultWarPosition());
   }
 
@@ -2275,8 +2280,9 @@ public final class Matches {
    * @param data
    *        cannot be null
    */
-  public static Match<PoliticalActionAttachment> politicalActionIsRelationshipChangeOf(final PlayerID player,
-      final Match<RelationshipType> currentRelation, final Match<RelationshipType> newRelation, final GameData data) {
+  public static Predicate<PoliticalActionAttachment> politicalActionIsRelationshipChangeOf(final PlayerID player,
+      final Predicate<RelationshipType> currentRelation, final Predicate<RelationshipType> newRelation,
+      final GameData data) {
     return Match.of(paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
         final String[] relationshipChange = relationshipChangeString.split(":");
@@ -2295,7 +2301,7 @@ public final class Matches {
     });
   }
 
-  public static Match<PoliticalActionAttachment> politicalActionAffectsAtLeastOneAlivePlayer(
+  public static Predicate<PoliticalActionAttachment> politicalActionAffectsAtLeastOneAlivePlayer(
       final PlayerID currentPlayer, final GameData data) {
     return Match.of(paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
@@ -2317,7 +2323,7 @@ public final class Matches {
     });
   }
 
-  public static Match<Territory> airCanLandOnThisAlliedNonConqueredLandTerritory(final PlayerID player,
+  public static Predicate<Territory> airCanLandOnThisAlliedNonConqueredLandTerritory(final PlayerID player,
       final GameData data) {
     return Match.of(t -> {
       if (!territoryIsLand().test(t)) {
@@ -2336,7 +2342,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryAllowsRocketsCanFlyOver(final PlayerID player, final GameData data) {
+  static Predicate<Territory> territoryAllowsRocketsCanFlyOver(final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (!territoryIsLand().test(t)) {
         return true;
@@ -2350,23 +2356,23 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitCanScrambleOnRouteDistance(final Route route) {
+  public static Predicate<Unit> unitCanScrambleOnRouteDistance(final Route route) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getMaxScrambleDistance() >= route.getMovementCost(unit));
   }
 
-  static Match<Unit> unitCanIntercept() {
+  static Predicate<Unit> unitCanIntercept() {
     return Match.of(u -> UnitAttachment.get(u.getType()).getCanIntercept());
   }
 
-  static Match<Unit> unitCanEscort() {
+  static Predicate<Unit> unitCanEscort() {
     return Match.of(u -> UnitAttachment.get(u.getType()).getCanEscort());
   }
 
-  static Match<Unit> unitCanAirBattle() {
+  static Predicate<Unit> unitCanAirBattle() {
     return Match.of(u -> UnitAttachment.get(u.getType()).getCanAirBattle());
   }
 
-  static Match<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
+  static Predicate<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
       final PlayerID attacker) {
     return Match.of(t -> {
       if (t.getOwner().equals(attacker)) {
@@ -2383,7 +2389,7 @@ public final class Matches {
     });
   }
 
-  static Match<Territory> territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(final PlayerID movingPlayer) {
+  static Predicate<Territory> territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(final PlayerID movingPlayer) {
     return Match.of(t -> {
       if (t.getOwner().equals(movingPlayer)) {
         return true;
@@ -2395,47 +2401,47 @@ public final class Matches {
     });
   }
 
-  public static Match<Unit> unitCanBeInBattle(final boolean attack, final boolean isLandBattle,
+  public static Predicate<Unit> unitCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
     return Match.of(unit -> unitTypeCanBeInBattle(attack, isLandBattle, unit.getOwner(), battleRound,
         includeAttackersThatCanNotMove, doNotIncludeAa, doNotIncludeBombardingSeaUnits).test(unit.getType()));
   }
 
-  public static Match<UnitType> unitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
+  public static Predicate<UnitType> unitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final PlayerID player, final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
 
     // Filter out anything like factories, or units that have no combat ability AND cannot be taken casualty
-    final PredicateBuilder<UnitType> canBeInBattleBuilder = PredicateBuilder.of(unitTypeIsInfrastructure().invert())
+    final PredicateBuilder<UnitType> canBeInBattleBuilder = PredicateBuilder.of(unitTypeIsInfrastructure().negate())
         .or(unitTypeIsSupporterOrHasCombatAbility(attack, player))
         .orIf(!doNotIncludeAa, Match.allOf(unitTypeIsAaForCombatOnly(), unitTypeIsAaThatCanFireOnRound(battleRound)));
 
     if (attack) {
       if (!includeAttackersThatCanNotMove) {
         canBeInBattleBuilder
-            .and(unitTypeCanNotMoveDuringCombatMove().invert())
+            .and(unitTypeCanNotMoveDuringCombatMove().negate())
             .and(unitTypeCanMove(player));
       }
       if (isLandBattle) {
         if (doNotIncludeBombardingSeaUnits) {
-          canBeInBattleBuilder.and(unitTypeIsSea().invert());
+          canBeInBattleBuilder.and(unitTypeIsSea().negate());
         }
       } else { // is sea battle
-        canBeInBattleBuilder.and(unitTypeIsLand().invert());
+        canBeInBattleBuilder.and(unitTypeIsLand().negate());
       }
     } else { // defense
-      canBeInBattleBuilder.and((isLandBattle ? unitTypeIsSea() : unitTypeIsLand()).invert());
+      canBeInBattleBuilder.and((isLandBattle ? unitTypeIsSea() : unitTypeIsLand()).negate());
     }
 
     return Match.of(canBeInBattleBuilder.build());
   }
 
-  static Match<Unit> unitIsAirborne() {
+  static Predicate<Unit> unitIsAirborne() {
     return Match.of(obj -> ((TripleAUnit) obj).getAirborne());
   }
 
-  public static <T> Match<T> isNotInList(final List<T> list) {
+  public static <T> Predicate<T> isNotInList(final List<T> list) {
     return Match.of(not(list::contains));
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2372,8 +2372,9 @@ public final class Matches {
     return Match.of(u -> UnitAttachment.get(u.getType()).getCanAirBattle());
   }
 
-  static Predicate<Territory>
-  territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(final PlayerID attacker) {
+  static Predicate<Territory> //
+      territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
+          final PlayerID attacker) {
     return Match.of(t -> {
       if (t.getOwner().equals(attacker)) {
         return false;

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2372,8 +2372,8 @@ public final class Matches {
     return Match.of(u -> UnitAttachment.get(u.getType()).getCanAirBattle());
   }
 
-  static Predicate<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
-      final PlayerID attacker) {
+  static Predicate<Territory>
+  territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(final PlayerID attacker) {
     return Match.of(t -> {
       if (t.getOwner().equals(attacker)) {
         return false;

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -141,7 +141,7 @@ public class MovePerformer implements Serializable {
         // battles on (note water could have enemy but its
         // not owned)
         final GameData data = bridge.getData();
-        final Match<Territory> mustFightThrough = getMustFightThroughMatch(id, data);
+        final Predicate<Territory> mustFightThrough = getMustFightThroughMatch(id, data);
         final Collection<Unit> arrived = Collections.unmodifiableList(Util.intersection(units, arrivingUnits));
         // Reset Optional
         arrivingUnits = new ArrayList<>();
@@ -173,7 +173,7 @@ public class MovePerformer implements Serializable {
           // could it be a bombing raid
           final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = Matches.getMatches(enemyUnits,
-              Match.allOf(Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
+              Match.allOf(Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().negate()));
           final boolean canCreateAirBattle =
               !enemyTargetsTotal.isEmpty()
                   && Properties.getRaidsMayBePreceededByAirBattles(data)
@@ -293,7 +293,7 @@ public class MovePerformer implements Serializable {
     m_executionStack.execute(m_bridge);
   }
 
-  private static Match<Territory> getMustFightThroughMatch(final PlayerID id, final GameData data) {
+  private static Predicate<Territory> getMustFightThroughMatch(final PlayerID id, final GameData data) {
     return Match.anyOf(
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data),
         Matches.territoryHasNonSubmergedEnemyUnits(id, data),
@@ -350,7 +350,7 @@ public class MovePerformer implements Serializable {
       // can't keep moving them
       // if there is an enemy destroyer there
       for (final Unit unit : Matches.getMatches(units,
-          Match.allOf(Matches.unitIsSub(), Matches.unitIsAir().invert()))) {
+          Match.allOf(Matches.unitIsSub(), Matches.unitIsAir().negate()))) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }
@@ -366,7 +366,7 @@ public class MovePerformer implements Serializable {
       return;
     }
     final GameData data = m_bridge.getData();
-    final Match<Unit> paratroopNAirTransports = Match.anyOf(
+    final Predicate<Unit> paratroopNAirTransports = Match.anyOf(
         Matches.unitIsAirTransport(),
         Matches.unitIsAirTransportable());
     final boolean paratroopsLanding = arrived.stream().anyMatch(paratroopNAirTransports)

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -102,7 +103,7 @@ public class NonFightingBattle extends DependentBattle {
   }
 
   boolean hasAttackingUnits() {
-    final Match<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.unitIsLand());
+    final Predicate<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.unitIsLand());
     return m_battleSite.getUnits().anyMatch(attackingLand);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -55,7 +56,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> politicsDelegateTriggerMatch = Match.allOf(
+      final Predicate<TriggerAttachment> politicsDelegateTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
           Match.anyOf(TriggerAttachment.relationshipChangeMatch()));
       // get all possible triggers based on this match.
@@ -171,15 +172,15 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    */
   private boolean actionIsAccepted(final PoliticalActionAttachment paa) {
     final GameData data = getData();
-    final Match<PoliticalActionAttachment> intoAlliedChainOrIntoOrOutOfWar =
+    final Predicate<PoliticalActionAttachment> intoAlliedChainOrIntoOrOutOfWar =
         Match.anyOf(
             Matches.politicalActionIsRelationshipChangeOf(null,
-                Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().invert(),
+                Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().negate(),
                 Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether(), data),
-            Matches.politicalActionIsRelationshipChangeOf(null, Matches.relationshipTypeIsAtWar().invert(),
+            Matches.politicalActionIsRelationshipChangeOf(null, Matches.relationshipTypeIsAtWar().negate(),
                 Matches.relationshipTypeIsAtWar(), data),
             Matches.politicalActionIsRelationshipChangeOf(null, Matches.relationshipTypeIsAtWar(),
-                Matches.relationshipTypeIsAtWar().invert(), data));
+                Matches.relationshipTypeIsAtWar().negate(), data));
     if (!Properties.getAlliancesCanChainTogether(data)
         || !intoAlliedChainOrIntoOrOutOfWar.test(paa)) {
       for (final PlayerID player : paa.getActionAccept()) {
@@ -440,7 +441,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
       final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
       if (Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().test(currentType)
-          && Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().invert().test(newType)) {
+          && Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().negate().test(newType)) {
         for (final PlayerID p3 : p1AlliedWith) {
           final RelationshipType currentOther = data.getRelationshipTracker().getRelationshipType(p3, player);
           if (!currentOther.equals(newType)) {
@@ -479,7 +480,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
       final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
       if (Matches.relationshipTypeIsAtWar().test(currentType)
-          && Matches.relationshipTypeIsAtWar().invert().test(newType)) {
+          && Matches.relationshipTypeIsAtWar().negate().test(newType)) {
         final Collection<PlayerID> otherPlayersAlliedWith =
             Matches.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(otherPlayer, data));
         if (!otherPlayersAlliedWith.contains(otherPlayer)) {

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -169,7 +169,8 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           // count how many units are yet to be placed or are in the field
           int currentlyBuilt = m_player.getUnits().countMatches(Matches.unitIsOfType(type));
 
-          final Predicate<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
+          final Predicate<Unit> unitTypeOwnedBy =
+              Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
             currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -61,7 +62,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
         // First set up a match for what we want to have fire as a default in this delegate. List out as a composite
         // match OR.
         // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-        final Match<TriggerAttachment> purchaseDelegateTriggerMatch = Match.allOf(
+        final Predicate<TriggerAttachment> purchaseDelegateTriggerMatch = Match.allOf(
             AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
             Match.anyOf(TriggerAttachment.prodMatch(),
                 TriggerAttachment.prodFrontierEditMatch(), TriggerAttachment.purchaseMatch()));
@@ -168,7 +169,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           // count how many units are yet to be placed or are in the field
           int currentlyBuilt = m_player.getUnits().countMatches(Matches.unitIsOfType(type));
 
-          final Match<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
+          final Predicate<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
             currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
@@ -74,8 +75,8 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   protected void setupBoard() {
     final GameData data = getData();
     final boolean randomTerritories = Properties.getTerritoriesAreAssignedRandomly(data);
-    final Match<Territory> pickableTerritoryMatch = getTerritoryPickableMatch();
-    final Match<PlayerID> playerCanPickMatch = getPlayerCanPickMatch();
+    final Predicate<Territory> pickableTerritoryMatch = getTerritoryPickableMatch();
+    final Predicate<PlayerID> playerCanPickMatch = getPlayerCanPickMatch();
     final List<Territory> allPickableTerritories =
         Matches.getMatches(data.getMap().getTerritories(), pickableTerritoryMatch);
     final List<PlayerID> playersCanPick = new ArrayList<>();
@@ -221,12 +222,12 @@ public class RandomStartDelegate extends BaseTripleADelegate {
     return playersCanPick.get(index);
   }
 
-  public Match<Territory> getTerritoryPickableMatch() {
+  public Predicate<Territory> getTerritoryPickableMatch() {
     return Match.allOf(Matches.territoryIsLand(), Matches.territoryIsNotImpassable(),
         Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.territoryIsEmpty());
   }
 
-  private static Match<PlayerID> getPlayerCanPickMatch() {
+  private static Predicate<PlayerID> getPlayerCanPickMatch() {
     return Match.of(player -> {
       if (player == null || player.equals(PlayerID.NULL_PLAYERID)) {
         return false;

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -136,7 +136,7 @@ public class RocketsFireHelper {
 
   static Set<Territory> getTerritoriesWithRockets(final GameData data, final PlayerID player) {
     final Set<Territory> territories = new HashSet<>();
-    final Match<Unit> ownedRockets = rocketMatch(player);
+    final Predicate<Unit> ownedRockets = rocketMatch(player);
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(data);
     for (final Territory current : data.getMap()) {
       if (tracker.wasConquered(current)) {
@@ -149,9 +149,9 @@ public class RocketsFireHelper {
     return territories;
   }
 
-  private static Match<Unit> rocketMatch(final PlayerID player) {
+  private static Predicate<Unit> rocketMatch(final PlayerID player) {
     return Match.allOf(Matches.unitIsRocket(), Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
-        Matches.unitIsBeingTransported().invert(), Matches.unitIsSubmerged().invert(), Matches.unitHasNotMoved());
+        Matches.unitIsBeingTransported().negate(), Matches.unitIsSubmerged().negate(), Matches.unitHasNotMoved());
   }
 
   private static Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data,
@@ -163,13 +163,13 @@ public class RocketsFireHelper {
         .of(Matches.territoryAllowsRocketsCanFlyOver(player, data))
         .andIf(!isRocketsCanFlyOverImpassables(data), Matches.territoryIsNotImpassable())
         .build();
-    final Match<Unit> attackableUnits =
-        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());
+    final Predicate<Unit> attackableUnits =
+        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().negate());
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, Match.of(allowed));
       if (route != null && route.numberOfSteps() <= maxDistance) {
         if (current.getUnits().anyMatch(Match.allOf(attackableUnits,
-            Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
+            Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).negate()))) {
           hasFactory.add(current);
         }
       }
@@ -191,9 +191,9 @@ public class RocketsFireHelper {
     final boolean damageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
-        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
+        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().negate()));
     final Collection<Unit> enemyTargetsTotal =
-        Matches.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
+        Matches.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).negate());
     final Collection<Unit> targets = new ArrayList<>();
     final Collection<Unit> rockets;
     // attackFrom could be null if WW2V1

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -173,7 +174,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     final boolean isEditMode = getEditMode(data);
     if (!isEditMode) {
       // make sure all units are at least friendly
-      for (final Unit unit : Matches.getMatches(units, Matches.unitIsOwnedBy(player).invert())) {
+      for (final Unit unit : Matches.getMatches(units, Matches.unitIsOwnedBy(player).negate())) {
         result.addDisallowedUnit("Can only move owned units", unit);
       }
     }
@@ -198,7 +199,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return result.setErrorReturnResult("Destination Is Out Of Range");
     }
     final Collection<PlayerID> alliesForBases = data.getRelationshipTracker().getAllies(player, true);
-    final Match<Unit> airborneBaseMatch = getAirborneMatch(airborneBases, alliesForBases);
+    final Predicate<Unit> airborneBaseMatch = getAirborneMatch(airborneBases, alliesForBases);
     final Territory start = route.getStart();
     final Territory end = route.getEnd();
     final Collection<Unit> basesAtStart = start.getUnits().getMatches(airborneBaseMatch);
@@ -280,15 +281,15 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     return result;
   }
 
-  private static Match<Unit> getAirborneBaseMatch(final PlayerID player, final GameData data) {
+  private static Predicate<Unit> getAirborneBaseMatch(final PlayerID player, final GameData data) {
     return getAirborneMatch(TechAbilityAttachment.getAirborneBases(player, data),
         data.getRelationshipTracker().getAllies(player, true));
   }
 
-  private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
+  private static Predicate<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
     return Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
         Matches.unitIsOfTypes(types), Matches.unitIsNotDisabled(), Matches.unitHasNotMoved(),
-        Matches.unitIsAirborne().invert());
+        Matches.unitIsAirborne().negate());
   }
 
   private static Change getNewAssignmentOfNumberLaunchedChange(int newNumberLaunched, final Collection<Unit> bases,

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -92,7 +93,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     // fill in defenders
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
-    final Match<Unit> defenders = Match.allOf(Matches.enemyUnit(m_attacker, m_data),
+    final Predicate<Unit> defenders = Match.allOf(Matches.enemyUnit(m_attacker, m_data),
         Match.anyOf(Matches.unitCanBeDamaged(),
             Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
                 Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data)));

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -58,7 +59,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> techActivationDelegateTriggerMatch = Match.allOf(
+      final Predicate<TriggerAttachment> techActivationDelegateTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
           Match.anyOf(TriggerAttachment.unitPropertyMatch(), TriggerAttachment.techMatch(),
               TriggerAttachment.supportMatch()));

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -72,7 +73,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> technologyDelegateTriggerMatch = Match.allOf(
+      final Predicate<TriggerAttachment> technologyDelegateTriggerMatch = Match.allOf(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
           Match.anyOf(TriggerAttachment.techAvailableMatch()));
       // get all possible triggers based on this match.

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -128,7 +128,7 @@ public class UndoableMove extends AbstractUndoableMove {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
                 .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerId(), data),
-                    Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().invert()));
+                    Matches.unitCanBeDamaged(), Matches.unitIsBeingTransported().negate()));
             final Collection<Unit> enemyTargets = Matches.getMatches(enemyTargetsTotal,
                 Matches.unitIsOfTypes(UnitAttachment.getAllowedBombingTargetsIntersection(
                     Matches.getMatches(Collections.singleton(unit), Matches.unitIsStrategicBomber()), data)));

--- a/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -11,7 +12,6 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.util.IntegerMap;
-import games.strategy.util.Match;
 
 public class UnitComparator {
   static Comparator<Unit> getLowestToHighestMovementComparator() {
@@ -74,7 +74,7 @@ public class UnitComparator {
   public static Comparator<Unit> getLoadableTransportsComparator(final List<Unit> transports, final Route route,
       final PlayerID player) {
     final Comparator<Unit> decreasingCapacityComparator = getDecreasingCapacityComparator(transports);
-    final Match<Unit> incapableTransportMatch = Matches.transportCannotUnload(route.getEnd());
+    final Predicate<Unit> incapableTransportMatch = Matches.transportCannotUnload(route.getEnd());
     return (u1, u2) -> {
       final TripleAUnit t1 = TripleAUnit.get(u1);
       final TripleAUnit t2 = TripleAUnit.get(u2);
@@ -122,7 +122,7 @@ public class UnitComparator {
   public static Comparator<Unit> getUnloadableTransportsComparator(final List<Unit> transports, final Route route,
       final PlayerID player, final boolean noTies) {
     final Comparator<Unit> decreasingCapacityComparator = getDecreasingCapacityComparator(transports);
-    final Match<Unit> incapableTransportMatch = Matches.transportCannotUnload(route.getEnd());
+    final Predicate<Unit> incapableTransportMatch = Matches.transportCannotUnload(route.getEnd());
     return (t1, t2) -> {
 
       // Check if transport is incapable due to game state

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -23,20 +23,20 @@ public class UnitsThatCantFightUtil {
 
   // TODO Used to notify of kamikazi attacks
   Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
-    final Match<Unit> enemyAttackUnits = Match.allOf(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
+    final Predicate<Unit> enemyAttackUnits = Match.allOf(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
     final Collection<Territory> cantFight = new ArrayList<>();
     for (final Territory current : m_data.getMap()) {
       // get all owned non-combat units
       final Predicate<Unit> ownedUnitsMatch = PredicateBuilder
-          .of(Matches.unitIsInfrastructure().invert())
-          .andIf(current.isWater(), Matches.unitIsLand().invert())
+          .of(Matches.unitIsInfrastructure().negate())
+          .andIf(current.isWater(), Matches.unitIsLand().negate())
           .and(Matches.unitIsOwnedBy(player))
           .build();
       // All owned units
       final int countAllOwnedUnits = current.getUnits().countMatches(ownedUnitsMatch);
       // only noncombat units
       final Collection<Unit> nonCombatUnits =
-          current.getUnits().getMatches(ownedUnitsMatch.and(Matches.unitCanAttack(player).invert()));
+          current.getUnits().getMatches(ownedUnitsMatch.and(Matches.unitCanAttack(player).negate()));
       if (nonCombatUnits.isEmpty() || nonCombatUnits.size() != countAllOwnedUnits) {
         continue;
       }

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -23,7 +23,8 @@ public class UnitsThatCantFightUtil {
 
   // TODO Used to notify of kamikazi attacks
   Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
-    final Predicate<Unit> enemyAttackUnits = Match.allOf(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
+    final Predicate<Unit> enemyAttackUnits =
+        Match.allOf(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
     final Collection<Territory> cantFight = new ArrayList<>();
     for (final Territory current : m_data.getMap()) {
       // get all owned non-combat units

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -592,8 +593,8 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       }
       if (submerge) {
         // submerge if all air vs subs
-        final Match<Unit> seaSub = Match.allOf(Matches.unitIsSea(), Matches.unitIsSub());
-        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.unitIsAir(), Matches.unitIsDestroyer().invert());
+        final Predicate<Unit> seaSub = Match.allOf(Matches.unitIsSea(), Matches.unitIsSub());
+        final Predicate<Unit> planeNotDestroyer = Match.allOf(Matches.unitIsAir(), Matches.unitIsDestroyer().negate());
         final List<Unit> ourUnits = getOurUnits();
         final List<Unit> enemyUnits = getEnemyUnits();
         if (ourUnits == null || enemyUnits == null) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -874,7 +875,7 @@ class OddsCalculatorPanel extends JPanel {
         return u1.getName().compareTo(u2.getName());
       });
       removeAll();
-      final Match<UnitType> predicate;
+      final Predicate<UnitType> predicate;
       if (land) {
         if (defender) {
           predicate = Matches.unitTypeIsNotSea();

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -208,7 +209,7 @@ public class ExtendedStats extends StatPanel {
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       int matchCount = 0;
-      final Match<Unit> ownedBy = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut));
+      final Predicate<Unit> ownedBy = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut));
       for (final Territory place : data.getMap().getTerritories()) {
         matchCount += place.getUnits().countMatches(ownedBy);
       }

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -753,7 +753,7 @@ public class MapPanel extends ImageScrollerLargeView {
       return;
     }
     final Tuple<Integer, Integer> movementLeft =
-        TripleAUnit.getMinAndMaxMovementLeft(Matches.getMatches(units, Matches.unitIsBeingTransported().invert()));
+        TripleAUnit.getMinAndMaxMovementLeft(Matches.getMatches(units, Matches.unitIsBeingTransported().negate()));
     movementLeftForCurrentUnits =
         movementLeft.getFirst() + (movementLeft.getSecond() > movementLeft.getFirst() ? "+" : "");
     final Set<UnitCategory> categories = UnitSeperator.categorize(units);

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -5,6 +5,7 @@ import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Predicate;
 
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
@@ -135,7 +136,7 @@ public class PlacePanel extends AbstractMovePanel {
             || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
           units = Matches.getMatches(units, Matches.unitIsSea());
         } else {
-          final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(
+          final Predicate<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(
               Matches.unitIsSea(),
               Matches.unitCanLandOnCarrier());
           units = Matches.getMatches(units, unitIsSeaOrCanLandOnCarrier);

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import javax.swing.Action;
 import javax.swing.ImageIcon;
@@ -124,7 +125,7 @@ public class ProductionRepairPanel extends JPanel {
     try {
       this.id = player;
       this.allowedPlayersToRepair = allowedPlayersToRepair;
-      final Match<Unit> myDamagedUnits =
+      final Predicate<Unit> myDamagedUnits =
           Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair),
               Matches.unitHasTakenSomeBombingUnitDamage());
       final Collection<Territory> terrsWithPotentiallyDamagedUnits =

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -41,7 +42,6 @@ import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.IntegerMap;
-import games.strategy.util.Match;
 
 public class StatPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 4340684166664492498L;
@@ -478,7 +478,7 @@ public class StatPanel extends AbstractStatPanel {
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       int matchCount = 0;
-      final Match<Unit> ownedBy = Matches.unitIsOwnedBy(player);
+      final Predicate<Unit> ownedBy = Matches.unitIsOwnedBy(player);
       for (final Territory place : data.getMap().getTerritories()) {
         matchCount += place.getUnits().countMatches(ownedBy);
       }
@@ -495,7 +495,7 @@ public class StatPanel extends AbstractStatPanel {
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
-      final Match<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
+      final Predicate<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
       int tuv = 0;
       for (final Territory place : data.getMap().getTerritories()) {
         final Collection<Unit> owned = place.getUnits().getMatches(unitIsOwnedBy);

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -28,7 +29,6 @@ import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
 import games.strategy.util.IntegerMap;
-import games.strategy.util.Match;
 
 final class UnitChooser extends JPanel {
   private static final long serialVersionUID = -4667032237550267682L;
@@ -41,7 +41,7 @@ final class UnitChooser extends JPanel {
   private JButton autoSelectButton;
   private JButton selectNoneButton;
   private final UiContext uiContext;
-  private final Match<Collection<Unit>> match;
+  private final Predicate<Collection<Unit>> match;
 
   UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent,
       final boolean allowTwoHit, final UiContext uiContext) {
@@ -54,7 +54,7 @@ final class UnitChooser extends JPanel {
   }
 
   private UnitChooser(final Map<Unit, Collection<Unit>> dependent, final boolean allowMultipleHits,
-      final UiContext uiContext, final Match<Collection<Unit>> match) {
+      final UiContext uiContext, final Predicate<Collection<Unit>> match) {
     dependents = dependent;
     this.allowMultipleHits = allowMultipleHits;
     this.uiContext = uiContext;
@@ -82,7 +82,7 @@ final class UnitChooser extends JPanel {
   UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final boolean categorizeMovement,
       final boolean categorizeTransportCost, final boolean allowMultipleHits,
-      final UiContext uiContext, final Match<Collection<Unit>> match) {
+      final UiContext uiContext, final Predicate<Collection<Unit>> match) {
     this(dependent, allowMultipleHits, uiContext, match);
     createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
     layoutEntries();

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -39,10 +39,6 @@ public final class Match<T> implements Predicate<T> {
     return condition.test(value);
   }
 
-  public Match<T> invert() {
-    return Match.of(condition.negate());
-  }
-
   /**
    * Creates a new match for the specified condition.
    *
@@ -65,7 +61,7 @@ public final class Match<T> implements Predicate<T> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <T> Match<T> allOf(final Predicate<T>... matches) {
+  public static <T> Predicate<T> allOf(final Predicate<T>... matches) {
     checkNotNull(matches);
 
     return allOf(Arrays.asList(matches));
@@ -78,7 +74,7 @@ public final class Match<T> implements Predicate<T> {
    *
    * @return A new match; never {@code null}.
    */
-  public static <T> Match<T> allOf(final Collection<Predicate<T>> matches) {
+  public static <T> Predicate<T> allOf(final Collection<Predicate<T>> matches) {
     checkNotNull(matches);
 
     return Match.of(value -> matches.stream().allMatch(match -> match.test(value)));
@@ -93,7 +89,7 @@ public final class Match<T> implements Predicate<T> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <T> Match<T> anyOf(final Predicate<T>... matches) {
+  public static <T> Predicate<T> anyOf(final Predicate<T>... matches) {
     checkNotNull(matches);
 
     return anyOf(Arrays.asList(matches));
@@ -106,7 +102,7 @@ public final class Match<T> implements Predicate<T> {
    *
    * @return A new match; never {@code null}.
    */
-  public static <T> Match<T> anyOf(final Collection<? extends Predicate<T>> matches) {
+  public static <T> Predicate<T> anyOf(final Collection<? extends Predicate<T>> matches) {
     checkNotNull(matches);
 
     return Match.of(value -> matches.stream().anyMatch(match -> match.test(value)));

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -102,7 +102,7 @@ public class BattleCalculatorTest {
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 1);
   }
 
   @Test
@@ -133,7 +133,7 @@ public class BattleCalculatorTest {
     assertEquals(3, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 0);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 2);
   }
 
   @Test
@@ -174,7 +174,7 @@ public class BattleCalculatorTest {
     assertEquals(casualties.size(), 2);
     // we selected all bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 2);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 0);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 0);
   }
 
   @Test
@@ -213,7 +213,7 @@ public class BattleCalculatorTest {
     assertEquals(casualties.size(), 3);
     // we selected all bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 3);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 0);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 0);
   }
 
   @Test
@@ -246,7 +246,7 @@ public class BattleCalculatorTest {
     assertEquals(2, randomSource.getTotalRolled());
     // should be 2 fighters and 1 bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 2);
   }
 
   @Test
@@ -279,7 +279,7 @@ public class BattleCalculatorTest {
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 1);
   }
 
   @Test
@@ -309,7 +309,7 @@ public class BattleCalculatorTest {
     assertEquals(casualties.size(), 3);
     // should be 2 fighters and 1 bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 2);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 2);
   }
   // Radar AA tests removed, because "revised" does not have radar tech.
 }

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -31,18 +32,18 @@ import games.strategy.util.Match;
 
 public final class MatchesTest {
 
-  private static final Match<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
+  private static final Predicate<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
   private static final Object VALUE = new Object();
 
-  private static <T> Matcher<Match<T>> matches(final @Nullable T value) {
-    return new TypeSafeDiagnosingMatcher<Match<T>>() {
+  private static <T> Matcher<Predicate<T>> matches(final @Nullable T value) {
+    return new TypeSafeDiagnosingMatcher<Predicate<T>>() {
       @Override
       public void describeTo(final Description description) {
         description.appendText("matcher matches using ").appendValue(value);
       }
 
       @Override
-      public boolean matchesSafely(final Match<T> match, final Description description) {
+      public boolean matchesSafely(final Predicate<T> match, final Description description) {
         if (!match.test(value)) {
           description.appendText("it does not match");
           return false;
@@ -52,15 +53,15 @@ public final class MatchesTest {
     };
   }
 
-  private static <T> Matcher<Match<T>> notMatches(final @Nullable T value) {
-    return new TypeSafeDiagnosingMatcher<Match<T>>() {
+  private static <T> Matcher<Predicate<T>> notMatches(final @Nullable T value) {
+    return new TypeSafeDiagnosingMatcher<Predicate<T>>() {
       @Override
       public void describeTo(final Description description) {
         description.appendText("matcher does not match using ").appendValue(value);
       }
 
       @Override
-      public boolean matchesSafely(final Match<T> match, final Description description) {
+      public boolean matchesSafely(final Predicate<T> match, final Description description) {
         if (match.test(value)) {
           description.appendText("it matches");
           return false;
@@ -97,7 +98,7 @@ public final class MatchesTest {
 
     assertEquals(Arrays.asList(), Matches.getMatches(Arrays.asList(), Matches.always()), "empty collection");
     assertEquals(Arrays.asList(), Matches.getMatches(input, Matches.never()), "none match");
-    assertEquals(Arrays.asList(-1, 1), Matches.getMatches(input, IS_ZERO_MATCH.invert()), "some match");
+    assertEquals(Arrays.asList(-1, 1), Matches.getMatches(input, IS_ZERO_MATCH.negate()), "some match");
     assertEquals(Arrays.asList(-1, 0, 1), Matches.getMatches(input, Matches.always()), "all match");
   }
 
@@ -136,7 +137,7 @@ public final class MatchesTest {
     private PlayerID enemyPlayer;
     private Territory territory;
 
-    private Match<Territory> newMatch() {
+    private Predicate<Territory> newMatch() {
       return Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, gameData);
     }
 
@@ -222,7 +223,7 @@ public final class MatchesTest {
     private Territory landTerritory;
     private Territory seaTerritory;
 
-    private Match<Territory> newMatch() {
+    private Predicate<Territory> newMatch() {
       return Matches.territoryIsNotUnownedWater();
     }
 

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -153,7 +153,7 @@ public class WW2V3Year41Test {
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 1);
   }
 
   @Test
@@ -186,7 +186,7 @@ public class WW2V3Year41Test {
     assertEquals(casualties.size(), 3);
     // should be 1 fighter and 2 bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 2);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 1);
   }
 
   @Test
@@ -222,7 +222,7 @@ public class WW2V3Year41Test {
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 2 bombers
     assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber()), 1);
-    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().invert()), 1);
+    assertEquals(Matches.countMatches(casualties, Matches.unitIsStrategicBomber().negate()), 1);
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -79,7 +79,7 @@ public class WW2V3Year42Test {
     when(dummyPlayer.shouldBomberBomb(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     // remove the russian units
-    removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.unitCanBeDamaged().invert()));
+    removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.unitCanBeDamaged().negate()));
     // move the bomber to attack
     move(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()), new Route(germany, sz5, karrelia));
     // move an infantry to invade

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -3,12 +3,14 @@ package games.strategy.util;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.delegate.Matches;
 
 public class MatchTest {
-  private static final Match<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
+  private static final Predicate<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
 
   private static final Object VALUE = new Object();
 
@@ -28,8 +30,8 @@ public class MatchTest {
 
   @Test
   public void testInverse() {
-    assertFalse(Matches.always().invert().test(VALUE));
-    assertTrue(Matches.never().invert().test(VALUE));
+    assertFalse(Matches.always().negate().test(VALUE));
+    assertTrue(Matches.never().negate().test(VALUE));
   }
 
   @Test


### PR DESCRIPTION
This PR is part 6 of a series where usages of the Match class will slowly be replaced by the underlying Predicate.

The diff has gotten slightly larger than expected. I originally just wanted to use the interface type Predicate instead of the match implementation, but this lead to invert() returning a Predicate which could simply replaced by negate(), sorry about that I realized it too late.