### PR TITLE
Add Unit Repaired Changes Into

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -212,6 +212,7 @@ public class UnitAttachment extends DefaultAttachment {
   // also an allowed setter is "setDestroyedWhenCapturedFrom" which will just create m_destroyedWhenCapturedBy with a
   // specific list
   private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsDamagedChangesInto = new HashMap<>();
+  private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsRepairedChangesInto = new HashMap<>();
   private Map<String, Tuple<String, IntegerMap<UnitType>>> m_whenCapturedChangesInto = new LinkedHashMap<>();
   private List<PlayerID> m_canBeCapturedOnEnteringBy = new ArrayList<>();
   private List<PlayerID> m_canBeGivenByTerritoryTo = new ArrayList<>();
@@ -444,7 +445,7 @@ public class UnitAttachment extends DefaultAttachment {
     final String[] s = value.split(":");
     if (s.length != 3) {
       throw new GameParseException(
-          "setWhenHitPointsDamagedChangesInto must have hitpoints:keepAttributes:unitType " + thisErrorMsg());
+          "setWhenHitPointsDamagedChangesInto must have damage:translateAttributes:unitType " + thisErrorMsg());
     }
     final UnitType unitType = getData().getUnitTypeList().getUnitType(s[2]);
     if (unitType == null) {
@@ -474,6 +475,46 @@ public class UnitAttachment extends DefaultAttachment {
 
   public void resetWhenHitPointsDamagedChangesInto() {
     m_whenHitPointsDamagedChangesInto = new HashMap<>();
+  }
+
+  /**
+   * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
+   */
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
+  public void setWhenHitPointsRepairedChangesInto(final String value) throws GameParseException {
+    final String[] s = value.split(":");
+    if (s.length != 3) {
+      throw new GameParseException(
+          "setWhenHitPointsRepairedChangesInto must have damage:translateAttributes:unitType " + thisErrorMsg());
+    }
+    final UnitType unitType = getData().getUnitTypeList().getUnitType(s[2]);
+    if (unitType == null) {
+      throw new GameParseException("setWhenHitPointsRepairedChangesInto: No unit type: " + s[2] + thisErrorMsg());
+    }
+    m_whenHitPointsRepairedChangesInto.put(getInt(s[0]), Tuple.of(getBool(s[1]), unitType));
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setWhenHitPointsRepairedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
+    m_whenHitPointsRepairedChangesInto = value;
+  }
+
+  /**
+   * Can remove null check and this comment for next incompatible release.
+   */
+  public Map<Integer, Tuple<Boolean, UnitType>> getWhenHitPointsRepairedChangesInto() {
+    if (m_whenHitPointsRepairedChangesInto == null) {
+      resetWhenHitPointsDamagedChangesInto(); // TODO: Can remove for incompatible release
+    }
+    return m_whenHitPointsRepairedChangesInto;
+  }
+
+  public void clearWhenHitPointsRepairedChangesInto() {
+    m_whenHitPointsRepairedChangesInto.clear();
+  }
+
+  public void resetWhenHitPointsRepairedChangesInto() {
+    m_whenHitPointsRepairedChangesInto = new HashMap<>();
   }
 
   /**
@@ -3030,6 +3071,10 @@ public class UnitAttachment extends DefaultAttachment {
         + "  whenHitPointsDamagedChangesInto:"
         + (m_whenHitPointsDamagedChangesInto != null
             ? (m_whenHitPointsDamagedChangesInto.size() == 0 ? "empty" : m_whenHitPointsDamagedChangesInto.toString())
+            : "null")
+        + "  whenHitPointsRepairedChangesInto:"
+        + (m_whenHitPointsRepairedChangesInto != null
+            ? (m_whenHitPointsRepairedChangesInto.size() == 0 ? "empty" : m_whenHitPointsRepairedChangesInto.toString())
             : "null")
         + "  canIntercept:" + m_canIntercept + "  canEscort:" + m_canEscort + "  canAirBattle:" + m_canAirBattle
         + "  airDefense:" + m_airDefense + "  airAttack:" + m_airAttack + "  canNotMoveDuringCombatMove:"

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2949,11 +2949,12 @@ public class UnitAttachment extends DefaultAttachment {
     return super.toString();
   }
 
+  /**
+   * Returns a list of all unit properties. Should cover ALL fields stored in UnitAttachment
+   * Remember to test for null and fix arrays. The stats exporter relies on this toString having
+   * two spaces after each entry, so do not change this please, except to add new abilities onto the end.
+   */
   public String allUnitStatsForExporter() {
-    // should cover ALL fields stored in UnitAttachment
-    // remember to test for null and fix arrays
-    // the stats exporter relies on this toString having two spaces after each entry, so do not change this please,
-    // except to add new abilities onto the end
     return this.getAttachedTo().toString().replaceFirst("games.strategy.engine.data.", "") + " with:"
         + "  isAir:" + m_isAir
         + "  isSea:" + m_isSea

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -725,7 +725,7 @@ public final class Matches {
 
   public static Predicate<Unit> unitIsLandTransportable() {
     return obj -> {
-      UnitAttachment ua = UnitAttachment.get(obj.getType());
+      final UnitAttachment ua = UnitAttachment.get(obj.getType());
       return ua.getIsLandTransportable() || ua.getIsInfantry();
     };
   }
@@ -2123,6 +2123,10 @@ public final class Matches {
 
   static Predicate<Unit> unitWhenHitPointsDamagedChangesInto() {
     return u -> !UnitAttachment.get(u.getType()).getWhenHitPointsDamagedChangesInto().isEmpty();
+  }
+
+  static Predicate<Unit> unitWhenHitPointsRepairedChangesInto() {
+    return u -> !UnitAttachment.get(u.getType()).getWhenHitPointsRepairedChangesInto().isEmpty();
   }
 
   static Predicate<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -474,7 +474,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   private static void repairedChangeInto(final Set<Unit> units, final Territory territory,
       final IDelegateBridge bridge) {
-    final List<Unit> changesIntoUnits = CollectionUtils.getMatches(units, Matches.unitWhenHitPointsRepairedChangesInto());
+    final List<Unit> changesIntoUnits =
+        CollectionUtils.getMatches(units, Matches.unitWhenHitPointsRepairedChangesInto());
     final CompositeChange changes = new CompositeChange();
     final List<Unit> unitsToRemove = new ArrayList<>();
     final List<Unit> unitsToAdd = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -20,6 +20,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.AutoSave;
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -35,6 +36,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PredicateBuilder;
+import games.strategy.util.Tuple;
 
 /**
  * Responsible for moving units on the board.
@@ -462,6 +464,43 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
     if (!clearAlliedAir.isEmpty()) {
       bridge.addChange(clearAlliedAir);
+    }
+
+    // Check if any repaired units change into different unit types
+    for (final Territory territory : damagedMap.keySet()) {
+      repairedChangeInto(damagedMap.get(territory), territory, bridge);
+    }
+  }
+
+  private static void repairedChangeInto(final Set<Unit> units, final Territory territory,
+      final IDelegateBridge bridge) {
+    final List<Unit> changesIntoUnits = CollectionUtils.getMatches(units, Matches.unitWhenHitPointsRepairedChangesInto());
+    final CompositeChange changes = new CompositeChange();
+    final List<Unit> unitsToRemove = new ArrayList<>();
+    final List<Unit> unitsToAdd = new ArrayList<>();
+    for (final Unit unit : changesIntoUnits) {
+      final Map<Integer, Tuple<Boolean, UnitType>> map =
+          UnitAttachment.get(unit.getType()).getWhenHitPointsRepairedChangesInto();
+      if (map.containsKey(unit.getHits())) {
+        final boolean translateAttributes = map.get(unit.getHits()).getFirst();
+        final UnitType unitType = map.get(unit.getHits()).getSecond();
+        final List<Unit> toAdd = unitType.create(1, unit.getOwner());
+        if (translateAttributes) {
+          final Change translate = TripleAUnit.translateAttributesToOtherUnits(unit, toAdd, territory);
+          changes.add(translate);
+        }
+        unitsToRemove.add(unit);
+        unitsToAdd.addAll(toAdd);
+      }
+    }
+    if (!unitsToRemove.isEmpty()) {
+      bridge.addChange(changes);
+      final String removeText = MyFormatter.unitsToText(unitsToRemove) + " removed in " + territory.getName();
+      bridge.getHistoryWriter().addChildToEvent(removeText, new ArrayList<>(unitsToRemove));
+      bridge.addChange(ChangeFactory.removeUnits(territory, unitsToRemove));
+      final String addText = MyFormatter.unitsToText(unitsToAdd) + " added in " + territory.getName();
+      bridge.getHistoryWriter().addChildToEvent(addText, new ArrayList<>(unitsToAdd));
+      bridge.addChange(ChangeFactory.addUnits(territory, unitsToAdd));
     }
   }
 


### PR DESCRIPTION
Addresses part 2 of feature request: https://forums.triplea-game.org/topic/327/unit-option-when-damaged-change-into-different-unit-weakened-battleships

**Functional Changes**
- Added new unit option whenHitPointsRepairedChangesInto to allow units to change into a different unit type when repaired

**Tested**
- Added the below example XML to TWW, as well as adding germanBattleshipDamaged to unit repair list, and tested repairing germanBattleshipDamaged

**Example XML**
```
    <attachment name="unitAttachment" attachTo="germanBattleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="2"/>
      <option name="attack" value="7"/>
      <option name="defense" value="8"/>
      <option name="canBombard" value="true"/>
      <option name="isSea" value="true"/>
      <option name="hitPoints" value="2"/>
      <option name="bombard" value="6"/>
      <option name="requiresUnits" value="germanDocks:germanFactory"/>
      <option name="consumesUnits" value="1:germanHull"/>
      <option name="whenHitPointsDamagedChangesInto" value="1:true:germanBattleshipDamaged"/>
    </attachment>
    <attachment name="unitAttachment" attachTo="germanBattleshipDamaged" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="1"/>
      <option name="attack" value="3"/>
      <option name="defense" value="4"/>
      <option name="canBombard" value="true"/>
      <option name="isSea" value="true"/>
      <option name="hitPoints" value="2"/>
      <option name="bombard" value="3"/>
      <option name="whenHitPointsRepairedChangesInto" value="0:true:germanBattleship"/>
    </attachment>
```