### PR TITLE
Checkstyle: Fix member name violations in delegate classes (part 1)

### DIFF
--- a/src/main/java/games/strategy/engine/xml/TestDelegate.java
+++ b/src/main/java/games/strategy/engine/xml/TestDelegate.java
@@ -14,12 +14,12 @@ public final class TestDelegate extends AbstractDelegate {
 
   @Override
   public void initialize(final String name, final String displayName) {
-    m_name = name;
+    this.name = name;
   }
 
   @Override
   public String getName() {
-    return m_name;
+    return name;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -16,10 +16,10 @@ import games.strategy.sound.ISound;
  * Code common to all delegates is implemented here.
  */
 public abstract class AbstractDelegate implements IDelegate {
-  protected String m_name;
-  protected String m_displayName;
-  protected PlayerID m_player;
-  protected IDelegateBridge m_bridge;
+  protected String name;
+  protected String displayName;
+  protected PlayerID player;
+  protected IDelegateBridge bridge;
 
   /**
    * Creates a new instance of the Delegate.
@@ -28,14 +28,14 @@ public abstract class AbstractDelegate implements IDelegate {
 
   @Override
   public void initialize(final String name, final String displayName) {
-    m_name = name;
-    m_displayName = displayName;
+    this.name = name;
+    this.displayName = displayName;
   }
 
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
-    m_bridge = delegateBridge;
-    m_player = delegateBridge.getPlayerId();
+    bridge = delegateBridge;
+    player = delegateBridge.getPlayerId();
   }
 
   /**
@@ -58,12 +58,12 @@ public abstract class AbstractDelegate implements IDelegate {
 
   @Override
   public String getName() {
-    return m_name;
+    return name;
   }
 
   @Override
   public String getDisplayName() {
-    return m_displayName;
+    return displayName;
   }
 
   /**
@@ -85,15 +85,15 @@ public abstract class AbstractDelegate implements IDelegate {
 
   @Override
   public IDelegateBridge getBridge() {
-    return m_bridge;
+    return bridge;
   }
 
   protected GameData getData() {
-    return m_bridge.getData();
+    return bridge.getData();
   }
 
   protected IDisplay getDisplay() {
-    return getDisplay(m_bridge);
+    return getDisplay(bridge);
   }
 
   protected static IDisplay getDisplay(final IDelegateBridge bridge) {
@@ -101,7 +101,7 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 
   protected ISound getSoundChannel() {
-    return getSoundChannel(m_bridge);
+    return getSoundChannel(bridge);
   }
 
   protected static ISound getSoundChannel(final IDelegateBridge bridge) {
@@ -109,7 +109,7 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 
   protected IRemotePlayer getRemotePlayer() {
-    return getRemotePlayer(m_bridge);
+    return getRemotePlayer(bridge);
   }
 
   protected static IRemotePlayer getRemotePlayer(final IDelegateBridge bridge) {
@@ -128,7 +128,7 @@ public abstract class AbstractDelegate implements IDelegate {
    * </p>
    */
   protected IRemotePlayer getRemotePlayer(final PlayerID player) {
-    return m_bridge.getRemotePlayer(player);
+    return bridge.getRemotePlayer(player);
   }
 }
 /*

--- a/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -24,10 +24,10 @@ import games.strategy.triplea.delegate.remote.IMoveDelegate;
  */
 public abstract class AbstractMoveDelegate extends BaseTripleADelegate implements IMoveDelegate {
   // A collection of UndoableMoves
-  protected List<UndoableMove> m_movesToUndo = new ArrayList<>();
+  protected List<UndoableMove> movesToUndo = new ArrayList<>();
   // protected final TransportTracker m_transportTracker = new TransportTracker();
   // if we are in the process of doing a move. this instance will allow us to resume the move
-  protected MovePerformer m_tempMovePerformer;
+  protected MovePerformer tempMovePerformer;
 
   public enum MoveType {
     DEFAULT, SPECIAL
@@ -38,17 +38,17 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   @Override
   public void start() {
     super.start();
-    if (m_tempMovePerformer != null) {
-      m_tempMovePerformer.initialize(this);
-      m_tempMovePerformer.resume();
-      m_tempMovePerformer = null;
+    if (tempMovePerformer != null) {
+      tempMovePerformer.initialize(this);
+      tempMovePerformer.resume();
+      tempMovePerformer = null;
     }
   }
 
   @Override
   public void end() {
     super.end();
-    m_movesToUndo.clear();
+    movesToUndo.clear();
   }
 
   @Override
@@ -56,8 +56,8 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     final AbstractMoveExtendedDelegateState state = new AbstractMoveExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_movesToUndo = m_movesToUndo;
-    state.m_tempMovePerformer = m_tempMovePerformer;
+    state.m_movesToUndo = movesToUndo;
+    state.m_tempMovePerformer = tempMovePerformer;
     return state;
   }
 
@@ -68,50 +68,50 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     // if the undo state wasnt saved, then dont load it. prevents overwriting undo state when we restore from an undo
     // move
     if (s.m_movesToUndo != null) {
-      m_movesToUndo = s.m_movesToUndo;
+      movesToUndo = s.m_movesToUndo;
     }
-    m_tempMovePerformer = s.m_tempMovePerformer;
+    tempMovePerformer = s.m_tempMovePerformer;
   }
 
   @Override
   public List<UndoableMove> getMovesMade() {
-    return new ArrayList<>(m_movesToUndo);
+    return new ArrayList<>(movesToUndo);
   }
 
   @Override
   public String undoMove(final int moveIndex) {
-    if (m_movesToUndo.isEmpty()) {
+    if (movesToUndo.isEmpty()) {
       return "No moves to undo";
     }
-    if (moveIndex >= m_movesToUndo.size()) {
+    if (moveIndex >= movesToUndo.size()) {
       return "Undo move index out of range";
     }
-    final UndoableMove moveToUndo = m_movesToUndo.get(moveIndex);
+    final UndoableMove moveToUndo = movesToUndo.get(moveIndex);
     if (!moveToUndo.getcanUndo()) {
       return moveToUndo.getReasonCantUndo();
     }
-    moveToUndo.undo(m_bridge);
-    m_movesToUndo.remove(moveIndex);
+    moveToUndo.undo(bridge);
+    movesToUndo.remove(moveIndex);
     updateUndoableMoveIndexes();
     return null;
   }
 
   private void updateUndoableMoveIndexes() {
-    for (int i = 0; i < m_movesToUndo.size(); i++) {
-      m_movesToUndo.get(i).setIndex(i);
+    for (int i = 0; i < movesToUndo.size(); i++) {
+      movesToUndo.get(i).setIndex(i);
     }
   }
 
   protected void updateUndoableMoves(final UndoableMove currentMove) {
-    currentMove.initializeDependencies(m_movesToUndo);
-    m_movesToUndo.add(currentMove);
+    currentMove.initializeDependencies(movesToUndo);
+    movesToUndo.add(currentMove);
     updateUndoableMoveIndexes();
   }
 
   protected PlayerID getUnitsOwner(final Collection<Unit> units) {
-    // if we are not in edit mode, return m_player. if we are in edit mode, we use whoever's units these are.
+    // if we are not in edit mode, return player. if we are in edit mode, we use whoever's units these are.
     if (units.isEmpty() || !BaseEditDelegate.getEditMode(getData())) {
-      return m_player;
+      return player;
     } else {
       return units.iterator().next().getOwner();
     }
@@ -145,17 +145,17 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
 
   @Override
   public Collection<Territory> getTerritoriesWhereAirCantLand(final PlayerID player) {
-    return new AirThatCantLandUtil(m_bridge).getTerritoriesWhereAirCantLand(player);
+    return new AirThatCantLandUtil(bridge).getTerritoriesWhereAirCantLand(player);
   }
 
   @Override
   public Collection<Territory> getTerritoriesWhereAirCantLand() {
-    return new AirThatCantLandUtil(m_bridge).getTerritoriesWhereAirCantLand(m_player);
+    return new AirThatCantLandUtil(bridge).getTerritoriesWhereAirCantLand(player);
   }
 
   @Override
   public Collection<Territory> getTerritoriesWhereUnitsCantFight() {
-    return new UnitsThatCantFightUtil(getData()).getTerritoriesWhereUnitsCantFight(m_player);
+    return new UnitsThatCantFightUtil(getData()).getTerritoriesWhereUnitsCantFight(player);
   }
 
   /**
@@ -166,7 +166,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
    * @return the route that a unit used to move into the given territory
    */
   public Route getRouteUsedToMoveInto(final Unit unit, final Territory end) {
-    return AbstractMoveDelegate.getRouteUsedToMoveInto(m_movesToUndo, unit, end);
+    return AbstractMoveDelegate.getRouteUsedToMoveInto(movesToUndo, unit, end);
   }
 
   /**
@@ -215,7 +215,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
 
   @Override
   public boolean postTurnSummary(final PBEMMessagePoster poster, final String title, final boolean includeSaveGame) {
-    return poster.post(m_bridge.getHistoryWriter(), title, includeSaveGame);
+    return poster.post(bridge.getHistoryWriter(), title, includeSaveGame);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -53,9 +53,9 @@ import games.strategy.util.Tuple;
  */
 public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implements IAbstractPlaceDelegate {
   // maps Territory-> Collection of units
-  protected Map<Territory, Collection<Unit>> m_produced = new HashMap<>();
+  protected Map<Territory, Collection<Unit>> produced = new HashMap<>();
   // a list of CompositeChanges
-  protected List<UndoablePlacement> m_placements = new ArrayList<>();
+  protected List<UndoablePlacement> placements = new ArrayList<>();
 
   public void initialize(final String name) {
     initialize(name, name);
@@ -73,19 +73,19 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   protected void doAfterEnd() {
-    final PlayerID player = m_bridge.getPlayerId();
+    final PlayerID player = bridge.getPlayerId();
     // clear all units not placed
     final Collection<Unit> units = player.getUnits().getUnits();
     final GameData data = getData();
     if (!Properties.getUnplacedUnitsLive(data) && !units.isEmpty()) {
-      m_bridge.getHistoryWriter()
+      bridge.getHistoryWriter()
           .startEvent(MyFormatter.unitsToTextNoOwner(units) + " were produced but were not placed", units);
       final Change change = ChangeFactory.removeUnits(player, units);
-      m_bridge.addChange(change);
+      bridge.addChange(change);
     }
     // reset ourselves for next turn
-    m_produced = new HashMap<>();
-    m_placements.clear();
+    produced = new HashMap<>();
+    placements.clear();
     if (GameStepPropertiesHelper.isRemoveAirThatCanNotLand(data)) {
       removeAirThatCantLand();
     }
@@ -94,17 +94,17 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
     // nothing to place
-    return !(m_player == null || (m_player.getUnits().size() == 0 && getPlacementsMade() == 0));
+    return !(player == null || (player.getUnits().size() == 0 && getPlacementsMade() == 0));
   }
 
   protected void removeAirThatCantLand() {
     // for LHTR type games
     final GameData data = getData();
-    final AirThatCantLandUtil util = new AirThatCantLandUtil(m_bridge);
-    util.removeAirThatCantLand(m_player, false);
+    final AirThatCantLandUtil util = new AirThatCantLandUtil(bridge);
+    util.removeAirThatCantLand(player, false);
     // if edit mode has been on, we need to clean up after all players
     for (final PlayerID player : data.getPlayerList()) {
-      if (!player.equals(m_player)) {
+      if (!player.equals(this.player)) {
         util.removeAirThatCantLand(player, false);
       }
     }
@@ -114,8 +114,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   public Serializable saveState() {
     final PlaceExtendedDelegateState state = new PlaceExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_produced = m_produced;
-    state.m_placements = m_placements;
+    state.m_produced = produced;
+    state.m_placements = placements;
     return state;
   }
 
@@ -123,8 +123,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   public void loadState(final Serializable state) {
     final PlaceExtendedDelegateState s = (PlaceExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_produced = s.m_produced;
-    m_placements = s.m_placements;
+    produced = s.m_produced;
+    placements = s.m_placements;
   }
 
   /**
@@ -134,58 +134,58 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   protected Collection<Unit> getAlreadyProduced(final Territory t) {
     // this list might be modified later
     final Collection<Unit> alreadyProducedUnits = new ArrayList<>();
-    if (m_produced.containsKey(t)) {
-      alreadyProducedUnits.addAll(m_produced.get(t));
+    if (produced.containsKey(t)) {
+      alreadyProducedUnits.addAll(produced.get(t));
     }
     return alreadyProducedUnits;
   }
 
   @Override
   public int getPlacementsMade() {
-    return m_placements.size();
+    return placements.size();
   }
 
   void setProduced(final Map<Territory, Collection<Unit>> produced) {
-    m_produced = produced;
+    this.produced = produced;
   }
 
   /**
-   * @return The actual m_produced variable, allowing direct editing of the variable.
+   * @return The actual produced variable, allowing direct editing of the variable.
    */
   protected final Map<Territory, Collection<Unit>> getProduced() {
-    return m_produced;
+    return produced;
   }
 
   @Override
   public List<UndoablePlacement> getMovesMade() {
-    return m_placements;
+    return placements;
   }
 
   @Override
   public String undoMove(final int moveIndex) {
-    if (moveIndex < m_placements.size() && moveIndex >= 0) {
-      final UndoablePlacement undoPlace = m_placements.get(moveIndex);
-      undoPlace.undo(m_bridge);
-      m_placements.remove(moveIndex);
+    if (moveIndex < placements.size() && moveIndex >= 0) {
+      final UndoablePlacement undoPlace = placements.get(moveIndex);
+      undoPlace.undo(bridge);
+      placements.remove(moveIndex);
       updateUndoablePlacementIndexes();
     }
     return null;
   }
 
   private void updateUndoablePlacementIndexes() {
-    for (int i = 0; i < m_placements.size(); i++) {
-      m_placements.get(i).setIndex(i);
+    for (int i = 0; i < placements.size(); i++) {
+      placements.get(i).setIndex(i);
     }
   }
 
   @Override
   public PlaceableUnits getPlaceableUnits(final Collection<Unit> units, final Territory to) {
-    final String error = canProduce(to, units, m_player);
+    final String error = canProduce(to, units, player);
     if (error != null) {
       return new PlaceableUnits(error);
     }
-    final Collection<Unit> placeableUnits = getUnitsToBePlaced(to, units, m_player);
-    final int maxUnits = getMaxUnitsToBePlaced(placeableUnits, to, m_player, true);
+    final Collection<Unit> placeableUnits = getUnitsToBePlaced(to, units, player);
+    final int maxUnits = getMaxUnitsToBePlaced(placeableUnits, to, player, true);
     return new PlaceableUnits(placeableUnits, maxUnits);
   }
 
@@ -194,20 +194,20 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (units == null || units.isEmpty()) {
       return null;
     }
-    final String error = isValidPlacement(units, at, m_player);
+    final String error = isValidPlacement(units, at, player);
     if (error != null) {
       return error;
     }
-    final List<Territory> producers = getAllProducers(at, m_player, units);
-    producers.sort(getBestProducerComparator(at, units, m_player));
-    final IntegerMap<Territory> maxPlaceableMap = getMaxUnitsToBePlacedMap(units, at, m_player, true);
+    final List<Territory> producers = getAllProducers(at, player, units);
+    producers.sort(getBestProducerComparator(at, units, player));
+    final IntegerMap<Territory> maxPlaceableMap = getMaxUnitsToBePlacedMap(units, at, player, true);
 
     // sort both producers and units so that the "to/at" territory comes first, and so that all constructions come first
     // this is because the PRODUCER for ALL CONSTRUCTIONS must be the SAME as the TERRITORY they are going into
     final List<Unit> unitsLeftToPlace = new ArrayList<>(units);
     unitsLeftToPlace.sort(getUnitConstructionComparator());
 
-    final List<Unit> remainingUnitsToPlace = new ArrayList<>(m_player.getUnits().getUnits());
+    final List<Unit> remainingUnitsToPlace = new ArrayList<>(player.getUnits().getUnits());
     remainingUnitsToPlace.removeAll(unitsLeftToPlace);
     while (!unitsLeftToPlace.isEmpty() && !producers.isEmpty()) {
       // Get next producer territory
@@ -232,18 +232,18 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
 
       unitsCanBePlacedByThisProducer.sort(getHardestToPlaceWithRequiresUnitsRestrictions(true));
-      final int maxForThisProducer = getMaxUnitsToBePlacedFrom(producer, unitsCanBePlacedByThisProducer, at, m_player);
+      final int maxForThisProducer = getMaxUnitsToBePlacedFrom(producer, unitsCanBePlacedByThisProducer, at, player);
       // don't forget that -1 == infinite
       if (maxForThisProducer == -1 || maxForThisProducer >= unitsCanBePlacedByThisProducer.size()) {
-        performPlaceFrom(producer, unitsCanBePlacedByThisProducer, at, m_player);
+        performPlaceFrom(producer, unitsCanBePlacedByThisProducer, at, player);
         unitsLeftToPlace.removeAll(unitsCanBePlacedByThisProducer);
         continue;
       }
       final int neededExtra = unitsCanBePlacedByThisProducer.size() - maxForThisProducer;
       if (maxPlaceable > maxForThisProducer) {
-        freePlacementCapacity(producer, neededExtra, unitsCanBePlacedByThisProducer, at, m_player);
+        freePlacementCapacity(producer, neededExtra, unitsCanBePlacedByThisProducer, at, player);
         final int newMaxForThisProducer =
-            getMaxUnitsToBePlacedFrom(producer, unitsCanBePlacedByThisProducer, at, m_player);
+            getMaxUnitsToBePlacedFrom(producer, unitsCanBePlacedByThisProducer, at, player);
         if (newMaxForThisProducer != maxPlaceable && neededExtra > newMaxForThisProducer) {
           throw new IllegalStateException("getMaxUnitsToBePlaced originally returned: " + maxPlaceable
               + ", \nWhich is not the same as it is returning after using freePlacementCapacity: "
@@ -255,13 +255,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
       final Collection<Unit> placedUnits =
           CollectionUtils.getNMatches(unitsCanBePlacedByThisProducer, maxPlaceable, Matches.always());
-      performPlaceFrom(producer, placedUnits, at, m_player);
+      performPlaceFrom(producer, placedUnits, at, player);
       unitsLeftToPlace.removeAll(placedUnits);
     }
 
     if (!unitsLeftToPlace.isEmpty()) {
       getDisplay().reportMessageToPlayers(
-          Collections.singletonList(m_player),
+          Collections.singletonList(player),
           Collections.emptyList(),
           "Not enough unit production territories available",
           "Unit Placement Canceled");
@@ -269,13 +269,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
     // play a sound
     if (units.stream().anyMatch(Matches.unitIsInfrastructure())) {
-      m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, m_player);
+      bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, player);
     } else if (units.stream().anyMatch(Matches.unitIsSea())) {
-      m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, m_player);
+      bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, player);
     } else if (units.stream().anyMatch(Matches.unitIsAir())) {
-      m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_AIR, m_player);
+      bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_AIR, player);
     } else {
-      m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_LAND, m_player);
+      bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_LAND, player);
     }
     return null;
   }
@@ -309,30 +309,30 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     change.add(remove);
     change.add(place);
     final UndoablePlacement currentPlacement = new UndoablePlacement(change, producer, at, placeableUnits);
-    m_placements.add(currentPlacement);
+    placements.add(currentPlacement);
     updateUndoablePlacementIndexes();
     final String transcriptText = MyFormatter.unitsToTextNoOwner(placeableUnits) + " placed in " + at.getName();
-    m_bridge.getHistoryWriter().startEvent(transcriptText, currentPlacement.getDescriptionObject());
+    bridge.getHistoryWriter().startEvent(transcriptText, currentPlacement.getDescriptionObject());
     if (movedAirTranscriptTextForHistory != null) {
-      m_bridge.getHistoryWriter().addChildToEvent(movedAirTranscriptTextForHistory);
+      bridge.getHistoryWriter().addChildToEvent(movedAirTranscriptTextForHistory);
     }
-    m_bridge.addChange(change);
+    bridge.addChange(change);
     updateProducedMap(producer, placeableUnits);
   }
 
   protected void updateProducedMap(final Territory producer, final Collection<Unit> additionallyProducedUnits) {
     final Collection<Unit> newProducedUnits = getAlreadyProduced(producer);
     newProducedUnits.addAll(additionallyProducedUnits);
-    m_produced.put(producer, newProducedUnits);
+    produced.put(producer, newProducedUnits);
   }
 
   protected void removeFromProducedMap(final Territory producer, final Collection<Unit> unitsToRemove) {
     final Collection<Unit> newProducedUnits = getAlreadyProduced(producer);
     newProducedUnits.removeAll(unitsToRemove);
     if (newProducedUnits.isEmpty()) {
-      m_produced.remove(producer);
+      produced.remove(producer);
     } else {
-      m_produced.put(producer, newProducedUnits);
+      produced.put(producer, newProducedUnits);
     }
   }
 
@@ -355,7 +355,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // territories the producer produced for (but not itself) and the amount of units it produced
     final HashMap<Territory, Integer> redoPlacementsCount = new HashMap<>();
     // find map place territory -> possible free space for producer
-    for (final UndoablePlacement placement : m_placements) {
+    for (final UndoablePlacement placement : placements) {
       // find placement move of producer that can be taken over
       if (placement.getProducerTerritory().equals(producer)) {
         final Territory placeTerritory = placement.getPlaceTerritory();
@@ -1001,7 +1001,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
     }
     if (weCanConsume && actuallyDoIt && change != null && !change.isEmpty()) {
-      m_bridge.getHistoryWriter().startEvent(
+      bridge.getHistoryWriter().startEvent(
           "Units in " + to.getName() + " being upgraded or consumed: " + MyFormatter.unitsToTextNoOwner(removedUnits),
           removedUnits);
     }
@@ -1085,7 +1085,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final boolean unitPlacementPerTerritoryRestricted = isUnitPlacementPerTerritoryRestricted();
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
-        factoryUnits.size() > 0 && m_player.equals(getOriginalFactoryOwner(producer));
+        factoryUnits.size() > 0 && this.player.equals(getOriginalFactoryOwner(producer));
     final RulesAttachment ra = (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     final Collection<Unit> alreadProducedUnits = getAlreadyProduced(producer);
     final int unitCountAlreadyProduced = alreadProducedUnits.size();
@@ -1149,7 +1149,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       int productionCanNotBeMoved = 0;
       int productionThatCanBeTakenOver = 0;
       // try to find a placement move (to an adjacent sea zone) that can be taken over by some other territory factory
-      for (final UndoablePlacement placementMove : m_placements) {
+      for (final UndoablePlacement placementMove : placements) {
         if (placementMove.getProducerTerritory().equals(producer)) {
           final Territory placeTerritory = placementMove.getPlaceTerritory();
           final Collection<Unit> unitsPlacedByCurrentPlacementMove = placementMove.getUnits();
@@ -1370,7 +1370,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
       if (!doNotCountNeighbors) {
         if (Matches.unitIsSea().test(unitWhichRequiresUnits)) {
-          for (final Territory current : getAllProducers(to, m_player,
+          for (final Territory current : getAllProducers(to, player,
               Collections.singletonList(unitWhichRequiresUnits), true)) {
             final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
             if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
@@ -1388,12 +1388,12 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!isUnitPlacementRestrictions() || !units.stream().anyMatch(Matches.unitRequiresUnitsOnCreation())) {
       return true;
     }
-    final IntegerMap<Territory> producersMap = getMaxUnitsToBePlacedMap(units, to, m_player, true);
-    final List<Territory> producers = getAllProducers(to, m_player, units);
+    final IntegerMap<Territory> producersMap = getMaxUnitsToBePlacedMap(units, to, player, true);
+    final List<Territory> producers = getAllProducers(to, player, units);
     if (producers.isEmpty()) {
       return false;
     }
-    Collections.sort(producers, getBestProducerComparator(to, units, m_player));
+    Collections.sort(producers, getBestProducerComparator(to, units, player));
     final Collection<Unit> unitsLeftToPlace = new ArrayList<>(units);
     for (final Territory t : producers) {
       if (unitsLeftToPlace.isEmpty()) {
@@ -1509,7 +1509,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final Collection<Unit> unitsInTo = to.getUnits().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     if (Matches.territoryIsWater().test(to)) {
-      for (final Territory current : getAllProducers(to, m_player, null, true)) {
+      for (final Territory current : getAllProducers(to, player, null, true)) {
         unitsPlacedAlready.addAll(getAlreadyProduced(current));
       }
     }
@@ -1556,7 +1556,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       throw new IllegalStateException("No factory in territory:" + territory);
     }
     for (final Unit factory : factoryUnits) {
-      if (m_player.equals(OriginalOwnerTracker.getOriginalOwner(factory))) {
+      if (player.equals(OriginalOwnerTracker.getOriginalOwner(factory))) {
         return OriginalOwnerTracker.getOriginalOwner(factory);
       }
     }
@@ -1580,7 +1580,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   @Override
   public Collection<Territory> getTerritoriesWhereAirCantLand() {
-    return new AirThatCantLandUtil(m_bridge).getTerritoriesWhereAirCantLand(m_player);
+    return new AirThatCantLandUtil(bridge).getTerritoriesWhereAirCantLand(player);
   }
 
   protected boolean canProduceFightersOnCarriers() {

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -43,7 +43,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
 
   private String checkPlayerId() {
     final IRemotePlayer remotePlayer = getRemotePlayer();
-    if (!m_bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
+    if (!bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
       return "Edit actions can only be performed during players turn";
     }
     return null;
@@ -62,11 +62,11 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
 
   public String setEditMode(final boolean editMode) {
     final IRemotePlayer remotePlayer = getRemotePlayer();
-    if (!m_bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
+    if (!bridge.getPlayerId().equals(remotePlayer.getPlayerId())) {
       return "Edit Mode can only be toggled during players turn";
     }
     logEvent((editMode ? EDITMODE_ON : EDITMODE_OFF), null);
-    m_bridge.addChange(ChangeFactory.setProperty(Constants.EDIT_MODE, editMode, getData()));
+    bridge.addChange(ChangeFactory.setProperty(Constants.EDIT_MODE, editMode, getData()));
     return null;
   }
 
@@ -101,9 +101,9 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
       gameData.releaseReadLock();
     }
     if (foundChild) {
-      m_bridge.getHistoryWriter().addChildToEvent(message, renderingObject);
+      bridge.getHistoryWriter().addChildToEvent(message, renderingObject);
     } else {
-      m_bridge.getHistoryWriter().startEvent(message, renderingObject);
+      bridge.getHistoryWriter().startEvent(message, renderingObject);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -19,8 +19,8 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
  * Code common to all TripleA delegates is implemented here.
  */
 public abstract class BaseTripleADelegate extends AbstractDelegate {
-  private boolean m_startBaseStepsFinished = false;
-  private boolean m_endBaseStepsFinished = false;
+  private boolean startBaseStepsFinished = false;
+  private boolean endBaseStepsFinished = false;
 
   /**
    * Creates a new instance of the Delegate.
@@ -38,8 +38,8 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   @Override
   public void start() {
     super.start();
-    if (!m_startBaseStepsFinished) {
-      m_startBaseStepsFinished = true;
+    if (!startBaseStepsFinished) {
+      startBaseStepsFinished = true;
       triggerWhenTriggerAttachments(TriggerAttachment.BEFORE);
     }
   }
@@ -54,30 +54,30 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   public void end() {
     super.end();
     // we are firing triggers, for maps that include them
-    if (!m_endBaseStepsFinished) {
-      m_endBaseStepsFinished = true;
+    if (!endBaseStepsFinished) {
+      endBaseStepsFinished = true;
       triggerWhenTriggerAttachments(TriggerAttachment.AFTER);
     }
     // these should probably be somewhere else, but we are relying on the fact that reloading a save go into the start
     // step,
     // but nothing goes into the end step, and therefore there is no way to save then have the end step repeat itself
-    m_startBaseStepsFinished = false;
-    m_endBaseStepsFinished = false;
+    startBaseStepsFinished = false;
+    endBaseStepsFinished = false;
   }
 
   @Override
   public Serializable saveState() {
     final BaseDelegateState state = new BaseDelegateState();
-    state.m_startBaseStepsFinished = m_startBaseStepsFinished;
-    state.m_endBaseStepsFinished = m_endBaseStepsFinished;
+    state.m_startBaseStepsFinished = startBaseStepsFinished;
+    state.m_endBaseStepsFinished = endBaseStepsFinished;
     return state;
   }
 
   @Override
   public void loadState(final Serializable state) {
     final BaseDelegateState s = (BaseDelegateState) state;
-    m_startBaseStepsFinished = s.m_startBaseStepsFinished;
-    m_endBaseStepsFinished = s.m_endBaseStepsFinished;
+    startBaseStepsFinished = s.m_startBaseStepsFinished;
+    endBaseStepsFinished = s.m_endBaseStepsFinished;
   }
 
   private void triggerWhenTriggerAttachments(final String beforeOrAfter) {
@@ -88,14 +88,14 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
       final Predicate<TriggerAttachment> baseDelegateWhenTriggerMatch = TriggerAttachment.availableUses
           .and(TriggerAttachment.whenOrDefaultMatch(beforeOrAfter, stepName));
       TriggerAttachment.collectAndFireTriggers(new HashSet<>(data.getPlayerList().getPlayers()),
-          baseDelegateWhenTriggerMatch, m_bridge, beforeOrAfter, stepName);
+          baseDelegateWhenTriggerMatch, bridge, beforeOrAfter, stepName);
     }
-    PoliticsDelegate.chainAlliancesTogether(m_bridge);
+    PoliticsDelegate.chainAlliancesTogether(bridge);
   }
 
   @Override
   protected ITripleADisplay getDisplay() {
-    return getDisplay(m_bridge);
+    return getDisplay(bridge);
   }
 
   protected static ITripleADisplay getDisplay(final IDelegateBridge bridge) {
@@ -104,7 +104,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
 
   @Override
   protected ITripleAPlayer getRemotePlayer() {
-    return getRemotePlayer(m_bridge);
+    return getRemotePlayer(bridge);
   }
 
   protected static ITripleAPlayer getRemotePlayer(final IDelegateBridge bridge) {
@@ -113,7 +113,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
 
   @Override
   protected ITripleAPlayer getRemotePlayer(final PlayerID player) {
-    return getRemotePlayer(player, m_bridge);
+    return getRemotePlayer(player, bridge);
   }
 
   protected static ITripleAPlayer getRemotePlayer(final PlayerID player, final IDelegateBridge bridge) {

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -33,11 +33,11 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
 
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
-    if (!doesPlayerHaveBid(getData(), m_player)) {
+    if (!doesPlayerHaveBid(getData(), player)) {
       return false;
     }
-    if ((m_player.getProductionFrontier() == null || m_player.getProductionFrontier().getRules().isEmpty())
-        && (m_player.getRepairFrontier() == null || m_player.getRepairFrontier().getRules().isEmpty())) {
+    if ((player.getProductionFrontier() == null || player.getProductionFrontier().getRules().isEmpty())
+        && (player.getRepairFrontier() == null || player.getRepairFrontier().getRules().isEmpty())) {
       return false;
     }
     return canWePurchaseOrRepair();
@@ -48,15 +48,15 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     final ResourceCollection bidCollection = new ResourceCollection(getData());
     // TODO: allow bids to have more than just PUs
     bidCollection.addResource(getData().getResourceList().getResource(Constants.PUS), m_bid);
-    if (m_player.getProductionFrontier() != null && m_player.getProductionFrontier().getRules() != null) {
-      for (final ProductionRule rule : m_player.getProductionFrontier().getRules()) {
+    if (player.getProductionFrontier() != null && player.getProductionFrontier().getRules() != null) {
+      for (final ProductionRule rule : player.getProductionFrontier().getRules()) {
         if (bidCollection.has(rule.getCosts())) {
           return true;
         }
       }
     }
-    if (m_player.getRepairFrontier() != null && m_player.getRepairFrontier().getRules() != null) {
-      for (final RepairRule rule : m_player.getRepairFrontier().getRules()) {
+    if (player.getRepairFrontier() != null && player.getRepairFrontier().getRules() != null) {
+      for (final RepairRule rule : player.getRepairFrontier().getRules()) {
         if (bidCollection.has(rule.getCosts())) {
           return true;
         }
@@ -79,7 +79,7 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     if (m_hasBid) {
       return;
     }
-    m_bid = getBidAmount(m_bridge.getData(), m_bridge.getPlayerId());
+    m_bid = getBidAmount(bridge.getData(), bridge.getPlayerId());
     m_spent = 0;
   }
 
@@ -96,11 +96,11 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     if (unspent == 0) {
       return;
     }
-    m_bridge.getHistoryWriter()
-        .startEvent(m_bridge.getPlayerId().getName() + " retains " + unspent + " PUS not spent in bid phase");
-    final Change unspentChange = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(),
+    bridge.getHistoryWriter()
+        .startEvent(bridge.getPlayerId().getName() + " retains " + unspent + " PUS not spent in bid phase");
+    final Change unspentChange = ChangeFactory.changeResourcesChange(bridge.getPlayerId(),
         super.getData().getResourceList().getResource(Constants.PUS), unspent);
-    m_bridge.addChange(unspentChange);
+    bridge.addChange(unspentChange);
     m_hasBid = false;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -61,7 +61,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       final List<Unit> unitsOwned = CollectionUtils.getMatches(units, Matches.unitIsOwnedBy(p));
       logEvent("Removing units owned by " + p.getName() + " from " + territory.getName() + ": "
           + MyFormatter.unitsToTextNoOwner(unitsOwned), unitsOwned);
-      m_bridge.addChange(ChangeFactory.removeUnits(territory, unitsOwned));
+      bridge.addChange(ChangeFactory.removeUnits(territory, unitsOwned));
     }
     return null;
   }
@@ -113,13 +113,13 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     // now perform the changes
     logEvent("Adding units owned by " + units.iterator().next().getOwner().getName() + " to " + territory.getName()
         + ": " + MyFormatter.unitsToTextNoOwner(units), units);
-    m_bridge.addChange(ChangeFactory.addUnits(territory, units));
+    bridge.addChange(ChangeFactory.addUnits(territory, units));
     if (Properties.getUnitsMayGiveBonusMovement(getData()) && GameStepPropertiesHelper.isGiveBonusMovement(data)) {
-      m_bridge.addChange(MoveDelegate.giveBonusMovementToUnits(player, data, territory));
+      bridge.addChange(MoveDelegate.giveBonusMovementToUnits(player, data, territory));
     }
     if (mapLoading != null && !mapLoading.isEmpty()) {
       for (final Entry<Unit, Unit> entry : mapLoading.entrySet()) {
-        m_bridge.addChange(TransportTracker.loadTransportChange((TripleAUnit) entry.getValue(), entry.getKey()));
+        bridge.addChange(TransportTracker.loadTransportChange((TripleAUnit) entry.getValue(), entry.getKey()));
       }
     }
     return null;
@@ -154,20 +154,20 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       // change ownership of friendly factories
       final Collection<Unit> units = territory.getUnits().getMatches(Matches.unitIsInfrastructure());
       for (final Unit unit : units) {
-        m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
+        bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
       final Predicate<Unit> enemyNonCom = Matches.unitIsInfrastructure().and(Matches.enemyUnit(player, data));
       final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
       // mark no movement for enemy units
-      m_bridge.addChange(ChangeFactory.markNoMovementChange(units));
+      bridge.addChange(ChangeFactory.markNoMovementChange(units));
       // change ownership of enemy AA and factories
       for (final Unit unit : units) {
-        m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
+        bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     }
     // change ownership of territory
-    m_bridge.addChange(ChangeFactory.changeOwner(territory, player));
+    bridge.addChange(ChangeFactory.changeOwner(territory, player));
     return null;
   }
 
@@ -186,7 +186,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       return "New PUs total is invalid";
     }
     logEvent("Changing PUs for " + player.getName() + " from " + oldTotal + " to " + newTotal, null);
-    m_bridge.addChange(ChangeFactory.changeResourcesChange(player, pus, (newTotal - oldTotal)));
+    bridge.addChange(ChangeFactory.changeResourcesChange(player, pus, (newTotal - oldTotal)));
     return null;
   }
 
@@ -205,7 +205,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       return "New token total is invalid";
     }
     logEvent("Changing tech tokens for " + player.getName() + " from " + oldTotal + " to " + newTotal, null);
-    m_bridge.addChange(ChangeFactory.changeResourcesChange(player, techTokens, (newTotal - oldTotal)));
+    bridge.addChange(ChangeFactory.changeResourcesChange(player, techTokens, (newTotal - oldTotal)));
     return null;
   }
 
@@ -220,7 +220,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     }
     for (final TechAdvance advance : advances) {
       logEvent("Adding Technology " + advance.getName() + " for " + player.getName(), null);
-      TechTracker.addAdvance(player, m_bridge, advance);
+      TechTracker.addAdvance(player, bridge, advance);
     }
     return null;
   }
@@ -236,7 +236,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     }
     for (final TechAdvance advance : advances) {
       logEvent("Removing Technology " + advance.getName() + " for " + player.getName(), null);
-      TechTracker.removeAdvance(player, m_bridge, advance);
+      TechTracker.removeAdvance(player, bridge, advance);
     }
     return null;
   }
@@ -265,7 +265,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final Collection<Unit> unitsFinal = new ArrayList<>(unitDamageMap.keySet());
     logEvent("Changing unit hit damage for these " + unitsFinal.iterator().next().getOwner().getName()
         + " owned units to: " + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false), unitsFinal);
-    m_bridge.addChange(ChangeFactory.unitsHit(unitDamageMap));
+    bridge.addChange(ChangeFactory.unitsHit(unitDamageMap));
     // territory.notifyChanged();
     return null;
   }
@@ -296,7 +296,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final Collection<Unit> unitsFinal = new ArrayList<>(unitDamageMap.keySet());
     logEvent("Changing unit bombing damage for these " + unitsFinal.iterator().next().getOwner().getName()
         + " owned units to: " + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false), unitsFinal);
-    m_bridge.addChange(ChangeFactory.bombingUnitDamage(unitDamageMap));
+    bridge.addChange(ChangeFactory.bombingUnitDamage(unitDamageMap));
     // territory.notifyChanged();
     return null;
   }
@@ -323,7 +323,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         logEvent("Editing Political Relationship for " + relationshipChange.getFirst().getName() + " and "
             + relationshipChange.getSecond().getName() + " from " + currentRelation.getName() + " to "
             + relationshipChange.getThird().getName(), null);
-        m_bridge.addChange(ChangeFactory.relationshipChange(relationshipChange.getFirst(),
+        bridge.addChange(ChangeFactory.relationshipChange(relationshipChange.getFirst(),
             relationshipChange.getSecond(), currentRelation, relationshipChange.getThird()));
         battleTracker.addRelationshipChangesThisTurn(relationshipChange.getFirst(), relationshipChange.getSecond(),
             currentRelation, relationshipChange.getThird());

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -57,24 +57,24 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       final PlayerAttachment pa = PlayerAttachment.get(japanese);
       if (pa != null && pa.getVps() >= 22) {
         victoryMessage = "Axis achieve VP victory";
-        m_bridge.getHistoryWriter().startEvent(victoryMessage);
+        bridge.getHistoryWriter().startEvent(victoryMessage);
         final Collection<PlayerID> winners = data.getAllianceTracker()
             .getPlayersInAlliance(data.getAllianceTracker().getAlliancesPlayerIsIn(japanese).iterator().next());
-        signalGameOver(victoryMessage, winners, m_bridge);
+        signalGameOver(victoryMessage, winners, bridge);
       }
     }
     // Check for Winning conditions
     if (isTotalVictory()) { // Check for Win by Victory Cities
       victoryMessage = " achieve TOTAL VICTORY with ";
-      checkVictoryCities(m_bridge, victoryMessage, " Total Victory VCs");
+      checkVictoryCities(bridge, victoryMessage, " Total Victory VCs");
     }
     if (isHonorableSurrender()) {
       victoryMessage = " achieve an HONORABLE VICTORY with ";
-      checkVictoryCities(m_bridge, victoryMessage, " Honorable Victory VCs");
+      checkVictoryCities(bridge, victoryMessage, " Honorable Victory VCs");
     }
     if (isProjectionOfPower()) {
       victoryMessage = " achieve victory through a PROJECTION OF POWER with ";
-      checkVictoryCities(m_bridge, victoryMessage, " Projection of Power VCs");
+      checkVictoryCities(bridge, victoryMessage, " Projection of Power VCs");
     }
     if (isEconomicVictory()) { // Check for regular economic victory
       for (final String allianceName : data.getAllianceTracker().getAlliances()) {
@@ -85,10 +85,10 @@ public class EndRoundDelegate extends BaseTripleADelegate {
           teamProd += getProduction(player);
           if (teamProd >= victoryAmount) {
             victoryMessage = allianceName + " achieve economic victory";
-            m_bridge.getHistoryWriter().startEvent(victoryMessage);
+            bridge.getHistoryWriter().startEvent(victoryMessage);
             final Collection<PlayerID> winners = data.getAllianceTracker().getPlayersInAlliance(allianceName);
             // Added this to end the game on victory conditions
-            signalGameOver(victoryMessage, winners, m_bridge);
+            signalGameOver(victoryMessage, winners, bridge);
           }
         }
       }
@@ -107,15 +107,15 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =
-            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, m_bridge);
+            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
         // get all triggers that are satisfied based on the tested conditions.
         final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
             CollectionUtils.getMatches(toFirePossible, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerActivateTriggerOther(testedConditions, toFireTestedAndSatisfied, m_bridge, null, null,
+        TriggerAttachment.triggerActivateTriggerOther(testedConditions, toFireTestedAndSatisfied, bridge, null, null,
             true, true, true, true);
         // will call
-        TriggerAttachment.triggerVictory(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true, true);
+        TriggerAttachment.triggerVictory(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
         // signalGameOver itself
       }
     }
@@ -156,14 +156,14 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     }
     victoryMessage = " achieve a military victory";
     if (germany && japan && count >= 2) {
-      m_bridge.getHistoryWriter().startEvent("Axis" + victoryMessage);
+      bridge.getHistoryWriter().startEvent("Axis" + victoryMessage);
       final Collection<PlayerID> winners = data.getAllianceTracker().getPlayersInAlliance("Axis");
-      signalGameOver("Axis" + victoryMessage, winners, m_bridge);
+      signalGameOver("Axis" + victoryMessage, winners, bridge);
     }
     if (russia && !germany && britain && !japan && america) {
-      m_bridge.getHistoryWriter().startEvent("Allies" + victoryMessage);
+      bridge.getHistoryWriter().startEvent("Allies" + victoryMessage);
       final Collection<PlayerID> winners = data.getAllianceTracker().getPlayersInAlliance("Allies");
-      signalGameOver("Allies" + victoryMessage, winners, m_bridge);
+      signalGameOver("Allies" + victoryMessage, winners, bridge);
     }
   }
 
@@ -177,8 +177,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         change.add(AbstractTriggerAttachment.triggerSetUsedForThisRound(player));
       }
       if (!change.isEmpty()) {
-        m_bridge.getHistoryWriter().startEvent("Setting uses for triggers used this round.");
-        m_bridge.addChange(change);
+        bridge.getHistoryWriter().startEvent("Setting uses for triggers used this round.");
+        bridge.addChange(change);
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -291,23 +291,23 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = bridge.getData();
     final CompositeChange change = new CompositeChange();
-    final Collection<Territory> territories = data.getMap().getTerritoriesOwnedBy(m_player);
+    final Collection<Territory> territories = data.getMap().getTerritoriesOwnedBy(player);
     final ResourceCollection productionCollection = getResourceProduction(territories, data);
     final IntegerMap<Resource> production = productionCollection.getResourcesCopy();
     for (final Entry<Resource, Integer> resource : production.entrySet()) {
       final Resource r = resource.getKey();
       int toAdd = resource.getValue();
-      int total = m_player.getResources().getQuantity(r) + toAdd;
+      int total = player.getResources().getQuantity(r) + toAdd;
       if (total < 0) {
         toAdd -= total;
         total = 0;
       }
       final String resourceText =
-          m_player.getName() + " collects " + toAdd + " " + MyFormatter.pluralize(r.getName(), toAdd) + "; ends with "
+          player.getName() + " collects " + toAdd + " " + MyFormatter.pluralize(r.getName(), toAdd) + "; ends with "
               + total + " " + MyFormatter.pluralize(r.getName(), total) + " total";
       bridge.getHistoryWriter().startEvent(resourceText);
       endTurnReport.append(resourceText).append("<br />");
-      change.add(ChangeFactory.changeResourcesChange(m_player, r, toAdd));
+      change.add(ChangeFactory.changeResourcesChange(player, r, toAdd));
     }
     if (!change.isEmpty()) {
       bridge.addChange(change);

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -39,15 +39,15 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   @Override
   public void initialize(final String name, final String displayName) {
-    m_name = name;
-    m_displayName = displayName;
+    this.name = name;
+    this.displayName = displayName;
   }
 
   @Override
   public void start() {
     super.start();
     if (m_needToInitialize) {
-      init(m_bridge);
+      init(bridge);
       m_needToInitialize = false;
     }
   }
@@ -97,8 +97,8 @@ public class InitializationDelegate extends BaseTripleADelegate {
   private void resetUnitState() {
     final Change change = MoveDelegate.getResetUnitStateChange(getData());
     if (!change.isEmpty()) {
-      m_bridge.getHistoryWriter().startEvent("Cleaning up unit state.");
-      m_bridge.addChange(change);
+      bridge.getHistoryWriter().startEvent("Cleaning up unit state.");
+      bridge.addChange(change);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -92,14 +92,14 @@ public class MoveDelegate extends AbstractMoveDelegate {
           .or(moveCombatDelegateAfterBonusTriggerMatch);
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAllTriggerMatch);
+            new HashSet<>(Collections.singleton(player)), moveCombatDelegateAllTriggerMatch);
         if (!toFirePossible.isEmpty()) {
 
           // collect conditions and test them for ALL triggers, both those that we will fire before and those we will
           // fire after.
-          testedConditions = TriggerAttachment.collectTestsForAllTriggers(toFirePossible, m_bridge);
+          testedConditions = TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
           final HashSet<TriggerAttachment> toFireBeforeBonus =
-              TriggerAttachment.collectForAllTriggersMatching(new HashSet<>(Collections.singleton(m_player)),
+              TriggerAttachment.collectForAllTriggersMatching(new HashSet<>(Collections.singleton(player)),
                   moveCombatDelegateBeforeBonusTriggerMatch);
           if (!toFireBeforeBonus.isEmpty()) {
 
@@ -108,19 +108,19 @@ public class MoveDelegate extends AbstractMoveDelegate {
                 .getMatches(toFireBeforeBonus, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
 
             // now list out individual types to fire, once for each of the matches above.
-            TriggerAttachment.triggerNotifications(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true,
+            TriggerAttachment.triggerNotifications(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
                 true);
-            TriggerAttachment.triggerPlayerPropertyChange(toFireTestedAndSatisfied, m_bridge, null, null, true, true,
+            TriggerAttachment.triggerPlayerPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true, true,
                 true, true);
-            TriggerAttachment.triggerRelationshipTypePropertyChange(toFireTestedAndSatisfied, m_bridge, null, null,
+            TriggerAttachment.triggerRelationshipTypePropertyChange(toFireTestedAndSatisfied, bridge, null, null,
                 true, true, true, true);
-            TriggerAttachment.triggerTerritoryPropertyChange(toFireTestedAndSatisfied, m_bridge, null, null, true,
+            TriggerAttachment.triggerTerritoryPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true,
                 true, true, true);
-            TriggerAttachment.triggerTerritoryEffectPropertyChange(toFireTestedAndSatisfied, m_bridge, null, null,
+            TriggerAttachment.triggerTerritoryEffectPropertyChange(toFireTestedAndSatisfied, bridge, null, null,
                 true, true, true, true);
-            TriggerAttachment.triggerChangeOwnership(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true,
+            TriggerAttachment.triggerChangeOwnership(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
                 true);
-            TriggerAttachment.triggerUnitRemoval(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true,
+            TriggerAttachment.triggerUnitRemoval(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
                 true);
           }
         }
@@ -129,7 +129,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // repair 2-hit units at beginning of turn (some maps have combat move before purchase, so i think it is better to
       // do this at beginning of combat move)
       if (GameStepPropertiesHelper.isRepairUnits(data)) {
-        MoveDelegate.repairMultipleHitPointUnits(m_bridge, m_player);
+        MoveDelegate.repairMultipleHitPointUnits(bridge, player);
       }
 
       // reset any bonus of units, and give movement to units which begin the turn in the same territory as units with
@@ -139,12 +139,12 @@ public class MoveDelegate extends AbstractMoveDelegate {
       }
 
       // take away all movement from allied fighters sitting on damaged carriers
-      removeMovementFromAirOnDamagedAlliedCarriers(m_bridge, m_player);
+      removeMovementFromAirOnDamagedAlliedCarriers(bridge, player);
 
       // placing triggered units at beginning of combat move, but after bonuses and repairing, etc, have been done.
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final HashSet<TriggerAttachment> toFireAfterBonus = TriggerAttachment.collectForAllTriggersMatching(
-            new HashSet<>(Collections.singleton(m_player)), moveCombatDelegateAfterBonusTriggerMatch);
+            new HashSet<>(Collections.singleton(player)), moveCombatDelegateAfterBonusTriggerMatch);
         if (!toFireAfterBonus.isEmpty()) {
 
           // get all triggers that are satisfied based on the tested conditions.
@@ -152,7 +152,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
               .getMatches(toFireAfterBonus, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
 
           // now list out individual types to fire, once for each of the matches above.
-          TriggerAttachment.triggerUnitPlacement(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true,
+          TriggerAttachment.triggerUnitPlacement(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
               true);
         }
       }
@@ -167,19 +167,19 @@ public class MoveDelegate extends AbstractMoveDelegate {
     boolean addedHistoryEvent = false;
     final Change changeReset = resetBonusMovement();
     if (!changeReset.isEmpty()) {
-      m_bridge.getHistoryWriter().startEvent("Resetting and Giving Bonus Movement to Units");
-      m_bridge.addChange(changeReset);
+      bridge.getHistoryWriter().startEvent("Resetting and Giving Bonus Movement to Units");
+      bridge.addChange(changeReset);
       addedHistoryEvent = true;
     }
     Change changeBonus = null;
     if (Properties.getUnitsMayGiveBonusMovement(getData())) {
-      changeBonus = giveBonusMovement(m_bridge, m_player);
+      changeBonus = giveBonusMovement(bridge, player);
     }
     if (changeBonus != null && !changeBonus.isEmpty()) {
       if (!addedHistoryEvent) {
-        m_bridge.getHistoryWriter().startEvent("Resetting and Giving Bonus Movement to Units");
+        bridge.getHistoryWriter().startEvent("Resetting and Giving Bonus Movement to Units");
       }
-      m_bridge.addChange(changeBonus);
+      bridge.addChange(changeBonus);
     }
   }
 
@@ -194,8 +194,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // WW2V2/WW2V3, fires at end of combat move
     // WW2V1, fires at end of non combat move
     if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (m_needToDoRockets && TechTracker.hasRocket(m_bridge.getPlayerId())) {
-        RocketsFireHelper.fireRockets(m_bridge, m_bridge.getPlayerId());
+      if (m_needToDoRockets && TechTracker.hasRocket(bridge.getPlayerId())) {
+        RocketsFireHelper.fireRockets(bridge, bridge.getPlayerId());
         m_needToDoRockets = false;
       }
     }
@@ -209,7 +209,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // Only air units can move during both CM and NCM in the same turn so moved units are set to no moves left
       final List<Unit> alreadyMovedNonAirUnits =
           CollectionUtils.getMatches(data.getUnits().getUnits(), Matches.unitHasMoved().and(Matches.unitIsNotAir()));
-      m_bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedNonAirUnits));
+      bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedNonAirUnits));
     }
     m_needToInitialize = true;
     m_needToDoRockets = true;
@@ -236,7 +236,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
-    final Predicate<Unit> moveableUnitOwnedByMe = PredicateBuilder.of(Matches.unitIsOwnedBy(m_player))
+    final Predicate<Unit> moveableUnitOwnedByMe = PredicateBuilder.of(Matches.unitIsOwnedBy(player))
         // right now, land units on transports have movement taken away when they their transport moves
         .and(Matches.unitHasMovementLeft()
             .or(Matches.unitIsLand().and(Matches.unitIsBeingTransported())))
@@ -268,8 +268,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     if (!change.isEmpty()) {
       // if no non-combat occurred, we may have cleanup left from combat
       // that we need to spawn an event for
-      m_bridge.getHistoryWriter().startEvent(CLEANING_UP_DURING_MOVEMENT_PHASE);
-      m_bridge.addChange(change);
+      bridge.getHistoryWriter().startEvent(CLEANING_UP_DURING_MOVEMENT_PHASE);
+      bridge.addChange(change);
     }
   }
 
@@ -549,7 +549,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // the reason we use this, is if we are in edit mode, we may have a different unit owner than the current player
     final PlayerID player = getUnitsOwner(units);
     final MoveValidationResult result = MoveValidator.validateMove(units, route, player, transportsThatCanBeLoaded,
-        newDependents, GameStepPropertiesHelper.isNonCombatMove(data, false), m_movesToUndo, data);
+        newDependents, GameStepPropertiesHelper.isNonCombatMove(data, false), movesToUndo, data);
     final StringBuilder errorMsg = new StringBuilder(100);
     final int numProblems = result.getTotalWarningCount() - (result.hasError() ? 0 : 1);
     final String numErrorsMsg =
@@ -582,7 +582,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // allow user to cancel move if aa guns will fire
     final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
-    aaInMoveUtil.initialize(m_bridge);
+    aaInMoveUtil.initialize(bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
       if (!getRemotePlayer().confirmMoveInFaceOfAa(aaFiringTerritores)) {
@@ -594,15 +594,15 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final UndoableMove currentMove = new UndoableMove(units, route);
     final String transcriptText = MyFormatter.unitsToTextNoOwner(units) + " moved from " + route.getStart().getName()
         + " to " + route.getEnd().getName();
-    m_bridge.getHistoryWriter().startEvent(transcriptText, currentMove.getDescriptionObject());
+    bridge.getHistoryWriter().startEvent(transcriptText, currentMove.getDescriptionObject());
     if (isKamikaze) {
-      m_bridge.getHistoryWriter().addChildToEvent("This was a kamikaze move, for at least some of the units",
+      bridge.getHistoryWriter().addChildToEvent("This was a kamikaze move, for at least some of the units",
           kamikazeUnits);
     }
-    m_tempMovePerformer = new MovePerformer();
-    m_tempMovePerformer.initialize(this);
-    m_tempMovePerformer.moveUnits(units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
-    m_tempMovePerformer = null;
+    tempMovePerformer = new MovePerformer();
+    tempMovePerformer.initialize(this);
+    tempMovePerformer.moveUnits(units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
+    tempMovePerformer = null;
     return null;
   }
 
@@ -617,20 +617,20 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final boolean lhtrCarrierProd = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     boolean hasProducedCarriers = false;
-    for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, m_player)) {
+    for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, player)) {
       if (p.getUnits().anyMatch(Matches.unitIsCarrier())) {
         hasProducedCarriers = true;
         break;
       }
     }
-    final AirThatCantLandUtil util = new AirThatCantLandUtil(m_bridge);
-    util.removeAirThatCantLand(m_player, lhtrCarrierProd && hasProducedCarriers);
+    final AirThatCantLandUtil util = new AirThatCantLandUtil(bridge);
+    util.removeAirThatCantLand(player, lhtrCarrierProd && hasProducedCarriers);
 
     // if edit mode has been on, we need to clean up after all players
     for (final PlayerID player : data.getPlayerList()) {
 
       // Check if player still has units to place
-      if (!player.equals(m_player)) {
+      if (!player.equals(this.player)) {
         util.removeAirThatCantLand(player,
             ((player.getUnits().anyMatch(Matches.unitIsCarrier()) || hasProducedCarriers) && lhtrCarrierProd));
       }

--- a/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -32,14 +32,14 @@ public class NoPUPurchaseDelegate extends PurchaseDelegate {
   public void start() {
     super.start();
     isPacific = isPacificTheater();
-    final PlayerID player = m_bridge.getPlayerId();
+    final PlayerID player = bridge.getPlayerId();
     final Collection<Territory> territories = getData().getMap().getTerritoriesOwnedBy(player);
     final Collection<Unit> units = getProductionUnits(territories, player);
     final Change productionChange = ChangeFactory.addUnits(player, units);
     final String transcriptText = player.getName() + " builds " + units.size() + " units.";
-    m_bridge.getHistoryWriter().startEvent(transcriptText);
+    bridge.getHistoryWriter().startEvent(transcriptText);
     if (productionChange != null) {
-      m_bridge.addChange(productionChange);
+      bridge.addChange(productionChange);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -32,7 +32,7 @@ import games.strategy.util.Tuple;
  * This delegate sets up the game according to Risk rules, with a few allowed customizations.
  * Either divide all neutral territories between players randomly, or let them pick one by one.
  * After that, any remaining units get placed one by one.
- * (Note that m_player may not be used here, because this delegate is not run by any player [it is null])
+ * (Note that player may not be used here, because this delegate is not run by any player [it is null])
  */
 @MapSupport
 public class RandomStartDelegate extends BaseTripleADelegate {
@@ -83,11 +83,11 @@ public class RandomStartDelegate extends BaseTripleADelegate {
     playersCanPick.addAll(CollectionUtils.getMatches(data.getPlayerList().getPlayers(), playerCanPickMatch));
     // we need a main event
     if (!playersCanPick.isEmpty()) {
-      m_bridge.getHistoryWriter().startEvent("Assigning Territories");
+      bridge.getHistoryWriter().startEvent("Assigning Territories");
     }
     // for random:
     final int[] hitRandom = (!randomTerritories ? new int[0]
-        : m_bridge.getRandom(allPickableTerritories.size(), allPickableTerritories.size(), null, DiceType.ENGINE,
+        : bridge.getRandom(allPickableTerritories.size(), allPickableTerritories.size(), null, DiceType.ENGINE,
             "Picking random territories"));
     int i = 0;
     int pos = 0;
@@ -118,9 +118,9 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         }
         change.add(ChangeFactory.removeUnits(m_currentPickingPlayer, unitsToPlace));
         change.add(ChangeFactory.addUnits(picked, unitsToPlace));
-        m_bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " receives territory "
+        bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " receives territory "
             + picked.getName() + " with units " + MyFormatter.unitsToTextNoOwner(unitsToPlace), picked);
-        m_bridge.addChange(change);
+        bridge.addChange(change);
       } else {
         Tuple<Territory, Set<Unit>> pick;
         Set<Unit> unitsToPlace;
@@ -149,9 +149,9 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         }
         change.add(ChangeFactory.removeUnits(m_currentPickingPlayer, unitsToPlace));
         change.add(ChangeFactory.addUnits(picked, unitsToPlace));
-        m_bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " picks territory "
+        bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " picks territory "
             + picked.getName() + " and places in it " + MyFormatter.unitsToTextNoOwner(unitsToPlace), unitsToPlace);
-        m_bridge.addChange(change);
+        bridge.addChange(change);
       }
       allPickableTerritories.remove(picked);
       final PlayerID lastPlayer = m_currentPickingPlayer;
@@ -196,9 +196,9 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       }
       change.add(ChangeFactory.removeUnits(m_currentPickingPlayer, unitsToPlace));
       change.add(ChangeFactory.addUnits(picked, unitsToPlace));
-      m_bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " places "
+      bridge.getHistoryWriter().addChildToEvent(m_currentPickingPlayer.getName() + " places "
           + MyFormatter.unitsToTextNoOwner(unitsToPlace) + " in territory " + picked.getName(), unitsToPlace);
-      m_bridge.addChange(change);
+      bridge.addChange(change);
       final PlayerID lastPlayer = m_currentPickingPlayer;
       m_currentPickingPlayer = getNextPlayer(playersCanPick, m_currentPickingPlayer);
       if (!playerCanPickMatch.test(lastPlayer)) {

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -54,7 +54,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   public void start() {
     super.start();
     final GameData data = getData();
-    if (!allowAirborne(m_player, data)) {
+    if (!allowAirborne(player, data)) {
       return;
     }
     final boolean onlyWhereUnderAttackAlready =
@@ -62,7 +62,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(data);
     if (m_needToInitialize && onlyWhereUnderAttackAlready) {
       // we do this to clear any 'finishedBattles' and also to create battles for units that didn't move
-      BattleDelegate.doInitialize(battleTracker, m_bridge);
+      BattleDelegate.doInitialize(battleTracker, bridge);
       m_needToInitialize = false;
     }
   }
@@ -90,13 +90,13 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
 
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
-    return allowAirborne(m_player, getData());
+    return allowAirborne(player, getData());
   }
 
   @Override
   public String move(final Collection<Unit> units, final Route route, final Collection<Unit> transportsThatCanBeLoaded,
       final Map<Unit, Collection<Unit>> newDependents) {
-    if (!allowAirborne(m_player, getData())) {
+    if (!allowAirborne(player, getData())) {
       return "No Airborne Movement Allowed Yet";
     }
     final GameData data = getData();
@@ -120,7 +120,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     }
     // allow user to cancel move if aa guns will fire
     final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
-    aaInMoveUtil.initialize(m_bridge);
+    aaInMoveUtil.initialize(bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {
       if (!getRemotePlayer().confirmMoveInFaceOfAa(aaFiringTerritores)) {
@@ -130,7 +130,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     // do the move
     final UndoableMove currentMove = new UndoableMove(units, route);
     // add dependencies (any move that came before this, from this start territory, is a dependency)
-    for (final UndoableMove otherMove : m_movesToUndo) {
+    for (final UndoableMove otherMove : movesToUndo) {
       if (otherMove.getStart().equals(route.getStart())) {
         currentMove.addDependency(otherMove);
       }
@@ -148,14 +148,14 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     // start event
     final String transcriptText = MyFormatter.unitsToTextNoOwner(units) + " moved from " + route.getStart().getName()
         + " to " + route.getEnd().getName();
-    m_bridge.getHistoryWriter().startEvent(transcriptText, currentMove.getDescriptionObject());
+    bridge.getHistoryWriter().startEvent(transcriptText, currentMove.getDescriptionObject());
     // actually do our special changes
-    m_bridge.addChange(airborneChange);
-    m_bridge.addChange(fillLaunchCapacity);
-    m_tempMovePerformer = new MovePerformer();
-    m_tempMovePerformer.initialize(this);
-    m_tempMovePerformer.moveUnits(units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
-    m_tempMovePerformer = null;
+    bridge.addChange(airborneChange);
+    bridge.addChange(fillLaunchCapacity);
+    tempMovePerformer = new MovePerformer();
+    tempMovePerformer.initialize(this);
+    tempMovePerformer.moveUnits(units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
+    tempMovePerformer = null;
     return null;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -44,16 +44,16 @@ public class TechActivationDelegate extends BaseTripleADelegate {
     }
     // Activate techs
     final Map<PlayerID, Collection<TechAdvance>> techMap = DelegateFinder.techDelegate(data).getAdvances();
-    final Collection<TechAdvance> advances = techMap.get(m_player);
+    final Collection<TechAdvance> advances = techMap.get(player);
     if ((advances != null) && (advances.size() > 0)) {
       // Start event
-      m_bridge.getHistoryWriter().startEvent(m_player.getName() + " activating " + advancesAsString(advances));
+      bridge.getHistoryWriter().startEvent(player.getName() + " activating " + advancesAsString(advances));
       for (final TechAdvance advance : advances) {
-        TechTracker.addAdvance(m_player, m_bridge, advance);
+        TechTracker.addAdvance(player, bridge, advance);
       }
     }
     // empty
-    techMap.put(m_player, null);
+    techMap.put(player, null);
     if (Properties.getTriggers(data)) {
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
@@ -65,19 +65,19 @@ public class TechActivationDelegate extends BaseTripleADelegate {
               .or(TriggerAttachment.supportMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(m_player)), techActivationDelegateTriggerMatch);
+          new HashSet<>(Collections.singleton(player)), techActivationDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =
-            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, m_bridge);
+            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
         // get all triggers that are satisfied based on the tested conditions.
         final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
             CollectionUtils.getMatches(toFirePossible, TriggerAttachment.isSatisfiedMatch(testedConditions)));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerUnitPropertyChange(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true,
+        TriggerAttachment.triggerUnitPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
             true);
-        TriggerAttachment.triggerTechChange(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true, true);
-        TriggerAttachment.triggerSupportChange(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true, true);
+        TriggerAttachment.triggerTechChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
+        TriggerAttachment.triggerSupportChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
       }
     }
     shareTechnology();
@@ -96,7 +96,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   }
 
   private void shareTechnology() {
-    final PlayerAttachment pa = PlayerAttachment.get(m_player);
+    final PlayerAttachment pa = PlayerAttachment.get(player);
     if (pa == null) {
       return;
     }
@@ -105,16 +105,16 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       return;
     }
     final GameData data = getData();
-    final Collection<TechAdvance> currentAdvances = TechTracker.getCurrentTechAdvances(m_player, data);
+    final Collection<TechAdvance> currentAdvances = TechTracker.getCurrentTechAdvances(player, data);
     for (final PlayerID p : shareWith) {
       final Collection<TechAdvance> availableTechs = TechnologyDelegate.getAvailableTechs(p, data);
       final Collection<TechAdvance> toGive = Util.intersection(currentAdvances, availableTechs);
       if (!toGive.isEmpty()) {
         // Start event
-        m_bridge.getHistoryWriter()
-            .startEvent(m_player.getName() + " giving technology to " + p.getName() + ": " + advancesAsString(toGive));
+        bridge.getHistoryWriter()
+            .startEvent(player.getName() + " giving technology to " + p.getName() + ": " + advancesAsString(toGive));
         for (final TechAdvance advance : toGive) {
-          TechTracker.addAdvance(p, m_bridge, advance);
+          TechTracker.addAdvance(p, bridge, advance);
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -77,16 +77,16 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
           .and(TriggerAttachment.techAvailableMatch());
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
-          new HashSet<>(Collections.singleton(m_player)), technologyDelegateTriggerMatch);
+          new HashSet<>(Collections.singleton(player)), technologyDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final HashMap<ICondition, Boolean> testedConditions =
-            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, m_bridge);
+            TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
         // get all triggers that are satisfied based on the tested conditions.
         final List<TriggerAttachment> toFireTestedAndSatisfied =
             CollectionUtils.getMatches(toFirePossible, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerAvailableTechChange(new HashSet<>(toFireTestedAndSatisfied), m_bridge,
+        TriggerAttachment.triggerAvailableTechChange(new HashSet<>(toFireTestedAndSatisfied), bridge,
             null, null, true, true, true, true);
       }
     }
@@ -121,22 +121,22 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     if (!Properties.getTechDevelopment(getData())) {
       return false;
     }
-    if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(m_player, getData())) {
+    if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData())) {
       return false;
     }
     if (Properties.getWW2V3TechModel(getData())) {
       final Resource techtokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
       if (techtokens != null) {
-        final int techTokens = m_player.getResources().getQuantity(techtokens);
+        final int techTokens = player.getResources().getQuantity(techtokens);
         if (techTokens > 0) {
           return true;
         }
       }
     }
-    final int techCost = TechTracker.getTechCost(m_player);
-    int money = m_player.getResources().getQuantity(Constants.PUS);
+    final int techCost = TechTracker.getTechCost(player);
+    int money = player.getResources().getQuantity(Constants.PUS);
     if (money < techCost) {
-      final PlayerAttachment pa = PlayerAttachment.get(m_player);
+      final PlayerAttachment pa = PlayerAttachment.get(player);
       if (pa == null) {
         return false;
       }
@@ -188,21 +188,21 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     chargeForTechRolls(rollCount, whoPaysHowMuch);
     int currTokens = 0;
     if (isWW2V3TechModel()) {
-      currTokens = m_player.getResources().getQuantity(Constants.TECH_TOKENS);
+      currTokens = player.getResources().getQuantity(Constants.TECH_TOKENS);
     }
     final GameData data = getData();
-    if (getAvailableTechs(m_player, data).isEmpty()) {
+    if (getAvailableTechs(player, data).isEmpty()) {
       if (isWW2V3TechModel()) {
         final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
-        final String transcriptText = m_player.getName() + " No more available tech advances.";
-        m_bridge.getHistoryWriter().startEvent(transcriptText);
+        final String transcriptText = player.getName() + " No more available tech advances.";
+        bridge.getHistoryWriter().startEvent(transcriptText);
         final Change removeTokens =
-            ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), techTokens, -currTokens);
-        m_bridge.addChange(removeTokens);
+            ChangeFactory.changeResourcesChange(bridge.getPlayerId(), techTokens, -currTokens);
+        bridge.addChange(removeTokens);
       }
       return new TechResults("No more available tech advances.");
     }
-    final String annotation = m_player.getName() + " rolling for tech.";
+    final String annotation = player.getName() + " rolling for tech.";
     final int[] random;
     int techHits;
     int remainder = 0;
@@ -215,25 +215,25 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       techHits = techRolls / diceSides;
       remainder = techRolls % diceSides;
       if (remainder > 0) {
-        random = m_bridge.getRandom(diceSides, 1, m_player, DiceType.TECH, annotation);
+        random = bridge.getRandom(diceSides, 1, player, DiceType.TECH, annotation);
         if (random[0] + 1 <= remainder) {
           techHits++;
         }
       } else {
-        random = m_bridge.getRandom(diceSides, 1, m_player, DiceType.TECH, annotation);
+        random = bridge.getRandom(diceSides, 1, player, DiceType.TECH, annotation);
         remainder = diceSides;
       }
     } else {
-      random = m_bridge.getRandom(diceSides, techRolls, m_player, DiceType.TECH, annotation);
+      random = bridge.getRandom(diceSides, techRolls, player, DiceType.TECH, annotation);
       techHits = getTechHits(random);
     }
     final boolean isRevisedModel = isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel());
     final String directedTechInfo = isRevisedModel ? " for " + techToRollFor.getTechs().get(0) : "";
     final DiceRoll renderDice = (isLowLuckTechOnly() ? new DiceRoll(random, techHits, remainder, false)
         : new DiceRoll(random, techHits, diceSides - 1, true));
-    m_bridge.getHistoryWriter()
+    bridge.getHistoryWriter()
         .startEvent(
-            m_player.getName() + (random.length > 1 ? " roll " : " rolls : ") + MyFormatter.asDice(random)
+            player.getName() + (random.length > 1 ? " roll " : " rolls : ") + MyFormatter.asDice(random)
                 + directedTechInfo + " and gets " + techHits + " " + MyFormatter.pluralize("hit", techHits),
             renderDice);
     if (isWW2V3TechModel()
@@ -241,12 +241,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       m_techCategory = techToRollFor;
       // remove all the tokens
       final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
-      final String transcriptText = m_player.getName() + " removing all Technology Tokens after "
+      final String transcriptText = player.getName() + " removing all Technology Tokens after "
           + (techHits > 0 ? "successful" : "unsuccessful") + " research.";
-      m_bridge.getHistoryWriter().startEvent(transcriptText);
+      bridge.getHistoryWriter().startEvent(transcriptText);
       final Change removeTokens =
-          ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), techTokens, -currTokens);
-      m_bridge.addChange(removeTokens);
+          ChangeFactory.changeResourcesChange(bridge.getPlayerId(), techTokens, -currTokens);
+      bridge.addChange(removeTokens);
     }
     final Collection<TechAdvance> advances;
     if (isRevisedModel) {
@@ -259,7 +259,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       advances = getTechAdvances(techHits);
     }
     // Put in techs so they can be activated later.
-    m_techs.put(m_player, advances);
+    m_techs.put(player, advances);
     final List<String> advancesAsString = new ArrayList<>();
     int count = advances.size();
     final StringBuilder text = new StringBuilder();
@@ -274,22 +274,22 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         text.append(" and ");
       }
     }
-    final String transcriptText = m_player.getName() + " discover " + text.toString();
+    final String transcriptText = player.getName() + " discover " + text.toString();
     if (advances.size() > 0) {
-      m_bridge.getHistoryWriter().startEvent(transcriptText);
+      bridge.getHistoryWriter().startEvent(transcriptText);
       // play a sound
-      getSoundChannel().playSoundForAll(SoundPath.CLIP_TECHNOLOGY_SUCCESSFUL, m_player);
+      getSoundChannel().playSoundForAll(SoundPath.CLIP_TECHNOLOGY_SUCCESSFUL, player);
     } else {
-      getSoundChannel().playSoundForAll(SoundPath.CLIP_TECHNOLOGY_FAILURE, m_player);
+      getSoundChannel().playSoundForAll(SoundPath.CLIP_TECHNOLOGY_FAILURE, player);
     }
-    return new TechResults(random, remainder, techHits, advancesAsString, m_player);
+    return new TechResults(random, remainder, techHits, advancesAsString, player);
   }
 
   boolean checkEnoughMoney(final int rolls, final IntegerMap<PlayerID> whoPaysHowMuch) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
-      final int has = m_bridge.getPlayerId().getResources().getQuantity(pus);
+      final int has = bridge.getPlayerId().getResources().getQuantity(pus);
       return has >= cost;
     } else {
       int runningTotal = 0;
@@ -309,10 +309,10 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
-      final String transcriptText = m_bridge.getPlayerId().getName() + " spend " + cost + " on tech rolls";
-      m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), pus, -cost);
-      m_bridge.addChange(charge);
+      final String transcriptText = bridge.getPlayerId().getName() + " spend " + cost + " on tech rolls";
+      bridge.getHistoryWriter().startEvent(transcriptText);
+      final Change charge = ChangeFactory.changeResourcesChange(bridge.getPlayerId(), pus, -cost);
+      bridge.addChange(charge);
     } else {
       for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
         final PlayerID p = entry.getKey();
@@ -322,15 +322,15 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         }
         cost -= pays;
         final String transcriptText = p.getName() + " spend " + pays + " on tech rolls";
-        m_bridge.getHistoryWriter().startEvent(transcriptText);
+        bridge.getHistoryWriter().startEvent(transcriptText);
         final Change charge = ChangeFactory.changeResourcesChange(p, pus, -pays);
-        m_bridge.addChange(charge);
+        bridge.addChange(charge);
       }
     }
     if (isWW2V3TechModel()) {
       final Resource tokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
-      final Change newTokens = ChangeFactory.changeResourcesChange(m_bridge.getPlayerId(), tokens, rolls);
-      m_bridge.addChange(newTokens);
+      final Change newTokens = ChangeFactory.changeResourcesChange(bridge.getPlayerId(), tokens, rolls);
+      bridge.addChange(newTokens);
     }
   }
 
@@ -362,7 +362,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       return Collections.emptyList();
     }
     final Collection<TechAdvance> newAdvances = new ArrayList<>(hits);
-    final String annotation = m_player.getName() + " rolling to see what tech advances are aquired";
+    final String annotation = player.getName() + " rolling to see what tech advances are aquired";
     final int[] random;
     if (isSelectableTechRoll() || BaseEditDelegate.getEditMode(getData())) {
       final ITripleAPlayer tripleaPlayer = getRemotePlayer();
@@ -373,7 +373,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // generating discrete rolls. messy, can't think of a more elegant way
       // hits guaranteed to be less than available at this point.
       for (int i = 0; i < hits; i++) {
-        int roll = m_bridge.getRandom(available.size() - i, null, DiceType.ENGINE, annotation);
+        int roll = bridge.getRandom(available.size() - i, null, DiceType.ENGINE, annotation);
         for (final int r : rolled) {
           if (roll >= r) {
             roll++;
@@ -392,12 +392,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         rolled.add(index);
       }
     }
-    m_bridge.getHistoryWriter().startEvent("Rolls to resolve tech hits:" + MyFormatter.asDice(random));
+    bridge.getHistoryWriter().startEvent("Rolls to resolve tech hits:" + MyFormatter.asDice(random));
     return newAdvances;
   }
 
   private List<TechAdvance> getAvailableAdvances() {
-    return getAvailableTechs(m_bridge.getPlayerId(), getData());
+    return getAvailableTechs(bridge.getPlayerId(), getData());
   }
 
   public static List<TechAdvance> getAvailableTechs(final PlayerID player, final GameData data) {
@@ -408,13 +408,13 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
 
   private List<TechAdvance> getAvailableAdvancesForCategory(final TechnologyFrontier techCategory) {
     final Collection<TechAdvance> playersAdvances =
-        TechTracker.getCurrentTechAdvances(m_bridge.getPlayerId(), getData());
+        TechTracker.getCurrentTechAdvances(bridge.getPlayerId(), getData());
     final List<TechAdvance> available = Util.difference(techCategory.getTechs(), playersAdvances);
     return available;
   }
 
   public int getTechCost() {
-    m_techCost = TechTracker.getTechCost(m_player);
+    m_techCost = TechTracker.getTechCost(player);
     return m_techCost;
   }
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in delegate classes.  Apparently, delegates themselves are not serializable, but rather save/load their state using a serializable memento via the `saveState()` and `loadState()` methods.

This PR is one part of several PRs in order to keep the review size reasonable.