### PR TITLE
Increment log level for battle errors

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -585,7 +585,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         for (final Territory current : entry.getValue()) {
           final String error = battleDelegate.fightBattle(current, entry.getKey().isBombingRun(), entry.getKey());
           if (error != null) {
-            logger.fine(error);
+            logger.warning(error);
           }
         }
       }


### PR DESCRIPTION
Noticed this while debugging #2663.  Any log records less than INFO level will not cause the Error Console to open in the client.  A battle error can result in an infinite loop, which seems pretty important to notify the user about (as opposed to the client just sitting there appearing to do nothing, which is what happened in #2663).

This PR bumps the log level for battle errors from FINE to WARNING.  Please advise if there's a known reason why these types of errors were not being reported to the user.