### PR TITLE
Remove unnecessary else clauses (part 2)

### DIFF
--- a/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -199,10 +199,6 @@ public class HeadlessChat implements IChatListener, IChatPanel {
 
   private static String trimMessage(final String originalMessage) {
     // dont allow messages that are too long
-    if (originalMessage.length() > 200) {
-      return originalMessage.substring(0, 199) + "...";
-    } else {
-      return originalMessage;
-    }
+    return (originalMessage.length() > 200) ? originalMessage.substring(0, 199) + "..." : originalMessage;
   }
 }

--- a/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -47,9 +47,8 @@ public class NumberProperty extends AEditableProperty {
       throw new RuntimeException(
           "Number properties are no longer stored as Strings. You should delete your option cache, located at "
               + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
-    } else {
-      m_value = (Integer) value;
     }
+    m_value = (Integer) value;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -182,11 +182,7 @@ public class GameSelectorModel extends Observable {
   }
 
   public synchronized String getFileName() {
-    if (gameData == null) {
-      return "-";
-    } else {
-      return fileName;
-    }
+    return (gameData == null) ? "-" : fileName;
   }
 
   public synchronized String getGameName() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -345,14 +345,10 @@ public class GameSelectorPanel extends JPanel implements Observer {
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();
       final String dirName = fileDialog.getDirectory();
-      if (fileName == null) {
-        return null;
-      } else {
-        return new File(dirName, fileName);
-      }
-    } else {
-      return GameRunner.showSaveGameFileChooser().orElse(null);
+      return (fileName == null) ? null : new File(dirName, fileName);
     }
+
+    return GameRunner.showSaveGameFileChooser().orElse(null);
   }
 
   private void selectGameFile(final boolean saved) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -342,10 +342,10 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
         layoutComponents();
       });
       return;
-    } else {
-      loadAll();
-      layoutComponents();
     }
+
+    loadAll();
+    layoutComponents();
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -138,10 +138,9 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     final GameChooserEntry other = (GameChooserEntry) obj;
     if (gameData == null && other.gameData != null) {
       return false;
-    } else {
-      if (other.gameData == null) {
-        return false;
-      }
+    }
+    if (other.gameData == null) {
+      return false;
     }
     return this.gameNameAndMapNameProperty.equals(other.gameNameAndMapNameProperty);
   }

--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -100,11 +100,7 @@ public class History extends DefaultTreeModel {
     final List<Change> deltaChanges =
         changes.subList(Math.min(firstChange, lastChange), Math.max(firstChange, lastChange));
     final Change compositeChange = new CompositeChange(deltaChanges);
-    if (lastChange >= firstChange) {
-      return compositeChange;
-    } else {
-      return compositeChange.invert();
-    }
+    return (lastChange >= firstChange) ? compositeChange : compositeChange.invert();
   }
 
   public synchronized void gotoNode(final HistoryNode node) {

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -183,11 +183,10 @@ public final class LobbyLoginValidator implements ILoginValidator {
     if (propertiesReadFromClient.containsKey(REGISTER_NEW_USER_KEY)) {
       return createUser(propertiesReadFromClient, clientName);
     }
-    if (propertiesReadFromClient.containsKey(ANONYMOUS_LOGIN)) {
-      return anonymousLogin(propertiesReadFromClient, clientName);
-    } else {
-      return validatePassword(propertiesReadFromClient, clientName);
-    }
+
+    return propertiesReadFromClient.containsKey(ANONYMOUS_LOGIN)
+      ? anonymousLogin(propertiesReadFromClient, clientName)
+      : validatePassword(propertiesReadFromClient, clientName);
   }
 
   private static String getBanDurationBreakdown(final Timestamp stamp) {
@@ -279,11 +278,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
         return DBUser.getUserNameValidationErrorMessage(hostName);
       }
     } else {
-      if (DBUser.isValidUserName(userName)) {
-        return null;
-      } else {
-        return DBUser.getUserNameValidationErrorMessage(userName);
-      }
+      return DBUser.isValidUserName(userName) ? null : DBUser.getUserNameValidationErrorMessage(userName);
     }
     return null;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -960,10 +960,10 @@ class ProCombatMoveAI {
       // Determine whether all attacks are successful or try to hold fewer territories
       if (territoryToRemove == null) {
         break;
-      } else {
-        prioritizedTerritories.remove(territoryToRemove);
-        ProLogger.debug("Removing " + territoryToRemove.getTerritory().getName());
       }
+
+      prioritizedTerritories.remove(territoryToRemove);
+      ProLogger.debug("Removing " + territoryToRemove.getTerritory().getName());
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -202,22 +202,22 @@ final class ProTechAI {
                 availInf += 2;
                 availOther += 1;
                 continue;
-              } else {
-                int inf = 2;
-                int other = 1;
-                for (final Unit checkUnit : thisTransUnits) {
-                  if (Matches.unitIsLandTransportable().test(checkUnit)) {
-                    inf--;
-                  }
-                  if (Matches.unitIsNotLandTransportable().test(checkUnit)) {
-                    inf--;
-                    other--;
-                  }
-                  loadedUnits.add(checkUnit);
-                }
-                availInf += inf;
-                availOther += other;
               }
+
+              int inf = 2;
+              int other = 1;
+              for (final Unit checkUnit : thisTransUnits) {
+                if (Matches.unitIsLandTransportable().test(checkUnit)) {
+                  inf--;
+                }
+                if (Matches.unitIsNotLandTransportable().test(checkUnit)) {
+                  inf--;
+                  other--;
+                }
+                loadedUnits.add(checkUnit);
+              }
+              availInf += inf;
+              availOther += other;
             }
             final Set<Territory> transNeighbors =
                 data.getMap().getNeighbors(t4, Matches.isTerritoryAllied(enemyPlayer, data));
