### PR TITLE
Add Capacity for Land Transports

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -209,10 +209,10 @@ final class ProTechAI {
                 int inf = 2;
                 int other = 1;
                 for (final Unit checkUnit : thisTransUnits) {
-                  if (Matches.unitIsInfantry().test(checkUnit)) {
+                  if (Matches.unitIsLandTransportable().test(checkUnit)) {
                     inf--;
                   }
-                  if (Matches.unitIsNotInfantry().test(checkUnit)) {
+                  if (Matches.unitIsNotLandTransportable().test(checkUnit)) {
                     inf--;
                     other--;
                   }
@@ -229,12 +229,12 @@ final class ProTechAI {
               transUnits.removeAll(alreadyLoaded);
               final List<Unit> availTransUnits = sortTransportUnits(transUnits);
               for (final Unit transUnit : availTransUnits) {
-                if (availInf > 0 && Matches.unitIsInfantry().test(transUnit)) {
+                if (availInf > 0 && Matches.unitIsLandTransportable().test(transUnit)) {
                   availInf--;
                   loadedUnits.add(transUnit);
                   alreadyLoaded.add(transUnit);
                 }
-                if (availInf > 0 && availOther > 0 && Matches.unitIsNotInfantry().test(transUnit)) {
+                if (availInf > 0 && availOther > 0 && Matches.unitIsNotLandTransportable().test(transUnit)) {
                   availInf--;
                   availOther--;
                   loadedUnits.add(transUnit);

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -111,8 +111,10 @@ public class UnitAttachment extends DefaultAttachment {
   private int m_carrierCost = -1;
   private boolean m_isAirTransport = false;
   private boolean m_isAirTransportable = false;
+  // isInfantry is DEPRECATED, use isLandTransportable
   private boolean m_isInfantry = false;
   private boolean m_isLandTransport = false;
+  private boolean m_isLandTransportable = false;
   // aa related
   // "isAA" and "isAAmovement" are also valid setters, used as shortcuts for calling multiple aa related setters. Must
   // keep.
@@ -1173,22 +1175,44 @@ public class UnitAttachment extends DefaultAttachment {
     m_isMarine = 0;
   }
 
+  @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setIsInfantry(final String s) {
     m_isInfantry = getBool(s);
   }
 
+  @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setIsInfantry(final Boolean s) {
     m_isInfantry = s;
   }
 
+  @Deprecated
   public boolean getIsInfantry() {
     return m_isInfantry;
   }
 
+  @Deprecated
   public void resetIsInfantry() {
     m_isInfantry = false;
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setIsLandTransportable(final String s) {
+    m_isLandTransportable = getBool(s);
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setIsLandTransportable(final Boolean s) {
+    m_isLandTransportable = s;
+  }
+
+  public boolean getIsLandTransportable() {
+    return m_isLandTransportable;
+  }
+
+  public void resetIsLandTransportable() {
+    m_isLandTransportable = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -2664,14 +2688,14 @@ public class UnitAttachment extends DefaultAttachment {
   public void validate(final GameData data) throws GameParseException {
     if (m_isAir) {
       if (m_isSea /* || m_isFactory */ || m_isSub || m_transportCost != -1 || m_carrierCapacity != -1 || m_canBlitz
-          || m_canBombard || m_isMarine != 0 || m_isInfantry || m_isLandTransport || m_isAirTransportable
-          || m_isCombatTransport) {
+          || m_canBombard || m_isMarine != 0 || m_isInfantry || m_isLandTransportable || m_isLandTransport
+          || m_isAirTransportable || m_isCombatTransport) {
         throw new GameParseException("air units cannot have certain properties, " + thisErrorMsg());
       }
     } else if (m_isSea) {
       if (m_canBlitz || m_isAir /* || m_isFactory */ || m_isStrategicBomber || m_carrierCost != -1
-          || m_transportCost != -1 || m_isMarine != 0 || m_isInfantry || m_isLandTransport || m_isAirTransportable
-          || m_isAirTransport || m_isKamikaze) {
+          || m_transportCost != -1 || m_isMarine != 0 || m_isInfantry || m_isLandTransportable || m_isLandTransport
+          || m_isAirTransportable || m_isAirTransport || m_isKamikaze) {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
       }
     } else { // if land
@@ -2851,22 +2875,47 @@ public class UnitAttachment extends DefaultAttachment {
     // remember to test for null and fix arrays
     // the stats exporter relies on this toString having two spaces after each entry, so do not change this please,
     // except to add new abilities onto the end
-    return this.getAttachedTo().toString().replaceFirst("games.strategy.engine.data.", "") + " with:" + "  isAir:"
-        + m_isAir + "  isSea:" + m_isSea + "  movement:" + m_movement + "  attack:" + m_attack + "  defense:"
-        + m_defense + "  hitPoints:" + m_hitPoints
-        + "  canBlitz:" + m_canBlitz + "  artillerySupportable:" + m_artillerySupportable + "  artillery:" + m_artillery
-        + "  unitSupportCount:" + m_unitSupportCount + "  attackRolls:" + m_attackRolls + "  defenseRolls:"
-        + m_defenseRolls + "  chooseBestRoll:" + m_chooseBestRoll + "  isMarine:" + m_isMarine + "  isInfantry:"
-        + m_isInfantry + "  isLandTransport:" + m_isLandTransport + "  isAirTransportable:" + m_isAirTransportable
-        + "  isAirTransport:" + m_isAirTransport + "  isStrategicBomber:" + m_isStrategicBomber + "  transportCapacity:"
-        + m_transportCapacity + "  transportCost:" + m_transportCost + "  carrierCapacity:" + m_carrierCapacity
-        + "  carrierCost:" + m_carrierCost + "  isSub:" + m_isSub + "  isDestroyer:" + m_isDestroyer + "  canBombard:"
-        + m_canBombard + "  bombard:" + m_bombard + "  isAAforCombatOnly:" + m_isAAforCombatOnly
-        + "  isAAforBombingThisUnitOnly:" + m_isAAforBombingThisUnitOnly + "  isAAforFlyOverOnly:"
-        + m_isAAforFlyOverOnly + "  attackAA:" + m_attackAA + "  offensiveAttackAA:" + m_offensiveAttackAA
-        + "  attackAAmaxDieSides:" + m_attackAAmaxDieSides + "  offensiveAttackAAmaxDieSides:"
-        + m_offensiveAttackAAmaxDieSides + "  maxAAattacks:" + m_maxAAattacks + "  maxRoundsAA:" + m_maxRoundsAA
-        + "  mayOverStackAA:" + m_mayOverStackAA + "  damageableAA:" + m_damageableAA + "  typeAA:" + m_typeAA
+    return this.getAttachedTo().toString().replaceFirst("games.strategy.engine.data.", "") + " with:"
+        + "  isAir:" + m_isAir
+        + "  isSea:" + m_isSea
+        + "  movement:" + m_movement
+        + "  attack:" + m_attack
+        + "  defense:" + m_defense
+        + "  hitPoints:" + m_hitPoints
+        + "  canBlitz:" + m_canBlitz
+        + "  artillerySupportable:" + m_artillerySupportable
+        + "  artillery:" + m_artillery
+        + "  unitSupportCount:" + m_unitSupportCount
+        + "  attackRolls:" + m_attackRolls
+        + "  defenseRolls:" + m_defenseRolls
+        + "  chooseBestRoll:" + m_chooseBestRoll
+        + "  isMarine:" + m_isMarine
+        + "  isInfantry:" + m_isInfantry
+        + "  isLandTransportable:" + m_isLandTransportable
+        + "  isLandTransport:" + m_isLandTransport
+        + "  isAirTransportable:" + m_isAirTransportable
+        + "  isAirTransport:" + m_isAirTransport
+        + "  isStrategicBomber:" + m_isStrategicBomber
+        + "  transportCapacity:" + m_transportCapacity
+        + "  transportCost:" + m_transportCost
+        + "  carrierCapacity:" + m_carrierCapacity
+        + "  carrierCost:" + m_carrierCost
+        + "  isSub:" + m_isSub
+        + "  isDestroyer:" + m_isDestroyer
+        + "  canBombard:" + m_canBombard
+        + "  bombard:" + m_bombard
+        + "  isAAforCombatOnly:" + m_isAAforCombatOnly
+        + "  isAAforBombingThisUnitOnly:" + m_isAAforBombingThisUnitOnly
+        + "  isAAforFlyOverOnly:" + m_isAAforFlyOverOnly
+        + "  attackAA:" + m_attackAA
+        + "  offensiveAttackAA:" + m_offensiveAttackAA
+        + "  attackAAmaxDieSides:" + m_attackAAmaxDieSides
+        + "  offensiveAttackAAmaxDieSides:" + m_offensiveAttackAAmaxDieSides
+        + "  maxAAattacks:" + m_maxAAattacks
+        + "  maxRoundsAA:" + m_maxRoundsAA
+        + "  mayOverStackAA:" + m_mayOverStackAA
+        + "  damageableAA:" + m_damageableAA
+        + "  typeAA:" + m_typeAA
         + "  targetsAA:"
         + (m_targetsAA != null ? (m_targetsAA.size() == 0 ? "empty" : m_targetsAA.toString()) : "all air units")
         + "  willNotFireIfPresent:"
@@ -3187,7 +3236,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (getIsAir() && (getIsKamikaze() || Properties.getKamikaze_Airplanes(getData()))) {
       stats.append("can use All Movement To Attack Target, ");
     }
-    if (getIsInfantry() && playerHasMechInf(player)) {
+    if ((getIsInfantry() || getIsLandTransportable()) && playerHasMechInf(player)) {
       stats.append("can be Transported By Land, ");
     }
     if (getIsLandTransport() && playerHasMechInf(player)) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2700,7 +2700,7 @@ public class UnitAttachment extends DefaultAttachment {
       }
     } else { // if land
       if (m_canBombard || m_isStrategicBomber || m_isSub || m_carrierCapacity != -1 || m_bombard != -1
-          || m_transportCapacity != -1 || m_isAirTransport || m_isCombatTransport || m_isKamikaze) {
+          || m_isAirTransport || m_isCombatTransport || m_isKamikaze) {
         throw new GameParseException("land units cannot have certain properties, " + thisErrorMsg());
       }
     }
@@ -2715,10 +2715,6 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (m_carrierCapacity != -1 && m_carrierCost != -1) {
       throw new GameParseException("carrierCost and carrierCapacity cannot be set at same time, " + thisErrorMsg());
-    }
-    if (m_transportCost != -1 && m_transportCapacity != -1) {
-      throw new GameParseException(
-          "transportCost and transportCapacity cannot be set at same time, " + thisErrorMsg());
     }
     if (((m_bombingBonus != 0 || m_bombingMaxDieSides >= 0) && !(m_isStrategicBomber || m_isRocket))
         || (m_bombingMaxDieSides < -1)) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -715,12 +715,15 @@ public final class Matches {
     };
   }
 
-  public static Predicate<Unit> unitIsInfantry() {
-    return obj -> UnitAttachment.get(obj.getType()).getIsInfantry();
+  public static Predicate<Unit> unitIsLandTransportable() {
+    return obj -> {
+      UnitAttachment ua = UnitAttachment.get(obj.getType());
+      return ua.getIsLandTransportable() || ua.getIsInfantry();
+    };
   }
 
-  public static Predicate<Unit> unitIsNotInfantry() {
-    return unitIsInfantry().negate();
+  public static Predicate<Unit> unitIsNotLandTransportable() {
+    return unitIsLandTransportable().negate();
   }
 
   public static Predicate<Unit> unitIsAirTransportable() {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -473,6 +473,14 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getIsLandTransport();
   }
 
+  static Predicate<Unit> unitIsLandTransportWithCapacity() {
+    return unit -> unitIsLandTransport().and(unitCanTransport()).test(unit);
+  }
+
+  static Predicate<Unit> unitIsLandTransportWithoutCapacity() {
+    return unit -> unitIsLandTransport().and(unitCanTransport().negate()).test(unit);
+  }
+
   static Predicate<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
       final Territory terr, final GameData data) {
     return unit -> !UnitAttachment.get(unit.getType()).getIsInfrastructure()

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -49,12 +49,16 @@ public class MoveValidator {
       "Transport may not unload to friendly territories until after combat is resolved";
   public static final String ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING =
       "Enemy Submarine Preventing Unescorted Amphibious Assault Landing";
-  public static final String TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO = "Transport has already unloaded units to ";
+  public static final String TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO =
+      "Transport has already unloaded units to ";
   public static final String CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND =
       "Cannot load and unload an allied transport in the same round";
-  public static final String CANT_MOVE_THROUGH_IMPASSABLE = "Can't move through impassable territories";
-  public static final String CANT_MOVE_THROUGH_RESTRICTED = "Can't move through restricted territories";
-  public static final String TOO_POOR_TO_VIOLATE_NEUTRALITY = "Not enough money to pay for violating neutrality";
+  public static final String CANT_MOVE_THROUGH_IMPASSABLE =
+      "Can't move through impassable territories";
+  public static final String CANT_MOVE_THROUGH_RESTRICTED =
+      "Can't move through restricted territories";
+  public static final String TOO_POOR_TO_VIOLATE_NEUTRALITY =
+      "Not enough money to pay for violating neutrality";
   public static final String CANNOT_VIOLATE_NEUTRALITY = "Cannot violate neutrality";
   public static final String NOT_ALL_AIR_UNITS_CAN_LAND = "Not all air units can land";
   public static final String TRANSPORT_CANNOT_LOAD_AND_UNLOAD_AFTER_COMBAT =
@@ -63,7 +67,8 @@ public class MoveValidator {
   public static final String NOT_ALL_UNITS_CAN_BLITZ = "Not all units can blitz";
 
   public static MoveValidationResult validateMove(final Collection<Unit> units, final Route route,
-      final PlayerID player, final Collection<Unit> transportsToLoad, final Map<Unit, Collection<Unit>> newDependents,
+      final PlayerID player, final Collection<Unit> transportsToLoad,
+      final Map<Unit, Collection<Unit>> newDependents,
       final boolean isNonCombat, final List<UndoableMove> undoableMoves, final GameData data) {
     final MoveValidationResult result = new MoveValidationResult();
     if (route.hasNoSteps()) {
@@ -88,7 +93,8 @@ public class MoveValidator {
         .getError() != null) {
       return result;
     }
-    if (AirMovementValidator.validateAirCanLand(data, units, route, player, result).getError() != null) {
+    if (AirMovementValidator.validateAirCanLand(data, units, route, player, result)
+        .getError() != null) {
       return result;
     }
     if (validateTransport(isNonCombat, data, undoableMoves, units, route, player, transportsToLoad,
@@ -114,7 +120,8 @@ public class MoveValidator {
       // but the original unit can still remain
       boolean unitsStartedInTerritory = true;
       for (final Unit unit : units) {
-        if (AbstractMoveDelegate.getRouteUsedToMoveInto(undoableMoves, unit, route.getEnd()) != null) {
+        if (AbstractMoveDelegate.getRouteUsedToMoveInto(undoableMoves, unit,
+            route.getEnd()) != null) {
           unitsStartedInTerritory = false;
           break;
         }
@@ -134,12 +141,14 @@ public class MoveValidator {
     return result;
   }
 
-  static MoveValidationResult validateFirst(final GameData data, final Collection<Unit> units, final Route route,
+  static MoveValidationResult validateFirst(final GameData data, final Collection<Unit> units,
+      final Route route,
       final PlayerID player, final MoveValidationResult result) {
     if (!units.isEmpty()
         && !getEditMode(data)) {
       final Collection<Unit> matches = CollectionUtils.getMatches(units,
-          Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player, data, true).negate());
+          Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player,
+              data, true).negate());
       if (matches.isEmpty() || !matches.stream().allMatch(Matches.unitIsOwnedBy(player))) {
         result.setError("Player, " + player.getName() + ", is not owner of all the units: "
             + MyFormatter.unitsToTextNoOwner(units));
@@ -161,19 +170,22 @@ public class MoveValidator {
     // cannot enter territories owned by a player to which we are neutral towards
     final Collection<Territory> landOnRoute = route.getMatches(Matches.territoryIsLand());
     if (!landOnRoute.isEmpty()) {
-      // TODO: if this ever changes, we need to also update getBestRoute(), because getBestRoute is also checking to
+      // TODO: if this ever changes, we need to also update getBestRoute(), because getBestRoute is
+      // also checking to
       // make sure we avoid land
       // territories owned by nations with these 2 relationship type attachment options
       for (final Territory t : landOnRoute) {
         if (units.stream().anyMatch(Matches.unitIsLand())) {
           if (!data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(player, t.getOwner())) {
-            result.setError(player.getName() + " may not move land units over land owned by " + t.getOwner().getName());
+            result.setError(player.getName() + " may not move land units over land owned by "
+                + t.getOwner().getName());
             return result;
           }
         }
         if (units.stream().anyMatch(Matches.unitIsAir())) {
           if (!data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(player, t.getOwner())) {
-            result.setError(player.getName() + " may not move air units over land owned by " + t.getOwner().getName());
+            result.setError(player.getName() + " may not move air units over land owned by "
+                + t.getOwner().getName());
             return result;
           }
         }
@@ -194,7 +206,8 @@ public class MoveValidator {
     return result;
   }
 
-  static MoveValidationResult validateFuel(final GameData data, final Collection<Unit> units, final Route route,
+  static MoveValidationResult validateFuel(final GameData data, final Collection<Unit> units,
+      final Route route,
       final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -206,11 +219,13 @@ public class MoveValidator {
     if (player.getResources().has(fuelCost.getResourcesCopy())) {
       return result;
     }
-    return result.setErrorReturnResult("Not enough resources to perform this move, you need: " + fuelCost
-        + " for this move");
+    return result
+        .setErrorReturnResult("Not enough resources to perform this move, you need: " + fuelCost
+            + " for this move");
   }
 
-  private static MoveValidationResult validateCanal(final GameData data, final Collection<Unit> units,
+  private static MoveValidationResult validateCanal(final GameData data,
+      final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -225,7 +240,8 @@ public class MoveValidator {
    * @param units
    *        (Can be null. If null we will assume all units would be stopped by the canal.)
    */
-  public static String validateCanal(final Route route, final Collection<Unit> units, final PlayerID player,
+  public static String validateCanal(final Route route, final Collection<Unit> units,
+      final PlayerID player,
       final GameData data) {
     for (final Territory routeTerritory : route.getAllTerritories()) {
       final Optional<String> result = validateCanal(routeTerritory, route, units, player, data);
@@ -237,11 +253,14 @@ public class MoveValidator {
   }
 
   /**
-   * Used for testing a single territory, either as part of a route, or just by itself. Returns Optional.empty if it
-   * can be passed through otherwise returns a failure message indicating why the canal can't be passed through.
+   * Used for testing a single territory, either as part of a route, or just by itself. Returns
+   * Optional.empty if it
+   * can be passed through otherwise returns a failure message indicating why the canal can't be
+   * passed through.
    *
    * @param route
-   *        (Can be null. If not null, we will check to see if the route includes both sea zones, and if it doesn't we
+   *        (Can be null. If not null, we will check to see if the route includes both sea zones,
+   *        and if it doesn't we
    *        will not test the
    *        canal)
    * @param units
@@ -259,66 +278,79 @@ public class MoveValidator {
       final boolean canPass = !failureMessage.isPresent();
       if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
           || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
-        break; // If need to control any canal and can pass OR need to control all canals and can't pass
+        break; // If need to control any canal and can pass OR need to control all canals and can't
+               // pass
       }
     }
     return failureMessage;
   }
 
-  private static MoveValidationResult validateCombat(final GameData data, final Collection<Unit> units,
+  private static MoveValidationResult validateCombat(final GameData data,
+      final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
     }
     for (final Territory t : route.getSteps()) {
       if (!Matches.territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(player).test(t)) {
-        return result.setErrorReturnResult("Cannot move into territories owned by " + t.getOwner().getName()
-            + " during Combat Movement Phase");
+        return result
+            .setErrorReturnResult("Cannot move into territories owned by " + t.getOwner().getName()
+                + " during Combat Movement Phase");
       }
     }
-    // we are in a contested territory owned by the enemy, and we want to move to another enemy owned territory. do not
+    // we are in a contested territory owned by the enemy, and we want to move to another enemy
+    // owned territory. do not
     // allow unless each
     // unit can blitz the current territory.
     if (!route.getStart().isWater()
         && Matches.isAtWar(route.getStart().getOwner(), data).test(player)
-        && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
-            .isTerritoryEnemy(player, data).negate(), false))) {
+        && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
+            && !route.allMatchMiddleSteps(Matches
+                .isTerritoryEnemy(player, data).negate(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).test(route.getStart())
           && (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))) {
-        return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
+        return result
+            .setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
       for (final Unit u : CollectionUtils.getMatches(units,
           Matches.unitCanBlitz().negate().and(Matches.unitIsNotAir()))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
-    // we are in a contested territory owned by us, and we want to move to an enemy owned territory. do not allow unless
+    // we are in a contested territory owned by us, and we want to move to an enemy owned territory.
+    // do not allow unless
     // the territory is
     // blitzable.
     if (!route.getStart().isWater()
         && !Matches.isAtWar(route.getStart().getOwner(), data).test(player)
-        && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
-            .isTerritoryEnemy(player, data).negate(), false))) {
+        && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
+            && !route.allMatchMiddleSteps(Matches
+                .isTerritoryEnemy(player, data).negate(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).test(route.getStart())
           && (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle into enemy territory");
       }
     }
-    // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a transport
+    // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a
+    // transport
     if (units.stream().anyMatch(Matches.unitCanNotMoveDuringCombatMove())
         && (!route.getStart().isWater() || !route.getEnd().isWater())) {
-      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitCanNotMoveDuringCombatMove())) {
+      for (final Unit unit : CollectionUtils.getMatches(units,
+          Matches.unitCanNotMoveDuringCombatMove())) {
         result.addDisallowedUnit("Cannot move AA guns in combat movement phase", unit);
       }
     }
     // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
-      if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
-        return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
+      if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))
+          && !isNeutralsBlitzable(data)) {
+        return result
+            .setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
     if (units.stream().anyMatch(Matches.unitIsLand()) && route.hasSteps()) {
-      // check all the territories but the end, if there are enemy territories, make sure they are blitzable
+      // check all the territories but the end, if there are enemy territories, make sure they are
+      // blitzable
       // if they are not blitzable, or we aren't all blitz units fail
       int enemyCount = 0;
       boolean allEnemyBlitzable = true;
@@ -341,21 +373,27 @@ public class MoveValidator {
         final Predicate<Unit> nonBlitzing = blitzingUnit.negate();
         final Collection<Unit> nonBlitzingUnits = CollectionUtils.getMatches(units, nonBlitzing);
         // remove any units that gain blitz due to certain abilities
-        nonBlitzingUnits.removeAll(UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
+        nonBlitzingUnits.removeAll(
+            UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
         final Predicate<Territory> territoryIsNotEnd = Matches.territoryIs(route.getEnd()).negate();
-        final Predicate<Territory> nonFriendlyTerritories = Matches.isTerritoryFriendly(player, data).negate();
-        final Predicate<Territory> notEndOrFriendlyTerrs = nonFriendlyTerritories.and(territoryIsNotEnd);
+        final Predicate<Territory> nonFriendlyTerritories =
+            Matches.isTerritoryFriendly(player, data).negate();
+        final Predicate<Territory> notEndOrFriendlyTerrs =
+            nonFriendlyTerritories.and(territoryIsNotEnd);
         final Predicate<Territory> foughtOver =
             Matches.territoryWasFoughOver(AbstractMoveDelegate.getBattleTracker(data));
         final Predicate<Territory> notEndWasFought = territoryIsNotEnd.and(foughtOver);
         final boolean wasStartFoughtOver =
             AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getStart())
                 || AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(route.getStart());
-        nonBlitzingUnits.addAll(CollectionUtils.getMatches(units, Matches.unitIsOfTypes(TerritoryEffectHelper
-            .getUnitTypesThatLostBlitz((wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
+        nonBlitzingUnits.addAll(CollectionUtils.getMatches(units,
+            Matches.unitIsOfTypes(TerritoryEffectHelper
+                .getUnitTypesThatLostBlitz(
+                    (wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
         for (final Unit unit : nonBlitzingUnits) {
           // TODO: Need to actually test if the unit is being air transported or land transported
-          if (Matches.unitIsAirTransportable().test(unit) || Matches.unitIsLandTransportable().test(unit)) {
+          if (Matches.unitIsAirTransportable().test(unit)
+              || Matches.unitIsLandTransportable().test(unit)) {
             continue;
           }
           final TripleAUnit taUnit = (TripleAUnit) unit;
@@ -376,7 +414,8 @@ public class MoveValidator {
     }
     // make sure no conquered territories on route
     if (MoveValidator.hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
-      // unless we are all air or we are in non combat OR the route is water (was a bug in convoy zone movement)
+      // unless we are all air or we are in non combat OR the route is water (was a bug in convoy
+      // zone movement)
       if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) {
         // what if we are paratroopers?
         return result.setErrorReturnResult("Cannot move through newly captured territories");
@@ -387,12 +426,14 @@ public class MoveValidator {
         && units.stream().anyMatch(Matches.unitWasUnloadedThisTurn())) {
       final Collection<Territory> end = Collections.singleton(route.getEnd());
       if (!end.isEmpty()
-          && end.stream().allMatch(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
+          && end.stream().allMatch(
+              Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
           && !route.getEnd().getUnits().isEmpty()) {
         return result.setErrorReturnResult("Units cannot participate in multiple battles");
       }
     }
-    // See if we are doing invasions in combat phase, with units or transports that can't do invasion.
+    // See if we are doing invasions in combat phase, with units or transports that can't do
+    // invasion.
     if (route.isUnload() && Matches.isTerritoryEnemy(player, data).test(route.getEnd())) {
       for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitCanInvade().negate())) {
         result.addDisallowedUnit(unit.getType().getName() + " can't invade from "
@@ -402,7 +443,8 @@ public class MoveValidator {
     return result;
   }
 
-  private static MoveValidationResult validateNonCombat(final GameData data, final Collection<Unit> units,
+  private static MoveValidationResult validateNonCombat(final GameData data,
+      final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -420,13 +462,15 @@ public class MoveValidator {
     // TODO need to account for subs AND transports that are ignored, not just OR
     final Territory end = route.getEnd();
     if (neutralOrEnemy.test(end)) {
-      // a convoy zone is controlled, so we must make sure we can still move there if there are actual battle there
+      // a convoy zone is controlled, so we must make sure we can still move there if there are
+      // actual battle there
       if (!end.isWater() || navalMayNotNonComIntoControlled) {
         return result.setErrorReturnResult("Cannot advance units to battle in non combat");
       }
     }
     // Subs can't travel under DDs
-    if (isSubmersibleSubsAllowed(data) && !units.isEmpty() && units.stream().allMatch(Matches.unitIsSub())) {
+    if (isSubmersibleSubsAllowed(data) && !units.isEmpty()
+        && units.stream().allMatch(Matches.unitIsSub())) {
       // this is ok unless there are destroyer on the path
       if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
@@ -437,7 +481,8 @@ public class MoveValidator {
         final Predicate<Unit> friendlyOrSubmerged = Matches.enemyUnit(player, data).negate()
             .or(Matches.unitIsSubmerged());
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
-            && !(!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()) && end.isWater())) {
+            && !(!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir())
+                && end.isWater())) {
           if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsSub())
               || !Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
 
@@ -446,29 +491,38 @@ public class MoveValidator {
         }
       }
     }
-    // if there are enemy units on the path blocking us, that is validated elsewhere (validateNonEnemyUnitsOnPath)
+    // if there are enemy units on the path blocking us, that is validated elsewhere
+    // (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
     if ((!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()))
-        || (units.stream().noneMatch(Matches.unitIsSea()) && !nonParatroopersPresent(player, units))) {
+        || (units.stream().noneMatch(Matches.unitIsSea())
+            && !nonParatroopersPresent(player, units))) {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.anyMatch(Matches.territoryIsNeutralButNotWater().and(Matches.territoryIsWater().negate()))
+      if (route.anyMatch(
+          Matches.territoryIsNeutralButNotWater().and(Matches.territoryIsWater().negate()))
           && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
-        return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
+        return result
+            .setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
-      // if sea units, or land units moving over/onto sea (ex: loading onto a transport), then only check if old rules
+      // if sea units, or land units moving over/onto sea (ex: loading onto a transport), then only
+      // check if old rules
       // stop us
-    } else if (units.stream().anyMatch(Matches.unitIsSea()) || route.anyMatch(Matches.territoryIsWater())) {
-      // if there are neutral or owned territories, we cannot move through them (only under old rules. under new rules
+    } else if (units.stream().anyMatch(Matches.unitIsSea())
+        || route.anyMatch(Matches.territoryIsWater())) {
+      // if there are neutral or owned territories, we cannot move through them (only under old
+      // rules. under new rules
       // we can move through
       // owned sea zones.)
       if (navalMayNotNonComIntoControlled && route.anyMatch(neutralOrEnemy)) {
-        return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
+        return result.setErrorReturnResult(
+            "Cannot move units through neutral or enemy territories in non combat");
       }
     } else {
       if (route.anyMatch(neutralOrEnemy)) {
-        return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
+        return result.setErrorReturnResult(
+            "Cannot move units through neutral or enemy territories in non combat");
       }
     }
     return result;
@@ -483,7 +537,8 @@ public class MoveValidator {
     if (!isMovementByTerritoryRestricted(data)) {
       return result;
     }
-    final RulesAttachment ra = (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
+    final RulesAttachment ra =
+        (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     if (ra == null || ra.getMovementRestrictionTerritories() == null) {
       return result;
     }
@@ -506,7 +561,8 @@ public class MoveValidator {
     return result;
   }
 
-  private static MoveValidationResult validateNonEnemyUnitsOnPath(final GameData data, final Collection<Unit> units,
+  private static MoveValidationResult validateNonEnemyUnitsOnPath(final GameData data,
+      final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -521,7 +577,8 @@ public class MoveValidator {
     }
     // subs may possibly carry units...
     if (isSubmersibleSubsAllowed(data)) {
-      final Collection<Unit> matches = CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
+      final Collection<Unit> matches =
+          CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
       if (!matches.isEmpty() && matches.stream().allMatch(Matches.unitIsSub())) {
         // this is ok unless there are destroyer on the path
         if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
@@ -542,7 +599,8 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateBasic(final GameData data,
-      final Collection<Unit> units, final Route route, final PlayerID player, final Collection<Unit> transportsToLoad,
+      final Collection<Unit> units, final Route route, final PlayerID player,
+      final Collection<Unit> transportsToLoad,
       final Map<Unit, Collection<Unit>> newDependents, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
     // make sure transports in the destination
@@ -557,21 +615,36 @@ public class MoveValidator {
         result.addDisallowedUnit("Can only move friendly units", unit);
       }
 
-      // Exclude transported units
+      // Ensure all air transports are included
+      for (Unit airTransport : newDependents.keySet()) {
+        if (!units.contains(airTransport)) {
+          for (Unit unit : newDependents.get(airTransport)) {
+            if (units.contains(unit)) {
+              result.addDisallowedUnit("Not all units have enough movement", unit);
+            }
+          }
+        }
+      }
+
+      // Ignore transported units
       Collection<Unit> moveTest = new ArrayList<>(units);
       if (route.getStart().isWater()) {
         moveTest = MoveValidator.getNonLand(units);
       }
       final Map<Unit, Collection<Unit>> dependentsMap =
           getDependents(CollectionUtils.getMatches(units, Matches.unitCanTransport()));
-      Set<Unit> dependents = dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
-      dependents.addAll(newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
+      Set<Unit> dependents =
+          dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+      dependents.addAll(
+          newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
       moveTest.removeAll(dependents);
 
       // Can only move owned units except transported units or allied air on carriers
-      for (final Unit unit : CollectionUtils.getMatches(moveTest, Matches.unitIsOwnedBy(player).negate())) {
-        if (!(UnitAttachment.get(unit.getType()).getCarrierCost() > 0 && data.getRelationshipTracker().isAllied(player,
-            unit.getOwner()))) {
+      for (final Unit unit : CollectionUtils.getMatches(moveTest,
+          Matches.unitIsOwnedBy(player).negate())) {
+        if (!(UnitAttachment.get(unit.getType()).getCarrierCost() > 0
+            && data.getRelationshipTracker().isAllied(player,
+                unit.getOwner()))) {
           result.addDisallowedUnit("Can only move own troops", unit);
         }
       }
@@ -593,13 +666,16 @@ public class MoveValidator {
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.test(unit)) {
           boolean unitOk = false;
-          if (Matches.unitIsOwnedBy(player).negate().test(unit) && Matches.alliedUnit(player, data).test(unit)
+          if (Matches.unitIsOwnedBy(player).negate().test(unit)
+              && Matches.alliedUnit(player, data).test(unit)
               && Matches.unitTypeCanLandOnCarrier().test(unit.getType())
               && moveTest.stream().anyMatch(Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
-            // this is so that if the unit is owned by any ally and it is cargo, then it will not count.
+            // this is so that if the unit is owned by any ally and it is cargo, then it will not
+            // count.
             // (shouldn't it be a dependent in this case??)
             unitOk = true;
-          } else if (Matches.unitHasNotMoved().test(unit) && Matches.unitIsLandTransportable().test(unit)) {
+          } else if (Matches.unitHasNotMoved().test(unit)
+              && Matches.unitIsLandTransportable().test(unit)) {
             if (numLandTransportsWithoutCapacity > 0) {
               numLandTransportsWithoutCapacity--;
               unitOk = true;
@@ -622,13 +698,16 @@ public class MoveValidator {
 
       // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
       if (route.hasNeutralBeforeEnd()) {
-        if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
-          return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
+        if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))
+            && !isNeutralsBlitzable(data)) {
+          return result.setErrorReturnResult(
+              "Must stop land units when passing through neutral territories");
         }
       }
       // a territory effect can disallow unit types in
       if (units.stream().anyMatch(
-          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(route.getSteps())))) {
+          Matches.unitIsOfTypes(TerritoryEffectHelper
+              .getUnitTypesForUnitsNotAllowedIntoTerritory(route.getSteps())))) {
         return result.setErrorReturnResult("Territory Effects disallow some units into "
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
@@ -636,13 +715,16 @@ public class MoveValidator {
       for (final Territory t : route.getAllTerritories()) {
         if (!moveTest.stream().allMatch(Matches.unitHasRequiredUnitsToMove(t, data))) {
           return result.setErrorReturnResult(
-              t.getName() + " doesn't have the required units to allow moving the selected units into it");
+              t.getName()
+                  + " doesn't have the required units to allow moving the selected units into it");
         }
       }
     } // !isEditMode
 
     // make sure that no non sea non transportable no carriable units end at sea
-    if (route.getEnd() != null && route.getEnd().isWater()) {
+    if (route.getEnd() != null && route.getEnd().isWater())
+
+    {
       for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
         result.addDisallowedUnit("Not all units can end at water", unit);
       }
@@ -658,7 +740,8 @@ public class MoveValidator {
     // test for stack limits per unit
     if (route.getEnd() != null) {
       final Collection<Unit> unitsWithStackingLimits =
-          CollectionUtils.getMatches(units, Matches.unitHasMovementLimit().or(Matches.unitHasAttackingLimit()));
+          CollectionUtils.getMatches(units,
+              Matches.unitHasMovementLimit().or(Matches.unitHasAttackingLimit()));
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)
@@ -667,15 +750,18 @@ public class MoveValidator {
             final UnitType ut = unit.getType();
             int maxAllowed =
                 UnitAttachment
-                    .getMaximumNumberOfThisUnitTypeToReachStackingLimit("attackingLimit", ut, t, player, data);
+                    .getMaximumNumberOfThisUnitTypeToReachStackingLimit("attackingLimit", ut, t,
+                        player, data);
             maxAllowed -= CollectionUtils.countMatches(unitsAllowedSoFar, Matches.unitIsOfType(ut));
             if (maxAllowed > 0) {
               unitsAllowedSoFar.add(unit);
             } else {
-              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit", unit);
+              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit",
+                  unit);
             }
           }
-          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("attackingLimit", units, t, player,
+          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("attackingLimit",
+              units, t, player,
               data)) {
             return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
           }
@@ -683,15 +769,19 @@ public class MoveValidator {
           for (final Unit unit : unitsWithStackingLimits) {
             final UnitType ut = unit.getType();
             int maxAllowed =
-                UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("movementLimit", ut, t, player, data);
+                UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("movementLimit",
+                    ut,
+                    t, player, data);
             maxAllowed -= CollectionUtils.countMatches(unitsAllowedSoFar, Matches.unitIsOfType(ut));
             if (maxAllowed > 0) {
               unitsAllowedSoFar.add(unit);
             } else {
-              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit", unit);
+              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit",
+                  unit);
             }
           }
-          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("movementLimit", units, t, player,
+          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("movementLimit",
+              units, t, player,
               data)) {
             return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
           }
@@ -712,7 +802,8 @@ public class MoveValidator {
     return result;
   }
 
-  private static int getNumLandTransportsWithoutCapacity(final Collection<Unit> units, final PlayerID player) {
+  private static int getNumLandTransportsWithoutCapacity(final Collection<Unit> units,
+      final PlayerID player) {
     if (TechAttachment.isMechanizedInfantry(player)) {
       final Predicate<Unit> transportLand =
           Matches.unitIsLandTransportWithoutCapacity().and(Matches.unitIsOwnedBy(player));
@@ -721,7 +812,8 @@ public class MoveValidator {
     return 0;
   }
 
-  private static IntegerMap<Unit> getLandTransportsWithCapacity(final Collection<Unit> units, final PlayerID player) {
+  private static IntegerMap<Unit> getLandTransportsWithCapacity(final Collection<Unit> units,
+      final PlayerID player) {
     IntegerMap<Unit> map = new IntegerMap<>();
     if (TechAttachment.isMechanizedInfantry(player)) {
       final Predicate<Unit> transportLand =
@@ -748,7 +840,8 @@ public class MoveValidator {
    * movement.
    * AA and factory dont count as enemy.
    */
-  static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
+  static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player,
+      final GameData data) {
     final Predicate<Unit> alliedOrNonCombat = Matches.unitIsInfrastructure()
         .or(Matches.enemyUnit(player, data).negate())
         .or(Matches.unitIsSubmerged());
@@ -765,7 +858,8 @@ public class MoveValidator {
    * Checks that there only transports, subs and/or allies on the route except at the end.
    * AA and factory dont count as enemy.
    */
-  static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player, final GameData data,
+  static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player,
+      final GameData data,
       final boolean ignoreRouteEnd) {
     final Predicate<Unit> subOnly = Matches.unitIsInfrastructure()
         .or(Matches.unitIsSub())
@@ -788,7 +882,8 @@ public class MoveValidator {
     } else {
       steps = route.getSteps();
     }
-    // if there are no steps, then we began in this sea zone, so see if there are ignored units in this sea zone (not
+    // if there are no steps, then we began in this sea zone, so see if there are ignored units in
+    // this sea zone (not
     // sure if we need
     // !ignoreRouteEnd here).
     if (steps.isEmpty() && route.numberOfStepsIncludingStart() == 1 && !ignoreRouteEnd) {
@@ -796,15 +891,18 @@ public class MoveValidator {
     }
     for (final Territory current : steps) {
       if (current.isWater()) {
-        if (getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(transportOrSubOnly)) {
+        if (getIgnoreTransportInMovement && getIgnoreSubInMovement
+            && current.getUnits().allMatch(transportOrSubOnly)) {
           validMove = true;
           continue;
         }
-        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement && current.getUnits().allMatch(transportOnly)) {
+        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement
+            && current.getUnits().allMatch(transportOnly)) {
           validMove = true;
           continue;
         }
-        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(subOnly)) {
+        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement
+            && current.getUnits().allMatch(subOnly)) {
           validMove = true;
           continue;
         }
@@ -814,8 +912,10 @@ public class MoveValidator {
     return validMove;
   }
 
-  private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
-    final Predicate<Unit> enemyDestroyer = Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
+  private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player,
+      final GameData data) {
+    final Predicate<Unit> enemyDestroyer =
+        Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
       if (current.getUnits().anyMatch(enemyDestroyer)) {
         return true;
@@ -828,7 +928,8 @@ public class MoveValidator {
     return BaseEditDelegate.getEditMode(data);
   }
 
-  private static boolean hasConqueredNonBlitzedNonWaterOnRoute(final Route route, final GameData data) {
+  private static boolean hasConqueredNonBlitzedNonWaterOnRoute(final Route route,
+      final GameData data) {
     for (final Territory current : route.getMiddleSteps()) {
       if (!Matches.territoryIsWater().test(current)
           && AbstractMoveDelegate.getBattleTracker(data).wasConquered(current)
@@ -840,7 +941,8 @@ public class MoveValidator {
   }
 
   // TODO KEV revise these to include paratroop load/unload
-  public static boolean isLoad(final Collection<Unit> units, final Map<Unit, Collection<Unit>> newDependents,
+  public static boolean isLoad(final Collection<Unit> units,
+      final Map<Unit, Collection<Unit>> newDependents,
       final Route route, final GameData data, final PlayerID player) {
     final Map<Unit, Collection<Unit>> alreadyLoaded =
         mustMoveWith(units, newDependents, route.getStart(), data, player);
@@ -850,18 +952,22 @@ public class MoveValidator {
     // See if we even need to go to the trouble of checking for AirTransported units
     final boolean checkForAlreadyTransported = !route.getStart().isWater() && route.hasWater();
     if (checkForAlreadyTransported) {
-      // TODO Leaving unitIsTransport() for potential use with amphib transports (hovercraft, ducks, etc...)
+      // TODO Leaving unitIsTransport() for potential use with amphib transports (hovercraft, ducks,
+      // etc...)
       final List<Unit> transports =
-          CollectionUtils.getMatches(units, Matches.unitIsTransport().or(Matches.unitIsAirTransport()));
+          CollectionUtils.getMatches(units,
+              Matches.unitIsTransport().or(Matches.unitIsAirTransport()));
       final List<Unit> transportable =
-          CollectionUtils.getMatches(units, Matches.unitCanBeTransported().or(Matches.unitIsAirTransportable()));
+          CollectionUtils.getMatches(units,
+              Matches.unitCanBeTransported().or(Matches.unitIsAirTransportable()));
       // Check if there are transports in the group to be checked
       if (alreadyLoaded.keySet().containsAll(transports)) {
         // Check each transportable unit -vs those already loaded.
         for (final Unit unit : transportable) {
           boolean found = false;
           for (final Unit transport : transports) {
-            if (alreadyLoaded.get(transport) == null || alreadyLoaded.get(transport).contains(unit)) {
+            if (alreadyLoaded.get(transport) == null
+                || alreadyLoaded.get(transport).contains(unit)) {
               found = true;
               break;
             }
@@ -924,18 +1030,21 @@ public class MoveValidator {
   // Determines whether we can pay the neutral territory charge for a
   // given route for air units. We can't cross neutral territories
   // in WW2V2.
-  private static MoveValidationResult canCrossNeutralTerritory(final GameData data, final Route route,
+  private static MoveValidationResult canCrossNeutralTerritory(final GameData data,
+      final Route route,
       final PlayerID player, final MoveValidationResult result) {
     // neutrals we will overfly in the first place
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
-    final int pus = (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
+    final int pus =
+        (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
     if (pus < getNeutralCharge(data, neutrals.size())) {
       return result.setErrorReturnResult(TOO_POOR_TO_VIOLATE_NEUTRALITY);
     }
     return result;
   }
 
-  private static Territory getTerritoryTransportHasUnloadedTo(final List<UndoableMove> undoableMoves,
+  private static Territory getTerritoryTransportHasUnloadedTo(
+      final List<UndoableMove> undoableMoves,
       final Unit transport) {
     for (final UndoableMove undoableMove : undoableMoves) {
       if (undoableMove.wasTransportUnloaded(transport)) {
@@ -945,8 +1054,10 @@ public class MoveValidator {
     return null;
   }
 
-  private static MoveValidationResult validateTransport(final boolean isNonCombat, final GameData data,
-      final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route, final PlayerID player,
+  private static MoveValidationResult validateTransport(final boolean isNonCombat,
+      final GameData data,
+      final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route,
+      final PlayerID player,
       final Collection<Unit> transportsToLoad, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
     if (!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir())) {
@@ -973,7 +1084,8 @@ public class MoveValidator {
         return result.setErrorReturnResult("Unloading units must stop where they are unloaded");
       }
       for (final Unit unit : TransportTracker.getUnitsLoadedOnAlliedTransportsThisTurn(units)) {
-        result.addDisallowedUnit(CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND, unit);
+        result.addDisallowedUnit(CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND,
+            unit);
       }
       final Collection<Unit> transports = TransportUtils.mapTransports(route, units, null).values();
       final boolean isScramblingOrKamikazeAttacksEnabled =
@@ -981,7 +1093,8 @@ public class MoveValidator {
               || Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
-      final Predicate<Unit> enemySubmarineMatch = Matches.unitIsEnemyOf(data, player).and(Matches.unitIsSub());
+      final Predicate<Unit> enemySubmarineMatch =
+          Matches.unitIsEnemyOf(data, player).and(Matches.unitIsSub());
       final Predicate<Unit> ownedSeaNonTransportMatch = Matches.unitIsOwnedBy(player)
           .and(Matches.unitIsSea())
           .and(Matches.unitIsNotTransportButCouldBeCombatTransport());
@@ -993,25 +1106,30 @@ public class MoveValidator {
             if (submarinesPreventUnescortedAmphibAssaults
                 && !Matches.territoryHasUnitsThatMatch(ownedSeaNonTransportMatch).test(routeStart)
                 && Matches.territoryHasUnitsThatMatch(enemySubmarineMatch).test(routeStart)) {
-              // we must have at least one warship (non-transport) unit, otherwise the enemy sub stops our unloading for
+              // we must have at least one warship (non-transport) unit, otherwise the enemy sub
+              // stops our unloading for
               // amphibious assault
               for (final Unit unit : TransportTracker.transporting(transport)) {
-                result.addDisallowedUnit(ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING, unit);
+                result.addDisallowedUnit(
+                    ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING, unit);
               }
             }
           } else if (!AbstractMoveDelegate.getBattleTracker(data).wasConquered(routeEnd)) {
             // this is an unload to a friendly territory
             if (isScramblingOrKamikazeAttacksEnabled
                 || !Matches.territoryIsEmptyOfCombatUnits(data, player).test(routeStart)) {
-              // Unloading a transport from a sea zone with a battle, to a friendly land territory, during combat move
+              // Unloading a transport from a sea zone with a battle, to a friendly land territory,
+              // during combat move
               // phase, is illegal
-              // and in addition to being illegal, it is also causing problems if the sea transports get killed (the
+              // and in addition to being illegal, it is also causing problems if the sea transports
+              // get killed (the
               // land units are not
               // dying)
               // TODO: should we use the battle tracker for this instead?
               for (final Unit unit : TransportTracker.transporting(transport)) {
                 result.addDisallowedUnit(
-                    TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED, unit);
+                    TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED,
+                    unit);
               }
             }
           }
@@ -1021,13 +1139,17 @@ public class MoveValidator {
         // check whether transport has already unloaded
         if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
           for (final Unit unit : TransportTracker.transporting(transport)) {
-            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
+            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE,
+                unit);
           }
           // check whether transport is restricted to another territory
-        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
-          final Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
+        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport,
+            route.getEnd())) {
+          final Territory alreadyUnloadedTo =
+              getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
           for (final Unit unit : TransportTracker.transporting(transport)) {
-            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
+            result.addDisallowedUnit(
+                TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
           }
           // Check if the transport has already loaded after being in combat
         } else if (TransportTracker.isTransportUnloadRestrictedInNonCombat(transport)) {
@@ -1049,12 +1171,15 @@ public class MoveValidator {
     }
     // make sure that the only the first or last territory is land
     // dont want situation where they go sea land sea
-    if (!isEditMode && route.hasLand() && !(route.getStart().isWater() || route.getEnd().isWater())) {
-      // needs to include all land and air to work, since it makes sure the land units can be carried by the air and
+    if (!isEditMode && route.hasLand()
+        && !(route.getStart().isWater() || route.getEnd().isWater())) {
+      // needs to include all land and air to work, since it makes sure the land units can be
+      // carried by the air and
       // that the air has enough
       // capacity
       if (nonParatroopersPresent(player, landAndAir)) {
-        return result.setErrorReturnResult("Invalid move, only start or end can be land when route has water.");
+        return result.setErrorReturnResult(
+            "Invalid move, only start or end can be land when route has water.");
       }
     }
     // simply because I dont want to handle it yet
@@ -1089,18 +1214,23 @@ public class MoveValidator {
       if (!isEditMode && !route.hasExactlyOneStep() && nonParatroopersPresent(player, landAndAir)) {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
-      final Predicate<Unit> enemyNonSubmerged = Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
-      if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
+      final Predicate<Unit> enemyNonSubmerged =
+          Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
+      if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged)
+          && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
-          if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
+          if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(
+              player,
               route.getEnd().getUnits().getUnits(), data)) {
             return result.setErrorReturnResult("Cannot load when enemy sea units are present");
           }
         }
       }
-      final Map<Unit, Unit> unitsToTransports = TransportUtils.mapTransports(route, land, transportsToLoad);
+      final Map<Unit, Unit> unitsToTransports =
+          TransportUtils.mapTransports(route, land, transportsToLoad);
       final Iterator<Unit> iter = land.iterator();
-      // CompositePredicate<Unit> landUnitsAtSea = new CompositeMatchOr<Unit>(Matches.unitIsLandAndOwnedBy(player),
+      // CompositePredicate<Unit> landUnitsAtSea = new
+      // CompositeMatchOr<Unit>(Matches.unitIsLandAndOwnedBy(player),
       // Matches.unitCanBeTransported());
       while (!isEditMode && iter.hasNext()) {
         final TripleAUnit unit = (TripleAUnit) iter.next();
@@ -1113,11 +1243,14 @@ public class MoveValidator {
         }
         if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
           result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
-        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
-          Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
+        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport,
+            route.getEnd())) {
+          Territory alreadyUnloadedTo =
+              getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
           for (final Unit transportToLoad : transportsToLoad) {
             final TripleAUnit trn = (TripleAUnit) transportToLoad;
-            if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(trn, route.getEnd())) {
+            if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(trn,
+                route.getEnd())) {
               final UnitAttachment ua = UnitAttachment.get(unit.getType());
               // UnitAttachment trna = UnitAttachment.get(trn.getType());
               if (TransportTracker.getAvailableCapacity(trn) >= ua.getTransportCost()) {
@@ -1127,7 +1260,8 @@ public class MoveValidator {
             }
           }
           if (alreadyUnloadedTo != null) {
-            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
+            result.addDisallowedUnit(
+                TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
           }
         }
       }
@@ -1171,25 +1305,31 @@ public class MoveValidator {
             .or(Matches.unitIsAir()))) {
       return false;
     }
-    // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
-    // due to various problems with units like tanks, we will assume that if we are in this method, then all the land
+    // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units,
+    // route);
+    // due to various problems with units like tanks, we will assume that if we are in this method,
+    // then all the land
     // units need transports
-    final List<Unit> paratroopsRequiringTransport = CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
+    final List<Unit> paratroopsRequiringTransport =
+        CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
     if (paratroopsRequiringTransport.isEmpty()) {
       return false;
     }
-    final List<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+    final List<Unit> airTransports =
+        CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
     final List<Unit> allParatroops =
         TransportUtils.findUnitsToLoadOnAirTransports(paratroopsRequiringTransport, airTransports);
     if (!allParatroops.containsAll(paratroopsRequiringTransport)) {
       return false;
     }
-    final Map<Unit, Unit> transportLoadMap = TransportUtils.mapTransportsToLoad(units, airTransports);
+    final Map<Unit, Unit> transportLoadMap =
+        TransportUtils.mapTransportsToLoad(units, airTransports);
     return transportLoadMap.keySet().containsAll(paratroopsRequiringTransport);
   }
 
   // checks if there are non-paratroopers present that cause move validations to fail
-  private static boolean nonParatroopersPresent(final PlayerID player, final Collection<Unit> units) {
+  private static boolean nonParatroopersPresent(final PlayerID player,
+      final Collection<Unit> units) {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
@@ -1204,14 +1344,17 @@ public class MoveValidator {
     return !allLandUnitsAreBeingParatroopered(units);
   }
 
-  private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
+  private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units,
+      final Route route) {
     return CollectionUtils.getMatches(units, Matches.unitIsAirTransportable()
         .and(u -> TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u)
             || route.crossesWater() || route.getEnd().isWater()));
   }
 
-  private static MoveValidationResult validateParatroops(final boolean nonCombat, final GameData data,
-      final Collection<Unit> units, final Route route, final PlayerID player, final MoveValidationResult result) {
+  private static MoveValidationResult validateParatroops(final boolean nonCombat,
+      final GameData data,
+      final Collection<Unit> units, final Route route, final PlayerID player,
+      final MoveValidationResult result) {
     if (!TechAttachment.isAirTransportable(player)) {
       return result;
     }
@@ -1230,9 +1373,11 @@ public class MoveValidator {
       if (paratroopsRequiringTransport.isEmpty()) {
         return result;
       }
-      final List<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+      final List<Unit> airTransports =
+          CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
       // TODO kev change below to mapAirTransports (or modify mapTransports to handle air cargo)
-      // Map<Unit, Unit> airTransportsAndParatroops = MoveDelegate.mapTransports(route, paratroopsRequiringTransport,
+      // Map<Unit, Unit> airTransportsAndParatroops = MoveDelegate.mapTransports(route,
+      // paratroopsRequiringTransport,
       // airTransports);
       final Map<Unit, Unit> airTransportsAndParatroops =
           TransportUtils.mapTransportsToLoad(paratroopsRequiringTransport, airTransports);
@@ -1256,11 +1401,13 @@ public class MoveValidator {
         }
         if (!nonCombat && Matches.isTerritoryFriendly(player, data).test(routeEnd)
             && isAirTransportableCanMoveDuringNonCombat(data)) {
-          result.addDisallowedUnit("Paratroops may only airlift during Non-Combat Movement Phase", paratroop);
+          result.addDisallowedUnit("Paratroops may only airlift during Non-Combat Movement Phase",
+              paratroop);
         }
       }
       if (!Properties.getParatroopersCanAttackDeepIntoEnemyTerritory(data)) {
-        for (final Territory current : CollectionUtils.getMatches(route.getMiddleSteps(), Matches.territoryIsLand())) {
+        for (final Territory current : CollectionUtils.getMatches(route.getMiddleSteps(),
+            Matches.territoryIsLand())) {
           if (Matches.isTerritoryEnemy(player, data).test(current)) {
             return result.setErrorReturnResult("Must stop paratroops in first enemy territory");
           }
@@ -1273,12 +1420,14 @@ public class MoveValidator {
   /*
    * Checks if route is either null or includes both canal territories so needs to be checked.
    */
-  private static boolean isCanalOnRoute(final CanalAttachment canalAttachment, final Route route, final GameData data) {
+  private static boolean isCanalOnRoute(final CanalAttachment canalAttachment, final Route route,
+      final GameData data) {
     if (route == null) {
       return true;
     }
     Territory last = null;
-    final Set<Territory> connectionToCheck = CanalAttachment.getAllCanalSeaZones(canalAttachment.getCanalName(), data);
+    final Set<Territory> connectionToCheck =
+        CanalAttachment.getAllCanalSeaZones(canalAttachment.getCanalName(), data);
     for (final Territory current : route.getAllTerritories()) {
       if (last != null) {
         final Collection<Territory> lastTwo = new ArrayList<>();
@@ -1294,7 +1443,8 @@ public class MoveValidator {
   }
 
   /*
-   * Checks if units can pass through canal and returns Optional.empty() if true or a failure message if false.
+   * Checks if units can pass through canal and returns Optional.empty() if true or a failure
+   * message if false.
    */
   private static Optional<String> canPassThroughCanal(final CanalAttachment canalAttachment,
       final Collection<Unit> units, final PlayerID player, final GameData data) {
@@ -1314,7 +1464,8 @@ public class MoveValidator {
     return Optional.empty();
   }
 
-  public static MustMoveWithDetails getMustMoveWith(final Territory start, final Collection<Unit> units,
+  public static MustMoveWithDetails getMustMoveWith(final Territory start,
+      final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents, final GameData data, final PlayerID player) {
     return new MustMoveWithDetails(mustMoveWith(units, newDependents, start, data, player));
   }
@@ -1364,7 +1515,8 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> transportsMustMoveWith(final Collection<Unit> units) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
     // map transports
-    final Collection<Unit> transports = CollectionUtils.getMatches(units, Matches.unitIsTransport());
+    final Collection<Unit> transports =
+        CollectionUtils.getMatches(units, Matches.unitIsTransport());
     final Iterator<Unit> iter = transports.iterator();
     while (iter.hasNext()) {
       final Unit transport = iter.next();
@@ -1377,7 +1529,8 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
-    final Collection<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+    final Collection<Unit> airTransports =
+        CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
     // Then check those that have already had their transportedBy set
     for (final Unit airTransport : airTransports) {
       if (!mustMoveWith.containsKey(airTransport)) {
@@ -1393,7 +1546,8 @@ public class MoveValidator {
     return mustMoveWith;
   }
 
-  public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units, final Territory start,
+  public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,
+      final Territory start,
       final GameData data, final PlayerID player) {
     return carrierMustMoveWith(units, start.getUnits().getUnits(), data, player);
   }
@@ -1413,7 +1567,8 @@ public class MoveValidator {
     final Predicate<Unit> friendlyNotOwnedCarrier = Matches.unitIsCarrier()
         .and(Matches.alliedUnit(player, data))
         .and(Matches.unitIsOwnedBy(player).negate());
-    final Collection<Unit> alliedCarrier = CollectionUtils.getMatches(startUnits, friendlyNotOwnedCarrier);
+    final Collection<Unit> alliedCarrier =
+        CollectionUtils.getMatches(startUnits, friendlyNotOwnedCarrier);
     final Iterator<Unit> alliedCarrierIter = alliedCarrier.iterator();
     while (alliedCarrierIter.hasNext()) {
       final Unit carrier = alliedCarrierIter.next();
@@ -1426,7 +1581,8 @@ public class MoveValidator {
     final Map<Unit, Collection<Unit>> mapping = new HashMap<>();
     // get air that must be carried by our carriers
     final Collection<Unit> ownedCarrier =
-        CollectionUtils.getMatches(units, Matches.unitIsCarrier().and(Matches.unitIsOwnedBy(player)));
+        CollectionUtils.getMatches(units,
+            Matches.unitIsCarrier().and(Matches.unitIsOwnedBy(player)));
     final Iterator<Unit> ownedCarrierIter = ownedCarrier.iterator();
     while (ownedCarrierIter.hasNext()) {
       final Unit carrier = ownedCarrierIter.next();
@@ -1450,11 +1606,13 @@ public class MoveValidator {
       final UnitAttachment planeAttachment = UnitAttachment.get(plane.getType());
       final int cost = planeAttachment.getCarrierCost();
       if (available >= cost) {
-        // this is to test if they started in the same sea zone or not, and its not a very good way of testing it.
+        // this is to test if they started in the same sea zone or not, and its not a very good way
+        // of testing it.
         if ((taCarrier.getAlreadyMoved() == taPlane.getAlreadyMoved())
             || (Matches.unitHasNotMoved().test(plane) && Matches.unitHasNotMoved().test(carrier))
-            || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane) && Matches.alliedUnit(
-                playerWhoIsDoingTheMovement, data).test(plane))) {
+            || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane)
+                && Matches.alliedUnit(
+                    playerWhoIsDoingTheMovement, data).test(plane))) {
           available -= cost;
           canCarry.add(plane);
         }
@@ -1475,7 +1633,8 @@ public class MoveValidator {
     final boolean hasAir = units.stream().anyMatch(Matches.unitIsAir());
     final boolean isNeutralsImpassable =
         isNeutralsImpassable(data) || (hasAir && !Properties.getNeutralFlyoverAllowed(data));
-    // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the route choice
+    // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the
+    // route choice
     // final Predicate<Territory> territoryIsEnd = Matches.territoryIs(end);
     // No neutral countries on route predicate
     final Predicate<Territory> noNeutral = Matches.territoryIsNeutralButNotWater().negate();
@@ -1486,7 +1645,8 @@ public class MoveValidator {
     // no impassable or restricted territories
     final Predicate<Territory> noImpassable = PredicateBuilder.of(
         Matches.territoryIsPassableAndNotRestricted(player, data))
-        // if we have air or land, we don't want to move over territories owned by players who's relationships will
+        // if we have air or land, we don't want to move over territories owned by players who's
+        // relationships will
         // not let us move into them
         .andIf(hasAir, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))
         .andIf(hasLand, Matches.territoryAllowsCanMoveLandUnitsOverOwnedLand(player, data))
@@ -1496,13 +1656,16 @@ public class MoveValidator {
         .of(noImpassable)
         .andIf(isNeutralsImpassable, noNeutral)
         .build());
-    // since all routes require at least noImpassable, then if we cannot find a route without impassables, just return
+    // since all routes require at least noImpassable, then if we cannot find a route without
+    // impassables, just return
     // any route
     if (defaultRoute == null) {
-      // at least try for a route without impassable territories, but allowing restricted territories, since there is a
+      // at least try for a route without impassable territories, but allowing restricted
+      // territories, since there is a
       // chance politics may change in the future.
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-          (isNeutralsImpassable ? noNeutral.and(Matches.territoryIsImpassable()) : Matches.territoryIsImpassable()));
+          (isNeutralsImpassable ? noNeutral.and(Matches.territoryIsImpassable())
+              : Matches.territoryIsImpassable()));
       // ok, so there really is nothing, so just return any route, without conditions
       if (defaultRoute == null) {
         return data.getMap().getRoute(start, end);
@@ -1512,7 +1675,9 @@ public class MoveValidator {
     // we don't want to look at the dependents
     final Collection<Unit> unitsWhichAreNotBeingTransportedOrDependent =
         new ArrayList<>(CollectionUtils.getMatches(units,
-            Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, defaultRoute, player, data, true)
+            Matches
+                .unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, defaultRoute,
+                    player, data, true)
                 .negate()));
     boolean mustGoLand = false;
     boolean mustGoSea = false;
@@ -1526,13 +1691,16 @@ public class MoveValidator {
                 .and(noNeutral)
                 .and(noImpassable));
       } else {
-        landRoute = data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsLand().and(noImpassable));
+        landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
+            Matches.territoryIsLand().and(noImpassable));
       }
       if (landRoute != null
-          && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
+          && ((landRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
               || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsLand())))) {
+                  && unitsWhichAreNotBeingTransportedOrDependent.stream()
+                      .anyMatch(Matches.unitIsLand())))) {
         defaultRoute = landRoute;
         mustGoLand = true;
       }
@@ -1541,11 +1709,15 @@ public class MoveValidator {
     // dont force a water route, since planes may be moving
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
-          data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsWater().and(noImpassable));
+          data.getMap().getRoute_IgnoreEnd(start, end,
+              Matches.territoryIsWater().and(noImpassable));
       if (waterRoute != null
-          && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsSea())))) {
+          && ((waterRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
+              || (forceLandOrSeaRoute
+                  && unitsWhichAreNotBeingTransportedOrDependent.stream()
+                      .anyMatch(Matches.unitIsSea())))) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }
@@ -1579,8 +1751,9 @@ public class MoveValidator {
       }
       final Route testRoute = data.getMap().getRoute_IgnoreEnd(start, end, testMatch);
       if (testRoute != null
-          && testRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) {
+          && testRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) {
         return testRoute;
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -547,9 +547,9 @@ public class MoveValidator {
       }
 
       // Ensure all air transports are included
-      for (Unit airTransport : newDependents.keySet()) {
+      for (final Unit airTransport : newDependents.keySet()) {
         if (!units.contains(airTransport)) {
-          for (Unit unit : newDependents.get(airTransport)) {
+          for (final Unit unit : newDependents.get(airTransport)) {
             if (units.contains(unit)) {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
@@ -564,7 +564,8 @@ public class MoveValidator {
       }
       final Map<Unit, Collection<Unit>> dependentsMap =
           getDependents(CollectionUtils.getMatches(units, Matches.unitCanTransport()));
-      Set<Unit> dependents = dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+      final Set<Unit> dependents =
+          dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
       dependents.addAll(newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
       moveTest.removeAll(dependents);
 
@@ -588,7 +589,7 @@ public class MoveValidator {
         data.releaseReadLock();
       }
       int numLandTransportsWithoutCapacity = getNumLandTransportsWithoutCapacity(units, player);
-      IntegerMap<Unit> landTransportsWithCapacity = getLandTransportsWithCapacity(units, player);
+      final IntegerMap<Unit> landTransportsWithCapacity = getLandTransportsWithCapacity(units, player);
       moveTest = TransportUtils.sortByTransportCostDescending(moveTest);
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.test(unit)) {
@@ -604,7 +605,7 @@ public class MoveValidator {
               numLandTransportsWithoutCapacity--;
               unitOk = true;
             } else {
-              for (Unit transport : landTransportsWithCapacity.keySet()) {
+              for (final Unit transport : landTransportsWithCapacity.keySet()) {
                 final int cost = UnitAttachment.get((unit).getType()).getTransportCost();
                 if (cost <= landTransportsWithCapacity.getInt(transport)) {
                   landTransportsWithCapacity.add(transport, -cost);
@@ -722,11 +723,11 @@ public class MoveValidator {
   }
 
   private static IntegerMap<Unit> getLandTransportsWithCapacity(final Collection<Unit> units, final PlayerID player) {
-    IntegerMap<Unit> map = new IntegerMap<>();
+    final IntegerMap<Unit> map = new IntegerMap<>();
     if (TechAttachment.isMechanizedInfantry(player)) {
       final Predicate<Unit> transportLand =
           Matches.unitIsLandTransportWithCapacity().and(Matches.unitIsOwnedBy(player));
-      for (Unit unit : CollectionUtils.getMatches(units, transportLand)) {
+      for (final Unit unit : CollectionUtils.getMatches(units, transportLand)) {
         map.put(unit, UnitAttachment.get(unit.getType()).getTransportCapacity());
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -43,22 +43,19 @@ import games.strategy.util.PredicateBuilder;
  * Provides some static methods for validating movement.
  */
 public class MoveValidator {
+
   public static final String TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE =
       "Transport has already unloaded units in a previous phase";
   public static final String TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED =
       "Transport may not unload to friendly territories until after combat is resolved";
   public static final String ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING =
       "Enemy Submarine Preventing Unescorted Amphibious Assault Landing";
-  public static final String TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO =
-      "Transport has already unloaded units to ";
+  public static final String TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO = "Transport has already unloaded units to ";
   public static final String CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND =
       "Cannot load and unload an allied transport in the same round";
-  public static final String CANT_MOVE_THROUGH_IMPASSABLE =
-      "Can't move through impassable territories";
-  public static final String CANT_MOVE_THROUGH_RESTRICTED =
-      "Can't move through restricted territories";
-  public static final String TOO_POOR_TO_VIOLATE_NEUTRALITY =
-      "Not enough money to pay for violating neutrality";
+  public static final String CANT_MOVE_THROUGH_IMPASSABLE = "Can't move through impassable territories";
+  public static final String CANT_MOVE_THROUGH_RESTRICTED = "Can't move through restricted territories";
+  public static final String TOO_POOR_TO_VIOLATE_NEUTRALITY = "Not enough money to pay for violating neutrality";
   public static final String CANNOT_VIOLATE_NEUTRALITY = "Cannot violate neutrality";
   public static final String NOT_ALL_AIR_UNITS_CAN_LAND = "Not all air units can land";
   public static final String TRANSPORT_CANNOT_LOAD_AND_UNLOAD_AFTER_COMBAT =
@@ -67,8 +64,7 @@ public class MoveValidator {
   public static final String NOT_ALL_UNITS_CAN_BLITZ = "Not all units can blitz";
 
   public static MoveValidationResult validateMove(final Collection<Unit> units, final Route route,
-      final PlayerID player, final Collection<Unit> transportsToLoad,
-      final Map<Unit, Collection<Unit>> newDependents,
+      final PlayerID player, final Collection<Unit> transportsToLoad, final Map<Unit, Collection<Unit>> newDependents,
       final boolean isNonCombat, final List<UndoableMove> undoableMoves, final GameData data) {
     final MoveValidationResult result = new MoveValidationResult();
     if (route.hasNoSteps()) {
@@ -89,16 +85,14 @@ public class MoveValidator {
     if (validateNonEnemyUnitsOnPath(data, units, route, player, result).getError() != null) {
       return result;
     }
-    if (validateBasic(data, units, route, player, transportsToLoad, newDependents, result)
-        .getError() != null) {
+    if (validateBasic(data, units, route, player, transportsToLoad, newDependents, result).getError() != null) {
       return result;
     }
-    if (AirMovementValidator.validateAirCanLand(data, units, route, player, result)
-        .getError() != null) {
+    if (AirMovementValidator.validateAirCanLand(data, units, route, player, result).getError() != null) {
       return result;
     }
-    if (validateTransport(isNonCombat, data, undoableMoves, units, route, player, transportsToLoad,
-        result).getError() != null) {
+    if (validateTransport(isNonCombat, data, undoableMoves, units, route, player, transportsToLoad, result)
+        .getError() != null) {
       return result;
     }
     if (validateParatroops(isNonCombat, data, units, route, player, result).getError() != null) {
@@ -120,8 +114,7 @@ public class MoveValidator {
       // but the original unit can still remain
       boolean unitsStartedInTerritory = true;
       for (final Unit unit : units) {
-        if (AbstractMoveDelegate.getRouteUsedToMoveInto(undoableMoves, unit,
-            route.getEnd()) != null) {
+        if (AbstractMoveDelegate.getRouteUsedToMoveInto(undoableMoves, unit, route.getEnd()) != null) {
           unitsStartedInTerritory = false;
           break;
         }
@@ -129,9 +122,8 @@ public class MoveValidator {
       if (!unitsStartedInTerritory) {
         final boolean unload = route.isUnload();
         final PlayerID endOwner = route.getEnd().getOwner();
-        final boolean attack =
-            !data.getRelationshipTracker().isAllied(endOwner, player)
-                || AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getEnd());
+        final boolean attack = !data.getRelationshipTracker().isAllied(endOwner, player)
+            || AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getEnd());
         // unless they are unloading into another battle
         if (!(unload && attack)) {
           return result.setErrorReturnResult("Cannot move units out of battle zone");
@@ -141,14 +133,11 @@ public class MoveValidator {
     return result;
   }
 
-  static MoveValidationResult validateFirst(final GameData data, final Collection<Unit> units,
-      final Route route,
+  static MoveValidationResult validateFirst(final GameData data, final Collection<Unit> units, final Route route,
       final PlayerID player, final MoveValidationResult result) {
-    if (!units.isEmpty()
-        && !getEditMode(data)) {
+    if (!units.isEmpty() && !getEditMode(data)) {
       final Collection<Unit> matches = CollectionUtils.getMatches(units,
-          Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player,
-              data, true).negate());
+          Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player, data, true).negate());
       if (matches.isEmpty() || !matches.stream().allMatch(Matches.unitIsOwnedBy(player))) {
         result.setError("Player, " + player.getName() + ", is not owner of all the units: "
             + MyFormatter.unitsToTextNoOwner(units));
@@ -177,15 +166,13 @@ public class MoveValidator {
       for (final Territory t : landOnRoute) {
         if (units.stream().anyMatch(Matches.unitIsLand())) {
           if (!data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(player, t.getOwner())) {
-            result.setError(player.getName() + " may not move land units over land owned by "
-                + t.getOwner().getName());
+            result.setError(player.getName() + " may not move land units over land owned by " + t.getOwner().getName());
             return result;
           }
         }
         if (units.stream().anyMatch(Matches.unitIsAir())) {
           if (!data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(player, t.getOwner())) {
-            result.setError(player.getName() + " may not move air units over land owned by "
-                + t.getOwner().getName());
+            result.setError(player.getName() + " may not move air units over land owned by " + t.getOwner().getName());
             return result;
           }
         }
@@ -206,8 +193,7 @@ public class MoveValidator {
     return result;
   }
 
-  static MoveValidationResult validateFuel(final GameData data, final Collection<Unit> units,
-      final Route route,
+  static MoveValidationResult validateFuel(final GameData data, final Collection<Unit> units, final Route route,
       final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -220,12 +206,10 @@ public class MoveValidator {
       return result;
     }
     return result
-        .setErrorReturnResult("Not enough resources to perform this move, you need: " + fuelCost
-            + " for this move");
+        .setErrorReturnResult("Not enough resources to perform this move, you need: " + fuelCost + " for this move");
   }
 
-  private static MoveValidationResult validateCanal(final GameData data,
-      final Collection<Unit> units,
+  private static MoveValidationResult validateCanal(final GameData data, final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -240,8 +224,7 @@ public class MoveValidator {
    * @param units
    *        (Can be null. If null we will assume all units would be stopped by the canal.)
    */
-  public static String validateCanal(final Route route, final Collection<Unit> units,
-      final PlayerID player,
+  public static String validateCanal(final Route route, final Collection<Unit> units, final PlayerID player,
       final GameData data) {
     for (final Territory routeTerritory : route.getAllTerritories()) {
       final Optional<String> result = validateCanal(routeTerritory, route, units, player, data);
@@ -278,79 +261,66 @@ public class MoveValidator {
       final boolean canPass = !failureMessage.isPresent();
       if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
           || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
-        break; // If need to control any canal and can pass OR need to control all canals and can't
-               // pass
+        break; // If need to control any canal and can pass OR need to control all canals and can't pass
       }
     }
     return failureMessage;
   }
 
-  private static MoveValidationResult validateCombat(final GameData data,
-      final Collection<Unit> units,
+  private static MoveValidationResult validateCombat(final GameData data, final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
     }
     for (final Territory t : route.getSteps()) {
       if (!Matches.territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(player).test(t)) {
-        return result
-            .setErrorReturnResult("Cannot move into territories owned by " + t.getOwner().getName()
-                + " during Combat Movement Phase");
+        return result.setErrorReturnResult(
+            "Cannot move into territories owned by " + t.getOwner().getName() + " during Combat Movement Phase");
       }
     }
+
     // we are in a contested territory owned by the enemy, and we want to move to another enemy
-    // owned territory. do not
-    // allow unless each
-    // unit can blitz the current territory.
-    if (!route.getStart().isWater()
-        && Matches.isAtWar(route.getStart().getOwner(), data).test(player)
+    // owned territory. do not allow unless each unit can blitz the current territory.
+    if (!route.getStart().isWater() && Matches.isAtWar(route.getStart().getOwner(), data).test(player)
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
-            && !route.allMatchMiddleSteps(Matches
-                .isTerritoryEnemy(player, data).negate(), false))) {
+            && !route.allMatchMiddleSteps(Matches.isTerritoryEnemy(player, data).negate(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).test(route.getStart())
           && (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))) {
-        return result
-            .setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
+        return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
       for (final Unit u : CollectionUtils.getMatches(units,
           Matches.unitCanBlitz().negate().and(Matches.unitIsNotAir()))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
+
     // we are in a contested territory owned by us, and we want to move to an enemy owned territory.
-    // do not allow unless
-    // the territory is
-    // blitzable.
-    if (!route.getStart().isWater()
-        && !Matches.isAtWar(route.getStart().getOwner(), data).test(player)
+    // do not allow unless the territory is blitzable.
+    if (!route.getStart().isWater() && !Matches.isAtWar(route.getStart().getOwner(), data).test(player)
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
-            && !route.allMatchMiddleSteps(Matches
-                .isTerritoryEnemy(player, data).negate(), false))) {
+            && !route.allMatchMiddleSteps(Matches.isTerritoryEnemy(player, data).negate(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).test(route.getStart())
           && (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle into enemy territory");
       }
     }
-    // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a
-    // transport
+
+    // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a transport
     if (units.stream().anyMatch(Matches.unitCanNotMoveDuringCombatMove())
         && (!route.getStart().isWater() || !route.getEnd().isWater())) {
-      for (final Unit unit : CollectionUtils.getMatches(units,
-          Matches.unitCanNotMoveDuringCombatMove())) {
+      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitCanNotMoveDuringCombatMove())) {
         result.addDisallowedUnit("Cannot move AA guns in combat movement phase", unit);
       }
     }
+
     // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
-      if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))
-          && !isNeutralsBlitzable(data)) {
-        return result
-            .setErrorReturnResult("Must stop land units when passing through neutral territories");
+      if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
+        return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
     if (units.stream().anyMatch(Matches.unitIsLand()) && route.hasSteps()) {
-      // check all the territories but the end, if there are enemy territories, make sure they are
-      // blitzable
+      // check all the territories but the end, if there are enemy territories, make sure they are blitzable
       // if they are not blitzable, or we aren't all blitz units fail
       int enemyCount = 0;
       boolean allEnemyBlitzable = true;
@@ -373,27 +343,20 @@ public class MoveValidator {
         final Predicate<Unit> nonBlitzing = blitzingUnit.negate();
         final Collection<Unit> nonBlitzingUnits = CollectionUtils.getMatches(units, nonBlitzing);
         // remove any units that gain blitz due to certain abilities
-        nonBlitzingUnits.removeAll(
-            UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
+        nonBlitzingUnits.removeAll(UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
         final Predicate<Territory> territoryIsNotEnd = Matches.territoryIs(route.getEnd()).negate();
-        final Predicate<Territory> nonFriendlyTerritories =
-            Matches.isTerritoryFriendly(player, data).negate();
-        final Predicate<Territory> notEndOrFriendlyTerrs =
-            nonFriendlyTerritories.and(territoryIsNotEnd);
+        final Predicate<Territory> nonFriendlyTerritories = Matches.isTerritoryFriendly(player, data).negate();
+        final Predicate<Territory> notEndOrFriendlyTerrs = nonFriendlyTerritories.and(territoryIsNotEnd);
         final Predicate<Territory> foughtOver =
             Matches.territoryWasFoughOver(AbstractMoveDelegate.getBattleTracker(data));
         final Predicate<Territory> notEndWasFought = territoryIsNotEnd.and(foughtOver);
-        final boolean wasStartFoughtOver =
-            AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getStart())
-                || AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(route.getStart());
-        nonBlitzingUnits.addAll(CollectionUtils.getMatches(units,
-            Matches.unitIsOfTypes(TerritoryEffectHelper
-                .getUnitTypesThatLostBlitz(
-                    (wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
+        final boolean wasStartFoughtOver = AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getStart())
+            || AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(route.getStart());
+        nonBlitzingUnits.addAll(CollectionUtils.getMatches(units, Matches.unitIsOfTypes(TerritoryEffectHelper
+            .getUnitTypesThatLostBlitz((wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
         for (final Unit unit : nonBlitzingUnits) {
           // TODO: Need to actually test if the unit is being air transported or land transported
-          if (Matches.unitIsAirTransportable().test(unit)
-              || Matches.unitIsLandTransportable().test(unit)) {
+          if (Matches.unitIsAirTransportable().test(unit) || Matches.unitIsLandTransportable().test(unit)) {
             continue;
           }
           final TripleAUnit taUnit = (TripleAUnit) unit;
@@ -405,8 +368,7 @@ public class MoveValidator {
       }
     }
     if (units.stream().anyMatch(Matches.unitIsAir())) { // check aircraft
-      if (route.hasSteps()
-          && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
+      if (route.hasSteps() && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         if (route.getMiddleSteps().stream().anyMatch(Matches.territoryIsNeutralButNotWater())) {
           return result.setErrorReturnResult("Air units cannot fly over neutral territories");
         }
@@ -414,8 +376,7 @@ public class MoveValidator {
     }
     // make sure no conquered territories on route
     if (MoveValidator.hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
-      // unless we are all air or we are in non combat OR the route is water (was a bug in convoy
-      // zone movement)
+      // unless we are all air or we are in non combat OR the route is water (was a bug in convoy zone movement)
       if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) {
         // what if we are paratroopers?
         return result.setErrorReturnResult("Cannot move through newly captured territories");
@@ -426,14 +387,12 @@ public class MoveValidator {
         && units.stream().anyMatch(Matches.unitWasUnloadedThisTurn())) {
       final Collection<Territory> end = Collections.singleton(route.getEnd());
       if (!end.isEmpty()
-          && end.stream().allMatch(
-              Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
+          && end.stream().allMatch(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
           && !route.getEnd().getUnits().isEmpty()) {
         return result.setErrorReturnResult("Units cannot participate in multiple battles");
       }
     }
-    // See if we are doing invasions in combat phase, with units or transports that can't do
-    // invasion.
+    // See if we are doing invasions in combat phase, with units or transports that can't do invasion.
     if (route.isUnload() && Matches.isTerritoryEnemy(player, data).test(route.getEnd())) {
       for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitCanInvade().negate())) {
         result.addDisallowedUnit(unit.getType().getName() + " can't invade from "
@@ -443,8 +402,7 @@ public class MoveValidator {
     return result;
   }
 
-  private static MoveValidationResult validateNonCombat(final GameData data,
-      final Collection<Unit> units,
+  private static MoveValidationResult validateNonCombat(final GameData data, final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -462,15 +420,13 @@ public class MoveValidator {
     // TODO need to account for subs AND transports that are ignored, not just OR
     final Territory end = route.getEnd();
     if (neutralOrEnemy.test(end)) {
-      // a convoy zone is controlled, so we must make sure we can still move there if there are
-      // actual battle there
+      // a convoy zone is controlled, so we must make sure we can still move there if there are actual battle there
       if (!end.isWater() || navalMayNotNonComIntoControlled) {
         return result.setErrorReturnResult("Cannot advance units to battle in non combat");
       }
     }
     // Subs can't travel under DDs
-    if (isSubmersibleSubsAllowed(data) && !units.isEmpty()
-        && units.stream().allMatch(Matches.unitIsSub())) {
+    if (isSubmersibleSubsAllowed(data) && !units.isEmpty() && units.stream().allMatch(Matches.unitIsSub())) {
       // this is ok unless there are destroyer on the path
       if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
@@ -478,11 +434,10 @@ public class MoveValidator {
     }
     if (end.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
-        final Predicate<Unit> friendlyOrSubmerged = Matches.enemyUnit(player, data).negate()
-            .or(Matches.unitIsSubmerged());
+        final Predicate<Unit> friendlyOrSubmerged =
+            Matches.enemyUnit(player, data).negate().or(Matches.unitIsSubmerged());
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
-            && !(!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir())
-                && end.isWater())) {
+            && !(!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()) && end.isWater())) {
           if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsSub())
               || !Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
 
@@ -495,50 +450,40 @@ public class MoveValidator {
     // (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
     if ((!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()))
-        || (units.stream().noneMatch(Matches.unitIsSea())
-            && !nonParatroopersPresent(player, units))) {
+        || (units.stream().noneMatch(Matches.unitIsSea()) && !nonParatroopersPresent(player, units))) {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.anyMatch(
-          Matches.territoryIsNeutralButNotWater().and(Matches.territoryIsWater().negate()))
+      if (route.anyMatch(Matches.territoryIsNeutralButNotWater().and(Matches.territoryIsWater().negate()))
           && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
-        return result
-            .setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
+        return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
       // if sea units, or land units moving over/onto sea (ex: loading onto a transport), then only
-      // check if old rules
-      // stop us
-    } else if (units.stream().anyMatch(Matches.unitIsSea())
-        || route.anyMatch(Matches.territoryIsWater())) {
+      // check if old rules stop us
+    } else if (units.stream().anyMatch(Matches.unitIsSea()) || route.anyMatch(Matches.territoryIsWater())) {
       // if there are neutral or owned territories, we cannot move through them (only under old
-      // rules. under new rules
-      // we can move through
-      // owned sea zones.)
+      // rules. under new rules we can move through owned sea zones.)
       if (navalMayNotNonComIntoControlled && route.anyMatch(neutralOrEnemy)) {
-        return result.setErrorReturnResult(
-            "Cannot move units through neutral or enemy territories in non combat");
+        return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
       }
     } else {
       if (route.anyMatch(neutralOrEnemy)) {
-        return result.setErrorReturnResult(
-            "Cannot move units through neutral or enemy territories in non combat");
+        return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
       }
     }
     return result;
   }
 
   // Added to handle restriction of movement to listed territories
-  static MoveValidationResult validateMovementRestrictedByTerritory(final GameData data,
-      final Route route, final PlayerID player, final MoveValidationResult result) {
+  static MoveValidationResult validateMovementRestrictedByTerritory(final GameData data, final Route route,
+      final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
     }
     if (!isMovementByTerritoryRestricted(data)) {
       return result;
     }
-    final RulesAttachment ra =
-        (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
+    final RulesAttachment ra = (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     if (ra == null || ra.getMovementRestrictionTerritories() == null) {
       return result;
     }
@@ -561,8 +506,7 @@ public class MoveValidator {
     return result;
   }
 
-  private static MoveValidationResult validateNonEnemyUnitsOnPath(final GameData data,
-      final Collection<Unit> units,
+  private static MoveValidationResult validateNonEnemyUnitsOnPath(final GameData data, final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     if (getEditMode(data)) {
       return result;
@@ -577,8 +521,7 @@ public class MoveValidator {
     }
     // subs may possibly carry units...
     if (isSubmersibleSubsAllowed(data)) {
-      final Collection<Unit> matches =
-          CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
+      final Collection<Unit> matches = CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
       if (!matches.isEmpty() && matches.stream().allMatch(Matches.unitIsSub())) {
         // this is ok unless there are destroyer on the path
         if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
@@ -598,9 +541,8 @@ public class MoveValidator {
     return result;
   }
 
-  private static MoveValidationResult validateBasic(final GameData data,
-      final Collection<Unit> units, final Route route, final PlayerID player,
-      final Collection<Unit> transportsToLoad,
+  private static MoveValidationResult validateBasic(final GameData data, final Collection<Unit> units,
+      final Route route, final PlayerID player, final Collection<Unit> transportsToLoad,
       final Map<Unit, Collection<Unit>> newDependents, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
     // make sure transports in the destination
@@ -633,18 +575,14 @@ public class MoveValidator {
       }
       final Map<Unit, Collection<Unit>> dependentsMap =
           getDependents(CollectionUtils.getMatches(units, Matches.unitCanTransport()));
-      Set<Unit> dependents =
-          dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
-      dependents.addAll(
-          newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
+      Set<Unit> dependents = dependentsMap.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+      dependents.addAll(newDependents.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
       moveTest.removeAll(dependents);
 
       // Can only move owned units except transported units or allied air on carriers
-      for (final Unit unit : CollectionUtils.getMatches(moveTest,
-          Matches.unitIsOwnedBy(player).negate())) {
+      for (final Unit unit : CollectionUtils.getMatches(moveTest, Matches.unitIsOwnedBy(player).negate())) {
         if (!(UnitAttachment.get(unit.getType()).getCarrierCost() > 0
-            && data.getRelationshipTracker().isAllied(player,
-                unit.getOwner()))) {
+            && data.getRelationshipTracker().isAllied(player, unit.getOwner()))) {
           result.addDisallowedUnit("Can only move own troops", unit);
         }
       }
@@ -666,16 +604,13 @@ public class MoveValidator {
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.test(unit)) {
           boolean unitOk = false;
-          if (Matches.unitIsOwnedBy(player).negate().test(unit)
-              && Matches.alliedUnit(player, data).test(unit)
+          if (Matches.unitIsOwnedBy(player).negate().test(unit) && Matches.alliedUnit(player, data).test(unit)
               && Matches.unitTypeCanLandOnCarrier().test(unit.getType())
               && moveTest.stream().anyMatch(Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
-            // this is so that if the unit is owned by any ally and it is cargo, then it will not
-            // count.
+            // this is so that if the unit is owned by any ally and it is cargo, then it will not count.
             // (shouldn't it be a dependent in this case??)
             unitOk = true;
-          } else if (Matches.unitHasNotMoved().test(unit)
-              && Matches.unitIsLandTransportable().test(unit)) {
+          } else if (Matches.unitHasNotMoved().test(unit) && Matches.unitIsLandTransportable().test(unit)) {
             if (numLandTransportsWithoutCapacity > 0) {
               numLandTransportsWithoutCapacity--;
               unitOk = true;
@@ -698,16 +633,13 @@ public class MoveValidator {
 
       // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
       if (route.hasNeutralBeforeEnd()) {
-        if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir()))
-            && !isNeutralsBlitzable(data)) {
-          return result.setErrorReturnResult(
-              "Must stop land units when passing through neutral territories");
+        if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
+          return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
         }
       }
       // a territory effect can disallow unit types in
       if (units.stream().anyMatch(
-          Matches.unitIsOfTypes(TerritoryEffectHelper
-              .getUnitTypesForUnitsNotAllowedIntoTerritory(route.getSteps())))) {
+          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(route.getSteps())))) {
         return result.setErrorReturnResult("Territory Effects disallow some units into "
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
@@ -715,8 +647,7 @@ public class MoveValidator {
       for (final Territory t : route.getAllTerritories()) {
         if (!moveTest.stream().allMatch(Matches.unitHasRequiredUnitsToMove(t, data))) {
           return result.setErrorReturnResult(
-              t.getName()
-                  + " doesn't have the required units to allow moving the selected units into it");
+              t.getName() + " doesn't have the required units to allow moving the selected units into it");
         }
       }
     } // !isEditMode
@@ -740,28 +671,23 @@ public class MoveValidator {
     // test for stack limits per unit
     if (route.getEnd() != null) {
       final Collection<Unit> unitsWithStackingLimits =
-          CollectionUtils.getMatches(units,
-              Matches.unitHasMovementLimit().or(Matches.unitHasAttackingLimit()));
+          CollectionUtils.getMatches(units, Matches.unitHasMovementLimit().or(Matches.unitHasAttackingLimit()));
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)
             || t.getUnits().anyMatch(Matches.unitIsEnemyOf(data, player))) {
           for (final Unit unit : unitsWithStackingLimits) {
             final UnitType ut = unit.getType();
-            int maxAllowed =
-                UnitAttachment
-                    .getMaximumNumberOfThisUnitTypeToReachStackingLimit("attackingLimit", ut, t,
-                        player, data);
+            int maxAllowed = UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("attackingLimit", ut, t,
+                player, data);
             maxAllowed -= CollectionUtils.countMatches(unitsAllowedSoFar, Matches.unitIsOfType(ut));
             if (maxAllowed > 0) {
               unitsAllowedSoFar.add(unit);
             } else {
-              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit",
-                  unit);
+              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit", unit);
             }
           }
-          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("attackingLimit",
-              units, t, player,
+          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("attackingLimit", units, t, player,
               data)) {
             return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
           }
@@ -769,19 +695,15 @@ public class MoveValidator {
           for (final Unit unit : unitsWithStackingLimits) {
             final UnitType ut = unit.getType();
             int maxAllowed =
-                UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("movementLimit",
-                    ut,
-                    t, player, data);
+                UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("movementLimit", ut, t, player, data);
             maxAllowed -= CollectionUtils.countMatches(unitsAllowedSoFar, Matches.unitIsOfType(ut));
             if (maxAllowed > 0) {
               unitsAllowedSoFar.add(unit);
             } else {
-              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit",
-                  unit);
+              result.addDisallowedUnit("UnitType " + ut.getName() + " has reached stacking limit", unit);
             }
           }
-          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("movementLimit",
-              units, t, player,
+          if (!PlayerAttachment.getCanTheseUnitsMoveWithoutViolatingStackingLimit("movementLimit", units, t, player,
               data)) {
             return result.setErrorReturnResult("Units Cannot Go Over Stacking Limit");
           }
@@ -802,8 +724,7 @@ public class MoveValidator {
     return result;
   }
 
-  private static int getNumLandTransportsWithoutCapacity(final Collection<Unit> units,
-      final PlayerID player) {
+  private static int getNumLandTransportsWithoutCapacity(final Collection<Unit> units, final PlayerID player) {
     if (TechAttachment.isMechanizedInfantry(player)) {
       final Predicate<Unit> transportLand =
           Matches.unitIsLandTransportWithoutCapacity().and(Matches.unitIsOwnedBy(player));
@@ -812,8 +733,7 @@ public class MoveValidator {
     return 0;
   }
 
-  private static IntegerMap<Unit> getLandTransportsWithCapacity(final Collection<Unit> units,
-      final PlayerID player) {
+  private static IntegerMap<Unit> getLandTransportsWithCapacity(final Collection<Unit> units, final PlayerID player) {
     IntegerMap<Unit> map = new IntegerMap<>();
     if (TechAttachment.isMechanizedInfantry(player)) {
       final Predicate<Unit> transportLand =
@@ -840,11 +760,9 @@ public class MoveValidator {
    * movement.
    * AA and factory dont count as enemy.
    */
-  static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player,
-      final GameData data) {
-    final Predicate<Unit> alliedOrNonCombat = Matches.unitIsInfrastructure()
-        .or(Matches.enemyUnit(player, data).negate())
-        .or(Matches.unitIsSubmerged());
+  static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
+    final Predicate<Unit> alliedOrNonCombat =
+        Matches.unitIsInfrastructure().or(Matches.enemyUnit(player, data).negate()).or(Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     for (final Territory current : route.getMiddleSteps()) {
       if (!current.getUnits().allMatch(alliedOrNonCombat)) {
@@ -858,21 +776,16 @@ public class MoveValidator {
    * Checks that there only transports, subs and/or allies on the route except at the end.
    * AA and factory dont count as enemy.
    */
-  static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player,
-      final GameData data,
+  static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player, final GameData data,
       final boolean ignoreRouteEnd) {
-    final Predicate<Unit> subOnly = Matches.unitIsInfrastructure()
-        .or(Matches.unitIsSub())
-        .or(Matches.enemyUnit(player, data).negate());
-    final Predicate<Unit> transportOnly = Matches.unitIsInfrastructure()
-        .or(Matches.unitIsTransportButNotCombatTransport())
-        .or(Matches.unitIsLand())
-        .or(Matches.enemyUnit(player, data).negate());
-    final Predicate<Unit> transportOrSubOnly = Matches.unitIsInfrastructure()
-        .or(Matches.unitIsTransportButNotCombatTransport())
-        .or(Matches.unitIsLand())
-        .or(Matches.unitIsSub())
-        .or(Matches.enemyUnit(player, data).negate());
+    final Predicate<Unit> subOnly =
+        Matches.unitIsInfrastructure().or(Matches.unitIsSub()).or(Matches.enemyUnit(player, data).negate());
+    final Predicate<Unit> transportOnly =
+        Matches.unitIsInfrastructure().or(Matches.unitIsTransportButNotCombatTransport()).or(Matches.unitIsLand())
+            .or(Matches.enemyUnit(player, data).negate());
+    final Predicate<Unit> transportOrSubOnly =
+        Matches.unitIsInfrastructure().or(Matches.unitIsTransportButNotCombatTransport()).or(Matches.unitIsLand())
+            .or(Matches.unitIsSub()).or(Matches.enemyUnit(player, data).negate());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
     boolean validMove = false;
@@ -883,26 +796,21 @@ public class MoveValidator {
       steps = route.getSteps();
     }
     // if there are no steps, then we began in this sea zone, so see if there are ignored units in
-    // this sea zone (not
-    // sure if we need
-    // !ignoreRouteEnd here).
+    // this sea zone (not sure if we need !ignoreRouteEnd here).
     if (steps.isEmpty() && route.numberOfStepsIncludingStart() == 1 && !ignoreRouteEnd) {
       steps.add(route.getStart());
     }
     for (final Territory current : steps) {
       if (current.isWater()) {
-        if (getIgnoreTransportInMovement && getIgnoreSubInMovement
-            && current.getUnits().allMatch(transportOrSubOnly)) {
+        if (getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(transportOrSubOnly)) {
           validMove = true;
           continue;
         }
-        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement
-            && current.getUnits().allMatch(transportOnly)) {
+        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement && current.getUnits().allMatch(transportOnly)) {
           validMove = true;
           continue;
         }
-        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement
-            && current.getUnits().allMatch(subOnly)) {
+        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(subOnly)) {
           validMove = true;
           continue;
         }
@@ -912,10 +820,8 @@ public class MoveValidator {
     return validMove;
   }
 
-  private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player,
-      final GameData data) {
-    final Predicate<Unit> enemyDestroyer =
-        Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
+  private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
+    final Predicate<Unit> enemyDestroyer = Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
       if (current.getUnits().anyMatch(enemyDestroyer)) {
         return true;
@@ -928,11 +834,9 @@ public class MoveValidator {
     return BaseEditDelegate.getEditMode(data);
   }
 
-  private static boolean hasConqueredNonBlitzedNonWaterOnRoute(final Route route,
-      final GameData data) {
+  private static boolean hasConqueredNonBlitzedNonWaterOnRoute(final Route route, final GameData data) {
     for (final Territory current : route.getMiddleSteps()) {
-      if (!Matches.territoryIsWater().test(current)
-          && AbstractMoveDelegate.getBattleTracker(data).wasConquered(current)
+      if (!Matches.territoryIsWater().test(current) && AbstractMoveDelegate.getBattleTracker(data).wasConquered(current)
           && !AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(current)) {
         return true;
       }
@@ -941,8 +845,7 @@ public class MoveValidator {
   }
 
   // TODO KEV revise these to include paratroop load/unload
-  public static boolean isLoad(final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> newDependents,
+  public static boolean isLoad(final Collection<Unit> units, final Map<Unit, Collection<Unit>> newDependents,
       final Route route, final GameData data, final PlayerID player) {
     final Map<Unit, Collection<Unit>> alreadyLoaded =
         mustMoveWith(units, newDependents, route.getStart(), data, player);
@@ -952,22 +855,18 @@ public class MoveValidator {
     // See if we even need to go to the trouble of checking for AirTransported units
     final boolean checkForAlreadyTransported = !route.getStart().isWater() && route.hasWater();
     if (checkForAlreadyTransported) {
-      // TODO Leaving unitIsTransport() for potential use with amphib transports (hovercraft, ducks,
-      // etc...)
+      // TODO Leaving unitIsTransport() for potential use with amphib transports (hovercraft, ducks, etc...)
       final List<Unit> transports =
-          CollectionUtils.getMatches(units,
-              Matches.unitIsTransport().or(Matches.unitIsAirTransport()));
+          CollectionUtils.getMatches(units, Matches.unitIsTransport().or(Matches.unitIsAirTransport()));
       final List<Unit> transportable =
-          CollectionUtils.getMatches(units,
-              Matches.unitCanBeTransported().or(Matches.unitIsAirTransportable()));
+          CollectionUtils.getMatches(units, Matches.unitCanBeTransported().or(Matches.unitIsAirTransportable()));
       // Check if there are transports in the group to be checked
       if (alreadyLoaded.keySet().containsAll(transports)) {
         // Check each transportable unit -vs those already loaded.
         for (final Unit unit : transportable) {
           boolean found = false;
           for (final Unit transport : transports) {
-            if (alreadyLoaded.get(transport) == null
-                || alreadyLoaded.get(transport).contains(unit)) {
+            if (alreadyLoaded.get(transport) == null || alreadyLoaded.get(transport).contains(unit)) {
               found = true;
               break;
             }
@@ -1028,23 +927,19 @@ public class MoveValidator {
   }
 
   // Determines whether we can pay the neutral territory charge for a
-  // given route for air units. We can't cross neutral territories
-  // in WW2V2.
-  private static MoveValidationResult canCrossNeutralTerritory(final GameData data,
-      final Route route,
+  // given route for air units. We can't cross neutral territories in WW2V2.
+  private static MoveValidationResult canCrossNeutralTerritory(final GameData data, final Route route,
       final PlayerID player, final MoveValidationResult result) {
     // neutrals we will overfly in the first place
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
-    final int pus =
-        (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
+    final int pus = (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
     if (pus < getNeutralCharge(data, neutrals.size())) {
       return result.setErrorReturnResult(TOO_POOR_TO_VIOLATE_NEUTRALITY);
     }
     return result;
   }
 
-  private static Territory getTerritoryTransportHasUnloadedTo(
-      final List<UndoableMove> undoableMoves,
+  private static Territory getTerritoryTransportHasUnloadedTo(final List<UndoableMove> undoableMoves,
       final Unit transport) {
     for (final UndoableMove undoableMove : undoableMoves) {
       if (undoableMove.wasTransportUnloaded(transport)) {
@@ -1054,10 +949,8 @@ public class MoveValidator {
     return null;
   }
 
-  private static MoveValidationResult validateTransport(final boolean isNonCombat,
-      final GameData data,
-      final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route,
-      final PlayerID player,
+  private static MoveValidationResult validateTransport(final boolean isNonCombat, final GameData data,
+      final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route, final PlayerID player,
       final Collection<Unit> transportsToLoad, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
     if (!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir())) {
@@ -1072,10 +965,6 @@ public class MoveValidator {
     if (!seaOrNoTransportsPresent) {
       return result;
     }
-    /*
-     * if(!MoveValidator.isLoad(units, route, data, player) && !MoveValidator.isUnload(route))
-     * return result;
-     */
     final Territory routeEnd = route.getEnd();
     final Territory routeStart = route.getStart();
     // if unloading make sure length of route is only 1
@@ -1084,19 +973,15 @@ public class MoveValidator {
         return result.setErrorReturnResult("Unloading units must stop where they are unloaded");
       }
       for (final Unit unit : TransportTracker.getUnitsLoadedOnAlliedTransportsThisTurn(units)) {
-        result.addDisallowedUnit(CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND,
-            unit);
+        result.addDisallowedUnit(CANNOT_LOAD_AND_UNLOAD_AN_ALLIED_TRANSPORT_IN_THE_SAME_ROUND, unit);
       }
       final Collection<Unit> transports = TransportUtils.mapTransports(route, units, null).values();
       final boolean isScramblingOrKamikazeAttacksEnabled =
-          Properties.getScramble_Rules_In_Effect(data)
-              || Properties.getUseKamikazeSuicideAttacks(data);
+          Properties.getScramble_Rules_In_Effect(data) || Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
-      final Predicate<Unit> enemySubmarineMatch =
-          Matches.unitIsEnemyOf(data, player).and(Matches.unitIsSub());
-      final Predicate<Unit> ownedSeaNonTransportMatch = Matches.unitIsOwnedBy(player)
-          .and(Matches.unitIsSea())
+      final Predicate<Unit> enemySubmarineMatch = Matches.unitIsEnemyOf(data, player).and(Matches.unitIsSub());
+      final Predicate<Unit> ownedSeaNonTransportMatch = Matches.unitIsOwnedBy(player).and(Matches.unitIsSea())
           .and(Matches.unitIsNotTransportButCouldBeCombatTransport());
       for (final Unit transport : transports) {
         if (!isNonCombat && route.numberOfStepsIncludingStart() == 2) {
@@ -1107,11 +992,9 @@ public class MoveValidator {
                 && !Matches.territoryHasUnitsThatMatch(ownedSeaNonTransportMatch).test(routeStart)
                 && Matches.territoryHasUnitsThatMatch(enemySubmarineMatch).test(routeStart)) {
               // we must have at least one warship (non-transport) unit, otherwise the enemy sub
-              // stops our unloading for
-              // amphibious assault
+              // stops our unloading for amphibious assault
               for (final Unit unit : TransportTracker.transporting(transport)) {
-                result.addDisallowedUnit(
-                    ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING, unit);
+                result.addDisallowedUnit(ENEMY_SUBMARINE_PREVENTING_UNESCORTED_AMPHIBIOUS_ASSAULT_LANDING, unit);
               }
             }
           } else if (!AbstractMoveDelegate.getBattleTracker(data).wasConquered(routeEnd)) {
@@ -1119,17 +1002,13 @@ public class MoveValidator {
             if (isScramblingOrKamikazeAttacksEnabled
                 || !Matches.territoryIsEmptyOfCombatUnits(data, player).test(routeStart)) {
               // Unloading a transport from a sea zone with a battle, to a friendly land territory,
-              // during combat move
-              // phase, is illegal
+              // during combat move phase, is illegal
               // and in addition to being illegal, it is also causing problems if the sea transports
-              // get killed (the
-              // land units are not
-              // dying)
+              // get killed (the land units are not dying)
               // TODO: should we use the battle tracker for this instead?
               for (final Unit unit : TransportTracker.transporting(transport)) {
                 result.addDisallowedUnit(
-                    TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED,
-                    unit);
+                    TRANSPORT_MAY_NOT_UNLOAD_TO_FRIENDLY_TERRITORIES_UNTIL_AFTER_COMBAT_IS_RESOLVED, unit);
               }
             }
           }
@@ -1139,17 +1018,13 @@ public class MoveValidator {
         // check whether transport has already unloaded
         if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
           for (final Unit unit : TransportTracker.transporting(transport)) {
-            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE,
-                unit);
+            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
           }
           // check whether transport is restricted to another territory
-        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport,
-            route.getEnd())) {
-          final Territory alreadyUnloadedTo =
-              getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
+        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
+          final Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
           for (final Unit unit : TransportTracker.transporting(transport)) {
-            result.addDisallowedUnit(
-                TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
+            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
           }
           // Check if the transport has already loaded after being in combat
         } else if (TransportTracker.isTransportUnloadRestrictedInNonCombat(transport)) {
@@ -1159,27 +1034,20 @@ public class MoveValidator {
         }
       }
     }
-    // if we are land make sure no water in route except for transport
-    // situations
+    // if we are land make sure no water in route except for transport situations
     final Collection<Unit> land = CollectionUtils.getMatches(units, Matches.unitIsLand());
-    final Collection<Unit> landAndAir =
-        CollectionUtils.getMatches(units, Matches.unitIsLand().or(Matches.unitIsAir()));
+    final Collection<Unit> landAndAir = CollectionUtils.getMatches(units, Matches.unitIsLand().or(Matches.unitIsAir()));
     // make sure we can be transported
     final Predicate<Unit> cantBeTransported = Matches.unitCanBeTransported().negate();
     for (final Unit unit : CollectionUtils.getMatches(land, cantBeTransported)) {
       result.addDisallowedUnit("Not all units can be transported", unit);
     }
-    // make sure that the only the first or last territory is land
-    // dont want situation where they go sea land sea
-    if (!isEditMode && route.hasLand()
-        && !(route.getStart().isWater() || route.getEnd().isWater())) {
+    // make sure that the only the first or last territory is land don't want situation where they go sea land sea
+    if (!isEditMode && route.hasLand() && !(route.getStart().isWater() || route.getEnd().isWater())) {
       // needs to include all land and air to work, since it makes sure the land units can be
-      // carried by the air and
-      // that the air has enough
-      // capacity
+      // carried by the air and that the air has enough capacity
       if (nonParatroopersPresent(player, landAndAir)) {
-        return result.setErrorReturnResult(
-            "Invalid move, only start or end can be land when route has water.");
+        return result.setErrorReturnResult("Invalid move, only start or end can be land when route has water.");
       }
     }
     // simply because I dont want to handle it yet
@@ -1214,24 +1082,17 @@ public class MoveValidator {
       if (!isEditMode && !route.hasExactlyOneStep() && nonParatroopersPresent(player, landAndAir)) {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
-      final Predicate<Unit> enemyNonSubmerged =
-          Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
-      if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged)
-          && nonParatroopersPresent(player, landAndAir)) {
+      final Predicate<Unit> enemyNonSubmerged = Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
+      if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
-          if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(
-              player,
+          if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
               route.getEnd().getUnits().getUnits(), data)) {
             return result.setErrorReturnResult("Cannot load when enemy sea units are present");
           }
         }
       }
-      final Map<Unit, Unit> unitsToTransports =
-          TransportUtils.mapTransports(route, land, transportsToLoad);
+      final Map<Unit, Unit> unitsToTransports = TransportUtils.mapTransports(route, land, transportsToLoad);
       final Iterator<Unit> iter = land.iterator();
-      // CompositePredicate<Unit> landUnitsAtSea = new
-      // CompositeMatchOr<Unit>(Matches.unitIsLandAndOwnedBy(player),
-      // Matches.unitCanBeTransported());
       while (!isEditMode && iter.hasNext()) {
         final TripleAUnit unit = (TripleAUnit) iter.next();
         if (Matches.unitHasMoved().test(unit)) {
@@ -1243,16 +1104,12 @@ public class MoveValidator {
         }
         if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
           result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
-        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport,
-            route.getEnd())) {
-          Territory alreadyUnloadedTo =
-              getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
+        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
+          Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
           for (final Unit transportToLoad : transportsToLoad) {
             final TripleAUnit trn = (TripleAUnit) transportToLoad;
-            if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(trn,
-                route.getEnd())) {
+            if (!TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(trn, route.getEnd())) {
               final UnitAttachment ua = UnitAttachment.get(unit.getType());
-              // UnitAttachment trna = UnitAttachment.get(trn.getType());
               if (TransportTracker.getAvailableCapacity(trn) >= ua.getTransportCost()) {
                 alreadyUnloadedTo = null;
                 break;
@@ -1260,8 +1117,7 @@ public class MoveValidator {
             }
           }
           if (alreadyUnloadedTo != null) {
-            result.addDisallowedUnit(
-                TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
+            result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
           }
         }
       }
@@ -1269,8 +1125,7 @@ public class MoveValidator {
         // some units didn't get mapped to a transport
         final Collection<UnitCategory> unitsToLoadCategories = UnitSeperator.categorize(land);
         if (unitsToTransports.size() == 0 || unitsToLoadCategories.size() == 1) {
-          // set all unmapped units as disallowed if there are no transports
-          // or only one unit category
+          // set all unmapped units as disallowed if there are no transports or only one unit category
           for (final Unit unit : land) {
             if (unitsToTransports.containsKey(unit)) {
               continue;
@@ -1278,17 +1133,14 @@ public class MoveValidator {
             final UnitAttachment ua = UnitAttachment.get(unit.getType());
             if (ua.getTransportCost() != -1) {
               result.addDisallowedUnit("Not enough transports", unit);
-              // System.out.println("adding disallowed unit (Not enough transports): "+unit);
             }
           }
         } else {
-          // set all units as unresolved if there is at least one transport
-          // and mixed unit categories
+          // set all units as unresolved if there is at least one transport and mixed unit categories
           for (final Unit unit : land) {
             final UnitAttachment ua = UnitAttachment.get(unit.getType());
             if (ua.getTransportCost() != -1) {
               result.addUnresolvedUnit("Not enough transports", unit);
-              // System.out.println("adding unresolved unit (Not enough transports): "+unit);
             }
           }
         }
@@ -1299,37 +1151,29 @@ public class MoveValidator {
 
   static boolean allLandUnitsAreBeingParatroopered(final Collection<Unit> units) {
     // some units that can't be paratrooped
-    if (units.isEmpty() || !units.stream().allMatch(
-        Matches.unitIsAirTransportable()
-            .or(Matches.unitIsAirTransport())
-            .or(Matches.unitIsAir()))) {
+    if (units.isEmpty() || !units.stream()
+        .allMatch(Matches.unitIsAirTransportable().or(Matches.unitIsAirTransport()).or(Matches.unitIsAir()))) {
       return false;
     }
-    // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units,
-    // route);
+    // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
     // due to various problems with units like tanks, we will assume that if we are in this method,
-    // then all the land
-    // units need transports
-    final List<Unit> paratroopsRequiringTransport =
-        CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
+    // then all the land units need transports
+    final List<Unit> paratroopsRequiringTransport = CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
     if (paratroopsRequiringTransport.isEmpty()) {
       return false;
     }
-    final List<Unit> airTransports =
-        CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+    final List<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
     final List<Unit> allParatroops =
         TransportUtils.findUnitsToLoadOnAirTransports(paratroopsRequiringTransport, airTransports);
     if (!allParatroops.containsAll(paratroopsRequiringTransport)) {
       return false;
     }
-    final Map<Unit, Unit> transportLoadMap =
-        TransportUtils.mapTransportsToLoad(units, airTransports);
+    final Map<Unit, Unit> transportLoadMap = TransportUtils.mapTransportsToLoad(units, airTransports);
     return transportLoadMap.keySet().containsAll(paratroopsRequiringTransport);
   }
 
   // checks if there are non-paratroopers present that cause move validations to fail
-  private static boolean nonParatroopersPresent(final PlayerID player,
-      final Collection<Unit> units) {
+  private static boolean nonParatroopersPresent(final PlayerID player, final Collection<Unit> units) {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
@@ -1344,17 +1188,14 @@ public class MoveValidator {
     return !allLandUnitsAreBeingParatroopered(units);
   }
 
-  private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units,
-      final Route route) {
-    return CollectionUtils.getMatches(units, Matches.unitIsAirTransportable()
-        .and(u -> TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u)
+  private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
+    return CollectionUtils.getMatches(units,
+        Matches.unitIsAirTransportable().and(u -> TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u)
             || route.crossesWater() || route.getEnd().isWater()));
   }
 
-  private static MoveValidationResult validateParatroops(final boolean nonCombat,
-      final GameData data,
-      final Collection<Unit> units, final Route route, final PlayerID player,
-      final MoveValidationResult result) {
+  private static MoveValidationResult validateParatroops(final boolean nonCombat, final GameData data,
+      final Collection<Unit> units, final Route route, final PlayerID player, final MoveValidationResult result) {
     if (!TechAttachment.isAirTransportable(player)) {
       return result;
     }
@@ -1366,18 +1207,15 @@ public class MoveValidator {
       return result.setErrorReturnResult("Paratroops may not move during NonCombat");
     }
     if (!getEditMode(data)) {
-      // if we can move without using paratroop tech, do so
-      // this allows moving a bomber/infantry from one friendly
+      // if we can move without using paratroop tech, do so this allows moving a bomber/infantry from one friendly
       // territory to another
       final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
       if (paratroopsRequiringTransport.isEmpty()) {
         return result;
       }
-      final List<Unit> airTransports =
-          CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+      final List<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
       // TODO kev change below to mapAirTransports (or modify mapTransports to handle air cargo)
-      // Map<Unit, Unit> airTransportsAndParatroops = MoveDelegate.mapTransports(route,
-      // paratroopsRequiringTransport,
+      // Map<Unit, Unit> airTransportsAndParatroops = MoveDelegate.mapTransports(route, paratroopsRequiringTransport,
       // airTransports);
       final Map<Unit, Unit> airTransportsAndParatroops =
           TransportUtils.mapTransportsToLoad(paratroopsRequiringTransport, airTransports);
@@ -1401,13 +1239,11 @@ public class MoveValidator {
         }
         if (!nonCombat && Matches.isTerritoryFriendly(player, data).test(routeEnd)
             && isAirTransportableCanMoveDuringNonCombat(data)) {
-          result.addDisallowedUnit("Paratroops may only airlift during Non-Combat Movement Phase",
-              paratroop);
+          result.addDisallowedUnit("Paratroops may only airlift during Non-Combat Movement Phase", paratroop);
         }
       }
       if (!Properties.getParatroopersCanAttackDeepIntoEnemyTerritory(data)) {
-        for (final Territory current : CollectionUtils.getMatches(route.getMiddleSteps(),
-            Matches.territoryIsLand())) {
+        for (final Territory current : CollectionUtils.getMatches(route.getMiddleSteps(), Matches.territoryIsLand())) {
           if (Matches.isTerritoryEnemy(player, data).test(current)) {
             return result.setErrorReturnResult("Must stop paratroops in first enemy territory");
           }
@@ -1420,14 +1256,12 @@ public class MoveValidator {
   /*
    * Checks if route is either null or includes both canal territories so needs to be checked.
    */
-  private static boolean isCanalOnRoute(final CanalAttachment canalAttachment, final Route route,
-      final GameData data) {
+  private static boolean isCanalOnRoute(final CanalAttachment canalAttachment, final Route route, final GameData data) {
     if (route == null) {
       return true;
     }
     Territory last = null;
-    final Set<Territory> connectionToCheck =
-        CanalAttachment.getAllCanalSeaZones(canalAttachment.getCanalName(), data);
+    final Set<Territory> connectionToCheck = CanalAttachment.getAllCanalSeaZones(canalAttachment.getCanalName(), data);
     for (final Territory current : route.getAllTerritories()) {
       if (last != null) {
         final Collection<Territory> lastTwo = new ArrayList<>();
@@ -1457,15 +1291,13 @@ public class MoveValidator {
         return Optional.of("Must control " + canalAttachment.getCanalName() + " to move through");
       }
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(borderTerritory)) {
-        return Optional.of("Must control " + canalAttachment.getCanalName()
-            + " for an entire turn to move through");
+        return Optional.of("Must control " + canalAttachment.getCanalName() + " for an entire turn to move through");
       }
     }
     return Optional.empty();
   }
 
-  public static MustMoveWithDetails getMustMoveWith(final Territory start,
-      final Collection<Unit> units,
+  public static MustMoveWithDetails getMustMoveWith(final Territory start, final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents, final GameData data, final PlayerID player) {
     return new MustMoveWithDetails(mustMoveWith(units, newDependents, start, data, player));
   }
@@ -1514,9 +1346,7 @@ public class MoveValidator {
 
   private static Map<Unit, Collection<Unit>> transportsMustMoveWith(final Collection<Unit> units) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
-    // map transports
-    final Collection<Unit> transports =
-        CollectionUtils.getMatches(units, Matches.unitIsTransport());
+    final Collection<Unit> transports = CollectionUtils.getMatches(units, Matches.unitIsTransport());
     final Iterator<Unit> iter = transports.iterator();
     while (iter.hasNext()) {
       final Unit transport = iter.next();
@@ -1529,8 +1359,7 @@ public class MoveValidator {
   private static Map<Unit, Collection<Unit>> airTransportsMustMoveWith(final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents) {
     final Map<Unit, Collection<Unit>> mustMoveWith = new HashMap<>();
-    final Collection<Unit> airTransports =
-        CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+    final Collection<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
     // Then check those that have already had their transportedBy set
     for (final Unit airTransport : airTransports) {
       if (!mustMoveWith.containsKey(airTransport)) {
@@ -1546,29 +1375,24 @@ public class MoveValidator {
     return mustMoveWith;
   }
 
-  public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,
-      final Territory start,
+  public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units, final Territory start,
       final GameData data, final PlayerID player) {
     return carrierMustMoveWith(units, start.getUnits().getUnits(), data, player);
   }
 
   static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,
       final Collection<Unit> startUnits, final GameData data, final PlayerID player) {
-    // we want to get all air units that are owned by our allies
-    // but not us that can land on a carrier
+    // we want to get all air units that are owned by our allies but not us that can land on a carrier
     final Predicate<Unit> friendlyNotOwnedAir = Matches.alliedUnit(player, data)
-        .and(Matches.unitIsOwnedBy(player).negate())
-        .and(Matches.unitCanLandOnCarrier());
+        .and(Matches.unitIsOwnedBy(player).negate()).and(Matches.unitCanLandOnCarrier());
     final Collection<Unit> alliedAir = CollectionUtils.getMatches(startUnits, friendlyNotOwnedAir);
     if (alliedAir.isEmpty()) {
       return Collections.emptyMap();
     }
     // remove air that can be carried by allied
-    final Predicate<Unit> friendlyNotOwnedCarrier = Matches.unitIsCarrier()
-        .and(Matches.alliedUnit(player, data))
-        .and(Matches.unitIsOwnedBy(player).negate());
-    final Collection<Unit> alliedCarrier =
-        CollectionUtils.getMatches(startUnits, friendlyNotOwnedCarrier);
+    final Predicate<Unit> friendlyNotOwnedCarrier =
+        Matches.unitIsCarrier().and(Matches.alliedUnit(player, data)).and(Matches.unitIsOwnedBy(player).negate());
+    final Collection<Unit> alliedCarrier = CollectionUtils.getMatches(startUnits, friendlyNotOwnedCarrier);
     final Iterator<Unit> alliedCarrierIter = alliedCarrier.iterator();
     while (alliedCarrierIter.hasNext()) {
       final Unit carrier = alliedCarrierIter.next();
@@ -1581,8 +1405,7 @@ public class MoveValidator {
     final Map<Unit, Collection<Unit>> mapping = new HashMap<>();
     // get air that must be carried by our carriers
     final Collection<Unit> ownedCarrier =
-        CollectionUtils.getMatches(units,
-            Matches.unitIsCarrier().and(Matches.unitIsOwnedBy(player)));
+        CollectionUtils.getMatches(units, Matches.unitIsCarrier().and(Matches.unitIsOwnedBy(player)));
     final Iterator<Unit> ownedCarrierIter = ownedCarrier.iterator();
     while (ownedCarrierIter.hasNext()) {
       final Unit carrier = ownedCarrierIter.next();
@@ -1606,13 +1429,11 @@ public class MoveValidator {
       final UnitAttachment planeAttachment = UnitAttachment.get(plane.getType());
       final int cost = planeAttachment.getCarrierCost();
       if (available >= cost) {
-        // this is to test if they started in the same sea zone or not, and its not a very good way
-        // of testing it.
+        // this is to test if they started in the same sea zone or not, and its not a very good way of testing it.
         if ((taCarrier.getAlreadyMoved() == taPlane.getAlreadyMoved())
             || (Matches.unitHasNotMoved().test(plane) && Matches.unitHasNotMoved().test(carrier))
             || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).negate().test(plane)
-                && Matches.alliedUnit(
-                    playerWhoIsDoingTheMovement, data).test(plane))) {
+                && Matches.alliedUnit(playerWhoIsDoingTheMovement, data).test(plane))) {
           available -= cost;
           canCarry.add(plane);
         }
@@ -1633,9 +1454,8 @@ public class MoveValidator {
     final boolean hasAir = units.stream().anyMatch(Matches.unitIsAir());
     final boolean isNeutralsImpassable =
         isNeutralsImpassable(data) || (hasAir && !Properties.getNeutralFlyoverAllowed(data));
-    // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the
-    // route choice
-    // final Predicate<Territory> territoryIsEnd = Matches.territoryIs(end);
+    // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the route choice
+
     // No neutral countries on route predicate
     final Predicate<Territory> noNeutral = Matches.territoryIsNeutralButNotWater().negate();
     // No aa guns on route predicate
@@ -1643,29 +1463,22 @@ public class MoveValidator {
     // no enemy units on the route predicate
     final Predicate<Territory> noEnemy = Matches.territoryHasEnemyUnits(player, data).negate();
     // no impassable or restricted territories
-    final Predicate<Territory> noImpassable = PredicateBuilder.of(
-        Matches.territoryIsPassableAndNotRestricted(player, data))
-        // if we have air or land, we don't want to move over territories owned by players who's
-        // relationships will
-        // not let us move into them
-        .andIf(hasAir, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))
-        .andIf(hasLand, Matches.territoryAllowsCanMoveLandUnitsOverOwnedLand(player, data))
-        .build();
+    final Predicate<Territory> noImpassable =
+        PredicateBuilder.of(Matches.territoryIsPassableAndNotRestricted(player, data))
+            // if we have air or land, we don't want to move over territories owned by players who's
+            // relationships will not let us move into them
+            .andIf(hasAir, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))
+            .andIf(hasLand, Matches.territoryAllowsCanMoveLandUnitsOverOwnedLand(player, data)).build();
     // now find the default route
-    Route defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, PredicateBuilder
-        .of(noImpassable)
-        .andIf(isNeutralsImpassable, noNeutral)
-        .build());
-    // since all routes require at least noImpassable, then if we cannot find a route without
-    // impassables, just return
+    Route defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
+        PredicateBuilder.of(noImpassable).andIf(isNeutralsImpassable, noNeutral).build());
+    // since all routes require at least noImpassable, then if we cannot find a route without impassables, just return
     // any route
     if (defaultRoute == null) {
       // at least try for a route without impassable territories, but allowing restricted
-      // territories, since there is a
-      // chance politics may change in the future.
+      // territories, since there is a chance politics may change in the future.
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-          (isNeutralsImpassable ? noNeutral.and(Matches.territoryIsImpassable())
-              : Matches.territoryIsImpassable()));
+          (isNeutralsImpassable ? noNeutral.and(Matches.territoryIsImpassable()) : Matches.territoryIsImpassable()));
       // ok, so there really is nothing, so just return any route, without conditions
       if (defaultRoute == null) {
         return data.getMap().getRoute(start, end);
@@ -1675,32 +1488,24 @@ public class MoveValidator {
     // we don't want to look at the dependents
     final Collection<Unit> unitsWhichAreNotBeingTransportedOrDependent =
         new ArrayList<>(CollectionUtils.getMatches(units,
-            Matches
-                .unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, defaultRoute,
-                    player, data, true)
+            Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, defaultRoute, player, data, true)
                 .negate()));
     boolean mustGoLand = false;
     boolean mustGoSea = false;
-    // If start and end are land, try a land route.
-    // don't force a land route, since planes may be moving
+    // If start and end are land, try a land route. Don't force a land route, since planes may be moving
     if (!start.isWater() && !end.isWater()) {
       final Route landRoute;
       if (isNeutralsImpassable) {
-        landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            Matches.territoryIsLand()
-                .and(noNeutral)
-                .and(noImpassable));
+        landRoute =
+            data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsLand().and(noNeutral).and(noImpassable));
       } else {
-        landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            Matches.territoryIsLand().and(noImpassable));
+        landRoute = data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsLand().and(noImpassable));
       }
       if (landRoute != null
-          && ((landRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
+          && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
               || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream()
-                      .anyMatch(Matches.unitIsLand())))) {
+                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsLand())))) {
         defaultRoute = landRoute;
         mustGoLand = true;
       }
@@ -1709,21 +1514,17 @@ public class MoveValidator {
     // dont force a water route, since planes may be moving
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
-          data.getMap().getRoute_IgnoreEnd(start, end,
-              Matches.territoryIsWater().and(noImpassable));
+          data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsWater().and(noImpassable));
       if (waterRoute != null
-          && ((waterRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
+          && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
               || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream()
-                      .anyMatch(Matches.unitIsSea())))) {
+                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsSea())))) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }
     }
-    // these are the conditions we would like the route to satisfy, starting
-    // with the most important
+    // these are the conditions we would like the route to satisfy, starting with the most important
     final List<Predicate<Territory>> tests;
     if (isNeutralsImpassable) {
       tests = new ArrayList<>(Arrays.asList(
@@ -1751,9 +1552,8 @@ public class MoveValidator {
       }
       final Route testRoute = data.getMap().getRoute_IgnoreEnd(start, end, testMatch);
       if (testRoute != null
-          && testRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-                  .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) {
+          && testRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) {
         return testRoute;
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -104,14 +104,13 @@ public class MoveValidator {
     if (validateFuel(data, units, route, player, result).getError() != null) {
       return result;
     }
-    // dont let the user move out of a battle zone
-    // the exception is air units and unloading units into a battle zone
+
+    // Don't let the user move out of a battle zone, the exception is air units and unloading units into a battle zone
     if (AbstractMoveDelegate.getBattleTracker(data).hasPendingBattle(route.getStart(), false)
         && units.stream().anyMatch(Matches.unitIsNotAir())) {
-      // if the units did not move into the territory, then they can move out
-      // this will happen if there is a submerged sub in the area, and
-      // a different unit moved into the sea zone setting up a battle
-      // but the original unit can still remain
+      // if the units did not move into the territory, then they can move out this will happen if there is a submerged
+      // sub in the area, and a different unit moved into the sea zone setting up a battle but the original unit can
+      // still remain
       boolean unitsStartedInTerritory = true;
       for (final Unit unit : units) {
         if (AbstractMoveDelegate.getRouteUsedToMoveInto(undoableMoves, unit, route.getEnd()) != null) {
@@ -159,10 +158,8 @@ public class MoveValidator {
     // cannot enter territories owned by a player to which we are neutral towards
     final Collection<Territory> landOnRoute = route.getMatches(Matches.territoryIsLand());
     if (!landOnRoute.isEmpty()) {
-      // TODO: if this ever changes, we need to also update getBestRoute(), because getBestRoute is
-      // also checking to
-      // make sure we avoid land
-      // territories owned by nations with these 2 relationship type attachment options
+      // TODO: if this ever changes, we need to also update getBestRoute(), because getBestRoute is also checking to
+      // make sure we avoid land territories owned by nations with these 2 relationship type attachment options
       for (final Territory t : landOnRoute) {
         if (units.stream().anyMatch(Matches.unitIsLand())) {
           if (!data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(player, t.getOwner())) {
@@ -221,8 +218,7 @@ public class MoveValidator {
   /**
    * Test a route's canals to see if you can move through it.
    *
-   * @param units
-   *        (Can be null. If null we will assume all units would be stopped by the canal.)
+   * @param units (Can be null. If null we will assume all units would be stopped by the canal.)
    */
   public static String validateCanal(final Route route, final Collection<Unit> units, final PlayerID player,
       final GameData data) {
@@ -236,18 +232,12 @@ public class MoveValidator {
   }
 
   /**
-   * Used for testing a single territory, either as part of a route, or just by itself. Returns
-   * Optional.empty if it
-   * can be passed through otherwise returns a failure message indicating why the canal can't be
-   * passed through.
+   * Used for testing a single territory, either as part of a route, or just by itself. Returns Optional.empty if it can
+   * be passed through otherwise returns a failure message indicating why the canal can't be passed through.
    *
-   * @param route
-   *        (Can be null. If not null, we will check to see if the route includes both sea zones,
-   *        and if it doesn't we
-   *        will not test the
-   *        canal)
-   * @param units
-   *        (Can be null. If null we will assume all units would be stopped by the canal.)
+   * @param route (Can be null. If not null, we will check to see if the route includes both sea zones, and if it
+   *        doesn't we will not test the canal)
+   * @param units (Can be null. If null we will assume all units would be stopped by the canal.)
    */
   public static Optional<String> validateCanal(final Territory territory, final Route route,
       final Collection<Unit> units, final PlayerID player, final GameData data) {
@@ -279,7 +269,7 @@ public class MoveValidator {
       }
     }
 
-    // we are in a contested territory owned by the enemy, and we want to move to another enemy
+    // We are in a contested territory owned by the enemy, and we want to move to another enemy
     // owned territory. do not allow unless each unit can blitz the current territory.
     if (!route.getStart().isWater() && Matches.isAtWar(route.getStart().getOwner(), data).test(player)
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
@@ -294,8 +284,8 @@ public class MoveValidator {
       }
     }
 
-    // we are in a contested territory owned by us, and we want to move to an enemy owned territory.
-    // do not allow unless the territory is blitzable.
+    // We are in a contested territory owned by us, and we want to move to an enemy owned territory.
+    // Do not allow unless the territory is blitzable.
     if (!route.getStart().isWater() && !Matches.isAtWar(route.getStart().getOwner(), data).test(player)
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data))
             && !route.allMatchMiddleSteps(Matches.isTerritoryEnemy(player, data).negate(), false))) {
@@ -313,14 +303,14 @@ public class MoveValidator {
       }
     }
 
-    // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
+    // If there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
       if ((units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) && !isNeutralsBlitzable(data)) {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
     if (units.stream().anyMatch(Matches.unitIsLand()) && route.hasSteps()) {
-      // check all the territories but the end, if there are enemy territories, make sure they are blitzable
+      // Check all the territories but the end, if there are enemy territories, make sure they are blitzable
       // if they are not blitzable, or we aren't all blitz units fail
       int enemyCount = 0;
       boolean allEnemyBlitzable = true;
@@ -446,8 +436,7 @@ public class MoveValidator {
         }
       }
     }
-    // if there are enemy units on the path blocking us, that is validated elsewhere
-    // (validateNonEnemyUnitsOnPath)
+    // if there are enemy units on the path blocking us, that is validated elsewhere (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
     if ((!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()))
         || (units.stream().noneMatch(Matches.unitIsSea()) && !nonParatroopersPresent(player, units))) {
@@ -710,7 +699,8 @@ public class MoveValidator {
         }
       }
     }
-    // don't allow move through impassable territories
+
+    // Don't allow move through impassable territories
     if (!isEditMode && route.anyMatch(Matches.territoryIsImpassable())) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
@@ -755,10 +745,8 @@ public class MoveValidator {
   }
 
   /**
-   * Checks that there are no enemy units on the route except possibly at the end.
-   * Submerged enemy units are not considered as they don't affect
-   * movement.
-   * AA and factory dont count as enemy.
+   * Checks that there are no enemy units on the route except possibly at the end. Submerged enemy units are not
+   * considered as they don't affect movement. AA and factory dont count as enemy.
    */
   static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
     final Predicate<Unit> alliedOrNonCombat =
@@ -773,8 +761,8 @@ public class MoveValidator {
   }
 
   /**
-   * Checks that there only transports, subs and/or allies on the route except at the end.
-   * AA and factory dont count as enemy.
+   * Checks that there only transports, subs and/or allies on the route except at the end. AA and factory dont count as
+   * enemy.
    */
   static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player, final GameData data,
       final boolean ignoreRouteEnd) {
@@ -926,8 +914,8 @@ public class MoveValidator {
     return least;
   }
 
-  // Determines whether we can pay the neutral territory charge for a
-  // given route for air units. We can't cross neutral territories in WW2V2.
+  // Determines whether we can pay the neutral territory charge for a given route for air units. We can't cross neutral
+  // territories in WW2V2.
   private static MoveValidationResult canCrossNeutralTerritory(final GameData data, final Route route,
       final PlayerID player, final MoveValidationResult result) {
     // neutrals we will overfly in the first place
@@ -1002,9 +990,8 @@ public class MoveValidator {
             if (isScramblingOrKamikazeAttacksEnabled
                 || !Matches.territoryIsEmptyOfCombatUnits(data, player).test(routeStart)) {
               // Unloading a transport from a sea zone with a battle, to a friendly land territory,
-              // during combat move phase, is illegal
-              // and in addition to being illegal, it is also causing problems if the sea transports
-              // get killed (the land units are not dying)
+              // during combat move phase, is illegal and in addition to being illegal, it is also causing problems if
+              // the sea transports get killed (the land units are not dying)
               // TODO: should we use the battle tracker for this instead?
               for (final Unit unit : TransportTracker.transporting(transport)) {
                 result.addDisallowedUnit(
@@ -1013,9 +1000,8 @@ public class MoveValidator {
             }
           }
         }
-        // TODO This is very sensitive to the order of the transport collection. The users may
-        // need to modify the order in which they perform their actions.
-        // check whether transport has already unloaded
+        // TODO This is very sensitive to the order of the transport collection. The users may need to modify the order
+        // in which they perform their actions. check whether transport has already unloaded
         if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
           for (final Unit unit : TransportTracker.transporting(transport)) {
             result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
@@ -1050,8 +1036,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Invalid move, only start or end can be land when route has water.");
       }
     }
-    // simply because I dont want to handle it yet
-    // checks are done at the start and end, dont want to worry about just
+    // simply because I dont want to handle it yet checks are done at the start and end, dont want to worry about just
     // using a transport as a bridge yet
     // TODO handle this
     if (!isEditMode && !route.getEnd().isWater() && !route.getStart().isWater()
@@ -1277,8 +1262,7 @@ public class MoveValidator {
   }
 
   /*
-   * Checks if units can pass through canal and returns Optional.empty() if true or a failure
-   * message if false.
+   * Checks if units can pass through canal and returns Optional.empty() if true or a failure message if false.
    */
   private static Optional<String> canPassThroughCanal(final CanalAttachment canalAttachment,
       final Collection<Unit> units, final PlayerID player, final GameData data) {
@@ -1510,8 +1494,7 @@ public class MoveValidator {
         mustGoLand = true;
       }
     }
-    // if the start and end are in water, try and get a water route
-    // dont force a water route, since planes may be moving
+    // If the start and end are water, try and get a water route don't force a water route, since planes may be moving
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
           data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsWater().and(noImpassable));

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -642,9 +642,7 @@ public class MoveValidator {
     } // !isEditMode
 
     // make sure that no non sea non transportable no carriable units end at sea
-    if (route.getEnd() != null && route.getEnd().isWater())
-
-    {
+    if (route.getEnd() != null && route.getEnd().isWater()) {
       for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
         result.addDisallowedUnit("Not all units can end at water", unit);
       }

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -188,7 +188,7 @@ public class TransportUtils {
     return cost;
   }
 
-  public static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
+  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
     final Comparator<Unit> transportCapacityComparator = (o1, o2) -> {
       final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
       final int capacityLeft2 = TransportTracker.getAvailableCapacity(o2);
@@ -204,6 +204,9 @@ public class TransportUtils {
     return canTransport;
   }
 
+  /**
+   * Creates a new list with the units sorted descending by transport cost.
+   */
   public static List<Unit> sortByTransportCostDescending(final Collection<Unit> units) {
     final Comparator<Unit> transportCostComparator = (o1, o2) -> {
       final int cost1 = UnitAttachment.get(o1.getType()).getTransportCost();

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -23,6 +23,9 @@ import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
 
+/**
+ * Utilities for loading/unloading various types of transports.
+ */
 public class TransportUtils {
 
   /**
@@ -54,7 +57,8 @@ public class TransportUtils {
     final Map<Unit, Unit> mapping = new HashMap<>();
     final IntegerMap<Unit> addedLoad = new IntegerMap<>();
     for (final Unit unit : canBeTransported) {
-      final Optional<Unit> transport = loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad);
+      final Optional<Unit> transport =
+          loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad);
 
       // Move loaded transport to end of list
       if (transport.isPresent()) {
@@ -66,7 +70,8 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Tries load max units into each transport before moving to next.
+   * Returns a map of unit -> transport. Tries load max units into each transport before moving to
+   * next.
    */
   public static Map<Unit, Unit> mapTransportsToLoadUsingMinTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
@@ -84,10 +89,12 @@ public class TransportUtils {
       final int capacity = TransportTracker.getAvailableCapacity(currentTransport);
       final int remainingCost = getTransportCost(canBeTransported);
       if (remainingCost <= capacity) {
-        if (!finalTransport.isPresent() || capacity < TransportTracker.getAvailableCapacity(finalTransport.get())) {
+        if (!finalTransport.isPresent()
+            || capacity < TransportTracker.getAvailableCapacity(finalTransport.get())) {
           finalTransport = Optional.of(currentTransport);
         }
-        continue; // Check all transports to find the one with the least remaining capacity that can fit all units
+        // Check all transports for the one with the least remaining capacity that can fit all units
+        continue;
       }
 
       // Check if we've found the final transport to load remaining units
@@ -112,8 +119,10 @@ public class TransportUtils {
   public static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
-    final Collection<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    final Collection<Unit> canBeTransported =
+        CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    final Collection<Unit> canTransport =
+        CollectionUtils.getMatches(transports, Matches.unitCanTransport());
 
     final Map<Unit, Unit> mapping = new HashMap<>();
     for (final Unit currentTransported : canBeTransported) {
@@ -130,17 +139,22 @@ public class TransportUtils {
   }
 
   /**
-   * Returns list of transports. Transports must contain all units. Can swap units with equivalent state in order to
+   * Returns list of transports. Transports must contain all units. Can swap units with equivalent
+   * state in order to
    * minimize transports used to unload.
    */
-  public static Set<Unit> findMinTransportsToUnload(final Collection<Unit> units, final Collection<Unit> transports) {
+  public static Set<Unit> findMinTransportsToUnload(final Collection<Unit> units,
+      final Collection<Unit> transports) {
     final Set<Unit> result = new HashSet<>();
-    Map<Unit, List<Unit>> unitToPotentialTransports = findTransportsThatUnitsCouldUnloadFrom(units, transports);
+    Map<Unit, List<Unit>> unitToPotentialTransports =
+        findTransportsThatUnitsCouldUnloadFrom(units, transports);
     while (!unitToPotentialTransports.isEmpty()) {
       unitToPotentialTransports = sortByTransportOptionsAscending(unitToPotentialTransports);
       final Unit currentUnit = unitToPotentialTransports.keySet().iterator().next();
-      final Unit selectedTransport = findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
-      unitToPotentialTransports = removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
+      final Unit selectedTransport =
+          findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
+      unitToPotentialTransports =
+          removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
       result.add(selectedTransport);
     }
     return result;
@@ -149,7 +163,8 @@ public class TransportUtils {
   public static List<Unit> findUnitsToLoadOnAirTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> airTransports = CollectionUtils.getMatches(transports, Matches.unitIsAirTransport());
+    final Collection<Unit> airTransports =
+        CollectionUtils.getMatches(transports, Matches.unitIsAirTransport());
     List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
     canBeTransported = sortByTransportCostDescending(canBeTransported);
 
@@ -157,16 +172,21 @@ public class TransportUtils {
     final List<Unit> totalLoad = new ArrayList<>();
 
     // Get a list of the unit categories
-    final Collection<UnitCategory> unitTypes = UnitSeperator.categorize(canBeTransported, null, false, true);
-    final Collection<UnitCategory> transportTypes = UnitSeperator.categorize(airTransports, null, false, false);
+    final Collection<UnitCategory> unitTypes =
+        UnitSeperator.categorize(canBeTransported, null, false, true);
+    final Collection<UnitCategory> transportTypes =
+        UnitSeperator.categorize(airTransports, null, false, false);
     for (final UnitCategory unitType : unitTypes) {
       final int transportCost = unitType.getTransportCost();
       for (final UnitCategory transportType : transportTypes) {
-        final int transportCapacity = UnitAttachment.get(transportType.getType()).getTransportCapacity();
+        final int transportCapacity =
+            UnitAttachment.get(transportType.getType()).getTransportCapacity();
         if (transportCost > 0 && transportCapacity >= transportCost) {
           final int transportCount =
-              CollectionUtils.countMatches(airTransports, Matches.unitIsOfType(transportType.getType()));
-          final int ttlTransportCapacity = transportCount * (int) Math.floor(transportCapacity / transportCost);
+              CollectionUtils.countMatches(airTransports,
+                  Matches.unitIsOfType(transportType.getType()));
+          final int ttlTransportCapacity =
+              transportCount * (int) Math.floor(transportCapacity / transportCost);
           totalLoad.addAll(CollectionUtils.getNMatches(canBeTransported, ttlTransportCapacity,
               Matches.unitIsOfType(unitType.getType())));
         }
@@ -188,7 +208,8 @@ public class TransportUtils {
     return cost;
   }
 
-  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
+  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(
+      final Collection<Unit> transports) {
     final Comparator<Unit> transportCapacityComparator = (o1, o2) -> {
       final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
       final int capacityLeft2 = TransportTracker.getAvailableCapacity(o2);
@@ -218,11 +239,13 @@ public class TransportUtils {
     return canBeTransported;
   }
 
-  private static Optional<Unit> loadUnitIntoFirstAvailableTransport(final Unit unit, final List<Unit> canTransport,
+  private static Optional<Unit> loadUnitIntoFirstAvailableTransport(final Unit unit,
+      final List<Unit> canTransport,
       final Map<Unit, Unit> mapping, final IntegerMap<Unit> addedLoad) {
     final int cost = UnitAttachment.get((unit).getType()).getTransportCost();
     for (final Unit transport : canTransport) {
-      final int capacity = TransportTracker.getAvailableCapacity(transport) - addedLoad.getInt(transport);
+      final int capacity =
+          TransportTracker.getAvailableCapacity(transport) - addedLoad.getInt(transport);
       if (capacity >= cost) {
         addedLoad.add(transport, cost);
         mapping.put(unit, transport);
@@ -246,10 +269,13 @@ public class TransportUtils {
     }
   }
 
-  private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(final Collection<Unit> units,
+  private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(
+      final Collection<Unit> units,
       final Collection<Unit> transports) {
-    final List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
-    final List<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    final List<Unit> canBeTransported =
+        CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    final List<Unit> canTransport =
+        CollectionUtils.getMatches(transports, Matches.unitCanTransport());
     final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
     for (final Unit unit : canBeTransported) {
       final List<Unit> transportOptions = new ArrayList<>();
@@ -280,7 +306,8 @@ public class TransportUtils {
       int transportOptions = 0;
       for (final Unit loadedUnit : TransportTracker.transporting(transport)) {
         if (containsEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet())) {
-          final Unit equivalentUnit = getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
+          final Unit equivalentUnit =
+              getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
           transportOptions += unitToPotentialTransports.get(equivalentUnit).size();
         } else {
           transportOptions = Integer.MAX_VALUE;

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -45,8 +45,7 @@ public class TransportUtils {
   /**
    * Returns a map of unit -> transport. Tries to load units evenly across all transports.
    */
-  public static Map<Unit, Unit> mapTransportsToLoad(final Collection<Unit> units,
-      final Collection<Unit> transports) {
+  public static Map<Unit, Unit> mapTransportsToLoad(final Collection<Unit> units, final Collection<Unit> transports) {
 
     List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
     canBeTransported = sortByTransportCostDescending(canBeTransported);
@@ -57,8 +56,7 @@ public class TransportUtils {
     final Map<Unit, Unit> mapping = new HashMap<>();
     final IntegerMap<Unit> addedLoad = new IntegerMap<>();
     for (final Unit unit : canBeTransported) {
-      final Optional<Unit> transport =
-          loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad);
+      final Optional<Unit> transport = loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad);
 
       // Move loaded transport to end of list
       if (transport.isPresent()) {
@@ -70,8 +68,7 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Tries load max units into each transport before moving to
-   * next.
+   * Returns a map of unit -> transport. Tries load max units into each transport before moving to next.
    */
   public static Map<Unit, Unit> mapTransportsToLoadUsingMinTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
@@ -89,8 +86,7 @@ public class TransportUtils {
       final int capacity = TransportTracker.getAvailableCapacity(currentTransport);
       final int remainingCost = getTransportCost(canBeTransported);
       if (remainingCost <= capacity) {
-        if (!finalTransport.isPresent()
-            || capacity < TransportTracker.getAvailableCapacity(finalTransport.get())) {
+        if (!finalTransport.isPresent() || capacity < TransportTracker.getAvailableCapacity(finalTransport.get())) {
           finalTransport = Optional.of(currentTransport);
         }
         // Check all transports for the one with the least remaining capacity that can fit all units
@@ -119,10 +115,8 @@ public class TransportUtils {
   public static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> canBeTransported =
-        CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
-    final Collection<Unit> canTransport =
-        CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    final Collection<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    final Collection<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
 
     final Map<Unit, Unit> mapping = new HashMap<>();
     for (final Unit currentTransported : canBeTransported) {
@@ -139,22 +133,17 @@ public class TransportUtils {
   }
 
   /**
-   * Returns list of transports. Transports must contain all units. Can swap units with equivalent
-   * state in order to
+   * Returns list of transports. Transports must contain all units. Can swap units with equivalent state in order to
    * minimize transports used to unload.
    */
-  public static Set<Unit> findMinTransportsToUnload(final Collection<Unit> units,
-      final Collection<Unit> transports) {
+  public static Set<Unit> findMinTransportsToUnload(final Collection<Unit> units, final Collection<Unit> transports) {
     final Set<Unit> result = new HashSet<>();
-    Map<Unit, List<Unit>> unitToPotentialTransports =
-        findTransportsThatUnitsCouldUnloadFrom(units, transports);
+    Map<Unit, List<Unit>> unitToPotentialTransports = findTransportsThatUnitsCouldUnloadFrom(units, transports);
     while (!unitToPotentialTransports.isEmpty()) {
       unitToPotentialTransports = sortByTransportOptionsAscending(unitToPotentialTransports);
       final Unit currentUnit = unitToPotentialTransports.keySet().iterator().next();
-      final Unit selectedTransport =
-          findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
-      unitToPotentialTransports =
-          removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
+      final Unit selectedTransport = findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
+      unitToPotentialTransports = removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
       result.add(selectedTransport);
     }
     return result;
@@ -163,8 +152,7 @@ public class TransportUtils {
   public static List<Unit> findUnitsToLoadOnAirTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> airTransports =
-        CollectionUtils.getMatches(transports, Matches.unitIsAirTransport());
+    final Collection<Unit> airTransports = CollectionUtils.getMatches(transports, Matches.unitIsAirTransport());
     List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
     canBeTransported = sortByTransportCostDescending(canBeTransported);
 
@@ -172,21 +160,16 @@ public class TransportUtils {
     final List<Unit> totalLoad = new ArrayList<>();
 
     // Get a list of the unit categories
-    final Collection<UnitCategory> unitTypes =
-        UnitSeperator.categorize(canBeTransported, null, false, true);
-    final Collection<UnitCategory> transportTypes =
-        UnitSeperator.categorize(airTransports, null, false, false);
+    final Collection<UnitCategory> unitTypes = UnitSeperator.categorize(canBeTransported, null, false, true);
+    final Collection<UnitCategory> transportTypes = UnitSeperator.categorize(airTransports, null, false, false);
     for (final UnitCategory unitType : unitTypes) {
       final int transportCost = unitType.getTransportCost();
       for (final UnitCategory transportType : transportTypes) {
-        final int transportCapacity =
-            UnitAttachment.get(transportType.getType()).getTransportCapacity();
+        final int transportCapacity = UnitAttachment.get(transportType.getType()).getTransportCapacity();
         if (transportCost > 0 && transportCapacity >= transportCost) {
           final int transportCount =
-              CollectionUtils.countMatches(airTransports,
-                  Matches.unitIsOfType(transportType.getType()));
-          final int ttlTransportCapacity =
-              transportCount * (int) Math.floor(transportCapacity / transportCost);
+              CollectionUtils.countMatches(airTransports, Matches.unitIsOfType(transportType.getType()));
+          final int ttlTransportCapacity = transportCount * (int) Math.floor(transportCapacity / transportCost);
           totalLoad.addAll(CollectionUtils.getNMatches(canBeTransported, ttlTransportCapacity,
               Matches.unitIsOfType(unitType.getType())));
         }
@@ -208,8 +191,7 @@ public class TransportUtils {
     return cost;
   }
 
-  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(
-      final Collection<Unit> transports) {
+  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
     final Comparator<Unit> transportCapacityComparator = (o1, o2) -> {
       final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
       final int capacityLeft2 = TransportTracker.getAvailableCapacity(o2);
@@ -239,13 +221,11 @@ public class TransportUtils {
     return canBeTransported;
   }
 
-  private static Optional<Unit> loadUnitIntoFirstAvailableTransport(final Unit unit,
-      final List<Unit> canTransport,
+  private static Optional<Unit> loadUnitIntoFirstAvailableTransport(final Unit unit, final List<Unit> canTransport,
       final Map<Unit, Unit> mapping, final IntegerMap<Unit> addedLoad) {
     final int cost = UnitAttachment.get((unit).getType()).getTransportCost();
     for (final Unit transport : canTransport) {
-      final int capacity =
-          TransportTracker.getAvailableCapacity(transport) - addedLoad.getInt(transport);
+      final int capacity = TransportTracker.getAvailableCapacity(transport) - addedLoad.getInt(transport);
       if (capacity >= cost) {
         addedLoad.add(transport, cost);
         mapping.put(unit, transport);
@@ -269,13 +249,10 @@ public class TransportUtils {
     }
   }
 
-  private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(
-      final Collection<Unit> units,
+  private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(final Collection<Unit> units,
       final Collection<Unit> transports) {
-    final List<Unit> canBeTransported =
-        CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
-    final List<Unit> canTransport =
-        CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    final List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    final List<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
     final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
     for (final Unit unit : canBeTransported) {
       final List<Unit> transportOptions = new ArrayList<>();
@@ -292,8 +269,7 @@ public class TransportUtils {
   private static Map<Unit, List<Unit>> sortByTransportOptionsAscending(
       final Map<Unit, List<Unit>> unitToPotentialTransports) {
     final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
-    unitToPotentialTransports.entrySet().stream()
-        .sorted((o1, o2) -> o1.getValue().size() - o2.getValue().size())
+    unitToPotentialTransports.entrySet().stream().sorted((o1, o2) -> o1.getValue().size() - o2.getValue().size())
         .forEachOrdered(e -> result.put(e.getKey(), e.getValue()));
     return result;
   }
@@ -306,8 +282,7 @@ public class TransportUtils {
       int transportOptions = 0;
       for (final Unit loadedUnit : TransportTracker.transporting(transport)) {
         if (containsEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet())) {
-          final Unit equivalentUnit =
-              getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
+          final Unit equivalentUnit = getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
           transportOptions += unitToPotentialTransports.get(equivalentUnit).size();
         } else {
           transportOptions = Integer.MAX_VALUE;

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -45,8 +45,10 @@ public class TransportUtils {
   public static Map<Unit, Unit> mapTransportsToLoad(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final List<Unit> canBeTransported = sortByTransportCostDescending(units);
-    final List<Unit> canTransport = sortByTransportCapacityDescendingThenMovesDescending(transports);
+    List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    canBeTransported = sortByTransportCostDescending(canBeTransported);
+    List<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    canTransport = sortByTransportCapacityDescendingThenMovesDescending(canTransport);
 
     // Add units to transports evenly
     final Map<Unit, Unit> mapping = new HashMap<>();
@@ -69,8 +71,10 @@ public class TransportUtils {
   public static Map<Unit, Unit> mapTransportsToLoadUsingMinTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final List<Unit> canBeTransported = sortByTransportCostDescending(units);
-    final List<Unit> canTransport = sortByTransportCapacityDescendingThenMovesDescending(transports);
+    List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    canBeTransported = sortByTransportCostDescending(canBeTransported);
+    List<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    canTransport = sortByTransportCapacityDescendingThenMovesDescending(canTransport);
 
     final Map<Unit, Unit> mapping = new HashMap<>();
     Optional<Unit> finalTransport = Optional.empty();
@@ -146,7 +150,8 @@ public class TransportUtils {
       final Collection<Unit> transports) {
 
     final Collection<Unit> airTransports = CollectionUtils.getMatches(transports, Matches.unitIsAirTransport());
-    final List<Unit> canBeTransported = sortByTransportCostDescending(units);
+    List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    canBeTransported = sortByTransportCostDescending(canBeTransported);
 
     // Define the max of all units that could be loaded
     final List<Unit> totalLoad = new ArrayList<>();
@@ -183,7 +188,7 @@ public class TransportUtils {
     return cost;
   }
 
-  private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
+  public static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
     final Comparator<Unit> transportCapacityComparator = (o1, o2) -> {
       final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
       final int capacityLeft2 = TransportTracker.getAvailableCapacity(o2);
@@ -194,18 +199,18 @@ public class TransportUtils {
       final int movementLeft2 = TripleAUnit.get(o2).getMovementLeft();
       return Integer.compare(movementLeft2, movementLeft1);
     };
-    final List<Unit> canTransport = CollectionUtils.getMatches(transports, Matches.unitCanTransport());
+    final List<Unit> canTransport = new ArrayList<>(transports);
     Collections.sort(canTransport, transportCapacityComparator);
     return canTransport;
   }
 
-  private static List<Unit> sortByTransportCostDescending(final Collection<Unit> units) {
+  public static List<Unit> sortByTransportCostDescending(final Collection<Unit> units) {
     final Comparator<Unit> transportCostComparator = (o1, o2) -> {
       final int cost1 = UnitAttachment.get(o1.getType()).getTransportCost();
       final int cost2 = UnitAttachment.get(o2.getType()).getTransportCost();
       return Integer.compare(cost2, cost1);
     };
-    final List<Unit> canBeTransported = CollectionUtils.getMatches(units, Matches.unitCanBeTransported());
+    final List<Unit> canBeTransported = new ArrayList<>(units);
     Collections.sort(canBeTransported, transportCostComparator);
     return canBeTransported;
   }

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -240,6 +240,20 @@ public class GameDataTestUtil {
   }
 
   /**
+   * Returns a truck UnitType object for the specified GameData object.
+   */
+  public static UnitType truck(final GameData data) {
+    return unitType("Truck", data);
+  }
+
+  /**
+   * Returns a truck UnitType object for the specified GameData object.
+   */
+  public static UnitType largeTruck(final GameData data) {
+    return unitType("LargeTruck", data);
+  }
+
+  /**
    * Returns a germanTrain UnitType object for the specified GameData object.
    */
   public static UnitType germanTrain(final GameData data) {

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -247,7 +247,7 @@ public class GameDataTestUtil {
   }
 
   /**
-   * Returns a truck UnitType object for the specified GameData object.
+   * Returns a large truck UnitType object for the specified GameData object.
    */
   public static UnitType largeTruck(final GameData data) {
     return unitType("LargeTruck", data);

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -169,4 +169,53 @@ public class MoveValidatorTest extends DelegateTest {
     assertTrue(results.isMoveValid());
   }
 
+  @Test
+  public void testValidateMoveForLandTransports() throws Exception {
+
+    final GameData twwGameData = TestMapGameData.TWW.getGameData();
+
+    // Move truck 2 territories
+    final PlayerID germans = GameDataTestUtil.germany(twwGameData);
+    final Territory berlin = territory("Berlin", twwGameData);
+    final Territory easternGermany = territory("Eastern Germany", twwGameData);
+    final Territory poland = territory("Poland", twwGameData);
+    final Route r = new Route(berlin, easternGermany, poland);
+    berlin.getUnits().clear();
+    GameDataTestUtil.truck(twwGameData).create(1, germans);
+    addTo(berlin, GameDataTestUtil.truck(twwGameData).create(1, germans));
+    MoveValidationResult results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertTrue(results.isMoveValid());
+
+    // Add an infantry for truck to transport
+    addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertTrue(results.isMoveValid());
+
+    // Add an infantry and the truck can't transport both
+    addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertFalse(results.isMoveValid());
+
+    // Add a large truck (has capacity for 2 infantry) to transport second infantry
+    addTo(berlin, GameDataTestUtil.largeTruck(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertTrue(results.isMoveValid());
+
+    // Add an infantry that the large truck can also transport
+    addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertTrue(results.isMoveValid());
+
+    // Add an infantry that can't be transported
+    addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+        new HashMap<>(), true, null, twwGameData);
+    assertFalse(results.isMoveValid());
+  }
+
 }

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -370,15 +370,6 @@ public class RevisedTest {
     final Territory uk = territory("United Kingdom", gameData);
     final Territory we = territory("Western Europe", gameData);
     final Territory se = territory("Southern Europe", gameData);
-    final Territory sz14 = territory("14 Sea Zone", gameData);
-    final Territory sz15 = territory("15 Sea Zone", gameData);
-    final Territory egypt = territory("Anglo Egypt", gameData);
-    // start a battle in se
-    removeFrom(sz14, sz14.getUnits().getUnits());
-    addTo(sz15, transport(gameData).create(1, british));
-    load(egypt.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(egypt, sz15));
-    move(sz15.getUnits().getUnits(), new Route(sz15, sz14));
-    move(sz14.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(sz14, se));
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
     move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired and hit

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -376,9 +376,9 @@ public class RevisedTest {
     // start a battle in se
     removeFrom(sz14, sz14.getUnits().getUnits());
     addTo(sz15, transport(gameData).create(1, british));
-    load(egypt.getUnits().getMatches(Matches.unitIsInfantry()), new Route(egypt, sz15));
+    load(egypt.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(egypt, sz15));
     move(sz15.getUnits().getUnits(), new Route(sz15, sz14));
-    move(sz14.getUnits().getMatches(Matches.unitIsInfantry()), new Route(sz14, se));
+    move(sz14.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(sz14, se));
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
     move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired and hit

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -349,7 +349,7 @@ public class WW2V3Year41Test {
     final List<Unit> transports = sz9.getUnits().getMatches(Matches.unitIsTransport());
     move(transports, sz9ToSz7);
     // load the transport
-    load(uk.getUnits().getMatches(Matches.unitIsInfantry()), new Route(uk, sz7));
+    load(uk.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
     moveDelegate(gameData).end();
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
     bridge.setRandomSource(randomSource);
@@ -781,7 +781,7 @@ public class WW2V3Year41Test {
     // move the transport where to the sub is
     assertValid(moveDelegate.move(sz8.getUnits().getUnits(), new Route(sz8, sz7)));
     // load the transport
-    load(uk.getUnits().getMatches(Matches.unitIsInfantry()), new Route(uk, sz7));
+    load(uk.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
     // move the transport out
     assertValid(
         moveDelegate.move(sz7.getUnits().getMatches(Matches.unitOwnedBy(british(gameData))), new Route(sz7, sz6)));
@@ -984,7 +984,7 @@ public class WW2V3Year41Test {
     final PlayerID british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
@@ -1035,7 +1035,7 @@ public class WW2V3Year41Test {
     addTo(sz14, transport(gameData).create(1, italians));
     addTo(sz14, destroyer(gameData).create(2, italians));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // unload the transports
@@ -1088,7 +1088,7 @@ public class WW2V3Year41Test {
     final Territory li = territory("Libya", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
@@ -1167,7 +1167,7 @@ public class WW2V3Year41Test {
     final List<Unit> toMove = new ArrayList<>();
     // 1 armour and 1 infantry
     toMove.addAll(france.getUnits().getMatches(Matches.unitCanBlitz()));
-    toMove.add(france.getUnits().getMatches(Matches.unitIsInfantry()).get(0));
+    toMove.add(france.getUnits().getMatches(Matches.unitIsLandTransportable()).get(0));
     move(toMove, r);
   }
 
@@ -1182,9 +1182,9 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // get rid of the infantry in france
-    removeFrom(france, france.getUnits().getMatches(Matches.unitIsInfantry()));
+    removeFrom(france, france.getUnits().getMatches(Matches.unitIsLandTransportable()));
     // move an infantry from germany to france
-    move(germany.getUnits().getMatches(Matches.unitIsInfantry()).subList(0, 1), new Route(germany, france));
+    move(germany.getUnits().getMatches(Matches.unitIsLandTransportable()).subList(0, 1), new Route(germany, france));
     // try to move all the units in france, the infantry should not be able to move
     final Route r = new Route(france, germany);
     final String error = moveDelegate(gameData).move(france.getUnits().getUnits(), r);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -83,7 +83,7 @@ public class WW2V3Year42Test {
     // move the bomber to attack
     move(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()), new Route(germany, sz5, karrelia));
     // move an infantry to invade
-    move(baltic.getUnits().getMatches(Matches.unitIsInfantry()), new Route(baltic, karrelia));
+    move(baltic.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
     // we should have a pending land battle, and a pending bombing raid
     assertNotNull(battleTracker.getPendingBattle(karrelia, false, null));

--- a/src/test/resources/Total_World_War_Dec1941.xml
+++ b/src/test/resources/Total_World_War_Dec1941.xml
@@ -2131,6 +2131,7 @@
     <unit name="chineseFortification"/>
     <unit name="chineseAirfield"/>
     <unit name="Truck"/>
+    <unit name="LargeTruck"/>
     <unit name="Airfield"/>
     <unit name="Protectorate"/>
     <unit name="Occupation"/>
@@ -6774,6 +6775,31 @@
       <option name="canDieFromReachingMaxDamage" value="true"/>
       <option name="isLandTransport" value="true"/>
       <option name="transportCost" value="2"/>
+      <option name="canBeGivenByTerritoryTo" value="Germany:Britain:Japan"/>
+      <option name="isInfrastructure" value="true"/>
+      <option name="requiresUnits" value="germanFactory"/>
+      <option name="requiresUnits" value="russianFactory"/>
+      <option name="requiresUnits" value="japaneseFactory"/>
+      <option name="requiresUnits" value="chineseFactory"/>
+      <option name="requiresUnits" value="britishFactory"/>
+      <option name="requiresUnits" value="italianFactory"/>
+      <option name="requiresUnits" value="americanFactory"/>
+      <option name="requiresUnits" value="spanishFactory"/>
+      <option name="requiresUnits" value="swedishFactory"/>
+      <option name="requiresUnits" value="turkishFactory"/>
+      <option name="requiresUnits" value="brazilianFactory"/>
+      <option name="isAAmovement" value="true"/>
+    </attachment>
+    <attachment name="unitAttachment" attachTo="LargeTruck" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="movement" value="2"/>
+      <option name="attack" value="0"/>
+      <option name="defense" value="0"/>
+      <option name="canBeDamaged" value="true"/>
+      <option name="maxDamage" value="1"/>
+      <option name="canDieFromReachingMaxDamage" value="true"/>
+      <option name="isLandTransport" value="true"/>
+      <option name="transportCost" value="2"/>
+      <option name="transportCapacity" value="5"/>
       <option name="canBeGivenByTerritoryTo" value="Germany:Britain:Japan"/>
       <option name="isInfrastructure" value="true"/>
       <option name="requiresUnits" value="germanFactory"/>


### PR DESCRIPTION
Addresses feature request: https://forums.triplea-game.org/topic/180/land-transport-improvements

The core change is in MoveValidator and the diff is pretty difficult to follow as its pretty close to a rewrite. I also ended up reformatting most of the class as it was driving me crazy.

**Functional Changes**
- Add new parameter "isLandTransportable" that functions the same as "isInfantry" which will be considered deprecated (some time in the future it will be removed all together as it is a very confusing property with a bad history).
- Fix bug that didn't allow air transports and land transports to be moved in the same move.
- Have units with "isLandTransport" utilize the "transportCapacity" property to determine how many units they can transport and if not set then default to being able to transport 1 unit (keeps current functionality unchanged).
- Have "isLandTransportable" units utilize "transportCost" so they then function similar to sea transports.
 The goal then is to have the engine make a best effort to load all selected land transports and transportable units but if it selects them incorrectly then the player may need to move 1 land transport at a time.

**Example Transport With Capacity XML**

```
<attachment name="unitAttachment" attachTo="LargeTruck" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="2"/>
      <option name="attack" value="0"/>
      <option name="defense" value="0"/>
      <option name="canBeDamaged" value="true"/>
      <option name="maxDamage" value="1"/>
      <option name="canDieFromReachingMaxDamage" value="true"/>
      <option name="isLandTransport" value="true"/>
      <option name="transportCost" value="2"/>
      **<option name="transportCapacity" value="5"/>**
      <option name="canBeGivenByTerritoryTo" value="Germany:Britain:Japan"/>
      <option name="isInfrastructure" value="true"/>
      <option name="isAAmovement" value="true"/>
    </attachment>
```

**Code Background**
The existing code was a mess with a bug on not handling land and air transports in the same move. I completely reworked it to just remove all dependent air units (as they are in the newDependents list). Then we just need to validate land transport units. The change is then to split land transports that set transport capacity vs those that don't. We then try to use those without capacity first then those with capacity for units that can be land transported and don't have enough movement.