### PR TITLE
Remove unnecessary else clauses (part 3)

### DIFF
--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -315,11 +315,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @return the territory before the end territory
    */
   public Territory getTerritoryBeforeEnd() {
-    if (m_steps.size() <= 1) {
-      return getStart();
-    } else {
-      return getTerritoryAtStep(m_steps.size() - 2);
-    }
+    return (m_steps.size() <= 1) ? getStart() : getTerritoryAtStep(m_steps.size() - 2);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -83,9 +83,8 @@ public class UnitType extends NamedAttachable {
     if (customTip == null || customTip.trim().length() <= 0) {
       return UnitAttachment.get(this).toStringShortAndOnlyImportantDifferences(
           (playerId == null ? PlayerID.NULL_PLAYERID : playerId), true, false);
-    } else {
-      return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
     }
+    return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -97,14 +97,8 @@ public class ServerLauncher extends AbstractLauncher {
     }
 
     final Map<String, String> players = serverModel.getPlayersToNodeListing();
-    if (players == null || players.isEmpty()) {
+    if (players == null || players.isEmpty() || players.containsValue(null)) {
       return true;
-    }
-
-    for (final String player : players.keySet()) {
-      if (players.get(player) == null) {
-        return true;
-      }
     }
 
     if (serverGame != null && serverGame.getPlayerManager() != null) {

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -94,18 +94,19 @@ public class ServerLauncher extends AbstractLauncher {
     }
     if (gameData == null || serverModel == null) {
       return true;
-    } else {
-      final Map<String, String> players = serverModel.getPlayersToNodeListing();
-      if (players == null || players.isEmpty()) {
+    }
+
+    final Map<String, String> players = serverModel.getPlayersToNodeListing();
+    if (players == null || players.isEmpty()) {
+      return true;
+    }
+
+    for (final String player : players.keySet()) {
+      if (players.get(player) == null) {
         return true;
-      } else {
-        for (final String player : players.keySet()) {
-          if (players.get(player) == null) {
-            return true;
-          }
-        }
       }
     }
+
     if (serverGame != null && serverGame.getPlayerManager() != null) {
       if (serverGame.getPlayerManager().isEmpty()) {
         return true;

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -337,9 +337,8 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
             (IObserverWaitingToJoin) remoteMessenger.getRemote(remoteName, true);
         serverLauncher.addObserver(observerWaitingToJoinBlocking, observerWaitingToJoinNonBlocking, newNode);
         return true;
-      } else {
-        return false;
       }
+      return false;
     }
 
     @Override
@@ -451,12 +450,11 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
             getLocalPlayerTypes(), new Version(0, 0), gameSelectorModel.getGameName(),
             gameSelectorModel.getGameRound(), new HashSet<>(playersAllowedToBeDisabled),
             new LinkedHashMap<>());
-      } else {
-        return new PlayerListing(new HashMap<>(playersToNodeListing),
-            new HashMap<>(playersEnabledListing), getLocalPlayerTypes(), data.getGameVersion(),
-            data.getGameName(), data.getSequence().getRound() + "",
-            new HashSet<>(playersAllowedToBeDisabled), playerNamesAndAlliancesInTurnOrder);
       }
+      return new PlayerListing(new HashMap<>(playersToNodeListing),
+          new HashMap<>(playersEnabledListing), getLocalPlayerTypes(), data.getGameVersion(),
+          data.getGameName(), data.getSequence().getRound() + "",
+          new HashSet<>(playersAllowedToBeDisabled), playerNamesAndAlliancesInTurnOrder);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -32,9 +32,9 @@ public class PropertiesSelector {
       final AtomicReference<Object> buttonRef = new AtomicReference<>();
       SwingAction.invokeAndWait(() -> buttonRef.set(showDialog(parent, title, properties, buttonOptions)));
       return buttonRef.get();
-    } else {
-      return showDialog(parent, title, properties, buttonOptions);
     }
+
+    return showDialog(parent, title, properties, buttonOptions);
   }
 
   private static Object showDialog(final JComponent parent, final String title,

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -55,11 +55,7 @@ public class RemoteMethodCall implements Externalizable {
   }
 
   private String debugMethodText() {
-    if (argTypes == null) {
-      return "." + methodName + "(" + ")";
-    } else {
-      return "." + methodName + "(" + Arrays.asList(argTypes) + ")";
-    }
+    return "." + methodName + "(" + (argTypes != null ? Arrays.toString(argTypes) : "") + ")";
   }
 
   /**

--- a/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -47,39 +47,39 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
     if (ignoreResults) {
       messenger.invoke(endPointName, remoteMethodMsg);
       return null;
-    } else {
-      final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);
-      if (response.getException() != null) {
-        if (response.getException() instanceof MessengerException) {
-          final MessengerException cle = (MessengerException) response.getException();
-          cle.fillInInvokerStackTrace();
-        } else {
-          // do not chain the exception, we want to keep whatever the original exception's class was, so just add our
-          // bit to the stack
-          // trace.
-          final Throwable throwable = response.getException();
-          final StackTraceElement[] exceptionTrace = throwable.getStackTrace();
-          final Exception ourException =
-              new Exception(throwable.getMessage() + " exception in response from other system");
-          // Thread.currentThread().getStackTrace();
-          final StackTraceElement[] ourTrace = ourException.getStackTrace();
-          if (exceptionTrace != null && ourTrace != null) {
-            final StackTraceElement[] combinedTrace = new StackTraceElement[(exceptionTrace.length + ourTrace.length)];
-            int i = 0;
-            for (final StackTraceElement element : exceptionTrace) {
-              combinedTrace[i] = element;
-              i++;
-            }
-            for (final StackTraceElement element : ourTrace) {
-              combinedTrace[i] = element;
-              i++;
-            }
-            throwable.setStackTrace(combinedTrace);
-          }
-        }
-        throw response.getException();
-      }
-      return response.getRVal();
     }
+
+    final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);
+    if (response.getException() != null) {
+      if (response.getException() instanceof MessengerException) {
+        final MessengerException cle = (MessengerException) response.getException();
+        cle.fillInInvokerStackTrace();
+      } else {
+        // do not chain the exception, we want to keep whatever the original exception's class was, so just add our
+        // bit to the stack
+        // trace.
+        final Throwable throwable = response.getException();
+        final StackTraceElement[] exceptionTrace = throwable.getStackTrace();
+        final Exception ourException =
+            new Exception(throwable.getMessage() + " exception in response from other system");
+        // Thread.currentThread().getStackTrace();
+        final StackTraceElement[] ourTrace = ourException.getStackTrace();
+        if (exceptionTrace != null && ourTrace != null) {
+          final StackTraceElement[] combinedTrace = new StackTraceElement[(exceptionTrace.length + ourTrace.length)];
+          int i = 0;
+          for (final StackTraceElement element : exceptionTrace) {
+            combinedTrace[i] = element;
+            i++;
+          }
+          for (final StackTraceElement element : ourTrace) {
+            combinedTrace[i] = element;
+            i++;
+          }
+          throwable.setStackTrace(combinedTrace);
+        }
+      }
+      throw response.getException();
+    }
+    return response.getRVal();
   }
 }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -98,17 +98,17 @@ public class UnifiedMessenger {
     if (local == null) {
       return invokeAndWaitRemote(remoteCall);
       // we have the implementor here, just invoke it
-    } else {
-      final long number = local.takeANumber();
-      final List<RemoteMethodCallResults> results = local.invokeLocal(remoteCall, number, getLocalNode());
-      if (results.size() == 0) {
-        throw new RemoteNotFoundException("Not found:" + endPointName);
-      }
-      if (results.size() > 1) {
-        throw new IllegalStateException("Too many implementors, got back:" + results);
-      }
-      return results.get(0);
     }
+
+    final long number = local.takeANumber();
+    final List<RemoteMethodCallResults> results = local.invokeLocal(remoteCall, number, getLocalNode());
+    if (results.size() == 0) {
+      throw new RemoteNotFoundException("Not found:" + endPointName);
+    }
+    if (results.size() > 1) {
+      throw new IllegalStateException("Too many implementors, got back:" + results);
+    }
+    return results.get(0);
   }
 
   private RemoteMethodCallResults invokeAndWaitRemote(final RemoteMethodCall remoteCall) {

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -279,9 +279,8 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         if (status == HttpStatus.SC_TEMPORARY_REDIRECT || status == HttpStatus.SC_MOVED_PERMANENTLY
             || status == HttpStatus.SC_MOVED_TEMPORARILY) {
           return RequestBuilder.copy(request).setUri(uri).build();
-        } else {
-          return new HttpGet(uri);
         }
+        return new HttpGet(uri);
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -222,11 +222,7 @@ public class ResourceLoader implements Closeable {
       return null;
     }
 
-    final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-    if (inputStream.isPresent()) {
-      return inputStream.get();
-    } else {
-      throw new IllegalStateException("Failed to open an input stream to: " + path);
-    }
+    return UrlStreams.openStream(url)
+        .orElseThrow(() -> new IllegalStateException("Failed to open an input stream to: " + path));
   }
 }

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -346,7 +346,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(errorContext, e);
     }
-    return airCantLand.isEmpty() ? true : ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
+    return airCantLand.isEmpty() || ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
   }
 
   private boolean canUnitsFight() {
@@ -359,7 +359,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
-    return unitsCantFight.isEmpty() ? false : !ui.getOkToLetUnitsDie(unitsCantFight, true);
+    return !(unitsCantFight.isEmpty() || ui.getOkToLetUnitsDie(unitsCantFight, true));
   }
 
   private void purchase(final boolean bid) {

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -346,11 +346,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(errorContext, e);
     }
-    if (airCantLand.isEmpty()) {
-      return true;
-    } else {
-      return ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
-    }
+    return airCantLand.isEmpty() ? true : ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
   }
 
   private boolean canUnitsFight() {
@@ -363,11 +359,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
-    if (unitsCantFight.isEmpty()) {
-      return false;
-    } else {
-      return !ui.getOkToLetUnitsDie(unitsCantFight, true);
-    }
+    return unitsCantFight.isEmpty() ? false : !ui.getOkToLetUnitsDie(unitsCantFight, true);
   }
 
   private void purchase(final boolean bid) {
@@ -514,9 +506,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
         if (!GameStepPropertiesHelper.isRemoveAirThatCanNotLand(getGameData()) || canAirLand(false, id)
             || getPlayerBridge().isGameOver()) {
           return;
-        } else {
-          continue;
         }
+        continue;
       }
       final String error = placeDel.placeUnits(placeData.getUnits(), placeData.getAt(),
           bid ? IAbstractPlaceDelegate.BidMode.BID : IAbstractPlaceDelegate.BidMode.NOT_BID);

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -343,11 +343,9 @@ public class TripleAUnit extends Unit {
       return 0;
     }
     final TripleAUnit taUnit = (TripleAUnit) u;
-    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(u.getData())) {
-      return Math.max(0, getHowMuchDamageCanThisUnitTakeTotal(u, t) - taUnit.getUnitDamage());
-    } else {
-      return Integer.MAX_VALUE;
-    }
+    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(u.getData())
+        ? Math.max(0, getHowMuchDamageCanThisUnitTakeTotal(u, t) - taUnit.getUnitDamage())
+        : Integer.MAX_VALUE;
   }
 
   /**
@@ -366,21 +364,17 @@ public class TripleAUnit extends Unit {
         // assume that if maxDamage <= 0, then the max damage must be based on the territory value
         // can use "production" or "unitProduction"
         return territoryUnitProduction * 2;
-      } else {
-        if (Matches.unitCanProduceUnits().test(u)) {
-          if (ua.getCanProduceXUnits() < 0) {
-            // can use "production" or "unitProduction"
-            return territoryUnitProduction * ua.getMaxDamage();
-          } else {
-            return ua.getMaxDamage();
-          }
-        } else {
-          return ua.getMaxDamage();
-        }
       }
-    } else {
-      return Integer.MAX_VALUE;
+
+      if (Matches.unitCanProduceUnits().test(u)) {
+        // can use "production" or "unitProduction"
+        return (ua.getCanProduceXUnits() < 0) ? territoryUnitProduction * ua.getMaxDamage() : ua.getMaxDamage();
+      }
+
+      return ua.getMaxDamage();
     }
+
+    return Integer.MAX_VALUE;
   }
 
   public int getHowMuchCanThisUnitBeRepaired(final Unit u, final Territory t) {
@@ -478,11 +472,7 @@ public class TripleAUnit extends Unit {
     if (territoryProduction >= TechAbilityAttachment.getMinimumTerritoryValueForProductionBonus(player, data)) {
       productionCapacity += TechAbilityAttachment.getProductionBonus(u.getType(), player, data);
     }
-    if (mathMaxZero) {
-      return Math.max(0, productionCapacity);
-    } else {
-      return productionCapacity;
-    }
+    return mathMaxZero ? Math.max(0, productionCapacity) : productionCapacity;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -509,10 +509,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
         if (min == -1) {
           continue;
         }
-
-        double fmin = min;
-        fmin = fmin / 100.0F;
-        repairDiscount -= fmin;
+        repairDiscount -= min / 100.0;
       }
     }
     return Math.max(0.0D, repairDiscount);

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -508,11 +508,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
         final int min = taa.getRepairDiscount();
         if (min == -1) {
           continue;
-        } else {
-          double fmin = min;
-          fmin = fmin / 100.0F;
-          repairDiscount -= fmin;
         }
+
+        double fmin = min;
+        fmin = fmin / 100.0F;
+        repairDiscount -= fmin;
       }
     }
     return Math.max(0.0D, repairDiscount);

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -63,9 +63,8 @@ public class TerritoryAttachment extends DefaultAttachment {
           if (player.equals(current.getOwner())) {
             if (data.getMap().getNeighbors(current).size() > 0) {
               return current;
-            } else {
-              noNeighborCapitals.add(current);
             }
+            noNeighborCapitals.add(current);
           } else {
             capitals.add(current);
           }

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -117,11 +117,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   public int getCombatEffect(final UnitType type, final boolean defending) {
-    if (defending) {
-      return m_combatDefenseEffect.getInt(type);
-    } else {
-      return m_combatOffenseEffect.getInt(type);
-    }
+    return defending ? m_combatDefenseEffect.getInt(type) : m_combatOffenseEffect.getInt(type);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -112,19 +112,19 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (playersToSearch == null) {
         throw new IllegalStateException(
             "Triggers: No trigger attachment for:" + player.getName() + " with name: " + nameOfAttachment);
-      } else {
-        for (final PlayerID otherPlayer : playersToSearch) {
-          if (otherPlayer == player) {
-            continue;
-          }
-          ta = (TriggerAttachment) otherPlayer.getAttachment(nameOfAttachment);
-          if (ta != null) {
-            return ta;
-          }
-        }
-        throw new IllegalStateException(
-            "Triggers: No trigger attachment for:" + player.getName() + " with name: " + nameOfAttachment);
       }
+
+      for (final PlayerID otherPlayer : playersToSearch) {
+        if (otherPlayer == player) {
+          continue;
+        }
+        ta = (TriggerAttachment) otherPlayer.getAttachment(nameOfAttachment);
+        if (ta != null) {
+          return ta;
+        }
+      }
+      throw new IllegalStateException(
+          "Triggers: No trigger attachment for:" + player.getName() + " with name: " + nameOfAttachment);
     }
     return ta;
   }
@@ -594,9 +594,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final Resource r = getData().getResourceList().getResource(s);
     if (r == null) {
       throw new GameParseException("Invalid resource: " + s + thisErrorMsg());
-    } else {
-      m_resource = s;
     }
+    m_resource = s;
   }
 
   public String getResource() {
@@ -903,11 +902,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   public List<PlayerID> getPlayers() {
-    if (m_players.isEmpty()) {
-      return new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo()));
-    } else {
-      return m_players;
-    }
+    return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
   }
 
   public void clearPlayers() {
@@ -1267,25 +1262,24 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final Territory territory = getData().getMap().getTerritory(s[i]);
     if (territory == null) {
       throw new GameParseException("Territory does not exist " + s[i] + thisErrorMsg());
-    } else {
-      i++;
-      final IntegerMap<UnitType> map = new IntegerMap<>();
-      for (; i < s.length; i++) {
-        final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
-        if (type == null) {
-          throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
-        } else {
-          map.add(type, count);
-        }
-      }
-      if (m_placement == null) {
-        m_placement = new HashMap<>();
-      }
-      if (m_placement.containsKey(territory)) {
-        map.add(m_placement.get(territory));
-      }
-      m_placement.put(territory, map);
     }
+
+    i++;
+    final IntegerMap<UnitType> map = new IntegerMap<>();
+    for (; i < s.length; i++) {
+      final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
+      if (type == null) {
+        throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
+      }
+      map.add(type, count);
+    }
+    if (m_placement == null) {
+      m_placement = new HashMap<>();
+    }
+    if (m_placement.containsKey(territory)) {
+      map.add(m_placement.get(territory));
+    }
+    m_placement.put(territory, map);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -1409,18 +1403,17 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     if (s.length < 1 || (s.length == 1 && count != -1)) {
       throw new GameParseException("Empty purchase list" + thisErrorMsg());
-    } else {
-      if (m_purchase == null) {
-        m_purchase = new IntegerMap<>();
+    }
+
+    if (m_purchase == null) {
+      m_purchase = new IntegerMap<>();
+    }
+    for (; i < s.length; i++) {
+      final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
+      if (type == null) {
+        throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
       }
-      for (; i < s.length; i++) {
-        final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
-        if (type == null) {
-          throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
-        } else {
-          m_purchase.add(type, count);
-        }
-      }
+      m_purchase.add(type, count);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -246,9 +246,8 @@ public class UnitSupportAttachment extends DefaultAttachment {
       final PlayerID player = getData().getPlayerList().getPlayerId(element);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
-      } else {
-        m_players.add(player);
       }
+      m_players.add(player);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -236,11 +236,7 @@ public abstract class TechAdvance extends NamedAttachable {
   public static List<TechAdvance> getTechAdvances(final GameData data, final PlayerID player) {
     final TechnologyFrontier technologyFrontier = data.getTechnologyFrontier();
     if (technologyFrontier != null && !technologyFrontier.isEmpty()) {
-      if (player != null) {
-        return player.getTechnologyFrontierList().getAdvances();
-      } else {
-        return technologyFrontier.getTechs();
-      }
+      return (player != null) ? player.getTechnologyFrontierList().getAdvances() : technologyFrontier.getTechs();
     }
     // the game has no techs, just return empty list
     return new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -291,18 +291,18 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
       final int has = bridge.getPlayerId().getResources().getQuantity(pus);
       return has >= cost;
-    } else {
-      int runningTotal = 0;
-      for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
-        final int has = entry.getKey().getResources().getQuantity(pus);
-        final int paying = entry.getValue();
-        if (paying > has) {
-          return false;
-        }
-        runningTotal += paying;
-      }
-      return runningTotal >= cost;
     }
+
+    int runningTotal = 0;
+    for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
+      final int has = entry.getKey().getResources().getQuantity(pus);
+      final int paying = entry.getValue();
+      if (paying > has) {
+        return false;
+      }
+      runningTotal += paying;
+    }
+    return runningTotal >= cost;
   }
 
   private void chargeForTechRolls(final int rolls, final IntegerMap<PlayerID> whoPaysHowMuch) {

--- a/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -18,11 +18,7 @@ import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 public class TerritoryEffectHelper {
   public static Collection<TerritoryEffect> getEffects(final Territory location) {
     final TerritoryAttachment ta = TerritoryAttachment.get(location);
-    if (ta != null) {
-      return TerritoryAttachment.get(location).getTerritoryEffect();
-    } else {
-      return new ArrayList<>();
-    }
+    return (ta != null) ? ta.getTerritoryEffect() : new ArrayList<>();
   }
 
   static int getTerritoryCombatBonus(final UnitType type, final Collection<TerritoryEffect> effects,

--- a/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -60,11 +60,7 @@ public class UnitComparator {
     return (t1, t2) -> {
       final int cost1 = capacityMap.getInt(t1);
       final int cost2 = capacityMap.getInt(t2);
-      if (increasing) {
-        return cost1 - cost2;
-      } else {
-        return cost2 - cost1;
-      }
+      return increasing ? (cost1 - cost2) : (cost2 - cost1);
     };
   }
 
@@ -159,11 +155,7 @@ public class UnitComparator {
       }
 
       // If noTies is set, sort by hashcode so that result is deterministic
-      if (noTies) {
-        return Integer.compare(t1.hashCode(), t2.hashCode());
-      } else {
-        return 0;
-      }
+      return noTies ? Integer.compare(t1.hashCode(), t2.hashCode()) : 0;
     };
   }
 
@@ -203,11 +195,7 @@ public class UnitComparator {
 
       // Sort by increasing movement normally, but by decreasing movement during loading
       if (left1 != left2) {
-        if (route != null && route.isLoad()) {
-          return left2 - left1;
-        } else {
-          return left1 - left2;
-        }
+        return (route != null && route.isLoad()) ? (left2 - left1) : (left1 - left2);
       }
 
       return Integer.compare(u1.hashCode(), u2.hashCode());

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -217,11 +217,9 @@ public final class TileImageFactory {
 
   private Image loadImage(final URL imageLocation, final String fileName, final boolean transparent,
       final boolean cache, final boolean scale) {
-    if (showMapBlends && showReliefImages && transparent) {
-      return loadBlendedImage(fileName, cache, scale);
-    } else {
-      return loadUnblendedImage(imageLocation, fileName, transparent, cache, scale);
-    }
+    return (showMapBlends && showReliefImages && transparent)
+        ? loadBlendedImage(fileName, cache, scale)
+        : loadUnblendedImage(imageLocation, fileName, transparent, cache, scale);
   }
 
   private Image loadBlendedImage(final String fileName, final boolean cache, final boolean scaled) {
@@ -285,13 +283,13 @@ public final class TileImageFactory {
         imageCache.put(fileName, ref);
       }
       return blendedImage;
-    } else {
-      final ImageRef ref = new ImageRef(baseFile);
-      if (cache) {
-        imageCache.put(fileName, ref);
-      }
-      return baseFile;
     }
+
+    final ImageRef ref = new ImageRef(baseFile);
+    if (cache) {
+      imageCache.put(fileName, ref);
+    }
+    return baseFile;
   }
 
   private Image loadUnblendedImage(final URL imageLocation, final String fileName, final boolean transparent,

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -210,12 +210,9 @@ public class ProductionPanel extends JPanel {
         data.releaseReadLock();
       }
       return bidCollection;
-    } else {
-      if (id == null || id.isNull()) {
-        return new ResourceCollection(data);
-      }
-      return id.getResources();
     }
+
+    return (id == null || id.isNull()) ? new ResourceCollection(data) : id.getResources();
   }
 
   class Rule {

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -217,9 +217,9 @@ public class ProductionRepairPanel extends JPanel {
         data.releaseReadLock();
       }
       return bidCollection;
-    } else {
-      return id.getResources();
     }
+
+    return id.getResources();
   }
 
   public class Rule extends JPanel {

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -259,16 +259,16 @@ public class StatPanel extends AbstractStatPanel {
     public synchronized int getRowCount() {
       if (!isDirty) {
         return collectedData.length;
-      } else {
-        // no need to recalculate all the stats just to get the row count
-        // getting the row count is a fairly frequent operation, and will
-        // happen even if we are not displayed!
-        gameData.acquireReadLock();
-        try {
-          return gameData.getPlayerList().size() + getAlliances().size();
-        } finally {
-          gameData.releaseReadLock();
-        }
+      }
+
+      // no need to recalculate all the stats just to get the row count
+      // getting the row count is a fairly frequent operation, and will
+      // happen even if we are not displayed!
+      gameData.acquireReadLock();
+      try {
+        return gameData.getPlayerList().size() + getAlliances().size();
+      } finally {
+        gameData.releaseReadLock();
       }
     }
 

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -125,9 +125,8 @@ public class TabbedProductionPanel extends ProductionPanel {
       final List<Tuple<String, List<Rule>>> ruleLists = properties.getRuleLists();
       checkLists(ruleLists);
       return ruleLists;
-    } else {
-      return getDefaultRuleLists();
     }
+    return getDefaultRuleLists();
   }
 
   private List<Tuple<String, List<Rule>>> getDefaultRuleLists() {

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -166,11 +166,7 @@ public class TechPanel extends ActionPanel {
       @Override
       public String getToolTipText(final MouseEvent e) {
         final int index = locationToIndex(e.getPoint());
-        if (-1 < index) {
-          return getTechListToolTipText(getModel().getElementAt(index));
-        } else {
-          return null;
-        }
+        return (-1 < index) ? getTechListToolTipText(getModel().getElementAt(index)) : null;
       }
     };
     final JPanel panel = new JPanel();
@@ -222,11 +218,7 @@ public class TechPanel extends ActionPanel {
         @Override
         public String getToolTipText(final MouseEvent e) {
           final int index = locationToIndex(e.getPoint());
-          if (-1 < index) {
-            return getTechListToolTipText(getModel().getElementAt(index));
-          } else {
-            return null;
-          }
+          return (-1 < index) ? getTechListToolTipText(getModel().getElementAt(index)) : null;
         }
       };
       final JPanel panel = new JPanel();
@@ -257,9 +249,8 @@ public class TechPanel extends ActionPanel {
       final TechAdvance advance = iterTechList.next();
       if (listedAlready.contains(advance)) {
         continue;
-      } else {
-        listedAlready.add(advance);
       }
+      listedAlready.add(advance);
       final int freq = Collections.frequency(techList, advance);
       strTechCategory.append(advance.getName()).append(freq > 1 ? " (" + freq + "/" + techList.size() + ")" : "");
       if (iterTechList.hasNext()) {

--- a/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -49,10 +49,8 @@ public class TooltipProperties {
   public String getToolTip(final UnitType ut, final PlayerID playerId) {
     final String tooltip = properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName() + "."
         + (playerId == null ? PlayerID.NULL_PLAYERID.getName() : playerId.getName()), "");
-    if (tooltip == null || tooltip.equals("")) {
-      return properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName(), "");
-    } else {
-      return tooltip;
-    }
+    return (tooltip == null || tooltip.equals(""))
+        ? properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName(), "")
+        : tooltip;
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2039,11 +2039,8 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public Optional<InGameLobbyWatcherWrapper> getInGameLobbyWatcher() {
-    if (ServerGame.class.isAssignableFrom(getGame().getClass())) {
-      final ServerGame serverGame = (ServerGame) getGame();
-      return Optional.ofNullable(serverGame.getInGameLobbyWatcher());
-    } else {
-      return Optional.empty();
-    }
+    return ServerGame.class.isAssignableFrom(getGame().getClass())
+        ? Optional.ofNullable(((ServerGame) getGame()).getInGameLobbyWatcher())
+        : Optional.empty();
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -91,17 +91,18 @@ public class UserActionPanel extends ActionPanel {
     if (validUserActions.isEmpty()) {
       // No Valid User actions, do nothing
       return null;
-    } else {
-      if (this.firstRun) {
-        ClipPlayer.play(SoundPath.CLIP_PHASE_USER_ACTIONS, getCurrentPlayer());
-      }
-      SwingUtilities.invokeLater(() -> {
-        selectUserActionButton.setEnabled(true);
-        doneButton.setEnabled(true);
-        // press the user action button for us.
-        selectUserActionAction.actionPerformed(null);
-      });
     }
+
+    if (this.firstRun) {
+      ClipPlayer.play(SoundPath.CLIP_PHASE_USER_ACTIONS, getCurrentPlayer());
+    }
+    SwingUtilities.invokeLater(() -> {
+      selectUserActionButton.setEnabled(true);
+      doneButton.setEnabled(true);
+      // press the user action button for us.
+      selectUserActionAction.actionPerformed(null);
+    });
+
     waitForRelease();
     return choice;
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -78,34 +78,35 @@ public class TripleAMenuBar extends JMenuBar {
       // If the user selects a filename that already exists,
       // the AWT Dialog on Mac OS X will ask the user for confirmation
       return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
-    } else { // Non-Mac platforms should use the normal Swing JFileChooser
-      final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
-      final int selectedOption = fileChooser.showSaveDialog(frame);
-      if (selectedOption != JFileChooser.APPROVE_OPTION) {
+    }
+
+    // Non-Mac platforms should use the normal Swing JFileChooser
+    final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
+    final int selectedOption = fileChooser.showSaveDialog(frame);
+    if (selectedOption != JFileChooser.APPROVE_OPTION) {
+      return null;
+    }
+    File f = fileChooser.getSelectedFile();
+    // disallow sub directories to be entered (in the form directory/name) for Windows boxes
+    if (SystemProperties.isWindows()) {
+      final int slashIndex = Math.min(f.getPath().lastIndexOf("\\"), f.getPath().length());
+      final String filePath = f.getPath().substring(0, slashIndex);
+      if (!fileChooser.getCurrentDirectory().toString().equals(filePath)) {
+        JOptionPane.showConfirmDialog(frame, "Sub directories are not allowed in the file name.  Please rename it.",
+            "Cancel?", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE);
         return null;
       }
-      File f = fileChooser.getSelectedFile();
-      // disallow sub directories to be entered (in the form directory/name) for Windows boxes
-      if (SystemProperties.isWindows()) {
-        final int slashIndex = Math.min(f.getPath().lastIndexOf("\\"), f.getPath().length());
-        final String filePath = f.getPath().substring(0, slashIndex);
-        if (!fileChooser.getCurrentDirectory().toString().equals(filePath)) {
-          JOptionPane.showConfirmDialog(frame, "Sub directories are not allowed in the file name.  Please rename it.",
-              "Cancel?", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE);
-          return null;
-        }
-      }
-      f = new File(f.getParent(), GameDataFileUtils.addExtensionIfAbsent(f.getName()));
-      // A small warning so users will not over-write a file
-      if (f.exists()) {
-        final int choice =
-            JOptionPane.showConfirmDialog(frame, "A file by that name already exists. Do you wish to over write it?",
-                "Over-write?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-        if (choice != JOptionPane.OK_OPTION) {
-          return null;
-        }
-      }
-      return f;
     }
+    f = new File(f.getParent(), GameDataFileUtils.addExtensionIfAbsent(f.getName()));
+    // A small warning so users will not over-write a file
+    if (f.exists()) {
+      final int choice =
+          JOptionPane.showConfirmDialog(frame, "A file by that name already exists. Do you wish to over write it?",
+              "Over-write?", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+      if (choice != JOptionPane.OK_OPTION) {
+        return null;
+      }
+    }
+    return f;
   }
 }

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -82,11 +82,7 @@ public class UnitSeperator {
         categories.put(entry, entry);
       }
     }
-    if (sort) {
-      return new TreeSet<>(categories.keySet());
-    } else {
-      return new LinkedHashSet<>(categories.keySet());
-    }
+    return sort ? new TreeSet<>(categories.keySet()) : new LinkedHashSet<>(categories.keySet());
   }
 
   /**

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -340,12 +340,7 @@ public class SwingComponents {
     }
 
     final int result = fileChooser.showOpenDialog(null);
-
-    if (result == JFileChooser.APPROVE_OPTION) {
-      return Optional.of(fileChooser.getSelectedFile());
-    } else {
-      return Optional.empty();
-    }
+    return (result == JFileChooser.APPROVE_OPTION) ? Optional.of(fileChooser.getSelectedFile()) : Optional.empty();
   }
 
   /**

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -71,11 +71,7 @@ public final class Util {
    * problems. Fix is to use 3Byte rather than INT.
    */
   public static BufferedImage createImage(final int width, final int height, final boolean needAlpha) {
-    if (needAlpha) {
-      return new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
-    } else {
-      return new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
-    }
+    return new BufferedImage(width, height, needAlpha ? BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
   }
 
   public static Dimension getDimension(final Image anImage, final ImageObserver obs) {

--- a/src/main/java/games/strategy/util/PropertyUtil.java
+++ b/src/main/java/games/strategy/util/PropertyUtil.java
@@ -52,15 +52,15 @@ public class PropertyUtil {
       } catch (final NoSuchFieldException e) {
         return getFieldIncludingFromSuperClasses(c, name, true);
       }
-    } else {
-      if (c.getSuperclass() == null) {
-        throw new IllegalStateException("No such Property Field: " + name);
-      }
-      try {
-        return c.getSuperclass().getDeclaredField(name); // TODO: unchecked reflection
-      } catch (final NoSuchFieldException e) {
-        return getFieldIncludingFromSuperClasses(c.getSuperclass(), name, true);
-      }
+    }
+
+    if (c.getSuperclass() == null) {
+      throw new IllegalStateException("No such Property Field: " + name);
+    }
+    try {
+      return c.getSuperclass().getDeclaredField(name); // TODO: unchecked reflection
+    } catch (final NoSuchFieldException e) {
+      return getFieldIncludingFromSuperClasses(c.getSuperclass(), name, true);
     }
   }
 

--- a/src/main/java/org/triplea/client/launch/screens/staging/panels/playerselection/SwingComponentTracker.java
+++ b/src/main/java/org/triplea/client/launch/screens/staging/panels/playerselection/SwingComponentTracker.java
@@ -51,14 +51,14 @@ public class SwingComponentTracker implements Consumer<PlayerSelectionModel> {
     } else if (playerSelectionModel.isCountryTakenByAnyPlayer(country)) {
       if (stagingScreen == StagingScreen.NETWORK_CLIENT) {
         return new JLabel(playerSelectionModel.getPlayerNameByCountry(country));
-      } else {
-        Preconditions.checkState(stagingScreen == StagingScreen.NETWORK_HOST);
-        return JButtonBuilder.builder()
-            .title(playerSelectionModel.getPlayerNameByCountry(country))
-            .toolTip("Click to remove " + playerSelectionModel.getPlayerNameByCountry(country) + " from " + country)
-            .actionListener(() -> playerSelectionModel.updateCountryToEmptyPlayerSelection(country))
-            .build();
       }
+
+      Preconditions.checkState(stagingScreen == StagingScreen.NETWORK_HOST);
+      return JButtonBuilder.builder()
+          .title(playerSelectionModel.getPlayerNameByCountry(country))
+          .toolTip("Click to remove " + playerSelectionModel.getPlayerNameByCountry(country) + " from " + country)
+          .actionListener(() -> playerSelectionModel.updateCountryToEmptyPlayerSelection(country))
+          .build();
     } else {
       return JButtonBuilder.builder()
           .title("Play")

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -137,12 +137,7 @@ public class ReliefImageBreaker {
    * @return map name entered by the user (if any, null returned if canceled)
    */
   private static String getMapDirectory() {
-    final String mapDir = JOptionPane.showInputDialog(null, "Enter the name of the map (ie. revised)");
-    if (mapDir != null) {
-      return mapDir;
-    } else {
-      return null;
-    }
+    return JOptionPane.showInputDialog(null, "Enter the name of the map (ie. revised)");
   }
 
   /**
@@ -165,9 +160,8 @@ public class ReliefImageBreaker {
         ClientLogger.logQuietly("interrupted while loading images", e);
         return loadImage();
       }
-    } else {
-      return null;
     }
+    return null;
   }
 
   private void processImage(final String territory, final Image map) throws IOException {

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -135,9 +135,8 @@ public class TileImageBreaker {
         ClientLogger.logQuietly(e);
         return loadImage();
       }
-    } else {
-      return null;
     }
+    return null;
   }
 
   private static String getValue(final String arg) {


### PR DESCRIPTION
This PR removes unnecessary `else` clauses as identified by static analysis.  In some cases, the surrounding `else` clause was simply removed and the code re-indented.  In other cases, an `if`-`else` statement that returned a value from both branches was changed to a single return using the ternary operator.

It is recommended to review this PR with whitespace changes ignored (`?w=1`).

This PR is the last part of several PRs in order to keep the review size reasonable.