### PR TITLE
Fix AI strength variable types

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -365,7 +365,7 @@ public class WeakAI extends AbstractAI {
         final Predicate<Unit> attackable = Matches.unitIsOwnedBy(player).and(o -> !unitsAlreadyMoved.contains(o));
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
-        int ourStrength = 0;
+        float ourStrength = 0;
         final Collection<Territory> attackFrom = data.getMap().getNeighbors(enemy, Matches.territoryIsWater());
         for (final Territory owned : attackFrom) {
           // dont risk units we are carrying
@@ -649,7 +649,7 @@ public class WeakAI extends AbstractAI {
             .and(Matches.unitIsNotSea());
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
-        int ourStrength = 0;
+        float ourStrength = 0;
         final Collection<Territory> attackFrom =
             data.getMap().getNeighbors(enemy, Matches.territoryHasLandUnitsOwnedBy(player));
         for (final Territory owned : attackFrom) {


### PR DESCRIPTION
Follow-up to #2742.

`AIUtils#strength()` returns a `float`, but some callers were storing this value in an `int`.  This PR fixes those callers to use a `float`.