### PR TITLE
Add delimiter between system properties in console

### DIFF
--- a/src/main/java/games/strategy/debug/DebugUtils.java
+++ b/src/main/java/games/strategy/debug/DebugUtils.java
@@ -80,7 +80,7 @@ public final class DebugUtils {
     Collections.sort(keys);
     for (final String property : keys) {
       final String value = props.getProperty(property);
-      buf.append(property).append(" ").append(value).append("\n");
+      buf.append(property).append("=").append(value).append("\n");
     }
     return buf.toString();
   }


### PR DESCRIPTION
I noticed this after asking a few users to dump their system properties to the console.  I thought it was odd that there was only whitespace between the property name and value, which made it difficult to parse the data by eye given it is usually displayed in a non-monospace font.  Apparently, this is the way it's been since the code was introduced in 2014, and I just never noticed.

No argument against closing this PR if others think the whitespace delimiter is clearer.