### PR TITLE
Consolidate macOS platform detection

### DIFF
--- a/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
+++ b/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
@@ -27,10 +27,6 @@ public final class SystemProperties {
     return checkNotNull(System.getProperty("java.home"));
   }
 
-  public static @Nullable String getMrjVersion() {
-    return System.getProperty("mrj.version");
-  }
-
   private static String getOsName() {
     return checkNotNull(System.getProperty("os.name"));
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -289,7 +289,7 @@ public class HelpMenu {
     editorPane.setText(text);
     final JScrollPane scroll = new JScrollPane(editorPane);
     scroll.setBorder(null);
-    if (SystemProperties.getMrjVersion() == null) {
+    if (!SystemProperties.isMac()) {
       parentMenu.addSeparator();
       parentMenu.add(SwingAction.of("About", e -> JOptionPane.showMessageDialog(null, editorPane,
           "About " + gameData.getGameName(), JOptionPane.PLAIN_MESSAGE))).setMnemonic(KeyEvent.VK_A);


### PR DESCRIPTION
Checking the `os.name` system property is preferable to checking the `mrj.version` system property \[[1](https://alvinalexander.com/blog/post/java/how-determine-application-running-mac-os-x-osx-version)\].