### PR TITLE
Checkstyle: Fix violations in InvocationResults

### DIFF
--- a/src/main/java/games/strategy/engine/message/RemoteMethodCallResults.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCallResults.java
@@ -7,43 +7,43 @@ import java.io.ObjectOutput;
 
 /**
  * The results of a method execution.
- * Note that either one of m_rVal or m_exception will be null,
+ * Note that either one of returnValue or exception will be null,
  * since the method can either throw or return
  */
 public class RemoteMethodCallResults implements Externalizable {
   private static final long serialVersionUID = 4562274411264858613L;
-  private Object m_rVal;
+  private Object returnValue;
   // throwable implements Serializable
-  private Throwable m_exception;
+  private Throwable exception;
 
   public RemoteMethodCallResults() {}
 
   public RemoteMethodCallResults(final Object returnValue) {
-    m_rVal = returnValue;
-    m_exception = null;
+    this.returnValue = returnValue;
+    exception = null;
   }
 
   public RemoteMethodCallResults(final Throwable exception) {
-    m_rVal = null;
-    m_exception = exception;
+    returnValue = null;
+    this.exception = exception;
   }
 
   public Throwable getException() {
-    return m_exception;
+    return exception;
   }
 
   public Object getRVal() {
-    return m_rVal;
+    return returnValue;
   }
 
   @Override
   public void writeExternal(final ObjectOutput out) throws IOException {
-    if (m_rVal != null) {
+    if (returnValue != null) {
       out.write(1);
-      out.writeObject(m_rVal);
+      out.writeObject(returnValue);
     } else {
       out.write(0);
-      out.writeObject(m_exception);
+      out.writeObject(exception);
     }
   }
 
@@ -51,16 +51,16 @@ public class RemoteMethodCallResults implements Externalizable {
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
     final boolean hasReturnValue = in.read() == 1;
     if (hasReturnValue) {
-      m_rVal = in.readObject();
+      returnValue = in.readObject();
     } else {
-      m_exception = (Throwable) in.readObject();
+      exception = (Throwable) in.readObject();
     }
   }
 
   @Override
   public String toString() {
-    final String exceptionMsg = (m_exception == null) ? "none" : m_exception.toString();
-    return "Return value: '" + m_rVal + "', exception: " + exceptionMsg;
+    final String exceptionMsg = (exception == null) ? "none" : exception.toString();
+    return "Return value: '" + returnValue + "', exception: " + exceptionMsg;
   }
 
 }

--- a/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -101,7 +101,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
   }
 
   private void results(final HubInvocationResults results, final INode from) {
-    final GUID methodId = results.methodCallID;
+    final GUID methodId = results.methodCallId;
     final InvocationInProgress invocationInProgress = invocations.get(methodId);
     final boolean done = invocationInProgress.process(results, from);
     if (done) {

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
@@ -8,7 +8,9 @@ import java.io.ObjectOutput;
 import games.strategy.engine.message.RemoteMethodCallResults;
 import games.strategy.net.GUID;
 
-// the results of a remote invocation
+/**
+ * The results of a remote invocation.
+ */
 public abstract class InvocationResults implements Externalizable {
   private static final long serialVersionUID = -382704036681832123L;
   public RemoteMethodCallResults results;

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
@@ -12,7 +12,7 @@ import games.strategy.net.GUID;
 public abstract class InvocationResults implements Externalizable {
   private static final long serialVersionUID = -382704036681832123L;
   public RemoteMethodCallResults results;
-  public GUID methodCallID;
+  public GUID methodCallId;
 
   public InvocationResults() {}
 
@@ -24,25 +24,25 @@ public abstract class InvocationResults implements Externalizable {
       throw new IllegalArgumentException("Null id");
     }
     this.results = results;
-    this.methodCallID = methodCallId;
+    this.methodCallId = methodCallId;
   }
 
   @Override
   public String toString() {
-    return "Invocation results for method id:" + methodCallID + " results:" + results;
+    return "Invocation results for method id:" + methodCallId + " results:" + results;
   }
 
   @Override
   public void writeExternal(final ObjectOutput out) throws IOException {
     results.writeExternal(out);
-    methodCallID.writeExternal(out);
+    methodCallId.writeExternal(out);
   }
 
   @Override
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
     results = new RemoteMethodCallResults();
     results.readExternal(in);
-    methodCallID = new GUID();
-    methodCallID.readExternal(in);
+    methodCallId = new GUID();
+    methodCallId.readExternal(in);
   }
 }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -293,7 +293,7 @@ public class UnifiedMessenger {
       // maybe an attempt to spoof a message
       assertIsServer(from);
       final SpokeInvocationResults spokeInvocationResults = (SpokeInvocationResults) msg;
-      final GUID methodId = spokeInvocationResults.methodCallID;
+      final GUID methodId = spokeInvocationResults.methodCallId;
       // both of these should already be populated
       // this list should be a synchronized list so we can do the add
       // all

--- a/src/main/java/games/strategy/net/GUID.java
+++ b/src/main/java/games/strategy/net/GUID.java
@@ -23,14 +23,14 @@ public final class GUID implements Externalizable {
   // this coupled with the unique vm prefix comprise
   // our unique id
   private static AtomicInteger lastId = new AtomicInteger();
-  private int m_id;
-  private VMID m_prefix;
+  private int id;
+  private VMID prefix;
 
   public GUID() {
-    m_id = lastId.getAndIncrement();
-    m_prefix = vmPrefix;
+    id = lastId.getAndIncrement();
+    prefix = vmPrefix;
     // handle wrap around if needed
-    if (m_id < 0) {
+    if (id < 0) {
       vmPrefix = new VMID();
       lastId = new AtomicInteger();
     }
@@ -39,16 +39,16 @@ public final class GUID implements Externalizable {
   public GUID(final VMID prefix, final int id) {
     checkNotNull(prefix);
 
-    m_id = id;
-    m_prefix = prefix;
+    this.id = id;
+    this.prefix = prefix;
   }
 
   public int getId() {
-    return m_id;
+    return id;
   }
 
   public VMID getPrefix() {
-    return m_prefix;
+    return prefix;
   }
 
   @Override
@@ -63,28 +63,28 @@ public final class GUID implements Externalizable {
     if (other == this) {
       return true;
     }
-    return this.m_id == other.m_id && (other.m_prefix == this.m_prefix || other.m_prefix.equals(this.m_prefix));
+    return this.id == other.id && (other.prefix == this.prefix || other.prefix.equals(this.prefix));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(m_id, m_prefix);
+    return Objects.hash(id, prefix);
   }
 
   @Override
   public String toString() {
-    return "GUID:" + m_prefix + ":" + m_id;
+    return "GUID:" + prefix + ":" + id;
   }
 
   @Override
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
-    m_id = in.readInt();
-    m_prefix = (VMID) in.readObject();
+    id = in.readInt();
+    prefix = (VMID) in.readObject();
   }
 
   @Override
   public void writeExternal(final ObjectOutput out) throws IOException {
-    out.writeInt(m_id);
-    out.writeObject(m_prefix);
+    out.writeInt(id);
+    out.writeObject(prefix);
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName, AbbreviationAsWordInName, and JavadocMethod rules in the `InvocationResults` and related class.  These classes are `Externalizable`, and unlike a `Serializable` class, the field names are not written to the stream.  Therefore, fields renames should not cause any compatibility issues.

#### Testing

I ran a network game between a server from this branch and a 3635 client.  I ensured the game hit the `readExternal()` and `writeExternal()` methods of `InvocationResults`.  I played two turns, including combat, and no issues were observed.