@@ -623,15 +623,15 @@ final class ProTechAI {
       current = q.remove();
       if (visited.getInt(current) == distance) {
         break;
-      } else {
-        for (final Territory neighbor : data.getMap().getNeighbors(current, canGo)) {
-          if (!visited.keySet().contains(neighbor)) {
-            q.add(neighbor);
-            final int dist = visited.getInt(current) + 1;
-            visited.put(neighbor, dist);
-            if (dist == distance && endCondition.test(neighbor)) {
-              frontier.add(neighbor);
-            }
+      }
+
+      for (final Territory neighbor : data.getMap().getNeighbors(current, canGo)) {
+        if (!visited.keySet().contains(neighbor)) {
+          q.add(neighbor);
+          final int dist = visited.getInt(current) + 1;
+          visited.put(neighbor, dist);
+          if (dist == distance && endCondition.test(neighbor)) {
+            frontier.add(neighbor);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -290,11 +290,18 @@ public class ProTerritory {
     return battleResult;
   }
 
+  /**
+   * Returns a description of the battle result in this territory.
+   */
   public String getResultString() {
-    return (battleResult == null)
-        ? "territory=" + territory.getName()
-        : "territory=" + territory.getName() + ", win%=" + battleResult.getWinPercentage() + ", TUVSwing="
-            + battleResult.getTuvSwing() + ", hasRemainingLandUnit=" + battleResult.isHasLandUnitRemaining();
+    final StringBuilder sb = new StringBuilder();
+    sb.append("territory=").append(territory.getName());
+    if (battleResult != null) {
+      sb.append(", win%=").append(battleResult.getWinPercentage());
+      sb.append(", TUVSwing=").append(battleResult.getTuvSwing());
+      sb.append(", hasRemainingLandUnit=").append(battleResult.isHasLandUnitRemaining());
+    }
+    return sb.toString();
   }
 
   public void setCantMoveUnits(final List<Unit> cantMoveUnits) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -132,13 +132,13 @@ public class ProTerritory {
   public List<Unit> getAllDefendersForCarrierCalcs(final GameData data, final PlayerID player) {
     if (Properties.getProduceNewFightersOnOldCarriers(data)) {
       return getAllDefenders();
-    } else {
-      final List<Unit> defenders =
-          CollectionUtils.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate());
-      defenders.addAll(units);
-      defenders.addAll(tempUnits);
-      return defenders;
     }
+
+    final List<Unit> defenders =
+        CollectionUtils.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate());
+    defenders.addAll(units);
+    defenders.addAll(tempUnits);
+    return defenders;
   }
 
   public List<Unit> getMaxDefenders() {
@@ -291,12 +291,10 @@ public class ProTerritory {
   }
 
   public String getResultString() {
-    if (battleResult == null) {
-      return "territory=" + territory.getName();
-    } else {
-      return "territory=" + territory.getName() + ", win%=" + battleResult.getWinPercentage() + ", TUVSwing="
-          + battleResult.getTuvSwing() + ", hasRemainingLandUnit=" + battleResult.isHasLandUnitRemaining();
-    }
+    return (battleResult == null)
+        ? "territory=" + territory.getName()
+        : "territory=" + territory.getName() + ", win%=" + battleResult.getWinPercentage() + ", TUVSwing="
+            + battleResult.getTuvSwing() + ", hasRemainingLandUnit=" + battleResult.isHasLandUnitRemaining();
   }
 
   public void setCantMoveUnits(final List<Unit> cantMoveUnits) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -600,9 +600,8 @@ public class ProTerritoryManager {
               if (!myRoute.getMiddleSteps().isEmpty()) {
                 eliminatedTerritories.addAll(myRoute.getMiddleSteps()); // Add failed canal territories to list
                 continue;
-              } else {
-                break;
               }
+              break;
             }
             final int myRouteLength = myRoute.numberOfSteps();
             if (myRouteLength > range) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -46,9 +46,9 @@ public class ProLogSettings implements Serializable {
       }
       lastSettings = result;
       return result;
-    } else {
-      return lastSettings;
     }
+
+    return lastSettings;
   }
 
   static void saveSettings(final ProLogSettings settings) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -158,14 +158,12 @@ public class ProOddsCalculator {
     // Create battle result object
     final List<Territory> territoryList = new ArrayList<>();
     territoryList.add(t);
-    if (!territoryList.isEmpty() && territoryList.stream().allMatch(Matches.territoryIsLand())) {
-      return new ProBattleResult(winPercentage, tuvSwing,
-          averageAttackersRemaining.stream().anyMatch(Matches.unitIsLand()), averageAttackersRemaining,
-          averageDefendersRemaining, results.getAverageBattleRoundsFought());
-    } else {
-      return new ProBattleResult(winPercentage, tuvSwing, !averageAttackersRemaining.isEmpty(),
-          averageAttackersRemaining, averageDefendersRemaining, results.getAverageBattleRoundsFought());
-    }
+    return (!territoryList.isEmpty() && territoryList.stream().allMatch(Matches.territoryIsLand()))
+        ? new ProBattleResult(winPercentage, tuvSwing,
+            averageAttackersRemaining.stream().anyMatch(Matches.unitIsLand()), averageAttackersRemaining,
+            averageDefendersRemaining, results.getAverageBattleRoundsFought())
+        : new ProBattleResult(winPercentage, tuvSwing, !averageAttackersRemaining.isEmpty(),
+            averageAttackersRemaining, averageDefendersRemaining, results.getAverageBattleRoundsFought());
   }
 
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -191,11 +191,7 @@ public class ProSortMoveOptionsUtils {
       }
       final double attackEfficiency2 = (double) minPower2 / ProData.unitValueMap.getInt(o2.getKey().getType());
       if (attackEfficiency1 != attackEfficiency2) {
-        if (attackEfficiency1 < attackEfficiency2) {
-          return 1;
-        } else {
-          return -1;
-        }
+        return (attackEfficiency1 < attackEfficiency2) ? 1 : -1;
       }
 
       // Check if unit types are equal and is air then sort by average distance

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -179,11 +179,7 @@ public class ProUtils {
         minDistance = distance;
       }
     }
-    if (minDistance < 10) {
-      return minDistance;
-    } else {
-      return -1;
-    }
+    return (minDistance < 10) ? minDistance : -1;
   }
 
   public static int getClosestEnemyOrNeutralLandTerritoryDistance(final GameData data, final PlayerID player,
@@ -206,11 +202,7 @@ public class ProUtils {
         minDistance = distance;
       }
     }
-    if (minDistance < 10) {
-      return minDistance;
-    } else {
-      return -1;
-    }
+    return (minDistance < 10) ? minDistance : -1;
   }
 
   public static int getClosestEnemyLandTerritoryDistanceOverWater(final GameData data, final PlayerID player,
@@ -226,11 +218,7 @@ public class ProUtils {
         minDistance = distance;
       }
     }
-    if (minDistance < 10) {
-      return minDistance;
-    } else {
-      return -1;
-    }
+    return (minDistance < 10) ? minDistance : -1;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -102,9 +102,8 @@ public class PlayerAttachment extends DefaultAttachment {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
           throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
-        } else {
-          types.add(ut);
         }
+        types.add(ut);
       }
     }
     m_placementLimit.add(Triple.of(max, s[1], types));
