### PR TITLE
Checkstyle: Fix member name violations

### DIFF
--- a/src/main/java/games/strategy/net/MessageHeader.java
+++ b/src/main/java/games/strategy/net/MessageHeader.java
@@ -6,9 +6,9 @@ import java.io.Serializable;
 // increase performance
 public class MessageHeader {
   // if null, then a broadcast
-  private final INode m_for;
-  private final Serializable m_message;
-  private final INode m_from;
+  private final INode to;
+  private final Serializable message;
+  private final INode from;
 
   /**
    * Creates a broadcast message.
@@ -19,33 +19,33 @@ public class MessageHeader {
 
   public MessageHeader(final INode to, final INode from, final Serializable message) {
     // for can be null if we are a broadcast
-    m_for = to;
+    this.to = to;
     // from can be null if the sending node doesnt know its own address
-    m_from = from;
-    m_message = message;
+    this.from = from;
+    this.message = message;
   }
 
   /**
    * null if a broadcast.
    */
   public INode getFor() {
-    return m_for;
+    return to;
   }
 
   public INode getFrom() {
-    return m_from;
+    return from;
   }
 
   public boolean isBroadcast() {
-    return m_for == null;
+    return to == null;
   }
 
   public Serializable getMessage() {
-    return m_message;
+    return message;
   }
 
   @Override
   public String toString() {
-    return "Message header. msg:" + m_message + " to:" + m_for + " from:" + m_from;
+    return "Message header. msg:" + message + " to:" + to + " from:" + from;
   }
 }

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -21,7 +21,7 @@ class SoundProperties {
   static final String GENERIC_FOLDER = "generic";
   private static SoundProperties instance = null;
   private static Instant timestamp = Instant.EPOCH;
-  private final Properties m_properties = new Properties();
+  private final Properties properties = new Properties();
 
   SoundProperties(final ResourceLoader loader) {
     final URL url = loader.getResource(PROPERTY_FILE);
@@ -29,7 +29,7 @@ class SoundProperties {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if (inputStream.isPresent()) {
         try {
-          m_properties.load(inputStream.get());
+          properties.load(inputStream.get());
         } catch (final IOException e) {
           System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
@@ -54,10 +54,10 @@ class SoundProperties {
    * @return The string property, or null if not found.
    */
   String getProperty(final String key) {
-    return m_properties.getProperty(key);
+    return properties.getProperty(key);
   }
 
   private String getProperty(final String key, final String defaultValue) {
-    return m_properties.getProperty(key, defaultValue);
+    return properties.getProperty(key, defaultValue);
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in non-serializable classes within the `g.s.net` and `g.s.sound` packages.

#### Testing

Just to be safe because I touched some core networking classes, I verified there were no issues by playing a network game with a server from this branch and a 3635 client.