### PR TITLE
Ensure transportedBy cleared for allied air units on carrier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
+    compile 'org.apache.commons:commons-collections4:4.1'
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.mindrot:jbcrypt:0.4'
     compile 'org.yaml:snakeyaml:1.18'

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -456,7 +456,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final CompositeChange clearAlliedAir = new CompositeChange();
     for (final Unit carrier : damagedCarriers) {
       final CompositeChange change = MustFightBattle.clearTransportedByForAlliedAirOnCarrier(
-          Collections.singleton(carrier), carrier.getOwner(), data);
+          Collections.singleton(carrier), fullyRepaired.get(carrier), carrier.getOwner(), data);
       if (!change.isEmpty()) {
         clearAlliedAir.add(change);
       }


### PR DESCRIPTION
Fixes #2630.

Allied air units transported as cargo on an attacking carrier are not part of the `attackingUnits` collection, and thus do not have their `transportedBy` property cleared at the end of the battle if they and their transporting carrier survive.  To ensure all applicable units have their `transportedBy` property cleared, the union of attacking units and battle site units must be used instead of just attacking units alone.

#### Testing

I used the [attached save game](https://github.com/triplea-game/triplea/files/1503248/issue-2630.zip) to verify the issue has been fixed.  After loading the save (at USA combat move step), the following actions are executed:

1. USA turn (round 1)
    1. Move carrier (with UK fighter as cargo) and fighter from SZ 52 to SZ 57.
    1. Resolve combat in SZ 57.  If USA carrier doesn't survive, restart test.
1. Wait for AI player turns to complete.
1. UK turn (round 2)
    1. Move fighter from SZ 57 to SZ 56.
    1. Resolve combat in SZ 56.

The test passes if the UK fighter participates in the combat step at (3)(ii).  I verified the test fails on `master` and passes on this branch.