### PR TITLE
Fix array equality check , clean 'logger.finer' statements

### DIFF
--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -3,14 +3,10 @@ package games.strategy.engine.message;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import games.strategy.util.Tuple;
 
 class RemoteInterfaceHelper {
-  private static final Logger logger = Logger.getLogger(RemoteInterfaceHelper.class.getName());
-
   static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
@@ -18,19 +14,8 @@ class RemoteInterfaceHelper {
     for (int i = 0; i < methods.length; i++) {
       if (methods[i].getName().equals(methodName)) {
         final Class<?>[] types = methods[i].getParameterTypes();
-        if ((types == null) && (argTypes == null)) {
+        if (Arrays.equals(types, argTypes)) {
           return i;
-        } else if ((types != null) && (argTypes != null) && (types.length == argTypes.length)) {
-          boolean match = true;
-          for (int j = 0; j < argTypes.length; j++) {
-            if (!argTypes[j].equals(types[j])) {
-              match = false;
-              break;
-            }
-          }
-          if (match) {
-            return i;
-          }
         }
       }
     }

--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -14,16 +14,13 @@ class RemoteInterfaceHelper {
   static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
-    if (logger.isLoggable(Level.FINEST)) {
-      logger.fine("Sorted methods:" + Arrays.asList(methods));
-    }
+
     for (int i = 0; i < methods.length; i++) {
       if (methods[i].getName().equals(methodName)) {
         final Class<?>[] types = methods[i].getParameterTypes();
-        // both null
-        if (types == argTypes) {
+        if ((types == null) && (argTypes == null)) {
           return i;
-        } else if (types != null && argTypes != null && types.length == argTypes.length) {
+        } else if ((types != null) && (argTypes != null) && (types.length == argTypes.length)) {
           boolean match = true;
           for (int j = 0; j < argTypes.length; j++) {
             if (!argTypes[j].equals(types[j])) {
@@ -43,9 +40,6 @@ class RemoteInterfaceHelper {
   static Tuple<String, Class<?>[]> getMethodInfo(final int methodNumber, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
-    if (logger.isLoggable(Level.FINEST)) {
-      logger.fine("Sorted methods:" + Arrays.asList(methods));
-    }
     return Tuple.of(methods[methodNumber].getName(), methods[methodNumber].getParameterTypes());
   }
 
@@ -61,8 +55,7 @@ class RemoteInterfaceHelper {
     }
     final Class<?>[] t1 = o1.getParameterTypes();
     final Class<?>[] t2 = o2.getParameterTypes();
-    // both null
-    if (t1 == t2) {
+    if ((t1 == null) && (t2 == null)) {
       return 0;
     }
     if (t1 == null) {

--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -15,7 +15,7 @@ class RemoteInterfaceHelper {
     return IntStream.range(0, methods.length)
         .filter(i -> methods[i].getName().equals(methodName))
         .filter(i -> Arrays.equals(argTypes, methods[i].getParameterTypes()))
-        .findFirst()
+        .findAny()
         .orElseThrow(() -> new IllegalStateException("Method not found: " + methodName));
   }
 

--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -3,6 +3,7 @@ package games.strategy.engine.message;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.stream.IntStream;
 
 import games.strategy.util.Tuple;
 
@@ -11,15 +12,11 @@ class RemoteInterfaceHelper {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
 
-    for (int i = 0; i < methods.length; i++) {
-      if (methods[i].getName().equals(methodName)) {
-        final Class<?>[] types = methods[i].getParameterTypes();
-        if (Arrays.equals(types, argTypes)) {
-          return i;
-        }
-      }
-    }
-    throw new IllegalStateException("Method not found");
+    return IntStream.range(0, methods.length)
+        .filter(i -> methods[i].getName().equals(methodName))
+        .filter(i -> Arrays.equals(argTypes, methods[i].getParameterTypes()))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("Method not found: " + methodName));
   }
 
   static Tuple<String, Class<?>[]> getMethodInfo(final int methodNumber, final Class<?> remoteInterface) {


### PR DESCRIPTION
Static analysis flagged two arrays being compared against each other (equality match as opposed to logical). Turns out we do this as a way to check if both arrays are null, in both cases we have a comment saying so. This is a bit 'overly clever', we can instead dumb it down and check if both variables are not null, and remove the comment.

Along the way there were a few logger.fine statements that could get removed.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
