### PR TITLE
IDE configuration - add eclipse import ordering file

### DIFF
--- a/eclipse/format/triplea_export_order.importorder
+++ b/eclipse/format/triplea_export_order.importorder
@@ -1,0 +1,6 @@
+#Organize Import Order
+#Mon Jan 01 22:20:26 PST 2018
+3=com
+2=org
+1=javax
+0=java


### PR DESCRIPTION
This file can be imported to eclipse and intellij IDE with eclipse formatter plugin. This way both IDE's can be configured to have same import ordering. Note, eclipse users will need to configure this, for now the ordering appears to match default.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
