### PR TITLE
Remove GameParser game name parameter

### DIFF
--- a/src/main/java/games/strategy/engine/data/EngineVersionException.java
+++ b/src/main/java/games/strategy/engine/data/EngineVersionException.java
@@ -1,6 +1,9 @@
 package games.strategy.engine.data;
 
-public class EngineVersionException extends Exception {
+/**
+ * A checked exception that indicates a game engine is not compatible with a map.
+ */
+public final class EngineVersionException extends Exception {
   private static final long serialVersionUID = 8800415601463715772L;
 
   public EngineVersionException(final String error) {

--- a/src/main/java/games/strategy/engine/data/GameParseException.java
+++ b/src/main/java/games/strategy/engine/data/GameParseException.java
@@ -1,22 +1,16 @@
 package games.strategy.engine.data;
 
-public class GameParseException extends Exception {
+/**
+ * A checked exception that indicates an error occurred while parsing a map.
+ */
+public final class GameParseException extends Exception {
   private static final long serialVersionUID = 4015574053053781872L;
 
-  public GameParseException(final String error) {
-    super(error);
-  }
-
-  public GameParseException(final String mapName, final String error) {
-    this("MapName: " + mapName + ", " + error);
-  }
-
-  public GameParseException(final String mapName, final String error, final Throwable cause) {
-    this("MapName: " + mapName + ", " + error, cause);
+  public GameParseException(final String message) {
+    super(message);
   }
 
   public GameParseException(final String message, final Throwable cause) {
     super(message, cause);
   }
-
 }

--- a/src/main/java/games/strategy/engine/data/GameParseException.java
+++ b/src/main/java/games/strategy/engine/data/GameParseException.java
@@ -10,6 +10,10 @@ public final class GameParseException extends Exception {
     super(message);
   }
 
+  public GameParseException(final Throwable cause) {
+    super(cause);
+  }
+
   public GameParseException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -76,14 +76,14 @@ public final class GameParser {
    * @return A complete {@link GameData} instance that can be used to play the game.
    */
   public static GameData parse(final String mapName, final InputStream stream)
-      throws GameParseException, SAXException, EngineVersionException {
+      throws GameParseException, EngineVersionException {
     checkNotNull(mapName);
     checkNotNull(stream);
 
     return new GameParser(mapName).parse(stream);
   }
 
-  private GameData parse(final InputStream stream) throws GameParseException, SAXException, EngineVersionException {
+  private GameData parse(final InputStream stream) throws GameParseException, EngineVersionException {
     final Element root = parseDom(stream);
     parseMapProperties(root);
     parseMapDetails(root);
@@ -108,22 +108,25 @@ public final class GameParser {
    *         displaying all available maps); it cannot be used to play the game.
    */
   public static GameData parseShallow(final String mapName, final InputStream stream)
-      throws GameParseException, SAXException, EngineVersionException {
+      throws GameParseException, EngineVersionException {
     checkNotNull(mapName);
     checkNotNull(stream);
 
     return new GameParser(mapName).parseShallow(stream);
   }
 
-  private GameData parseShallow(final InputStream stream)
-      throws GameParseException, SAXException, EngineVersionException {
+  private GameData parseShallow(final InputStream stream) throws GameParseException, EngineVersionException {
     final Element root = parseDom(stream);
     parseMapProperties(root);
     return data;
   }
 
-  private Element parseDom(final InputStream stream) throws SAXException {
-    return getDocument(stream).getDocumentElement();
+  private Element parseDom(final InputStream stream) throws GameParseException {
+    try {
+      return getDocument(stream).getDocumentElement();
+    } catch (final SAXException e) {
+      throw newGameParseException("failed to parse XML document", e);
+    }
   }
 
   private void parseMapProperties(final Element root) throws GameParseException, EngineVersionException {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -20,7 +20,6 @@ import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -180,12 +179,11 @@ public class AvailableGames {
     if (uri == null) {
       return false;
     }
-    final AtomicReference<String> gameName = new AtomicReference<>();
 
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        final GameData data = GameParser.parse(uri.toString(), input, gameName);
+        final GameData data = GameParser.parse(uri.toString(), input);
         final String name = data.getGameName();
         final String mapName = data.getProperties().get(Constants.MAP_NAME, "");
         if (!availableGames.containsKey(name)) {
@@ -196,8 +194,7 @@ public class AvailableGames {
           return true;
         }
       } catch (final Exception e) {
-        ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
-            + (gameName.get() != null ? gameName.get() + " : " : ""), e);
+        ClientLogger.logError("Exception while parsing: " + uri.toString(), e);
       }
     }
     return false;
@@ -207,15 +204,13 @@ public class AvailableGames {
     if (uri == null) {
       return null;
     }
-    final AtomicReference<String> gameName = new AtomicReference<>();
 
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        return GameParser.parse(uri.toString(), input, gameName);
+        return GameParser.parse(uri.toString(), input);
       } catch (final Exception e) {
-        ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
-            + (gameName.get() != null ? gameName.get() + " : " : ""), e);
+        ClientLogger.logError("Exception while parsing: " + uri.toString(), e);
       }
     }
     return null;

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Observable;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -84,12 +83,11 @@ public class GameSelectorModel extends Observable {
       return;
     }
     final GameData newData;
-    final AtomicReference<String> gameName = new AtomicReference<>();
     try {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
-        try (FileInputStream fis = new FileInputStream(file)) {
-          newData = GameParser.parse(file.getAbsolutePath(), fis, gameName);
+        try (InputStream fis = new FileInputStream(file)) {
+          newData = GameParser.parse(file.getAbsolutePath(), fis);
         }
       } else {
         // try to load it as a saved game whatever the extension
@@ -108,8 +106,7 @@ public class GameSelectorModel extends Observable {
       if (message == null && e.getStackTrace() != null) {
         message = e.getClass().getName() + "  at  " + e.getStackTrace()[0].toString();
       }
-      message = "Exception while parsing: " + file.getName() + " : "
-          + (gameName.get() != null ? gameName.get() + " : " : "") + message;
+      message = "Exception while parsing: " + file.getName() + " : " + message;
       ClientLogger.logQuietly(e);
       if (ui != null) {
         error(message + "\r\nPlease see console for full error log!", ui);

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -6,9 +6,6 @@ import java.net.URI;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
@@ -31,13 +28,12 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     final URI uri = URI.create(ClientSetting.SELECTED_GAME_LOCATION.value());
     try {
       return new GameChooserEntry(uri);
-    } catch (final IOException | GameParseException | SAXException | EngineVersionException e) {
+    } catch (final IOException | GameParseException | EngineVersionException e) {
       throw new IllegalStateException(e);
     }
   }
 
-  public GameChooserEntry(final URI uri)
-      throws IOException, GameParseException, SAXException, EngineVersionException {
+  public GameChooserEntry(final URI uri) throws IOException, GameParseException, EngineVersionException {
     url = uri;
 
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
@@ -66,17 +62,15 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     try (InputStream input = inputStream.get()) {
       gameData = GameParser.parse(url.toString(), input);
       gameDataFullyLoaded = true;
-
     } catch (final EngineVersionException e) {
       ClientLogger.logQuietly(e);
-      throw new GameParseException(e.getMessage());
-    } catch (final SAXParseException e) {
-      ClientLogger.logError(String.format("Could not parse: %s error at line: %s column: %s",
-          url, e.getLineNumber(), e.getColumnNumber()), e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(e);
+    } catch (final GameParseException e) {
+      ClientLogger.logError("Could not parse:" + url, e);
+      throw e;
     } catch (final Exception e) {
       ClientLogger.logError("Could not parse:" + url, e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(e);
     }
     return gameData;
   }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -24,9 +24,6 @@ import java.util.zip.ZipFile;
 import javax.swing.DefaultListModel;
 import javax.swing.JOptionPane;
 
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
@@ -185,11 +182,6 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       }
     } catch (final EngineVersionException e) {
       System.out.println(e.getMessage());
-    } catch (final SAXParseException e) {
-      final String msg =
-          "Could not parse:" + uri + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
-      System.err.println(msg);
-      ClientLogger.logQuietly(e);
     } catch (final Exception e) {
       System.err.println("Could not parse:" + uri);
       ClientLogger.logQuietly(e);
@@ -206,7 +198,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
   }
 
   private static GameChooserEntry createEntry(final URI uri)
-      throws IOException, GameParseException, SAXException, EngineVersionException {
+      throws IOException, GameParseException, EngineVersionException {
     return new GameChooserEntry(uri);
   }
 


### PR DESCRIPTION
Follow-up of [this discussion](https://github.com/triplea-game/triplea/pull/2683/files#r155970801) in #2683.

The `gameName` out parameter of `GameParser#parse()` was a smell.  It appears this was added as a hack to get the game name **only in the case where parsing failed**.  (Because if parsing succeeded, the game name is available in the returned `GameData` via `GameData#getGameName()`.)  Since this value was only required to include the game name in the resulting error message, I modified the parser to include it (if available) in the message of the `GameParseException` that is thrown by `GameParser` itself.

#### Functional changes

None.

#### Refactoring changes

* Removed the `gameName` parameter from the `GameParser#parse()` method.
* Extracted a private helper method, `GameParser#newGameParseException()` to encapsulate the details of including the map name (really the map URI) and game name (if available) in the resulting exception message.
* Wrap any `SAXException` thrown by `GameParser` in a `GameParseException` (so the game name will be included in the error message) to ensure parity with the previous code.
* Fixed some missing Javadoc Checkstyle violations.