### PR TITLE
Use parenthesis to explicitly declare operator precendece

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -567,7 +567,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     } catch (final Exception e) {
       m_atWarCount = 0;
     }
-    if (s.length < 1 || s.length == 1 && count != -1) {
+    if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty enemy list" + thisErrorMsg());
     }
     m_atWarPlayers = new HashSet<>();
@@ -610,7 +610,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     } catch (final Exception e) {
       m_techCount = 0;
     }
-    if (s.length < 1 || s.length == 1 && count != -1) {
+    if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty tech list" + thisErrorMsg());
     }
     m_techs = new ArrayList<>();
@@ -901,12 +901,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       if (!relationShipExistsLongEnnough(currentRelationship, relationshipsExistance)) {
         return false;
       }
-      if (!(relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
-          && Matches.relationshipTypeIsAllied().test(currentRelationshipType)
-          || relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
-              && Matches.relationshipTypeIsNeutral().test(currentRelationshipType)
-          || relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
-              && Matches.relationshipTypeIsAtWar().test(currentRelationshipType)
+      if (!((relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
+          && Matches.relationshipTypeIsAllied().test(currentRelationshipType))
+          || (relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
+              && Matches.relationshipTypeIsNeutral().test(currentRelationshipType))
+          || (relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
+              && Matches.relationshipTypeIsAtWar().test(currentRelationshipType))
           || currentRelationshipType
               .equals(getData().getRelationshipTypeList().getRelationshipType(relationCheck[2])))) {
         return false;

--- a/src/main/java/games/strategy/triplea/image/BlendComposite.java
+++ b/src/main/java/games/strategy/triplea/image/BlendComposite.java
@@ -112,7 +112,7 @@ class BlendComposite implements Composite {
           dstPixels[x] = ((int) (dstPixel[3] + (result[3] - dstPixel[3]) * alpha) & 0xFF) << 24
               | ((int) (dstPixel[0] + (result[0] - dstPixel[0]) * alpha) & 0xFF) << 16
               | ((int) (dstPixel[1] + (result[1] - dstPixel[1]) * alpha) & 0xFF) << 8
-              | (int) (dstPixel[2] + (result[2] - dstPixel[2]) * alpha) & 0xFF;
+              | ((int) (dstPixel[2] + (result[2] - dstPixel[2]) * alpha) & 0xFF);
         }
         dstOut.setDataElements(0, y, width, 1, dstPixels);
       }
@@ -135,9 +135,9 @@ class BlendComposite implements Composite {
           return new Blender() {
             @Override
             public int[] blend(final int[] src, final int[] dst) {
-              return new int[] {dst[0] < 128 ? dst[0] * src[0] >> 7 : 255 - ((255 - dst[0]) * (255 - src[0]) >> 7),
-                  dst[1] < 128 ? dst[1] * src[1] >> 7 : 255 - ((255 - dst[1]) * (255 - src[1]) >> 7),
-                  dst[2] < 128 ? dst[2] * src[2] >> 7 : 255 - ((255 - dst[2]) * (255 - src[2]) >> 7),
+              return new int[] {dst[0] < 128 ? (dst[0] * src[0]) >> 7 : 255 - (((255 - dst[0]) * (255 - src[0])) >> 7),
+                  dst[1] < 128 ? (dst[1] * src[1]) >> 7 : 255 - (((255 - dst[1]) * (255 - src[1])) >> 7),
+                  dst[2] < 128 ? (dst[2] * src[2]) >> 7 : 255 - (((255 - dst[2]) * (255 - src[2])) >> 7),
                   Math.min(255, src[3] + dst[3])};
             }
           };
@@ -145,9 +145,9 @@ class BlendComposite implements Composite {
           return new Blender() {
             @Override
             public int[] blend(final int[] src, final int[] dst) {
-              return new int[] {dst[0] < 128 ? dst[0] + src[0] >> 7 - 255 : dst[0] + (src[0] - 128) >> 7,
-                  dst[1] < 128 ? dst[1] + src[1] >> 7 - 255 : dst[1] + (src[1] - 128) >> 7,
-                  dst[2] < 128 ? dst[2] + src[2] >> 7 - 255 : dst[2] + (src[2] - 128) >> 7,
+              return new int[] {dst[0] < 128 ? (dst[0] + src[0]) >> (7 - 255) : (dst[0] + (src[0] - 128)) >> 7,
+                  dst[1] < 128 ? (dst[1] + src[1]) >> (7 - 255) : (dst[1] + (src[1] - 128)) >> 7,
+                  dst[2] < 128 ? (dst[2] + src[2]) >> (7 - 255) : (dst[2] + (src[2] - 128)) >> 7,
                   Math.min(255, src[3] + dst[3])};
             }
           };

--- a/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -35,15 +35,15 @@ public class RouteDescription {
       return false;
     }
     final RouteDescription other = (RouteDescription) o;
-    if (start == null && other.start != null || other.start == null && start != null
+    if ((start == null && other.start != null) || (other.start == null && start != null)
         || (start != other.start && !start.equals(other.start))) {
       return false;
     }
-    if (route == null && other.route != null || other.route == null && route != null
+    if ((route == null && other.route != null) || (other.route == null && route != null)
         || (route != other.route && !route.equals(other.route))) {
       return false;
     }
-    if (end == null && other.end != null || other.end == null && end != null) {
+    if ((end == null && other.end != null) || (other.end == null && end != null)) {
       return false;
     }
     if (cursorImage != other.cursorImage) {


### PR DESCRIPTION
This fixes a couple of errorprone "violations"