### PR TITLE
Replace the json.org library with Open JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
     compile 'org.postgresql:postgresql:42.1.4'
     compile 'com.github.insubstantial:substance:7.3'
+    compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:23.2-jre'
     compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
@@ -97,7 +98,6 @@ dependencies {
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'org.mindrot:jbcrypt:0.4'
     compile 'org.yaml:snakeyaml:1.18'
-    compile 'org.json:json:20170516'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
 

--- a/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
+++ b/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
@@ -6,14 +6,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.stream.StreamSupport;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.yaml.snakeyaml.Yaml;
+
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
 
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.util.OpenJsonUtils;
 import games.strategy.util.Version;
 
 /**
@@ -25,7 +26,7 @@ class LobbyPropertyFileParser {
 
   public static LobbyServerProperties parse(final File file, final Version currentVersion) {
     try {
-      return new LobbyServerProperties(matchCurrentVersion(loadYaml(file), currentVersion).toMap());
+      return new LobbyServerProperties(OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(file), currentVersion)));
     } catch (final IOException e) {
       throw new RuntimeException("Failed loading file: " + file.getAbsolutePath() + ", please try again, if the "
           + "problem does not go away please report a bug: " + UrlConstants.GITHUB_ISSUES);
@@ -35,7 +36,7 @@ class LobbyPropertyFileParser {
   private static JSONObject matchCurrentVersion(final JSONArray lobbyProps, final Version currentVersion) {
     checkNotNull(lobbyProps);
 
-    return StreamSupport.stream(lobbyProps.spliterator(), false)
+    return OpenJsonUtils.stream(lobbyProps)
         .map(JSONObject.class::cast)
         .filter(props -> currentVersion.equals(new Version(props.getString("version"))))
         .findFirst()

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -3,12 +3,13 @@ package games.strategy.engine.framework.map.download;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.StreamSupport;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.yaml.snakeyaml.Yaml;
 
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
+
+import games.strategy.util.OpenJsonUtils;
 import games.strategy.util.Version;
 
 /**
@@ -31,18 +32,20 @@ final class DownloadFileParser {
     final JSONArray yamlData = new JSONArray(new Yaml().loadAs(is, List.class));
 
     final List<DownloadFileDescription> downloads = new ArrayList<>();
-    StreamSupport.stream(yamlData.spliterator(), false).map(JSONObject.class::cast).forEach(yaml -> {
+    OpenJsonUtils.stream(yamlData).map(JSONObject.class::cast).forEach(yaml -> {
       final String url = yaml.getString(Tags.url.toString());
       final String description = yaml.getString(Tags.description.toString());
       final String mapName = yaml.getString(Tags.mapName.toString());
 
       final Version version = new Version(yaml.getInt(Tags.version.toString()), 0);
-      final DownloadFileDescription.DownloadType downloadType = yaml.optEnum(
+      final DownloadFileDescription.DownloadType downloadType = OpenJsonUtils.optEnum(
+          yaml,
           DownloadFileDescription.DownloadType.class,
           Tags.mapType.toString(),
           DownloadFileDescription.DownloadType.MAP);
 
-      final DownloadFileDescription.MapCategory mapCategory = yaml.optEnum(
+      final DownloadFileDescription.MapCategory mapCategory = OpenJsonUtils.optEnum(
+          yaml,
           DownloadFileDescription.MapCategory.class,
           Tags.mapCategory.toString(),
           DownloadFileDescription.MapCategory.EXPERIMENTAL);

--- a/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -18,8 +18,9 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
+
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.HttpProxy;

--- a/src/main/java/games/strategy/util/OpenJsonUtils.java
+++ b/src/main/java/games/strategy/util/OpenJsonUtils.java
@@ -2,10 +2,10 @@ package games.strategy.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -58,12 +58,11 @@ public final class OpenJsonUtils {
   public static Stream<Object> stream(final JSONArray jsonArray) {
     checkNotNull(jsonArray);
 
-    final int size = jsonArray.length();
-    final List<Object> list = new ArrayList<>(size);
-    for (int i = 0; i < size; ++i) {
-      list.add(jsonArray.get(i));
+    final Stream.Builder<Object> streamBuilder = Stream.builder();
+    for (int i = 0, size = jsonArray.length(); i < size; ++i) {
+      streamBuilder.add(jsonArray.get(i));
     }
-    return list.stream();
+    return streamBuilder.build();
   }
 
   /**
@@ -78,12 +77,9 @@ public final class OpenJsonUtils {
   public static List<Object> toList(final JSONArray jsonArray) {
     checkNotNull(jsonArray);
 
-    final int size = jsonArray.length();
-    final List<Object> list = new ArrayList<>(size);
-    for (int i = 0; i < size; ++i) {
-      list.add(unwrap(jsonArray.get(i)));
-    }
-    return list;
+    return stream(jsonArray)
+        .map(OpenJsonUtils::unwrap)
+        .collect(Collectors.toList());
   }
 
   private static @Nullable Object unwrap(final @Nullable Object value) {

--- a/src/main/java/games/strategy/util/OpenJsonUtils.java
+++ b/src/main/java/games/strategy/util/OpenJsonUtils.java
@@ -1,0 +1,119 @@
+package games.strategy.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
+
+/**
+ * A collection of methods that extend the functionality of the Open JSON library.
+ *
+ * @see https://github.com/openjson/openjson
+ */
+public final class OpenJsonUtils {
+  private OpenJsonUtils() {}
+
+  /**
+   * Returns the enum value of the specified property if it exists, or the specified default value if no such mapping
+   * exists.
+   *
+   * @param jsonObject The JSON object.
+   * @param type The type of the enum value.
+   * @param name The property name to retrieve.
+   * @param defaultValue The value to return if the property does not exist.
+   *
+   * @return The enum value of the property if it exists or the default value if no such mapping exists.
+   *
+   * @throws IllegalArgumentException If the property value is not a valid enum constant of the specified type.
+   */
+  public static <T extends Enum<T>> T optEnum(
+      final JSONObject jsonObject,
+      final Class<T> type,
+      final String name,
+      final T defaultValue) {
+    checkNotNull(jsonObject);
+    checkNotNull(type);
+    checkNotNull(name);
+    checkNotNull(defaultValue);
+
+    final String valueName = jsonObject.optString(name);
+    return valueName.isEmpty() ? defaultValue : Enum.valueOf(type, valueName);
+  }
+
+  /**
+   * Streams the elements of the specified JSON array.
+   *
+   * @param jsonArray The JSON array.
+   *
+   * @return A stream containing the elements of the specified JSON array.
+   */
+  public static Stream<Object> stream(final JSONArray jsonArray) {
+    checkNotNull(jsonArray);
+
+    final int size = jsonArray.length();
+    final List<Object> list = new ArrayList<>(size);
+    for (int i = 0; i < size; ++i) {
+      list.add(jsonArray.get(i));
+    }
+    return list.stream();
+  }
+
+  /**
+   * Converts the specified JSON array into a list of equivalent Java types. Any {@link JSONArray} element will be
+   * converted into an equivalent {@code List<Object>}; any {@link JSONObject} element will be converted into an
+   * equivalent {@code Map<String, Object>}.
+   *
+   * @param jsonArray The JSON array.
+   *
+   * @return A list of the specified JSON array's elements converted to their equivalent Java types.
+   */
+  public static List<Object> toList(final JSONArray jsonArray) {
+    checkNotNull(jsonArray);
+
+    final int size = jsonArray.length();
+    final List<Object> list = new ArrayList<>(size);
+    for (int i = 0; i < size; ++i) {
+      list.add(unwrap(jsonArray.get(i)));
+    }
+    return list;
+  }
+
+  private static @Nullable Object unwrap(final @Nullable Object value) {
+    if (value == null || JSONObject.NULL.equals(value)) {
+      return null;
+    } else if (value instanceof JSONArray) {
+      return toList((JSONArray) value);
+    } else if (value instanceof JSONObject) {
+      return toMap((JSONObject) value);
+    }
+    return value;
+  }
+
+  /**
+   * Converts the properties of the specified JSON object into a map of equivalent Java types. Any {@link JSONArray}
+   * property value will be converted into an equivalent {@code List<Object>}; any {@link JSONObject} property value
+   * will be converted into an equivalent {@code Map<String, Object>}.
+   *
+   * @param jsonObject The JSON object.
+   *
+   * @return A map of the specified JSON object's properties converted to their equivalent Java types. The keys are the
+   *         property names; the values are the property values.
+   */
+  public static Map<String, Object> toMap(final JSONObject jsonObject) {
+    checkNotNull(jsonObject);
+
+    final Map<String, Object> map = new HashMap<>(jsonObject.length());
+    for (final String name : jsonObject.keySet()) {
+      map.put(name, unwrap(jsonObject.get(name)));
+    }
+    return map;
+  }
+}

--- a/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
+++ b/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
@@ -1,0 +1,199 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.openjson.JSONArray;
+import com.github.openjson.JSONObject;
+import com.google.common.collect.ImmutableMap;
+
+public final class OpenJsonUtilsTest {
+  private enum TestEnum {
+    FIRST, SECOND;
+  }
+
+  @Test
+  public void optEnum_ShouldReturnEnumValueWhenPresent() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", TestEnum.FIRST.toString()));
+
+    final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
+
+    assertThat(value, is(TestEnum.FIRST));
+  }
+
+  @Test
+  public void optEnum_ShouldReturnDefaultValueWhenAbsent() {
+    final JSONObject jsonObject = new JSONObject();
+
+    final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
+
+    assertThat(value, is(TestEnum.SECOND));
+  }
+
+  @Test
+  public void optEnum_ShouldThrowExceptionWhenPresentButNotEnumValue() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", "unknown"));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND));
+  }
+
+  @Test
+  public void streamJsonArray_ShouldReturnEmptyStreamWhenJsonArrayIsEmpty() {
+    final JSONArray jsonArray = new JSONArray();
+
+    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+    assertThat(elements, is(empty()));
+  }
+
+  @Test
+  public void streamJsonArray_ShouldReturnStreamContainingJsonArrayElements() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
+
+    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+    assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
+  }
+
+  @Test
+  public void streamJsonArray_ShouldNotConvertNullSentinelValue() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+
+    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+    assertThat(elements, is(Arrays.asList(JSONObject.NULL)));
+  }
+
+  @Test
+  public void streamJsonArray_ShouldNotConvertJsonArrayValue() {
+    final List<Object> expectedElements = Arrays.asList(new JSONArray(Arrays.asList(42)));
+    final JSONArray jsonArray = new JSONArray(expectedElements);
+
+    final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+    assertThat(actualElements, is(expectedElements));
+  }
+
+  @Test
+  public void streamJsonArray_ShouldNotConvertJsonObjectValue() {
+    final List<Object> expectedElements = Arrays.asList(new JSONObject(ImmutableMap.of("name", 42)));
+    final JSONArray jsonArray = new JSONArray(expectedElements);
+
+    final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+    assertThat(actualElements, is(expectedElements));
+  }
+
+  @Test
+  public void toList_ShouldReturnEmptyListWhenJsonArrayIsEmpty() {
+    final JSONArray jsonArray = new JSONArray();
+
+    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+    assertThat(elements, is(empty()));
+  }
+
+  @Test
+  public void toList_ShouldReturnListContainingJsonArrayElements() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
+
+    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+    assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
+  }
+
+  @Test
+  public void toList_ShouldConvertNullSentinelValueToNull() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+
+    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+    // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
+    assertThat(elements.get(0), is(nullValue()));
+  }
+
+  @Test
+  public void toList_ShouldConvertJsonArrayValueToList() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONArray(Arrays.asList(42))));
+
+    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+    assertThat(elements, is(Arrays.asList(Arrays.asList(42))));
+  }
+
+  @Test
+  public void toList_ShouldConvertJsonObjectValueToMap() {
+    final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONObject(ImmutableMap.of("name", 42))));
+
+    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+    assertThat(elements, is(Arrays.asList(ImmutableMap.of("name", 42))));
+  }
+
+  @Test
+  public void toMap_ShouldReturnEmptyMapWhenJsonObjectHasNoProperties() {
+    final JSONObject jsonObject = new JSONObject();
+
+    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
+
+    assertThat(properties, is(anEmptyMap()));
+  }
+
+  @Test
+  public void toMap_ShouldReturnMapContainingJsonObjectProperties() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+        "name1", "value1",
+        "name2", 2,
+        "name3", 3.0));
+
+    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
+
+    assertThat(properties, is(ImmutableMap.of(
+        "name1", "value1",
+        "name2", 2,
+        "name3", 3.0)));
+  }
+
+  @Test
+  public void toMap_ShouldConvertNullSentinelValueToNull() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", JSONObject.NULL));
+
+    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
+
+    // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
+    assertThat(properties.get("name"), is(nullValue()));
+  }
+
+  @Test
+  public void toMap_ShouldConvertJsonArrayValueToList() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+        "name", new JSONArray(Arrays.asList(42))));
+
+    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
+
+    assertThat(properties, is(ImmutableMap.of("name", Arrays.asList(42))));
+  }
+
+  @Test
+  public void toMap_ShouldConvertJsonObjectValueToMap() {
+    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+        "name", new JSONObject(ImmutableMap.of("childName", 42))));
+
+    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
+
+    assertThat(properties, is(ImmutableMap.of("name", ImmutableMap.of("childName", 42))));
+  }
+}


### PR DESCRIPTION
Resolves #2672.

The json.org library uses a license that is incompatible with the GPL.  Open JSON uses the Apache License 2.0 which is compatible with GPLv3 (but not GPLv2).  We use other libraries licensed under the Apache License 2.0 (e.g. Guava), so this doesn't introduce any new issues.  However, we should consider opening a separate issue to discuss changing the TripleA license to GPLv3.

Open JSON is pretty much a drop-in replacement for the json.org library.  However, it is based on an older API version and is missing some of the newer convenience methods we rely on.  I added equivalent methods in the new `OpenJsonUtils` class to provide this missing functionality.  These can be easily removed if a new version of Open JSON provides equivalent functionality in the future.

In summary, the following replacements were made:

Old method | New method
:-- | :--
`JSONArray#spliterator()` | `OpenJsonUtils#stream(JSONArray)`
`JSONObject#optEnum()` | `OpenJsonUtils#optEnum(JSONObject, ...)`
`JSONObject#toMap()` | `OpenJsonUtils#toMap(JSONObject)`

#### Testing

Unit tests were added for all new methods in `OpenJsonUtils`.

I smoke tested the following three features that rely on parsing JSON documents:

* Download maps
* Lobby
* PBF via `forums.triplea-game.org`