### PR TITLE
Announce lobby update

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -2,6 +2,9 @@
   host: lobby.triplea-game.org
   port: 3304
   message: |
+    IMPORTANT: The Lobby will be down for some maintenance on Thursday, the 30th November 2017 at 9:00am UTC.
+    Sorry for your inconvenience.
+    
     Welcome to TripleA 1.9 - For help: http://www.triplea-game.org/help/
     No talking politics in the lobby! Take your political comments to a private game!
     Lobby Rules: https://forums.triplea-game.org/topic/4

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -3,7 +3,7 @@
   port: 3304
   message: |
     IMPORTANT: The Lobby will be down for some maintenance on Thursday, the 30th November 2017 at 9:00am UTC.
-    Sorry for your inconvenience.
+    Sorry for your inconvenience, maintenance shouldn't take longer than an hours.
     
     Welcome to TripleA 1.9 - For help: http://www.triplea-game.org/help/
     No talking politics in the lobby! Take your political comments to a private game!

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -3,7 +3,7 @@
   port: 3304
   message: |
     IMPORTANT: The Lobby will be down for some maintenance on Thursday, the 30th November 2017 at 9:00am UTC.
-    Sorry for your inconvenience, maintenance shouldn't take longer than an hours.
+    Sorry for your inconvenience, maintenance shouldn't take longer than an hour.
     
     Welcome to TripleA 1.9 - For help: http://www.triplea-game.org/help/
     No talking politics in the lobby! Take your political comments to a private game!


### PR DESCRIPTION
See https://forums.triplea-game.org/topic/398/lobby-maintenance-on-thursday-the-30th-novermber-2017

I decided to do it then because the stats for the forum show that to that time the fewest users are being active.
This is in order to verify no bugs are in the code since the latest lobby upgrade.
@prastle I'd appreciate if you could regularily remind players of this in the lobby, especially a day before this.

@ssoloff Do you have any suggestions regarding upgrading the DB scheme?
As you might recall, we created individual files to modify the db scheme on an update, and I'd like to have some sort of automated way to do it instead of just executing the SQL, so that future updates will be easier.