@@ -151,9 +150,8 @@ public class PlayerAttachment extends DefaultAttachment {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
           throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
-        } else {
-          types.add(ut);
         }
+        types.add(ut);
       }
     }
     m_movementLimit.add(Triple.of(max, s[1], types));
@@ -200,9 +198,8 @@ public class PlayerAttachment extends DefaultAttachment {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
           throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
-        } else {
-          types.add(ut);
         }
+        types.add(ut);
       }
     }
     m_attackingLimit.add(Triple.of(max, s[1], types));

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -50,19 +50,19 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       if (playersToSearch == null) {
         throw new IllegalStateException(
             "PoliticalActionAttachment: No attachment for:" + player.getName() + " with name: " + nameOfAttachment);
-      } else {
-        for (final PlayerID otherPlayer : playersToSearch) {
-          if (otherPlayer == player) {
-            continue;
-          }
-          paa = (PoliticalActionAttachment) otherPlayer.getAttachment(nameOfAttachment);
-          if (paa != null) {
-            return paa;
-          }
-        }
-        throw new IllegalStateException(
-            "PoliticalActionAttachment: No attachment for:" + player.getName() + " with name: " + nameOfAttachment);
       }
+
+      for (final PlayerID otherPlayer : playersToSearch) {
+        if (otherPlayer == player) {
+          continue;
+        }
+        paa = (PoliticalActionAttachment) otherPlayer.getAttachment(nameOfAttachment);
+        if (paa != null) {
+          return paa;
+        }
+      }
+      throw new IllegalStateException(
+          "PoliticalActionAttachment: No attachment for:" + player.getName() + " with name: " + nameOfAttachment);
     }
     return paa;
   }

