### PR TITLE
Clarify difference between engine and map versions in GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,9 +10,9 @@ appreciate you reporting problems to the TripleA team
 
 ### My Operating System:
 
-### TripleA version:
+### Engine version:
 
-### Map:
+### Map name and version:
 
 ### Can you describe how to trigger the error? (eg: what sequence of actions will recreate it?)
 


### PR DESCRIPTION
I noticed in #2663 that the OP mistakenly specified the map version in place of the engine version.  To make it easier for users to provide this information, I changed the text in the GitHub issue template to match the corresponding labels used on the main menu.