### PR TITLE
Release from Java 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: java
 matrix:
   include:
   - jdk: oraclejdk8
-    env: TRIPLEA_RELEASE=false
-  - jdk: oraclejdk9
     env: TRIPLEA_RELEASE=true
+  - jdk: oraclejdk9
+    env: TRIPLEA_RELEASE=false
 addons:
   postgresql: "9.5"
   apt:


### PR DESCRIPTION
Fixes #2801.

The Java 9 build seems to have some backwards incompatibilities when targetting Java 8.

**EDIT:** Actually, the problem appears to be because we're not specifying a Java 8 boot classpath when using JDK 9 to build for Java 8.