### PR TITLE
Checkstyle: Fix member name violations in delegate classes (part 2)

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -50,17 +50,16 @@ import games.strategy.util.Tuple;
 @MapSupport
 @AutoSave(beforeStepStart = true, afterStepEnd = true)
 public class BattleDelegate extends BaseTripleADelegate implements IBattleDelegate {
-  protected BattleTracker m_battleTracker = new BattleTracker();
-  // private OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
-  private boolean m_needToInitialize = true;
-  private boolean m_needToScramble = true;
-  private boolean m_needToKamikazeSuicideAttacks = true;
-  private boolean m_needToClearEmptyAirBattleAttacks = true;
-  private boolean m_needToAddBombardmentSources = true;
-  private boolean m_needToRecordBattleStatistics = true;
-  private boolean m_needToCheckDefendingPlanesCanLand = true;
-  private boolean m_needToCleanup = true;
-  protected IBattle m_currentBattle = null;
+  private BattleTracker battleTracker = new BattleTracker();
+  private boolean needToInitialize = true;
+  private boolean needToScramble = true;
+  private boolean needToKamikazeSuicideAttacks = true;
+  private boolean needToClearEmptyAirBattleAttacks = true;
+  private boolean needToAddBombardmentSources = true;
+  private boolean needToRecordBattleStatistics = true;
+  private boolean needToCheckDefendingPlanesCanLand = true;
+  private boolean needToCleanup = true;
+  private IBattle currentBattle = null;
 
   @Override
   public void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge) {
@@ -72,58 +71,58 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     super.start();
     // we may start multiple times due to loading after saving
     // only initialize once
-    if (m_needToInitialize) {
-      doInitialize(m_battleTracker, bridge);
-      m_needToInitialize = false;
+    if (needToInitialize) {
+      doInitialize(battleTracker, bridge);
+      needToInitialize = false;
     }
     // do pre-combat stuff, like scrambling, after we have setup all battles, but before we have bombardment, etc.
     // the order of all of this stuff matters quite a bit.
-    if (m_needToScramble) {
+    if (needToScramble) {
       doScrambling();
-      m_needToScramble = false;
+      needToScramble = false;
     }
-    if (m_needToKamikazeSuicideAttacks) {
+    if (needToKamikazeSuicideAttacks) {
       doKamikazeSuicideAttacks();
-      m_needToKamikazeSuicideAttacks = false;
+      needToKamikazeSuicideAttacks = false;
     }
-    if (m_needToClearEmptyAirBattleAttacks) {
-      clearEmptyAirBattleAttacks(m_battleTracker, bridge);
-      m_needToClearEmptyAirBattleAttacks = false;
+    if (needToClearEmptyAirBattleAttacks) {
+      clearEmptyAirBattleAttacks(battleTracker, bridge);
+      needToClearEmptyAirBattleAttacks = false;
     }
-    if (m_needToAddBombardmentSources) {
+    if (needToAddBombardmentSources) {
       addBombardmentSources();
-      m_needToAddBombardmentSources = false;
+      needToAddBombardmentSources = false;
     }
-    m_battleTracker.fightAirRaidsAndStrategicBombing(bridge);
-    m_battleTracker.fightDefenselessBattles(bridge);
-    m_battleTracker.fightBattleIfOnlyOne(bridge);
+    battleTracker.fightAirRaidsAndStrategicBombing(bridge);
+    battleTracker.fightDefenselessBattles(bridge);
+    battleTracker.fightBattleIfOnlyOne(bridge);
   }
 
   @Override
   public void end() {
-    if (m_needToRecordBattleStatistics) {
+    if (needToRecordBattleStatistics) {
       getBattleTracker().sendBattleRecordsToGameData(bridge);
-      m_needToRecordBattleStatistics = false;
+      needToRecordBattleStatistics = false;
     }
-    if (m_needToCleanup) {
+    if (needToCleanup) {
       getBattleTracker().clearBattleRecords();
       scramblingCleanup();
       airBattleCleanup();
-      m_needToCleanup = false;
+      needToCleanup = false;
     }
-    if (m_needToCheckDefendingPlanesCanLand) {
+    if (needToCheckDefendingPlanesCanLand) {
       checkDefendingPlanesCanLand();
-      m_needToCheckDefendingPlanesCanLand = false;
+      needToCheckDefendingPlanesCanLand = false;
     }
     super.end();
-    m_needToInitialize = true;
-    m_needToScramble = true;
-    m_needToKamikazeSuicideAttacks = true;
-    m_needToClearEmptyAirBattleAttacks = true;
-    m_needToAddBombardmentSources = true;
-    m_needToRecordBattleStatistics = true;
-    m_needToCleanup = true;
-    m_needToCheckDefendingPlanesCanLand = true;
+    needToInitialize = true;
+    needToScramble = true;
+    needToKamikazeSuicideAttacks = true;
+    needToClearEmptyAirBattleAttacks = true;
+    needToAddBombardmentSources = true;
+    needToRecordBattleStatistics = true;
+    needToCleanup = true;
+    needToCheckDefendingPlanesCanLand = true;
   }
 
   @Override
@@ -131,17 +130,16 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final BattleExtendedDelegateState state = new BattleExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_battleTracker = m_battleTracker;
-    // state.m_originalOwnerTracker = m_originalOwnerTracker;
-    state.m_needToInitialize = m_needToInitialize;
-    state.m_needToScramble = m_needToScramble;
-    state.m_needToKamikazeSuicideAttacks = m_needToKamikazeSuicideAttacks;
-    state.m_needToClearEmptyAirBattleAttacks = m_needToClearEmptyAirBattleAttacks;
-    state.m_needToAddBombardmentSources = m_needToAddBombardmentSources;
-    state.m_needToRecordBattleStatistics = m_needToRecordBattleStatistics;
-    state.m_needToCheckDefendingPlanesCanLand = m_needToCheckDefendingPlanesCanLand;
-    state.m_needToCleanup = m_needToCleanup;
-    state.m_currentBattle = m_currentBattle;
+    state.m_battleTracker = battleTracker;
+    state.m_needToInitialize = needToInitialize;
+    state.m_needToScramble = needToScramble;
+    state.m_needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
+    state.m_needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
+    state.m_needToAddBombardmentSources = needToAddBombardmentSources;
+    state.m_needToRecordBattleStatistics = needToRecordBattleStatistics;
+    state.m_needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
+    state.m_needToCleanup = needToCleanup;
+    state.m_currentBattle = currentBattle;
     return state;
   }
 
@@ -149,16 +147,16 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   public void loadState(final Serializable state) {
     final BattleExtendedDelegateState s = (BattleExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_battleTracker = s.m_battleTracker;
-    m_needToInitialize = s.m_needToInitialize;
-    m_needToScramble = s.m_needToScramble;
-    m_needToKamikazeSuicideAttacks = s.m_needToKamikazeSuicideAttacks;
-    m_needToClearEmptyAirBattleAttacks = s.m_needToClearEmptyAirBattleAttacks;
-    m_needToAddBombardmentSources = s.m_needToAddBombardmentSources;
-    m_needToRecordBattleStatistics = s.m_needToRecordBattleStatistics;
-    m_needToCheckDefendingPlanesCanLand = s.m_needToCheckDefendingPlanesCanLand;
-    m_needToCleanup = s.m_needToCleanup;
-    m_currentBattle = s.m_currentBattle;
+    battleTracker = s.m_battleTracker;
+    needToInitialize = s.m_needToInitialize;
+    needToScramble = s.m_needToScramble;
+    needToKamikazeSuicideAttacks = s.m_needToKamikazeSuicideAttacks;
+    needToClearEmptyAirBattleAttacks = s.m_needToClearEmptyAirBattleAttacks;
+    needToAddBombardmentSources = s.m_needToAddBombardmentSources;
+    needToRecordBattleStatistics = s.m_needToRecordBattleStatistics;
+    needToCheckDefendingPlanesCanLand = s.m_needToCheckDefendingPlanesCanLand;
+    needToCleanup = s.m_needToCleanup;
+    currentBattle = s.m_currentBattle;
   }
 
   @Override
@@ -188,37 +186,37 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   @Override
   public String fightCurrentBattle() {
-    if (m_currentBattle == null) {
+    if (currentBattle == null) {
       return null;
     }
     // fight the battle
-    m_currentBattle.fight(bridge);
-    m_currentBattle = null;
+    currentBattle.fight(bridge);
+    currentBattle = null;
     // and were done
     return null;
   }
 
   @Override
   public String fightBattle(final Territory territory, final boolean bombing, final BattleType type) {
-    final IBattle battle = m_battleTracker.getPendingBattle(territory, bombing, type);
-    if (m_currentBattle != null && m_currentBattle != battle) {
-      return "Must finish " + getFightingWord(m_currentBattle) + " in " + m_currentBattle.getTerritory() + " first";
+    final IBattle battle = battleTracker.getPendingBattle(territory, bombing, type);
+    if (currentBattle != null && currentBattle != battle) {
+      return "Must finish " + getFightingWord(currentBattle) + " in " + currentBattle.getTerritory() + " first";
     }
     // does the battle exist
     if (battle == null) {
       return "No pending battle in" + territory.getName();
     }
     // are there battles that must occur first
-    final Collection<IBattle> allMustPrecede = m_battleTracker.getDependentOn(battle);
+    final Collection<IBattle> allMustPrecede = battleTracker.getDependentOn(battle);
     if (!allMustPrecede.isEmpty()) {
       final IBattle firstPrecede = allMustPrecede.iterator().next();
       final String name = firstPrecede.getTerritory().getName();
       return "Must complete " + getFightingWord(firstPrecede) + " in " + name + " first";
     }
-    m_currentBattle = battle;
+    currentBattle = battle;
     // fight the battle
     battle.fight(bridge);
-    m_currentBattle = null;
+    currentBattle = null;
     // and were done
     return null;
   }
@@ -229,7 +227,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   @Override
   public BattleListing getBattles() {
-    return m_battleTracker.getPendingBattleSites();
+    return battleTracker.getPendingBattleSites();
   }
 
   private static boolean isShoreBombardPerGroundUnitRestricted(final GameData data) {
@@ -237,7 +235,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   public BattleTracker getBattleTracker() {
-    return m_battleTracker;
+    return battleTracker;
   }
 
   public IDelegateBridge getBattleBridge() {
@@ -254,7 +252,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Territory, Collection<IBattle>> adjBombardment = getPossibleBombardingTerritories();
     final boolean shoreBombardPerGroundUnitRestricted = isShoreBombardPerGroundUnitRestricted(getData());
     for (final Territory t : adjBombardment.keySet()) {
-      if (!m_battleTracker.hasPendingBattle(t, false)) {
+      if (!battleTracker.hasPendingBattle(t, false)) {
         Collection<IBattle> battles = adjBombardment.get(t);
         battles = CollectionUtils.getMatches(battles, Matches.battleIsAmphibious());
         if (!battles.isEmpty()) {
@@ -300,8 +298,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
    */
   private Map<Territory, Collection<IBattle>> getPossibleBombardingTerritories() {
     final Map<Territory, Collection<IBattle>> possibleBombardingTerritories = new HashMap<>();
-    for (final Territory t : m_battleTracker.getPendingBattleSites(false)) {
-      final IBattle battle = m_battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
+    for (final Territory t : battleTracker.getPendingBattleSites(false)) {
+      final IBattle battle = battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
       // we only care about battles where we must fight
       // this check is really to avoid implementing getAttackingFrom() in other battle subclasses
       if (!(battle instanceof MustFightBattle)) {
@@ -311,7 +309,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Map<Territory, Collection<Unit>> attackingFromMap = ((MustFightBattle) battle).getAttackingFromMap();
       for (final Territory neighbor : ((MustFightBattle) battle).getAttackingFrom()) {
         // we do not allow bombarding from certain sea zones (like if there was a kamikaze suicide attack there, etc)
-        if (m_battleTracker.noBombardAllowedFromHere(neighbor)) {
+        if (battleTracker.noBombardAllowedFromHere(neighbor)) {
           continue;
         }
         final Collection<Unit> neighbourUnits = attackingFromMap.get(neighbor);
@@ -641,10 +639,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
     final Map<Territory, Set<Territory>> scrambleTerrs = new HashMap<>();
     final Set<Territory> territoriesWithBattles =
-        m_battleTracker.getPendingBattleSites().getNormalBattlesIncludingAirBattles();
+        battleTracker.getPendingBattleSites().getNormalBattlesIncludingAirBattles();
     if (toSbr) {
       territoriesWithBattles
-          .addAll(m_battleTracker.getPendingBattleSites().getStrategicBombingRaidsIncludingAirBattles());
+          .addAll(battleTracker.getPendingBattleSites().getStrategicBombingRaidsIncludingAirBattles());
     }
     final Set<Territory> territoriesWithBattlesWater = new HashSet<>();
     final Set<Territory> territoriesWithBattlesLand = new HashSet<>();
@@ -665,7 +663,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           scrambleTerrs.put(battleTerr, canScrambleFrom);
         }
       }
-      final IBattle battle = m_battleTracker.getPendingBattle(battleTerr, false, BattleType.NORMAL);
+      final IBattle battle = battleTracker.getPendingBattle(battleTerr, false, BattleType.NORMAL);
       // do not forget we may already have the territory in the list, so we need to add to the collection, not overwrite
       // it.
       if (battle != null && battle.isAmphibious() && battle instanceof DependentBattle) {
@@ -699,7 +697,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           new HashMap<>();
       // find who we should ask
       PlayerID defender = null;
-      if (m_battleTracker.hasPendingBattle(to, false)) {
+      if (battleTracker.hasPendingBattle(to, false)) {
         defender = AbstractBattle.findDefender(to, player, data);
       }
       for (final Territory from : scrambleTerrs.get(to)) {
@@ -818,8 +816,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       // make sure the units join the battle, or create a new battle.
-      final IBattle bombing = m_battleTracker.getPendingBattle(to, true, null);
-      IBattle battle = m_battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
+      final IBattle bombing = battleTracker.getPendingBattle(to, true, null);
+      IBattle battle = battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
       if (battle == null) {
         final List<Unit> attackingUnits = to.getUnits().getMatches(Matches.unitIsOwnedBy(player));
         if (bombing != null) {
@@ -835,8 +833,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .startEvent(defender.getName() + " scrambles to create a battle in territory " + to.getName());
         // TODO: the attacking sea units do not remember where they came from, so they cannot retreat anywhere. Need to
         // fix.
-        m_battleTracker.addBattle(new RouteScripted(to), attackingUnits, player, bridge, null, null);
-        battle = m_battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
+        battleTracker.addBattle(new RouteScripted(to), attackingUnits, player, bridge, null, null);
+        battle = battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
         if (battle instanceof MustFightBattle) {
           // this is an ugly mess of hacks, but will have to stay here till all transport related code is gutted and
           // refactored.
@@ -876,7 +874,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             mfb.addDependentUnits(dependencies.get(to));
             for (final Territory territoryNeighborToNewBattle : neighborsLand) {
               final IBattle battleInTerritoryNeighborToNewBattle =
-                  m_battleTracker.getPendingBattle(territoryNeighborToNewBattle, false, BattleType.NORMAL);
+                  battleTracker.getPendingBattle(territoryNeighborToNewBattle, false, BattleType.NORMAL);
               if (battleInTerritoryNeighborToNewBattle != null
                   && battleInTerritoryNeighborToNewBattle instanceof MustFightBattle) {
                 final MustFightBattle mfbattleInTerritoryNeighborToNewBattle =
@@ -913,10 +911,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // now make sure any amphibious battles that are dependent on this 'new' sea battle have their dependencies set.
       if (to.isWater()) {
         for (final Territory t : data.getMap().getNeighbors(to, Matches.territoryIsLand())) {
-          final IBattle battleAmphib = m_battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
+          final IBattle battleAmphib = battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
           if (battleAmphib != null) {
-            if (!m_battleTracker.getDependentOn(battle).contains(battleAmphib)) {
-              m_battleTracker.addDependency(battleAmphib, battle);
+            if (!battleTracker.getDependentOn(battle).contains(battleAmphib)) {
+              battleTracker.addDependency(battleAmphib, battle);
             }
             if (battleAmphib instanceof MustFightBattle) {
               // and we want to reset the defenders if the scrambling air has left that battle
@@ -962,7 +960,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         final String historyText;
         if (!mustReturnToBase || !Matches.isTerritoryAllied(u.getOwner(), data).test(originatedFrom)) {
           final Collection<Territory> possible = whereCanAirLand(Collections.singletonList(u), t, u.getOwner(), data,
-              m_battleTracker, carrierCostOfCurrentTerr, 1, !mustReturnToBase);
+              battleTracker, carrierCostOfCurrentTerr, 1, !mustReturnToBase);
           if (possible.size() > 1) {
             landingTerr = getRemotePlayer(u.getOwner()).selectTerritoryForAirToLand(possible, t,
                 "Select territory for air units to land. (Current territory is " + t.getName() + "): "
@@ -1038,7 +1036,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   private void checkDefendingPlanesCanLand() {
     final GameData data = getData();
-    final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = m_battleTracker.getDefendingAirThatCanNotLand();
+    final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = battleTracker.getDefendingAirThatCanNotLand();
     final boolean isWW2v2orIsSurvivingAirMoveToLand = Properties.getWW2V2(data)
         || Properties.getSurvivingAirMoveToLand(data);
     final Predicate<Unit> alliedDefendingAir = Matches.unitIsAir().and(Matches.unitWasScrambled().negate());
@@ -1196,7 +1194,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         .and(Matches.unitIsNotSub());
     final boolean onlyWhereThereAreBattlesOrAmphibious =
         Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data);
-    final Collection<Territory> pendingBattles = m_battleTracker.getPendingBattleSites(false);
+    final Collection<Territory> pendingBattles = battleTracker.getPendingBattleSites(false);
     // create a list of all kamikaze zones, listed by enemy
     final HashMap<PlayerID, Collection<Territory>> kamikazeZonesByEnemy =
         new HashMap<>();
@@ -1233,10 +1231,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             boolean amphib = false;
             final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsLand());
             for (final Territory neighbor : landNeighbors) {
-              final IBattle battle = m_battleTracker.getPendingBattle(neighbor, false, BattleType.NORMAL);
+              final IBattle battle = battleTracker.getPendingBattle(neighbor, false, BattleType.NORMAL);
               if (battle == null) {
                 final Map<Territory, Collection<Unit>> whereFrom =
-                    m_battleTracker.getFinishedBattlesUnitAttackFromMap().get(neighbor);
+                    battleTracker.getFinishedBattlesUnitAttackFromMap().get(neighbor);
                 if (whereFrom != null && whereFrom.containsKey(t)) {
                   amphib = true;
                   break;
@@ -1412,7 +1410,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       bridge.addChange(change);
     }
     // kamikaze suicide attacks, even if unsuccessful, deny the ability to bombard from this sea zone
-    m_battleTracker.addNoBombardAllowedFromHere(location);
+    battleTracker.addNoBombardAllowedFromHere(location);
     // TODO: display this as actual dice for both players
     final Collection<PlayerID> playersInvolved = new ArrayList<>();
     playersInvolved.add(player);
@@ -1532,7 +1530,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   @Override
   public Territory getCurrentBattleTerritory() {
-    final IBattle b = m_currentBattle;
+    final IBattle b = currentBattle;
     if (b != null) {
       return b.getTerritory();
     } else {
@@ -1542,6 +1540,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   @Override
   public IBattle getCurrentBattle() {
-    return m_currentBattle;
+    return currentBattle;
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -17,9 +17,9 @@ import games.strategy.util.IntegerMap;
 
 @MapSupport
 public class BidPurchaseDelegate extends PurchaseDelegate {
-  private int m_bid;
-  private int m_spent;
-  private boolean m_hasBid = false;
+  private int bid;
+  private int spent;
+  private boolean hasBid = false;
 
   private static int getBidAmount(final GameData data, final PlayerID currentPlayer) {
     final String propertyName = currentPlayer.getName() + " bid";
@@ -47,7 +47,7 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   protected boolean canWePurchaseOrRepair() {
     final ResourceCollection bidCollection = new ResourceCollection(getData());
     // TODO: allow bids to have more than just PUs
-    bidCollection.addResource(getData().getResourceList().getResource(Constants.PUS), m_bid);
+    bidCollection.addResource(getData().getResourceList().getResource(Constants.PUS), bid);
     if (player.getProductionFrontier() != null && player.getProductionFrontier().getRules() != null) {
       for (final ProductionRule rule : player.getProductionFrontier().getRules()) {
         if (bidCollection.has(rule.getCosts())) {
@@ -69,30 +69,30 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   protected boolean canAfford(final IntegerMap<Resource> costs, final PlayerID player) {
     final ResourceCollection bidCollection = new ResourceCollection(getData());
     // TODO: allow bids to have more than just PUs
-    bidCollection.addResource(getData().getResourceList().getResource(Constants.PUS), m_bid);
+    bidCollection.addResource(getData().getResourceList().getResource(Constants.PUS), bid);
     return bidCollection.has(costs);
   }
 
   @Override
   public void start() {
     super.start();
-    if (m_hasBid) {
+    if (hasBid) {
       return;
     }
-    m_bid = getBidAmount(bridge.getData(), bridge.getPlayerId());
-    m_spent = 0;
+    bid = getBidAmount(bridge.getData(), bridge.getPlayerId());
+    spent = 0;
   }
 
   @Override
   protected String removeFromPlayer(final IntegerMap<Resource> resources, final CompositeChange change) {
-    m_spent = resources.getInt(super.getData().getResourceList().getResource(Constants.PUS));
-    return (m_bid - m_spent) + " PU unused";
+    spent = resources.getInt(super.getData().getResourceList().getResource(Constants.PUS));
+    return (bid - spent) + " PU unused";
   }
 
   @Override
   public void end() {
     super.end();
-    final int unspent = m_bid - m_spent;
+    final int unspent = bid - spent;
     if (unspent == 0) {
       return;
     }
@@ -101,16 +101,16 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
     final Change unspentChange = ChangeFactory.changeResourcesChange(bridge.getPlayerId(),
         super.getData().getResourceList().getResource(Constants.PUS), unspent);
     bridge.addChange(unspentChange);
-    m_hasBid = false;
+    hasBid = false;
   }
 
   @Override
   public Serializable saveState() {
     final BidPurchaseExtendedDelegateState state = new BidPurchaseExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_bid = m_bid;
-    state.m_hasBid = m_hasBid;
-    state.m_spent = this.m_spent;
+    state.m_bid = bid;
+    state.m_hasBid = hasBid;
+    state.m_spent = this.spent;
     return state;
   }
 
@@ -118,8 +118,8 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   public void loadState(final Serializable state) {
     final BidPurchaseExtendedDelegateState s = (BidPurchaseExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_bid = s.m_bid;
-    m_spent = s.m_spent;
-    m_hasBid = s.m_hasBid;
+    bid = s.m_bid;
+    spent = s.m_spent;
+    hasBid = s.m_hasBid;
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -38,8 +38,8 @@ import games.strategy.util.LocalizeHtml;
  */
 @MapSupport
 public class EndRoundDelegate extends BaseTripleADelegate {
-  private boolean m_gameOver = false;
-  private Collection<PlayerID> m_winners = new ArrayList<>();
+  private boolean gameOver = false;
+  private Collection<PlayerID> winners = new ArrayList<>();
 
   /** Creates a new instance of EndRoundDelegate. */
   public EndRoundDelegate() {}
@@ -47,7 +47,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   @Override
   public void start() {
     super.start();
-    if (m_gameOver) {
+    if (gameOver) {
       return;
     }
     String victoryMessage;
@@ -187,8 +187,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   public Serializable saveState() {
     final EndRoundExtendedDelegateState state = new EndRoundExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_gameOver = m_gameOver;
-    state.m_winners = m_winners;
+    state.m_gameOver = gameOver;
+    state.m_winners = winners;
     return state;
   }
 
@@ -196,8 +196,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final EndRoundExtendedDelegateState s = (EndRoundExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_gameOver = s.m_gameOver;
-    m_winners = s.m_winners;
+    gameOver = s.m_gameOver;
+    winners = s.m_winners;
   }
 
   @Override
@@ -257,11 +257,11 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     // TO NOT USE playerBridge, because it might be null here! use aBridge instead.
     // If the game is over, we need to be able to alert all UIs to that fact.
     // The display object can send a message to all UIs.
-    if (!m_gameOver) {
-      m_gameOver = true;
-      m_winners = winners;
+    if (!gameOver) {
+      gameOver = true;
+      this.winners = winners;
       bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_GAME_WON,
-          ((m_winners != null && !m_winners.isEmpty()) ? m_winners.iterator().next()
+          ((this.winners != null && !this.winners.isEmpty()) ? this.winners.iterator().next()
               : PlayerID.NULL_PLAYERID));
       // send a message to everyone's screen except the HOST (there is no 'current player' for the end round delegate)
       final String title = "Victory Achieved"
@@ -298,10 +298,10 @@ public class EndRoundDelegate extends BaseTripleADelegate {
    * if null, the game is not over yet.
    */
   public Collection<PlayerID> getWinners() {
-    if (!m_gameOver) {
+    if (!gameOver) {
       return null;
     }
-    return m_winners;
+    return winners;
   }
 
   private boolean isWW2V2() {

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -32,7 +32,7 @@ import games.strategy.util.IntegerMap;
  * This delegate is only supposed to be run once, per game, at the start of the game.
  */
 public class InitializationDelegate extends BaseTripleADelegate {
-  private boolean m_needToInitialize = true;
+  private boolean needToInitialize = true;
 
   /** Creates a new instance of InitializationDelegate. */
   public InitializationDelegate() {}
@@ -46,9 +46,9 @@ public class InitializationDelegate extends BaseTripleADelegate {
   @Override
   public void start() {
     super.start();
-    if (m_needToInitialize) {
+    if (needToInitialize) {
       init(bridge);
-      m_needToInitialize = false;
+      needToInitialize = false;
     }
   }
 
@@ -62,7 +62,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
     final InitializationExtendedDelegateState state = new InitializationExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_needToInitialize = this.m_needToInitialize;
+    state.m_needToInitialize = this.needToInitialize;
     return state;
   }
 
@@ -70,7 +70,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final InitializationExtendedDelegateState s = (InitializationExtendedDelegateState) state;
     super.loadState(s.superState);
-    this.m_needToInitialize = s.m_needToInitialize;
+    this.needToInitialize = s.m_needToInitialize;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -52,9 +52,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   // needToInitialize means we only do certain things once, so that if a game is saved then
   // loaded, they aren't done again
-  private boolean m_needToInitialize = true;
-  private boolean m_needToDoRockets = true;
-  private IntegerMap<Territory> m_PUsLost = new IntegerMap<>();
+  private boolean needToInitialize = true;
+  private boolean needToDoRockets = true;
+  private IntegerMap<Territory> pusLost = new IntegerMap<>();
 
   public MoveDelegate() {}
 
@@ -67,7 +67,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   public void start() {
     super.start();
     final GameData data = getData();
-    if (m_needToInitialize) {
+    if (needToInitialize) {
 
       // territory property changes triggered at beginning of combat move
       // TODO create new delegate called "start of turn" and move them there.
@@ -159,7 +159,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (GameStepPropertiesHelper.isResetUnitStateAtStart(data)) {
         resetUnitStateAndDelegateState();
       }
-      m_needToInitialize = false;
+      needToInitialize = false;
     }
   }
 
@@ -194,9 +194,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // WW2V2/WW2V3, fires at end of combat move
     // WW2V1, fires at end of non combat move
     if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (m_needToDoRockets && TechTracker.hasRocket(bridge.getPlayerId())) {
+      if (needToDoRockets && TechTracker.hasRocket(bridge.getPlayerId())) {
         RocketsFireHelper.fireRockets(bridge, bridge.getPlayerId());
-        m_needToDoRockets = false;
+        needToDoRockets = false;
       }
     }
 
@@ -211,17 +211,17 @@ public class MoveDelegate extends AbstractMoveDelegate {
           CollectionUtils.getMatches(data.getUnits().getUnits(), Matches.unitHasMoved().and(Matches.unitIsNotAir()));
       bridge.addChange(ChangeFactory.markNoMovementChange(alreadyMovedNonAirUnits));
     }
-    m_needToInitialize = true;
-    m_needToDoRockets = true;
+    needToInitialize = true;
+    needToDoRockets = true;
   }
 
   @Override
   public Serializable saveState() {
     final MoveExtendedDelegateState state = new MoveExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = m_needToInitialize;
-    state.m_needToDoRockets = m_needToDoRockets;
-    state.m_PUsLost = m_PUsLost;
+    state.m_needToInitialize = needToInitialize;
+    state.m_needToDoRockets = needToDoRockets;
+    state.m_PUsLost = pusLost;
     return state;
   }
 
@@ -229,9 +229,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
   public void loadState(final Serializable state) {
     final MoveExtendedDelegateState s = (MoveExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_needToInitialize = s.m_needToInitialize;
-    m_needToDoRockets = s.m_needToDoRockets;
-    m_PUsLost = s.m_PUsLost;
+    needToInitialize = s.m_needToInitialize;
+    needToDoRockets = s.m_needToDoRockets;
+    pusLost = s.m_PUsLost;
   }
 
   @Override
@@ -263,7 +263,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   private void resetUnitStateAndDelegateState() {
     // while not a 'unit state', this is fine here for now. since we only have one instance of this delegate, as long as
     // it gets cleared once per player's turn block, we are fine.
-    m_PUsLost.clear();
+    pusLost.clear();
     final Change change = getResetUnitStateChange(getData());
     if (!change.isEmpty()) {
       // if no non-combat occurred, we may have cleanup left from combat
@@ -639,11 +639,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   @Override
   public int pusAlreadyLost(final Territory t) {
-    return m_PUsLost.getInt(t);
+    return pusLost.getInt(t);
   }
 
   @Override
   public void pusLost(final Territory t, final int amt) {
-    m_PUsLost.add(t, amt);
+    pusLost.add(t, amt);
   }
 }

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -49,14 +49,14 @@ import games.strategy.util.IntegerMap;
  */
 @MapSupport
 public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDelegate {
-  private boolean m_needToInitialize = true;
+  private boolean needToInitialize = true;
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
 
   @Override
   public void start() {
     super.start();
     final GameData data = getData();
-    if (m_needToInitialize) {
+    if (needToInitialize) {
       if (Properties.getTriggers(data)) {
         // First set up a match for what we want to have fire as a default in this delegate. List out as a composite
         // match OR.
@@ -84,21 +84,21 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           TriggerAttachment.triggerPurchase(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
         }
       }
-      m_needToInitialize = false;
+      needToInitialize = false;
     }
   }
 
   @Override
   public void end() {
     super.end();
-    m_needToInitialize = true;
+    needToInitialize = true;
   }
 
   @Override
   public Serializable saveState() {
     final PurchaseExtendedDelegateState state = new PurchaseExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = m_needToInitialize;
+    state.m_needToInitialize = needToInitialize;
     return state;
   }
 
@@ -106,7 +106,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   public void loadState(final Serializable state) {
     final PurchaseExtendedDelegateState s = (PurchaseExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.m_needToInitialize;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -40,9 +40,8 @@ import games.strategy.util.IntegerMap;
  */
 @MapSupport
 public class SpecialMoveDelegate extends AbstractMoveDelegate {
-  private boolean m_needToInitialize = true;
+  private boolean needToInitialize = true;
 
-  // private boolean m_allowAirborne = true;
   public SpecialMoveDelegate() {}
 
   @Override
@@ -60,24 +59,24 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     final boolean onlyWhereUnderAttackAlready =
         Properties.getAirborneAttacksOnlyInExistingBattles(data);
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(data);
-    if (m_needToInitialize && onlyWhereUnderAttackAlready) {
+    if (needToInitialize && onlyWhereUnderAttackAlready) {
       // we do this to clear any 'finishedBattles' and also to create battles for units that didn't move
       BattleDelegate.doInitialize(battleTracker, bridge);
-      m_needToInitialize = false;
+      needToInitialize = false;
     }
   }
 
   @Override
   public void end() {
     super.end();
-    m_needToInitialize = true;
+    needToInitialize = true;
   }
 
   @Override
   public Serializable saveState() {
     final SpecialMoveExtendedDelegateState state = new SpecialMoveExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = m_needToInitialize;
+    state.m_needToInitialize = needToInitialize;
     return state;
   }
 
@@ -85,7 +84,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   public void loadState(final Serializable state) {
     final SpecialMoveExtendedDelegateState s = (SpecialMoveExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.m_needToInitialize;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -26,7 +26,7 @@ import games.strategy.util.Util;
  */
 @MapSupport
 public class TechActivationDelegate extends BaseTripleADelegate {
-  private boolean m_needToInitialize = true;
+  private boolean needToInitialize = true;
 
   /** Creates new TechActivationDelegate. */
   public TechActivationDelegate() {}
@@ -39,7 +39,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   public void start() {
     super.start();
     final GameData data = getData();
-    if (!m_needToInitialize) {
+    if (!needToInitialize) {
       return;
     }
     // Activate techs
@@ -81,13 +81,13 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       }
     }
     shareTechnology();
-    m_needToInitialize = false;
+    needToInitialize = false;
   }
 
   @Override
   public void end() {
     super.end();
-    m_needToInitialize = true;
+    needToInitialize = true;
   }
 
   @Override
@@ -124,7 +124,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   public Serializable saveState() {
     final TechActivationExtendedDelegateState state = new TechActivationExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = m_needToInitialize;
+    state.m_needToInitialize = needToInitialize;
     return state;
   }
 
@@ -132,7 +132,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final TechActivationExtendedDelegateState s = (TechActivationExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.m_needToInitialize;
   }
 
   // Return string representing all advances in collection

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -42,10 +42,10 @@ import games.strategy.util.Util;
  */
 @MapSupport
 public class TechnologyDelegate extends BaseTripleADelegate implements ITechDelegate {
-  private int m_techCost;
-  private HashMap<PlayerID, Collection<TechAdvance>> m_techs;
-  private TechnologyFrontier m_techCategory;
-  private boolean m_needToInitialize = true;
+  private int techCost;
+  private HashMap<PlayerID, Collection<TechAdvance>> techs;
+  private TechnologyFrontier techCategory;
+  private boolean needToInitialize = true;
 
   /** Creates new TechnolgoyDelegate. */
   public TechnologyDelegate() {}
@@ -53,8 +53,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   @Override
   public void initialize(final String name, final String displayName) {
     super.initialize(name, displayName);
-    m_techs = new HashMap<>();
-    m_techCost = -1;
+    techs = new HashMap<>();
+    techCost = -1;
   }
 
   @Override
@@ -65,7 +65,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   @Override
   public void start() {
     super.start();
-    if (!m_needToInitialize) {
+    if (!needToInitialize) {
       return;
     }
     if (Properties.getTriggers(getData())) {
@@ -90,21 +90,21 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
             null, null, true, true, true, true);
       }
     }
-    m_needToInitialize = false;
+    needToInitialize = false;
   }
 
   @Override
   public void end() {
     super.end();
-    m_needToInitialize = true;
+    needToInitialize = true;
   }
 
   @Override
   public Serializable saveState() {
     final TechnologyExtendedDelegateState state = new TechnologyExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = m_needToInitialize;
-    state.m_techs = m_techs;
+    state.m_needToInitialize = needToInitialize;
+    state.m_techs = techs;
     return state;
   }
 
@@ -112,8 +112,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   public void loadState(final Serializable state) {
     final TechnologyExtendedDelegateState s = (TechnologyExtendedDelegateState) state;
     super.loadState(s.superState);
-    m_needToInitialize = s.m_needToInitialize;
-    m_techs = s.m_techs;
+    needToInitialize = s.m_needToInitialize;
+    techs = s.m_techs;
   }
 
   @Override
@@ -155,7 +155,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   public Map<PlayerID, Collection<TechAdvance>> getAdvances() {
-    return m_techs;
+    return techs;
   }
 
   private boolean isWW2V2() {
@@ -238,7 +238,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
             renderDice);
     if (isWW2V3TechModel()
         && (techHits > 0 || Properties.getRemoveAllTechTokensAtEndOfTurn(data))) {
-      m_techCategory = techToRollFor;
+      techCategory = techToRollFor;
       // remove all the tokens
       final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
       final String transcriptText = player.getName() + " removing all Technology Tokens after "
@@ -259,7 +259,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       advances = getTechAdvances(techHits);
     }
     // Put in techs so they can be activated later.
-    m_techs.put(player, advances);
+    techs.put(player, advances);
     final List<String> advancesAsString = new ArrayList<>();
     int count = advances.size();
     final StringBuilder text = new StringBuilder();
@@ -347,7 +347,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   private Collection<TechAdvance> getTechAdvances(int hits) {
     final List<TechAdvance> available;
     if (hits > 0 && isWW2V3TechModel()) {
-      available = getAvailableAdvancesForCategory(m_techCategory);
+      available = getAvailableAdvancesForCategory(techCategory);
       hits = 1;
     } else {
       available = getAvailableAdvances();
@@ -414,8 +414,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   public int getTechCost() {
-    m_techCost = TechTracker.getTechCost(player);
-    return m_techCost;
+    techCost = TechTracker.getTechCost(player);
+    return techCost;
   }
 
   @Override


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in delegate classes.  Apparently, delegates themselves are not serializable, but rather save/load their state using a serializable memento via the `saveState()` and `loadState()` methods.

This PR is the last part of several PRs in order to keep the review size reasonable.