### PR TITLE
Output exact version at startup

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -136,8 +136,10 @@ public class GameRunner {
       HttpProxy.updateSystemProxy();
     }
 
-    final String version = System.getProperty(ENGINE_VERSION_BIN);
     final Version engineVersion = ClientContext.engineVersion();
+    System.out.println("TripleA engine version " + engineVersion.getExactVersion());
+
+    final String version = System.getProperty(ENGINE_VERSION_BIN);
     if (version != null && version.length() > 0) {
       final Version testVersion;
       try {


### PR DESCRIPTION
I've noticed in some instances that users, when they report an issue, will attach the log but fail to specify the engine version (specifically the build number), and then we have to request this information.  It's not a big deal to ask for the engine version, but if we can automate it in certain cases, it seems that would be preferable.

I don't know if everyone will agree with my solution, but this PR simply outputs the value of `ClientContext.engineVersion().getExactString()` to stdout at startup so it will be included in any attached log.  For example:

```
TripleA engine version 1.9.0.0.8253
```

#### Notes

When I first approached this PR, I thought I would simply expand the value that's written for the `ENGINE_VERSION_BIN` system property, which we already output at startup:

```
triplea.engine.version.bin:1.9
```

to include all version components.

However, after some research, I can't determine what this system property is being used for.  No decisions seem to be made based on its value (other than adding it to the command line for spawned processes in `ProcessRunnerUtil`).  I suspect it may have been used for the Old Jar functionality because I found it being used for some logic in a7f85cf87.  Just wondering if we can get rid of it?