### PR TITLE
Checkstyle: Fix violations in invoke

### DIFF
--- a/src/main/java/games/strategy/engine/message/InvocationInProgress.java
+++ b/src/main/java/games/strategy/engine/message/InvocationInProgress.java
@@ -45,7 +45,7 @@ class InvocationInProgress {
   }
 
   GUID getMethodCallId() {
-    return methodCall.methodCallID;
+    return methodCall.methodCallId;
   }
 
   boolean shouldSendResults() {

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -21,15 +21,15 @@ import games.strategy.util.Tuple;
 public class RemoteMethodCall implements Externalizable {
   private static final long serialVersionUID = 4630825927685836207L;
   private static final Logger logger = Logger.getLogger(RemoteMethodCall.class.getName());
-  private String m_remoteName;
-  private String m_methodName;
-  private Object[] m_args;
+  private String remoteName;
+  private String methodName;
+  private Object[] args;
   // to save space, we dont serialize method name/types
   // instead we just serialize a number which can be transalted into
   // the correct method.
-  private int m_methodNumber;
+  private int methodNumber;
   // stored as a String[] so we can be serialzed
-  private String[] m_argTypes;
+  private String[] argTypes;
 
   public RemoteMethodCall() {}
 
@@ -44,21 +44,21 @@ public class RemoteMethodCall implements Externalizable {
     if (args != null && args.length != argTypes.length) {
       throw new IllegalArgumentException("Arg and arg type lengths dont match");
     }
-    m_remoteName = remoteName;
-    m_methodName = methodName;
-    m_args = args;
-    m_argTypes = classesToString(argTypes, args);
-    m_methodNumber = RemoteInterfaceHelper.getNumber(methodName, argTypes, remoteInterface);
+    this.remoteName = remoteName;
+    this.methodName = methodName;
+    this.args = args;
+    this.argTypes = classesToString(argTypes, args);
+    methodNumber = RemoteInterfaceHelper.getNumber(methodName, argTypes, remoteInterface);
     if (logger.isLoggable(Level.FINE)) {
       logger.fine("Remote Method Call:" + debugMethodText());
     }
   }
 
   private String debugMethodText() {
-    if (m_argTypes == null) {
-      return "." + m_methodName + "(" + ")";
+    if (argTypes == null) {
+      return "." + methodName + "(" + ")";
     } else {
-      return "." + m_methodName + "(" + Arrays.asList(m_argTypes) + ")";
+      return "." + methodName + "(" + Arrays.asList(argTypes) + ")";
     }
   }
 
@@ -66,28 +66,28 @@ public class RemoteMethodCall implements Externalizable {
    * @return Returns the channelName.
    */
   public String getRemoteName() {
-    return m_remoteName;
+    return remoteName;
   }
 
   /**
    * @return Returns the methodName.
    */
   public String getMethodName() {
-    return m_methodName;
+    return methodName;
   }
 
   /**
    * @return Returns the args.
    */
   public Object[] getArgs() {
-    return m_args;
+    return args;
   }
 
   /**
    * @return Returns the argTypes.
    */
   public Class<?>[] getArgTypes() {
-    return stringsToClasses(m_argTypes, m_args);
+    return stringsToClasses(argTypes, args);
   }
 
   private static Class<?>[] stringsToClasses(final String[] strings, final Object[] args) {
@@ -147,18 +147,18 @@ public class RemoteMethodCall implements Externalizable {
 
   @Override
   public String toString() {
-    return "Remote method call, method name:" + m_methodName + " remote name:" + m_remoteName;
+    return "Remote method call, method name:" + methodName + " remote name:" + remoteName;
   }
 
   @Override
   public void writeExternal(final ObjectOutput out) throws IOException {
-    out.writeUTF(m_remoteName);
-    out.writeByte(m_methodNumber);
-    if (m_args == null) {
+    out.writeUTF(remoteName);
+    out.writeByte(methodNumber);
+    if (args == null) {
       out.writeByte(Byte.MAX_VALUE);
     } else {
-      out.writeByte(m_args.length);
-      for (final Object arg : m_args) {
+      out.writeByte(args.length);
+      for (final Object arg : args) {
         out.writeObject(arg);
       }
     }
@@ -166,13 +166,13 @@ public class RemoteMethodCall implements Externalizable {
 
   @Override
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
-    m_remoteName = in.readUTF();
-    m_methodNumber = in.readByte();
+    remoteName = in.readUTF();
+    methodNumber = in.readByte();
     final byte count = in.readByte();
     if (count != Byte.MAX_VALUE) {
-      m_args = new Object[count];
+      args = new Object[count];
       for (int i = 0; i < count; i++) {
-        m_args[i] = in.readObject();
+        args[i] = in.readObject();
       }
     }
   }
@@ -183,12 +183,12 @@ public class RemoteMethodCall implements Externalizable {
    * what class we operate on.
    */
   public void resolve(final Class<?> remoteType) {
-    if (m_methodName != null) {
+    if (methodName != null) {
       return;
     }
-    final Tuple<String, Class<?>[]> values = RemoteInterfaceHelper.getMethodInfo(m_methodNumber, remoteType);
-    m_methodName = values.getFirst();
-    m_argTypes = classesToString(values.getSecond(), m_args);
+    final Tuple<String, Class<?>[]> values = RemoteInterfaceHelper.getMethodInfo(methodNumber, remoteType);
+    methodName = values.getFirst();
+    argTypes = classesToString(values.getSecond(), args);
     if (logger.isLoggable(Level.FINE)) {
       logger.fine("Remote Method for class:" + remoteType.getSimpleName() + " Resolved To:" + debugMethodText());
     }

--- a/src/main/java/games/strategy/engine/message/SpokeInvoke.java
+++ b/src/main/java/games/strategy/engine/message/SpokeInvoke.java
@@ -11,7 +11,7 @@ import games.strategy.net.Node;
 
 public class SpokeInvoke extends Invoke {
   private static final long serialVersionUID = -2007645463748969L;
-  private INode m_invoker;
+  private INode invoker;
 
   public SpokeInvoke() {
     super();
@@ -20,23 +20,23 @@ public class SpokeInvoke extends Invoke {
   public SpokeInvoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call,
       final INode invoker) {
     super(methodCallId, needReturnValues, call);
-    m_invoker = invoker;
+    this.invoker = invoker;
   }
 
   public INode getInvoker() {
-    return m_invoker;
+    return invoker;
   }
 
   @Override
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
     super.readExternal(in);
-    m_invoker = new Node();
-    ((Node) m_invoker).readExternal(in);
+    invoker = new Node();
+    ((Node) invoker).readExternal(in);
   }
 
   @Override
   public void writeExternal(final ObjectOutput out) throws IOException {
     super.writeExternal(out);
-    ((Node) m_invoker).writeExternal(out);
+    ((Node) invoker).writeExternal(out);
   }
 }

--- a/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -87,7 +87,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
         if (invoke.needReturnValues) {
           final RemoteMethodCallResults results =
               new RemoteMethodCallResults(new RemoteNotFoundException("Not found:" + invoke.call.getRemoteName()));
-          send(new SpokeInvocationResults(results, invoke.methodCallID), from);
+          send(new SpokeInvocationResults(results, invoke.methodCallId), from);
         }
         // no end points, this is ok, we
         // we are a channel with no implementors
@@ -126,11 +126,11 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
       }
       final InvocationInProgress invocationInProgress =
           new InvocationInProgress(remote.iterator().next(), hubInvoke, from);
-      invocations.put(hubInvoke.methodCallID, invocationInProgress);
+      invocations.put(hubInvoke.methodCallId, invocationInProgress);
     }
     // invoke remotely
     final SpokeInvoke invoke =
-        new SpokeInvoke(hubInvoke.methodCallID, hubInvoke.needReturnValues, hubInvoke.call, from);
+        new SpokeInvoke(hubInvoke.methodCallId, hubInvoke.needReturnValues, hubInvoke.call, from);
     for (final INode node : remote) {
       send(invoke, node);
     }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
@@ -11,7 +11,7 @@ import games.strategy.net.GUID;
 // someone wants us to invoke something locally
 public abstract class Invoke implements Externalizable {
   private static final long serialVersionUID = -5453883962199970896L;
-  public GUID methodCallID;
+  public GUID methodCallId;
   public boolean needReturnValues;
   public RemoteMethodCall call;
 
@@ -20,7 +20,7 @@ public abstract class Invoke implements Externalizable {
   @Override
   public String toString() {
     return "invoke on:" + call.getRemoteName() + " method name:" + call.getMethodName() + " method call id:"
-        + methodCallID;
+        + methodCallId;
   }
 
   public Invoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call) {
@@ -30,7 +30,7 @@ public abstract class Invoke implements Externalizable {
     if (!needReturnValues && methodCallId != null) {
       throw new IllegalArgumentException("Cant have id and not need return values");
     }
-    this.methodCallID = methodCallId;
+    this.methodCallId = methodCallId;
     this.needReturnValues = needReturnValues;
     this.call = call;
   }
@@ -39,7 +39,7 @@ public abstract class Invoke implements Externalizable {
   public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
     needReturnValues = in.read() == 1;
     if (needReturnValues) {
-      methodCallID = (GUID) in.readObject();
+      methodCallId = (GUID) in.readObject();
     }
     call = new RemoteMethodCall();
     call.readExternal(in);
@@ -49,7 +49,7 @@ public abstract class Invoke implements Externalizable {
   public void writeExternal(final ObjectOutput out) throws IOException {
     out.write(needReturnValues ? 1 : 0);
     if (needReturnValues) {
-      out.writeObject(methodCallID);
+      out.writeObject(methodCallId);
     }
     call.writeExternal(out);
   }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
@@ -8,7 +8,9 @@ import java.io.ObjectOutput;
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.net.GUID;
 
-// someone wants us to invoke something locally
+/**
+ * Someone wants us to invoke something locally.
+ */
 public abstract class Invoke implements Externalizable {
   private static final long serialVersionUID = -5453883962199970896L;
   public GUID methodCallId;

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -259,7 +259,7 @@ public class UnifiedMessenger {
           send(new HubInvocationResults(
               new RemoteMethodCallResults(new RemoteNotFoundException(
                   "No implementors for " + invoke.call + ", inode: " + from + ", msg: " + msg)),
-              invoke.methodCallID), from);
+              invoke.methodCallId), from);
         }
         return;
       }
@@ -285,7 +285,7 @@ public class UnifiedMessenger {
             result = new RemoteMethodCallResults(
                 new IllegalStateException("Invalid result count" + results.size()) + " for end point:" + localFinal);
           }
-          send(new HubInvocationResults(result, invoke.methodCallID), from);
+          send(new HubInvocationResults(result, invoke.methodCallId), from);
         }
       });
     } else if (msg instanceof SpokeInvocationResults) { // a remote machine is returning results


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName, AbbreviationAsWordInName, and JavadocMethod rules in the `Invoke` and related class.  These classes are `Externalizable`, and unlike a `Serializable` class, the field names are not written to the stream.  Therefore, fields renames should not cause any compatibility issues.

#### Testing

I ran a network game between a server from this branch and a 3635 client.  I ensured the game hit the `readExternal()` and `writeExternal()` methods of `Invoke`.  I played two turns, including combat, and no issues were observed.