### PR TITLE
Download Substance dependencies from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 .idea
 .project
+.remote-libs/
 .settings
 .checkstyle
 
@@ -11,4 +12,3 @@
 bin/
 build/
 out/
-

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ mainClassName = 'games.strategy.engine.framework.GameRunner'
 ext {
     artifactsDir = file("$buildDir/artifacts")
     releasesDir = file("$buildDir/releases")
+    remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")
     schemasDir = file('config/triplea/schemas')
 
@@ -50,6 +51,16 @@ def getEngineVersion() {
 
     throw new GradleException("unable to determine engine version: "
         + "you must define either the project property 'engineVersion' or the game engine property 'engine_version'")
+}
+
+def remoteFile(url) {
+    def file = file("$remoteLibsDir/${java.nio.file.Paths.get(new URI(url).path).fileName}")
+    download {
+        src url
+        dest file
+        overwrite false
+    }
+    files(file)
 }
 
 version = getEngineVersion()
@@ -81,10 +92,6 @@ jar {
 
 repositories {
     jcenter()
-
-    maven {
-        url 'https://dl.bintray.com/ssoloff/maven/'
-    }
 }
 
 dependencies {
@@ -96,7 +103,6 @@ dependencies {
     compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
     compile 'com.sun.mail:javax.mail:1.6.0'
     compile 'commons-io:commons-io:2.5'
-    compile 'io.github.ssoloff:substance:7.1.01'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
     compile 'org.apache.commons:commons-math3:3.6.1'
@@ -104,8 +110,9 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.18'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
+    compile remoteFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/substance-7.1.01.jar')
 
-    runtime 'io.github.ssoloff:trident:1.4.00'
+    runtime remoteFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
     testCompile 'org.apiguardian:apiguardian-api:1.0.0'
@@ -117,6 +124,10 @@ dependencies {
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.2'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.2'
     testRuntime 'org.slf4j:slf4j-nop:1.7.25'
+}
+
+task cleanRemoteLibs(type: Delete, group: LifecycleBasePlugin.BUILD_GROUP, description: 'Deletes the remote libraries directory.') {
+    delete remoteLibsDir
 }
 
 task integTest(type: JavaExec, dependsOn: [compileIntegTestJava]) {


### PR DESCRIPTION
This is the second of two proposed solutions to the issue raised [here](https://github.com/triplea-game/triplea/issues/2769#issuecomment-354628127), namely that dependencies must not be hosted in my Bintray account.

This solution is a slight modification to what @RoiEXLab originally proposed in #2717: downloading the dependencies directly from their host repo on GitHub.  It works around the Gradle lifecycle problem by not storing the jars under the _build/_ folder, but rather in a sibling folder (_.remote-libs/_) that is ignored by Git.  This prevents the dependencies from being deleted when a Gradle run includes the `clean` task.

**Note that this solution is subject to the same defect as hosting the dependencies in my personal Bintray account: the owner of the originating GitHub repository could choose to shut it down one day, thus breaking our build.**

A separate Gradle task (`cleanRemoteLibs`) that is independent of `clean` is provided to remove any dependencies downloaded using the `remoteFile()` mechanism.  (One could also simply `rm -rf .remote-libs/`.)

There is one caveat to the `cleanRemoteLibs` task.  If it is run after the dependencies have already been removed (e.g. running the task twice in a row), the dependencies will be downloaded and then immediately removed.  That is, it wastes time and bandwidth performing the unnecessary downloads.  However, this task will most likely only be used in very rare circumstances, and so this caveat is probably not a big deal.