### PR TITLE
Support ephemeral port binding in ServerMessenger

### DIFF
--- a/src/integ_test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -26,14 +26,12 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
 import games.strategy.sound.SoundPath;
-import games.strategy.test.TestUtil;
 
 public final class ChatIntegrationTest {
   private static final String CHAT_NAME = "c";
   private static final int MESSAGE_COUNT = 50;
   private static final int NODE_COUNT = 3;
 
-  private final int serverPort = TestUtil.getUniquePort();
   private IServerMessenger serverMessenger;
   private IMessenger client1Messenger;
   private IMessenger client2Messenger;
@@ -50,8 +48,9 @@ public final class ChatIntegrationTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    serverMessenger = new ServerMessenger("Server", serverPort);
+    serverMessenger = new ServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
+    final int serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();
     client1Messenger = new ClientMessenger("localhost", serverPort, "client1", mac);
     client2Messenger = new ClientMessenger("localhost", serverPort, "client2", mac);

--- a/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -18,22 +18,22 @@ import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
-import games.strategy.test.TestUtil;
 
 public final class ClientLoginIntegrationTest {
   private static final String PASSWORD = "password";
   private static final String OTHER_PASSWORD = "otherPassword";
 
   private IServerMessenger serverMessenger;
-  private final int serverPort = TestUtil.getUniquePort();
+  private int serverPort;
 
   @BeforeEach
   public void setUp() throws Exception {
     serverMessenger = newServerMessenger();
+    serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
   }
 
-  private IServerMessenger newServerMessenger() throws Exception {
-    final ServerMessenger serverMessenger = new ServerMessenger("server", serverPort);
+  private static IServerMessenger newServerMessenger() throws Exception {
+    final ServerMessenger serverMessenger = new ServerMessenger("server", 0);
     serverMessenger.setAcceptNewConnections(true);
     serverMessenger.setLoginValidator(newLoginValidator(serverMessenger));
     return serverMessenger;

--- a/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.test.TestUtil;
 import games.strategy.util.ThreadUtil;
 
 public class MessengerIntegrationTest {
@@ -32,10 +31,10 @@ public class MessengerIntegrationTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverPort = TestUtil.getUniquePort();
-    serverMessenger = new ServerMessenger("Server", serverPort);
+    serverMessenger = new ServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
     serverMessenger.addMessageListener(serverMessageListener);
+    serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();
     client1Messenger = new ClientMessenger("localhost", serverPort, "client1", mac);
     client1Messenger.addMessageListener(client1MessageListener);

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -77,8 +77,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     } else {
       node = new Node(name, InetAddress.getLocalHost(), boundPortNumber);
     }
-    final Thread t = new Thread(new ConnectionHandler(), "Server Messenger Connection Handler");
-    t.start();
+    new Thread(new ConnectionHandler(), "Server Messenger Connection Handler").start();
   }
 
   @Override

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -19,7 +19,6 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
-import games.strategy.test.TestUtil;
 import games.strategy.util.ThreadUtil;
 
 public class ChannelMessengerTest {
@@ -32,9 +31,9 @@ public class ChannelMessengerTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverPort = TestUtil.getUniquePort();
-    serverMessenger = new ServerMessenger("Server", serverPort);
+    serverMessenger = new ServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
+    serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();
     clientMessenger = new ClientMessenger("localhost", serverPort, "client1", mac);
     final UnifiedMessenger unifiedMessenger = new UnifiedMessenger(serverMessenger);

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -39,11 +39,9 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
 import games.strategy.net.ServerMessenger;
-import games.strategy.test.TestUtil;
 import games.strategy.util.ThreadUtil;
 
 public class RemoteMessengerTest {
-  private int serverPort = -1;
   private IServerMessenger serverMessenger = mock(IServerMessenger.class);
   private RemoteMessenger remoteMessenger;
   private UnifiedMessengerHub unifiedMessengerHub;
@@ -79,7 +77,6 @@ public class RemoteMessengerTest {
     when(serverMessenger.getServerNode()).thenReturn(dummyNode);
     when(serverMessenger.isServer()).thenReturn(true);
     remoteMessenger = new RemoteMessenger(new UnifiedMessenger(serverMessenger));
-    serverPort = TestUtil.getUniquePort();
   }
 
   @AfterEach
@@ -169,8 +166,9 @@ public class RemoteMessengerTest {
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = new ServerMessenger("server", serverPort);
+      server = new ServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
+      final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
@@ -212,8 +210,9 @@ public class RemoteMessengerTest {
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = new ServerMessenger("server", serverPort);
+      server = new ServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
+      final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
       final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(server));
@@ -239,8 +238,9 @@ public class RemoteMessengerTest {
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = new ServerMessenger("server", serverPort);
+      server = new ServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
+      final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
@@ -264,8 +264,9 @@ public class RemoteMessengerTest {
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = new ServerMessenger("server", serverPort);
+      server = new ServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
+      final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -23,7 +23,6 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
 import games.strategy.net.ServerMessenger;
-import games.strategy.test.TestUtil;
 
 /**
  * Comment(KG): This test is broken, If you run each test individually they all work, but when running all test in the
@@ -32,7 +31,6 @@ import games.strategy.test.TestUtil;
  * The UnifiedMessenger will create a new ThreadPool with each instantiation, and this pool is never shutdown.
  */
 public class VaultTest {
-  private int serverPort = -1;
   private IServerMessenger serverMessenger;
   private IMessenger clientMessenger;
   private Vault clientVault;
@@ -40,9 +38,9 @@ public class VaultTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverPort = TestUtil.getUniquePort();
-    serverMessenger = new ServerMessenger("Server", serverPort);
+    serverMessenger = new ServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
+    final int serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();
     clientMessenger = new ClientMessenger("localhost", serverPort, "client1", mac);
     final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(serverMessenger);

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -28,29 +28,6 @@ public final class TestUtil {
   }
 
   /**
-   * A server socket has a time to live after it is closed in which it is still
-   * bound to its port. For testing, we need to use a new port each time
-   * to prevent socket already bound errors
-   */
-  public static int getUniquePort() {
-    // store/get from SystemProperties
-    // to get around junit reloading
-    final String key = "triplea.test.port";
-    String prop = System.getProperty(key);
-    if (prop == null) {
-      // start off with something fairly random, between 12000 - 14000
-      prop = Integer.toString(12000 + (int) (Math.random() % 2000));
-    }
-    int val = Integer.parseInt(prop);
-    val++;
-    if (val > 15000) {
-      val = 12000;
-    }
-    System.setProperty(key, "" + val);
-    return val;
-  }
-
-  /**
    * Blocks until all Swing event thread actions have completed.
    *
    * <p>


### PR DESCRIPTION
The purpose of this PR is to remove the need for the `TestUtil#getUniquePort()` method.

Server sockets support binding to port 0, which instructs the socket to bind to any available port.  Instead of guessing for an available port to use when running `ServerMessenger` tests, we now specify port 0 and query the `ServerMessenger` for the actual port that was bound.