### PR TITLE
Fix casualty selection window size

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -498,12 +498,14 @@ public class BattleDisplay extends JPanel {
             chooserScrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
             final Dimension size = chooserScrollPane.getPreferredSize();
             chooserScrollPane.setPreferredSize(new Dimension(
-                (size.width > availWidth ? availWidth
-                    : (size.height > availHeight
-                        ? size.width + 22
-                        : size.width)),
-                (size.height > availHeight ? availHeight
-                    : size.height)));
+                size.width > availWidth
+                    ? availWidth
+                    : size.width + (size.height > availHeight
+                        ? chooserScrollPane.getVerticalScrollBar().getPreferredSize().width
+                        : 0),
+                size.height > availHeight
+                    ? availHeight
+                    : size.height));
           }
           final String[] options = {"Ok", "Cancel"};
           final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -496,6 +496,7 @@ public class BattleDisplay extends JPanel {
             int availHeight = screenResolution.height - 80;
             final int availWidth = screenResolution.width - 30;
             availHeight -= 50;
+            chooserScrollPane.setBorder(new LineBorder(chooserScrollPane.getBackground()));
             chooserScrollPane.setPreferredSize(new Dimension(
                 (chooserScrollPane.getPreferredSize().width > availWidth ? availWidth
                     : (chooserScrollPane.getPreferredSize().height > availHeight
@@ -503,7 +504,6 @@ public class BattleDisplay extends JPanel {
                         : chooserScrollPane.getPreferredSize().width)),
                 (chooserScrollPane.getPreferredSize().height > availHeight ? availHeight
                     : chooserScrollPane.getPreferredSize().height)));
-            chooserScrollPane.setBorder(new LineBorder(chooserScrollPane.getBackground()));
           }
           final String[] options = {"Ok", "Cancel"};
           final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -498,14 +498,10 @@ public class BattleDisplay extends JPanel {
             chooserScrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
             final Dimension size = chooserScrollPane.getPreferredSize();
             chooserScrollPane.setPreferredSize(new Dimension(
-                size.width > availWidth
-                    ? availWidth
-                    : size.width + (size.height > availHeight
-                        ? chooserScrollPane.getVerticalScrollBar().getPreferredSize().width
-                        : 0),
-                size.height > availHeight
-                    ? availHeight
-                    : size.height));
+                Math.min(availWidth, size.width + (size.height > availHeight
+                    ? chooserScrollPane.getVerticalScrollBar().getPreferredSize().width
+                    : 0)),
+                Math.min(availHeight, size.height)));
           }
           final String[] options = {"Ok", "Cancel"};
           final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -493,17 +493,17 @@ public class BattleDisplay extends JPanel {
             }
             chooserScrollPane = new JScrollPane(chooser);
             final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
-            int availHeight = screenResolution.height - 80;
+            final int availHeight = screenResolution.height - 130;
             final int availWidth = screenResolution.width - 30;
-            availHeight -= 50;
             chooserScrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
+            final Dimension size = chooserScrollPane.getPreferredSize();
             chooserScrollPane.setPreferredSize(new Dimension(
-                (chooserScrollPane.getPreferredSize().width > availWidth ? availWidth
-                    : (chooserScrollPane.getPreferredSize().height > availHeight
-                        ? chooserScrollPane.getPreferredSize().width + 22
-                        : chooserScrollPane.getPreferredSize().width)),
-                (chooserScrollPane.getPreferredSize().height > availHeight ? availHeight
-                    : chooserScrollPane.getPreferredSize().height)));
+                (size.width > availWidth ? availWidth
+                    : (size.height > availHeight
+                        ? size.width + 22
+                        : size.width)),
+                (size.height > availHeight ? availHeight
+                    : size.height)));
           }
           final String[] options = {"Ok", "Cancel"};
           final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -46,7 +47,6 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
-import javax.swing.border.LineBorder;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
@@ -496,7 +496,7 @@ public class BattleDisplay extends JPanel {
             int availHeight = screenResolution.height - 80;
             final int availWidth = screenResolution.width - 30;
             availHeight -= 50;
-            chooserScrollPane.setBorder(new LineBorder(chooserScrollPane.getBackground()));
+            chooserScrollPane.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
             chooserScrollPane.setPreferredSize(new Dimension(
                 (chooserScrollPane.getPreferredSize().width > availWidth ? availWidth
                     : (chooserScrollPane.getPreferredSize().height > availHeight


### PR DESCRIPTION
This PR partially addresses #2810 by fixing the size of the casualty selection window.

The fix is in the first commit.  The preferred size was being calculated before the border was added, and this is what caused the scroll bars to appear.  I have no idea what changed in Substance that caused this issue to surface now.  Also note that this issue only seems to occur when a Substance L&F is active; it does not occur under Nimbus.

The remaining commits are small refactorings in this same area of the code.  The commit messages should be self-explanatory.

#### Substance Twilight

##### Before

![casualty-selection-substance-old](https://user-images.githubusercontent.com/4826349/34618058-92a0f3ce-f20b-11e7-9a53-55ec733bc33b.png)

##### After

![casualty-selection-substance-new](https://user-images.githubusercontent.com/4826349/34625363-65ff9832-f226-11e7-9965-625b26092d5f.png)

##### After (with simulated available height constraint)

![casualty-selection-substance-new-large](https://user-images.githubusercontent.com/4826349/34625365-6b5fd332-f226-11e7-86a1-be5b241f337d.png)

#### Nimbus

##### Before

![casualty-selection-nimbus-old](https://user-images.githubusercontent.com/4826349/34618086-a237aba2-f20b-11e7-9c5b-219c2b16e534.png)

##### After

![casualty-selection-nimbus-new](https://user-images.githubusercontent.com/4826349/34621967-29bd3058-f219-11e7-88a0-4462f7e5a3c2.png)

##### After (with simulated available height constraint)

![casualty-selection-nimbus-new-large](https://user-images.githubusercontent.com/4826349/34621968-2eec6abc-f219-11e7-92d8-b241a1fd52e6.png)
  