### PR TITLE
Fix versioned jar file name

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -19,7 +19,6 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSetting;
-import games.strategy.util.Version;
 
 /**
  * Pure utility class, final and private constructor to enforce this
@@ -44,7 +43,7 @@ public final class ClientFileSystemHelper {
     }
 
     final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains("triplea_" + tripleaJarNameWithEngineVersion + ".jar!")) {
+    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
       return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
     }
 
@@ -66,8 +65,7 @@ public final class ClientFileSystemHelper {
 
 
   private static String getTripleaJarWithEngineVersionStringPath() {
-    final Version version = ClientContext.engineVersion();
-    return "triplea_" + version.toStringFull('_') + ".jar!";
+    return String.format("triplea-%s-all.jar!", ClientContext.engineVersion().getExactVersion());
   }
 
   private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {


### PR DESCRIPTION
This PR fixes a regression caused by #2729 as documented [here](https://github.com/triplea-game/triplea/pull/2729#issuecomment-353741706).

The name of the _triplea.jar_ file was changed to _triplea-$version-all.jar_ in #2729.  The code in
`ClientFileSystemHelper#getRootFolder()` depends on the name of the jar file to find the root of the classpath.  The versioned jar file name case was using the wrong format, and thus this method failed to find the classpath root triggering an NPE.

#### Testing

Started a local game using both the Unix and Windows x64 installers.  The game started correctly and no NPE was triggered.

#### Notes

I think the `ClientFileSystemHelper#getRootFolder()` method can be cleaned up further, but I will do that in a separate PR so the regression on `master` can be fixed ASAP.

The _triplea.jar_ file check can probably be removed.

The versioned jar file name check modified in this PR appears to be there to support the old jar file mechanism (based on how the file name was formatted), which is no longer used.  So this dead code now comes alive again. :smile: