### PR TITLE
Remove unnecessary lambda parameter type

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -296,7 +296,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   }
 
   private static final Comparator<RepairRule> repairRuleComparator = Comparator.comparing(
-      (final RepairRule o) -> (UnitType) o.getResults().keySet().iterator().next(),
+      o -> (UnitType) o.getResults().keySet().iterator().next(),
       new UnitTypeComparator());
 
   private static IntegerMap<Resource> getCosts(final IntegerMap<ProductionRule> productionRules) {


### PR DESCRIPTION
Both the compiler in my IDE and in Gradle correctly infer the lambda parameter type (probably from the assignment?).  Please advise if someone experiences different behavior.