### PR TITLE
Remove legacy jar file name check

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -37,11 +37,6 @@ public final class ClientFileSystemHelper {
   public static File getRootFolder() {
     final String fileName = getGameRunnerFileLocation(GameRunner.class.getSimpleName() + ".class");
 
-    final String tripleaJarName = "triplea.jar!";
-    if (fileName.contains(tripleaJarName)) {
-      return getRootFolderRelativeToJar(fileName, tripleaJarName);
-    }
-
     final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
     if (fileName.contains(tripleaJarNameWithEngineVersion)) {
       return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -46,15 +46,13 @@ public final class ClientFileSystemHelper {
   private static String getGameRunnerClassFilePath() {
     final String runnerClassName = GameRunner.class.getSimpleName() + ".class";
     final URL url = GameRunner.class.getResource(runnerClassName);
-    String path = url.getFile();
-
+    final String path = url.getFile();
     try {
       // Deal with spaces in the file name which would be url encoded
-      path = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
+      return URLDecoder.decode(path, StandardCharsets.UTF_8.name());
     } catch (final UnsupportedEncodingException e) {
-      ClientLogger.logError("Unsupported encoding of path: " + path + ", error: " + e.getMessage());
+      throw new AssertionError("platform does not support UTF-8 charset", e);
     }
-    return path;
   }
 
   private static File getRootFolderRelativeToJar(final String path, final String jarFileName) {

--- a/src/main/java/games/strategy/util/Version.java
+++ b/src/main/java/games/strategy/util/Version.java
@@ -195,14 +195,7 @@ public final class Version implements Serializable, Comparable<Version> {
    * Creates a complete version string with '.' as separator, even if some version numbers are 0.
    */
   public String toStringFull() {
-    return toStringFull('.');
-  }
-
-  /**
-   * Creates a complete version string with the given separator, even if some version numbers are 0.
-   */
-  public String toStringFull(final char separator) {
-    return Joiner.on(separator).join(m_major, m_minor, m_point, m_micro == Integer.MAX_VALUE ? "dev" : m_micro);
+    return Joiner.on('.').join(m_major, m_minor, m_point, m_micro == Integer.MAX_VALUE ? "dev" : m_micro);
   }
 
   @Override

--- a/src/test/java/games/strategy/util/VersionTest.java
+++ b/src/test/java/games/strategy/util/VersionTest.java
@@ -95,7 +95,7 @@ public class VersionTest {
 
   @Test
   public void testToStringFull() {
-    assertEquals("1_2_3_dev", new Version("1.2.3.dev").toStringFull('_'));
+    assertEquals("1.2.3.dev", new Version("1.2.3.dev").toStringFull());
   }
 
   @Test


### PR DESCRIPTION
Follow-up to #2731.

#### Functional changes

* No longer check if the class path is relative to _triplea.jar_.  After renaming the TripleA jar file in #2731, this check is no longer necessary.

#### Refactoring changes

* Clean up `ClientFileSystemHelper`:
    * Rename local variables and methods to distinguish between file paths and file names.
    * Inline `getTripleaJarWithEngineVersionStringPath()`.
    * Update Javadocs.
* Removed unused `Version#toStringFull(char)` method overload.

#### Testing

I built the installer, installed TripleA, and verified I could start a local game to ensure the code path through `ClientFileSystemHelper#getRootFolder()` was hit (i.e. the same test that was run in #2731).

#### Notes

The functional change for this PR is in the first commit.  It is recommended to review that commit in isolation, and then review the PR as a whole.