--- a/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
@@ -16,11 +16,7 @@ public class GenericTechAdvance extends TechAdvance {
 
   @Override
   public String getProperty() {
-    if (m_advance != null) {
-      return m_advance.getProperty();
-    } else {
-      return getName();
-    }
+    return (m_advance != null) ? m_advance.getProperty() : getName();
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -345,9 +345,8 @@ public final class Matches {
       if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(unit.getData())) {
         final TripleAUnit taUnit = (TripleAUnit) unit;
         return taUnit.getUnitDamage() >= taUnit.getHowMuchDamageCanThisUnitTakeTotal(unit, t);
-      } else {
-        return false;
       }
+      return false;
     };
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -511,11 +511,9 @@ public class MoveValidator {
       final Collection<Unit> matches = CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
       if (!matches.isEmpty() && matches.stream().allMatch(Matches.unitIsSub())) {
         // this is ok unless there are destroyer on the path
-        if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
-          return result.setErrorReturnResult("Cannot move submarines under destroyers");
-        } else {
-          return result;
-        }
+        return MoveValidator.enemyDestroyerOnPath(route, player, data)
+          ? result.setErrorReturnResult("Cannot move submarines under destroyers")
+          : result;
       }
     }
     if (onlyIgnoredUnitsOnPath(route, player, data, true)) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -417,11 +417,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
 
     @Override
     public IRemotePlayer getRemotePlayer(final PlayerID id) {
-      if (id.equals(attacker)) {
-        return attackingPlayer;
-      } else {
-        return defendingPlayer;
-      }
+      return id.equals(attacker) ? attackingPlayer : defendingPlayer;
     }
 
     @Override
@@ -605,38 +601,38 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
           return possibleTerritories.iterator().next();
         }
         return null;
