### PR TITLE
Remove redundant null checks

### DIFF
--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -41,11 +41,9 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   }
 
   void createLobbyWatcher() {
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(m_model.getMessenger(), null,
-          m_lobbyWatcher.getInGameLobbyWatcher()));
-      m_lobbyWatcher.setGameSelectorModel(m_gameSelectorModel);
-    }
+    m_lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(m_model.getMessenger(), null,
+        m_lobbyWatcher.getInGameLobbyWatcher()));
+    m_lobbyWatcher.setGameSelectorModel(m_gameSelectorModel);
   }
 
   synchronized void repostLobbyWatcher(final IGame game) {
@@ -63,9 +61,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   }
 
   void shutDownLobbyWatcher() {
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
-    }
+    m_lobbyWatcher.shutDown();
   }
 
   private void setupListeners() {}
@@ -77,18 +73,14 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   public void shutDown() {
     m_model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
     m_model.shutDown();
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
-    }
+    m_lobbyWatcher.shutDown();
   }
 
   @Override
   public void cancel() {
     m_model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
     m_model.cancel();
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
-    }
+    m_lobbyWatcher.shutDown();
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -25,7 +25,6 @@ import games.strategy.util.ThreadUtil;
  * Server setup model.
  */
 public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
-  private static final long serialVersionUID = 9021977178348892504L;
   private final List<Observer> m_listeners = new CopyOnWriteArrayList<>();
   private final ServerModel m_model;
   private final GameSelectorModel m_gameSelectorModel;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.startup.ui;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Observer;
 
@@ -13,7 +12,7 @@ import games.strategy.engine.framework.startup.launcher.ILauncher;
  * Made so that we can have a headless setup. (this is probably a hack, but used because i do not want to rewrite the
  * entire setup model).
  */
-public interface ISetupPanel extends Serializable {
+public interface ISetupPanel {
   boolean isMetaSetupPanelInstance();
 
   void addObserver(final Observer observer);


### PR DESCRIPTION
I observed that the `HeadlessServerSetup#m_lobbyWatcher` field is `final` and initialized to a non-`null` value.  Therefore, the various `null` checks against this field are redundant.

However, I then discovered that this class was `Serializable` due to its implementation of the `ISetupPanel` interface.  That implied that a `null` value for `m_lobbyWatcher` _could_ be loaded from the serialization stream.  I tried to track down the need for `ISetupPanel` being `Serializable` but came up empty.  Most implementations of this interface are UI classes, and are thus naturally `Serializable`, but `HeadlessServerSetup` is the only non-UI implementation.  After some testing with a bot, I could not find a code path that attempted to serialize instances of `HeadlessServerSetup`.

#### Functional changes

None.

#### Refactoring changes

* Remove requirement that `ISetupPanel` implementations be `Serializable`.
* Remove redundant `null` checks of `HeadlessServerSetup#m_lobbyWatcher`.

#### Testing

I played with a client and bot from this branch.  I both saved and loaded games but never observed serialization errors from either process.

#### Notes

Viewing with whitespace changes ignored (`?w=1`) will shrink the diff further.