### PR TITLE
Use Guava to truncate long strings

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -26,6 +26,8 @@ import javax.swing.text.Document;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 
+import com.google.common.base.Ascii;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.net.INode;
 import games.strategy.net.ServerMessenger;
@@ -277,7 +279,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   private void addChatMessage(final String originalMessage, final String from, final boolean thirdperson) {
-    final String message = trimMessage(originalMessage);
+    final String message = Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";
     final Document doc = text.getDocument();
     try {
@@ -340,11 +342,6 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     } catch (final BadLocationException e) {
       ClientLogger.logError("There was an Error whilst trying trimming Chat", e);
     }
-  }
-
-  private static String trimMessage(final String originalMessage) {
-    // don't allow messages that are too long
-    return (originalMessage.length() > 200) ? originalMessage.substring(0, 199) + "..." : originalMessage;
   }
 
   private final Action setStatusAction = SwingAction.of("Status...", e -> {

--- a/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import javax.swing.DefaultListCellRenderer;
 
+import com.google.common.base.Ascii;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.chat.Chat.ChatSoundProfile;
 import games.strategy.engine.message.IChannelMessenger;
@@ -161,7 +163,7 @@ public class HeadlessChat implements IChatListener, IChatPanel {
   }
 
   private void addChatMessage(final String originalMessage, final String from, final boolean thirdperson) {
-    final String message = trimMessage(originalMessage);
+    final String message = Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";
     final String prefix = thirdperson ? (showTime ? "* " + time + " " + from : "* " + from)
         : (showTime ? time + " " + from + ": " : from + ": ");
@@ -195,10 +197,5 @@ public class HeadlessChat implements IChatListener, IChatPanel {
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
     }
-  }
-
-  private static String trimMessage(final String originalMessage) {
-    // dont allow messages that are too long
-    return (originalMessage.length() > 200) ? originalMessage.substring(0, 199) + "..." : originalMessage;
   }
 }


### PR DESCRIPTION
Follow-up to the introduction of Guava's `Ascii#truncate()` method in #2782.  This PR simply replaces other occurrences where we truncate a long string with an ellipsis with `Ascii#truncate()`.  In  both occurrences, the custom `trimMessage()` methods only had one caller, so I just inlined them.