### PR TITLE
Clean up ForumPosterComponent

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
@@ -86,7 +86,7 @@ public abstract class AbstractForumPosterPanel extends ActionPanel {
     SwingUtilities.invokeLater(() -> {
       removeAll();
       add(actionLabel);
-      add(forumPosterComponent.layoutComponents(pbemMessagePoster, getForumPosterDelegate(), playerBridge,
+      add(forumPosterComponent.layoutComponents(pbemMessagePoster, getForumPosterDelegate(),
           tripleAFrame, hasPosted,
           allowIncludeTerritorySummary(), allowIncludeTerritoryAllPlayersSummary(), allowIncludeProductionSummary(),
           allowDiceBattleDetails(), allowDiceStatistics()));


### PR DESCRIPTION
Just a few small refactorings of `ForumPosterComponent` that I noticed could be performed recently.

#### Functional changes

None.

#### Refactoring changes

* Reduce member accessibility
* Remove unused fields
* Extract methods for component actions
* Inline Action fields
* Rename fields for consistency
* Mark fields `final` where possible
* Add missing Javadocs
* Initialize post button in constructor

#### Testing

I smoke tested this panel to ensure I could still post both a PBEM and PBF game after a turn.