### PR TITLE
Add unit option for when hit points damaged changes into

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -473,7 +473,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public void resetWhenHitPointsDamagedChangesInto() {
-    m_whenHitPointsDamagedChangesInto = new LinkedHashMap<>();
+    m_whenHitPointsDamagedChangesInto = new HashMap<>();
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -208,6 +209,7 @@ public class UnitAttachment extends DefaultAttachment {
   private List<Tuple<String, PlayerID>> m_destroyedWhenCapturedBy = new ArrayList<>();
   // also an allowed setter is "setDestroyedWhenCapturedFrom" which will just create m_destroyedWhenCapturedBy with a
   // specific list
+  private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsDamagedChangesInto = new HashMap<>();
   private Map<String, Tuple<String, IntegerMap<UnitType>>> m_whenCapturedChangesInto = new LinkedHashMap<>();
   private List<PlayerID> m_canBeCapturedOnEnteringBy = new ArrayList<>();
   private List<PlayerID> m_canBeGivenByTerritoryTo = new ArrayList<>();
@@ -430,6 +432,43 @@ public class UnitAttachment extends DefaultAttachment {
 
   public void resetCanBeCapturedOnEnteringBy() {
     m_canBeCapturedOnEnteringBy = new ArrayList<>();
+  }
+
+  /**
+   * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
+   */
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
+  public void setWhenHitPointsDamagedChangesInto(final String value) throws GameParseException {
+    final String[] s = value.split(":");
+    if (s.length != 3) {
+      throw new GameParseException(
+          "setWhenHitPointsDamagedChangesInto must have hitpoints:keepAttributes:unitType " + thisErrorMsg());
+    }
+    final UnitType unitType = getData().getUnitTypeList().getUnitType(s[2]);
+    if (unitType == null) {
+      throw new GameParseException("setWhenHitPointsDamagedChangesInto: No unit type: " + s[2] + thisErrorMsg());
+    }
+    m_whenHitPointsDamagedChangesInto.put(getInt(s[0]), Tuple.of(getBool(s[1]), unitType));
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setWhenHitPointsDamagedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
+    m_whenHitPointsDamagedChangesInto = value;
+  }
+
+  public Map<Integer, Tuple<Boolean, UnitType>> getWhenHitPointsDamagedChangesInto() {
+    if (m_whenHitPointsDamagedChangesInto == null) {
+      resetWhenHitPointsDamagedChangesInto(); // TODO: Can remove for incompatible release
+    }
+    return m_whenHitPointsDamagedChangesInto;
+  }
+
+  public void clearWhenHitPointsDamagedChangesInto() {
+    m_whenHitPointsDamagedChangesInto.clear();
+  }
+
+  public void resetWhenHitPointsDamagedChangesInto() {
+    m_whenHitPointsDamagedChangesInto = new LinkedHashMap<>();
   }
 
   /**
@@ -2935,9 +2974,14 @@ public class UnitAttachment extends DefaultAttachment {
         + "  repairsUnits:"
         + (m_repairsUnits != null ? (m_repairsUnits.isEmpty() ? "empty" : m_repairsUnits.toString()) : "null")
         + "  canScramble:" + m_canScramble + "  maxScrambleDistance:" + m_maxScrambleDistance + "  isAirBase:"
-        + m_isAirBase + "  maxScrambleCount:" + m_maxScrambleCount + "  whenCapturedChangesInto:"
+        + m_isAirBase + "  maxScrambleCount:" + m_maxScrambleCount
+        + "  whenCapturedChangesInto:"
         + (m_whenCapturedChangesInto != null
             ? (m_whenCapturedChangesInto.size() == 0 ? "empty" : m_whenCapturedChangesInto.toString())
+            : "null")
+        + "  whenHitPointsDamagedChangesInto:"
+        + (m_whenHitPointsDamagedChangesInto != null
+            ? (m_whenHitPointsDamagedChangesInto.size() == 0 ? "empty" : m_whenHitPointsDamagedChangesInto.toString())
             : "null")
         + "  canIntercept:" + m_canIntercept + "  canEscort:" + m_canEscort + "  canAirBattle:" + m_canAirBattle
         + "  airDefense:" + m_airDefense + "  airAttack:" + m_airAttack + "  canNotMoveDuringCombatMove:"

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -458,6 +458,9 @@ public class UnitAttachment extends DefaultAttachment {
     m_whenHitPointsDamagedChangesInto = value;
   }
 
+  /**
+   * Can remove null check and this comment for next incompatible release.
+   */
   public Map<Integer, Tuple<Boolean, UnitType>> getWhenHitPointsDamagedChangesInto() {
     if (m_whenHitPointsDamagedChangesInto == null) {
       resetWhenHitPointsDamagedChangesInto(); // TODO: Can remove for incompatible release

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1419,10 +1419,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         change.add(ChangeFactory.removeUnits(location, Collections.singleton(unitUnderFire)));
       } else {
         final IntegerMap<Unit> hitMap = new IntegerMap<>();
-        hitMap.put(unitUnderFire, hits + unitUnderFire.getHits());
-        change.add(ChangeFactory.unitsHit(hitMap));
-        m_bridge.getHistoryWriter().addChildToEvent(
-            "Units damaged: " + MyFormatter.unitsToText(Collections.singleton(unitUnderFire)), unitUnderFire);
+        hitMap.put(unitUnderFire, hits);
+        change.add(createDamageChange(hitMap, m_bridge));
       }
     }
     if (!change.isEmpty()) {
@@ -1445,20 +1443,17 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     for (final Unit u : damaged) {
       damagedMap.add(u, 1);
     }
-    markDamaged(damagedMap, bridge, true);
+    bridge.addChange(createDamageChange(damagedMap, bridge));
   }
 
-  private static void markDamaged(final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge,
-      final boolean addPreviousHits) {
+  private static Change createDamageChange(final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge) {
     final Set<Unit> units = new HashSet<>(damagedMap.keySet());
-    if (addPreviousHits) {
-      for (final Unit u : units) {
-        damagedMap.add(u, u.getHits());
-      }
+    for (final Unit u : units) {
+      damagedMap.add(u, u.getHits());
     }
     final Change damagedChange = ChangeFactory.unitsHit(damagedMap);
     bridge.getHistoryWriter().addChildToEvent("Units damaged: " + MyFormatter.unitsToText(units), units);
-    bridge.addChange(damagedChange);
+    return damagedChange;
   }
 
   private static Collection<Territory> whereCanAirLand(final Collection<Unit> strandedAir, final Territory currentTerr,

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2110,6 +2110,10 @@ public final class Matches {
     };
   }
 
+  static Predicate<Unit> unitWhenHitPointsDamagedChangesInto() {
+    return u -> !UnitAttachment.get(u.getType()).getWhenHitPointsDamagedChangesInto().isEmpty();
+  }
+
   static Predicate<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {
     return u -> !UnitAttachment.get(u.getType()).getWhenCapturedChangesInto().isEmpty();
   }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -52,6 +52,9 @@ import games.strategy.util.Util;
  */
 public class MustFightBattle extends DependentBattle implements BattleStepStrings {
 
+  /**
+   * Determines whether casualties can return fire for various battle phases.
+   */
   public enum ReturnFire {
     ALL, SUBS, NONE
   }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -44,6 +44,7 @@ import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PredicateBuilder;
+import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
 /**
@@ -670,7 +671,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          clearWaitingToDie(bridge);
+          clearWaitingToDieAndDamagedChangesInto(bridge);
         }
       });
     }
@@ -769,7 +770,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        clearWaitingToDie(bridge);
+        clearWaitingToDieAndDamagedChangesInto(bridge);
       }
     });
     steps.add(new IExecutable() {
@@ -2391,13 +2392,48 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
   }
 
-  private void clearWaitingToDie(final IDelegateBridge bridge) {
-    final Collection<Unit> units = new ArrayList<>();
-    units.addAll(m_attackingWaitingToDie);
-    units.addAll(m_defendingWaitingToDie);
-    remove(units, bridge, m_battleSite, null);
+  private void clearWaitingToDieAndDamagedChangesInto(final IDelegateBridge bridge) {
+    final Collection<Unit> unitsToRemove = new ArrayList<>();
+    unitsToRemove.addAll(m_attackingWaitingToDie);
+    unitsToRemove.addAll(m_defendingWaitingToDie);
+    remove(unitsToRemove, bridge, m_battleSite, null);
     m_defendingWaitingToDie.clear();
     m_attackingWaitingToDie.clear();
+    damagedChangeInto(m_attackingUnits, bridge);
+    damagedChangeInto(m_defendingUnits, bridge);
+  }
+
+  private void damagedChangeInto(final List<Unit> units, final IDelegateBridge bridge) {
+    final List<Unit> damagedUnits = CollectionUtils.getMatches(units,
+        Matches.unitWhenHitPointsDamagedChangesInto().and(Matches.unitHasTakenSomeDamage()));
+    final CompositeChange changes = new CompositeChange();
+    final List<Unit> unitsToRemove = new ArrayList<>();
+    final List<Unit> unitsToAdd = new ArrayList<>();
+    for (final Unit unit : damagedUnits) {
+      final Map<Integer, Tuple<Boolean, UnitType>> map =
+          UnitAttachment.get(unit.getType()).getWhenHitPointsDamagedChangesInto();
+      if (map.containsKey(unit.getHits())) {
+        final boolean translateAttributes = map.get(unit.getHits()).getFirst();
+        final UnitType unitType = map.get(unit.getHits()).getSecond();
+        final List<Unit> toAdd = unitType.create(1, unit.getOwner());
+        if (translateAttributes) {
+          final Change translate = TripleAUnit.translateAttributesToOtherUnits(unit, toAdd, m_battleSite);
+          changes.add(translate);
+        }
+        unitsToRemove.add(unit);
+        unitsToAdd.addAll(toAdd);
+      }
+    }
+    if (!unitsToRemove.isEmpty()) {
+      bridge.addChange(changes);
+      remove(unitsToRemove, bridge, m_battleSite, null);
+      final String transcriptText = MyFormatter.unitsToText(unitsToAdd) + " added in " + m_battleSite.getName();
+      bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(unitsToAdd));
+      bridge.addChange(ChangeFactory.addUnits(m_battleSite, unitsToAdd));
+      units.addAll(unitsToAdd);
+      getDisplay(bridge).changedUnitsNotification(m_battleID, unitsToRemove.get(0).getOwner(), unitsToRemove,
+          unitsToAdd, null);
+    }
   }
 
   private void defenderWins(final IDelegateBridge bridge) {
@@ -2599,7 +2635,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void endBattle(final IDelegateBridge bridge) {
-    clearWaitingToDie(bridge);
+    clearWaitingToDieAndDamagedChangesInto(bridge);
     m_isOver = true;
     m_battleTracker.removeBattle(this);
 


### PR DESCRIPTION
Addresses the first part of feature request: https://forums.triplea-game.org/topic/327/unit-option-when-damaged-change-into-different-unit-weakened-battleships

**Functional Changes**
- Added new unit option whenHitPointsDamagedChangesInto to allow units to change into a different unit type when damaged during battle

**Tested**
- Added the below example XML to TWW and tested running battles where battleships are damaged

**Example XML**
```
    <attachment name="unitAttachment" attachTo="germanBattleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="2"/>
      <option name="attack" value="7"/>
      <option name="defense" value="8"/>
      <option name="canBombard" value="true"/>
      <option name="isSea" value="true"/>
      <option name="hitPoints" value="2"/>
      <option name="bombard" value="6"/>
      <option name="requiresUnits" value="germanDocks:germanFactory"/>
      <option name="consumesUnits" value="1:germanHull"/>
      <option name="whenHitPointsDamagedChangesInto" value="1:true:germanBattleshipDamaged"/>
    </attachment>
    <attachment name="unitAttachment" attachTo="germanBattleshipDamaged" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="1"/>
      <option name="attack" value="3"/>
      <option name="defense" value="4"/>
      <option name="canBombard" value="true"/>
      <option name="isSea" value="true"/>
      <option name="hitPoints" value="2"/>
      <option name="bombard" value="3"/>
    </attachment>
```