### PR TITLE
Substance fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ mainClassName = "games.strategy.engine.framework.GameRunner"
 
 ext {
     artifactsDir = file("$buildDir/artifacts")
-    downloadsDir = file("${project.gradle.gradleUserHomeDir}/caches/modules-2/files-2.1")
     releasesDir = file("$buildDir/releases")
     rootFilesDir = file("$buildDir/rootFiles")
     schemasDir = file('config/triplea/schemas')
@@ -82,28 +81,22 @@ jar {
 
 repositories {
     jcenter()
-}
 
-def urlFile = { url ->
-    def file = file("$downloadsDir/${java.nio.file.Paths.get(new URI(url).path).fileName}")
-    download {
-        src url
-        dest file
-        overwrite false
+    maven {
+        url 'https://dl.bintray.com/ssoloff/maven/'
     }
-    files(file)
 }
 
 dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
     compile 'org.postgresql:postgresql:42.1.4'
-    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar')
     compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:23.2-jre'
     compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
     compile 'com.sun.mail:javax.mail:1.6.0'
     compile 'commons-io:commons-io:2.5'
+    compile 'io.github.ssoloff:substance:7.1.01'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
     compile 'org.apache.commons:commons-math3:3.6.1'
@@ -111,8 +104,8 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
-    
-    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar')
+
+    runtime 'io.github.ssoloff:trident:1.4.00'
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -83,10 +83,23 @@ repositories {
     jcenter()
 }
 
+def urlFile = { url, name ->
+    File file = new File("$buildDir/download/${name}.jar")
+    file.parentFile.mkdirs()
+    if (!file.exists()) {
+        new URL(url).withInputStream { downloadStream ->
+            file.withOutputStream { fileOut ->
+                fileOut << downloadStream
+            }
+        }
+    }
+    files(file.absolutePath)
+}
+
 dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
     compile 'org.postgresql:postgresql:42.1.4'
-    compile 'org.codehaus.griffon.plugins:griffon-lookandfeel-substance:2.0.0'
+    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar', 'substance')
     compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:23.2-jre'
@@ -100,6 +113,8 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
+    
+    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar', 'trident')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ mainClassName = "games.strategy.engine.framework.GameRunner"
 
 ext {
     artifactsDir = file("$buildDir/artifacts")
+    downloadsDir = file("${project.gradle.gradleUserHomeDir}/caches/modules-2/files-2.1")
     releasesDir = file("$buildDir/releases")
     rootFilesDir = file("$buildDir/rootFiles")
     schemasDir = file('config/triplea/schemas')
@@ -83,20 +84,20 @@ repositories {
     jcenter()
 }
 
-def urlFile = { url, name ->
-    File file = new File("$buildDir/download/${name}.jar")
+def urlFile = { url ->
+    def file = file("$downloadsDir/${java.nio.file.Paths.get(new URI(url).path).fileName}")
     download {
         src url
-        dest file.absolutePath
+        dest file
         overwrite false
     }
-    files(file.absolutePath)
+    files(file)
 }
 
 dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
     compile 'org.postgresql:postgresql:42.1.4'
-    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar', 'substance-7.1.01')
+    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar')
     compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:23.2-jre'
@@ -111,7 +112,7 @@ dependencies {
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
     
-    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar', 'trident-1.4')
+    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -85,13 +85,10 @@ repositories {
 
 def urlFile = { url, name ->
     File file = new File("$buildDir/download/${name}.jar")
-    file.parentFile.mkdirs()
-    if (!file.exists()) {
-        new URL(url).withInputStream { downloadStream ->
-            file.withOutputStream { fileOut ->
-                fileOut << downloadStream
-            }
-        }
+    download {
+        src url
+        dest file.absolutePath
+        overwrite false
     }
     files(file.absolutePath)
 }
@@ -99,7 +96,7 @@ def urlFile = { url, name ->
 dependencies {
     errorprone 'com.google.errorprone:error_prone_core:2.0.5'
     compile 'org.postgresql:postgresql:42.1.4'
-    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar', 'substance')
+    compile urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar', 'substance-7.1.01')
     compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:23.2-jre'
@@ -114,7 +111,7 @@ dependencies {
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
     
-    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar', 'trident')
+    runtime urlFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar', 'trident-1.4')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -17,7 +17,9 @@ import org.pushingpixels.substance.api.skin.SubstanceDustCoffeeLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceDustLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGeminiLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteAquaLookAndFeel;
+import org.pushingpixels.substance.api.skin.SubstanceGraphiteChalkLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteGlassLookAndFeel;
+import org.pushingpixels.substance.api.skin.SubstanceGraphiteGoldLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceMagellanLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceMarinerLookAndFeel;
@@ -51,7 +53,8 @@ public class LookAndFeel {
         SubstanceCremeCoffeeLookAndFeel.class.getName(), SubstanceCremeLookAndFeel.class.getName(),
         SubstanceDustCoffeeLookAndFeel.class.getName(), SubstanceDustLookAndFeel.class.getName(),
         SubstanceGeminiLookAndFeel.class.getName(), SubstanceGraphiteAquaLookAndFeel.class.getName(),
-        SubstanceGraphiteGlassLookAndFeel.class.getName(), SubstanceGraphiteLookAndFeel.class.getName(),
+        SubstanceGraphiteChalkLookAndFeel.class.getName(), SubstanceGraphiteGlassLookAndFeel.class.getName(),
+        SubstanceGraphiteGoldLookAndFeel.class.getName(), SubstanceGraphiteLookAndFeel.class.getName(),
         SubstanceMagellanLookAndFeel.class.getName(), SubstanceMarinerLookAndFeel.class.getName(),
         SubstanceMistAquaLookAndFeel.class.getName(), SubstanceMistSilverLookAndFeel.class.getName(),
         SubstanceModerateLookAndFeel.class.getName(), SubstanceNebulaBrickWallLookAndFeel.class.getName(),

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -11,12 +11,10 @@ import org.pushingpixels.substance.api.skin.SubstanceBusinessBlackSteelLookAndFe
 import org.pushingpixels.substance.api.skin.SubstanceBusinessBlueSteelLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceBusinessLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceCeruleanLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceChallengerDeepLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceCremeCoffeeLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceCremeLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceDustCoffeeLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceDustLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceEmeraldDuskLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGeminiLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteAquaLookAndFeel;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteGlassLookAndFeel;
@@ -50,9 +48,8 @@ public class LookAndFeel {
     substanceLooks.addAll(Arrays.asList(SubstanceAutumnLookAndFeel.class.getName(),
         SubstanceBusinessBlackSteelLookAndFeel.class.getName(), SubstanceBusinessBlueSteelLookAndFeel.class.getName(),
         SubstanceBusinessLookAndFeel.class.getName(), SubstanceCeruleanLookAndFeel.class.getName(),
-        SubstanceChallengerDeepLookAndFeel.class.getName(), SubstanceCremeCoffeeLookAndFeel.class.getName(),
-        SubstanceCremeLookAndFeel.class.getName(), SubstanceDustCoffeeLookAndFeel.class.getName(),
-        SubstanceDustLookAndFeel.class.getName(), SubstanceEmeraldDuskLookAndFeel.class.getName(),
+        SubstanceCremeCoffeeLookAndFeel.class.getName(), SubstanceCremeLookAndFeel.class.getName(),
+        SubstanceDustCoffeeLookAndFeel.class.getName(), SubstanceDustLookAndFeel.class.getName(),
         SubstanceGeminiLookAndFeel.class.getName(), SubstanceGraphiteAquaLookAndFeel.class.getName(),
         SubstanceGraphiteGlassLookAndFeel.class.getName(), SubstanceGraphiteLookAndFeel.class.getName(),
         SubstanceMagellanLookAndFeel.class.getName(), SubstanceMarinerLookAndFeel.class.getName(),


### PR DESCRIPTION
It seems I did a mistake with #2680
Everything I told you was correct, but I didn't actually use the new version of substance, just a new reupload from the old version 🙈 
This PR basically works around the issue that this new dependency is not present on mavenCentral or jCenter, by downloading the file manually from the github repository.
I'm not a huge fan of this, but I have no clue how to publish artifacts to mavenCentral 🤔 (the guy working on substanceallowed this explicitly), so if anyone knows how to do this, they should feel free to do so, preferably keeping those artifacts up to date.


Functional Changes:
2 LookAndFeels were no longer available, but 2 were added as some sort of replacement.
Also the Look has improved. Not going to spoil you, have a look yourself, it looks really good. We might need to change our UI to match the new changes, you'll notice some alignment issues in the Engine Preferences

I actually noticed this issue when playing around with java 9 again.
The "old issue" was still present but is fixed with the latest binaries.