### PR TITLE
Remove unused "JDK.Version" authentication response property

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -10,7 +10,6 @@ import javax.swing.JPasswordField;
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.net.IConnectionLogin;
 
 /**
@@ -24,7 +23,6 @@ import games.strategy.net.IConnectionLogin;
  */
 public class ClientLogin implements IConnectionLogin {
   public static final String ENGINE_VERSION_PROPERTY = "Engine.Version";
-  private static final String JDK_VERSION_PROPERTY = "JDK.Version";
 
   private final Component parentComponent;
 
@@ -41,7 +39,6 @@ public class ClientLogin implements IConnectionLogin {
     }
 
     response.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().toString());
-    response.put(JDK_VERSION_PROPERTY, SystemProperties.getJavaRuntimeVersion());
 
     return response;
   }

--- a/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
+++ b/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
@@ -27,10 +27,6 @@ public final class SystemProperties {
     return checkNotNull(System.getProperty("java.home"));
   }
 
-  public static @Nullable String getJavaRuntimeVersion() {
-    return System.getProperty("java.runtime.version");
-  }
-
   public static @Nullable String getMrjVersion() {
     return System.getProperty("mrj.version");
   }


### PR DESCRIPTION
The `JDK.Version` property is sent by a network game client during authentication.  It was added in 28141c611 (circa 2006), but, since then, I can find no commits where it was actually used by the server-side code in `ClientLoginValidator`.  It appears to be a YAGNI that was intended to ensure some kind of JDK compatibility between the client and server.

#### Functional changes

None.

#### Refactoring changes

* The `JDK.Version` property is no longer sent in the network game authentication response.
* The `SystemProperties#getJavaRuntimeVersion()` method is no longer used after the above change and was also removed.

#### Testing

I verified I could start a network game between a client and server from this branch.