### PR TITLE
Set table header and row text color to black

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -124,6 +124,7 @@ public class HelpMenu {
     final String color3 = "FEECE2";
     final StringBuilder hints = new StringBuilder();
     hints.append("<html>");
+    hints.append("<head><style>th, tr{color:black}</style></head>");
     try {
       gameData.acquireReadLock();
       final Map<PlayerID, Map<UnitType, ResourceCollection>> costs =


### PR DESCRIPTION
Fixes addition issues from #2769 where unit help text appears white instead of black after substance update.

After fix:
![image](https://user-images.githubusercontent.com/1427689/34464963-98df3dc4-ee5d-11e7-9839-d63a9f4e788b.png)
