### PR TITLE
Host Substance dependencies in Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/*.jar filter=lfs diff=lfs merge=lfs -text

--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,6 @@ jar {
 
 repositories {
     jcenter()
-
-    maven {
-        url 'https://dl.bintray.com/ssoloff/maven/'
-    }
 }
 
 dependencies {
@@ -96,7 +92,6 @@ dependencies {
     compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
     compile 'com.sun.mail:javax.mail:1.6.0'
     compile 'commons-io:commons-io:2.5'
-    compile 'io.github.ssoloff:substance:7.1.01'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
     compile 'org.apache.commons:commons-math3:3.6.1'
@@ -104,8 +99,9 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
+    compile files('lib/substance-7.1.01.jar')
 
-    runtime 'io.github.ssoloff:trident:1.4.00'
+    runtime files('lib/trident-1.4.jar')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'

--- a/lib/substance-7.1.01.jar
+++ b/lib/substance-7.1.01.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98f51e5a0fe7cbb624fcb9a7385cb5d32afbd9232d6170bad2c55c884e5f0105
+size 1814133

--- a/lib/trident-1.4.jar
+++ b/lib/trident-1.4.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40513d203ffda4b73ead63f04b542108afa6e263d224ba5ed3f8ab10193f556e
+size 78947


### PR DESCRIPTION
This is the first of two proposed solutions to the issue raised [here](https://github.com/triplea-game/triplea/issues/2769#issuecomment-354628127), namely that dependencies must not be hosted in my Bintray account.

This solution simply stores the dependencies in the Git repo under the _lib/_ folder.  (This folder was used in the past for a similar purpose before all dependencies were pulled from Maven Central or jCenter.)

# :warning: :warning: :warning: NOTICE :warning: :warning: :warning:

This solution uses Git LFS to store the jar files.  **If merged, devs will have to [install a Git LFS client](https://github.com/git-lfs/git-lfs#getting-started) in order to build locally.**  Using Git LFS has been proposed to reduce the size of the `assets` repo (see [this discussion](https://github.com/triplea-game/triplea/issues/2682#issuecomment-354489825)).  It would make sense to also use it here to avoid tracking MiB-sized binary files in the repo.

Apparently, Travis has a Git LFS client pre-installed, as the build is successful over there.

If Git LFS is too controversial, I can update this PR to store the jars directly in the repo without the LFS indirection.