### PR TITLE
Fix table rendering of Start Time

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -1,14 +1,10 @@
 package games.strategy.engine.lobby.client.ui;
 
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +21,6 @@ import javax.swing.JTextPane;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-import javax.swing.table.DefaultTableCellRenderer;
 
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
@@ -37,7 +32,6 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.Node;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.TimeManager;
 
 class LobbyGamePanel extends JPanel {
   private static final long serialVersionUID = -2576314388949606337L;
@@ -92,18 +86,6 @@ class LobbyGamePanel extends JPanel {
         .setPreferredWidth(130);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Host))
         .setPreferredWidth(67);
-    gameTable.setDefaultRenderer(Instant.class, new DefaultTableCellRenderer() {
-      private static final long serialVersionUID = -2807387751127250972L;
-
-      @Override
-      public Component getTableCellRendererComponent(final JTable table, final Object value, final boolean isSelected,
-          final boolean hasFocus, final int row, final int column) {
-        super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-        setText(TimeManager
-            .getLocalizedTimeWithoutSeconds(LocalDateTime.ofInstant((Instant) value, ZoneOffset.systemDefault())));
-        return this;
-      }
-    });
   }
 
   private void layoutComponents() {

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -1,6 +1,8 @@
 package games.strategy.engine.lobby.client.ui;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +18,7 @@ import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.net.GUID;
 import games.strategy.net.IMessenger;
+import games.strategy.util.TimeManager;
 import games.strategy.util.Tuple;
 
 class LobbyGameTableModel extends AbstractTableModel {
@@ -84,14 +87,6 @@ class LobbyGameTableModel extends AbstractTableModel {
 
   GameDescription get(final int i) {
     return gameList.get(i).getSecond();
-  }
-
-  @Override
-  public Class<?> getColumnClass(final int columnIndex) {
-    if (columnIndex == getColumnIndex(Column.Started)) {
-      return Instant.class;
-    }
-    return Object.class;
   }
 
   private void assertSentFromServer() {
@@ -164,11 +159,15 @@ class LobbyGameTableModel extends AbstractTableModel {
       case Comments:
         return description.getComment();
       case Started:
-        return description.getStartDateTime();
+        return formatBotStartTime(description.getStartDateTime());
       case GUID:
         return gameList.get(rowIndex).getFirst();
       default:
         throw new IllegalStateException("Unknown column:" + column);
     }
+  }
+
+  private static String formatBotStartTime(final Instant instant) {
+    return TimeManager.getLocalizedTimeWithoutSeconds(LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()));
   }
 }


### PR DESCRIPTION
This PR fixes the rendering issue you can see below when hovering over a table row:
![Bug](https://user-images.githubusercontent.com/8350879/34206542-329473a6-e587-11e7-8656-13c3a4762f08.png)
As you can see the Started Cell has no white background.
The downside of this: Now the strings are being compared by the table sorter. Not the underlying instances.
This means we are now down to a minute accuracy from a nanosecond accuracy