### PR TITLE
Make remaining operator precedence explicit

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1261,7 +1261,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     } catch (final Exception e) {
       count = 1;
     }
-    if (s.length < 1 || s.length == 1 && count != -1) {
+    if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty placement list" + thisErrorMsg());
     }
     final Territory territory = getData().getMap().getTerritory(s[i]);
@@ -1329,7 +1329,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     } catch (final Exception e) {
       count = 1;
     }
-    if (s.length < 1 || s.length == 1 && count != -1) {
+    if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty removeUnits list" + thisErrorMsg());
     }
     final Collection<Territory> territories = new ArrayList<>();
@@ -1407,7 +1407,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     } catch (final Exception e) {
       count = 1;
     }
-    if (s.length < 1 || s.length == 1 && count != -1) {
+    if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty purchase list" + thisErrorMsg());
     } else {
       if (m_purchase == null) {


### PR DESCRIPTION
Should've been part of #2736
The warning is currently being suppressed by the javac limit.