### PR TITLE
Minimize MD5Crypt deprecation warnings

### DIFF
--- a/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -24,7 +24,6 @@ import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Node;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
 public class ModeratorControllerIntegrationTest {
@@ -32,6 +31,10 @@ public class ModeratorControllerIntegrationTest {
   private ModeratorController moderatorController;
   private ConnectionChangeListener connectionChangeListener;
   private INode adminNode;
+
+  private static String md5Crypt(final String value) {
+    return games.strategy.util.MD5Crypt.crypt(value);
+  }
 
   @BeforeEach
   public void setUp() throws UnknownHostException {
@@ -41,7 +44,7 @@ public class ModeratorControllerIntegrationTest {
     final DBUser dbUser = new DBUser(new DBUser.UserName(adminName), new DBUser.UserEmail("n@n.n"), DBUser.Role.ADMIN);
 
     final UserController userController = new UserController();
-    userController.createUser(dbUser, new HashedPassword(MD5Crypt.crypt(adminName)));
+    userController.createUser(dbUser, new HashedPassword(md5Crypt(adminName)));
     userController.makeAdmin(dbUser);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
@@ -70,14 +73,14 @@ public class ModeratorControllerIntegrationTest {
   @Test
   public void testCantResetAdminPassword() {
     MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = MD5Crypt.crypt("" + System.currentTimeMillis());
+    final String newPassword = md5Crypt("" + System.currentTimeMillis());
     assertNotNull(moderatorController.setPassword(adminNode, newPassword));
   }
 
   @Test
   public void testResetUserPasswordUnknownUser() throws UnknownHostException {
     MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = MD5Crypt.crypt("" + System.currentTimeMillis());
+    final String newPassword = md5Crypt("" + System.currentTimeMillis());
     final INode node = new Node(Util.createUniqueTimeStamp(), InetAddress.getLocalHost(), 0);
     assertNotNull(moderatorController.setPassword(node, newPassword));
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
@@ -12,14 +12,13 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
 public class BannedMacControllerIntegrationTest {
 
   private final BannedMacController controller = spy(new BannedMacController());
-  private final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  private final String hashedMac = games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
 
   @Test
   public void testBanMacForever() {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Strings;
 
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
 /**
@@ -49,7 +48,7 @@ public class EmailLimitIntegrationTest {
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
-      ps.setString(3, MD5Crypt.crypt("password"));
+      ps.setString(3, games.strategy.util.MD5Crypt.crypt("password"));
       ps.execute();
     }
   }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -10,13 +10,12 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
 public class MutedMacControllerIntegrationTest {
 
   private final MutedMacController controller = spy(new MutedMacController());
-  final String hashedMac = MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  private final String hashedMac = games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
 
   @Test
   public void testMuteMacForever() {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -18,7 +18,6 @@ import org.mindrot.jbcrypt.BCrypt;
 
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.engine.lobby.server.userDB.DBUser;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
 public class UserControllerIntegrationTest {
@@ -53,13 +52,13 @@ public class UserControllerIntegrationTest {
   public void testCreateDupe() {
     assertThrows(Exception.class,
         () -> controller.createUser(createUserWithMd5CryptHash(),
-            new HashedPassword(MD5Crypt.crypt(Util.createUniqueTimeStamp()))),
+            new HashedPassword(md5Crypt(Util.createUniqueTimeStamp()))),
         "Should not be allowed to create a dupe user");
   }
 
   @Test
   public void testLogin() {
-    final String password = MD5Crypt.crypt(Util.createUniqueTimeStamp());
+    final String password = md5Crypt(Util.createUniqueTimeStamp());
     final DBUser user = createUserWithHash(password, Function.identity());
     controller.updateUser(user, new HashedPassword(bcrypt(obfuscate(password))));
     assertTrue(controller.login(user.getName(), new HashedPassword(password)));
@@ -70,7 +69,7 @@ public class UserControllerIntegrationTest {
   public void testUpdate() throws Exception {
     final DBUser user = createUserWithMd5CryptHash();
     assertTrue(controller.doesUserExist(user.getName()));
-    final String password2 = MD5Crypt.crypt("foo");
+    final String password2 = md5Crypt("foo");
     final String email2 = "foo@foo.foo";
     controller.updateUser(
         new DBUser(new DBUser.UserName(user.getName()), new DBUser.UserEmail(email2)),
@@ -89,7 +88,7 @@ public class UserControllerIntegrationTest {
   }
 
   private DBUser createUserWithMd5CryptHash() {
-    return createUserWithHash(Util.createUniqueTimeStamp(), MD5Crypt::crypt);
+    return createUserWithHash(Util.createUniqueTimeStamp(), UserControllerIntegrationTest::md5Crypt);
   }
 
   private DBUser createUserWithBCryptHash() {
@@ -116,6 +115,10 @@ public class UserControllerIntegrationTest {
 
   private static String bcrypt(final String string) {
     return BCrypt.hashpw(string, BCrypt.gensalt());
+  }
+
+  private static String md5Crypt(final String value) {
+    return games.strategy.util.MD5Crypt.crypt(value);
   }
 
   private static String obfuscate(final String string) {

--- a/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -28,7 +28,6 @@ import games.strategy.engine.lobby.server.db.UserController;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MacFinder;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Util;
 
 public class LobbyLoginValidatorIntegrationTest {
@@ -39,7 +38,7 @@ public class LobbyLoginValidatorIntegrationTest {
     final ChallengeResultFunction challengeFunction = generateChallenge(null);
     final Map<String, String> response = new HashMap<>();
     response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
-    response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt("123"));
+    response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt("123"));
     assertNull(challengeFunction.apply(challenge -> response));
     // try to create a duplicate user, should not work
     assertNotNull(challengeFunction.apply(challenge -> response));
@@ -67,6 +66,10 @@ public class LobbyLoginValidatorIntegrationTest {
 
   private static void createUser(final String name, final String email, final HashedPassword password) {
     new UserController().createUser(new DBUser(new DBUser.UserName(name), new DBUser.UserEmail(email)), password);
+  }
+
+  private static String md5Crypt(final String value) {
+    return games.strategy.util.MD5Crypt.crypt(value);
   }
 
   @Test
@@ -106,7 +109,7 @@ public class LobbyLoginValidatorIntegrationTest {
 
     // create a user, verify we can't login with a username that already exists
     // we should not be able to login now
-    assertNotNull(generateChallenge(new HashedPassword(MD5Crypt.crypt("foo"))).apply(challenge -> response));
+    assertNotNull(generateChallenge(new HashedPassword(md5Crypt("foo"))).apply(challenge -> response));
   }
 
   @Test
@@ -119,7 +122,7 @@ public class LobbyLoginValidatorIntegrationTest {
       // word previously
     }
     assertEquals(LobbyLoginValidator.ErrorMessages.THATS_NOT_A_NICE_NAME,
-        generateChallenge(name, new HashedPassword(MD5Crypt.crypt("foo"))).apply(challenge -> new HashMap<>(
+        generateChallenge(name, new HashedPassword(md5Crypt("foo"))).apply(challenge -> new HashMap<>(
             Collections.singletonMap(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString()))));
   }
 

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -34,7 +34,6 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.TimeManager;
 import games.strategy.util.Util;
@@ -165,9 +164,16 @@ public class HeadlessGameServer {
   }
 
   public String getSalt() {
-    final String encryptedPassword = MD5Crypt.crypt(System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, ""));
-    final String salt = MD5Crypt.getSalt(encryptedPassword);
-    return salt;
+    final String encryptedPassword = md5Crypt(System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, ""));
+    return games.strategy.util.MD5Crypt.getSalt(encryptedPassword);
+  }
+
+  private static String md5Crypt(final String value) {
+    return games.strategy.util.MD5Crypt.crypt(value);
+  }
+
+  private static String md5Crypt(final String value, final String salt) {
+    return games.strategy.util.MD5Crypt.crypt(value, salt);
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {
@@ -176,7 +182,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
         System.out.println("Remote Shutdown Initiated.");
@@ -194,7 +200,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final ServerGame serverGame = m_iGame;
       if (serverGame != null) {
@@ -222,7 +228,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final IChatPanel chat = getServerModel().getChatPanel();
       if (chat == null || chat.getAllText() == null) {
@@ -241,7 +247,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     // (48 hours max)
     final Instant expire = Instant.now().plus(Duration.ofMinutes(Math.min(60 * 24 * 2, minutes)));
     if (encryptedPassword.equals(hashedPassword)) {
@@ -286,7 +292,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
@@ -325,7 +331,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
+    final String encryptedPassword = md5Crypt(localPassword, salt);
     // milliseconds (30 days max)
     final Instant expire = Instant.now().plus(Duration.ofHours(Math.min(24 * 30, hours)));
     if (encryptedPassword.equals(hashedPassword)) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -166,7 +166,7 @@ public class HeadlessGameServer {
 
   public String getSalt() {
     final String encryptedPassword = MD5Crypt.crypt(System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, ""));
-    final String salt = MD5Crypt.getSalt(MD5Crypt.MAGIC, encryptedPassword);
+    final String salt = MD5Crypt.getSalt(encryptedPassword);
     return salt;
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -13,7 +13,6 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
@@ -31,7 +30,7 @@ public final class ClientLoginValidator implements ILoginValidator {
   @VisibleForTesting
   static final int MAC_ADDRESS_LENGTH = 28;
   @VisibleForTesting
-  static final String MAC_MAGIC_STRING_PREFIX = MD5Crypt.MAGIC + "MH$";
+  static final String MAC_MAGIC_STRING_PREFIX = games.strategy.util.MD5Crypt.MAGIC + "MH$";
 
 
   @VisibleForTesting

--- a/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
@@ -6,8 +6,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-import games.strategy.util.MD5Crypt;
-
 /**
  * Implements the MD5-crypt authentication protocol for peer-to-peer network games.
  *
@@ -41,7 +39,7 @@ final class Md5CryptAuthenticator {
    */
   static Map<String, String> newChallenge() {
     return Maps.newHashMap(ImmutableMap.of(
-        ChallengePropertyNames.SALT, MD5Crypt.newSalt()));
+        ChallengePropertyNames.SALT, games.strategy.util.MD5Crypt.newSalt()));
   }
 
   /**
@@ -95,7 +93,7 @@ final class Md5CryptAuthenticator {
   }
 
   private static String digest(final String password, final String salt) {
-    return MD5Crypt.crypt(password, salt);
+    return games.strategy.util.MD5Crypt.crypt(password, salt);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -19,7 +19,6 @@ import games.strategy.net.IConnectionLogin;
 import games.strategy.net.IMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.triplea.UrlConstants;
-import games.strategy.util.MD5Crypt;
 
 public class LobbyLogin {
   private final Window parentWindow;
@@ -86,8 +85,9 @@ public class LobbyLogin {
             if (anonymousLogin) {
               response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
             } else {
-              final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, MD5Crypt.newSalt());
-              response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(password, salt));
+              final String salt =
+                  challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, games.strategy.util.MD5Crypt.newSalt());
+              response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.MD5Crypt.crypt(password, salt));
               if (RsaAuthenticator.canProcessChallenge(challenge)) {
                 response.putAll(RsaAuthenticator.newResponse(challenge, password));
               }
@@ -165,7 +165,7 @@ public class LobbyLogin {
             response.put(LobbyLoginValidator.EMAIL_KEY, email);
             // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
             // backwards-compatibility
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, MD5Crypt.crypt(password));
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.MD5Crypt.crypt(password));
             if (RsaAuthenticator.canProcessChallenge(challenge)) {
               response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -37,7 +37,6 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.Node;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.TimeManager;
 
 class LobbyGamePanel extends JPanel {
@@ -388,7 +387,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response = controller.getChatLogHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     final JTextPane textPane = new JTextPane();
     textPane.setEditable(false);
@@ -401,6 +400,10 @@ class LobbyGamePanel extends JPanel {
     scroll.setPreferredSize(new Dimension(Math.min(availWidth, scroll.getPreferredSize().width),
         Math.min(availHeight, scroll.getPreferredSize().height)));
     JOptionPane.showMessageDialog(null, scroll, "Bot Chat Log", JOptionPane.INFORMATION_MESSAGE);
+  }
+
+  private static String md5Crypt(final String value, final String salt) {
+    return games.strategy.util.MD5Crypt.crypt(value, salt);
   }
 
   private INode getLobbyWatcherNodeForTableRow(final int selectedIndex) {
@@ -458,7 +461,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response =
         controller.mutePlayerHeadlessHostBot(lobbyWatcherNode, playerToBeMuted, min, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -498,7 +501,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response =
         controller.bootPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBooted, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -550,7 +553,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response =
         controller.banPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBanned, hrs, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -585,7 +588,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response = controller.stopGameHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted stop of current game on host" : "Failed: " + response));
@@ -618,7 +621,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = MD5Crypt.crypt(password, salt);
+    final String hashedPassword = md5Crypt(password, salt);
     final String response = controller.shutDownHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted to shut down host" : "Failed: " + response));

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -14,7 +14,6 @@ import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
-import games.strategy.util.MD5Crypt;
 
 public class ModeratorController extends AbstractModeratorController {
   public ModeratorController(final IServerMessenger serverMessenger, final Messengers messengers) {
@@ -322,8 +321,9 @@ public class ModeratorController extends AbstractModeratorController {
     builder.append("\r\nHost Name: ").append(node.getAddress().getHostName());
     builder.append("\r\nIP Address: ").append(node.getAddress().getHostAddress());
     builder.append("\r\nPort: ").append(node.getPort());
-    builder.append("\r\nHashed Mac: ")
-        .append((mac != null && mac.startsWith(MD5Crypt.MAGIC + "MH$") ? mac.substring(6) : mac + " (Invalid)"));
+    builder.append("\r\nHashed Mac: ").append(mac != null && mac.startsWith(games.strategy.util.MD5Crypt.MAGIC + "MH$")
+        ? mac.substring(6)
+        : mac + " (Invalid)");
     builder.append("\r\nAliases: ").append(getAliasesFor(node));
     return builder.toString();
   }

--- a/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
@@ -5,8 +5,6 @@ import java.util.Objects;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 
-import games.strategy.util.MD5Crypt;
-
 /**
  * A Wrapper class for salted password hashes.
  * If the given String is not matching the format
@@ -31,7 +29,7 @@ public final class HashedPassword {
   }
 
   public boolean isMd5Crypted() {
-    return value != null && value.startsWith(MD5Crypt.MAGIC);
+    return value != null && value.startsWith(games.strategy.util.MD5Crypt.MAGIC);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -29,7 +29,6 @@ import games.strategy.engine.lobby.server.db.UserController;
 import games.strategy.engine.lobby.server.db.UserDao;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
@@ -112,11 +111,11 @@ public final class LobbyLoginValidator implements ILoginValidator {
   private Map<String, String> newMd5CryptAuthenticatorChallenge(final String userName) {
     final Map<String, String> challenge = new HashMap<>();
     if (lobbyPropertyReader.isMaintenanceMode()) {
-      challenge.put(SALT_KEY, MD5Crypt.newSalt());
+      challenge.put(SALT_KEY, games.strategy.util.MD5Crypt.newSalt());
     } else {
       final HashedPassword password = userDao.getLegacyPassword(userName);
       if (password != null && Strings.emptyToNull(password.value) != null) {
-        challenge.put(SALT_KEY, MD5Crypt.getSalt(password.value));
+        challenge.put(SALT_KEY, games.strategy.util.MD5Crypt.getSalt(password.value));
       }
     }
     return challenge;
@@ -165,7 +164,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
     if (hashedMac == null) {
       return ErrorMessages.UNABLE_TO_OBTAIN_MAC;
     }
-    if (hashedMac.length() != 28 || !hashedMac.startsWith(MD5Crypt.MAGIC + "MH$")
+    if (hashedMac.length() != 28 || !hashedMac.startsWith(games.strategy.util.MD5Crypt.MAGIC + "MH$")
         || !hashedMac.matches("[0-9a-zA-Z$./]+")) {
       // Must have been tampered with
       return ErrorMessages.INVALID_MAC;

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -116,7 +116,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
     } else {
       final HashedPassword password = userDao.getLegacyPassword(userName);
       if (password != null && Strings.emptyToNull(password.value) != null) {
-        challenge.put(SALT_KEY, MD5Crypt.getSalt(MD5Crypt.MAGIC, password.value));
+        challenge.put(SALT_KEY, MD5Crypt.getSalt(password.value));
       }
     }
     return challenge;

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -17,7 +17,6 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.primitives.Bytes;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.util.MD5Crypt;
 
 public class MacFinder {
 
@@ -30,7 +29,7 @@ public class MacFinder {
       throw new IllegalArgumentException(
           "You have an invalid MAC address or TripleA can't find your mac address");
     }
-    return MD5Crypt.crypt(mac, "MH");
+    return games.strategy.util.MD5Crypt.crypt(mac, "MH");
   }
 
   private static String getMacAddress() {

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -39,10 +39,11 @@ import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
-import games.strategy.util.MD5Crypt;
 
 public class LobbyMenu extends JMenuBar {
   private static final long serialVersionUID = 4980621864542042057L;
+  private static final String HASHED_MAC_PREFIX = games.strategy.util.MD5Crypt.MAGIC + "MH$";
+
   private final LobbyFrame lobbyFrame;
 
   public LobbyMenu(final LobbyFrame frame) {
@@ -178,12 +179,11 @@ public class LobbyMenu extends JMenuBar {
       if (mac == null || mac.length() < 1) {
         return;
       }
-      final String prefix = MD5Crypt.MAGIC + "MH$";
       final String error;
       if (mac.length() != 28) {
         error = "Must be 28 characters long";
-      } else if (!mac.startsWith(prefix)) {
-        error = "Must start with: " + prefix;
+      } else if (!mac.startsWith(HASHED_MAC_PREFIX)) {
+        error = "Must start with: " + HASHED_MAC_PREFIX;
       } else if (!mac.matches("[0-9a-zA-Z$./]+")) {
         error = "Must use only these characters: 0-9a-zA-Z$./";
       } else {
@@ -244,12 +244,11 @@ public class LobbyMenu extends JMenuBar {
       if (mac == null || mac.length() < 1) {
         return;
       }
-      final String prefix = MD5Crypt.MAGIC + "MH$";
       final String error;
       if (mac.length() != 28) {
         error = "Must be 28 characters long";
-      } else if (!mac.startsWith(prefix)) {
-        error = "Must start with: " + prefix;
+      } else if (!mac.startsWith(HASHED_MAC_PREFIX)) {
+        error = "Must start with: " + HASHED_MAC_PREFIX;
       } else if (!mac.matches("[0-9a-zA-Z$./]+")) {
         error = "Must use only these characters: 0-9a-zA-Z$./";
       } else {
@@ -337,9 +336,14 @@ public class LobbyMenu extends JMenuBar {
     if (returnValue == CreateUpdateAccountPanel.ReturnValue.CANCEL) {
       return;
     }
-    final String error = Strings.emptyToNull(Strings
-        .nullToEmpty(manager.updateUser(panel.getUserName(), panel.getEmail(), MD5Crypt.crypt(panel.getPassword())))
-        + Strings.nullToEmpty(manager.updateUser(panel.getUserName(), panel.getEmail(),
+    final String error = Strings.emptyToNull(""
+        + Strings.nullToEmpty(manager.updateUser(
+            panel.getUserName(),
+            panel.getEmail(),
+            games.strategy.util.MD5Crypt.crypt(panel.getPassword())))
+        + Strings.nullToEmpty(manager.updateUser(
+            panel.getUserName(),
+            panel.getEmail(),
             RsaAuthenticator.hashPasswordWithSalt(panel.getPassword()))));
     if (error != null) {
       JOptionPane.showMessageDialog(this, error, "Error", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -70,7 +70,7 @@ public class MD5Crypt {
    * @return The encrypted password as an MD5 hash
    */
   public static String crypt(final String password) {
-    return crypt(password, newSalt(), MAGIC);
+    return crypt(password, newSalt());
   }
 
   /**
@@ -82,29 +82,11 @@ public class MD5Crypt {
    *        Password to be encrypted
    * @return The encrypted password as an MD5 hash
    */
-  public static String crypt(final String password, final String salt) {
-    return crypt(password, salt, MAGIC);
-  }
-
-  /**
-   * Linux/BSD MD5Crypt function.
-   *
-   * @param magic
-   *        $1$ for Linux/BSB, $apr1$ for Apache crypt
-   * @param salt
-   *        8 byte permutation string
-   * @param password
-   *        user password
-   * @return The encrypted password as an MD5 hash
-   */
-  public static String crypt(final String password, String salt, final String magic) {
+  public static String crypt(final String password, String salt) {
     if (password == null) {
       throw new IllegalArgumentException("Null password!");
     }
     if (salt == null) {
-      throw new IllegalArgumentException("Null salt!");
-    }
-    if (magic == null) {
       throw new IllegalArgumentException("Null salt!");
     }
     /*
@@ -121,8 +103,8 @@ public class MD5Crypt {
     }
     /* Refine the Salt first */
     /* If it starts with the magic string, then skip that */
-    if (salt.startsWith(magic)) {
-      salt = salt.substring(magic.length());
+    if (salt.startsWith(MAGIC)) {
+      salt = salt.substring(MAGIC.length());
     }
     /* It stops at the first '$', max 8 chars */
     if (salt.indexOf('$') != -1) {
@@ -138,7 +120,7 @@ public class MD5Crypt {
      * Raw salt
      */
     ctx.update(password.getBytes());
-    ctx.update(magic.getBytes());
+    ctx.update(MAGIC.getBytes());
     ctx.update(salt.getBytes());
     /* Then just as many characters of the MD5(pw,salt,pw) */
     ctx1.update(password.getBytes());
@@ -198,7 +180,7 @@ public class MD5Crypt {
     }
     /* Now make the output string */
     final StringBuilder result = new StringBuilder();
-    result.append(magic);
+    result.append(MAGIC);
     result.append(salt);
     result.append("$");
     /*
@@ -237,8 +219,8 @@ public class MD5Crypt {
     return salt.toString();
   }
 
-  public static String getSalt(final String magic, final String encrypted) {
-    final String valNoMagic = encrypted.substring(magic.length());
+  public static String getSalt(final String encrypted) {
+    final String valNoMagic = encrypted.substring(MAGIC.length());
     return valNoMagic.substring(0, valNoMagic.indexOf("$"));
   }
 }

--- a/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Maps;
 
 import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.ChallengePropertyNames;
 import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.ResponsePropertyNames;
-import games.strategy.util.MD5Crypt;
 
 public final class Md5CryptAuthenticatorTest {
   private static final String PASSWORD = "←PASSWORD↑WITH→UNICODE↓CHARS";
@@ -84,7 +83,7 @@ public final class Md5CryptAuthenticatorTest {
   @Test
   public void newResponse_ShouldIncludeResponseWhenChallengeContainsSalt() throws Exception {
     final Map<String, String> challenge = ImmutableMap.of(
-        ChallengePropertyNames.SALT, MD5Crypt.newSalt());
+        ChallengePropertyNames.SALT, games.strategy.util.MD5Crypt.newSalt());
 
     final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 

--- a/src/test/java/games/strategy/engine/lobby/server/db/HashedPasswordTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/db/HashedPasswordTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.util.MD5Crypt;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class HashedPasswordTest {
@@ -18,11 +17,13 @@ public class HashedPasswordTest {
 
   @Test
   public void isValidSyntax() {
+    final String md5CryptMagic = games.strategy.util.MD5Crypt.MAGIC;
+
     Arrays.asList(
-        MD5Crypt.MAGIC,
-        MD5Crypt.MAGIC + " ",
-        MD5Crypt.MAGIC + "_",
-        MD5Crypt.MAGIC + "abc").forEach(
+        md5CryptMagic,
+        md5CryptMagic + " ",
+        md5CryptMagic + "_",
+        md5CryptMagic + "abc").forEach(
             valid -> assertThat(
                 "Expecting this to look valid, starts with magic: " + valid,
                 new HashedPassword(valid).isHashedWithSalt(), is(true)));

--- a/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -39,7 +39,6 @@ import games.strategy.engine.lobby.server.db.HashedPassword;
 import games.strategy.engine.lobby.server.db.UserDao;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.security.TestSecurityUtils;
-import games.strategy.util.MD5Crypt;
 import games.strategy.util.Tuple;
 
 public final class LobbyLoginValidatorTest {
@@ -76,7 +75,7 @@ public final class LobbyLoginValidatorTest {
 
     private final DBUser dbUser = new DBUser(new DBUser.UserName(USERNAME), new DBUser.UserEmail(EMAIL));
 
-    private final String md5CryptSalt = MD5Crypt.newSalt();
+    private final String md5CryptSalt = games.strategy.util.MD5Crypt.newSalt();
 
     @BeforeEach
     public void setUp() throws IOException, GeneralSecurityException {
@@ -102,7 +101,7 @@ public final class LobbyLoginValidatorTest {
     }
 
     final String md5Crypt(final String password) {
-      return MD5Crypt.crypt(password, md5CryptSalt);
+      return games.strategy.util.MD5Crypt.crypt(password, md5CryptSalt);
     }
 
     final void givenAuthenticationWillUseMd5CryptedPasswordAndSucceed() {


### PR DESCRIPTION
The `MD5Crypt` deprecation warnings overwhelm the compiler output when building from Gradle.  This PR attempts to minimize those deprecation warnings to avoid the noise.  The number of `MD5Crypt` deprecation warnings was reduced by 60%.

#### Functional changes

None.

#### Refactoring changes

* Removed the magic prefix parameter from `MD5Crypt#crypt(String, String, String)` and `MD5Crypt#getSalt()`.  In both cases, all callers passed `MD5Crypt#MAGIC`, so I just inlined this value.
* Extracted private helper methods where the same `MD5Crypt` method was invoked multiple times within the same type.
* Removed imports and replaced with fully-qualified `MD5Crypt` class name.  The compiler reports two deprecation warnings on each line where an `MD5Crypt` static method is called (one for the type and one for the method), so the import simply adds one additional type deprecation warning per file.  I realize this violates our convention for not using fully-qualified type names, but I think it's worth it in this case, especially considering that `MD5Crypt` will eventually be removed.