### PR TITLE
Prevent exception when lobby host override set but port override not set

### DIFF
--- a/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
@@ -1,73 +1,171 @@
 package games.strategy.engine.config.client;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 
 import org.junit.experimental.extensions.MockitoExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
 import games.strategy.engine.framework.map.download.DownloadUtils;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
+import games.strategy.triplea.settings.GameSetting;
+import games.strategy.util.OptionalUtils;
 import games.strategy.util.Version;
 
 @ExtendWith(MockitoExtension.class)
 public class LobbyServerPropertiesFetcherTest {
-
-  private static final Version fakeVersion = new Version("0.0.0.0");
-
   @Mock
   private LobbyLocationFileDownloader mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;
 
-  /**
-   * Sets up a test object with mocked dependencies. We will primarily verify control flow.
-   */
   @BeforeEach
   public void setup() {
     testObj = new LobbyServerPropertiesFetcher(mockFileDownloader);
   }
 
-  /**
-   * Happy case test path, download file, parse it, return values parsed.
-   */
-  @Test
-  public void downloadAndParseRemoteFile() throws Exception {
-    givenHappyCase();
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class DownloadAndParseRemoteFileTest {
+    /**
+     * Happy case test path, download file, parse it, return values parsed.
+     */
+    @Test
+    public void happyCase() throws Exception {
+      givenHappyCase();
 
-    final LobbyServerProperties result = testObj.downloadAndParseRemoteFile(TestData.url,
-        fakeVersion, (a, b) -> TestData.lobbyServerProperties);
+      final LobbyServerProperties result = testObj.downloadAndParseRemoteFile(TestData.url,
+          TestData.version, (a, b) -> TestData.lobbyServerProperties);
 
-    assertThat(result, sameInstance(TestData.lobbyServerProperties));
-  }
+      assertThat(result, sameInstance(TestData.lobbyServerProperties));
+    }
 
-  private void givenHappyCase() throws Exception {
-    final File temp = File.createTempFile("temp", "tmp");
-    temp.deleteOnExit();
-    when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.success(temp));
-  }
-
-  @Test
-  public void throwsOnDownloadFailure() {
-    assertThrows(IOException.class, () -> {
+    private void givenHappyCase() throws Exception {
       final File temp = File.createTempFile("temp", "tmp");
       temp.deleteOnExit();
-      when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.FAILURE);
+      when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.success(temp));
+    }
 
-      testObj.downloadAndParseRemoteFile(TestData.url, fakeVersion, (a, b) -> TestData.lobbyServerProperties);
-    });
+    @Test
+    public void throwsOnDownloadFailure() {
+      assertThrows(IOException.class, () -> {
+        when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.FAILURE);
+
+        testObj.downloadAndParseRemoteFile(TestData.url, TestData.version, (a, b) -> TestData.lobbyServerProperties);
+      });
+    }
   }
 
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class GetTestOverridePropertiesTest {
+    @Mock
+    private GameSetting testLobbyHostSetting;
+
+    @Mock
+    private GameSetting testLobbyPortSetting;
+
+    private Optional<LobbyServerProperties> result;
+
+    private void givenTestLobbyHostIsNotSet() {
+      when(testLobbyHostSetting.isSet()).thenReturn(false);
+    }
+
+    private void givenTestLobbyHostIsSet() {
+      givenTestLobbyHostIsSetTo("host");
+    }
+
+    private void givenTestLobbyHostIsSetTo(final String host) {
+      when(testLobbyHostSetting.isSet()).thenReturn(true);
+      when(testLobbyHostSetting.value()).thenReturn(host);
+    }
+
+    private void givenTestLobbyPortIsNotSet() {
+      when(testLobbyPortSetting.isSet()).thenReturn(false);
+    }
+
+    private void givenTestLobbyPortIsSet() {
+      givenTestLobbyPortIsSetTo(0);
+    }
+
+    private void givenTestLobbyPortIsSetTo(final int port) {
+      when(testLobbyPortSetting.isSet()).thenReturn(true);
+      when(testLobbyPortSetting.intValue()).thenReturn(port);
+    }
+
+    private void whenGetTestOverrideProperties() {
+      result = LobbyServerPropertiesFetcher.getTestOverrideProperties(testLobbyHostSetting, testLobbyPortSetting);
+    }
+
+    private void thenResultIsEmpty() {
+      assertThat(result, is(Optional.empty()));
+    }
+
+    private void thenResultHasHostAndPort(final String host, final int port) {
+      OptionalUtils.ifPresentOrElse(
+          result,
+          it -> {
+            assertThat(it.host, is(host));
+            assertThat(it.port, is(port));
+          },
+          () -> fail("expected non-empty properties, but was empty"));
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenHostNotSetAndPortNotSet() {
+      givenTestLobbyHostIsNotSet();
+      givenTestLobbyPortIsNotSet();
+
+      whenGetTestOverrideProperties();
+
+      thenResultIsEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenHostSetAndPortNotSet() {
+      givenTestLobbyHostIsSet();
+      givenTestLobbyPortIsNotSet();
+
+      whenGetTestOverrideProperties();
+
+      thenResultIsEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenHostNotSetAndPortSet() {
+      givenTestLobbyHostIsNotSet();
+      givenTestLobbyPortIsSet();
+
+      whenGetTestOverrideProperties();
+
+      thenResultIsEmpty();
+    }
+
+    @Test
+    public void shouldReturnPropertiesWhenHostSetAndPortSet() {
+      givenTestLobbyHostIsSetTo("foo");
+      givenTestLobbyPortIsSetTo(4242);
+
+      whenGetTestOverrideProperties();
+
+      thenResultHasHostAndPort("foo", 4242);
+    }
+  }
 
   private interface TestData {
+    Version version = new Version("0.0.0.0");
     String url = "someUrl";
     LobbyServerProperties lobbyServerProperties = new LobbyServerProperties("host", 123);
   }


### PR DESCRIPTION
This PR prevents an exception from being raised when the test lobby host setting is set but the test lobby port setting is not set, as reported [here](https://github.com/triplea-game/triplea/pull/2759#discussion_r159116395).

The solution I chose was to require both host and port to be set simultaneously.  Otherwise, the override is ignored.  If only one setting has been set, a helpful message will be quietly written to the console informing the user their override has been ignored.

I considered some other solutions, which are briefly described at the end of this description.

To reduce some of the indentation noise, it is suggested to review this PR with whitespace changes ignored (`?w=1`).

#### Functional changes

To override the lobby server connection information, both host and port must be specified.  Previously, if you only specified the host, a `NumberFormatException` would be raised; and if you only specified the port, the override would be ignored.  So this solution only changes the exceptional behavior.

#### Refactoring changes

In order to easily unit test this change, I had to break a dependency on `ClientSetting` when retrieving the test lobby override settings.  I could have taken this further by also breaking the dependency on the last lobby used settings, but chose not to do that at this time because they do not affect the fix.

#### Testing

I tested the following combinations:

Host Override | Port Override | Log Message Displayed? | Server Properties Source
:-- | :-- | :-- | :--
Not Set | Not Set | No | Remote
Set | Not Set | Yes | Remote
Not Set | Set | Yes | Remote
Set | Set | No | Override

No exceptions were observed.

#### Notes

I considered the following alternatives, but felt the chosen solution most closely aligns with the spirit of the original author's intent.  Please advise if any seem preferable to the chosen solution.

##### Use default port if port override not set

If the host override is set, but the port override is not set, use a default port of 3304.

##### Allow independent host and port overrides

If the host override is set, use it; otherwise use the host from the remote.  If the port override is set, use it; otherwise use the port from the remote.  This would allow the host and port overrides to be independent of each other, but the possible combinations of override and remote host/port seemed like they might not be appropriate in all cases.