### PR TITLE
Avoid new processes (needs testing)

### DIFF
--- a/src/main/java/games/strategy/engine/ClientContext.java
+++ b/src/main/java/games/strategy/engine/ClientContext.java
@@ -3,6 +3,7 @@ package games.strategy.engine;
 import java.util.List;
 
 import games.strategy.engine.config.client.GameEnginePropertyReader;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.map.download.DownloadCoordinator;
 import games.strategy.engine.framework.map.download.DownloadFileDescription;
 import games.strategy.engine.framework.map.download.DownloadRunnable;
@@ -46,7 +47,7 @@ public final class ClientContext {
   private static final ClientContext instance = new ClientContext();
 
   private final GameEnginePropertyReader gameEnginePropertyReader = new GameEnginePropertyReader();
-  private final MapDownloadController mapDownloadController = new MapDownloadController();
+  private final MapDownloadController mapDownloadController = new MapDownloadController(new GameRunner());
   private final DownloadCoordinator downloadCoordinator = new DownloadCoordinator();
 
   private ClientContext() {}

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -44,6 +44,7 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.StringProperty;
 import games.strategy.engine.delegate.IDelegate;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleA;
@@ -932,9 +933,7 @@ public final class GameParser {
     if (childName.equals("boolean")) {
       editableProperty = new BooleanProperty(name, null, Boolean.valueOf(defaultValue).booleanValue());
     } else if (childName.equals("file")) {
-      // Not sure if it's safe to create a FileProperty instance using null here.
-      // Needs further digging
-      editableProperty = new FileProperty(name, null, defaultValue, null);
+      editableProperty = new FileProperty(name, null, defaultValue, new GameRunner());
     } else if (childName.equals("list") || childName.equals("combo")) {
       final StringTokenizer tokenizer = new StringTokenizer(child.getAttribute("values"), ",");
       final Collection<String> values = new ArrayList<>();

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -932,7 +932,9 @@ public final class GameParser {
     if (childName.equals("boolean")) {
       editableProperty = new BooleanProperty(name, null, Boolean.valueOf(defaultValue).booleanValue());
     } else if (childName.equals("file")) {
-      editableProperty = new FileProperty(name, null, defaultValue);
+      // Not sure if it's safe to create a FileProperty instance using null here.
+      // Needs further digging
+      editableProperty = new FileProperty(name, null, defaultValue, null);
     } else if (childName.equals("list") || childName.equals("combo")) {
       final StringTokenizer tokenizer = new StringTokenizer(child.getAttribute("values"), ",");
       final Collection<String> values = new ArrayList<>();

--- a/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -29,6 +29,7 @@ public class FileProperty extends AEditableProperty {
 
   private final String[] m_acceptableSuffixes;
   private File m_file;
+  private final GameRunner gameRunner;
 
   /**
    * Construct a new file property.
@@ -36,8 +37,8 @@ public class FileProperty extends AEditableProperty {
    * @param name - The name of the property
    * @param fileName - The name of the file to be associated with this property
    */
-  public FileProperty(final String name, final String description, final String fileName) {
-    this(name, description, getFileIfExists(new File(fileName)));
+  public FileProperty(final String name, final String description, final String fileName, final GameRunner gameRunner) {
+    this(name, description, getFileIfExists(new File(fileName)), gameRunner);
   }
 
   private static File getFileIfExists(final File file) {
@@ -48,14 +49,16 @@ public class FileProperty extends AEditableProperty {
   }
 
 
-  public FileProperty(final String name, final String description, final File file) {
-    this(name, description, file, defaultImageSuffixes);
+  public FileProperty(final String name, final String description, final File file, final GameRunner gameRunner) {
+    this(name, description, file, defaultImageSuffixes, gameRunner);
   }
 
-  public FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes) {
+  public FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes,
+      final GameRunner gameRunner) {
     super(name, description);
     m_file = getFileIfExists(file);
     m_acceptableSuffixes = acceptableSuffixes;
+    this.gameRunner = gameRunner;
   }
 
   /**
@@ -90,7 +93,7 @@ public class FileProperty extends AEditableProperty {
     label.addMouseListener(new MouseListener() {
       @Override
       public void mouseClicked(final MouseEvent e) {
-        final File selection = getFileUsingDialog(m_acceptableSuffixes);
+        final File selection = getFileUsingDialog(gameRunner, m_acceptableSuffixes);
         if (selection != null) {
           m_file = selection;
           label.setText(m_file.getAbsolutePath());
@@ -117,12 +120,12 @@ public class FileProperty extends AEditableProperty {
   /**
    * Prompts the user to select a file.
    */
-  private static File getFileUsingDialog(final String... acceptableSuffixes) {
+  private static File getFileUsingDialog(final GameRunner gameRunner, final String... acceptableSuffixes) {
     // For some strange reason,
     // the only way to get a Mac OS X native-style file dialog
     // is to use an AWT FileDialog instead of a Swing JDialog
     if (SystemProperties.isMac()) {
-      final FileDialog fileDialog = GameRunner.newFileDialog();
+      final FileDialog fileDialog = gameRunner.newFileDialog();
       fileDialog.setMode(FileDialog.LOAD);
       fileDialog.setFilenameFilter((dir, name) -> {
         if (acceptableSuffixes == null || acceptableSuffixes.length == 0) {
@@ -143,7 +146,7 @@ public class FileProperty extends AEditableProperty {
       }
       return new File(dirName, fileName);
     }
-    final Optional<File> selectedFile = GameRunner.showFileChooser(new FileFilter() {
+    final Optional<File> selectedFile = gameRunner.showFileChooser(new FileFilter() {
       @Override
       public boolean accept(final File file) {
         if (file == null) {

--- a/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import javax.swing.JComponent;
 
+import games.strategy.engine.framework.GameRunner;
+
 /**
  * Basically creates a map of other properties.
  *
@@ -23,10 +25,12 @@ public class MapProperty<T, U> extends AEditableProperty {
   private static final long serialVersionUID = -8021039503574228146L;
   private Map<T, U> m_map;
   final List<IEditableProperty> m_properties = new ArrayList<>();
+  private final transient GameRunner gameRunner;
 
-  public MapProperty(final String name, final String description, final Map<T, U> map) {
+  public MapProperty(final String name, final String description, final Map<T, U> map, final GameRunner gameRunner) {
     super(name, description);
     m_map = map;
+    this.gameRunner = gameRunner;
     resetProperties(map, m_properties, name, description);
   }
 
@@ -42,7 +46,7 @@ public class MapProperty<T, U> extends AEditableProperty {
       } else if (value instanceof Color) {
         properties.add(new ColorProperty(key, description, ((Color) value)));
       } else if (value instanceof File) {
-        properties.add(new FileProperty(key, description, ((File) value)));
+        properties.add(new FileProperty(key, description, ((File) value), gameRunner));
       } else if (value instanceof String) {
         properties.add(new StringProperty(key, description, ((String) value)));
       } else if (value instanceof Collection || value instanceof List || value instanceof Set) {

--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -60,13 +60,13 @@ public final class ArgParser {
       if (remainingArgs[0].startsWith(TRIPLEA_PROTOCOL)) {
         final String encoding = StandardCharsets.UTF_8.displayName();
         try {
-          setSystemPropertyOrClientSetting(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY,
+          setSystemPropertyOrClientSetting(CliProperties.TRIPLEA_MAP_DOWNLOAD_PROPERTY,
               URLDecoder.decode(remainingArgs[0].substring(TRIPLEA_PROTOCOL.length()), encoding));
         } catch (final UnsupportedEncodingException e) {
           throw new AssertionError(encoding + " is not a supported encoding!", e);
         }
       } else {
-        setSystemPropertyOrClientSetting(GameRunner.TRIPLEA_GAME_PROPERTY, remainingArgs[0]);
+        setSystemPropertyOrClientSetting(CliProperties.TRIPLEA_GAME_PROPERTY, remainingArgs[0]);
       }
     } else if (remainingArgs.length > 1) {
       throw new IllegalArgumentException("Too much arguments: " + Arrays.toString(remainingArgs));
@@ -120,10 +120,39 @@ public final class ArgParser {
   }
 
   private static boolean handleGameSetting(final String key, final String value) {
-    if (GameRunner.MAP_FOLDER.equals(key)) {
+    if (CliProperties.MAP_FOLDER.equals(key)) {
       ClientSetting.MAP_FOLDER_OVERRIDE.save(value);
       return true;
     }
     return false;
+  }
+
+
+  public interface CliProperties {
+    // argument options below:
+    static final String TRIPLEA_GAME_HOST_CONSOLE_PROPERTY = "triplea.game.host.console";
+    static final String TRIPLEA_GAME_PROPERTY = "triplea.game";
+    final String TRIPLEA_MAP_DOWNLOAD_PROPERTY = "triplea.map.download";
+    static final String TRIPLEA_SERVER_PROPERTY = "triplea.server";
+    static final String TRIPLEA_CLIENT_PROPERTY = "triplea.client";
+    static final String TRIPLEA_HOST_PROPERTY = "triplea.host";
+    static final String TRIPLEA_PORT_PROPERTY = "triplea.port";
+    static final String TRIPLEA_NAME_PROPERTY = "triplea.name";
+    static final String TRIPLEA_SERVER_PASSWORD_PROPERTY = "triplea.server.password";
+    static final String TRIPLEA_STARTED = "triplea.started";
+    static final String LOBBY_HOST = "triplea.lobby.host";
+    static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";
+    static final String LOBBY_GAME_HOSTED_BY = "triplea.lobby.game.hostedBy";
+    static final String LOBBY_GAME_SUPPORT_EMAIL = "triplea.lobby.game.supportEmail";
+    static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
+    static final String LOBBY_GAME_RECONNECTION = "triplea.lobby.game.reconnection";
+    static final String TRIPLEA_ENGINE_VERSION_BIN = "triplea.engine.version.bin";
+    static final String TRIPLEA_DO_NOT_CHECK_FOR_UPDATES = "triplea.doNotCheckForUpdates";
+    static final String TRIPLEA_LOBBY_PORT_PROPERTY = "triplea.lobby.port";
+
+    static final String TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME = "triplea.server.startGameSyncWaitTime";
+    static final String TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME = "triplea.server.observerJoinWaitTime";
+
+    static final String MAP_FOLDER = "mapFolder";
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -13,15 +13,12 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoField;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nullable;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -466,29 +463,25 @@ public class GameRunner {
     return img;
   }
 
-  public static void hostGame(final int port, final String playerName, final String comments, final String password,
+  public static void hostGame(
+      final int port,
+      final String playerName,
+      final String comments,
+      final String password,
       final Messengers messengers) {
-    final List<String> commands = new ArrayList<>();
-    ProcessRunnerUtil.populateBasicJavaArgs(commands);
-    commands.add("-D" + TRIPLEA_SERVER_PROPERTY + "=true");
-    commands.add("-D" + TRIPLEA_PORT_PROPERTY + "=" + port);
-    commands.add("-D" + TRIPLEA_NAME_PROPERTY + "=" + playerName);
-    commands.add("-D" + LOBBY_HOST + "="
-        + messengers.getMessenger().getRemoteServerSocketAddress().getAddress().getHostAddress());
-    commands.add("-D" + GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY + "="
-        + messengers.getMessenger().getRemoteServerSocketAddress().getPort());
-    commands.add("-D" + LOBBY_GAME_COMMENTS + "=" + comments);
-    commands.add("-D" + LOBBY_GAME_HOSTED_BY + "=" + messengers.getMessenger().getLocalNode().getName());
+    System.setProperty(TRIPLEA_SERVER_PROPERTY, String.valueOf(true));
+    System.setProperty(TRIPLEA_PORT_PROPERTY, String.valueOf(port));
+    System.setProperty(TRIPLEA_NAME_PROPERTY, playerName);
+    System.setProperty(LOBBY_HOST,
+        messengers.getMessenger().getRemoteServerSocketAddress().getAddress().getHostAddress());
+    System.setProperty(TRIPLEA_LOBBY_PORT_PROPERTY,
+        String.valueOf(messengers.getMessenger().getRemoteServerSocketAddress().getPort()));
+    System.setProperty(LOBBY_GAME_COMMENTS, comments);
+    System.setProperty(LOBBY_GAME_HOSTED_BY, messengers.getMessenger().getLocalNode().getName());
     if (password != null && password.length() > 0) {
-      commands.add("-D" + TRIPLEA_SERVER_PASSWORD_PROPERTY + "=" + password);
+      System.setProperty(TRIPLEA_SERVER_PASSWORD_PROPERTY, password);
     }
-    final String fileName = System.getProperty(TRIPLEA_GAME_PROPERTY, "");
-    if (fileName.length() > 0) {
-      commands.add("-D" + TRIPLEA_GAME_PROPERTY + "=" + fileName);
-    }
-    final String javaClass = GameRunner.class.getName();
-    commands.add(javaClass);
-    ProcessRunnerUtil.exec(commands);
+    showMainFrame();
   }
 
   public static void joinGame(final GameDescription description, final Messengers messengers, final Container parent) {
@@ -497,7 +490,6 @@ public class GameRunner {
       return;
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
-    final String newClassPath = null;
     if (!GameEngineVersion.of(ClientContext.engineVersion()).isCompatibleWithEngineVersion(engineVersionOfGameToJoin)) {
       JOptionPane.showMessageDialog(parent,
           "Host is using version " + engineVersionOfGameToJoin.toStringFull()
@@ -505,20 +497,15 @@ public class GameRunner {
           "Incompatible TripleA engine", JOptionPane.ERROR_MESSAGE);
       return;
     }
-    joinGame(description.getPort(), description.getHostedBy().getAddress().getHostAddress(), newClassPath, messengers);
+    joinGame(description.getPort(), description.getHostedBy().getAddress().getHostAddress(), messengers);
   }
 
-  private static void joinGame(final int port, final String hostAddressIp, final @Nullable String newClassPath,
-      final Messengers messengers) {
-    final List<String> commands = new ArrayList<>();
-    ProcessRunnerUtil.populateBasicJavaArgs(commands, newClassPath);
-    final String prefix = "-D";
-    commands.add(prefix + TRIPLEA_CLIENT_PROPERTY + "=true");
-    commands.add(prefix + TRIPLEA_PORT_PROPERTY + "=" + port);
-    commands.add(prefix + TRIPLEA_HOST_PROPERTY + "=" + hostAddressIp);
-    commands.add(prefix + TRIPLEA_NAME_PROPERTY + "=" + messengers.getMessenger().getLocalNode().getName());
-    commands.add(GameRunner.class.getName());
-    ProcessRunnerUtil.exec(commands);
+  private static void joinGame(final int port, final String hostAddressIp, final Messengers messengers) {
+    System.setProperty(TRIPLEA_CLIENT_PROPERTY, String.valueOf(true));
+    System.setProperty(TRIPLEA_PORT_PROPERTY, String.valueOf(port));
+    System.setProperty(TRIPLEA_HOST_PROPERTY, hostAddressIp);
+    System.setProperty(TRIPLEA_NAME_PROPERTY, messengers.getMessenger().getLocalNode().getName());
+    showMainFrame();
   }
 
 

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -218,11 +218,11 @@ public class GameRunner {
     return new BackgroundTaskRunner(mainFrame);
   }
 
-  public static GameSelectorModel getGameSelectorModel() {
+  public GameSelectorModel getGameSelectorModel() {
     return gameSelectorModel;
   }
 
-  public static SetupPanelModel getSetupPanelModel() {
+  public SetupPanelModel getSetupPanelModel() {
     return setupPanelModel;
   }
 

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -1,5 +1,28 @@
 package games.strategy.engine.framework;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_COMMENTS;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_RECONNECTION;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_SUPPORT_EMAIL;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_SUPPORT_PASSWORD;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.ArgParser.CliProperties.MAP_FOLDER;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_CLIENT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_DO_NOT_CHECK_FOR_UPDATES;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_ENGINE_VERSION_BIN;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_GAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_HOST_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_LOBBY_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_MAP_DOWNLOAD_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_NAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PASSWORD_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_STARTED;
+
 import java.awt.AWTEvent;
 import java.awt.Container;
 import java.awt.EventQueue;
@@ -64,7 +87,6 @@ import games.strategy.util.Version;
 public class GameRunner {
 
   public static final String TRIPLEA_HEADLESS = "triplea.headless";
-  public static final String TRIPLEA_GAME_HOST_CONSOLE_PROPERTY = "triplea.game.host.console";
   public static final int LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM = 21600;
   public static final int LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT = 2 * LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM;
   public static final String NO_REMOTE_REQUESTS_ALLOWED = "noRemoteRequestsAllowed";
@@ -73,32 +95,8 @@ public class GameRunner {
   public static final int PORT = 3300;
   // do not include this in the getProperties list. they are only for loading an old savegame.
   public static final String OLD_EXTENSION = ".old";
-  // argument options below:
-  public static final String TRIPLEA_GAME_PROPERTY = "triplea.game";
-  static final String TRIPLEA_MAP_DOWNLOAD_PROPERTY = "triplea.map.download";
-  public static final String TRIPLEA_SERVER_PROPERTY = "triplea.server";
-  public static final String TRIPLEA_CLIENT_PROPERTY = "triplea.client";
-  public static final String TRIPLEA_HOST_PROPERTY = "triplea.host";
-  public static final String TRIPLEA_PORT_PROPERTY = "triplea.port";
-  public static final String TRIPLEA_NAME_PROPERTY = "triplea.name";
-  public static final String TRIPLEA_SERVER_PASSWORD_PROPERTY = "triplea.server.password";
-  public static final String TRIPLEA_STARTED = "triplea.started";
-  public static final String LOBBY_HOST = "triplea.lobby.host";
-  public static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";
-  public static final String LOBBY_GAME_HOSTED_BY = "triplea.lobby.game.hostedBy";
-  public static final String LOBBY_GAME_SUPPORT_EMAIL = "triplea.lobby.game.supportEmail";
-  public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
-  public static final String LOBBY_GAME_RECONNECTION = "triplea.lobby.game.reconnection";
-  static final String TRIPLEA_ENGINE_VERSION_BIN = "triplea.engine.version.bin";
-  private static final String TRIPLEA_DO_NOT_CHECK_FOR_UPDATES = "triplea.doNotCheckForUpdates";
-  public static final String TRIPLEA_LOBBY_PORT_PROPERTY = "triplea.lobby.port";
 
-  public static final String TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME = "triplea.server.startGameSyncWaitTime";
-  public static final String TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME = "triplea.server.observerJoinWaitTime";
   public static final int MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME = 20;
-
-  public static final String MAP_FOLDER = "mapFolder";
-
 
   private static final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private static final SetupPanelModel setupPanelModel = new SetupPanelModel(gameSelectorModel);
@@ -272,9 +270,9 @@ public class GameRunner {
 
       loadGame();
 
-      if (System.getProperty(GameRunner.TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {
+      if (System.getProperty(TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {
         setupPanelModel.showServer(mainFrame);
-      } else if (System.getProperty(GameRunner.TRIPLEA_CLIENT_PROPERTY, "false").equals("true")) {
+      } else if (System.getProperty(TRIPLEA_CLIENT_PROPERTY, "false").equals("true")) {
         setupPanelModel.showClient(mainFrame);
       }
     });
@@ -284,12 +282,12 @@ public class GameRunner {
     try {
       newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
         gameSelectorModel.loadDefaultGame(false);
-        final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
+        final String fileName = System.getProperty(TRIPLEA_GAME_PROPERTY, "");
         if (fileName.length() > 0) {
           gameSelectorModel.load(new File(fileName), mainFrame);
         }
 
-        final String downloadableMap = System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY, "");
+        final String downloadableMap = System.getProperty(TRIPLEA_MAP_DOWNLOAD_PROPERTY, "");
         if (!downloadableMap.isEmpty()) {
           SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(downloadableMap));
         }

--- a/src/main/java/games/strategy/engine/framework/GameRunnerContext.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunnerContext.java
@@ -1,0 +1,65 @@
+package games.strategy.engine.framework;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.*;
+
+public class GameRunnerContext {
+
+  private final Map<String, String> properties = new HashMap<>();
+
+  /**
+   * Gets the property indicated by the specified key.
+   *
+   * @param key the name of the property.
+   * @return the string value of the property,
+   *         or <code>null</code> if there is no property with that key.
+   * 
+   * @exception NullPointerException if <code>key</code> is
+   *            <code>null</code>.
+   * @exception IllegalArgumentException if <code>key</code> is empty.
+   */
+  public String getProperty(final String key) {
+    checkNotNull(key);
+    checkArgument(!key.isEmpty());
+    return properties.get(key);
+  }
+
+  /**
+   * Gets the property indicated by the specified key.
+   *
+   * @param key the name of the property.
+   * @param def a default value.
+   * @return the string value of the property,
+   *         or <code>null</code> if there is no property with that key.
+   * 
+   * @exception NullPointerException if <code>key</code> is
+   *            <code>null</code>.
+   * @exception IllegalArgumentException if <code>key</code> is empty.
+   */
+  public String getProperty(final String key, final String defaultValue) {
+    checkNotNull(key);
+    checkArgument(!key.isEmpty());
+    return properties.getOrDefault(key, defaultValue);
+  }
+
+  /**
+   * Sets the property indicated by the specified key.
+   * 
+   * @param key the name of the property.
+   * @param value the value of the property.
+   * @return the previous value of the property,
+   *         or <code>null</code> if it did not have one.
+   * 
+   * @exception NullPointerException if <code>key</code> or
+   *            <code>value</code> is <code>null</code>.
+   * @exception IllegalArgumentException if <code>key</code> is empty.
+   */
+  public String setProperty(final String key, final String value) {
+    checkNotNull(key);
+    checkNotNull(value);
+    checkArgument(!key.isEmpty());
+    return properties.put(key, value);
+  }
+}

--- a/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.framework;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_ENGINE_VERSION_BIN;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,12 +63,12 @@ public class ProcessRunnerUtil {
         commands.add("-Xdock:icon=" + icons.getAbsolutePath() + "");
       }
     }
-    final String version = System.getProperty(GameRunner.TRIPLEA_ENGINE_VERSION_BIN);
+    final String version = System.getProperty(TRIPLEA_ENGINE_VERSION_BIN);
     if (version != null && version.length() > 0) {
       final Version testVersion;
       try {
         testVersion = new Version(version);
-        commands.add("-D" + GameRunner.TRIPLEA_ENGINE_VERSION_BIN + "=" + testVersion.toString());
+        commands.add("-D" + TRIPLEA_ENGINE_VERSION_BIN + "=" + testVersion.toString());
       } catch (final Exception e) {
         // nothing
       }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -402,6 +402,8 @@ public class HeadlessGameServer {
 
   private HeadlessGameServer() {
     super();
+    final GameRunner gameRunner = new GameRunner();
+    // We should really avoid this dependency here!
     if (instance != null) {
       throw new IllegalStateException("Instance already exists");
     }
@@ -411,7 +413,7 @@ public class HeadlessGameServer {
       shutdown();
     }));
     m_availableGames = new AvailableGames();
-    m_gameSelectorModel = new GameSelectorModel();
+    m_gameSelectorModel = new GameSelectorModel(gameRunner);
     final String fileName = System.getProperty(TRIPLEA_GAME_PROPERTY, "");
     if (fileName.length() > 0) {
       try {
@@ -423,7 +425,7 @@ public class HeadlessGameServer {
     }
     new Thread(() -> {
       System.out.println("Headless Start");
-      m_setupPanelModel = new HeadlessServerSetupPanelModel(m_gameSelectorModel, null);
+      m_setupPanelModel = new HeadlessServerSetupPanelModel(m_gameSelectorModel, null, gameRunner);
       m_setupPanelModel.showSelectType();
       System.out.println("Waiting for users to connect.");
       waitForUsersHeadless();

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -1,5 +1,21 @@
 package games.strategy.engine.framework.headlessGameServer;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_COMMENTS;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_RECONNECTION;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_SUPPORT_EMAIL;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_SUPPORT_PASSWORD;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.ArgParser.CliProperties.MAP_FOLDER;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_GAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_LOBBY_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_NAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME;
+
 import java.io.File;
 import java.io.InputStream;
 import java.time.Duration;
@@ -165,17 +181,17 @@ public class HeadlessGameServer {
   }
 
   public String getSalt() {
-    final String encryptedPassword = MD5Crypt.crypt(System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, ""));
+    final String encryptedPassword = MD5Crypt.crypt(System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, ""));
     final String salt = MD5Crypt.getSalt(MD5Crypt.MAGIC, encryptedPassword);
     return salt;
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
@@ -189,11 +205,11 @@ public class HeadlessGameServer {
   }
 
   public String remoteStopGame(final String hashedPassword, final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final ServerGame serverGame = m_iGame;
@@ -217,11 +233,11 @@ public class HeadlessGameServer {
   }
 
   public String remoteGetChatLog(final String hashedPassword, final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final IChatPanel chat = getServerModel().getChatPanel();
@@ -236,11 +252,11 @@ public class HeadlessGameServer {
 
   public String remoteMutePlayer(final String playerName, final int minutes, final String hashedPassword,
       final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     // (48 hours max)
     final Instant expire = Instant.now().plus(Duration.ofMinutes(Math.min(60 * 24 * 2, minutes)));
@@ -281,11 +297,11 @@ public class HeadlessGameServer {
   }
 
   public String remoteBootPlayer(final String playerName, final String hashedPassword, final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
@@ -320,11 +336,11 @@ public class HeadlessGameServer {
 
   public String remoteBanPlayer(final String playerName, final int hours, final String hashedPassword,
       final String salt) {
-    final String password = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(GameRunner.NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
-    final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
+    final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     // milliseconds (30 days max)
     final Instant expire = Instant.now().plus(Duration.ofHours(Math.min(24 * 30, hours)));
@@ -396,7 +412,7 @@ public class HeadlessGameServer {
     }));
     m_availableGames = new AvailableGames();
     m_gameSelectorModel = new GameSelectorModel();
-    final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
+    final String fileName = System.getProperty(TRIPLEA_GAME_PROPERTY, "");
     if (fileName.length() > 0) {
       try {
         final File file = new File(fileName);
@@ -415,7 +431,7 @@ public class HeadlessGameServer {
 
     int reconnect;
     try {
-      final String reconnectionSeconds = System.getProperty(GameRunner.LOBBY_GAME_RECONNECTION,
+      final String reconnectionSeconds = System.getProperty(LOBBY_GAME_RECONNECTION,
           "" + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT);
       reconnect =
           Math.max(Integer.parseInt(reconnectionSeconds), GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM);
@@ -459,9 +475,9 @@ public class HeadlessGameServer {
 
   public static void resetLobbyHostOldExtensionProperties() {
     for (final String property : getProperties()) {
-      if (GameRunner.LOBBY_HOST.equals(property)
-          || GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY.equals(property)
-          || GameRunner.LOBBY_GAME_HOSTED_BY.equals(property)) {
+      if (LOBBY_HOST.equals(property)
+          || TRIPLEA_LOBBY_PORT_PROPERTY.equals(property)
+          || LOBBY_GAME_HOSTED_BY.equals(property)) {
         // for these 3 properties, we clear them after hosting, but back them up.
         final String oldValue = System.getProperty(property + GameRunner.OLD_EXTENSION);
         if (oldValue != null) {
@@ -472,13 +488,13 @@ public class HeadlessGameServer {
   }
 
   private static Set<String> getProperties() {
-    return new HashSet<>(Arrays.asList(GameRunner.TRIPLEA_GAME_PROPERTY, GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY,
-        GameRunner.TRIPLEA_SERVER_PROPERTY, GameRunner.TRIPLEA_PORT_PROPERTY,
-        GameRunner.TRIPLEA_NAME_PROPERTY, GameRunner.LOBBY_HOST, GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY,
-        GameRunner.LOBBY_GAME_COMMENTS, GameRunner.LOBBY_GAME_HOSTED_BY, GameRunner.LOBBY_GAME_SUPPORT_EMAIL,
-        GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, GameRunner.LOBBY_GAME_RECONNECTION,
-        GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME, GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
-        GameRunner.MAP_FOLDER));
+    return new HashSet<>(Arrays.asList(TRIPLEA_GAME_PROPERTY, TRIPLEA_GAME_HOST_CONSOLE_PROPERTY,
+        TRIPLEA_SERVER_PROPERTY, TRIPLEA_PORT_PROPERTY,
+        TRIPLEA_NAME_PROPERTY, LOBBY_HOST, TRIPLEA_LOBBY_PORT_PROPERTY,
+        LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY, LOBBY_GAME_SUPPORT_EMAIL,
+        LOBBY_GAME_SUPPORT_PASSWORD, LOBBY_GAME_RECONNECTION,
+        TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME, TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
+        MAP_FOLDER));
   }
 
   String getStatus() {
@@ -669,24 +685,24 @@ public class HeadlessGameServer {
   private static void usage() {
     // TODO replace this method with the generated usage of commons-cli
     System.out.println("\nUsage and Valid Arguments:\n"
-        + "   " + GameRunner.TRIPLEA_GAME_PROPERTY + "=<FILE_NAME>\n"
-        + "   " + GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY + "=<true/false>\n"
-        + "   " + GameRunner.TRIPLEA_SERVER_PROPERTY + "=true\n"
-        + "   " + GameRunner.TRIPLEA_PORT_PROPERTY + "=<PORT>\n"
-        + "   " + GameRunner.TRIPLEA_NAME_PROPERTY + "=<PLAYER_NAME>\n"
-        + "   " + GameRunner.LOBBY_HOST + "=<LOBBY_HOST>\n"
-        + "   " + GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY + "=<LOBBY_PORT>\n"
-        + "   " + GameRunner.LOBBY_GAME_COMMENTS + "=<LOBBY_GAME_COMMENTS>\n"
-        + "   " + GameRunner.LOBBY_GAME_HOSTED_BY + "=<LOBBY_GAME_HOSTED_BY>\n"
-        + "   " + GameRunner.LOBBY_GAME_SUPPORT_EMAIL + "=<youremail@emailprovider.com>\n"
-        + "   " + GameRunner.LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
-        + "   " + GameRunner.LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
+        + "   " + TRIPLEA_GAME_PROPERTY + "=<FILE_NAME>\n"
+        + "   " + TRIPLEA_GAME_HOST_CONSOLE_PROPERTY + "=<true/false>\n"
+        + "   " + TRIPLEA_SERVER_PROPERTY + "=true\n"
+        + "   " + TRIPLEA_PORT_PROPERTY + "=<PORT>\n"
+        + "   " + TRIPLEA_NAME_PROPERTY + "=<PLAYER_NAME>\n"
+        + "   " + LOBBY_HOST + "=<LOBBY_HOST>\n"
+        + "   " + TRIPLEA_LOBBY_PORT_PROPERTY + "=<LOBBY_PORT>\n"
+        + "   " + LOBBY_GAME_COMMENTS + "=<LOBBY_GAME_COMMENTS>\n"
+        + "   " + LOBBY_GAME_HOSTED_BY + "=<LOBBY_GAME_HOSTED_BY>\n"
+        + "   " + LOBBY_GAME_SUPPORT_EMAIL + "=<youremail@emailprovider.com>\n"
+        + "   " + LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
+        + "   " + LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
         + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
-        + "   " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME
+        + "   " + TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME
         + "=<seconds to wait for all clients to start the game>\n"
-        + "   " + GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME
+        + "   " + TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME
         + "=<seconds to wait for an observer joining the game>\n"
-        + "   " + GameRunner.MAP_FOLDER + "=mapFolder"
+        + "   " + MAP_FOLDER + "=mapFolder"
         + "\n"
         + "   You must start the Name and HostedBy with \"Bot\".\n"
         + "   Game Comments must have this string in it: \"automated_host\".\n"
@@ -701,43 +717,43 @@ public class HeadlessGameServer {
 
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
-    final String playerName = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY, "");
-    final String hostName = System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, "");
+    final String playerName = System.getProperty(TRIPLEA_NAME_PROPERTY, "");
+    final String hostName = System.getProperty(LOBBY_GAME_HOSTED_BY, "");
     if (playerName.length() < 7 || hostName.length() < 7 || !hostName.equals(playerName)
         || !playerName.startsWith("Bot") || !hostName.startsWith("Bot")) {
       System.out.println(
-          "Invalid argument: " + GameRunner.TRIPLEA_NAME_PROPERTY + " and " + GameRunner.LOBBY_GAME_HOSTED_BY
+          "Invalid argument: " + TRIPLEA_NAME_PROPERTY + " and " + LOBBY_GAME_HOSTED_BY
               + " must start with \"Bot\" and be at least 7 characters long and be the same.");
       printUsage = true;
     }
 
-    final String comments = System.getProperty(GameRunner.LOBBY_GAME_COMMENTS, "");
+    final String comments = System.getProperty(LOBBY_GAME_COMMENTS, "");
     if (!comments.contains("automated_host")) {
       System.out.println(
-          "Invalid argument: " + GameRunner.LOBBY_GAME_COMMENTS + " must contain the string \"automated_host\".");
+          "Invalid argument: " + LOBBY_GAME_COMMENTS + " must contain the string \"automated_host\".");
       printUsage = true;
     }
 
-    final String email = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_EMAIL, "");
+    final String email = System.getProperty(LOBBY_GAME_SUPPORT_EMAIL, "");
     if (email.length() < 3 || !Util.isMailValid(email)) {
       System.out.println(
-          "Invalid argument: " + GameRunner.LOBBY_GAME_SUPPORT_EMAIL + " must contain a valid email address.");
+          "Invalid argument: " + LOBBY_GAME_SUPPORT_EMAIL + " must contain a valid email address.");
       printUsage = true;
     }
 
-    final String reconnection = System.getProperty(GameRunner.LOBBY_GAME_RECONNECTION,
+    final String reconnection = System.getProperty(LOBBY_GAME_RECONNECTION,
         "" + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT);
     try {
       final int reconnect = Integer.parseInt(reconnection);
       if (reconnect < GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM) {
-        System.out.println("Invalid argument: " + GameRunner.LOBBY_GAME_RECONNECTION
+        System.out.println("Invalid argument: " + LOBBY_GAME_RECONNECTION
             + " must be an integer equal to or greater than " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM
             + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT
             + " or " + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");
         printUsage = true;
       }
     } catch (final NumberFormatException e) {
-      System.out.println("Invalid argument: " + GameRunner.LOBBY_GAME_RECONNECTION
+      System.out.println("Invalid argument: " + LOBBY_GAME_RECONNECTION
           + " must be an integer equal to or greater than " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM
           + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT + " or "
           + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.headlessGameServer;
 
 import java.awt.Component;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
@@ -13,8 +14,9 @@ import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 public class HeadlessServerSetupPanelModel extends SetupPanelModel {
   protected final Component m_ui;
 
-  public HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel, final Component ui) {
-    super(gameSelectorModel);
+  public HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel, final Component ui,
+      final GameRunner gameRunner) {
+    super(gameSelectorModel, gameRunner);
     m_ui = ui;
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -61,10 +61,10 @@ public class DownloadMapsWindow extends JFrame {
    *
    * @throws IllegalStateException If this method is not called from the EDT.
    */
-  public static void showDownloadMapsWindow() {
+  public static void showDownloadMapsWindow(final GameRunner gameRunner) {
     checkState(SwingUtilities.isEventDispatchThread());
 
-    showDownloadMapsWindowAndDownload(Collections.emptyList());
+    showDownloadMapsWindowAndDownload(Collections.emptyList(), gameRunner);
   }
 
   /**
@@ -78,11 +78,11 @@ public class DownloadMapsWindow extends JFrame {
    *
    * @throws IllegalStateException If this method is not called from the EDT.
    */
-  public static void showDownloadMapsWindowAndDownload(final String mapName) {
+  public static void showDownloadMapsWindowAndDownload(final String mapName, final GameRunner gameRunner) {
     checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(mapName);
 
-    showDownloadMapsWindowAndDownload(Collections.singletonList(mapName));
+    showDownloadMapsWindowAndDownload(Collections.singletonList(mapName), gameRunner);
   }
 
   /**
@@ -96,11 +96,11 @@ public class DownloadMapsWindow extends JFrame {
    *
    * @throws IllegalStateException If this method is not called from the EDT.
    */
-  public static void showDownloadMapsWindowAndDownload(final Collection<String> mapNames) {
+  public static void showDownloadMapsWindowAndDownload(final Collection<String> mapNames, final GameRunner gameRunner) {
     checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(mapNames);
 
-    SINGLETON_MANAGER.showAndDownload(mapNames);
+    SINGLETON_MANAGER.showAndDownload(mapNames, gameRunner);
   }
 
   private static final class SingletonManager {
@@ -122,12 +122,12 @@ public class DownloadMapsWindow extends JFrame {
       window = null;
     }
 
-    void showAndDownload(final Collection<String> mapNames) {
+    void showAndDownload(final Collection<String> mapNames, final GameRunner gameRunner) {
       assert SwingUtilities.isEventDispatchThread();
 
       switch (state) {
         case UNINITIALIZED:
-          initialize(mapNames);
+          initialize(mapNames, gameRunner);
           break;
 
         case INITIALIZING:
@@ -145,13 +145,13 @@ public class DownloadMapsWindow extends JFrame {
       }
     }
 
-    private void initialize(final Collection<String> mapNames) {
+    private void initialize(final Collection<String> mapNames, final GameRunner gameRunner) {
       assert SwingUtilities.isEventDispatchThread();
       assert state == State.UNINITIALIZED;
 
       state = State.INITIALIZING;
       try {
-        final List<DownloadFileDescription> downloads = GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
+        final List<DownloadFileDescription> downloads = gameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
             "Downloading list of available maps...",
             ClientContext::getMapDownloadList);
         createAndShow(mapNames, downloads);

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -16,6 +16,7 @@ import com.google.common.base.Strings;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingComponents;
@@ -24,7 +25,11 @@ import games.strategy.util.Version;
 /** Controller for in-game map download actions. */
 public class MapDownloadController {
 
-  public MapDownloadController() {}
+  private final GameRunner gameRunner;
+
+  public MapDownloadController(final GameRunner gameRunner) {
+    this.gameRunner = gameRunner;
+  }
 
   /**
    * Return true if all locally downloaded maps are latest versions, false if any can are out of date or their version
@@ -59,7 +64,7 @@ public class MapDownloadController {
         }
         text.append("</ul></html>");
         SwingComponents.promptUser("Update Your Maps?", text.toString(),
-            () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(outOfDateMapNames));
+            () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(outOfDateMapNames, gameRunner));
         return true;
       }
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameToSaveGameClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameToSaveGameClientAction.java
@@ -5,6 +5,7 @@ import java.io.File;
 
 import javax.swing.AbstractAction;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.GameSelectorPanel;
 import games.strategy.net.IClientMessenger;
 
@@ -14,15 +15,17 @@ import games.strategy.net.IClientMessenger;
 public class ChangeGameToSaveGameClientAction extends AbstractAction {
   private static final long serialVersionUID = -6986376382381381377L;
   private final IClientMessenger clientMessenger;
+  private final GameRunner gameRunner;
 
-  public ChangeGameToSaveGameClientAction(final IClientMessenger clientMessenger) {
+  public ChangeGameToSaveGameClientAction(final IClientMessenger clientMessenger, final GameRunner gameRunner) {
     super("Change To Gamesave (Load Game)");
     this.clientMessenger = clientMessenger;
+    this.gameRunner = gameRunner;
   }
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    final File file = GameSelectorPanel.selectGameFile();
+    final File file = GameSelectorPanel.selectGameFile(gameRunner);
     if (file == null || !file.exists()) {
       return;
     }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -81,6 +81,7 @@ public class ClientModel implements IMessengerErrorListener {
   private final GameObjectStreamFactory objectStreamFactory = new GameObjectStreamFactory(null);
   private final GameSelectorModel gameSelectorModel;
   private final SetupPanelModel typePanelModel;
+  private final GameRunner gameRunner;
   private final WaitWindow gameLoadingWindow = new WaitWindow();
   private IRemoteModelListener listener = IRemoteModelListener.NULL_LISTENER;
   private IChannelMessenger channelMessenger;
@@ -128,7 +129,7 @@ public class ClientModel implements IMessengerErrorListener {
     @Override
     public void gameReset() {
       objectStreamFactory.setData(null);
-      SwingAction.invokeAndWait(GameRunner::showMainFrame);
+      SwingAction.invokeAndWait(gameRunner::showMainFrame);
     }
 
     @Override
@@ -143,9 +144,11 @@ public class ClientModel implements IMessengerErrorListener {
     }
   };
 
-  public ClientModel(final GameSelectorModel gameSelectorModel, final SetupPanelModel typePanelModel) {
+  public ClientModel(final GameSelectorModel gameSelectorModel, final SetupPanelModel typePanelModel,
+      final GameRunner gameRunner) {
     this.typePanelModel = typePanelModel;
     this.gameSelectorModel = gameSelectorModel;
+    this.gameRunner = gameRunner;
   }
 
   public void setRemoteModelListener(@Nonnull final IRemoteModelListener listener) {
@@ -345,7 +348,7 @@ public class ClientModel implements IMessengerErrorListener {
             gameLoadingWindow.doneWait();
             // an ugly hack, we need a better
             // way to get the main frame
-            GameRunner.clientLeftGame();
+            gameRunner.clientLeftGame();
           }
         }
         if (!gameRunning) {
@@ -395,13 +398,15 @@ public class ClientModel implements IMessengerErrorListener {
 
   /**
    * Returns a map of player node name -> enabled.
-   */  public synchronized Map<String, Boolean> getPlayersEnabledListing() {
+   */
+  public synchronized Map<String, Boolean> getPlayersEnabledListing() {
     return new HashMap<>(playersEnabledListing);
   }
 
   /**
    * Returns the set of players that can be disabled.
-   */  public synchronized Collection<String> getPlayersAllowedToBeDisabled() {
+   */
+  public synchronized Collection<String> getPlayersAllowedToBeDisabled() {
     return new HashSet<>(playersAllowedToBeDisabled);
   }
 
@@ -422,7 +427,7 @@ public class ClientModel implements IMessengerErrorListener {
   public void messengerInvalid(final IMessenger messenger, final Exception reason) {
     // The self chat disconnect notification is simply so we have an on-screen notification of the disconnect.
     // In case for example there are many game windows open, it may not be clear which game disconnected.
-    GameRunner.getChat().sendMessage("*** Was Disconnected ***", false);
+    gameRunner.getChat().sendMessage("*** Was Disconnected ***", false);
     EventThreadJOptionPane.showMessageDialog(ui, "Connection to game host lost.\nPlease save and restart.",
         "Connection Lost!", JOptionPane.ERROR_MESSAGE);
   }
@@ -454,7 +459,7 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   public Action getHostBotChangeGameToSaveGameClientAction() {
-    return new ChangeGameToSaveGameClientAction(getMessenger());
+    return new ChangeGameToSaveGameClientAction(getMessenger(), gameRunner);
   }
 
   public Action getHostBotChangeToAutosaveClientAction(final Component parent,

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -1,5 +1,12 @@
 package games.strategy.engine.framework.startup.mc;
 
+
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_CLIENT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_HOST_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_NAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_STARTED;
+
 import java.awt.Component;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -146,13 +153,13 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   private static ClientProps getProps(final Component ui) {
-    if (System.getProperties().getProperty(GameRunner.TRIPLEA_CLIENT_PROPERTY, "false").equals("true")
-        && System.getProperties().getProperty(GameRunner.TRIPLEA_STARTED, "").equals("")) {
+    if (System.getProperties().getProperty(TRIPLEA_CLIENT_PROPERTY, "false").equals("true")
+        && System.getProperties().getProperty(TRIPLEA_STARTED, "").equals("")) {
       final ClientProps props = new ClientProps();
-      props.setHost(System.getProperty(GameRunner.TRIPLEA_HOST_PROPERTY));
-      props.setName(System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY));
-      props.setPort(Integer.parseInt(System.getProperty(GameRunner.TRIPLEA_PORT_PROPERTY)));
-      System.setProperty(GameRunner.TRIPLEA_STARTED, "true");
+      props.setHost(System.getProperty(TRIPLEA_HOST_PROPERTY));
+      props.setName(System.getProperty(TRIPLEA_NAME_PROPERTY));
+      props.setPort(Integer.parseInt(System.getProperty(TRIPLEA_PORT_PROPERTY)));
+      System.setProperty(TRIPLEA_STARTED, "true");
       return props;
     }
     // load in the saved name!

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -19,6 +19,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameDataManager;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.engine.framework.ui.GameChooserModel;
 import games.strategy.triplea.ai.proAI.ProAI;
@@ -40,10 +41,12 @@ public class GameSelectorModel extends Observable {
   // just for host bots, so we can get the actions for loading/saving games on the bots
   // from this model
   private ClientModel m_clientModelForHostBots = null;
+  private GameRunner gameRunner;
 
-  public GameSelectorModel() {
+  public GameSelectorModel(final GameRunner gameRunner) {
     setGameData(null);
     m_fileName = "";
+    this.gameRunner = gameRunner;
   }
 
   public void resetGameDataToNull() {
@@ -294,7 +297,7 @@ public class GameSelectorModel extends Observable {
     }
     final String userPreferredDefaultGameName = ClientSetting.DEFAULT_GAME_NAME_PREF.value();
 
-    final GameChooserModel model = new GameChooserModel();
+    final GameChooserModel model = new GameChooserModel(gameRunner);
     GameChooserEntry selectedGame = model.findByName(userPreferredDefaultGameName);
     if (selectedGame == null) {
       selectedGame = model.findByName(userPreferredDefaultGameName);

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -1,5 +1,11 @@
 package games.strategy.engine.framework.startup.mc;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_NAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PASSWORD_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_STARTED;
+
 import java.awt.Component;
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -193,15 +199,15 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
   }
 
   private ServerConnectionProps getServerProps(final Component ui) {
-    if (System.getProperties().getProperty(GameRunner.TRIPLEA_SERVER_PROPERTY, "false").equals("true")
-        && System.getProperties().getProperty(GameRunner.TRIPLEA_STARTED, "").equals("")) {
+    if (System.getProperties().getProperty(TRIPLEA_SERVER_PROPERTY, "false").equals("true")
+        && System.getProperties().getProperty(TRIPLEA_STARTED, "").equals("")) {
       final ServerConnectionProps props = new ServerConnectionProps();
-      props.setName(System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY));
-      props.setPort(Integer.parseInt(System.getProperty(GameRunner.TRIPLEA_PORT_PROPERTY)));
-      if (System.getProperty(GameRunner.TRIPLEA_SERVER_PASSWORD_PROPERTY) != null) {
-        props.setPassword(System.getProperty(GameRunner.TRIPLEA_SERVER_PASSWORD_PROPERTY));
+      props.setName(System.getProperty(TRIPLEA_NAME_PROPERTY));
+      props.setPort(Integer.parseInt(System.getProperty(TRIPLEA_PORT_PROPERTY)));
+      if (System.getProperty(TRIPLEA_SERVER_PASSWORD_PROPERTY) != null) {
+        props.setPassword(System.getProperty(TRIPLEA_SERVER_PASSWORD_PROPERTY));
       }
-      System.setProperty(GameRunner.TRIPLEA_STARTED, "true");
+      System.setProperty(TRIPLEA_STARTED, "true");
       return props;
     }
     final String playername = ClientSetting.PLAYER_NAME.value();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -110,11 +110,11 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
   private CountDownLatch removeConnectionsLatch = null;
   private final Observer gameSelectorObserver = (observable, value) -> gameDataChanged();
 
-  public ServerModel(final ServerConnectionProps props) {
-    this(GameRunner.getGameSelectorModel(),
-        GameRunner.getSetupPanelModel(),
+  public ServerModel(final ServerConnectionProps props, final GameRunner gameRunner) {
+    this(gameRunner.getGameSelectorModel(),
+        gameRunner.getSetupPanelModel(),
         ServerModel.InteractionMode.SWING_CLIENT_UI);
-    GameRunner.getSetupPanelModel().setServerMode(this, props);
+    gameRunner.getSetupPanelModel().setServerMode(this, props);
   }
 
   ServerModel(final GameSelectorModel gameSelectorModel, final SetupPanelModel typePanelModel) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -9,6 +9,7 @@ import javax.swing.JPanel;
 
 import com.google.common.base.Preconditions;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.ClientSetupPanel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
 import games.strategy.engine.framework.startup.ui.LocalSetupPanel;
@@ -19,9 +20,11 @@ import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 public class SetupPanelModel extends Observable {
   protected final GameSelectorModel gameSelectorModel;
   protected ISetupPanel panel = null;
+  private final GameRunner gameRunner;
 
-  public SetupPanelModel(final GameSelectorModel gameSelectorModel) {
+  public SetupPanelModel(final GameSelectorModel gameSelectorModel, final GameRunner gameRunner) {
     this.gameSelectorModel = gameSelectorModel;
+    this.gameRunner = gameRunner;
   }
 
   public GameSelectorModel getGameSelectorModel() {
@@ -35,7 +38,7 @@ public class SetupPanelModel extends Observable {
   }
 
   public void showSelectType() {
-    setGameTypePanel(new MetaSetupPanel(this));
+    setGameTypePanel(new MetaSetupPanel(this, gameRunner));
   }
 
   public void showLocal() {
@@ -43,7 +46,7 @@ public class SetupPanelModel extends Observable {
   }
 
   public void showPbem() {
-    setGameTypePanel(new PBEMSetupPanel(gameSelectorModel));
+    setGameTypePanel(new PBEMSetupPanel(gameSelectorModel, gameRunner));
   }
 
   public void showServer(final Component ui) {
@@ -62,7 +65,7 @@ public class SetupPanelModel extends Observable {
   }
 
   public void showClient(final Component ui) {
-    final ClientModel model = new ClientModel(gameSelectorModel, this);
+    final ClientModel model = new ClientModel(gameSelectorModel, this, gameRunner);
     if (!model.createClientMessenger(ui)) {
       model.cancel();
       return;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -1,5 +1,12 @@
 package games.strategy.engine.framework.startup.ui;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_COMMENTS;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_LOBBY_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_PORT_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_SERVER_PASSWORD_PROPERTY;
+
 import java.awt.Frame;
 import java.time.Instant;
 import java.util.HashMap;
@@ -78,20 +85,20 @@ public class InGameLobbyWatcher {
    */
   public static InGameLobbyWatcher newInGameLobbyWatcher(final IServerMessenger gameMessenger, final JComponent parent,
       final InGameLobbyWatcher oldWatcher) {
-    final String host = System.getProperties().getProperty(GameRunner.LOBBY_HOST);
-    final String port = System.getProperties().getProperty(GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY);
-    final String hostedBy = System.getProperties().getProperty(GameRunner.LOBBY_GAME_HOSTED_BY);
+    final String host = System.getProperties().getProperty(LOBBY_HOST);
+    final String port = System.getProperties().getProperty(TRIPLEA_LOBBY_PORT_PROPERTY);
+    final String hostedBy = System.getProperties().getProperty(LOBBY_GAME_HOSTED_BY);
     if (host == null || port == null) {
       return null;
     }
     // clear the properties
-    System.getProperties().remove(GameRunner.LOBBY_HOST);
-    System.getProperties().remove(GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY);
-    System.getProperties().remove(GameRunner.LOBBY_GAME_HOSTED_BY);
+    System.getProperties().remove(LOBBY_HOST);
+    System.getProperties().remove(TRIPLEA_LOBBY_PORT_PROPERTY);
+    System.getProperties().remove(LOBBY_GAME_HOSTED_BY);
     // add them as temporary properties (in case we load an old savegame and need them again)
-    System.getProperties().setProperty(GameRunner.LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
-    System.getProperties().setProperty(GameRunner.TRIPLEA_LOBBY_PORT_PROPERTY + GameRunner.OLD_EXTENSION, port);
-    System.getProperties().setProperty(GameRunner.LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
+    System.getProperties().setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
+    System.getProperties().setProperty(TRIPLEA_LOBBY_PORT_PROPERTY + GameRunner.OLD_EXTENSION, port);
+    System.getProperties().setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override
       public Map<String, String> getProperties(final Map<String, String> challengeProperties) {
@@ -157,7 +164,7 @@ public class InGameLobbyWatcher {
     this.messenger = messenger;
     this.remoteMessenger = remoteMessenger;
     this.serverMessenger = serverMessenger;
-    final String password = System.getProperty(GameRunner.TRIPLEA_SERVER_PASSWORD_PROPERTY);
+    final String password = System.getProperty(TRIPLEA_SERVER_PASSWORD_PROPERTY);
     final boolean passworded = password != null && password.length() > 0;
     final Instant startDateTime = (oldWatcher == null || oldWatcher.gameDescription == null
         || oldWatcher.gameDescription.getStartDateTime() == null) ? Instant.now()
@@ -182,7 +189,7 @@ public class InGameLobbyWatcher {
         gameStatus,
         gameRound,
         serverMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner.LOBBY_GAME_COMMENTS),
+        System.getProperty(LOBBY_GAME_COMMENTS),
         passworded,
         ClientContext.engineVersion().toString(), "0");
     final ILobbyGameController controller =
@@ -217,7 +224,7 @@ public class InGameLobbyWatcher {
         if (isActive()) {
           shutDown();
           SwingUtilities.invokeLater(() -> {
-            String portString = System.getProperty(GameRunner.TRIPLEA_PORT_PROPERTY);
+            String portString = System.getProperty(TRIPLEA_PORT_PROPERTY);
             if (portString == null || portString.trim().length() <= 0) {
               portString = "3300";
             }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -53,7 +53,7 @@ public class MainPanel extends JPanel implements Observer {
    * MainPanel is the full contents of the 'mainFrame'. This panel represents the
    * welcome screen and subsequent screens..
    */
-  public MainPanel(final SetupPanelModel typePanelModel) {
+  public MainPanel(final SetupPanelModel typePanelModel, final GameRunner gameRunner) {
     gameTypePanelModel = typePanelModel;
     final GameSelectorModel gameSelectorModel = typePanelModel.getGameSelectorModel();
 
@@ -65,7 +65,7 @@ public class MainPanel extends JPanel implements Observer {
     quitButton.setToolTipText("Close TripleA.");
     cancelButton = new JButton("Cancel");
     cancelButton.setToolTipText("Go back to main screen.");
-    final GameSelectorPanel gameSelectorPanel = new GameSelectorPanel(gameSelectorModel);
+    final GameSelectorPanel gameSelectorPanel = new GameSelectorPanel(gameSelectorModel, gameRunner);
     gameSelectorPanel.setBorder(new EtchedBorder());
     gameSetupPanelHolder = new JPanel();
     gameSetupPanelHolder.setLayout(new BorderLayout());
@@ -102,7 +102,7 @@ public class MainPanel extends JPanel implements Observer {
       try {
         gameSetupPanel.shutDown();
       } finally {
-        GameRunner.quitGame();
+        gameRunner.quitGame();
       }
     });
     cancelButton.addActionListener(e -> gameTypePanelModel.showSelectType());

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -43,9 +43,11 @@ public class MetaSetupPanel extends SetupPanel {
   private JButton helpButton;
 
   private final SetupPanelModel model;
+  private final GameRunner gameRunner;
 
-  public MetaSetupPanel(final SetupPanelModel model) {
+  public MetaSetupPanel(final SetupPanelModel model, final GameRunner instance) {
     this.model = model;
+    this.gameRunner = instance;
 
     createComponents();
     layoutComponents();
@@ -153,13 +155,14 @@ public class MetaSetupPanel extends SetupPanel {
     final LobbyServerProperties lobbyServerProperties = new LobbyServerPropertiesFetcher().fetchLobbyServerProperties();
     final LobbyLogin login = new LobbyLogin(
         JOptionPane.getFrameForComponent(this),
-        lobbyServerProperties);
+        lobbyServerProperties,
+        gameRunner);
     final LobbyClient client = login.login();
     if (client == null) {
       return;
     }
-    final LobbyFrame lobbyFrame = new LobbyFrame(client, lobbyServerProperties);
-    GameRunner.hideMainFrame();
+    final LobbyFrame lobbyFrame = new LobbyFrame(client, lobbyServerProperties, gameRunner);
+    gameRunner.hideMainFrame();
     lobbyFrame.setVisible(true);
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -33,6 +33,7 @@ import javax.swing.border.TitledBorder;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.launcher.LocalLauncher;
@@ -69,6 +70,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   private final List<PlayerSelectorRow> playerTypes = new ArrayList<>();
   private final JPanel localPlayerPanel = new JPanel();
   private final JButton localPlayerSelection = new JButton("Select Local Players and AI's");
+  private final GameRunner gameRunner;
 
   /**
    * Creates a new instance.
@@ -76,8 +78,9 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
    * @param model
    *        the GameSelectionModel, though which changes are obtained when new games are chosen, or save games loaded
    */
-  public PBEMSetupPanel(final GameSelectorModel model) {
+  public PBEMSetupPanel(final GameSelectorModel model, final GameRunner gameRunner) {
     gameSelectorModel = model;
+    this.gameRunner = gameRunner;
     diceServerEditor = new SelectAndViewEditor("Dice Server", "");
     forumPosterEditor = new SelectAndViewEditor("Post to Forum", "forumPosters.html");
     emailSenderEditor = new SelectAndViewEditor("Provider", "emailSenders.html");
@@ -201,8 +204,8 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     // get the forum posters,
     final List<IForumPoster> forumPosters = new ArrayList<>();
     forumPosters.add(useCacheIfAvailable(new NullForumPoster()));
-    forumPosters.add(useCacheIfAvailable(new AxisAndAlliesForumPoster()));
-    forumPosters.add(useCacheIfAvailable(new TripleAForumPoster()));
+    forumPosters.add(useCacheIfAvailable(new AxisAndAlliesForumPoster(gameRunner)));
+    forumPosters.add(useCacheIfAvailable(new TripleAForumPoster(gameRunner)));
     forumPosterEditor.setBeans(forumPosters);
     // now get the poster stored in the save game
     final IForumPoster forumPoster = (IForumPoster) data.getProperties().get(PBEMMessagePoster.FORUM_POSTER_PROP_NAME);
@@ -230,9 +233,9 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     // The list of email, either loaded from cache or created
     final List<IEmailSender> emailSenders = new ArrayList<>();
     emailSenders.add(useCacheIfAvailable(new NullEmailSender()));
-    emailSenders.add(useCacheIfAvailable(new GmailEmailSender()));
-    emailSenders.add(useCacheIfAvailable(new HotmailEmailSender()));
-    emailSenders.add(useCacheIfAvailable(new GenericEmailSender()));
+    emailSenders.add(useCacheIfAvailable(new GmailEmailSender(gameRunner)));
+    emailSenders.add(useCacheIfAvailable(new HotmailEmailSender(gameRunner)));
+    emailSenders.add(useCacheIfAvailable(new GenericEmailSender(gameRunner)));
     emailSenderEditor.setBeans(emailSenders);
     // now get the sender from the save game, update it with credentials from the cache, and set it
     final IEmailSender sender = (IEmailSender) data.getProperties().get(PBEMMessagePoster.EMAIL_SENDER_PROP_NAME);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -44,6 +44,7 @@ public class EmailSenderEditor extends EditorPanel {
   private final JButton testEmail = new JButton("Test Email");
   private final JCheckBox alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
   private final JCheckBox credentialsSaved = new JCheckBox("Remember me");
+  private final GameRunner gameRunner;
 
   /**
    * creates a new instance.
@@ -53,7 +54,8 @@ public class EmailSenderEditor extends EditorPanel {
    * @param editorConfiguration
    *        configures which editor fields should be visible
    */
-  public EmailSenderEditor(final GenericEmailSender bean, final EditorConfiguration editorConfiguration) {
+  public EmailSenderEditor(final GenericEmailSender bean, final EditorConfiguration editorConfiguration,
+      final GameRunner gameRunner) {
     super();
     genericEmailSender = bean;
     subject.setText(genericEmailSender.getSubjectPrefix());
@@ -64,6 +66,7 @@ public class EmailSenderEditor extends EditorPanel {
     password.setText(genericEmailSender.getPassword());
     credentialsSaved.setSelected(genericEmailSender.areCredentialsSaved());
     useTls.setSelected(genericEmailSender.getEncryption() == GenericEmailSender.Encryption.TLS);
+    this.gameRunner = gameRunner;
 
     final int bottomSpace = 1;
     final int labelSpace = 2;
@@ -148,7 +151,7 @@ public class EmailSenderEditor extends EditorPanel {
    * Tests the email sender. This must be called from the swing event thread
    */
   private void testEmail() {
-    final ProgressWindow progressWindow = GameRunner.newProgressWindow("Sending test email...");
+    final ProgressWindow progressWindow = gameRunner.newProgressWindow("Sending test email...");
     progressWindow.setVisible(true);
     // start a background thread
     new Thread(() -> {
@@ -175,7 +178,7 @@ public class EmailSenderEditor extends EditorPanel {
         final int finalMessageType = messageType;
         SwingUtilities.invokeLater(() -> {
           try {
-            GameRunner.showMessageDialog(
+            gameRunner.showMessageDialog(
                 finalMessage,
                 GameRunner.Title.of("Email Test"),
                 finalMessageType);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -42,9 +42,11 @@ public class ForumPosterEditor extends EditorPanel {
   private final JCheckBox alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
   private final JCheckBox credentialsSaved = new JCheckBox("Remember me");
   private final IForumPoster bean;
+  private final GameRunner gameRunner;
 
-  public ForumPosterEditor(final IForumPoster bean) {
+  public ForumPosterEditor(final IForumPoster bean, final GameRunner gameRunner) {
     this.bean = bean;
+    this.gameRunner = gameRunner;
     final int bottomSpace = 1;
     final int labelSpace = 2;
     int row = 0;
@@ -112,7 +114,7 @@ public class ForumPosterEditor extends EditorPanel {
    */
   void testForum() {
     final IForumPoster poster = (IForumPoster) getBean();
-    final ProgressWindow progressWindow = GameRunner.newProgressWindow(poster.getTestMessage());
+    final ProgressWindow progressWindow = gameRunner.newProgressWindow(poster.getTestMessage());
     progressWindow.setVisible(true);
     // start a background thread
     new Thread(() -> {
@@ -149,7 +151,7 @@ public class ForumPosterEditor extends EditorPanel {
       // now that we have a result, marshall it back unto the swing thread
       SwingUtilities.invokeLater(() -> {
         try {
-          GameRunner.showMessageDialog(
+          gameRunner.showMessageDialog(
               bean.getTurnSummaryRef(),
               GameRunner.Title.of("Test Turn Summary Post"),
               JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -98,12 +98,13 @@ public class GameChooser extends JDialog {
     infoPanel.add(notesScroll, BorderLayout.CENTER);
   }
 
-  public static GameChooserEntry chooseGame(final Frame parent, final String defaultGameName)
+  public static GameChooserEntry chooseGame(final Frame parent, final String defaultGameName,
+      final GameRunner gameRunner)
       throws InterruptedException {
     final GameChooserModel gameChooserModel =
-        new GameChooserModel(GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
+        new GameChooserModel(gameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
             "Loading all available games...",
-            GameChooserModel::parseMapFiles));
+            () -> GameChooserModel.parseMapFiles(gameRunner)));
     final GameChooser chooser = new GameChooser(parent, gameChooserModel);
     chooser.setSize(800, 600);
     chooser.setLocationRelativeTo(parent);

--- a/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -1,12 +1,14 @@
 package games.strategy.engine.framework.ui;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_NAME_PROPERTY;
+
 import java.io.File;
 
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
 import games.strategy.engine.framework.GameDataFileUtils;
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.triplea.settings.ClientSetting;
 
@@ -39,8 +41,8 @@ public class SaveGameFileChooser extends JFileChooser {
 
   public static String getAutoSaveFileName() {
     if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY,
-          System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, ""));
+      final String saveSuffix = System.getProperty(TRIPLEA_NAME_PROPERTY,
+          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
       if (saveSuffix.length() > 0) {
         return saveSuffix + "_" + AUTOSAVE_FILE_NAME;
       }
@@ -50,8 +52,8 @@ public class SaveGameFileChooser extends JFileChooser {
 
   public static String getAutoSaveOddFileName() {
     if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY,
-          System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, ""));
+      final String saveSuffix = System.getProperty(TRIPLEA_NAME_PROPERTY,
+          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
       if (saveSuffix.length() > 0) {
         return saveSuffix + "_" + AUTOSAVE_ODD_ROUND_FILE_NAME;
       }
@@ -61,8 +63,8 @@ public class SaveGameFileChooser extends JFileChooser {
 
   public static String getAutoSaveEvenFileName() {
     if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY,
-          System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, ""));
+      final String saveSuffix = System.getProperty(TRIPLEA_NAME_PROPERTY,
+          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
       if (saveSuffix.length() > 0) {
         return saveSuffix + "_" + AUTOSAVE_EVEN_ROUND_FILE_NAME;
       }

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -21,9 +21,7 @@ public final class BackgroundTaskRunner {
   private final JFrame frame;
 
   public BackgroundTaskRunner(final JFrame frame) {
-    checkNotNull(frame);
-
-    this.frame = frame;
+    this.frame = checkNotNull(frame);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -24,10 +24,13 @@ import games.strategy.util.MD5Crypt;
 public class LobbyLogin {
   private final Window parentWindow;
   private final LobbyServerProperties lobbyServerProperties;
+  private final GameRunner gameRunner;
 
-  public LobbyLogin(final Window parent, final LobbyServerProperties lobbyServerProperties) {
+  public LobbyLogin(final Window parent, final LobbyServerProperties lobbyServerProperties,
+      final GameRunner gameRunner) {
     parentWindow = parent;
     this.lobbyServerProperties = lobbyServerProperties;
+    this.gameRunner = gameRunner;
   }
 
   /**
@@ -54,7 +57,7 @@ public class LobbyLogin {
 
   private @Nullable LobbyClient login(final LoginPanel panel) {
     try {
-      final IMessenger messenger = GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
+      final IMessenger messenger = gameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
           "Connecting to lobby...",
           () -> login(panel.getUserName(), panel.getPassword(), panel.isAnonymousLogin()),
           IOException.class);
@@ -132,7 +135,7 @@ public class LobbyLogin {
 
   private @Nullable LobbyClient createAccount(final CreateUpdateAccountPanel panel) {
     try {
-      final IMessenger messenger = GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
+      final IMessenger messenger = gameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
           "Connecting to lobby...",
           () -> createAccount(panel.getUserName(), panel.getPassword(), panel.getEmail()),
           IOException.class);

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -4,6 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import javax.swing.JSpinner;
 import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
 
 import com.google.common.collect.ImmutableList;
 
@@ -49,9 +51,12 @@ public class LobbyFrame extends JFrame {
 
   private final LobbyClient client;
   private final ChatMessagePanel chatMessagePanel;
+  private final GameRunner gameRunner;
 
-  public LobbyFrame(final LobbyClient client, final LobbyServerProperties lobbyServerProperties) {
+  public LobbyFrame(final LobbyClient client, final LobbyServerProperties lobbyServerProperties,
+      final GameRunner gameRunner) {
     super("TripleA Lobby");
+    this.gameRunner = gameRunner;
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     setIconImage(GameRunner.getGameIcon(this));
     this.client = client;
@@ -220,7 +225,13 @@ public class LobbyFrame extends JFrame {
   public void shutdown() {
     setVisible(false);
     dispose();
-    GameRunner.showMainFrame();
+    try {
+      SwingUtilities.invokeAndWait(gameRunner::showMainFrame);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException("Failed to show MainFrame", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
     client.getMessenger().shutDown();
     GameRunner.exitGameIfFinished();
   }

--- a/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -1,12 +1,13 @@
 package games.strategy.engine.lobby.server;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_SUPPORT_EMAIL;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.time.Instant;
 
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.net.INode;
 import games.strategy.net.Node;
@@ -53,7 +54,7 @@ public class GameDescription implements Externalizable, Cloneable {
   private String m_engineVersion;
   private String m_gameVersion;
   private String m_botSupportEmail =
-      HeadlessGameServer.getInstance() != null ? System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_EMAIL, "") : "";
+      HeadlessGameServer.getInstance() != null ? System.getProperty(LOBBY_GAME_SUPPORT_EMAIL, "") : "";
 
   // if you add a field, add it to write/read object as well for Externalizable
   public GameDescription() {}

--- a/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -7,6 +7,7 @@ import java.io.ObjectOutputStream;
 import java.util.Objects;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.ForumPosterEditor;
 import games.strategy.security.CredentialManager;
@@ -45,6 +46,12 @@ public abstract class AbstractForumPoster implements IForumPoster {
   protected transient String m_saveGameFileName = null;
   private boolean credentialsSaved = false;
   private boolean credentialsProtected = false;
+  protected final transient GameRunner gameRunner;
+
+
+  protected AbstractForumPoster(final GameRunner gameRunner) {
+    this.gameRunner = gameRunner;
+  }
 
   private void writeObject(final ObjectOutputStream out) throws IOException {
     final String username = m_username;
@@ -180,7 +187,7 @@ public abstract class AbstractForumPoster implements IForumPoster {
 
   @Override
   public EditorPanel getEditor() {
-    return new ForumPosterEditor(this);
+    return new ForumPosterEditor(this, gameRunner);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -27,6 +27,7 @@ import javax.mail.internet.MimeMultipart;
 import javax.mail.util.ByteArrayDataSource;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.EmailSenderEditor;
 import games.strategy.security.CredentialManager;
@@ -75,6 +76,11 @@ public class GenericEmailSender implements IEmailSender {
   private boolean m_alsoPostAfterCombatMove = false;
   private boolean credentialsSaved = false;
   private boolean credentialsProtected = false;
+  protected GameRunner gameRunner;
+
+  public GenericEmailSender(final GameRunner gameRunner) {
+    this.gameRunner = gameRunner;
+  }
 
   private void writeObject(final ObjectOutputStream out) throws IOException {
     final String userName = m_userName;
@@ -329,7 +335,7 @@ public class GenericEmailSender implements IEmailSender {
 
   @Override
   public IEmailSender clone() {
-    final GenericEmailSender sender = new GenericEmailSender();
+    final GenericEmailSender sender = new GenericEmailSender(gameRunner);
     sender.setSubjectPrefix(getSubjectPrefix());
     sender.setEncryption(getEncryption());
     sender.setHost(getHost());
@@ -368,7 +374,7 @@ public class GenericEmailSender implements IEmailSender {
 
   @Override
   public EditorPanel getEditor() {
-    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration(true, true, true));
+    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration(true, true, true), gameRunner);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.pbem;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.EmailSenderEditor;
 import games.strategy.triplea.help.HelpSupport;
@@ -10,7 +11,8 @@ public class GmailEmailSender extends GenericEmailSender {
   /**
    * Initializes a new instance of the {@code GmailEmailSender} class.
    */
-  public GmailEmailSender() {
+  public GmailEmailSender(final GameRunner gameRunner) {
+    super(gameRunner);
     setHost("smtp.gmail.com");
     setPort(587);
     setEncryption(Encryption.TLS);
@@ -18,7 +20,7 @@ public class GmailEmailSender extends GenericEmailSender {
 
   @Override
   public EditorPanel getEditor() {
-    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration());
+    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration(), gameRunner);
   }
 
   @Override
@@ -28,7 +30,7 @@ public class GmailEmailSender extends GenericEmailSender {
 
   @Override
   public IEmailSender clone() {
-    final GenericEmailSender sender = new GmailEmailSender();
+    final GenericEmailSender sender = new GmailEmailSender(gameRunner);
     sender.setSubjectPrefix(getSubjectPrefix());
     sender.setPassword(getPassword());
     sender.setToAddress(getToAddress());

--- a/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.pbem;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.EmailSenderEditor;
 import games.strategy.triplea.help.HelpSupport;
@@ -13,7 +14,8 @@ public class HotmailEmailSender extends GenericEmailSender {
   /**
    * Initializes a new instance of the {@code HotmailEmailSender} class.
    */
-  public HotmailEmailSender() {
+  public HotmailEmailSender(final GameRunner gameRunner) {
+    super(gameRunner);
     setHost("smtp.live.com");
     setPort(587);
     setEncryption(Encryption.TLS);
@@ -21,7 +23,7 @@ public class HotmailEmailSender extends GenericEmailSender {
 
   @Override
   public EditorPanel getEditor() {
-    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration());
+    return new EmailSenderEditor(this, new EmailSenderEditor.EditorConfiguration(), gameRunner);
   }
 
   @Override
@@ -31,7 +33,7 @@ public class HotmailEmailSender extends GenericEmailSender {
 
   @Override
   public IEmailSender clone() {
-    final GenericEmailSender sender = new HotmailEmailSender();
+    final GenericEmailSender sender = new HotmailEmailSender(gameRunner);
     sender.setSubjectPrefix(getSubjectPrefix());
     sender.setPassword(getPassword());
     sender.setToAddress(getToAddress());

--- a/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -23,6 +23,7 @@ import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.triplea.UrlConstants;
@@ -33,6 +34,11 @@ public class TripleAForumPoster extends AbstractForumPoster {
   private static final long serialVersionUID = -3380344469767981030L;
 
   private static final String tripleAForumURL = UrlConstants.TRIPLEA_FORUM.toString();
+
+
+  public TripleAForumPoster(GameRunner gameRunner) {
+    super(gameRunner);
+  }
 
   @Override
   public boolean postTurnSummary(final String summary, final String title) {
@@ -172,7 +178,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
 
   @Override
   public IForumPoster doClone() {
-    final TripleAForumPoster clone = new TripleAForumPoster();
+    final TripleAForumPoster clone = new TripleAForumPoster(gameRunner);
     clone.setTopicId(getTopicId());
     clone.setIncludeSaveGame(getIncludeSaveGame());
     clone.setAlsoPostAfterCombatMove(getAlsoPostAfterCombatMove());

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import games.strategy.ui.SwingComponents;
@@ -57,7 +58,7 @@ public class ResourceLoader implements Closeable {
       SwingComponents.promptUser("Download Map?",
           "Map missing: " + mapName + ", could not join game.\nWould you like to download the map now?"
               + "\nOnce the download completes, you may reconnect to this game.",
-          () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
+          () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName, new GameRunner()));
 
       throw new MapNotFoundException();
     }

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -14,6 +14,7 @@ import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.LocalPlayers;
@@ -48,9 +49,14 @@ public class TripleA implements IGameLoader {
   public static final String PRO_COMPUTER_PLAYER_TYPE = "Hard (AI)";
   public static final String DOESNOTHINGAI_COMPUTER_PLAYER_TYPE = "Does Nothing (AI)";
   protected transient ITripleADisplay display;
+  private final transient GameRunner gameRunner;
 
   protected transient ISound soundChannel;
   protected transient IGame game;
+
+  public TripleA(final GameRunner gameRunner) {
+    this.gameRunner = gameRunner;
+  }
 
   @Override
   public Set<IGamePlayer> createPlayers(final Map<String, String> playerNames) {
@@ -121,7 +127,7 @@ public class TripleA implements IGameLoader {
       try {
         SwingUtilities.invokeAndWait(() -> {
           final TripleAFrame frame;
-          frame = new TripleAFrame(game, localPlayers);
+          frame = new TripleAFrame(game, localPlayers, gameRunner);
           display = new TripleADisplay(frame);
           game.addDisplay(display);
           soundChannel = new DefaultSoundChannel(localPlayers);

--- a/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -26,6 +26,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.pbem.AbstractForumPoster;
 import games.strategy.engine.pbem.IForumPoster;
@@ -41,6 +42,8 @@ import games.strategy.util.ThreadUtil;
  * The poster logs in, and out every time it posts, this way we don't nee to manage any state between posts
  */
 public class AxisAndAlliesForumPoster extends AbstractForumPoster {
+
+
   private static final long serialVersionUID = 8896923978584346664L;
   // the patterns used to extract values from hidden form fields posted to the server
   public static final Pattern NUM_REPLIES_PATTERN =
@@ -59,6 +62,11 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
       .compile(".*<tr\\s+class=\"windowbg\">\\s*<td[^>]*>([^<]*)</td>.*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
   public static final Pattern ERROR_LIST_PATTERN =
       Pattern.compile(".*id=\"error_list[^>]*>\\s+([^<]*)\\s+<.*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+
+
+  public AxisAndAlliesForumPoster(GameRunner gameRunner) {
+    super(gameRunner);
+  }
 
   /**
    * Logs into axisandallies.org
@@ -244,7 +252,7 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
 
   @Override
   public IForumPoster doClone() {
-    final AxisAndAlliesForumPoster clone = new AxisAndAlliesForumPoster();
+    final AxisAndAlliesForumPoster clone = new AxisAndAlliesForumPoster(gameRunner);
     clone.setTopicId(getTopicId());
     clone.setIncludeSaveGame(getIncludeSaveGame());
     clone.setAlsoPostAfterCombatMove(getAlsoPostAfterCombatMove());

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -208,13 +208,15 @@ public class TripleAFrame extends MainGameFrame {
   private final Map<PlayerID, Boolean> requiredTurnSeries = new HashMap<>();
   private final ThreadPool messageAndDialogThreadPool;
   private final TripleAMenuBar menu;
+  private final GameRunner gameRunner;
   private boolean isCtrlPressed = false;
 
   /** Creates new TripleAFrame. */
-  public TripleAFrame(final IGame game, final LocalPlayers players) {
+  public TripleAFrame(final IGame game, final LocalPlayers players, final GameRunner gameRunner) {
     super("TripleA - " + game.getData().getGameName(), players);
     this.game = game;
     data = game.getData();
+    this.gameRunner = gameRunner;
     messageAndDialogThreadPool = new ThreadPool(1);
     addZoomKeyboardShortcuts();
     this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -241,7 +243,7 @@ public class TripleAFrame extends MainGameFrame {
         hideCommentLog();
       }
     });
-    menu = new TripleAMenuBar(this);
+    menu = new TripleAMenuBar(this, gameRunner);
     this.setJMenuBar(menu);
     final ImageScrollModel model = new ImageScrollModel();
     model.setScrollX(uiContext.getMapData().scrollWrapX());
@@ -264,7 +266,7 @@ public class TripleAFrame extends MainGameFrame {
     chatSplit.setOneTouchExpandable(true);
     chatSplit.setDividerSize(8);
     chatSplit.setResizeWeight(0.95);
-    if (GameRunner.hasChat()) {
+    if (gameRunner.hasChat()) {
       commentSplit = new JSplitPane();
       commentSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);
       commentSplit.setOneTouchExpandable(true);
@@ -272,7 +274,7 @@ public class TripleAFrame extends MainGameFrame {
       commentSplit.setResizeWeight(0.5);
       commentSplit.setTopComponent(commentPanel);
       commentSplit.setBottomComponent(null);
-      chatPanel = new ChatPanel(GameRunner.getChat());
+      chatPanel = new ChatPanel(gameRunner.getChat());
       chatPanel.setPlayerRenderer(new PlayerChatRenderer(this.game, uiContext));
       final Dimension chatPrefSize = new Dimension((int) chatPanel.getPreferredSize().getWidth(), 95);
       chatPanel.setPreferredSize(chatPrefSize);
@@ -580,7 +582,7 @@ public class TripleAFrame extends MainGameFrame {
       ((ClientGame) game).shutDown();
       // an ugly hack, we need a better
       // way to get the main frame
-      GameRunner.clientLeftGame();
+      gameRunner.clientLeftGame();
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -12,6 +12,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
 
 import games.strategy.engine.framework.GameDataFileUtils;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
@@ -25,10 +26,10 @@ public class TripleAMenuBar extends JMenuBar {
   private static final long serialVersionUID = -1447295944297939539L;
   protected final TripleAFrame frame;
 
-  public TripleAMenuBar(final TripleAFrame frame) {
+  public TripleAMenuBar(final TripleAFrame frame, final GameRunner gameRunner) {
     this.frame = frame;
     new FileMenu(this, frame);
-    new ViewMenu(this, frame);
+    new ViewMenu(this, frame, gameRunner);
     new GameMenu(this, frame);
     new ExportMenu(this, frame);
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -61,11 +61,13 @@ class ViewMenu {
   private final GameData gameData;
   private final TripleAFrame frame;
   private final UiContext uiContext;
+  private final GameRunner gameRunner;
 
-  ViewMenu(final JMenuBar menuBar, final TripleAFrame frame) {
+  ViewMenu(final JMenuBar menuBar, final TripleAFrame frame, final GameRunner gameRunner) {
     this.frame = frame;
     this.uiContext = frame.getUiContext();
     gameData = frame.getGame().getData();
+    this.gameRunner = gameRunner;
 
 
     final JMenu menuView = new JMenu("View");
@@ -507,6 +509,6 @@ class ViewMenu {
     chatTimeBox.addActionListener(e -> frame.setShowChatTime(chatTimeBox.isSelected()));
     chatTimeBox.setSelected(false);
     parentMenu.add(chatTimeBox);
-    chatTimeBox.setEnabled(GameRunner.hasChat());
+    chatTimeBox.setEnabled(gameRunner.hasChat());
   }
 }

--- a/src/main/java/org/triplea/client/launch/screens/HostNetworkGameSetup.java
+++ b/src/main/java/org/triplea/client/launch/screens/HostNetworkGameSetup.java
@@ -19,15 +19,15 @@ import swinglib.JTextFieldBuilder;
  */
 class HostNetworkGameSetup {
 
-  static JPanel build() {
+  static JPanel build(final GameRunner gameRunner) {
     return JPanelBuilder.builder()
         .borderLayout()
-        .addCenter(buildMain())
+        .addCenter(buildMain(gameRunner))
         .addSouth(NavigationPanelFactory.buildWithDisabledPlayButton(LaunchScreen.HOST_NETWORK_GAME_OPTIONS))
         .build();
   }
 
-  private static JPanel buildMain() {
+  private static JPanel buildMain(final GameRunner gameRunner) {
     final JTextField playerNameField = JTextFieldBuilder.builder()
         .text(ClientSetting.PLAYER_NAME.value())
         .columns(12)
@@ -72,7 +72,7 @@ class HostNetworkGameSetup {
                           props.setName(playerNameField.getText().trim());
                           props.setPassword(passwordField.getText().trim());
                           props.setPort(extractPortValue(portField));
-                          LaunchScreenWindow.drawWithServerNetworking(StagingScreen.NETWORK_HOST, props);
+                          LaunchScreenWindow.drawWithServerNetworking(StagingScreen.NETWORK_HOST, props, gameRunner);
                         })
                         .build())
                 .build())

--- a/src/main/java/org/triplea/client/launch/screens/InitialLaunchScreen.java
+++ b/src/main/java/org/triplea/client/launch/screens/InitialLaunchScreen.java
@@ -5,6 +5,7 @@ import javax.swing.JPanel;
 
 import org.triplea.client.launch.screens.staging.StagingScreen;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingComponents;
 import swinglib.JButtonBuilder;
@@ -12,15 +13,15 @@ import swinglib.JPanelBuilder;
 
 class InitialLaunchScreen {
 
-  static JPanel build() {
+  static JPanel build(final GameRunner gameRunner) {
     return JPanelBuilder.builder()
         .borderLayout()
-        .addCenter(buildMain())
+        .addCenter(buildMain(gameRunner))
         .addSouth(NavigationPanelFactory.buildWithDisabledPlayButton(LaunchScreen.INITIAL))
         .build();
   }
 
-  private static JPanel buildMain() {
+  private static JPanel buildMain(final GameRunner gameRunner) {
     return JPanelBuilder.builder()
         .flowLayoutWrapper()
         .verticalBoxLayout()
@@ -34,7 +35,7 @@ class InitialLaunchScreen {
         .add(JButtonBuilder.builder()
             .title("Play Single Player")
             .biggerFont()
-            .actionListener(() -> LaunchScreenWindow.draw(StagingScreen.SINGLE_PLAYER))
+            .actionListener(() -> LaunchScreenWindow.draw(StagingScreen.SINGLE_PLAYER, gameRunner))
             .build())
         .add(Box.createVerticalStrut(40))
         .add(JButtonBuilder.builder()

--- a/src/main/java/org/triplea/client/launch/screens/LaunchScreen.java
+++ b/src/main/java/org/triplea/client/launch/screens/LaunchScreen.java
@@ -5,20 +5,22 @@ import java.util.function.Supplier;
 
 import javax.swing.JComponent;
 
+import games.strategy.engine.framework.GameRunner;
+
 /**
  * Enumeration of the various setup screen configurations leading up to the 'game staging screen'.
  */
 public enum LaunchScreen {
-  INITIAL(InitialLaunchScreen::build),
+  INITIAL(() -> InitialLaunchScreen.build(new GameRunner())),
 
   MORE_OPTIONS(INITIAL, MoreOptions::build),
 
 
-  NETWORK_GAME_TYPE_SELECT(INITIAL, NetworkGameTypeSelectionScreen::build),
+  NETWORK_GAME_TYPE_SELECT(INITIAL, () -> NetworkGameTypeSelectionScreen.build(new GameRunner())),
 
   JOIN_NETWORK_GAME_OPTIONS(NETWORK_GAME_TYPE_SELECT, JoinNetworkGameSetup::build),
 
-  HOST_NETWORK_GAME_OPTIONS(NETWORK_GAME_TYPE_SELECT, HostNetworkGameSetup::build),
+  HOST_NETWORK_GAME_OPTIONS(NETWORK_GAME_TYPE_SELECT, () -> HostNetworkGameSetup.build(new GameRunner())),
 
   PLAY_BY_FORUM_OPTIONS(NETWORK_GAME_TYPE_SELECT, PlayByForumSetup::build),
 

--- a/src/main/java/org/triplea/client/launch/screens/LaunchScreenWindow.java
+++ b/src/main/java/org/triplea/client/launch/screens/LaunchScreenWindow.java
@@ -76,8 +76,9 @@ public enum LaunchScreenWindow {
   public static void draw(
       final LaunchScreen previousScreen,
       final StagingScreen stagingScreen,
-      final GameData gameData) {
-    replaceContents(stagingScreen.buildScreen(previousScreen, gameData));
+      final GameData gameData,
+      final GameRunner gameRunner) {
+    replaceContents(stagingScreen.buildScreen(previousScreen, gameData, gameRunner));
   }
 
   public static void draw(final LaunchScreen launchScreen) {
@@ -87,9 +88,9 @@ public enum LaunchScreenWindow {
   /**
    * Makes the launch screen window visible if it is not already.
    */
-  public static void draw(final StagingScreen stagingScreen) {
+  public static void draw(final StagingScreen stagingScreen, final GameRunner gameRunner) {
     final GameData data = parseGameData();
-    replaceContents(stagingScreen.buildScreen(stagingScreen.previousScreen, data));
+    replaceContents(stagingScreen.buildScreen(stagingScreen.previousScreen, data, gameRunner));
   }
 
   private static GameData parseGameData() {
@@ -117,14 +118,15 @@ public enum LaunchScreenWindow {
 
   static void drawWithServerNetworking(
       @Nonnull final StagingScreen stagingScreen,
-      @Nonnull final ServerConnectionProps serverProps) {
+      @Nonnull final ServerConnectionProps serverProps,
+      final GameRunner gameRunner) {
     final GameData data = parseGameData();
 
-    final ServerModel serverModel = new ServerModel(serverProps);
+    final ServerModel serverModel = new ServerModel(serverProps, gameRunner);
 
     final ChatSupport chatSupport = new ChatSupport((ChatPanel) serverModel.getChatPanel());
     final Consumer<GameData> launchAction = gameData -> {
-      GameRunner.getGameSelectorModel().load(gameData, "");
+      gameRunner.getGameSelectorModel().load(gameData, "");
       final ILauncher launcher = serverModel.getLauncher();
 
       launcher.launch(null);
@@ -134,7 +136,7 @@ public enum LaunchScreenWindow {
 
 
     replaceContents(stagingScreen.buildScreen(stagingScreen.previousScreen, data, chatSupport, launchAction,
-        serverModel, null));
+        serverModel, null, gameRunner));
   }
 
   /**

--- a/src/main/java/org/triplea/client/launch/screens/NetworkGameTypeSelectionScreen.java
+++ b/src/main/java/org/triplea/client/launch/screens/NetworkGameTypeSelectionScreen.java
@@ -5,6 +5,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
 import games.strategy.engine.config.client.LobbyServerPropertiesFetcher;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.client.login.LobbyLogin;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
@@ -14,15 +15,15 @@ import swinglib.JPanelBuilder;
 
 class NetworkGameTypeSelectionScreen {
 
-  static JPanel build() {
+  static JPanel build(final GameRunner gameRunner) {
     return JPanelBuilder.builder()
         .borderLayout()
-        .addCenter(buildMain())
+        .addCenter(buildMain(gameRunner))
         .addSouth(NavigationPanelFactory.buildWithDisabledPlayButton(LaunchScreen.NETWORK_GAME_TYPE_SELECT))
         .build();
   }
 
-  private static JPanel buildMain() {
+  private static JPanel buildMain(final GameRunner gameRunner) {
     return JPanelBuilder.builder()
         .flowLayoutWrapper()
         .verticalBoxLayout()
@@ -30,7 +31,7 @@ class NetworkGameTypeSelectionScreen {
         .add(JButtonBuilder.builder()
             .biggerFont()
             .title("Play Online")
-            .actionListener(openLobbyWindow())
+            .actionListener(openLobbyWindow(gameRunner))
             .build())
         .add(Box.createVerticalStrut(40))
         .add(JButtonBuilder.builder()
@@ -62,18 +63,19 @@ class NetworkGameTypeSelectionScreen {
   /**
    * Show a popup for lobby login, then do login and show the {@code LobbyFrame}.
    */
-  private static Runnable openLobbyWindow() {
+  private static Runnable openLobbyWindow(final GameRunner gameRunner) {
     return () -> {
       final LobbyServerProperties lobbyServerProperties =
           new LobbyServerPropertiesFetcher().fetchLobbyServerProperties();
       final LobbyLogin login = new LobbyLogin(
           JOptionPane.getFrameForComponent(null),
-          lobbyServerProperties);
+          lobbyServerProperties,
+          gameRunner);
       final LobbyClient client = login.login();
       if (client == null) {
         return;
       }
-      final LobbyFrame lobbyFrame = new LobbyFrame(client, lobbyServerProperties);
+      final LobbyFrame lobbyFrame = new LobbyFrame(client, lobbyServerProperties, gameRunner);
       lobbyFrame.setVisible(true);
       LaunchScreenWindow.dispose();
     };

--- a/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
+++ b/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
@@ -7,6 +7,7 @@ import org.triplea.client.launch.screens.LaunchScreenWindow;
 import org.triplea.client.launch.screens.staging.StagingScreen;
 
 import games.strategy.engine.data.GameParseException;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.triplea.settings.ClientSetting;
@@ -21,17 +22,20 @@ public class SelectGameWindow {
    * Returns a Runnable that can be attached to a Swing button,
    * the Runnable will open the select map window.
    */
-  public static Runnable openSelectGameWindow(final LaunchScreen previousScreen, final StagingScreen stagingScreen) {
+  public static Runnable openSelectGameWindow(final LaunchScreen previousScreen,
+      final StagingScreen stagingScreen,
+      final GameRunner gameRunner) {
     return () -> {
       try {
         final GameChooserEntry entry;
         entry = GameChooser.chooseGame(
             JOptionPane.getFrameForComponent(null),
-            ClientSetting.SELECTED_GAME_LOCATION.value());
+            ClientSetting.SELECTED_GAME_LOCATION.value(),
+            gameRunner);
         if (entry != null) {
           ClientSetting.SELECTED_GAME_LOCATION.save(entry.getLocation());
           try {
-            LaunchScreenWindow.draw(previousScreen, stagingScreen, entry.fullyParseGameData());
+            LaunchScreenWindow.draw(previousScreen, stagingScreen, entry.fullyParseGameData(), gameRunner);
           } catch (final GameParseException e) {
             throw new IllegalStateException(String.format("Could not parse: %s", entry.toString()), e);
           }

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -28,6 +28,7 @@ import games.strategy.engine.data.properties.MapProperty;
 import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
 import games.strategy.engine.data.properties.StringProperty;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.util.PropertyUtil;
 import games.strategy.util.Tuple;
 
@@ -49,7 +50,8 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
   @SuppressWarnings("unused")
   private final Method getter = null;
 
-  private MapPropertyWrapper(final String name, final String description, final T defaultValue, final Method setter) {
+  private MapPropertyWrapper(final String name, final String description, final T defaultValue, final Method setter,
+      final GameRunner gameRunner) {
     super(name, description);
     this.setter = setter;
 
@@ -59,13 +61,13 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     } else if (defaultValue instanceof Color) {
       property = new ColorProperty(name, description, ((Color) defaultValue));
     } else if (defaultValue instanceof File) {
-      property = new FileProperty(name, description, ((File) defaultValue));
+      property = new FileProperty(name, description, ((File) defaultValue), gameRunner);
     } else if (defaultValue instanceof String) {
       property = new StringProperty(name, description, ((String) defaultValue));
     } else if (defaultValue instanceof Collection || defaultValue instanceof List || defaultValue instanceof Set) {
       property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
     } else if (defaultValue instanceof Map || defaultValue instanceof HashMap) {
-      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
+      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue), gameRunner);
     } else if (defaultValue instanceof Integer) {
       property =
           new NumberProperty(name, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
@@ -118,7 +120,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     }
   }
 
-  private static List<MapPropertyWrapper<?>> createProperties(final Object object) {
+  private static List<MapPropertyWrapper<?>> createProperties(final Object object, final GameRunner gameRunner) {
     final List<MapPropertyWrapper<?>> properties = new ArrayList<>();
     for (final Method setter : object.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");
@@ -142,7 +144,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       }
       try {
         final MapPropertyWrapper<?> wrapper =
-            new MapPropertyWrapper<>(propertyName, null, currentValue, setter);
+            new MapPropertyWrapper<>(propertyName, null, currentValue, setter, gameRunner);
         properties.add(wrapper);
       } catch (final Exception e) {
         ClientLogger.logQuietly(e);
@@ -165,7 +167,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
 
   static Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> createPropertiesUi(final Object object,
       final boolean editable) {
-    final List<MapPropertyWrapper<?>> properties = createProperties(object);
+    final List<MapPropertyWrapper<?>> properties = createProperties(object, new GameRunner());
     final PropertiesUI ui = new PropertiesUI(properties, editable);
     return Tuple.of(ui, properties);
   }
@@ -177,7 +179,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
 
   public static void main(final String[] args) {
     final MapProperties mapProperties = new MapProperties();
-    final List<MapPropertyWrapper<?>> properties = createProperties(mapProperties);
+    final List<MapPropertyWrapper<?>> properties = createProperties(mapProperties, new GameRunner());
     final PropertiesUI ui = createPropertiesUi(properties, true);
     final JFrame frame = new JFrame();
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.framework;
 
+import static games.strategy.engine.framework.ArgParser.CliProperties.MAP_FOLDER;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_GAME_PROPERTY;
+import static games.strategy.engine.framework.ArgParser.CliProperties.TRIPLEA_MAP_DOWNLOAD_PROPERTY;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -20,7 +23,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @AfterEach
   public void teardown() {
-    System.clearProperty(GameRunner.TRIPLEA_GAME_PROPERTY);
+    System.clearProperty(TRIPLEA_GAME_PROPERTY);
   }
 
   @Test
@@ -47,30 +50,30 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void singleFileArgIsAssumedToBeGameProperty() {
-    new ArgParser(Collections.singleton(GameRunner.TRIPLEA_GAME_PROPERTY))
+    new ArgParser(Collections.singleton(TRIPLEA_GAME_PROPERTY))
         .handleCommandLineArgs(new String[] {TestData.propValue});
     assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
-        System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY), is(TestData.propValue));
+        System.getProperty(TRIPLEA_GAME_PROPERTY), is(TestData.propValue));
   }
 
   @Test
   public void singleUrlArgIsAssumedToBeMapDownloadProperty() {
     final String testUrl = "triplea:" + TestData.propValue;
-    new ArgParser(Collections.singleton(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY))
+    new ArgParser(Collections.singleton(TRIPLEA_MAP_DOWNLOAD_PROPERTY))
         .handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it's assumed to mean we are specifying the 'map download property'",
-        System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is(TestData.propValue));
+        System.getProperty(TRIPLEA_MAP_DOWNLOAD_PROPERTY), is(TestData.propValue));
   }
 
   @Test
   public void singleUrlArgIsUrlDecoded() {
     final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
-    new ArgParser(Collections.singleton(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY))
+    new ArgParser(Collections.singleton(TRIPLEA_MAP_DOWNLOAD_PROPERTY))
         .handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it should be properly URL-decoded as it's probably coming from a browser",
-        System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is("Something with spaces and Special chars 🤔"));
+        System.getProperty(TRIPLEA_MAP_DOWNLOAD_PROPERTY), is("Something with spaces and Special chars 🤔"));
   }
 
   @Test
@@ -98,7 +101,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
     final String mapFolderPath = "/path/to/maps";
 
-    new ArgParser(Collections.singleton(GameRunner.MAP_FOLDER))
+    new ArgParser(Collections.singleton(MAP_FOLDER))
         .handleCommandLineArgs(new String[] {"-PmapFolder=" + mapFolderPath});
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +25,7 @@ import org.mockito.Mockito;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.framework.GameDataFileUtils;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
@@ -72,7 +74,7 @@ public class GameSelectorModelTest extends AbstractClientSettingTestCase {
 
   @BeforeEach
   public void setup() {
-    testObj = new GameSelectorModel();
+    testObj = new GameSelectorModel(mock(GameRunner.class));
     assertHasEmptyData(testObj);
     testObj.addObserver(mockObserver);
   }


### PR DESCRIPTION
This PR changes the internal behaviour of TripleA so that the engine doesn't spawn a new JVM just to host or join a game.
Pros:
 - Debuggers work for hosted game scenarios
 - Less overhead because only one JVM is required
 - Avoids having "ghost" java processes running in the background because something crashed

(Current) Cons:
 - A lot of the code call System.exit to terminate a game, this kills of course all other running instances as well, goal would be to find those calls and replace them with something appropriate

I did some testing which included hosting 2 games concurrently (on different ports, because using the same port resulted in an exception as expected), setting them up one after another and joining 2 games at the same time, one after another, because there's just one "selection screen" now.
I haven't gotten any exceptions so far, but I didn't really tried to break anything so far, I just checked if it's possible to host and join multiple games, which works without any severe problems (just an uneccessary popup)

After this PR the only use case for the ProcessUtil class is for the MapCreator classes which are still being invoked using a fresh JVM, and use that as common procedure to invoke other map creator tools :(
So we should probably consider to either move this class to the MapCreator package, or to fix the map creator to not spawn JVMs, which would also fix the LAF issues btw.

So before merging an important goal would be to find any issues with this PR and fix them.

@ssoloff Could you tell me how you set your repo up to create binary builds so we can let the "testing group" do some testing?