### PR TITLE
Disable error popup

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -4,6 +4,7 @@ import java.awt.GraphicsEnvironment;
 import java.io.PrintStream;
 
 import javax.annotation.Nullable;
+import javax.swing.SwingUtilities;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -88,6 +89,10 @@ public final class ClientLogger {
   }
 
   private static void showErrorMessage(final String msg) {
+    // FIXME: Temporary fix for #2820: prevent error popup and restore legacy behavior
+    SwingUtilities.invokeLater(ErrorConsole::showConsole);
+    enableErrorPopup = false;
+
     if (GraphicsEnvironment.isHeadless() || !enableErrorPopup) {
       // skip the pop-up if we there is no Swing UI to show the error message.
       // in all cases the error information should have been quiet logged, the error message pop-up is only

--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -20,7 +20,7 @@ import swinglib.ErrorMessageBuilder;
 public final class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
 
-  private static boolean enableErrorPopup = true;
+  private static volatile boolean enableErrorPopup = true;
 
   private ClientLogger() {}
 


### PR DESCRIPTION
This is a temporary fix for #2820.  It disables the error popup and restores the legacy behavior in which the error console is displayed whenever an error is logged.

There is a second unrelated commit which fixes a potential thread-safety issue when accessing the `ClientLogger#enableErrorPopup` field.

#### Testing

I ran the scenario described in [this comment](https://github.com/triplea-game/triplea/issues/2820#issuecomment-355891032).  No error popup was displayed.  The error console was displayed with all expected missing image error messages.