### PR TITLE
Bypass calls to System#getProperties()

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -147,11 +147,11 @@ public class GameRunner {
           System.out.println("Current Engine version in use: " + engineVersion);
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
+        System.setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
         System.out.println(ENGINE_VERSION_BIN + ":" + engineVersion);
       }
     } else {
-      System.getProperties().setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
+      System.setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
       System.out.println(ENGINE_VERSION_BIN + ":" + engineVersion);
     }
 

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -674,7 +674,7 @@ public class HeadlessGameServer {
   public static void main(final String[] args) {
     ClientSetting.initialize();
 
-    System.getProperties().setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
+    System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
     if (!new ArgParser(getProperties()).handleCommandLineArgs(args)) {
       usage();
       return;

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -152,8 +152,8 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   private static ClientProps getProps(final Component ui) {
-    if (System.getProperties().getProperty(TRIPLEA_CLIENT, "false").equals("true")
-        && System.getProperties().getProperty(TRIPLEA_STARTED, "").equals("")) {
+    if (System.getProperty(TRIPLEA_CLIENT, "false").equals("true")
+        && System.getProperty(TRIPLEA_STARTED, "").equals("")) {
       final ClientProps props = new ClientProps();
       props.setHost(System.getProperty(TRIPLEA_HOST));
       props.setName(System.getProperty(TRIPLEA_NAME));

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -199,8 +199,8 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
   }
 
   private ServerConnectionProps getServerProps(final Component ui) {
-    if (System.getProperties().getProperty(TRIPLEA_SERVER, "false").equals("true")
-        && System.getProperties().getProperty(TRIPLEA_STARTED, "").equals("")) {
+    if (System.getProperty(TRIPLEA_SERVER, "false").equals("true")
+        && System.getProperty(TRIPLEA_STARTED, "").equals("")) {
       final ServerConnectionProps props = new ServerConnectionProps();
       props.setName(System.getProperty(TRIPLEA_NAME));
       props.setPort(Integer.parseInt(System.getProperty(TRIPLEA_PORT)));

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -85,20 +85,20 @@ public class InGameLobbyWatcher {
    */
   public static InGameLobbyWatcher newInGameLobbyWatcher(final IServerMessenger gameMessenger, final JComponent parent,
       final InGameLobbyWatcher oldWatcher) {
-    final String host = System.getProperties().getProperty(LOBBY_HOST);
-    final String port = System.getProperties().getProperty(LOBBY_PORT);
-    final String hostedBy = System.getProperties().getProperty(LOBBY_GAME_HOSTED_BY);
+    final String host = System.getProperty(LOBBY_HOST);
+    final String port = System.getProperty(LOBBY_PORT);
+    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
     if (host == null || port == null) {
       return null;
     }
     // clear the properties
-    System.getProperties().remove(LOBBY_HOST);
-    System.getProperties().remove(LOBBY_PORT);
-    System.getProperties().remove(LOBBY_GAME_HOSTED_BY);
+    System.clearProperty(LOBBY_HOST);
+    System.clearProperty(LOBBY_PORT);
+    System.clearProperty(LOBBY_GAME_HOSTED_BY);
     // add them as temporary properties (in case we load an old savegame and need them again)
-    System.getProperties().setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
-    System.getProperties().setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
-    System.getProperties().setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
+    System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
+    System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
+    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override
       public Map<String, String> getProperties(final Map<String, String> challengeProperties) {

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -505,7 +505,7 @@ public class AutoPlacementFinder {
         for (final String propertie : properties) {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
-            System.getProperties().setProperty(propertie, value);
+            System.setProperty(propertie, value);
             System.out.println(propertie + ":" + value);
             found = true;
             break;

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -393,7 +393,7 @@ public class MapPropertiesMaker extends JFrame {
         for (final String propertie : properties) {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
-            System.getProperties().setProperty(propertie, value);
+            System.setProperty(propertie, value);
             System.out.println(propertie + ":" + value);
             found = true;
             break;

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -627,7 +627,7 @@ public class PlacementPicker extends JFrame {
         for (final String propertie : properties) {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
-            System.getProperties().setProperty(propertie, value);
+            System.setProperty(propertie, value);
             System.out.println(propertie + ":" + value);
             found = true;
             break;

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -36,7 +36,7 @@ public final class TestUtil {
     // store/get from SystemProperties
     // to get around junit reloading
     final String key = "triplea.test.port";
-    String prop = System.getProperties().getProperty(key);
+    String prop = System.getProperty(key);
     if (prop == null) {
       // start off with something fairly random, between 12000 - 14000
       prop = Integer.toString(12000 + (int) (Math.random() % 2000));
@@ -46,7 +46,7 @@ public final class TestUtil {
     if (val > 15000) {
       val = 12000;
     }
-    System.getProperties().put(key, "" + val);
+    System.setProperty(key, "" + val);
     return val;
   }
 


### PR DESCRIPTION
#### Functional changes

None.

#### Refactoring changes

Bypass calls through `System#getProperties()` to clear/get/set system properties, and instead call the `System#[clear|get|set]Property()` methods directly.  For example, replace this code:

```java
System.getProperties().getProperty("name")
```

with this code:

```java
System.getProperty("name")
```

#### Notes

Please merge this PR after #2709.  The conflicts will be easier to fix here.