### PR TITLE
Add MARTI staging dice server properties

### DIFF
--- a/dice_servers/tripleawarclub-staging.properties
+++ b/dice_servers/tripleawarclub-staging.properties
@@ -1,7 +1,7 @@
 # when placing in the list, sort by order
 order=11
 # name to display to the user
-name=dice.tripleawarclub.org (BETA)
+name=dice.tripleawarclub.org (experimental BETA)
 # dice server host
 host=www.tripleawarclub.org
 # path in dice server post to post too

--- a/dice_servers/tripleawarclub-staging.properties
+++ b/dice_servers/tripleawarclub-staging.properties
@@ -3,9 +3,9 @@ order=11
 # name to display to the user
 name=dice.tripleawarclub.org (experimental BETA)
 # dice server host
-host=www.tripleawarclub.org
+host=dice-staging.tripleawarclub.org
 # path in dice server post to post too
-path=/dice-staging/MARTI.php
+path=/MARTI.php
 roll.single.start=your dice are: 
 roll.single.end=<p>
 roll.multiple.start=your dice are: 

--- a/dice_servers/tripleawarclub-staging.properties
+++ b/dice_servers/tripleawarclub-staging.properties
@@ -17,6 +17,6 @@ message.maxlength=200
 error.start=fatal error:
 error.end=!
 infotext=Enter your your email address in the "To" field, and you opponents in in the "CC" field, you may enter multiple addresses each separated by a space.<br> \n\
-Visit https://www.tripleawarclub.org/dice-staging/index.php to register your email addresses, this must be done to receive dice emails.<br> \n\
+Visit http://dice-staging.tripleawarclub.org/ to register your email addresses, this must be done to receive dice emails.<br> \n\
 If this is a league match you must enter a Game ID or Challenge ID, as requested by your tournament organizer
 gameid=true

--- a/dice_servers/tripleawarclub-staging.properties
+++ b/dice_servers/tripleawarclub-staging.properties
@@ -1,7 +1,7 @@
 # when placing in the list, sort by order
 order=11
 # name to display to the user
-name=dice.tripleawarclub.org (experimental BETA)
+name=dice-staging.tripleawarclub.org (experimental BETA)
 # dice server host
 host=dice-staging.tripleawarclub.org
 # path in dice server post to post too

--- a/dice_servers/tripleawarclub-staging.properties
+++ b/dice_servers/tripleawarclub-staging.properties
@@ -1,0 +1,22 @@
+# when placing in the list, sort by order
+order=11
+# name to display to the user
+name=dice.tripleawarclub.org (BETA)
+# dice server host
+host=www.tripleawarclub.org
+# path in dice server post to post too
+path=/dice-staging/MARTI.php
+roll.single.start=your dice are: 
+roll.single.end=<p>
+roll.multiple.start=your dice are: 
+roll.multiple.end=<p>
+message.maxlength=200
+# mark error the start and end of error delimiters
+# if error start and and are found in the returned email,
+# we do not report dice, but instead show the error message.
+error.start=fatal error:
+error.end=!
+infotext=Enter your your email address in the "To" field, and you opponents in in the "CC" field, you may enter multiple addresses each separated by a space.<br> \n\
+Visit https://www.tripleawarclub.org/dice-staging/index.php to register your email addresses, this must be done to receive dice emails.<br> \n\
+If this is a league match you must enter a Game ID or Challenge ID, as requested by your tournament organizer
+gameid=true


### PR DESCRIPTION
In support of #2603.

The new MARTI code has been deployed to the staging server at `http://www.tripleawarclub.org/dice-staging/`.  Before promoting this code to production, I would like to have some volunteers use it for an extended period of time.  I thought the easiest way to do this would be to add a new entry to the dice server dropdown on the PBEM/PBF configuration screen.  Once merged, I would make an announcement on the forum asking for testing help.

This PR adds a new dice server entry named `dice.tripleawarclub.org (BETA)` that points to the MARTI staging server.  The new entry will appear after the existing MARTI entry but before the internal dice server entry.

However, I'm not sure of the following:

* Is the `(BETA)` label sufficient to distinguish the two versions of MARTI?  Is there a better term?  Should there be more "noise" in the label to make sure users realize it is a beta server (e.g. `(***BETA***)`)?
* Should the new server only be displayed if the user has the "Enable Beta Features" engine setting enabled?  I didn't do this initially because it will require a code change and probably a new property in the _.properties_ file to distinguish beta servers from non-beta servers.