### PR TITLE
Remove redundant null check

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -234,13 +234,13 @@ class AAInMoveUtil implements Serializable {
     if (units.stream().anyMatch(Matches.unitIsOwnedBy(m_player))) {
       return m_player;
     }
-    if (units != null) {
-      for (final Unit u : units) {
-        if (u != null && u.getOwner() != null) {
-          return u.getOwner();
-        }
+
+    for (final Unit u : units) {
+      if (u != null && u.getOwner() != null) {
+        return u.getOwner();
       }
     }
+
     return PlayerID.NULL_PLAYERID;
   }
 


### PR DESCRIPTION
This PR simply removes a redundant `null` check, as identified by static analysis.  In this case, if `units` is `null`, an NPE will be thrown on line 234 when `units.stream()` is called.  Therefore, the `null` check on line 237 is redundant.

I considered the possibility that we should instead check `units` against `null` at the very top of the method and return `PlayerID#NULL_PLAYERID` in that case.  However, after analyzing all callers of this method, a `null` argument for `units` does not appear to be possible.  In all cases, a `null` `units` would trigger an NPE in upstream code before it ever reached this method.  And since this method is private, I see no need for an additional precondition check.