### PR TITLE
Remove unnecessary synchronization of GameParser

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -88,7 +88,7 @@ public final class GameParser {
     final Element root = parseDom(stream);
     parseMapProperties(root, gameName);
     // everything until here is needed to select a game
-    parseMapDetails(root, gameName);
+    parseMapDetails(root);
     return data;
   }
 
@@ -134,7 +134,7 @@ public final class GameParser {
     }
   }
 
-  private void parseMapDetails(final Element root, final AtomicReference<String> gameName) throws GameParseException {
+  private void parseMapDetails(final Element root) throws GameParseException {
     parseMap(getSingleChild("map", root));
     final Element resourceList = getSingleChild("resourceList", root, true);
     if (resourceList != null) {

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -72,8 +72,7 @@ public class GameParser {
    * 
    * @return The root Element of the DOM
    */
-  private synchronized Element parseDom(final InputStream stream)
-      throws SAXException {
+  private Element parseDom(final InputStream stream) throws SAXException {
     Preconditions.checkNotNull(stream, "InputStream must be non-null!");
     return getDocument(stream).getDocumentElement();
   }
@@ -81,7 +80,7 @@ public class GameParser {
   /**
    * Parses a file into a GameData object.
    */
-  public synchronized GameData parse(final InputStream stream, final AtomicReference<String> gameName)
+  public GameData parse(final InputStream stream, final AtomicReference<String> gameName)
       throws GameParseException, SAXException, EngineVersionException {
     final Element root = parseDom(stream);
     parseMapProperties(root, gameName);
@@ -94,14 +93,14 @@ public class GameParser {
    * Parses just the essential parts of the maps.
    * Used to display all available maps.
    */
-  public synchronized GameData parseMapProperties(final InputStream stream, final AtomicReference<String> gameName)
+  public GameData parseMapProperties(final InputStream stream, final AtomicReference<String> gameName)
       throws GameParseException, SAXException, EngineVersionException {
     final Element root = parseDom(stream);
     parseMapProperties(root, gameName);
     return data;
   }
 
-  private synchronized void parseMapProperties(final Element root, final AtomicReference<String> gameName)
+  private void parseMapProperties(final Element root, final AtomicReference<String> gameName)
       throws GameParseException, EngineVersionException {
     // mandatory fields
     // get the name of the map
@@ -132,8 +131,7 @@ public class GameParser {
     }
   }
 
-  private synchronized void parseMapDetails(final Element root, final AtomicReference<String> gameName)
-      throws GameParseException {
+  private void parseMapDetails(final Element root, final AtomicReference<String> gameName) throws GameParseException {
     parseMap(getSingleChild("map", root));
     final Element resourceList = getSingleChild("resourceList", root, true);
     if (resourceList != null) {

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -56,7 +56,10 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
-public class GameParser {
+/**
+ * Parses a game XML file into a {@link GameData} domain object.
+ */
+public final class GameParser {
   private static final Class<?>[] SETTER_ARGS = {String.class};
   private final GameData data = new GameData();
   private final Collection<SAXParseException> errorsSax = new ArrayList<>();

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -59,7 +59,7 @@ import games.strategy.util.Version;
 public class GameParser {
   private static final Class<?>[] SETTER_ARGS = {String.class};
   private final GameData data = new GameData();
-  private final Collection<SAXParseException> errorsSAX = new ArrayList<>();
+  private final Collection<SAXParseException> errorsSax = new ArrayList<>();
   public static final String DTD_FILE_NAME = "game.dtd";
   private final String mapName;
 
@@ -114,8 +114,8 @@ public class GameParser {
     // if we manage to get this far, past the minimum engine version number test, AND we are still good, then check and
     // see if we have any
     // SAX errors we need to show
-    if (!errorsSAX.isEmpty()) {
-      for (final SAXParseException error : errorsSAX) {
+    if (!errorsSax.isEmpty()) {
+      for (final SAXParseException error : errorsSax) {
         System.err.println("SAXParseException: game: "
             + (data == null ? "?" : (data.getGameName() == null ? "?" : data.getGameName())) + ", line: "
             + error.getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage());
@@ -276,17 +276,17 @@ public class GameParser {
       builder.setErrorHandler(new ErrorHandler() {
         @Override
         public void fatalError(final SAXParseException exception) {
-          errorsSAX.add(exception);
+          errorsSax.add(exception);
         }
 
         @Override
         public void error(final SAXParseException exception) {
-          errorsSAX.add(exception);
+          errorsSax.add(exception);
         }
 
         @Override
         public void warning(final SAXParseException exception) {
-          errorsSAX.add(exception);
+          errorsSax.add(exception);
         }
       });
       return builder.parse(input, system);


### PR DESCRIPTION
This PR is a follow-up to #2657.  As discussed there, no instance of `GameParser` ever escapes from the thread on which it is created.  Therefore, it will never be accessed concurrently, and synchronization is not necessary.  There are currently six uses of `GameParser`, and they all follow the following pattern (where `parse()` may be replaced with `parseMapProperties()` in some cases):

```java
final GameData data = new GameParser(uri.toString()).parse(input, gameName);
```

That is, the `GameParser` reference is immediately discarded at the completion of the statement, and there is no chance for another thread to receive it.

#### Refactoring changes

I performed a few minor refactoring changes while I was here:

1. Fixed one violation each of the Checkstyle AbbreviationAsWordInName and JavadocType rules.
1. Removed an unused parameter in the private `parseMapDetails()` method.