### PR TITLE
Checkstyle: Fix constant name violations

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/src/main/java/games/strategy/engine/data/GameStep.java
@@ -22,20 +22,28 @@ public class GameStep extends GameDataComponent {
   private int m_runCount = 0;
   private int m_maxRunCount = -1;
   private final Properties m_properties;
-  public static final String PROPERTY_skipPosting = "skipPosting";
-  public static final String PROPERTY_turnSummaryPlayers = "turnSummaryPlayers";
-  public static final String PROPERTY_airborneMove = "airborneMove";
-  public static final String PROPERTY_combatMove = "combatMove";
-  public static final String PROPERTY_nonCombatMove = "nonCombatMove";
-  public static final String PROPERTY_fireRockets = "fireRockets";
-  public static final String PROPERTY_repairUnits = "repairUnits";
-  public static final String PROPERTY_giveBonusMovement = "giveBonusMovement";
-  public static final String PROPERTY_removeAirThatCanNotLand = "removeAirThatCanNotLand";
-  public static final String PROPERTY_resetUnitStateAtStart = "resetUnitStateAtStart";
-  public static final String PROPERTY_resetUnitStateAtEnd = "resetUnitStateAtEnd";
-  public static final String PROPERTY_bid = "bid";
-  public static final String PROPERTY_combinedTurns = "combinedTurns";
-  public static final String PROPERTY_repairPlayers = "repairPlayers";
+
+  /**
+   * The keys for all supported game step properties.
+   *
+   * @see GameStep#getProperties()
+   */
+  public interface PropertyKeys {
+    String SKIP_POSTING = "skipPosting";
+    String TURN_SUMMARY_PLAYERS = "turnSummaryPlayers";
+    String AIRBORNE_MOVE = "airborneMove";
+    String COMBAT_MOVE = "combatMove";
+    String NON_COMBAT_MOVE = "nonCombatMove";
+    String FIRE_ROCKETS = "fireRockets";
+    String REPAIR_UNITS = "repairUnits";
+    String GIVE_BONUS_MOVEMENT = "giveBonusMovement";
+    String REMOVE_AIR_THAT_CAN_NOT_LAND = "removeAirThatCanNotLand";
+    String RESET_UNIT_STATE_AT_START = "resetUnitStateAtStart";
+    String RESET_UNIT_STATE_AT_END = "resetUnitStateAtEnd";
+    String BID = "bid";
+    String COMBINED_TURNS = "combinedTurns";
+    String REPAIR_PLAYERS = "repairPlayers";
+  }
 
   /**
    * Creates new GameStep.

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -274,7 +274,7 @@ public class WeakAI extends AbstractAI {
     final Territory lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Predicate<Unit> ownedAndNotMoved = Matches.unitIsOwnedBy(player)
         .and(Matches.unitHasNotMoved())
-        .and(Transporting);
+        .and(Matches.unitIsTransporting());
     final List<Unit> unitsToMove = new ArrayList<>();
     final List<Unit> transports = firstSeaZoneOnAmphib.getUnits().getMatches(ownedAndNotMoved);
     if (transports.size() <= maxTrans) {
@@ -1064,6 +1064,4 @@ public class WeakAI extends AbstractAI {
   public boolean shouldBomberBomb(final Territory territory) {
     return true;
   }
-
-  public static final Predicate<Unit> Transporting = o -> TripleAUnit.get(o).getTransporting().size() > 0;
 }

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -22,7 +22,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       skipPosting = Boolean.parseBoolean(
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_skipPosting, "false"));
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.SKIP_POSTING, "false"));
     } finally {
       data.releaseReadLock();
     }
@@ -41,14 +41,14 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String allowedPlayers =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_turnSummaryPlayers);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.TURN_SUMMARY_PLAYERS);
       if (allowedPlayers != null) {
         allowedIDs = new HashSet<>();
         for (final String p : allowedPlayers.split(":")) {
           final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
-                + GameStep.PROPERTY_turnSummaryPlayers + " player: " + p + " DOES NOT EXIST");
+                + GameStep.PropertyKeys.TURN_SUMMARY_PLAYERS + " player: " + p + " DOES NOT EXIST");
           } else {
             allowedIDs.add(id);
           }
@@ -69,7 +69,7 @@ public class GameStepPropertiesHelper {
     final boolean isAirborneMove;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_airborneMove);
+      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.AIRBORNE_MOVE);
       if (prop != null) {
         isAirborneMove = Boolean.parseBoolean(prop);
       } else {
@@ -88,7 +88,7 @@ public class GameStepPropertiesHelper {
     final boolean isCombatMove;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_combatMove);
+      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.COMBAT_MOVE);
       if (prop != null) {
         isCombatMove = Boolean.parseBoolean(prop);
       } else if (isCombatDelegate(data)) {
@@ -111,7 +111,8 @@ public class GameStepPropertiesHelper {
     final boolean isNonCombatMove;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_nonCombatMove);
+      final String prop =
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.NON_COMBAT_MOVE);
       if (prop != null) {
         isNonCombatMove = Boolean.parseBoolean(prop);
       } else if (isNonCombatDelegate(data)) {
@@ -137,7 +138,7 @@ public class GameStepPropertiesHelper {
     final boolean isFireRockets;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_fireRockets);
+      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.FIRE_ROCKETS);
       if (prop != null) {
         isFireRockets = Boolean.parseBoolean(prop);
       } else if (Properties.getWW2V2(data) || Properties.getWW2V3(data)) {
@@ -164,7 +165,8 @@ public class GameStepPropertiesHelper {
       if (!repairAtStartAndOnlyOwn && !repairAtEndAndAll) {
         isRepairUnits = false;
       } else {
-        final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_repairUnits);
+        final String prop =
+            data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.REPAIR_UNITS);
         if (prop != null) {
           isRepairUnits = Boolean.parseBoolean(prop);
         } else {
@@ -185,7 +187,8 @@ public class GameStepPropertiesHelper {
     final boolean isBonus;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_giveBonusMovement);
+      final String prop =
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.GIVE_BONUS_MOVEMENT);
       if (prop != null) {
         isBonus = Boolean.parseBoolean(prop);
       } else {
@@ -206,7 +209,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String prop =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_removeAirThatCanNotLand);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.REMOVE_AIR_THAT_CAN_NOT_LAND);
       if (prop != null) {
         isRemoveAir = Boolean.parseBoolean(prop);
       } else if (data.getSequence().getStep().getDelegate() != null
@@ -235,7 +238,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String allowedPlayers =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_combinedTurns);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.COMBINED_TURNS);
       if (player != null) {
         allowedIDs.add(player);
       }
@@ -244,7 +247,7 @@ public class GameStepPropertiesHelper {
           final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
-                + GameStep.PROPERTY_combinedTurns + " player: " + p + " DOES NOT EXIST");
+                + GameStep.PropertyKeys.COMBINED_TURNS + " player: " + p + " DOES NOT EXIST");
           } else {
             allowedIDs.add(id);
           }
@@ -264,7 +267,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String prop =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_resetUnitStateAtStart);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.RESET_UNIT_STATE_AT_START);
       isReset = (prop != null) && Boolean.parseBoolean(prop);
     } finally {
       data.releaseReadLock();
@@ -281,7 +284,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String prop =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_resetUnitStateAtEnd);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.RESET_UNIT_STATE_AT_END);
       if (prop != null) {
         isReset = Boolean.parseBoolean(prop);
       } else {
@@ -297,7 +300,7 @@ public class GameStepPropertiesHelper {
     final boolean isBid;
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_bid);
+      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.BID);
       if (prop != null) {
         isBid = Boolean.parseBoolean(prop);
       } else {
@@ -319,7 +322,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String allowedPlayers =
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_repairPlayers);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.REPAIR_PLAYERS);
       if (player != null) {
         allowedIDs.add(player);
       }
@@ -328,7 +331,7 @@ public class GameStepPropertiesHelper {
           final PlayerID id = data.getPlayerList().getPlayerId(p);
           if (id == null) {
             System.err.println("gamePlay sequence step: " + data.getSequence().getStep().getName() + " stepProperty: "
-                + GameStep.PROPERTY_repairPlayers + " player: " + p + " DOES NOT EXIST");
+                + GameStep.PropertyKeys.REPAIR_PLAYERS + " player: " + p + " DOES NOT EXIST");
           } else {
             allowedIDs.add(id);
           }

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -46,12 +46,12 @@ public final class Util {
     return results.get();
   }
 
-  private static final Component c = new Component() {
+  private static final Component component = new Component() {
     private static final long serialVersionUID = 1800075529163275600L;
   };
 
   public static void ensureImageLoaded(final Image anImage) {
-    final MediaTracker tracker = new MediaTracker(c);
+    final MediaTracker tracker = new MediaTracker(component);
     tracker.addImage(anImage, 1);
     try {
       tracker.waitForAll();


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule.

The constants in `GameStep` looked suspiciously like they were being accessed reflectively due to the `PROPERTY_` prefix and the rest of the name being identical to the value.  However, I was unable to locate any reflective usage of these fields; they appear to simply be referenced in `GameStepPropertiesHelper`.