### PR TITLE
Add ClientLogger#logError() overload for ExecutionException

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -1,5 +1,7 @@
 package games.strategy.debug;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.GraphicsEnvironment;
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -94,7 +96,10 @@ public final class ClientLogger {
    * tasks through the {@code Executor} API. We only log the cause to reduce the number of stack trace frames visible
    * to the user.
    */
-  public static void logError(final @Nullable String msg, final ExecutionException e) {
+  public static void logError(final String msg, final ExecutionException e) {
+    checkNotNull(msg);
+    checkNotNull(e);
+
     logError(msg, e.getCause());
   }
 

--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -2,6 +2,7 @@ package games.strategy.debug;
 
 import java.awt.GraphicsEnvironment;
 import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
 
@@ -85,6 +86,16 @@ public final class ClientLogger {
   public static void logError(final @Nullable String msg, final Throwable e) {
     logQuietly(msg, e);
     showErrorMessage(msg);
+  }
+
+  /**
+   * Overload of {@link #logError(String, Throwable)} specialized for {@code ExecutionException}. An
+   * {@code ExecutionException} contains no useful information; it's simply an adapter to tunnel exceptions thrown by
+   * tasks through the {@code Executor} API. We only log the cause to reduce the number of stack trace frames visible
+   * to the user.
+   */
+  public static void logError(final @Nullable String msg, final ExecutionException e) {
+    logError(msg, e.getCause());
   }
 
   private static void showErrorMessage(final String msg) {

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -90,10 +90,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        // ExecutionException contains no useful information; it's simply an adapter to tunnel
-        // exceptions thrown by tasks through the Executor API. Log the cause only to reducase
-        // stack trace frames.
-        ClientLogger.logError("Failed to parse a map", e.getCause());
+        ClientLogger.logError("Failed to parse a map", e);
       }
     }
     return parsedMapSet;

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -90,7 +90,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        ClientLogger.logError("Failed to parse a map", e);
+        ClientLogger.logError("Failed to parse a map: " + e.getMessage(), e);
       }
     }
     return parsedMapSet;

--- a/src/main/java/games/strategy/thread/ThreadPool.java
+++ b/src/main/java/games/strategy/thread/ThreadPool.java
@@ -53,11 +53,7 @@ public class ThreadPool {
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (final ExecutionException e) {
-        // ExecutionException contains no useful information; it's simply an adapter to tunnel
-        // exceptions thrown by tasks through the Executor API. Log the cause only to reducase
-        // stack trace frames.
-        ClientLogger.logError("Threading execution exception: " + e.getCause().getMessage(),
-            e.getCause());
+        ClientLogger.logError("Threading execution exception: " + e.getMessage(), e);
       }
     }
   }


### PR DESCRIPTION
This PR adds the new `ClientLogger#logError(String, ExecutionException)` overload.  This overload was added so devs don't have to remember that `ExecutionException` is just an adapter around the root cause of an executor task failure that contains no useful information.  We only want to log the stack trace of the cause to avoid the useless stack frames from the `ExecutionException` itself.