### PR TITLE
Show error dialog instead of console

### DIFF
--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -15,20 +15,34 @@ public final class ErrorConsole extends GenericConsole {
   }
 
   /**
+   * Makes the error console visible.
+   */
+  public static void showConsole() {
+    getConsole().setVisible(true);
+  }
+
+  /**
    * Gets the singleton instance of the {@code ErrorConsole} class.
    *
    * @return An {@code ErrorConsole}.
    */
   public static ErrorConsole getConsole() {
     if (console == null) {
-      SwingAction.invokeAndWait(() -> {
-        console = new ErrorConsole();
-        console.displayStandardOutput();
-        console.displayStandardError();
-        ErrorHandler.registerExceptionHandler();
-      });
+      createConsole();
     }
     return console;
+  }
+
+  /**
+   * If not yet created, initializes the error console.
+   */
+  public static void createConsole() {
+    SwingAction.invokeAndWait(() -> {
+      console = new ErrorConsole();
+      console.displayStandardOutput();
+      console.displayStandardError();
+      ErrorHandler.registerExceptionHandler();
+    });
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -28,6 +28,8 @@ public final class ClientFileSystemHelper {
   private ClientFileSystemHelper() {}
 
   /**
+   * Returns top-most, or the root folder for the TripleA installation folder.
+   *
    * @return Folder that is the 'root' of the tripleA binary installation. This folder and
    *         contents contains the versioned content downloaded and initially installed. This is
    *         in contrast to the user root folder that is not replaced between installations.
@@ -96,6 +98,10 @@ public final class ClientFileSystemHelper {
   }
 
   /**
+   * TripleA stores two folders, one for user content that survives between game installs,
+   * and a second that contains binaries. This method returns the 'user folder', which contains
+   * maps and save games.
+   *
    * @return Folder where tripleA 'user data' is stored between game installations. This folder
    *         would contain as some examples: save games, downloaded maps. This location is currently
    *         not configurable (ideally we would allow this to be set during install perhaps).
@@ -107,6 +113,8 @@ public final class ClientFileSystemHelper {
   }
 
   /**
+   * Returns location of the folder containing downloaded TripleA maps.
+   *
    * @return Folder where maps are downloaded and stored. Default location is relative
    *         to users home folder and not the engine install folder, this allows it to be
    *         retained between engine installations. Users can override this location in settings.
@@ -115,11 +123,7 @@ public final class ClientFileSystemHelper {
     final String path = getUserMapsFolderPath(ClientSetting.USER_MAPS_FOLDER_PATH, ClientSetting.MAP_FOLDER_OVERRIDE);
     final File mapsFolder = new File(path);
     if (!mapsFolder.exists()) {
-      try {
-        mapsFolder.mkdirs();
-      } catch (final SecurityException e) {
-        ClientLogger.logError(e);
-      }
+      mapsFolder.mkdirs();
     }
     if (!mapsFolder.exists()) {
       ClientLogger.logError("Error, downloaded maps folder does not exist: " + mapsFolder.getAbsolutePath());

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -123,7 +123,7 @@ public class GameRunner {
     ClientSetting.initialize();
 
     if (!ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
-      ErrorConsole.getConsole();
+      ErrorConsole.createConsole();
     }
     if (!new ArgParser(COMMAND_LINE_ARGS).handleCommandLineArgs(args)) {
       usage();
@@ -188,6 +188,12 @@ public class GameRunner {
     return new FileDialog(mainFrame);
   }
 
+  /**
+   * Opens a Swing FileChooser menu.
+   * 
+   * @return Empty optional if dialog is closed without selection, otherwise returns the user
+   *         selection.
+   */
   public static Optional<File> showFileChooser(final FileFilter fileFilter) {
     final JFileChooser fileChooser = new JFileChooser();
     fileChooser.setFileFilter(fileFilter);
@@ -200,6 +206,10 @@ public class GameRunner {
   }
 
 
+  /**
+   * Opens a file selection dialog where a user can select/create a file for TripleA save game.
+   * An empty optional is returned if user just closes down the dialog window.
+   */
   public static Optional<File> showSaveGameFileChooser() {
     // Non-Mac platforms should use the normal Swing JFileChooser
     final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
@@ -308,7 +318,7 @@ public class GameRunner {
       final String msg = String.format(
           "Warning!! %d system checks failed. Some game features may not be available or may not work correctly.\n%s",
           exceptions.size(), localSystemChecker.getStatusMessage());
-      ClientLogger.logError(msg, exceptions);
+      ClientLogger.logError(msg);
     }
   }
 
@@ -352,7 +362,7 @@ public class GameRunner {
           super.dispatchEvent(newEvent);
           // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
         } catch (final Throwable t) {
-          ClientLogger.logError(t);
+          ClientLogger.logError("Failed while setting up logging", t);
           throw t;
         }
       }
@@ -388,7 +398,7 @@ public class GameRunner {
   }
 
   /**
-   * @return true if we are out of date or this is the first time this triplea has ever been run.
+   * Returns true if we are out of date or this is the first time this triplea has ever been run.
    */
   private static boolean checkForLatestEngineVersionOut() {
     try {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -16,6 +16,8 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
+import com.google.common.base.Ascii;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner;
@@ -167,8 +169,9 @@ public class EmailSenderEditor extends EditorPanel {
         message = "Email sent, it should arrive shortly, otherwise check your spam folder";
         messageType = JOptionPane.INFORMATION_MESSAGE;
       } catch (final IOException ioe) {
-        message = "Unable to send email; see TripleA Console for details.";
-        ClientLogger.logError(ioe);
+        message = "Unable to send email, check SMTP server credentials: "
+            + Ascii.truncate(ioe.getMessage(), 200, "...");
+        ClientLogger.logError(message, ioe);
       } finally {
         // now that we have a result, marshall it back unto the swing thread
         final String finalMessage = message;

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -90,7 +90,10 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        ClientLogger.logError(e.getCause());
+        // ExecutionException contains no useful information; it's simply an adapter to tunnel
+        // exceptions thrown by tasks through the Executor API. Log the cause only to reducase
+        // stack trace frames.
+        ClientLogger.logError("Failed to parse a map", e.getCause());
       }
     }
     return parsedMapSet;
@@ -170,6 +173,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
   }
 
   /**
+   * From a given URI, creates a GameChooserEntry and adds to the given entries list.
    * @param entries
    *        list of entries where to add the new entry.
    * @param uri
@@ -178,7 +182,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
   private static void addNewGameChooserEntry(final List<GameChooserEntry> entries, final URI uri) {
     try {
       final GameChooserEntry newEntry = createEntry(uri);
-      if (newEntry != null && !entries.contains(newEntry)) {
+      if (!entries.contains(newEntry)) {
         entries.add(newEntry);
       }
     } catch (final EngineVersionException e) {

--- a/src/main/java/games/strategy/thread/ThreadPool.java
+++ b/src/main/java/games/strategy/thread/ThreadPool.java
@@ -53,7 +53,11 @@ public class ThreadPool {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        ClientLogger.logError(e.getCause());
+        // ExecutionException contains no useful information; it's simply an adapter to tunnel
+        // exceptions thrown by tasks through the Executor API. Log the cause only to reducase
+        // stack trace frames.
+        ClientLogger.logError("Threading execution exception: " + e.getCause().getMessage(),
+            e.getCause());
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui;
 
+import java.awt.GraphicsEnvironment;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 
@@ -26,18 +28,12 @@ public class ErrorHandler implements Thread.UncaughtExceptionHandler, ErrorHandl
    */
   @Override
   public void handle(final Throwable throwable) {
-    try {
-      ClientLogger.logError(throwable);
-    } catch (final Throwable t) {
-      try {
-        // if client logger fails fall back to methods that may still work
-        final String msg =
-            "Original error: " + throwable.getMessage() + ", next error while handling it: " + t.getMessage();
-        System.err.println(msg);
-        t.printStackTrace();
-      } catch (final Throwable fatal) {
-        // Swallow this last error, if anything is thrown we can have an infinite loop of error handling.
-      }
+    if (GraphicsEnvironment.isHeadless()) {
+      final String msg = "Error: " + throwable.getMessage();
+      System.err.println(msg);
+      throwable.printStackTrace();
+    } else {
+      ClientLogger.logError("Error: " + throwable.getMessage(), throwable);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -22,7 +22,7 @@ class DebugMenu {
     menuBar.add(debugMenu);
 
     final Set<IGamePlayer> players = frame.getLocalPlayers().getLocalPlayers();
-    final boolean areThereProAIs = players.stream().filter(player -> player instanceof ProAI).findFirst().isPresent();
+    final boolean areThereProAIs = players.stream().anyMatch(ProAI.class::isInstance);
     if (areThereProAIs) {
       ProAI.initialize(frame);
       debugMenu.add(SwingAction.of("Show Hard AI Logs", e -> ProAI.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
@@ -30,7 +30,7 @@ class DebugMenu {
 
     debugMenu.add(new EnablePerformanceLoggingCheckBox());
     debugMenu.add(SwingAction.of("Show Console", e -> {
-      ErrorConsole.getConsole().setVisible(true);
+      ErrorConsole.showConsole();
       ErrorConsole.getConsole().append(DebugUtils.getMemory());
     })).setMnemonic(KeyEvent.VK_C);
   }

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -17,7 +17,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.debug.ClientLogger;
 
 /**
- * Builder class for using Lambda expressions to create 'AbstractAction'
+ * Builder class for using Lambda expressions to create 'AbstractAction'.
  *
  * <p>
  * For example, instead of:
@@ -41,6 +41,12 @@ import games.strategy.debug.ClientLogger;
 public class SwingAction {
 
   /**
+   * Creates a Swing 'Action' object around a given name and action listener. Example:
+   * <pre><code>
+   *   private final Action nullAction = SwingAction.of(" ", e -> {
+   *   });
+   * </code></pre>
+   *
    * @param name Name for the abstract action, passed along to the AbstractAction constructor.
    * @param swingAction Lambda java.tools.function.Consumer object, accepts one arg and returns void.
    */
@@ -74,7 +80,7 @@ public class SwingAction {
         SwingUtilities.invokeAndWait(action);
       }
     } catch (final InvocationTargetException e) {
-      ClientLogger.logError(e);
+      ClientLogger.logError("Failed while invoking a swing UI action", e);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -173,13 +173,13 @@ public class PointFileReaderWriter {
         current = reader.readLine();
       }
     } catch (final IOException ioe) {
-      ClientLogger.logError(ioe);
+      ClientLogger.logError("PointFileReaderWriter error, " + ioe.getMessage(), ioe);
       System.exit(0);
     } finally {
       try {
         stream.close();
       } catch (final IOException e) {
-        ClientLogger.logError(e);
+        ClientLogger.logError("Failed to close point file reader", e);
       }
     }
     return mapping;
@@ -208,7 +208,7 @@ public class PointFileReaderWriter {
           stream.close();
         }
       } catch (final IOException e) {
-        ClientLogger.logError(e);
+        ClientLogger.logError("Failed to close polygon reader stream", e);
       }
     }
     return mapping;

--- a/src/main/java/swinglib/ErrorMessageBuilder.java
+++ b/src/main/java/swinglib/ErrorMessageBuilder.java
@@ -1,0 +1,117 @@
+package swinglib;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JOptionPane;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import games.strategy.ui.SwingAction;
+
+
+/**
+ * Swing builder for an error message pop-up (Uses JOptionPane). Example usages:
+ * <code><pre>
+ *   JOptionPaneBuilder.builder()
+ *     .title("Something Crashed")
+ *     .message("Error Details")
+ *     .option("ok", () -> {})
+ *     .option("quit", () -> System.exit(0))
+ *     .buildAndShow();
+ * </pre></code>
+ * Default error dialog with an 'ok' button:
+ * <code><pre>
+ *   JOptionPaneBuilder.builder()
+ *     .message("error details")
+ *     .buildAndShow();
+ * </pre></code>
+ */
+public class ErrorMessageBuilder {
+
+  private String title = "Error";
+  private String message;
+  private final List<CloseButton> actions = new ArrayList<>();
+
+  private static class CloseButton {
+    private final String buttonText;
+    private final Runnable closeAction;
+
+    private CloseButton(final String buttonText, final Runnable closeAction) {
+      this.buttonText = buttonText;
+      this.closeAction = closeAction;
+    }
+  }
+
+  private ErrorMessageBuilder() {}
+
+  public static ErrorMessageBuilder builder() {
+    return new ErrorMessageBuilder();
+  }
+
+  public ErrorMessageBuilder message(final String message) {
+    this.message = message;
+    return this;
+  }
+
+  /**
+   * Constructs a Swing JDialog using current builder values.
+   * Values that must be set: title, contents
+   */
+  public void buildAndShow() {
+    SwingAction.invokeAndWait(this::buildAndShowSwingSafe);
+  }
+
+  private void buildAndShowSwingSafe() {
+    checkState(!GraphicsEnvironment.isHeadless(), "JOptionPane throws an exception in headless environments");
+    checkNotNull(message);
+
+    if (actions.isEmpty()) {
+      actions.add(new CloseButton("OK", () -> {
+      }));
+    }
+
+    final String[] buttonOptions = actions.stream()
+        .map(button -> button.buttonText)
+        .toArray(String[]::new);
+
+    final int value = JOptionPane.showOptionDialog(
+        null,
+        message,
+        title,
+        JOptionPane.DEFAULT_OPTION,
+        JOptionPane.ERROR_MESSAGE,
+        null,
+        buttonOptions,
+        0);
+
+    actions.get(value).closeAction.run();
+  }
+
+  /**
+   * Adds another 'option' button to error message dialog window. Buttons are added in left to right order.
+   * 
+   * @param buttonText Text of the option button.
+   * @param buttonAction Action to be performed when the button is clicked.
+   */
+  public ErrorMessageBuilder option(final String buttonText, final Runnable buttonAction) {
+    // Swing adds elements right to left, but we want clients to add components left to right.
+    // To fix this we always insert the next component at the front of the list instead of tail.
+    actions.add(0, new CloseButton(buttonText, buttonAction));
+    return this;
+  }
+
+  /**
+   * Sets the value that will be displayed in the dialog window title bar.
+   */
+  public ErrorMessageBuilder title(final String title) {
+    Preconditions.checkArgument(!Strings.nullToEmpty(title).trim().isEmpty());
+    this.title = title;
+    return this;
+  }
+}

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -6,6 +6,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.border.Border;
 
+import com.google.common.base.Ascii;
 import com.google.common.base.Preconditions;
 
 /**
@@ -24,7 +25,7 @@ public class JLabelBuilder {
   private String text;
   private Alignment alignment;
   private Dimension maxSize;
-  private int maxTextLength;
+  private int maxTextLength = Integer.MAX_VALUE;
   private String tooltip;
   private Border border;
 
@@ -42,9 +43,7 @@ public class JLabelBuilder {
     Preconditions.checkNotNull(text);
     Preconditions.checkState(!text.trim().isEmpty());
 
-    final String truncated =
-        (maxTextLength > 0 && text.length() > maxTextLength) ? text.substring(0, maxTextLength) + "..." : text;
-
+    final String truncated = Ascii.truncate(text, maxTextLength, "...");
     final JLabel label = new JLabel(truncated);
 
     if (alignment != null) {

--- a/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
+++ b/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
@@ -6,9 +6,12 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.attachments.CanalAttachment;
@@ -22,6 +25,18 @@ public class XmlGameElementMapperTest {
   private static final String NAME_THAT_DOES_NOT_EXIST = "this is surely not a valid identifier";
 
   private XmlGameElementMapper testObj;
+
+  @BeforeAll
+  public static void disableErrorPopup() {
+    ClientLogger.disableErrorPopupForTesting();
+  }
+
+  @AfterAll
+  public static void resetErrorPopup() {
+    // we do this to make sure any other tests will show the popup and have a similar method
+    // call. We do not want test ordering to be important.
+    ClientLogger.resetErrorPopupForTesting();
+  }
 
   @BeforeEach
   public void setup() {

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1578,7 +1578,7 @@ public class WW2V3Year41Test {
   }
 
   @Test
-  public void testOccupiedTerrOfAttachmentWithCapital() {
+  public void testOccupiedTerrOfAttachmentWithCapital() throws GameParseException {
     // Set up test
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
@@ -1594,14 +1594,9 @@ public class WW2V3Year41Test {
     // Remove original capital
     final TerritoryAttachment taMongolia = TerritoryAttachment.get(mongolia);
     final TerritoryAttachment taKiangsu = TerritoryAttachment.get(kiangsu);
-    try {
-      final String noVal = null;
-      taMongolia.setCapital(noVal);
-      // Set as NEW capital
-      taKiangsu.setCapital(Constants.PLAYER_NAME_CHINESE);
-    } catch (final GameParseException e) {
-      ClientLogger.logError(e);
-    }
+    taMongolia.setCapital(null);
+    // Set as NEW capital
+    taKiangsu.setCapital(Constants.PLAYER_NAME_CHINESE);
     // Remove all units
     removeFrom(kiangsu, kiangsu.getUnits().getUnits());
     removeFrom(hupeh, hupeh.getUnits().getUnits());


### PR DESCRIPTION
### Summary
This PR updates how we do error handling for the Client GUI. With this update instead of showing the error console to the user on error events, we instead show a pop-up box. The pop-up box has two options "ok", to close the pop-up, and "show details" which will close the pop-up and reveal the error console.

This fixes a number of problems with showing the console:
- the error message can be very hard to find in the stack trace, it can be hard to even know what the error was, particularly if a user has never seen the content of the error console before.
- the console window scrolls to the bottom, again this makes it not clear what the error message was to an average user who has to scroll up and hunt for it.

I hope that this also sets us up in a good position to have a 'send error report' button included with the error message dialog. Clicking that button would upload the error message to our server with stack trace and any other details we would want. It was a bit painful to get the client->server communication set up, so in the meantime this was a good stepping stone in that direction.

### Context, Background on Error Handling
Error handling was once done by overriding System.out and System.err to print to a console window, where System.err messages would reveal the console window if not already visible. This then evolved, we collected all such System.out and System.err print statements to a 'ClientLogger' class. The console window suffers from a number of problems, the error messages printed there are not always very clear to users what has happened.

### API updates
- Deprecated the `ClientLogger.logQuietly(Throwable)` API (too many usages to convert outright to `logQuietly(String,Throwable)`). Deprecation reasoning is that we should always include very user-friendly error message if something happened, this API allows for a bad UX where the average user is given a good error message that tells them what happened and what impact it has on the game.

- Add error messages to convert usages of: `ClientLogger.logError(Throwable)` to:  `logError(String, Throwable)`

- Add some helper methods/fixed up API of `ErrorConsole`, so you'll see method calls like `ErrorConsole.showConsole` instead of `ErrorConsole.getConsole`
### How to demo:

It's pretty easy to test on a laptop or any OS where you can disable networking. To demo, disable networking and then launch the game, we show a start-up error message if networking is not available.

### Screenshots

#### Before
<img width="1056" alt="screen shot 2018-01-01 at 2 48 26 pm" src="https://user-images.githubusercontent.com/12397753/34471865-89bad94c-ef08-11e7-836c-5bcbd3ebba8a.png">

#### After
<img width="1082" alt="screen shot 2018-01-01 at 2 21 59 pm" src="https://user-images.githubusercontent.com/12397753/34471600-b34287e8-ef02-11e7-9e8a-3c96b6d8db28.png">

### Review notes

3 of 5 commits fixed checkstyle violations in the files that were modified, mostly commentary updates. One could review the other 2 commits individually without much trouble, but I'd recommend looking at the overall diff, the pure checkstyle fixes add some noise to the diff, but it did not seem too excessive.
