### PR TITLE
Remove uneccessary throws declarations

### DIFF
--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -55,7 +55,7 @@ public class ModeratorControllerIntegrationTest {
 
     doAnswer(new Answer<Void>() {
       @Override
-      public Void answer(final InvocationOnMock invocation) throws Throwable {
+      public Void answer(final InvocationOnMock invocation) {
         connectionChangeListener.connectionRemoved(invocation.getArgument(0));
         return null;
       }

--- a/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -89,7 +89,7 @@ public class MessengerIntegrationTest {
   }
 
   @Test
-  public void testServerSendToClient2() throws Exception {
+  public void testServerSendToClient2() {
     final String message = "Hello";
     serverMessenger.send(message, client2Messenger.getLocalNode());
     assertEquals(client2MessageListener.getLastMessage(), message);

--- a/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -31,7 +31,7 @@ public class GameObjectInputStream extends ObjectInputStream {
   }
 
   @Override
-  protected Object resolveObject(final Object obj) throws IOException {
+  protected Object resolveObject(final Object obj) {
     // when loading units, we want to maintain == relationships for many
     // of the game data objects.
     // this is to prevent the situation where we have 2 Territory objects for the

--- a/src/main/java/games/strategy/engine/data/GameObjectOutputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectOutputStream.java
@@ -28,7 +28,7 @@ public class GameObjectOutputStream extends ObjectOutputStream {
   }
 
   @Override
-  protected Object replaceObject(final Object obj) throws IOException {
+  protected Object replaceObject(final Object obj) {
     if (obj instanceof Named) {
       final Named named = (Named) obj;
       if (GameObjectStreamData.canSerialize(named)) {

--- a/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -205,7 +205,7 @@ public class GameDescription implements Externalizable, Cloneable {
   }
 
   @Override
-  public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
+  public void readExternal(final ObjectInput in) throws IOException {
     m_hostedBy = new Node();
     ((Node) m_hostedBy).readExternal(in);
     m_port = in.readInt();

--- a/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -1,8 +1,6 @@
 package games.strategy.engine.random;
 
-import java.io.IOException;
 import java.io.ObjectStreamException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
 
 import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
@@ -29,7 +27,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
 
   @Override
   public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
-      final String gameUuid) throws IOException {
+      final String gameUuid) {
     // the interface is rather stupid, you have to return a string here, which is then passed back in getDice()
     final int[] ints = _randomSource.getRandom(max, numDice, "Internal Dice Server");
     final StringBuilder sb = new StringBuilder();
@@ -41,7 +39,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
   }
 
   @Override
-  public int[] getDice(final String string, final int count) throws IOException, InvocationTargetException {
+  public int[] getDice(final String string, final int count) {
     final String[] strArray = string.split(",");
     final int[] intArray = new int[strArray.length];
     for (int i = 0; i < strArray.length; i++) {
@@ -91,7 +89,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
    * @throws ObjectStreamException
    *         should never occur (unless runtime exceptions is thrown from constructor)
    */
-  public Object readResolve() throws ObjectStreamException {
+  public Object readResolve() {
     return new InternalDiceServer();
   }
 

--- a/src/main/java/games/strategy/net/Node.java
+++ b/src/main/java/games/strategy/net/Node.java
@@ -87,7 +87,7 @@ public class Node implements INode, Externalizable {
   }
 
   @Override
-  public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
+  public void readExternal(final ObjectInput in) throws IOException {
     name = in.readUTF();
     port = in.readInt();
     final int length = in.read();

--- a/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -377,5 +377,5 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public abstract void validate(final GameData data) throws GameParseException;
 }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -375,7 +375,4 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       delegateBridge.addChange(ChangeFactory.attachmentPropertyChange(this, newChance, CHANCE));
     }
   }
-
-  @Override
-  public abstract void validate(final GameData data) throws GameParseException;
 }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -325,8 +325,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {
-    super.validate(data);
+  public void validate(final GameData data) {
     validateNames(m_movementRestrictionTerritories);
   }
 }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -428,9 +428,4 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     }
     return territories;
   }
-
-  @Override
-  public void validate(final GameData data) throws GameParseException {
-    super.validate(data);
-  }
 }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -299,7 +299,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
 
   @Override
   public void validate(final GameData data) throws GameParseException {
-    super.validate(data);
     if (m_conditions == null) {
       throw new GameParseException("must contain at least one condition: " + thisErrorMsg());
     }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -199,7 +199,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   @Override
   public void validate(final GameData data) throws GameParseException {
-    super.validate(data);
     if (m_text.trim().length() <= 0) {
       throw new GameParseException("value: text can't be empty" + thisErrorMsg());
     }

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -592,5 +592,5 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -401,5 +401,5 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1148,8 +1148,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {
-    super.validate(data);
+  public void validate(final GameData data) {
     validateNames(m_alliedOwnershipTerritories);
     validateNames(m_enemyExclusionTerritories);
     validateNames(m_enemySurfaceExclusionTerritories);

--- a/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.engine.data.annotations.InternalDoNotExport;
@@ -401,7 +400,7 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 
   public static boolean isMechanizedInfantry(final PlayerID player) {
     final TechAttachment ta = (TechAttachment) player.getAttachment(Constants.TECH_ATTACHMENT_NAME);

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -800,7 +800,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 
 
 }

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -195,5 +195,5 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -414,5 +414,5 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -204,7 +204,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
   }
 
   @Override
-  public AggregateResults call() throws Exception {
+  public AggregateResults call() {
     return calculate();
   }
 

--- a/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
+++ b/src/test/java/games/strategy/debug/SynchedByteArrayOutputStreamTest.java
@@ -27,7 +27,7 @@ public final class SynchedByteArrayOutputStreamTest {
   private SynchedByteArrayOutputStream os;
 
   @Test
-  public void writeByte_ShouldTriggerReadFromDifferentThread() throws Exception {
+  public void writeByte_ShouldTriggerReadFromDifferentThread() {
     assertTimeoutPreemptively(timeout, () -> {
       final String expected = "X";
       final AtomicReference<String> actualRef = new AtomicReference<>();
@@ -51,7 +51,7 @@ public final class SynchedByteArrayOutputStreamTest {
   }
 
   @Test
-  public void writeBytes_ShouldTriggerReadFromDifferentThread() throws Exception {
+  public void writeBytes_ShouldTriggerReadFromDifferentThread() {
     assertTimeoutPreemptively(timeout, () -> {
       final String expected = "the quick brown fox";
       final AtomicReference<String> actualRef = new AtomicReference<>();

--- a/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
@@ -56,7 +56,7 @@ public class LobbyServerPropertiesFetcherTest {
   }
 
   @Test
-  public void throwsOnDownloadFailure() throws Exception {
+  public void throwsOnDownloadFailure() {
     assertThrows(IOException.class, () -> {
       final File temp = File.createTempFile("temp", "tmp");
       temp.deleteOnExit();

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -18,7 +18,7 @@ public class AllianceTrackerTest {
   }
 
   @Test
-  public void testAddAlliance() throws Exception {
+  public void testAddAlliance() {
     final PlayerID bush = gameData.getPlayerList().getPlayerId("bush");
     final PlayerID castro = gameData.getPlayerList().getPlayerId("castro");
     final AllianceTracker allianceTracker = gameData.getAllianceTracker();

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -224,7 +224,7 @@ public class ChangeTest {
   }
 
   @Test
-  public void testPlayerOwnerChange() throws Exception {
+  public void testPlayerOwnerChange() {
     final PlayerID can = gameData.getPlayerList().getPlayerId("chretian");
     final PlayerID us = gameData.getPlayerList().getPlayerId("bush");
     final UnitType infantry = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);

--- a/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
@@ -120,5 +119,5 @@ public class ExampleAttachment extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
@@ -33,5 +32,5 @@ public class InvalidClearExample extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 
 /**
  * Class with an invalid field that doesn't match the setter annotated with @GameProperty.
@@ -30,5 +29,5 @@ public class InvalidFieldNameExample extends DefaultAttachment {
   public void resetAttribute() {}
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
@@ -33,5 +32,5 @@ public class InvalidFieldTypeExample extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 
 /**
  * An example where the @GameProperty is used on a non-setter.
@@ -29,5 +28,5 @@ public class InvalidGetterExample extends DefaultAttachment {
   public void resetAttribute() {}
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
@@ -35,5 +34,5 @@ public class InvalidResetExample extends DefaultAttachment {
   }
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.annotations;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 
 /**
  * Example that used @GameProperty and has a getter with an invalid return type.
@@ -30,5 +29,5 @@ public class InvalidReturnTypeExample extends DefaultAttachment {
   public void resetAttribute() {}
 
   @Override
-  public void validate(final GameData data) throws GameParseException {}
+  public void validate(final GameData data) {}
 }

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
@@ -227,7 +227,7 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
     }
 
     @Test
-    public void shouldThrowExceptionWhenContentLengthHeaderValueIsAbsent() throws Exception {
+    public void shouldThrowExceptionWhenContentLengthHeaderValueIsAbsent() {
       when(contentLengthHeader.getValue()).thenReturn(null);
 
       final Exception e = assertThrows(IOException.class, () -> getDownloadLengthFromHost());
@@ -236,7 +236,7 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
     }
 
     @Test
-    public void shouldThrowExceptionWhenContentLengthHeaderValueIsNotNumber() throws Exception {
+    public void shouldThrowExceptionWhenContentLengthHeaderValueIsNotNumber() {
       when(contentLengthHeader.getValue()).thenReturn("value");
 
       final Exception e = assertThrows(IOException.class, () -> getDownloadLengthFromHost());

--- a/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -17,7 +17,7 @@ public class FileDownloadTest {
   private DownloadFileDescription mockDownload;
 
   @Test
-  public void testBasicStartCancel() throws Exception {
+  public void testBasicStartCancel() {
     final DownloadFile testObj = new DownloadFile(mockDownload, mock(DownloadListener.class));
     assertThat(testObj.getDownloadState(), is(DownloadState.NOT_STARTED));
 

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -34,7 +34,7 @@ public class MapDownloadListTest extends AbstractClientSettingTestCase {
   private final List<DownloadFileDescription> descriptions = new ArrayList<>();
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     descriptions.add(TEST_MAP);
   }
 

--- a/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -92,7 +92,7 @@ public final class Md5CryptAuthenticatorTest {
   }
 
   @Test
-  public void newResponse_ShouldThrowExceptionWhenChallengeDoesNotContainSalt() throws Exception {
+  public void newResponse_ShouldThrowExceptionWhenChallengeDoesNotContainSalt() {
     final Map<String, String> challenge = ImmutableMap.of();
 
     final Exception e =

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -54,14 +54,14 @@ public class RemoteMessengerTest {
     final List<IConnectionChangeListener> connectionListeners = new CopyOnWriteArrayList<>();
     doAnswer(new Answer<Void>() {
       @Override
-      public Void answer(final InvocationOnMock invocation) throws Throwable {
+      public Void answer(final InvocationOnMock invocation) {
         connectionListeners.add(invocation.getArgument(0));
         return null;
       }
     }).when(serverMessenger).addConnectionChangeListener(any());
     doAnswer(new Answer<Void>() {
       @Override
-      public Void answer(final InvocationOnMock invocation) throws Throwable {
+      public Void answer(final InvocationOnMock invocation) {
         for (final IConnectionChangeListener listener : connectionListeners) {
           listener.connectionRemoved(invocation.getArgument(0));
         }
@@ -83,7 +83,7 @@ public class RemoteMessengerTest {
   }
 
   @AfterEach
-  public void tearDown() throws Exception {
+  public void tearDown() {
     serverMessenger = null;
     remoteMessenger = null;
   }

--- a/src/test/java/games/strategy/security/DefaultCredentialManagerTest.java
+++ b/src/test/java/games/strategy/security/DefaultCredentialManagerTest.java
@@ -29,7 +29,7 @@ public final class DefaultCredentialManagerTest {
   private DefaultCredentialManager credentialManager;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     credentialManager = DefaultCredentialManager.newInstance(MASTER_PASSWORD);
   }
 
@@ -82,14 +82,14 @@ public final class DefaultCredentialManagerTest {
   }
 
   @Test
-  public void unprotect_ShouldThrowExceptionWhenProtectedCredentialContainsLessThanOnePeriod() throws Exception {
+  public void unprotect_ShouldThrowExceptionWhenProtectedCredentialContainsLessThanOnePeriod() {
     final Exception e = assertThrows(CredentialManagerException.class, () -> credentialManager.unprotect("AAAABBBB"));
 
     assertThat(e.getMessage(), containsString("malformed protected credential"));
   }
 
   @Test
-  public void unprotect_ShouldThrowExceptionWhenProtectedCredentialContainsMoreThanOnePeriod() throws Exception {
+  public void unprotect_ShouldThrowExceptionWhenProtectedCredentialContainsMoreThanOnePeriod() {
     final Exception e =
         assertThrows(CredentialManagerException.class, () -> credentialManager.unprotect("AAAA.BBBB.CCCC"));
 

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -324,7 +324,7 @@ public class AirThatCantLandUtilTest {
   private static ITripleAPlayer getDummyPlayer() {
     final InvocationHandler handler = new InvocationHandler() {
       @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+      public Object invoke(final Object proxy, final Method method, final Object[] args) {
         return null;
       }
     };

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -3,8 +3,6 @@ package games.strategy.triplea.delegate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Map.Entry;
@@ -322,13 +320,7 @@ public class AirThatCantLandUtilTest {
    */
   @Deprecated
   private static ITripleAPlayer getDummyPlayer() {
-    final InvocationHandler handler = new InvocationHandler() {
-      @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) {
-        return null;
-      }
-    };
     return (ITripleAPlayer) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
-        TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
+        TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -151,7 +151,7 @@ public class BattleCalculatorTest {
         any(),
         any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
-          public CasualtyDetails answer(final InvocationOnMock invocation) throws Throwable {
+          public CasualtyDetails answer(final InvocationOnMock invocation) {
             final Collection<Unit> selectFrom = invocation.getArgument(0);
             final int count = invocation.getArgument(2);
 
@@ -191,7 +191,7 @@ public class BattleCalculatorTest {
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), anyBoolean(),
         any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
-          public CasualtyDetails answer(final InvocationOnMock invocation) throws Throwable {
+          public CasualtyDetails answer(final InvocationOnMock invocation) {
             final Collection<Unit> selectFrom = invocation.getArgument(0);
             final int count = invocation.getArgument(2);
             final List<Unit> selected = CollectionUtils.getNMatches(selectFrom, count, Matches.unitIsStrategicBomber());

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -153,7 +153,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testSerialize() throws Exception {
+  public void testSerialize() {
     for (int i = 0; i < 254; i++) {
       for (int j = 0; j < 254; j++) {
         final Die hit = new Die(i, j, DieType.MISS);

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.List;
@@ -107,17 +105,9 @@ public class LhtrTest {
     delegate.start();
     // if we try to move aa, then the game will ask us if we want to move
     // fail if we are called
-    final InvocationHandler handler = new InvocationHandler() {
-      @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        fail("method called:" + method);
-        // never reached
-        return null;
-      }
-    };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> fail("method called:" + m));
     bridge.setRemote(player);
     // move 1 fighter over the aa gun in caucus
     final Route route = new Route();
@@ -167,15 +157,9 @@ public class LhtrTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 2, 3}));
     // if we try to move aa, then the game will ask us if we want to move
     // fail if we are called
-    final InvocationHandler handler = new InvocationHandler() {
-      @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return null;
-      }
-    };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
     bridge.setRemote(player);
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);
@@ -208,15 +192,9 @@ public class LhtrTest {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {3, 3, 2, 3, 0, 1}));
     // if we try to move aa, then the game will ask us if we want to move
     // fail if we are called
-    final InvocationHandler handler = new InvocationHandler() {
-      @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return null;
-      }
-    };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
     bridge.setRemote(player);
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -95,7 +95,7 @@ public class RevisedTest {
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(),
         anyBoolean(), any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
-          public CasualtyDetails answer(final InvocationOnMock invocation) throws Throwable {
+          public CasualtyDetails answer(final InvocationOnMock invocation) {
             final CasualtyList defaultCasualties = invocation.getArgument(11);
             if (defaultCasualties != null) {
               return new CasualtyDetails(defaultCasualties.getKilled(), defaultCasualties.getDamaged(), true);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -104,7 +104,7 @@ public class WW2V3Year41Test {
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(),
         anyBoolean(), any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
-          public CasualtyDetails answer(final InvocationOnMock invocation) throws Throwable {
+          public CasualtyDetails answer(final InvocationOnMock invocation) {
             final CasualtyList defaultCasualties = invocation.getArgument(11);
             if (defaultCasualties != null) {
               return new CasualtyDetails(defaultCasualties.getKilled(), defaultCasualties.getDamaged(), true);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -93,7 +93,7 @@ public class WW2V3Year42Test {
   }
 
   @Test
-  public void testLingeringSeaUnitsJoinBattle() throws Exception {
+  public void testLingeringSeaUnitsJoinBattle() {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory sz6 = territory("6 Sea Zone", gameData);
     final Territory sz7 = territory("7 Sea Zone", gameData);
@@ -116,7 +116,7 @@ public class WW2V3Year42Test {
   }
 
   @Test
-  public void testLingeringFightersAndALliedUnitsJoinBattle() throws Exception {
+  public void testLingeringFightersAndALliedUnitsJoinBattle() {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory sz6 = territory("6 Sea Zone", gameData);
     final Territory sz7 = territory("7 Sea Zone", gameData);
@@ -143,7 +143,7 @@ public class WW2V3Year42Test {
   }
 
   @Test
-  public void testLingeringSeaUnitsCanMoveAwayFromBattle() throws Exception {
+  public void testLingeringSeaUnitsCanMoveAwayFromBattle() {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory sz6 = territory("6 Sea Zone", gameData);
     final Territory sz7 = territory("7 Sea Zone", gameData);

--- a/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -30,7 +30,7 @@ public class SaveFunctionTest {
   private GameSetting mockSetting;
 
   @Test
-  public void messageOnValidIsInformation() throws Exception {
+  public void messageOnValidIsInformation() {
     givenValidationResults(true, true);
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
         Arrays.asList(mockBinding, mockBinding2), () -> {
@@ -51,7 +51,7 @@ public class SaveFunctionTest {
   }
 
   @Test
-  public void messageOnNotValidResultIsWarning() throws Exception {
+  public void messageOnNotValidResultIsWarning() {
     givenValidationResults(false, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
@@ -63,7 +63,7 @@ public class SaveFunctionTest {
   }
 
   @Test
-  public void messageOnMixedResultIsWarning() throws Exception {
+  public void messageOnMixedResultIsWarning() {
     givenValidationResults(true, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
@@ -76,7 +76,7 @@ public class SaveFunctionTest {
   }
 
   @Test
-  public void valueSavedWhenValid() throws Exception {
+  public void valueSavedWhenValid() {
     final AtomicInteger callCount = new AtomicInteger(0);
 
     Mockito.when(mockBinding.isValid()).thenReturn(true);
@@ -95,7 +95,7 @@ public class SaveFunctionTest {
   }
 
   @Test
-  public void noSettingsSavedIfAllInvalid() throws Exception {
+  public void noSettingsSavedIfAllInvalid() {
     final AtomicInteger callCount = new AtomicInteger(0);
 
     Mockito.when(mockBinding.isValid()).thenReturn(false);

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -27,8 +27,7 @@ public final class EventThreadJOptionPaneTest {
   private final CountDownLatchHandler latchHandler = new CountDownLatchHandler();
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread()
-      throws Exception {
+  public void testShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread() {
     assertTimeoutPreemptively(timeout, () -> {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicBoolean runOnEventDispatchThread = new AtomicBoolean(false);
@@ -47,7 +46,7 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEventDispatchThread() throws Exception {
+  public void testShouldNotDeadlockWhenCalledFromEventDispatchThread() {
     assertTimeoutPreemptively(timeout, () -> {
       final CountDownLatch latch = new CountDownLatch(1);
       final AtomicBoolean run = new AtomicBoolean(false);
@@ -66,7 +65,7 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldReturnSupplierResult() {
+  public void testShouldReturnSupplierResult() {
     assertTimeoutPreemptively(timeout, () -> {
       final Object expectedResult = new Object();
 
@@ -78,7 +77,7 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
+  public void testShouldRegisterAndUnregisterLatchWithLatchHandler() {
     assertTimeoutPreemptively(timeout, () -> {
       EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
 
@@ -88,7 +87,7 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithIntSupplier_ShouldReturnIntSupplierResult() {
+  public void testShouldReturnIntSupplierResult() {
     assertTimeoutPreemptively(timeout, () -> {
       final int expectedResult = 42;
 

--- a/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -78,7 +78,7 @@ public class JComboBoxBuilderTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  public void useLastSelectionAsFutureDefaultWithStringKey() throws Exception {
+  public void useLastSelectionAsFutureDefaultWithStringKey() {
     final String settingKey = "settingKey";
     ClientSetting.save(settingKey, "");
     MatcherAssert.assertThat("establish a preconditions state to avoid pollution between runs",
@@ -102,7 +102,7 @@ public class JComboBoxBuilderTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  public void useLastSelectionAsFutureDefaultWithClientKey() throws Exception {
+  public void useLastSelectionAsFutureDefaultWithClientKey() {
     ClientSetting.TEST_SETTING.saveAndFlush("");
 
     final JComboBox<String> box = JComboBoxBuilder.builder()

--- a/src/test/java/swinglib/JTabbedPaneBuilderTest.java
+++ b/src/test/java/swinglib/JTabbedPaneBuilderTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 public class JTabbedPaneBuilderTest {
   @Test
-  public void addTab() throws Exception {
+  public void addTab() {
     final JLabel label = new JLabel("value");
     final JComponent component = new JTextField("sample component");
     final JTabbedPane pane = JTabbedPaneBuilder.builder()

--- a/src/test/java/swinglib/JTextFieldBuilderTest.java
+++ b/src/test/java/swinglib/JTextFieldBuilderTest.java
@@ -47,7 +47,7 @@ public class JTextFieldBuilderTest {
   }
 
   @Test
-  public void columns() throws Exception {
+  public void columns() {
     MatcherAssert.assertThat(
         JTextFieldBuilder.builder()
             .columns(3)


### PR DESCRIPTION
Also simplify some of the code
Most of this PR removes uneccessary/explicit throws declarations.
There was a slight refactoring change to one attachment class though, a method was made abstract, so my sensitive eclipse compiler wouldn't complain about an uneccessary declaration