-      } else {
-        final MustFightBattle battle = getBattle();
-        if (battle == null) {
-          return null;
-        }
-        if (retreatAfterRound > -1 && battle.getBattleRound() >= retreatAfterRound) {
-          return possibleTerritories.iterator().next();
-        }
-        if (!retreatWhenOnlyAirLeft && retreatAfterXUnitsLeft <= -1) {
-          return null;
-        }
-        final Collection<Unit> unitsLeft = isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits();
-        final Collection<Unit> airLeft = CollectionUtils.getMatches(unitsLeft, Matches.unitIsAir());
-        if (retreatWhenOnlyAirLeft) {
-          // lets say we have a bunch of 3 attack air unit, and a 4 attack non-air unit,
-          // and we want to retreat when we have all air units left + that 4 attack non-air (cus it gets taken
-          // casualty
-          // last)
-          // then we add the number of air, to the retreat after X left number (which we would set to '1')
-          int retreatNum = airLeft.size();
-          if (retreatAfterXUnitsLeft > 0) {
-            retreatNum += retreatAfterXUnitsLeft;
-          }
-          if (retreatNum >= unitsLeft.size()) {
-            return possibleTerritories.iterator().next();
-          }
-        }
-        if (retreatAfterXUnitsLeft > -1 && retreatAfterXUnitsLeft >= unitsLeft.size()) {
-          return possibleTerritories.iterator().next();
-        }
+      }
+
+      final MustFightBattle battle = getBattle();
+      if (battle == null) {
         return null;
       }
+      if (retreatAfterRound > -1 && battle.getBattleRound() >= retreatAfterRound) {
+        return possibleTerritories.iterator().next();
+      }
+      if (!retreatWhenOnlyAirLeft && retreatAfterXUnitsLeft <= -1) {
+        return null;
+      }
+      final Collection<Unit> unitsLeft = isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits();
+      final Collection<Unit> airLeft = CollectionUtils.getMatches(unitsLeft, Matches.unitIsAir());
+      if (retreatWhenOnlyAirLeft) {
+        // lets say we have a bunch of 3 attack air unit, and a 4 attack non-air unit,
+        // and we want to retreat when we have all air units left + that 4 attack non-air (cus it gets taken
+        // casualty
+        // last)
+        // then we add the number of air, to the retreat after X left number (which we would set to '1')
+        int retreatNum = airLeft.size();
+        if (retreatAfterXUnitsLeft > 0) {
+          retreatNum += retreatAfterXUnitsLeft;
+        }
+        if (retreatNum >= unitsLeft.size()) {
+          return possibleTerritories.iterator().next();
+        }
+      }
+      if (retreatAfterXUnitsLeft > -1 && retreatAfterXUnitsLeft >= unitsLeft.size()) {
+        return possibleTerritories.iterator().next();
+      }
+      return null;
     }
 
     // Added new collection autoKilled to handle killing units prior to casualty selection

--- a/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -136,11 +136,7 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitDamage damaged, final UnitEnable disabled) {
     final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, damaged == UnitDamage.DAMAGED,
         disabled == UnitEnable.DISABLED);
-    if (image.isPresent()) {
-      return new JLabel(image.get());
-    } else {
-      return new JLabel();
-    }
+    return image.isPresent() ? new JLabel(image.get()) : new JLabel();
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -136,7 +136,7 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitDamage damaged, final UnitEnable disabled) {
     final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, damaged == UnitDamage.DAMAGED,
         disabled == UnitEnable.DISABLED);
