### PR TITLE
Remove delayParseGameData()

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -309,8 +309,6 @@ public class GameSelectorModel extends Observable {
       try {
         selectedGame.fullyParseGameData();
       } catch (final GameParseException e) {
-        // Load real default game...
-        selectedGame.delayParseGameData();
         model.removeEntry(selectedGame);
         loadDefaultGame(true);
         return null;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -389,7 +389,6 @@ public class GameSelectorPanel extends JPanel implements Observer {
               try {
                 entry.fullyParseGameData();
               } catch (final GameParseException e) {
-                entry.delayParseGameData();
                 // TODO remove bad entries from the underlying model
                 return;
               }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -75,33 +75,6 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     }
   }
 
-  /**
-   * Do not use this if possible. Instead try to remove the bad map from the GameChooserModel.
-   * If that fails, then do a short parse so the user doesn't get a null pointer error.
-   */
-  public void delayParseGameData() {
-    gameData = null;
-
-    final AtomicReference<String> gameName = new AtomicReference<>();
-    final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-    if (!inputStream.isPresent()) {
-      return;
-    }
-    try (InputStream input = inputStream.get()) {
-      gameData = new GameParser(url.toString()).parse(input, gameName, true);
-      gameDataFullyLoaded = false;
-    } catch (final EngineVersionException e) {
-      System.out.println(e.getMessage());
-    } catch (final SAXParseException e) {
-      System.err.println(
-          "Could not parse:" + url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
-      ClientLogger.logQuietly(e);
-    } catch (final Exception e) {
-      System.err.println("Could not parse:" + url);
-      ClientLogger.logQuietly(e);
-    }
-  }
-
   public boolean isGameDataLoaded() {
     return gameDataFullyLoaded;
   }


### PR DESCRIPTION
The method is used for error handling, but appears to be unnecessary. Introducing a map parse error, it does not appear that this line makes a difference in error handling, behavior is same including this line or not.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
