### PR TITLE
Use java 9 compiler, continue targeting java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 dist: trusty
 sudo: false
 language: java
-jdk:
-- oraclejdk9
++matrix:
+  include:
+  - jdk: oraclejdk8
+    env: TRIPLEA_RELEASE=false
+  - jdk: oraclejdk9
+    env: TRIPLEA_RELEASE=true
 addons:
   postgresql: "9.5"
   apt:
@@ -33,6 +37,7 @@ deploy:
   prerelease: true
   on:
     tags: false
+    condition: "$TRIPLEA_RELEASE = true"
     repo: triplea-game/triplea
     branches:
       only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk9
 addons:
   postgresql: "9.5"
   apt:


### PR DESCRIPTION
Closes #1882
Interestingly enough upgrading resulted in test failures (all of the same kind) that really should have happened with JDK 8 already.
Basically `MutedMacController#getMacUnmuteTime` and `MutedUsernameController#getUsernameUnmuteTime` return a milisecond-precision value that is compared against a nanosecond-precision Instant.
I workaround this issue by simply ignoring the nanoseconds, but I will submit a follow-up PR adressing this issue the right way, by fixing this instead of working around it.
I just didn't want to increase the scope of this small PR for a change that requires quite some refactoring.

This change is fully backwards compatible, all of the binaries should (if the gradle passes source and target correctly to the compiler) still be executable on JREs >= 8
Install4j supports Java 9, postgres triggers a reflection warning, that should be fixed in the next driver release, gradle itself triggers such a warning as well, but we can be pretty confident this will be fixed as well ^^