### PR TITLE
Update shadowJar configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,10 +154,10 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
 }
 
 shadowJar {
-    destinationDir = new File("$libsDir/all/")
+    destinationDir = libsDir
     baseName = 'triplea'
-    classifier = null
-    version = null
+    classifier = 'all'
+    version = version
 }
 
 task downloadAssets(group: 'release') {
@@ -241,11 +241,6 @@ task prepareInstallers(group: 'release', dependsOn: [generateInstallers]) {
 
 task prepareArtifacts(group: 'release', dependsOn: [generateZipReleases, prepareInstallers]) {
     doLast {
-	    copy {
-	        from "$libsDir/all/triplea.jar"
-	        into "$libsDir/"
-	        rename ".*", "triplea-$version-all.jar"
-	    }
         def artifacts = [
             file("$libsDir/triplea-$version-all.jar"),
             file("$distsDir/triplea-$version-all_platforms.zip"),

--- a/build.install4j
+++ b/build.install4j
@@ -28,7 +28,9 @@
       <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <fileEntry mountPoint="23" file="build/libs/all/triplea.jar" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <dirEntry mountPoint="23" file="build/libs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+        <exclude />
+      </dirEntry>
       <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
@@ -49,7 +51,7 @@
       </splashScreen>
       <java mainClass="games.strategy.engine.framework.GameRunner" mainMode="1" vmParameters="" arguments="" allowVMPassthroughParameters="true" preferredVM="" bundleRuntime="true">
         <classPath>
-          <archive location="bin/triplea.jar" failOnError="false" />
+          <scanDirectory location="bin" failOnError="false" />
         </classPath>
         <modulePath />
         <nativeLibraryDirectories />


### PR DESCRIPTION
This PR changes the `shadowJar` task to write the shadow jar directly to its expected location instead of having to copy it after-the-fact.

#### Testing

I ran `./gradlew clean release` locally, and it built all artifacts without issue.