### PR TITLE
Encapsulate access to Java-managed system properties

### DIFF
--- a/src/main/java/games/strategy/debug/DebugUtils.java
+++ b/src/main/java/games/strategy/debug/DebugUtils.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import games.strategy.engine.framework.system.SystemProperties;
+
 /**
  * A collection of methods that provide information about the JVM state that may be useful for debugging.
  */
@@ -73,7 +75,7 @@ public final class DebugUtils {
 
   static String getProperties() {
     final StringBuilder buf = new StringBuilder("SYSTEM PROPERTIES\n");
-    final Properties props = System.getProperties();
+    final Properties props = SystemProperties.all();
     final List<String> keys = new ArrayList<>(props.stringPropertyNames());
     Collections.sort(keys);
     for (final String property : keys) {

--- a/src/main/java/games/strategy/debug/LoggingConfiguration.java
+++ b/src/main/java/games/strategy/debug/LoggingConfiguration.java
@@ -7,6 +7,8 @@ import java.util.logging.LogManager;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import games.strategy.engine.framework.system.SystemProperties;
+
 /**
  * Provides support for configuring the Java platform's core logging facilities.
  */
@@ -23,7 +25,7 @@ public final class LoggingConfiguration {
    * </p>
    */
   public static void initialize() {
-    initialize(LogManager.getLogManager(), System.getProperties());
+    initialize(LogManager.getLogManager(), SystemProperties.all());
   }
 
   @VisibleForTesting

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -97,7 +97,7 @@ public final class ClientFileSystemHelper {
 
     if (!f.exists()) {
       System.err.println("Could not find root folder, does  not exist:" + f);
-      return new File(System.getProperties().getProperty("user.dir"));
+      return new File(SystemProperties.getUserDir());
     }
     return f;
   }
@@ -116,7 +116,7 @@ public final class ClientFileSystemHelper {
    *         not configurable (ideally we would allow this to be set during install perhaps).
    */
   public static File getUserRootFolder() {
-    final File userHome = new File(System.getProperties().getProperty("user.home"));
+    final File userHome = new File(SystemProperties.getUserHome());
     final File rootDir = new File(new File(userHome, "Documents"), "triplea");
     return rootDir.exists() ? rootDir : new File(userHome, "triplea");
   }

--- a/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -27,11 +27,11 @@ public class ProcessRunnerUtil {
   }
 
   public static void populateBasicJavaArgs(final List<String> commands) {
-    populateBasicJavaArgs(commands, System.getProperty("java.class.path"));
+    populateBasicJavaArgs(commands, SystemProperties.getJavaClassPath());
   }
 
   public static void populateBasicJavaArgs(final List<String> commands, final long maxMemory) {
-    populateBasicJavaArgs(commands, System.getProperty("java.class.path"), Optional.of(String.valueOf(maxMemory)));
+    populateBasicJavaArgs(commands, SystemProperties.getJavaClassPath(), Optional.of(String.valueOf(maxMemory)));
   }
 
   static void populateBasicJavaArgs(final List<String> commands, final String newClasspath) {
@@ -41,13 +41,13 @@ public class ProcessRunnerUtil {
 
   private static void populateBasicJavaArgs(final List<String> commands, final String classpath,
       final Optional<String> maxMemory) {
-    final String javaCommand = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+    final String javaCommand = SystemProperties.getJavaHome() + File.separator + "bin" + File.separator + "java";
     commands.add(javaCommand);
     commands.add("-classpath");
     if (classpath != null && classpath.length() > 0) {
       commands.add(classpath);
     } else {
-      commands.add(System.getProperty("java.class.path"));
+      commands.add(SystemProperties.getJavaClassPath());
     }
     if (maxMemory.isPresent()) {
       System.out.println("Setting memory for new triplea process to: " + maxMemory.get());

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -10,6 +10,7 @@ import javax.swing.JPasswordField;
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.net.IConnectionLogin;
 
 /**
@@ -40,7 +41,7 @@ public class ClientLogin implements IConnectionLogin {
     }
 
     response.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().toString());
-    response.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
+    response.put(JDK_VERSION_PROPERTY, SystemProperties.getJavaRuntimeVersion());
 
     return response;
   }

--- a/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -57,10 +57,8 @@ public class HttpProxy {
   }
 
   private static Optional<InetSocketAddress> getSystemProxy() {
-    final String javaNetUseSystemProxies = "java.net.useSystemProxies";
-
     // this property is temporarily needed to turn on proxying
-    System.setProperty(javaNetUseSystemProxies, "true");
+    SystemProperties.setJavaNetUseSystemProxies("true");
     try {
       final ProxySelector def = ProxySelector.getDefault();
       if (def != null) {
@@ -77,7 +75,7 @@ public class HttpProxy {
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
     } finally {
-      System.setProperty(javaNetUseSystemProxies, "false");
+      SystemProperties.setJavaNetUseSystemProxies("false");
     }
     return Optional.empty();
   }

--- a/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
+++ b/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
@@ -1,27 +1,69 @@
 package games.strategy.engine.framework.system;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Properties;
+
+import javax.annotation.Nullable;
 
 /**
  * Wrapper class around System.getProperties(), use this class to set/get System properties.
  * Prefer to use system props only for command line usage. TripleA code base has made pretty extensive use
  * of System props to pass values, which is not a best practice. Converting those usages to this wrapper interface
- * will make different parts of the code that use systemn properties much easier to manage.
+ * will make different parts of the code that use system properties much easier to manage.
  */
-// final + private constructor to disallow inheritance, all access to the system is static
 public final class SystemProperties {
+  private SystemProperties() {}
 
-  private SystemProperties() {
-
+  public static Properties all() {
+    return System.getProperties();
   }
 
-  public static boolean isWindows() {
-    return System.getProperties().getProperty("os.name").toLowerCase().contains("windows");
+  public static String getJavaClassPath() {
+    return checkNotNull(System.getProperty("java.class.path"));
+  }
+
+  public static String getJavaHome() {
+    return checkNotNull(System.getProperty("java.home"));
+  }
+
+  public static @Nullable String getJavaRuntimeVersion() {
+    return System.getProperty("java.runtime.version");
+  }
+
+  public static @Nullable String getMrjVersion() {
+    return System.getProperty("mrj.version");
+  }
+
+  private static String getOsName() {
+    return checkNotNull(System.getProperty("os.name"));
+  }
+
+  public static String getUserDir() {
+    return checkNotNull(System.getProperty("user.dir"));
+  }
+
+  public static String getUserHome() {
+    return checkNotNull(System.getProperty("user.home"));
+  }
+
+  public static String getUserName() {
+    return checkNotNull(System.getProperty("user.name"));
   }
 
   public static boolean isMac() {
-    return System.getProperties().getProperty("os.name").toLowerCase().contains("mac");
+    return getOsName().toLowerCase().contains("mac");
   }
 
+  public static boolean isWindows() {
+    return getOsName().toLowerCase().contains("windows");
+  }
 
+  public static @Nullable String setJavaNetUseSystemProxies(final String value) {
+    return System.setProperty("java.net.useSystemProxies", checkNotNull(value));
+  }
+
+  public static @Nullable String setSunAwtExceptionHandler(final String value) {
+    return System.setProperty("sun.awt.exception.handler", checkNotNull(value));
+  }
 }

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -112,7 +112,7 @@ public enum ClientSetting implements GameSetting {
 
   WHEEL_SCROLL_AMOUNT(60),
 
-  PLAYER_NAME(System.getProperty("user.name")),
+  PLAYER_NAME(SystemProperties.getUserName()),
 
   /* for testing purposes, to be used in unit tests only */
   @VisibleForTesting

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.system.SystemProperties;
 
 /**
  * When dealing with swing threads and new threads, exception handling can get tricky. Namely without
@@ -45,6 +46,6 @@ public class ErrorHandler implements Thread.UncaughtExceptionHandler, ErrorHandl
    */
   public static void registerExceptionHandler() {
     Thread.setDefaultUncaughtExceptionHandler(new ErrorHandler());
-    System.setProperty("sun.awt.exception.handler", ErrorHandler.class.getName());
+    SystemProperties.setSunAwtExceptionHandler(ErrorHandler.class.getName());
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
@@ -11,8 +11,7 @@ package games.strategy.triplea.ui;
  *
  * <ul>
  * <li>have a zero arg constructor</li>
- * <li>register the class name with a system property, like this:
- * <code>System.setProperty("sun.awt.exception.handler", &lt;your_implementing_instance>.class.getName());</code></li>
+ * <li>set the value of the "sun.awt.exception.handler" system property to the class name</li>
  * </ul>
  *
  * @see ErrorHandler

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -35,6 +35,7 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.export.GameDataExporter;
 import games.strategy.engine.framework.GameDataUtils;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
 import games.strategy.engine.history.Step;
@@ -84,7 +85,7 @@ class ExportMenu {
   private void exportXmlFile() {
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-    final File rootDir = new File(System.getProperties().getProperty("user.dir"));
+    final File rootDir = new File(SystemProperties.getUserDir());
 
     final int round = gameData.getCurrentRound();
     String defaultFileName =
@@ -142,7 +143,7 @@ class ExportMenu {
     final ExtendedStats statPanel = new ExtendedStats(gameData, uiContext);
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-    final File rootDir = new File(System.getProperties().getProperty("user.dir"));
+    final File rootDir = new File(SystemProperties.getUserDir());
     final int currentRound = gameData.getCurrentRound();
     String defaultFileName =
         "stats_" + dateTimeFormatter.format(LocalDateTime.now()) + "_" + gameData.getGameName() + "_round_"
@@ -380,7 +381,7 @@ class ExportMenu {
     final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Unit Charts", e -> {
       final JFileChooser chooser = new JFileChooser();
       chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-      final File rootDir = new File(System.getProperties().getProperty("user.dir"));
+      final File rootDir = new File(SystemProperties.getUserDir());
       String defaultFileName = gameData.getGameName() + "_unit_stats";
       defaultFileName = FileNameUtils.removeIllegalCharacters(defaultFileName);
       defaultFileName = defaultFileName + ".html";

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -32,6 +32,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.UiContext;
@@ -288,7 +289,7 @@ public class HelpMenu {
     editorPane.setText(text);
     final JScrollPane scroll = new JScrollPane(editorPane);
     scroll.setBorder(null);
-    if (System.getProperty("mrj.version") == null) {
+    if (SystemProperties.getMrjVersion() == null) {
       parentMenu.addSeparator();
       parentMenu.add(SwingAction.of("About", e -> JOptionPane.showMessageDialog(null, editorPane,
           "About " + gameData.getGameName(), JOptionPane.PLAIN_MESSAGE))).setMnemonic(KeyEvent.VK_A);

--- a/src/main/java/tools/image/FileOpen.java
+++ b/src/main/java/tools/image/FileOpen.java
@@ -5,6 +5,8 @@ import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.framework.system.SystemProperties;
+
 public class FileOpen {
   private File file = null;
 
@@ -23,7 +25,7 @@ public class FileOpen {
   }
 
   public FileOpen(final String title, final String... extensions) {
-    this(title, new File(System.getProperties().getProperty("user.dir")), extensions);
+    this(title, new File(SystemProperties.getUserDir()), extensions);
   }
 
   public FileOpen(final String title, final File currentDirectory) {
@@ -41,7 +43,7 @@ public class FileOpen {
       chooser.setSelectedFile(selectedFile);
     }
     chooser.setCurrentDirectory(((currentDirectory == null || !currentDirectory.exists())
-        ? new File(System.getProperties().getProperty("user.dir"))
+        ? new File(SystemProperties.getUserDir())
         : currentDirectory));
     /*
      * Show only text and gif files

--- a/src/main/java/tools/image/FileSave.java
+++ b/src/main/java/tools/image/FileSave.java
@@ -5,6 +5,8 @@ import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
+import games.strategy.engine.framework.system.SystemProperties;
+
 public class FileSave {
   private File file = null;
 
@@ -14,7 +16,7 @@ public class FileSave {
    * their files to be saved in.
    */
   public FileSave(final String title, final String name) {
-    this(title, name, new File(System.getProperties().getProperty("user.dir")));
+    this(title, name, new File(SystemProperties.getUserDir()));
   }
 
   public FileSave(final String title, final String name, final File currentDirectory) {
@@ -53,7 +55,7 @@ public class FileSave {
       chooser.setSelectedFile(selectedFile);
     }
     chooser.setCurrentDirectory(((currentDirectory == null || !currentDirectory.exists())
-        ? new File(System.getProperties().getProperty("user.dir"))
+        ? new File(SystemProperties.getUserDir())
         : currentDirectory));
     if (fileFilter != null) {
       chooser.setFileFilter(fileFilter);


### PR DESCRIPTION
As discussed in #2665.  The purpose of this PR is to help distinguish the difference between TripleA's use of Java-managed and TripleA-managed system properties.  To that end, all Java-managed system properties have been encapsulated within the `g.s.engine.framework.system.SystemProperties` class.  Based on the Javadocs of this existing class, that purpose appears to have been the original author's intention:

> Wrapper class around System.getProperties(), use this class to set/get System properties. Prefer to use system props only for command line usage. TripleA code base has made pretty extensive use of System props to pass values, which is not a best practice. Converting those usages to this wrapper interface will make different parts of the code that use system properties much easier to manage.

#### Functional changes

None.

#### Refactoring changes

All calls to get/set Java-managed system properties have been replaced with getters/setters in the `SystemProperties` class.