### PR TITLE
Prevent exception when assigning a default color to a player

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
@@ -1,12 +1,14 @@
 package games.strategy.triplea.ui.mapdata;
 
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.google.common.collect.ImmutableList;
 
 final class DefaultColors {
-  private final List<Color> colors = new ArrayList<>(Arrays.asList(
+  private static final List<Color> COLORS = ImmutableList.of(
       Color.RED,
       Color.MAGENTA,
       Color.YELLOW,
@@ -14,12 +16,14 @@ final class DefaultColors {
       Color.CYAN,
       Color.GREEN,
       Color.PINK,
-      Color.GRAY));
+      Color.GRAY);
+
+  private final Iterator<Color> colorIterator = COLORS.iterator();
 
   /**
-   * @throws IndexOutOfBoundsException If the available default colors have been exhausted.
+   * @throws NoSuchElementException If the available default colors have been exhausted.
    */
   Color nextColor() {
-    return colors.remove(0);
+    return colorIterator.next();
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
@@ -5,10 +5,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 final class DefaultColors {
-  private static final List<Color> COLORS = ImmutableList.of(
+  @VisibleForTesting
+  static final List<Color> COLORS = ImmutableList.of(
       Color.RED,
       Color.MAGENTA,
       Color.YELLOW,

--- a/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
@@ -1,0 +1,25 @@
+package games.strategy.triplea.ui.mapdata;
+
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class DefaultColors {
+  private final List<Color> colors = new ArrayList<>(Arrays.asList(
+      Color.RED,
+      Color.MAGENTA,
+      Color.YELLOW,
+      Color.ORANGE,
+      Color.CYAN,
+      Color.GREEN,
+      Color.PINK,
+      Color.GRAY));
+
+  /**
+   * @throws IndexOutOfBoundsException If the available default colors have been exhausted.
+   */
+  Color nextColor() {
+    return colors.remove(0);
+  }
+}

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -86,8 +86,7 @@ public class MapData implements Closeable {
   private static final String KAMIKAZE_FILE = "kamikaze_place.txt";
   private static final String DECORATIONS_FILE = "decorations.txt";
 
-  private final List<Color> defaultColors = new ArrayList<>(Arrays.asList(Color.RED, Color.MAGENTA, Color.YELLOW,
-      Color.ORANGE, Color.CYAN, Color.GREEN, Color.PINK, Color.GRAY));
+  private final DefaultColors defaultColors = new DefaultColors();
   private final Map<String, Color> playerColors = new HashMap<>();
   private Map<String, List<Point>> place;
   private Map<String, List<Polygon>> polys;
@@ -441,10 +440,10 @@ public class MapData implements Closeable {
       throw new IllegalStateException("Player colors must be a 6 digit hex number, eg FF0011");
     }
     if (color == null) {
-      color = defaultColors.remove(0);
+      // dont crash, use one of our default colors
+      // its ugly, but usable
+      color = defaultColors.nextColor();
     }
-    // dont crash, use one of our default colors
-    // its ugly, but usable
     playerColors.put(playerName, color);
     return color;
   }

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -86,8 +86,8 @@ public class MapData implements Closeable {
   private static final String KAMIKAZE_FILE = "kamikaze_place.txt";
   private static final String DECORATIONS_FILE = "decorations.txt";
 
-  private final List<Color> defaultColors = Arrays.asList(Color.RED, Color.MAGENTA, Color.YELLOW, Color.ORANGE,
-      Color.CYAN, Color.GREEN, Color.PINK, Color.GRAY);
+  private final List<Color> defaultColors = new ArrayList<>(Arrays.asList(Color.RED, Color.MAGENTA, Color.YELLOW,
+      Color.ORANGE, Color.CYAN, Color.GREEN, Color.PINK, Color.GRAY));
   private final Map<String, Color> playerColors = new HashMap<>();
   private Map<String, List<Point>> place;
   private Map<String, List<Polygon>> polys;

--- a/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
+++ b/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.NoSuchElementException;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
@@ -21,7 +22,7 @@ public final class DefaultColorsTest {
   @Test
   public void nextColor_ShouldThrowExceptionWhenNoColorsAvailable() {
     assertThrows(
-        IndexOutOfBoundsException.class,
+        NoSuchElementException.class,
         () -> IntStream.iterate(0, IntUnaryOperator.identity()).forEach(i -> defaultColors.nextColor()));
   }
 }

--- a/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
+++ b/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
@@ -1,0 +1,27 @@
+package games.strategy.triplea.ui.mapdata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.function.IntUnaryOperator;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+public final class DefaultColorsTest {
+  private final DefaultColors defaultColors = new DefaultColors();
+
+  @Test
+  public void nextColor_ShouldReturnNextColorWhenColorsAvailable() {
+    assertThat(defaultColors.nextColor(), is(notNullValue()));
+  }
+
+  @Test
+  public void nextColor_ShouldThrowExceptionWhenNoColorsAvailable() {
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> IntStream.iterate(0, IntUnaryOperator.identity()).forEach(i -> defaultColors.nextColor()));
+  }
+}

--- a/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
+++ b/src/test/java/games/strategy/triplea/ui/mapdata/DefaultColorsTest.java
@@ -2,11 +2,9 @@ package games.strategy.triplea.ui.mapdata;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.NoSuchElementException;
-import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
@@ -16,13 +14,13 @@ public final class DefaultColorsTest {
 
   @Test
   public void nextColor_ShouldReturnNextColorWhenColorsAvailable() {
-    assertThat(defaultColors.nextColor(), is(notNullValue()));
+    assertThat(defaultColors.nextColor(), is(DefaultColors.COLORS.get(0)));
   }
 
   @Test
   public void nextColor_ShouldThrowExceptionWhenNoColorsAvailable() {
     assertThrows(
         NoSuchElementException.class,
-        () -> IntStream.iterate(0, IntUnaryOperator.identity()).forEach(i -> defaultColors.nextColor()));
+        () -> IntStream.range(0, DefaultColors.COLORS.size() + 1).forEach(i -> defaultColors.nextColor()));
   }
 }


### PR DESCRIPTION
Partially addresses #2703.

#### Functional changes

Existing code uses the default colors list as a stack, and pops colors off the list as they are required.  Thus, the list must be mutable.  However, it was made immutable in 6d7783c, and thus the `remove()` operation will raise an `UnsupportedOperationException` if called.  This PR restores the mutability of the default colors list so the `remove()` operation will not fail as long as the list is not empty.

#### Refactoring changes

I wanted to add a test to prevent a similar regression in the future, but the `MapData` class is too coupled to the file system to make writing a test easy.  So I extracted the trivial `DefaultColors` class in order to add the test.

This class captures the current behavior of throwing an `IndexOutOfBoundsException` if the default colors list is exhausted.  I considered changing the behavior to simply rotate back to the front of the list and reuse previously distributed default colors.  However, I wasn't sure if this would cause a problem if duplicate colors were used in a single map.

Please advise if the behavior should be changed or if a different exception should be thrown (e.g. `IllegalStateException` would probably be more accurate from the `DefaultColors` class interface).