### PR TITLE
Add JUnit platform launcher dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
+    testCompile 'org.junit.platform:junit-platform-launcher:1.0.2'
     testCompile 'org.mockito:mockito-core:2.13.0'
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
 


### PR DESCRIPTION
Not sure what happened in the past 24 hours, but I'm no longer able to run JUnit 5 tests from within Eclipse.  The Gradle dependencies that were recently upgraded seem unrelated to the problem (unless there's something about the latest Error Prone release introducing some issues in order to support Java 9).  I'm basically experiencing the same problem described [here](https://stackoverflow.com/questions/46717693/eclipse-no-tests-found-using-junit-5-caused-by-noclassdeffounderror).  Before I had a chance to dig too deeply, I made the mistake of answering yes to Eclipse's prompt to upgrade me to Oxygen.2.  So I'm not sure if I had some issue specific to my machine that I can no longer go back and analyze.  (And I still could not run the tests after the Oxygen.2 upgrade.)

In order to be able to run the tests, I had to add the `org.junit.platform:junit-platform-launcher` dependency.  I'm pretty sure we used to have this dependency, but it was removed because it was implicitly included by the IDE or something (I'm too tired to go through history right now).

I'd be interested in hearing if any other Eclipse user is experiencing this problem before we merge this.