### PR TITLE
Remove code that is adding paratroopers to a second transport

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -38,9 +38,7 @@ import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.oddsCalculator.ta.BattleResults;
 import games.strategy.triplea.ui.display.ITripleADisplay;
-import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.TuvUtils;
-import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PredicateBuilder;
@@ -218,36 +216,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
         // remove transported fighters from battle display
         m_attackingUnits.removeAll(fighters);
-      }
-    }
-    // Set the dependent paratroopers so they die if the bomber dies.
-    // TODO: this might be legacy code that can be deleted since we now keep paratrooper dependencies til they land (but
-    // need to double check)
-    if (TechAttachment.isAirTransportable(m_attacker)) {
-      final Collection<Unit> airTransports = CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
-      final Collection<Unit> paratroops = CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
-      if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
-        // Load capable bombers by default
-        final Map<Unit, Unit> unitsToCapableAirTransports =
-            TransportUtils.mapTransportsToLoad(paratroops, airTransports);
-        final HashMap<Unit, Collection<Unit>> dependentUnits = new HashMap<>();
-        final Collection<Unit> singleCollection = new ArrayList<>();
-        for (final Unit unit : unitsToCapableAirTransports.keySet()) {
-          final Collection<Unit> unitList = new ArrayList<>();
-          unitList.add(unit);
-          final Unit bomber = unitsToCapableAirTransports.get(unit);
-          singleCollection.add(unit);
-          // Set transportedBy for paratrooper
-          change.add(ChangeFactory.unitPropertyChange(unit, bomber, TripleAUnit.TRANSPORTED_BY));
-          // Set the dependents
-          if (dependentUnits.get(bomber) != null) {
-            dependentUnits.get(bomber).addAll(unitList);
-          } else {
-            dependentUnits.put(bomber, unitList);
-          }
-        }
-        dependencies.putAll(dependentUnits);
-        UnitSeperator.categorize(airTransports, dependentUnits, false, false);
       }
     }
     addDependentUnits(dependencies);


### PR DESCRIPTION
Addresses bug reported in #2776 

Functional Changes
- Removes unnecessary paratrooper code that was adding paratroopers to empty air transports after they had already been assigned to an air transport. This error only occurs if you move both loaded and unloaded air transports in the same move and then lose an unloaded air transport to AA (so pretty rare).

Testing
- Before this change, load save from above bug report and follow reproduction steps to get the original error.
- After this change, load save from above bug report. Undo move 13 (17 bomber & 16 inf) and then perform the move again. Then follow battle reproduction steps and you shouldn't see an error.

@veqryn Just in case you want to reminiscence about some old code or have a look at this. It appears 6 years ago when you fixed a different paratrooper display bug that you had a feeling this code wasn't needed and actually ended up causing this bug by not removing it. Old commit: https://github.com/triplea-game/triplea/commit/73c285dc8794a68e8264042f954bd1139d99cd3b