### PR TITLE
Remove unnecessary else clauses (part 1)

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -344,11 +344,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
 
   private static String trimMessage(final String originalMessage) {
     // don't allow messages that are too long
-    if (originalMessage.length() > 200) {
-      return originalMessage.substring(0, 199) + "...";
-    } else {
-      return originalMessage;
-    }
+    return (originalMessage.length() > 200) ? originalMessage.substring(0, 199) + "..." : originalMessage;
   }
 
   private final Action setStatusAction = SwingAction.of("Status...", e -> {

--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -85,11 +85,7 @@ public class AllianceTracker implements Serializable {
 
   public Collection<String> getAlliancesPlayerIsIn(final PlayerID player) {
     final Collection<String> alliancesPlayerIsIn = alliances.get(player);
-    if (!alliancesPlayerIsIn.isEmpty()) {
-      return alliancesPlayerIsIn;
-    } else {
-      return Collections.singleton(player.getName());
-    }
+    return !alliancesPlayerIsIn.isEmpty() ? alliancesPlayerIsIn : Collections.singleton(player.getName());
   }
 
   Set<PlayerID> getAllies(final PlayerID currentPlayer) {

--- a/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -35,9 +35,8 @@ public class BattleRecordsList extends GameDataComponent {
     final BattleRecords current = recordList.get(round);
     if (current == null) {
       throw new IllegalStateException("Trying to remove records for round that does not exist");
-    } else {
-      current.removeRecord(other);
     }
+    current.removeRecord(other);
   }
 
   public BattleRecords getCurrentRound() {
@@ -46,11 +45,7 @@ public class BattleRecordsList extends GameDataComponent {
 
   private BattleRecords getCurrentRoundCopy() {
     final BattleRecords current = battleRecords.get(getData().getSequence().getRound());
-    if (current == null) {
-      return new BattleRecords();
-    } else {
-      return new BattleRecords(current);
-    }
+    return (current == null) ? new BattleRecords() : new BattleRecords(current);
   }
 
   public Map<Integer, BattleRecords> getBattleRecordsMap() {

--- a/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -50,9 +50,8 @@ public class DoubleProperty extends AEditableProperty {
       throw new RuntimeException("Double and Number properties are no longer stored as Strings. "
           + "You should delete your option cache, located at "
           + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
-    } else {
-      m_value = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
     }
+    m_value = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -102,20 +102,14 @@ public class DownloadFileDescription {
    * @return Name of the zip file.
    */
   String getMapZipFileName() {
-    if (url != null && url.contains("/")) {
-      return url.substring(url.lastIndexOf('/') + 1, url.length());
-    } else {
-      return "";
-    }
+    return (url != null && url.contains("/")) ? url.substring(url.lastIndexOf('/') + 1, url.length()) : "";
   }
 
   /** Translates the stored URL into a github new issue link. */
   String getFeedbackUrl() {
-    if (url.contains("github.com") && url.contains("/releases/")) {
-      return url.substring(0, url.indexOf("/releases/")) + "/issues/new";
-    } else {
-      return "";
-    }
+    return (url.contains("github.com") && url.contains("/releases/"))
+        ? url.substring(0, url.indexOf("/releases/")) + "/issues/new"
+        : "";
   }
 
   /** File reference for where to install the file. */

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -30,11 +30,7 @@ public class DownloadRunnable {
    * we assume a local file reference and parse that.
    */
   public List<DownloadFileDescription> getDownloads() {
-    if (beginsWithHttpProtocol(urlString)) {
-      return downloadFile();
-    } else {
-      return readLocalFile();
-    }
+    return beginsWithHttpProtocol(urlString) ? downloadFile() : readLocalFile();
   }
 
   private static boolean beginsWithHttpProtocol(final String urlString) {

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -24,14 +24,10 @@ class FileSystemAccessStrategy {
 
     if (!potentialFile.exists()) {
       return Optional.empty();
-    } else {
-      final DownloadFileProperties props = DownloadFileProperties.loadForZip(potentialFile);
-      if (props.getVersion() == null) {
-        return Optional.empty();
-      } else {
-        return Optional.of(props.getVersion());
-      }
     }
+
+    final DownloadFileProperties props = DownloadFileProperties.loadForZip(potentialFile);
+    return (props.getVersion() == null) ? Optional.empty() : Optional.of(props.getVersion());
   }
 
   static void remove(final List<DownloadFileDescription> toRemove, final DefaultListModel<String> listModel) {
@@ -117,9 +113,8 @@ class FileSystemAccessStrategy {
       if (i > maxMapsToList) {
         sb.append("<li>...</li>");
         break;
-      } else {
-        sb.append("<li>").append(outputFunction.apply(mapList.get(i))).append("</li>");
       }
+      sb.append("<li>").append(outputFunction.apply(mapList.get(i))).append("</li>");
     }
     return sb.toString();
   }

--- a/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -155,9 +155,8 @@ public class DefaultPlayerBridge implements IPlayerBridge {
       } catch (final InvocationTargetException ite) {
         if (!game.isGameOver()) {
           throw ite.getCause();
-        } else {
-          throw new GameOverException("Game Over Exception!");
         }
+        throw new GameOverException("Game Over Exception!");
       } catch (final RemoteNotFoundException rnfe) {
         throw new GameOverException("Game Over!");
       }

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -42,11 +42,7 @@ public class AIUtils {
   static int getCost(final UnitType unitType, final PlayerID player, final GameData data) {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final ProductionRule rule = getProductionRule(unitType, player);
-    if (rule == null) {
-      return Integer.MAX_VALUE;
-    } else {
-      return rule.getCosts().getInt(pus);
-    }
+    return (rule == null) ? Integer.MAX_VALUE : rule.getCosts().getInt(pus);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -79,11 +79,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   public List<PlayerID> getPlayers() {
-    if (m_players.isEmpty()) {
-      return new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo()));
-    } else {
-      return m_players;
-    }
+    return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
   }
 
   public void clearPlayers() {
@@ -353,13 +349,13 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
           && !terrs[1].equals("enemy")) {
         // Get the list of territories
         return getListedTerritories(terrs, true, true);
-      } else {
-        final Set<Territory> territories = getTerritoriesBasedOnStringName(terrs[1], players, data);
-        // set it a second time, since getTerritoriesBasedOnStringName also sets it (so do it
-        setTerritoryCount(String.valueOf(terrs[0]));
-        // after the method call).
-        return territories;
       }
+
+      final Set<Territory> territories = getTerritoriesBasedOnStringName(terrs[1], players, data);
+      // set it a second time, since getTerritoriesBasedOnStringName also sets it (so do it
+      setTerritoryCount(String.valueOf(terrs[0]));
+      // after the method call).
+      return territories;
     } else {
       // Get the list of territories
       return getListedTerritories(terrs, true, true);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -110,11 +110,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
 
   protected PlayerID getUnitsOwner(final Collection<Unit> units) {
     // if we are not in edit mode, return player. if we are in edit mode, we use whoever's units these are.
-    if (units.isEmpty() || !BaseEditDelegate.getEditMode(getData())) {
-      return player;
-    } else {
-      return units.iterator().next().getOwner();
-    }
+    return (units.isEmpty() || !BaseEditDelegate.getEditMode(getData())) ? player : units.iterator().next().getOwner();
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1178,21 +1178,21 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
                 currentAvailablePlacementForOtherProducers.put(potentialOtherProducer, potential);
                 productionThatCanBeTakenOverFromThisPlacement = maxProductionThatCanBeTakenOverFromThisPlacement;
                 break;
+              }
+
+              final int needed =
+                  maxProductionThatCanBeTakenOverFromThisPlacement - productionThatCanBeTakenOverFromThisPlacement;
+              final int surplus = potential - needed;
+              if (surplus > 0) {
+                currentAvailablePlacementForOtherProducers.put(potentialOtherProducer, surplus);
+                productionThatCanBeTakenOverFromThisPlacement += needed;
               } else {
-                final int needed =
-                    maxProductionThatCanBeTakenOverFromThisPlacement - productionThatCanBeTakenOverFromThisPlacement;
-                final int surplus = potential - needed;
-                if (surplus > 0) {
-                  currentAvailablePlacementForOtherProducers.put(potentialOtherProducer, surplus);
-                  productionThatCanBeTakenOverFromThisPlacement += needed;
-                } else {
-                  currentAvailablePlacementForOtherProducers.put(potentialOtherProducer, 0);
-                  productionThatCanBeTakenOverFromThisPlacement += potential;
-                  notUsableAsOtherProducers.add(potentialOtherProducer);
-                }
-                if (surplus >= 0) {
-                  break;
-                }
+                currentAvailablePlacementForOtherProducers.put(potentialOtherProducer, 0);
+                productionThatCanBeTakenOverFromThisPlacement += potential;
+                notUsableAsOtherProducers.add(potentialOtherProducer);
+              }
+              if (surplus >= 0) {
+                break;
               }
             }
             if (productionThatCanBeTakenOverFromThisPlacement > maxProductionThatCanBeTakenOverFromThisPlacement) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -150,13 +150,11 @@ public class AirMovementValidator {
   }
 
   private static int getMovementLeftForAirUnitNotMovedYet(final Unit airBeingValidated, final Route route) {
-    if (route.getEnd().getUnits().getUnits().contains(airBeingValidated)) {
-      // they are not being moved, they are already at the end
-      return ((TripleAUnit) airBeingValidated).getMovementLeft();
-    } else {
-      // they are being moved (they are still at the start location)
-      return route.getMovementLeft(airBeingValidated);
-    }
+    return route.getEnd().getUnits().getUnits().contains(airBeingValidated)
+        // they are not being moved, they are already at the end
+        ? ((TripleAUnit) airBeingValidated).getMovementLeft()
+        // they are being moved (they are still at the start location)
+        : route.getMovementLeft(airBeingValidated);
   }
 
   private static IntegerMap<Territory> populateStaticAlliedAndBuildingCarrierCapacity(
@@ -562,11 +560,11 @@ public class AirMovementValidator {
           Matches.airCanFlyOver(player, data, areNeutralsPassableByAir));
       return (neutralViolatingRoute != null && neutralViolatingRoute.getMovementCost(unit) <= movementLeft
           && getNeutralCharge(data, neutralViolatingRoute) <= player.getResources().getQuantity(Constants.PUS));
-    } else {
-      final Route noNeutralRoute = data.getMap().getRoute(currentSpot, landingSpot,
-          Matches.airCanFlyOver(player, data, areNeutralsPassableByAir));
-      return (noNeutralRoute != null && noNeutralRoute.getMovementCost(unit) <= movementLeft);
     }
+
+    final Route noNeutralRoute = data.getMap().getRoute(currentSpot, landingSpot,
+        Matches.airCanFlyOver(player, data, areNeutralsPassableByAir));
+    return noNeutralRoute != null && noNeutralRoute.getMovementCost(unit) <= movementLeft;
   }
 
   /**
@@ -641,9 +639,9 @@ public class AirMovementValidator {
       final int capacity = carrierCapacity(friendly, territory);
       final int cost = carrierCost(friendly);
       return capacity >= cost;
-    } else {
-      return data.getRelationshipTracker().canLandAirUnitsOnOwnedLand(player, territory.getOwner());
     }
+
+    return data.getRelationshipTracker().canLandAirUnitsOnOwnedLand(player, territory.getOwner());
   }
 
   private static Collection<Unit> getAirThatMustLandOnCarriers(final GameData data, final Collection<Unit> ownedAir,
@@ -700,14 +698,14 @@ public class AirMovementValidator {
             }
           }
           return cargo;
-        } else {
-          // capacity = zero 0
-          return 0;
         }
-      } else {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        return ua.getCarrierCapacity();
+
+        // capacity = zero 0
+        return 0;
       }
+
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return ua.getCarrierCapacity();
     }
     return 0;
   }

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1531,11 +1531,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   @Override
   public Territory getCurrentBattleTerritory() {
     final IBattle b = currentBattle;
-    if (b != null) {
-      return b.getTerritory();
-    } else {
-      return null;
-    }
+    return (b != null) ? b.getTerritory() : null;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -46,23 +46,23 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       } else {
         return null;
       }
-    } else {
-      // we can place on territories we own
-      if (units.stream().anyMatch(Matches.unitIsSea())) {
-        return "Cant place sea units on land";
-      } else if (to.getOwner() == null) {
-        return "You dont own " + to.getName();
-      } else if (!to.getOwner().equals(player)) {
-        final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
-        if (pa != null && pa.getGiveUnitControl() != null && pa.getGiveUnitControl().contains(player)) {
-          return null;
-        } else if (to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
-          return null;
-        }
-        return "You dont own " + to.getName();
-      } else {
+    }
+
+    // we can place on territories we own
+    if (units.stream().anyMatch(Matches.unitIsSea())) {
+      return "Cant place sea units on land";
+    } else if (to.getOwner() == null) {
+      return "You dont own " + to.getName();
+    } else if (!to.getOwner().equals(player)) {
+      final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
+      if (pa != null && pa.getGiveUnitControl() != null && pa.getGiveUnitControl().contains(player)) {
+        return null;
+      } else if (to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
         return null;
       }
+      return "You dont own " + to.getName();
+    } else {
+      return null;
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -369,10 +369,9 @@ public class DiceRoll implements Externalizable {
     if (Properties.getLow_Luck(bridge.getData())) {
       return rollDiceLowLuck(units, defending, player, bridge, battle, annotation, territoryEffects,
           allEnemyUnitsAliveOrWaitingToDie);
-    } else {
-      return rollDiceNormal(units, defending, player, bridge, battle, annotation, territoryEffects,
-          allEnemyUnitsAliveOrWaitingToDie);
     }
+    return rollDiceNormal(units, defending, player, bridge, battle, annotation, territoryEffects,
+        allEnemyUnitsAliveOrWaitingToDie);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -159,9 +159,8 @@ public class BattleRecords implements Serializable {
           if (currentRecord.containsKey(guid)) {
             throw new IllegalStateException("Should not be adding battle record for player " + p.getName()
                 + " when they are already on the record. " + "Trying to add: " + br.toString());
-          } else {
-            currentRecord.put(guid, br);
           }
+          currentRecord.put(guid, br);
         }
         m_records.put(p, currentRecord);
       } else {
@@ -181,9 +180,8 @@ public class BattleRecords implements Serializable {
         final GUID guid = entry.getKey();
         if (!currentRecord.containsKey(guid)) {
           throw new IllegalStateException("Trying to remove a battle record but record does not exist");
-        } else {
-          currentRecord.remove(guid);
         }
+        currentRecord.remove(guid);
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -307,11 +307,7 @@ public class BattleDisplay extends JPanel {
   }
 
   Territory getRetreat(final String message, final Collection<Territory> possible, final boolean submerge) {
-    if (!submerge || possible.size() > 1) {
-      return getRetreatInternal(message, possible);
-    } else {
-      return getSubmerge(message);
-    }
+    return (!submerge || possible.size() > 1) ? getRetreatInternal(message, possible) : getSubmerge(message);
   }
 
   private Territory getSubmerge(final String message) {

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -366,15 +366,15 @@ public class BattlePanel extends ActionPanel {
     if (battleId == null) {
       return getCasualtiesAa(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
           allowMultipleHitsPerUnit);
-    } else {
-      // something is wong
-      if (!ensureBattleIsDisplayed(battleId)) {
-        System.out.println("Battle Not Displayed?? " + message);
-        return new CasualtyDetails(defaultCasualties.getKilled(), defaultCasualties.getDamaged(), true);
-      }
-      return battleDisplay.getCasualties(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
-          allowMultipleHitsPerUnit);
     }
+
+    // something is wong
+    if (!ensureBattleIsDisplayed(battleId)) {
+      System.out.println("Battle Not Displayed?? " + message);
+      return new CasualtyDetails(defaultCasualties.getKilled(), defaultCasualties.getDamaged(), true);
+    }
+    return battleDisplay.getCasualties(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
+        allowMultipleHitsPerUnit);
   }
 
   private CasualtyDetails getCasualtiesAa(final Collection<Unit> selectFrom,

--- a/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -125,13 +125,13 @@ public class EconomyPanel extends AbstractStatPanel {
     public synchronized int getRowCount() {
       if (!isDirty) {
         return collectedData.length;
-      } else {
-        gameData.acquireReadLock();
-        try {
-          return gameData.getPlayerList().size() + getAlliances().size();
-        } finally {
-          gameData.releaseReadLock();
-        }
+      }
+
+      gameData.acquireReadLock();
+      try {
+        return gameData.getPlayerList().size() + getAlliances().size();
+      } finally {
+        gameData.releaseReadLock();
       }
     }
 

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -51,13 +51,13 @@ public class ExtendedStats extends StatPanel {
     for (final Resource r : resources) {
       if (r.getName().equals(Constants.PUS) || r.getName().equals(Constants.TECH_TOKENS)) {
         continue;
-      } else {
-        final GenericResourceStat resourceStat = new GenericResourceStat();
-        resourceStat.init(r.getName());
-        final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
-        statsExtended.add(resourceStat);
-        this.statsExtended = statsExtended.toArray(new IStat[statsExtended.size()]);
       }
+
+      final GenericResourceStat resourceStat = new GenericResourceStat();
+      resourceStat.init(r.getName());
+      final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
+      statsExtended.add(resourceStat);
+      this.statsExtended = statsExtended.toArray(new IStat[statsExtended.size()]);
     }
     // add tech related stuff
     if (Properties.getTechDevelopment(data)) {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -41,13 +41,13 @@ public class BattleDrawable extends TerritoryDrawable implements IDrawable {
           attacker = p;
           draw = true;
           break;
-        } else {
-          // O(n^2), but n is usually 2, and almost always < 10
-          for (final PlayerID p2 : players) {
-            if (data.getRelationshipTracker().isAtWar(p, p2)) {
-              draw = true;
-              break;
-            }
+        }
+
+        // O(n^2), but n is usually 2, and almost always < 10
+        for (final PlayerID p2 : players) {
+          if (data.getRelationshipTracker().isAtWar(p, p2)) {
+            draw = true;
+            break;
           }
         }
       } else {

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -242,12 +242,7 @@ public class AutoPlacementFinder {
    * of course, without the quotes.
    */
   private static String getMapDirectory() {
-    final String mapDir = JOptionPane.showInputDialog(null, "Enter the map name (ie. folder name)");
-    if (mapDir != null) {
-      return mapDir;
-    } else {
-      return null;
-    }
+    return JOptionPane.showInputDialog(null, "Enter the map name (ie. folder name)");
   }
 
   private static File getMapPropertiesFile(final String mapDir) {
@@ -270,11 +265,7 @@ public class AutoPlacementFinder {
   private static String getUnitsScale() {
     final String unitsScale = JOptionPane.showInputDialog(null,
         "Enter the unit's scale (zoom).\r\n(e.g. 1.25, 1, 0.875, 0.8333, 0.75, 0.6666, 0.5625, 0.5)");
-    if (unitsScale != null) {
-      return unitsScale;
-    } else {
-      return "1";
-    }
+    return (unitsScale != null) ? unitsScale : "1";
   }
 
   /**

--- a/src/main/java/tools/image/FileOpen.java
+++ b/src/main/java/tools/image/FileOpen.java
@@ -101,10 +101,6 @@ public class FileOpen {
    * @return java.lang.String
    */
   public String getPathString() {
-    if (file == null) {
-      return null;
-    } else {
-      return file.getPath();
-    }
+    return (file == null) ? null : file.getPath();
   }
 }

--- a/src/main/java/tools/image/FileSave.java
+++ b/src/main/java/tools/image/FileSave.java
@@ -82,10 +82,6 @@ public class FileSave {
    * Returns the directory path as as string.
    */
   public String getPathString() {
-    if (file == null) {
-      return null;
-    } else {
-      return file.getPath();
-    }
+    return (file == null) ? null : file.getPath();
   }
 }


### PR DESCRIPTION
This PR removes unnecessary `else` clauses as identified by static analysis.  In some cases, the surrounding `else` clause was simply removed and the code re-indented.  In other cases, an `if`-`else` statement that returned a value from both branches was changed to a single return using the ternary operator.

It is recommended to review this PR with whitespace changes ignored (`?w=1`).

This PR is one part of several PRs in order to keep the review size reasonable.