### PR TITLE
Clean up TestUtil class

### DIFF
--- a/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
+++ b/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
@@ -7,15 +7,13 @@ import java.util.Comparator;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.test.TestUtil;
-
 public class RemoteInterfaceHelperTest {
 
   @Test
   public void testSimple() {
     assertEquals("compare", RemoteInterfaceHelper.getMethodInfo(0, Comparator.class).getFirst());
     assertEquals("add", RemoteInterfaceHelper.getMethodInfo(0, Collection.class).getFirst());
-    assertEquals(0, RemoteInterfaceHelper.getNumber("add", TestUtil.getClassArrayFrom(Object.class), Collection.class));
-    assertEquals(2, RemoteInterfaceHelper.getNumber("clear", TestUtil.getClassArrayFrom(), Collection.class));
+    assertEquals(0, RemoteInterfaceHelper.getNumber("add", new Class<?>[] {Object.class}, Collection.class));
+    assertEquals(2, RemoteInterfaceHelper.getNumber("clear", new Class<?>[] {}, Collection.class));
   }
 }

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteMethodCallResults;
-import games.strategy.test.TestUtil;
 
 public class EndPointTest {
 
@@ -18,7 +17,7 @@ public class EndPointTest {
     final EndPoint endPoint = new EndPoint("", Comparator.class, false);
     endPoint.addImplementor((Comparator<Object>) (o1, o2) -> 2);
     final RemoteMethodCall call = new RemoteMethodCall("", "compare", new Object[] {"", ""},
-        TestUtil.getClassArrayFrom(Object.class, Object.class), Comparator.class);
+        new Class<?>[] {Object.class, Object.class}, Comparator.class);
     final List<RemoteMethodCallResults> results = endPoint.invokeLocal(call, endPoint.takeANumber(), null);
     assertEquals(results.size(), 1);
     assertEquals(2, (results.iterator().next()).getRVal());

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -40,8 +40,4 @@ public final class TestUtil {
     SwingAction.invokeAndWait(() -> {
     });
   }
-
-  public static Class<?>[] getClassArrayFrom(final Class<?>... classes) {
-    return classes;
-  }
 }

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -1,11 +1,5 @@
 package games.strategy.test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-import com.google.common.io.Files;
-
 import games.strategy.ui.SwingAction;
 
 /**
@@ -13,19 +7,6 @@ import games.strategy.ui.SwingAction;
  */
 public final class TestUtil {
   private TestUtil() {}
-
-  /** Create and returns a simple delete on exit temp file with contents equal to the String parameter. */
-  public static File createTempFile(final String contents) {
-    final File file;
-    try {
-      file = File.createTempFile("testFile", ".tmp");
-      file.deleteOnExit();
-      Files.asCharSink(file, StandardCharsets.UTF_8).write(contents);
-      return file;
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   /**
    * Blocks until all Swing event thread actions have completed.

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -18,7 +18,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.random.ScriptedRandomSource;
-import games.strategy.test.TestUtil;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -321,6 +320,6 @@ public class AirThatCantLandUtilTest {
   @Deprecated
   private static ITripleAPlayer getDummyPlayer() {
     return (ITripleAPlayer) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
-        TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
+        new Class<?>[] {ITripleAPlayer.class}, (p, m, a) -> null);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -23,7 +23,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.random.ScriptedRandomSource;
-import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -107,7 +106,7 @@ public class LhtrTest {
     // fail if we are called
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> fail("method called:" + m));
+            new Class<?>[] {ITripleAPlayer.class}, (p, m, a) -> fail("method called:" + m));
     bridge.setRemote(player);
     // move 1 fighter over the aa gun in caucus
     final Route route = new Route();
@@ -159,7 +158,7 @@ public class LhtrTest {
     // fail if we are called
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
+            new Class<?>[] {ITripleAPlayer.class}, (p, m, a) -> null);
     bridge.setRemote(player);
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);
@@ -194,7 +193,7 @@ public class LhtrTest {
     // fail if we are called
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), (p, m, a) -> null);
+            new Class<?>[] {ITripleAPlayer.class}, (p, m, a) -> null);
     bridge.setRemote(player);
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -70,7 +70,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.random.ScriptedRandomSource;
-import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
@@ -928,7 +927,7 @@ public class RevisedTest {
     final InvocationHandler handler = (proxy, method, args) -> null;
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
+            new Class<?>[] {ITripleAPlayer.class}, handler);
     bridge.setRemote(player);
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);

--- a/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
+++ b/src/test/java/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
@@ -9,11 +9,9 @@ import java.lang.reflect.Proxy;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.test.TestUtil;
-
 public final class WrappedInvocationHandlerTest {
   private Object newProxy(final InvocationHandler handler) {
-    return Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler);
+    return Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] {}, handler);
   }
 
   @Test


### PR DESCRIPTION
#### Functional changes

None.

#### Refactoring changes

* Inlined the `TestUtil#getClassArrayFrom()` method.  It takes fewer characters to create a new class array literal (17 for `new Class<?>[] {...}`) than to call this method (28 for `TestUtil.getClassArrayFrom(...)`).
* Removed the unused `TestUtil#createTempFile()` method.