-    return image.isPresent() ? new JLabel(image.get()) : new JLabel();
+    return image.map(JLabel::new).orElseGet(JLabel::new);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -112,11 +112,9 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   private PlayerID getUnitOwner(final Collection<Unit> units) {
-    if (BaseEditDelegate.getEditMode(getData()) && units != null && !units.isEmpty()) {
-      return units.iterator().next().getOwner();
-    } else {
-      return getCurrentPlayer();
-    }
+    return (BaseEditDelegate.getEditMode(getData()) && units != null && !units.isEmpty())
+      ? units.iterator().next().getOwner()
+      : getCurrentPlayer();
   }
 
   /**
@@ -388,11 +386,9 @@ public class MovePanel extends AbstractMovePanel {
   private Route getRoute(final Territory start, final Territory end, final Collection<Unit> selectedUnits) {
     getData().acquireReadLock();
     try {
-      if (forced == null) {
-        return getRouteNonForced(start, end, selectedUnits);
-      } else {
-        return getRouteForced(start, end, selectedUnits);
-      }
+      return (forced == null)
+          ? getRouteNonForced(start, end, selectedUnits)
+          : getRouteForced(start, end, selectedUnits);
     } finally {
       getData().releaseReadLock();
     }
@@ -1106,10 +1102,9 @@ public class MovePanel extends AbstractMovePanel {
         if (canMove.isEmpty()) {
           cancelMove();
           return;
-        } else {
-          selectedUnits.clear();
-          selectedUnits.addAll(canMove);
         }
+        selectedUnits.clear();
+        selectedUnits.addAll(canMove);
       } else {
         // keep a map of the max number of each eligible unitType that can be chosen
         final IntegerMap<UnitType> maxMap = new IntegerMap<>();

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -379,11 +379,7 @@ public class ObjectivePanel extends AbstractStatPanel {
 
     @Override
     public String getColumnName(final int col) {
-      if (col == 0) {
-        return "Done";
-      } else {
-        return "Objective Name";
-      }
+      return (col == 0) ? "Done" : "Objective Name";
     }
 
     @Override
@@ -395,13 +391,13 @@ public class ObjectivePanel extends AbstractStatPanel {
     public synchronized int getRowCount() {
       if (!isDirty) {
         return collectedData.length;
-      } else {
-        gameData.acquireReadLock();
-        try {
-          return getRowTotal();
-        } finally {
-          gameData.releaseReadLock();
-        }
+      }
+
+      gameData.acquireReadLock();
+      try {
+        return getRowTotal();
+      } finally {
+        gameData.releaseReadLock();
       }
     }
 

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -121,48 +121,48 @@ public class PoliticalStateOverview extends JPanel {
       final RelationshipType relType) {
     if (!editable) {
       return new JLabel(relType.getName());
-    } else {
-      final JButton button = new JButton(relType.getName());
-      button.addActionListener(e -> {
-        final List<RelationshipType> types =
-            new ArrayList<>(data.getRelationshipTypeList().getAllRelationshipTypes());
-        types.remove(data.getRelationshipTypeList().getNullRelation());
-        types.remove(data.getRelationshipTypeList().getSelfRelation());
-        final Object[] possibilities = types.toArray();
-        final RelationshipType chosenRelationship =
-            (RelationshipType) JOptionPane.showInputDialog(PoliticalStateOverview.this,
-                "Change Current Relationship between " + player1.getName() + " and " + player2.getName(),
-                "Change Current Relationship", JOptionPane.PLAIN_MESSAGE, null, possibilities, relType);
-        if (chosenRelationship != null) {
-          // remove any old ones
-          final Iterator<Triple<PlayerID, PlayerID, RelationshipType>> iter = editChanges.iterator();
-          while (iter.hasNext()) {
-            final Triple<PlayerID, PlayerID, RelationshipType> changesSoFar = iter.next();
-            if ((player1.equals(changesSoFar.getFirst()) && player2.equals(changesSoFar.getSecond()))
-                || (player2.equals(changesSoFar.getFirst()) && player1.equals(changesSoFar.getSecond()))) {
-              iter.remove();
-            }
-          }
-
-          // see if there is actually a change
-          final RelationshipType actualRelationship;
-          data.acquireReadLock();
-          try {
-            actualRelationship = data.getRelationshipTracker().getRelationshipType(player1, player2);
-          } finally {
-            data.releaseReadLock();
-          }
-          if (!chosenRelationship.equals(actualRelationship)) {
-            // add new change
-            editChanges.add(Triple.of(player1, player2, chosenRelationship));
-          }
-          // redraw everything
-          redrawPolitics();
-        }
-      });
-      button.setBackground(getRelationshipTypeColor(relType));
-      return button;
     }
+
+    final JButton button = new JButton(relType.getName());
+    button.addActionListener(e -> {
+      final List<RelationshipType> types =
+          new ArrayList<>(data.getRelationshipTypeList().getAllRelationshipTypes());
+      types.remove(data.getRelationshipTypeList().getNullRelation());
+      types.remove(data.getRelationshipTypeList().getSelfRelation());
+      final Object[] possibilities = types.toArray();
+      final RelationshipType chosenRelationship =
+          (RelationshipType) JOptionPane.showInputDialog(PoliticalStateOverview.this,
+              "Change Current Relationship between " + player1.getName() + " and " + player2.getName(),
+              "Change Current Relationship", JOptionPane.PLAIN_MESSAGE, null, possibilities, relType);
+      if (chosenRelationship != null) {
+        // remove any old ones
+        final Iterator<Triple<PlayerID, PlayerID, RelationshipType>> iter = editChanges.iterator();
+        while (iter.hasNext()) {
+          final Triple<PlayerID, PlayerID, RelationshipType> changesSoFar = iter.next();
+          if ((player1.equals(changesSoFar.getFirst()) && player2.equals(changesSoFar.getSecond()))
+              || (player2.equals(changesSoFar.getFirst()) && player1.equals(changesSoFar.getSecond()))) {
+            iter.remove();
+          }
+        }
+
+        // see if there is actually a change
+        final RelationshipType actualRelationship;
+        data.acquireReadLock();
+        try {
+          actualRelationship = data.getRelationshipTracker().getRelationshipType(player1, player2);
+        } finally {
+          data.releaseReadLock();
+        }
+        if (!chosenRelationship.equals(actualRelationship)) {
+          // add new change
+          editChanges.add(Triple.of(player1, player2, chosenRelationship));
+        }
+        // redraw everything
+        redrawPolitics();
+      }
+    });
+    button.setBackground(getRelationshipTypeColor(relType));
+    return button;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -91,17 +91,18 @@ public class PoliticsPanel extends ActionPanel {
     if (this.firstRun && validPoliticalActions.isEmpty()) {
       // No Valid political actions, do nothing
       return null;
-    } else {
-      if (this.firstRun) {
-        ClipPlayer.play(SoundPath.CLIP_PHASE_POLITICS, getCurrentPlayer());
-      }
-      SwingUtilities.invokeLater(() -> {
-        selectPoliticalActionButton.setEnabled(true);
-        doneButton.setEnabled(true);
-        // press the politics button for us.
-        selectPoliticalActionAction.actionPerformed(null);
-      });
     }
+
+    if (this.firstRun) {
+      ClipPlayer.play(SoundPath.CLIP_PHASE_POLITICS, getCurrentPlayer());
+    }
+    SwingUtilities.invokeLater(() -> {
+      selectPoliticalActionButton.setEnabled(true);
+      doneButton.setEnabled(true);
+      // press the politics button for us.
+      selectPoliticalActionAction.actionPerformed(null);
+    });
+
     waitForRelease();
     return choice;
   }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -561,11 +561,7 @@ public class PlacementPicker extends JFrame {
   private static String getUnitsScale() {
     final String unitsScale = JOptionPane.showInputDialog(null,
         "Enter the unit's scale (zoom).\r\n(e.g. 1.25, 1, 0.875, 0.8333, 0.75, 0.6666, 0.5625, 0.5)");
-    if (unitsScale != null) {
-      return unitsScale;
-    } else {
-      return "1";
-    }
+    return (unitsScale != null) ? unitsScale : "1";
   }
 
   private static String getValue(final String arg) {

--- a/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
+++ b/src/test/java/org/junit/experimental/extensions/MockitoExtension.java
@@ -53,11 +53,9 @@ public class MockitoExtension implements TestInstancePostProcessor, ParameterRes
     final Store mocks = extensionContext.getStore(Namespace.create(MockitoExtension.class, mockType));
     final String mockName = getMockName(parameter);
 
-    if (mockName != null) {
-      return mocks.getOrComputeIfAbsent(mockName, key -> mock(mockType, mockName));
-    } else {
-      return mocks.getOrComputeIfAbsent(mockType.getCanonicalName(), key -> mock(mockType));
-    }
+    return (mockName != null)
+      ? mocks.getOrComputeIfAbsent(mockName, key -> mock(mockType, mockName))
+      : mocks.getOrComputeIfAbsent(mockType.getCanonicalName(), key -> mock(mockType));
   }
 
   private String getMockName(final Parameter parameter) {
@@ -71,4 +69,3 @@ public class MockitoExtension implements TestInstancePostProcessor, ParameterRes
   }
 
 }
-


### PR DESCRIPTION
This PR removes unnecessary `else` clauses as identified by static analysis.  In some cases, the surrounding `else` clause was simply removed and the code re-indented.  In other cases, an `if`-`else` statement that returned a value from both branches was changed to a single return using the ternary operator.

It is recommended to review this PR with whitespace changes ignored (`?w=1`).

This PR is one part of several PRs in order to keep the review size reasonable.