### PR TITLE
Move static 'gameDataToBytes(GameData)' method to GameData

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -23,9 +23,11 @@ import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.engine.data.events.GameMapListener;
 import games.strategy.engine.data.events.TerritoryListener;
 import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.history.History;
+import games.strategy.io.IoUtils;
 import games.strategy.thread.LockUtil;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.util.Tuple;
@@ -118,6 +120,18 @@ public class GameData implements Serializable {
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
     lockUtil = LockUtil.INSTANCE;
+  }
+
+  /**
+   * Converts the current GameData object to a byte array, useful for serialization or for
+   * copying the game data.
+   */
+  public byte[] toBytes() {
+    try {
+      return IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, this));
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to write game data to bytes", e);
+    }
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
 import java.io.File;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -19,10 +18,8 @@ import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.DebugUtils;
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.GameDataFileUtils;
-import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.message.PlayerListing;
@@ -40,7 +37,6 @@ import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.MessengerException;
 import games.strategy.engine.random.CryptoRandomSource;
-import games.strategy.io.IoUtils;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
@@ -132,13 +128,7 @@ public class ServerLauncher extends AbstractLauncher {
       m_gameData.doPreGameStartDataModifications(playerListing);
       logger.fine("Starting server");
       abortLaunch = testShouldWeAbort();
-      final byte[] gameDataAsBytes;
-      try {
-        gameDataAsBytes = gameDataToBytes(m_gameData);
-      } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
-        throw new IllegalStateException(e.getMessage());
-      }
+      final byte[] gameDataAsBytes  = m_gameData.toBytes();
       final Set<IGamePlayer> localPlayerSet =
           m_gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypes());
       final Messengers messengers = new Messengers(messenger, remoteMessenger, channelMessenger);
@@ -308,10 +298,6 @@ public class ServerLauncher extends AbstractLauncher {
       return;
     }
     serverGame.addObserver(blockingObserver, nonBlockingObserver, newNode);
-  }
-
-  private static byte[] gameDataToBytes(final GameData data) throws IOException {
-    return IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
   }
 
   public void connectionLost(final INode node) {


### PR DESCRIPTION
There may be more usages out there, we can aggregate as we find them. For now we fix a 'feature envy' code smell between ServerLauncher and GameData (Serverlauncher is providing features that can be provided locally by GameData instead).

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
