### PR TITLE
Add Show Console command to main menu

### DIFF
--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -14,6 +14,7 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 
 /**
@@ -63,7 +64,7 @@ public abstract class GenericConsole extends JFrame {
    */
   protected void displayStandardError() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.err);
-    final ThreadReader reader = new ThreadReader(out, textArea, true, getConsoleInstance());
+    final ThreadReader reader = new ThreadReader(out, textArea, Boolean.TRUE::booleanValue, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std err reader");
     thread.setDaemon(true);
     thread.start();
@@ -73,7 +74,8 @@ public abstract class GenericConsole extends JFrame {
 
   protected void displayStandardOutput() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.out);
-    final ThreadReader reader = new ThreadReader(out, textArea, false, getConsoleInstance());
+    final ThreadReader reader =
+        new ThreadReader(out, textArea, ClientSetting.SHOW_CONSOLE_ALWAYS::booleanValue, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std out reader");
     thread.setDaemon(true);
     thread.start();

--- a/src/main/java/games/strategy/debug/ThreadReader.java
+++ b/src/main/java/games/strategy/debug/ThreadReader.java
@@ -1,5 +1,7 @@
 package games.strategy.debug;
 
+import java.util.function.BooleanSupplier;
+
 import javax.swing.JTextArea;
 
 import games.strategy.util.ThreadUtil;
@@ -8,14 +10,17 @@ final class ThreadReader implements Runnable {
   private static final int CONSOLE_UPDATE_INTERVAL_MS = 100;
   private final JTextArea text;
   private final SynchedByteArrayOutputStream in;
-  private final boolean displayConsoleOnWrite;
+  private final BooleanSupplier displayConsoleOnWriteSupplier;
   private final GenericConsole parentConsole;
 
-  ThreadReader(final SynchedByteArrayOutputStream in, final JTextArea text, final boolean displayConsoleOnWrite,
+  ThreadReader(
+      final SynchedByteArrayOutputStream in,
+      final JTextArea text,
+      final BooleanSupplier displayConsoleOnWriteSupplier,
       final GenericConsole parentConsole) {
     this.in = in;
     this.text = text;
-    this.displayConsoleOnWrite = displayConsoleOnWrite;
+    this.displayConsoleOnWriteSupplier = displayConsoleOnWriteSupplier;
     this.parentConsole = parentConsole;
   }
 
@@ -23,7 +28,7 @@ final class ThreadReader implements Runnable {
   public void run() {
     while (true) {
       text.append(in.readFully());
-      if (displayConsoleOnWrite && !parentConsole.isVisible()) {
+      if (displayConsoleOnWriteSupplier.getAsBoolean() && !parentConsole.isVisible()) {
         parentConsole.setVisible(true);
       }
       if (!ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS)) {

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -92,6 +92,8 @@ public enum ClientSetting implements GameSetting {
 
   SHOW_BETA_FEATURES(false),
 
+  SHOW_CONSOLE_ALWAYS(false),
+
   TEST_LOBBY_HOST,
 
   TEST_LOBBY_PORT,

--- a/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -115,6 +115,13 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "under development and potentially may not be working yet.\n"
           + "Restart to fully activate"),
 
+  SHOW_CONSOLE_ALWAYS(
+      "Show Console Always",
+      SettingType.TESTING,
+      ClientSetting.SHOW_CONSOLE_ALWAYS,
+      "Enable to show the console when any message is written to the console. "
+          + "Disable to show the console only when an error message is written to the console."),
+
   MAP_LIST_OVERRIDE_BINDING(
       "Map List Override",
       SettingType.TESTING,


### PR DESCRIPTION
Resolves #2703.

Since the **Show Console** command was removed from the main menu in c93a3c8, map makers have noted on several occasions that it is difficult to debug errors in their maps.  This PR simply restores the command in pretty much the same location it was before it was removed:

![show-console-button](https://user-images.githubusercontent.com/4826349/34128110-90fe3ce0-e40d-11e7-9ce4-38ee38ad2359.png)

This command was consciously removed for usability reasons with a note that we will revisit adding it back in a more appropriate location.  From the above commit:

> With console button the only one on the main window hidden behind a beta flag, it does not make sense to have it there at all. WE can evaluate where/how we want to show that control, the main window is not the rihgt place for it.

I'm open to suggestions for doing that in this PR if anyone has a better idea.