### PR TITLE
Remove logger.fine statements

### DIFF
--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -36,7 +36,6 @@ public class CompositeRouteFinder {
   public CompositeRouteFinder(final GameMap map, final Map<Predicate<Territory>, Integer> matches) {
     this.map = map;
     this.matches = matches;
-    logger.finer("Initializing CompositeRouteFinderClass...");
   }
 
   Route findRoute(final Territory start, final Territory end) {

--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -6,11 +6,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import games.strategy.engine.GameOverException;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.message.MessengerException;
 import games.strategy.triplea.util.WrappedInvocationHandler;
 
@@ -57,38 +55,13 @@ public class DelegateExecutionManager {
    * </p>
    */
   public boolean blockDelegateExecution(final int timeToWaitMs) throws InterruptedException {
-    final boolean lockAcquired = readWriteLock.writeLock().tryLock(timeToWaitMs, TimeUnit.MILLISECONDS);
-    if (!lockAcquired) {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine("Could not block delegate execution. Read Lock count: " + readWriteLock.getReadLockCount()
-            + " Write Hold count: " + readWriteLock.getWriteHoldCount() + " Queue Length: "
-            + readWriteLock.getQueueLength() + " Current Thread Has Lock: "
-            + readWriteLock.isWriteLockedByCurrentThread() + " Has Queued Threads: "
-            + readWriteLock.hasQueuedThreads() + " Is Write Locked: " + readWriteLock.isWriteLocked()
-            + " toString: " + readWriteLock.toString());
-      } else {
-        HeadlessGameServer.log("Could not block delegate execution. Read Lock count: "
-            + readWriteLock.getReadLockCount() + " Write Hold count: " + readWriteLock.getWriteHoldCount()
-            + " Queue Length: " + readWriteLock.getQueueLength() + " Current Thread Has Lock: "
-            + readWriteLock.isWriteLockedByCurrentThread() + " Has Queued Threads: "
-            + readWriteLock.hasQueuedThreads() + " Is Write Locked: " + readWriteLock.isWriteLocked()
-            + " toString: " + readWriteLock.toString());
-      }
-    } else {
-      if (logger.isLoggable(Level.FINE)) {
-        logger.fine(Thread.currentThread().getName() + " block delegate execution.");
-      }
-    }
-    return lockAcquired;
+    return readWriteLock.writeLock().tryLock(timeToWaitMs, TimeUnit.MILLISECONDS);
   }
 
   /**
    * Allow delegate execution to resume.
    */
   public void resumeDelegateExecution() {
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine(Thread.currentThread().getName() + " resumes delegate execution.");
-    }
     readWriteLock.writeLock().unlock();
   }
 
@@ -169,17 +142,11 @@ public class DelegateExecutionManager {
   }
 
   public void leaveDelegateExecution() {
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine(Thread.currentThread().getName() + " leaves delegate execution.");
-    }
     readWriteLock.readLock().unlock();
     currentThreadHasReadLock.set(null);
   }
 
   public void enterDelegateExecution() {
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine(Thread.currentThread().getName() + " enters delegate execution.");
-    }
     if (currentThreadHasReadLock()) {
       throw new IllegalStateException("Already locked?");
     }

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -57,9 +57,7 @@ public class LocalLauncher extends AbstractLauncher {
     }
     try {
       if (exceptionLoadingGame == null) {
-        logger.fine("Game starting");
         game.startGame();
-        logger.fine("Game over");
       }
     } finally {
       // todo(kg), this does not occur on the swing thread, and this notifies setupPanel observers

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -125,7 +125,6 @@ public class ServerLauncher extends AbstractLauncher {
       }
       remoteMessenger.registerRemote(serverReady, ClientModel.CLIENT_READY_CHANNEL);
       gameData.doPreGameStartDataModifications(playerListing);
-      logger.fine("Starting server");
       abortLaunch = testShouldWeAbort();
       final byte[] gameDataAsBytes = gameData.toBytes();
       final Set<IGamePlayer> localPlayerSet =

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -78,9 +78,6 @@ class LobbyGameController implements ILobbyGameController {
   public void updateGame(final GUID gameId, final GameDescription description) {
     final INode from = MessageContext.getSender();
     assertCorrectHost(description, from);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("Game updated:" + description);
-    }
     synchronized (mutex) {
       final GameDescription oldDescription = allGames.get(gameId);
       // out of order updates
@@ -121,13 +118,10 @@ class LobbyGameController implements ILobbyGameController {
     assertCorrectHost(description, from);
     final int port = description.getPort();
     final String host = description.getHostedBy().getAddress().getHostAddress();
-    logger.fine("Testing game connection on host:" + host + " port:" + port);
     try (Socket s = new Socket()) {
       s.connect(new InetSocketAddress(host, port), 10 * 1000);
-      logger.fine("Connection test passed for host:" + host + " port:" + port);
       return null;
     } catch (final IOException e) {
-      logger.fine("Connection test failed for host:" + host + " port:" + port + " reason:" + e.getMessage());
       return "host:" + host + " " + " port:" + port;
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -62,7 +62,6 @@ public class BannedMacController extends TimedController implements BannedMacDao
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);
           if (banTill != null && banTill.toInstant().isBefore(now())) {
-            logger.fine("Ban expired for:" + mac);
             removeBannedMac(mac);
             return Tuple.of(false, banTill);
           }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -19,7 +19,6 @@ public class BannedUsernameController extends TimedController implements BannedU
   @Override
   public void addBannedUsername(final String username, final Instant banTill) {
     if (banTill == null || banTill.isAfter(now())) {
-      logger.fine("Banning username:" + username);
 
       try (Connection con = Database.getPostgresConnection();
           PreparedStatement ps = con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)"
@@ -37,7 +36,6 @@ public class BannedUsernameController extends TimedController implements BannedU
   }
 
   private static void removeBannedUsername(final String username) {
-    logger.fine("Removing banned username:" + username);
 
     try (Connection con = Database.getPostgresConnection();
         PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?")) {
@@ -64,7 +62,6 @@ public class BannedUsernameController extends TimedController implements BannedU
         if (rs.next()) {
           final Timestamp banTill = rs.getTimestamp(2);
           if (banTill != null && banTill.toInstant().isBefore(now())) {
-            logger.fine("Ban expired for:" + username);
             removeBannedUsername(username);
             return Tuple.of(false, banTill);
           }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -24,7 +24,6 @@ public class MutedMacController extends TimedController {
    */
   public void addMutedMac(final String mac, final Instant muteTill) {
     if (muteTill == null || muteTill.isAfter(now())) {
-      logger.fine("Muting mac:" + mac);
 
       try (Connection con = Database.getPostgresConnection();
           PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)"
@@ -42,7 +41,6 @@ public class MutedMacController extends TimedController {
   }
 
   private static void removeMutedMac(final String mac) {
-    logger.fine("Removing muted mac:" + mac);
 
     try (Connection con = Database.getPostgresConnection();
         PreparedStatement ps = con.prepareStatement("delete from muted_macs where mac=?")) {
@@ -81,7 +79,6 @@ public class MutedMacController extends TimedController {
           }
           final Instant expiration = muteTill.toInstant();
           if (expiration.isBefore(now())) {
-            logger.fine("Mute expired for:" + mac);
             // If the mute has expired, allow the mac
             removeMutedMac(mac);
             // Signal as not-muted

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -24,7 +24,6 @@ public class MutedUsernameController extends TimedController {
    */
   public void addMutedUsername(final String username, final Instant muteTill) {
     if (muteTill == null || muteTill.isAfter(now())) {
-      logger.fine("Muting username:" + username);
 
       try (Connection con = Database.getPostgresConnection();
           PreparedStatement ps = con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
@@ -42,7 +41,6 @@ public class MutedUsernameController extends TimedController {
   }
 
   private static void removeMutedUsername(final String username) {
-    logger.fine("Removing muted username:" + username);
 
     try (Connection con = Database.getPostgresConnection();
         PreparedStatement ps = con.prepareStatement("delete from muted_usernames where username = ?")) {
@@ -82,7 +80,6 @@ public class MutedUsernameController extends TimedController {
           final Instant expiration = muteTill.toInstant();
           if (expiration.isBefore(now())) {
             // If the mute has expired, allow the username
-            logger.fine("Mute expired for:" + username);
             removeMutedUsername(username);
             // Signal as not-muted
             return Optional.empty();

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -49,9 +49,6 @@ public class RemoteMethodCall implements Externalizable {
     this.args = args;
     this.argTypes = classesToString(argTypes, args);
     methodNumber = RemoteInterfaceHelper.getNumber(methodName, argTypes, remoteInterface);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("Remote Method Call:" + debugMethodText());
-    }
   }
 
   private String debugMethodText() {
@@ -185,8 +182,5 @@ public class RemoteMethodCall implements Externalizable {
     final Tuple<String, Class<?>[]> values = RemoteInterfaceHelper.getMethodInfo(methodNumber, remoteType);
     methodName = values.getFirst();
     argTypes = classesToString(values.getSecond(), args);
-    if (logger.isLoggable(Level.FINE)) {
-      logger.fine("Remote Method for class:" + remoteType.getSimpleName() + " Resolved To:" + debugMethodText());
-    }
   }
 }

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -139,16 +139,10 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     if (shutdown) {
       return;
     }
-    if (logger.isLoggable(Level.FINEST)) {
-      logger.log(Level.FINEST, "Sending" + msg + " to:" + to);
-    }
     final MessageHeader header = new MessageHeader(to, node, msg);
     final SocketChannel socketChannel = nodeToChannel.get(to);
     // the socket was removed
     if (socketChannel == null) {
-      if (logger.isLoggable(Level.FINER)) {
-        logger.log(Level.FINER, "no channel for node:" + to + " dropping message:" + msg);
-      }
       // the socket has not been added yet
       return;
     }
@@ -685,9 +679,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   public void socketUnqaurantined(final SocketChannel channel, final QuarantineConversation conversation) {
     final ServerQuarantineConversation con = (ServerQuarantineConversation) conversation;
     final INode remote = new Node(con.getRemoteName(), (InetSocketAddress) channel.socket().getRemoteSocketAddress());
-    if (logger.isLoggable(Level.FINER)) {
-      logger.log(Level.FINER, "Unquarntined node:" + remote);
-    }
     nodeToChannel.put(remote, channel);
     channelToNode.put(channel, remote);
     notifyConnectionsChanged(true, remote);

--- a/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -103,9 +103,6 @@ public class ClientQuarantineConversation extends QuarantineConversation {
         case READ_CHALLENGE:
           // read name, send challenge
           final Map<String, String> challenge = (Map<String, String>) o;
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "read challenge:" + challenge);
-          }
           if (challenge != null) {
             challengeProperties = challenge;
             showLatch.countDown();
@@ -117,24 +114,15 @@ public class ClientQuarantineConversation extends QuarantineConversation {
             if (isClosed) {
               return Action.NONE;
             }
-            if (logger.isLoggable(Level.FINER)) {
-              logger.log(Level.FINER, "writing response" + challengeResponse);
-            }
             send((Serializable) challengeResponse);
           } else {
             showLatch.countDown();
-            if (logger.isLoggable(Level.FINER)) {
-              logger.log(Level.FINER, "sending null response");
-            }
             send(null);
           }
           step = Step.READ_ERROR;
           return Action.NONE;
         case READ_ERROR:
           if (o != null) {
-            if (logger.isLoggable(Level.FINER)) {
-              logger.log(Level.FINER, "error:" + o);
-            }
             errorMessage = (String) o;
             // acknowledge the error
             send(null);
@@ -144,9 +132,6 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           return Action.NONE;
         case READ_NAMES:
           final String[] strings = ((String[]) o);
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "new local name:" + strings[0]);
-          }
           localName = strings[0];
           serverName = strings[1];
           step = Step.READ_ADDRESS;
@@ -157,12 +142,6 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           // this is the address the server thinks he is
           networkVisibleAddress = address[0];
           serverLocalAddress = address[1];
-          if (logger.isLoggable(Level.FINE)) {
-            logger.log(Level.FINE, "Server local address:" + serverLocalAddress);
-            logger.log(Level.FINE, "channel remote address:" + channel.socket().getRemoteSocketAddress());
-            logger.log(Level.FINE, "network visible address:" + networkVisibleAddress);
-            logger.log(Level.FINE, "channel local adresss:" + channel.socket().getLocalSocketAddress());
-          }
           return Action.UNQUARANTINE;
         default:
           throw new IllegalStateException("Invalid state");

--- a/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/src/main/java/games/strategy/net/nio/Decoder.java
@@ -67,9 +67,6 @@ class Decoder {
         if (data == null || !running) {
           continue;
         }
-        if (logger.isLoggable(Level.FINEST)) {
-          logger.finest("Decoding packet:" + data);
-        }
         try {
           final MessageHeader header = IoUtils.readFromMemory(data.getData(), is -> {
             try {
@@ -78,9 +75,6 @@ class Decoder {
               throw new IOException(e);
             }
           });
-          if (logger.isLoggable(Level.FINEST)) {
-            logger.log(Level.FINEST, "header decoded:" + header);
-          }
           // make sure we are still open
           final Socket s = data.getChannel().socket();
           if (!running || s == null || s.isInputShutdown()) {
@@ -95,9 +89,6 @@ class Decoder {
             }
             if (header.getFrom() == null) {
               throw new IllegalArgumentException("Null from:" + header);
-            }
-            if (logger.isLoggable(Level.FINER)) {
-              logger.log(Level.FINER, "decoded  msg:" + header.getMessage() + " size:" + data.size());
             }
             nioSocket.messageReceived(header, data.getChannel());
           }
@@ -120,16 +111,10 @@ class Decoder {
       final MessageHeader header) {
     final Action a = conversation.message(header.getMessage());
     if (a == Action.TERMINATE) {
-      if (logger.isLoggable(Level.FINER)) {
-        logger.log(Level.FINER, "Terminating quarantined connection to:" + channel.socket().getRemoteSocketAddress());
-      }
       conversation.close();
       // we need to indicate the channel was closed
       errorReporter.error(channel, new CouldNotLogInException());
     } else if (a == Action.UNQUARANTINE) {
-      if (logger.isLoggable(Level.FINER)) {
-        logger.log(Level.FINER, "Accepting quarantined connection to:" + channel.socket().getRemoteSocketAddress());
-      }
       nioSocket.unquarantine(channel, conversation);
       quarantine.remove(channel);
     }

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -28,9 +28,6 @@ class Encoder {
   }
 
   void write(final SocketChannel to, final MessageHeader header) {
-    if (logger.isLoggable(Level.FINEST)) {
-      logger.log(Level.FINEST, "Encoding msg:" + header + " to:" + to);
-    }
     if (header.getFrom() == null) {
       throw new IllegalArgumentException("No from node");
     }
@@ -40,9 +37,6 @@ class Encoder {
     try {
       final byte[] bytes = IoUtils.writeToMemory(os -> write(header, objectStreamFactory.create(os), to));
       final SocketWriteData data = new SocketWriteData(bytes, bytes.length);
-      if (logger.isLoggable(Level.FINER)) {
-        logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
-      }
       writer.enque(data, to);
     } catch (final IOException e) {
       // we arent doing any io, just writing in memory

--- a/src/main/java/games/strategy/net/nio/NioReader.java
+++ b/src/main/java/games/strategy/net/nio/NioReader.java
@@ -83,9 +83,6 @@ class NioReader {
   private void loop() {
     while (running) {
       try {
-        if (logger.isLoggable(Level.FINEST)) {
-          logger.finest("selecting...");
-        }
         try {
           // exceptions can be thrown here, nothing we can do
           // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
@@ -98,9 +95,6 @@ class NioReader {
         }
         selectNewChannels();
         final Set<SelectionKey> selected = selector.selectedKeys();
-        if (logger.isLoggable(Level.FINEST)) {
-          logger.finest("selected:" + selected.size());
-        }
         final Iterator<SelectionKey> iter = selected.iterator();
         while (iter.hasNext()) {
           final SelectionKey key = iter.next();
@@ -108,9 +102,6 @@ class NioReader {
           if (key.isValid() && key.isReadable()) {
             final SocketChannel channel = (SocketChannel) key.channel();
             final SocketReadData packet = getReadData(channel);
-            if (logger.isLoggable(Level.FINEST)) {
-              logger.finest("reading packet:" + packet + " from:" + channel.socket().getRemoteSocketAddress());
-            }
             try {
               final boolean done = packet.read(channel);
               if (done) {
@@ -136,7 +127,6 @@ class NioReader {
               errorReporter.error(channel, e);
             }
           } else if (!key.isValid()) {
-            logger.fine("Remotely closed");
             final SocketChannel channel = (SocketChannel) key.channel();
             key.cancel();
             errorReporter.error(channel, new SocketException("triplea:key cancelled"));

--- a/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -64,22 +64,13 @@ public class ServerQuarantineConversation extends QuarantineConversation {
         case READ_NAME:
           // read name, send challent
           remoteName = (String) o;
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "read name:" + remoteName);
-          }
           step = Step.READ_MAC;
           return Action.NONE;
         case READ_MAC:
           // read name, send challent
           remoteMac = (String) o;
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "read mac:" + remoteMac);
-          }
           if (validator != null) {
             challenge = validator.getChallengeProperties(remoteName, channel.socket().getRemoteSocketAddress());
-          }
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "writing challenge:" + challenge);
           }
           send((Serializable) challenge);
           step = Step.CHALLENGE;
@@ -87,15 +78,9 @@ public class ServerQuarantineConversation extends QuarantineConversation {
         case CHALLENGE:
           @SuppressWarnings("unchecked")
           final Map<String, String> response = (Map<String, String>) o;
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "read challenge response:" + response);
-          }
           if (validator != null) {
             final String error = validator.verifyConnection(challenge, response, remoteName, remoteMac,
                 channel.socket().getRemoteSocketAddress());
-            if (logger.isLoggable(Level.FINER)) {
-              logger.log(Level.FINER, "error:" + error);
-            }
             send(error);
             if (error != null) {
               step = Step.ACK_ERROR;
@@ -106,9 +91,6 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           }
           // get a unique name
           remoteName = serverMessenger.getUniqueName(remoteName);
-          if (logger.isLoggable(Level.FINER)) {
-            logger.log(Level.FINER, "Sending name:" + remoteName);
-          }
           // send the node its name and our name
           send(new String[] {remoteName, serverMessenger.getLocalNode().getName()});
           // send the node its and our address as we see it

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -245,17 +245,13 @@ public class WeakAI extends AbstractAI {
       pause();
       if (moveRoutes.get(i) == null || moveRoutes.get(i).getEnd() == null || moveRoutes.get(i).getStart() == null
           || moveRoutes.get(i).hasNoSteps()) {
-        logger.fine("Route not valid" + moveRoutes.get(i) + " units:" + moveUnits.get(i));
         continue;
       }
-      final String result;
+
       if (transportsToLoad == null) {
-        result = moveDel.move(moveUnits.get(i), moveRoutes.get(i));
+         moveDel.move(moveUnits.get(i), moveRoutes.get(i));
       } else {
-        result = moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
-      }
-      if (result != null) {
-        logger.fine("could not move " + moveUnits.get(i) + " over " + moveRoutes.get(i) + " because : " + result);
+         moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
       }
     }
   }
@@ -376,7 +372,6 @@ public class WeakAI extends AbstractAI {
           ourStrength += AIUtils.strength(owned.getUnits().getMatches(attackable), true, true);
         }
         if (ourStrength > 1.32 * enemyStrength) {
-          logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength);
           for (final Territory owned : attackFrom) {
             if (dontMoveFrom.contains(owned)) {
               continue;
@@ -685,8 +680,6 @@ public class WeakAI extends AbstractAI {
               moveRoutes.add(data.getMap().getRoute(owned, enemy));
             }
           }
-          logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength
-              + " remaining strength needed " + remainingStrengthNeeded);
         }
       }
     }
@@ -1052,11 +1045,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static void doPlace(final Territory where, final Collection<Unit> toPlace, final IAbstractPlaceDelegate del) {
-    final String message = del.placeUnits(new ArrayList<>(toPlace), where, IAbstractPlaceDelegate.BidMode.NOT_BID);
-    if (message != null) {
-      logger.fine(message);
-      logger.fine("Attempt was at:" + where + " with:" + toPlace);
-    }
+    del.placeUnits(new ArrayList<>(toPlace), where, IAbstractPlaceDelegate.BidMode.NOT_BID);
     pause();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.logging.Logger;
 
 import com.google.common.collect.Streams;
 
@@ -48,9 +47,7 @@ import games.strategy.util.Util;
  * A very weak ai, based on some simple rules.<p>
  */
 public class WeakAI extends AbstractAI {
-  private static final Logger logger = Logger.getLogger(WeakAI.class.getName());
 
-  /** Creates new WeakAI. */
   public WeakAI(final String name, final String type) {
     super(name, type);
   }
@@ -249,9 +246,9 @@ public class WeakAI extends AbstractAI {
       }
 
       if (transportsToLoad == null) {
-         moveDel.move(moveUnits.get(i), moveRoutes.get(i));
+        moveDel.move(moveUnits.get(i), moveRoutes.get(i));
       } else {
-         moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
+        moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -43,8 +43,8 @@ import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Util;
 
-/*
- * A very weak ai, based on some simple rules.<p>
+/**
+ * A very weak ai, based on some simple rules.
  */
 public class WeakAI extends AbstractAI {
 

--- a/src/main/java/games/strategy/triplea/image/ImageRef.java
+++ b/src/main/java/games/strategy/triplea/image/ImageRef.java
@@ -24,7 +24,6 @@ class ImageRef {
       while (true) {
         try {
           referenceQueue.remove();
-          logger.finer("Removed soft reference image. Image count:" + imageCount.decrementAndGet());
         } catch (final InterruptedException e) {
           ClientLogger.logQuietly(e);
         }
@@ -38,7 +37,6 @@ class ImageRef {
 
   public ImageRef(final Image image) {
     this.image = new SoftReference<>(image, referenceQueue);
-    logger.finer("Added soft reference image. Image count:" + imageCount.incrementAndGet());
   }
 
   public Image getImage() {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -58,7 +58,6 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
   public ConcurrentOddsCalculator(final String threadNamePrefix) {
     executor = Executors.newFixedThreadPool(MAX_THREADS,
         new DaemonThreadFactory(true, threadNamePrefix + " ConcurrentOddsCalculator Worker"));
-    logger.fine("Initialized executor thread pool with size: " + MAX_THREADS);
   }
 
   @Override
@@ -190,7 +189,6 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
     latchWorkerThreadsCreation.countDown();
     // allow calcing and other stuff to go ahead
     latchSetData.countDown();
-    logger.fine("Initialized worker thread pool with size: " + workers.size());
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -205,7 +205,6 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   final void cleanUp() {
     SwingUtilities.invokeLater(() -> {
-      logger.fine("cleanup");
       if (!listening) {
         throw new IllegalStateException("Not listening");
       }
@@ -265,7 +264,6 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   protected final void setUp(final IPlayerBridge bridge) {
     SwingUtilities.invokeLater(() -> {
-      logger.fine("setup");
       setUpSpecific();
       this.bridge = bridge;
       updateMoves();


### PR DESCRIPTION
Few reasons to remove:
- reduces code, fewer things to maintain "shave and a haircut"

Benefit we are losing:
- debugging value. I suspect these were mostly useful when developing the features, as is it can make it a bit hard to read and I'm not sure if we would want these exact debug statemetns if we modify related areas of the code. Seems to favor the cost/benefit to remove so we can maintain the code more easily.

------------

In another PR i removed a similar logger.fine statement, figured it made sense to fix that everywhere rather than one or two at a time.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
