### PR TITLE
Require Platform Launcher just at test runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,11 +111,11 @@ dependencies {
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
-    testCompile 'org.junit.platform:junit-platform-launcher:1.0.2'
     testCompile 'org.mockito:mockito-core:2.13.0'
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
 
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.2'
+    testRuntime 'org.junit.platform:junit-platform-launcher:1.0.2'
     testRuntime 'org.slf4j:slf4j-nop:1.7.25'
 }
 


### PR DESCRIPTION
Follow up of #2732
Self-merging as this is essentially a no-brainer. I verified everything works as expected (I don't even think eclipse makes a difference between those 2 options)