### PR TITLE
Hide GameParser Method Object details behind facade

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -98,22 +98,18 @@ public final class GameParser {
    * @return A partial {@link GameData} instance that can be used to display metadata about the game (e.g. when
    *         displaying all available maps); it cannot be used to play the game.
    */
-  public static GameData parseShallow(
-      final String mapName,
-      final InputStream stream,
-      final AtomicReference<String> gameName)
+  public static GameData parseShallow(final String mapName, final InputStream stream)
       throws GameParseException, SAXException, EngineVersionException {
     checkNotNull(mapName);
     checkNotNull(stream);
-    checkNotNull(gameName);
 
-    return new GameParser(mapName).parseShallow(stream, gameName);
+    return new GameParser(mapName).parseShallow(stream);
   }
 
-  private GameData parseShallow(final InputStream stream, final AtomicReference<String> gameName)
+  private GameData parseShallow(final InputStream stream)
       throws GameParseException, SAXException, EngineVersionException {
     final Element root = parseDom(stream);
-    parseMapProperties(root, gameName);
+    parseMapProperties(root, new AtomicReference<>());
     return data;
   }
 

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -75,6 +75,18 @@ public final class GameParser {
    *
    * @return A complete {@link GameData} instance that can be used to play the game.
    */
+  public static GameData parse(final String mapName, final InputStream stream)
+      throws GameParseException, SAXException, EngineVersionException {
+    return parse(mapName, stream, new AtomicReference<>());
+  }
+
+  /**
+   * Performs a deep parse of the game definition contained in the specified stream.
+   *
+   * @param gameName Receives the game name parsed from the game definition.
+   *
+   * @return A complete {@link GameData} instance that can be used to play the game.
+   */
   public static GameData parse(final String mapName, final InputStream stream, final AtomicReference<String> gameName)
       throws GameParseException, SAXException, EngineVersionException {
     checkNotNull(mapName);

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -185,7 +185,7 @@ public class AvailableGames {
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        final GameData data = new GameParser(uri.toString()).parse(input, gameName);
+        final GameData data = GameParser.parse(uri.toString(), input, gameName);
         final String name = data.getGameName();
         final String mapName = data.getProperties().get(Constants.MAP_NAME, "");
         if (!availableGames.containsKey(name)) {
@@ -212,7 +212,7 @@ public class AvailableGames {
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        return new GameParser(uri.toString()).parse(input, gameName);
+        return GameParser.parse(uri.toString(), input, gameName);
       } catch (final Exception e) {
         ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
             + (gameName.get() != null ? gameName.get() + " : " : ""), e);

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -89,7 +89,7 @@ public class GameSelectorModel extends Observable {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
         try (FileInputStream fis = new FileInputStream(file)) {
-          newData = new GameParser(file.getAbsolutePath()).parse(fis, gameName);
+          newData = GameParser.parse(file.getAbsolutePath(), fis, gameName);
         }
       } else {
         // try to load it as a saved game whatever the extension

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -27,7 +27,6 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
   public GameChooserEntry(final URI uri)
       throws IOException, GameParseException, SAXException, EngineVersionException {
     url = uri;
-    final AtomicReference<String> gameName = new AtomicReference<>();
 
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (!inputStream.isPresent()) {
@@ -37,7 +36,7 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     }
 
     try (InputStream input = inputStream.get()) {
-      gameData = GameParser.parseShallow(uri.toString(), input, gameName);
+      gameData = GameParser.parseShallow(uri.toString(), input);
       gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
     }
   }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -46,15 +45,13 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     // correct order for things to work, and that is bads.
     gameData = null;
 
-    final AtomicReference<String> gameName = new AtomicReference<>();
-
     final Optional<InputStream> inputStream = UrlStreams.openStream(url);
     if (!inputStream.isPresent()) {
       return;
     }
 
     try (InputStream input = inputStream.get()) {
-      gameData = GameParser.parse(url.toString(), input, gameName);
+      gameData = GameParser.parse(url.toString(), input);
       gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -37,7 +37,7 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     }
 
     try (InputStream input = inputStream.get()) {
-      gameData = new GameParser(uri.toString()).parseMapProperties(input, gameName);
+      gameData = GameParser.parseShallow(uri.toString(), input, gameName);
       gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
     }
   }
@@ -55,7 +55,7 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     }
 
     try (InputStream input = inputStream.get()) {
-      gameData = new GameParser(url.toString()).parse(input, gameName);
+      gameData = GameParser.parse(url.toString(), input, gameName);
       gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.xml;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Paths;
-import java.util.concurrent.atomic.AtomicReference;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
@@ -60,7 +59,7 @@ public enum TestMapGameData {
    */
   public GameData getGameData() throws Exception {
     try (InputStream is = new FileInputStream(Paths.get("src", "test", "resources", fileName).toFile())) {
-      return GameParser.parse("game name", is, new AtomicReference<>());
+      return GameParser.parse("game name", is);
     }
   }
 }

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -60,7 +60,7 @@ public enum TestMapGameData {
    */
   public GameData getGameData() throws Exception {
     try (InputStream is = new FileInputStream(Paths.get("src", "test", "resources", fileName).toFile())) {
-      return new GameParser("game name").parse(is, new AtomicReference<>());
+      return GameParser.parse("game name", is, new AtomicReference<>());
     }
   }
 }


### PR DESCRIPTION
This PR is a follow-up to #2657.  As discussed there, `GameParser` follows the _Method Object_ pattern, and instances of this class are not re-usable after parsing a game definition.  To prevent
accidental misuse of this type, the _Method Object_ details are hidden behind static methods that act as a facade for its usage.

#### Functional changes

None.

#### Refactoring changes

* The parsing methods were renamed to better clarify the difference between the two.  `parse()` completely parses a game definition, while `parseShallow()` only partially parses a game definition sufficient for use in the map list.
* The game name `AtomicReference` is no longer required if the caller does not need the parsed game name.  There were several call sites that did not require this information.

#### Testing

I smoke tested the Download Maps list, as well as starting a new game.  Those two features should exercise both the `parse()` and `parseShallow()` code paths.