### PR TITLE
Audit lobby bans

### DIFF
--- a/config/lobby/db/004_audit_bans
+++ b/config/lobby/db/004_audit_bans
@@ -1,0 +1,23 @@
+start transaction;
+
+alter table banned_macs
+  add column mod_username varchar(40),
+  add column mod_ip varchar(45),
+  add column mod_mac char(28),
+  add constraint banned_macs_mod_mac_check check (char_length(mod_mac)=28);
+
+comment on column banned_macs.mod_username is 'The username of the moderator that executed the ban.';
+comment on column banned_macs.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the ban.';
+comment on column banned_macs.mod_mac is 'The hashed MAC address of the moderator that executed the ban.';
+
+alter table banned_usernames
+  add column mod_username varchar(40),
+  add column mod_ip varchar(45),
+  add column mod_mac char(28),
+  add constraint banned_usernames_mod_mac_check check (char_length(mod_mac)=28);
+
+comment on column banned_usernames.mod_username is 'The username of the moderator that executed the ban.';
+comment on column banned_usernames.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the ban.';
+comment on column banned_usernames.mod_mac is 'The hashed MAC address of the moderator that executed the ban.';
+
+commit;

--- a/config/lobby/db/004_audit_bans
+++ b/config/lobby/db/004_audit_bans
@@ -1,20 +1,30 @@
 start transaction;
 
 alter table banned_macs
-  add column mod_username varchar(40),
-  add column mod_ip varchar(45),
-  add column mod_mac char(28),
+  add column mod_username varchar(40) not null default '__unknown__',
+  add column mod_ip varchar(45) not null default '0.0.0.0',
+  add column mod_mac char(28) not null default '$1$MH$WarCz.YHukJf1YVqmMBoS0',
   add constraint banned_macs_mod_mac_check check (char_length(mod_mac)=28);
+
+alter table banned_macs
+  alter column mod_username drop default,
+  alter column mod_ip drop default,
+  alter column mod_mac drop default;
 
 comment on column banned_macs.mod_username is 'The username of the moderator that executed the ban.';
 comment on column banned_macs.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the ban.';
 comment on column banned_macs.mod_mac is 'The hashed MAC address of the moderator that executed the ban.';
 
 alter table banned_usernames
-  add column mod_username varchar(40),
-  add column mod_ip varchar(45),
-  add column mod_mac char(28),
+  add column mod_username varchar(40) not null default '__unknown__',
+  add column mod_ip varchar(45) not null default '0.0.0.0',
+  add column mod_mac char(28) not null default '$1$MH$WarCz.YHukJf1YVqmMBoS0',
   add constraint banned_usernames_mod_mac_check check (char_length(mod_mac)=28);
+
+alter table banned_usernames
+  alter column mod_username drop default,
+  alter column mod_ip drop default,
+  alter column mod_mac drop default;
 
 comment on column banned_usernames.mod_username is 'The username of the moderator that executed the ban.';
 comment on column banned_usernames.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the ban.';

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
@@ -4,21 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
 public class BannedMacControllerIntegrationTest {
 
   private final BannedMacController controller = spy(new BannedMacController());
-  private final String hashedMac = games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  private final String hashedMac = newHashedMacAddress();
+  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testBanMacForever() {
@@ -72,9 +82,58 @@ public class BannedMacControllerIntegrationTest {
     assertEquals(banUntil, macDetails2.getSecond().toInstant());
   }
 
+  @Test
+  public void testBanMacUpdatesModerator() {
+    banMacForSeconds(Long.MAX_VALUE, moderator);
+
+    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    banMacForSeconds(Long.MAX_VALUE, otherModerator);
+
+    assertModeratorForBannedMacEquals(otherModerator);
+  }
+
   private Instant banMacForSeconds(final long length) {
+    return banMacForSeconds(length, moderator);
+  }
+
+  private Instant banMacForSeconds(final long length, final Moderator moderator) {
     final Instant banEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addBannedMac(hashedMac, banEnd);
+    controller.addBannedMac(hashedMac, banEnd, moderator);
     return banEnd;
+  }
+
+  private static InetAddress newInetAddress() {
+    final byte[] addr = new byte[4];
+    new Random().nextBytes(addr);
+    try {
+      return InetAddress.getByAddress(addr);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen", e);
+    }
+  }
+
+  private static String newHashedMacAddress() {
+    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  }
+
+  private void assertModeratorForBannedMacEquals(final Moderator expected) {
+    final String sql = "select mod_username, mod_ip, mod_mac from banned_macs where mac=?";
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, hashedMac);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          assertEquals(expected.getUsername(), rs.getString(1));
+          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
+          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
+        } else {
+          fail("unknown banned hashed MAC address: " + hashedMac);
+        }
+      }
+    } catch (final UnknownHostException e) {
+      fail("malformed moderator IP address", e);
+    } catch (final SQLException e) {
+      fail("moderator query failed", e);
+    }
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
@@ -4,14 +4,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
@@ -19,6 +28,7 @@ public class BannedUsernameControllerIntegrationTest {
 
   private final BannedUsernameController controller = spy(new BannedUsernameController());
   private final String username = Util.createUniqueTimeStamp();
+  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testBanUsernameForever() {
@@ -72,9 +82,58 @@ public class BannedUsernameControllerIntegrationTest {
     assertEquals(banUntil, usernameDetails2.getSecond().toInstant());
   }
 
+  @Test
+  public void testBanUsernameUpdatesModerator() {
+    banUsernameForSeconds(Long.MAX_VALUE, moderator);
+
+    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    banUsernameForSeconds(Long.MAX_VALUE, otherModerator);
+
+    assertModeratorForBannedUsernameEquals(otherModerator);
+  }
+
   private Instant banUsernameForSeconds(final long length) {
+    return banUsernameForSeconds(length, moderator);
+  }
+
+  private Instant banUsernameForSeconds(final long length, final Moderator moderator) {
     final Instant banEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addBannedUsername(username, banEnd);
+    controller.addBannedUsername(username, banEnd, moderator);
     return banEnd;
+  }
+
+  private static InetAddress newInetAddress() {
+    final byte[] addr = new byte[4];
+    new Random().nextBytes(addr);
+    try {
+      return InetAddress.getByAddress(addr);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen", e);
+    }
+  }
+
+  private static String newHashedMacAddress() {
+    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  }
+
+  private void assertModeratorForBannedUsernameEquals(final Moderator expected) {
+    final String sql = "select mod_username, mod_ip, mod_mac from banned_usernames where username=?";
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, username);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          assertEquals(expected.getUsername(), rs.getString(1));
+          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
+          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
+        } else {
+          fail("unknown banned username: " + username);
+        }
+      }
+    } catch (final UnknownHostException e) {
+      fail("malformed moderator IP address", e);
+    } catch (final SQLException e) {
+      fail("moderator query failed", e);
+    }
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/Moderator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/Moderator.java
@@ -1,0 +1,36 @@
+package games.strategy.engine.lobby.server;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.InetAddress;
+
+/**
+ * Information about the moderator that performed a lobby maintenance operation.
+ */
+public final class Moderator {
+  private final String hashedMacAddress;
+  private final InetAddress inetAddress;
+  private final String username;
+
+  public Moderator(final String username, final InetAddress inetAddress, final String hashedMacAddress) {
+    checkNotNull(username);
+    checkNotNull(inetAddress);
+    checkNotNull(hashedMacAddress);
+
+    this.hashedMacAddress = hashedMacAddress;
+    this.inetAddress = inetAddress;
+    this.username = username;
+  }
+
+  public String getHashedMacAddress() {
+    return hashedMacAddress;
+  }
+
+  public InetAddress getInetAddress() {
+    return inetAddress;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+}

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -3,6 +3,8 @@ package games.strategy.engine.lobby.server;
 import java.time.Instant;
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.lobby.server.db.BannedMacController;
 import games.strategy.engine.lobby.server.db.BannedUsernameController;
 import games.strategy.engine.lobby.server.db.MutedMacController;
@@ -32,7 +34,7 @@ public class ModeratorController extends AbstractModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    new BannedUsernameController().addBannedUsername(getRealName(node), banExpires);
+    new BannedUsernameController().addBannedUsername(getRealName(node), banExpires, getModeratorForNode(modNode));
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
     logger.info(String.format(
         "User was banned from the lobby(Username ban). "
@@ -60,19 +62,23 @@ public class ModeratorController extends AbstractModeratorController {
     return user != null && user.isAdmin();
   }
 
+  private Moderator getModeratorForNode(final INode node) {
+    return new Moderator(node.getName(), node.getAddress(), getNodeMacAddress(node));
+  }
+
   @Override
   public void banMac(final INode node, final Date banExpires) {
     banMac(node, banExpires != null ? banExpires.toInstant() : null);
   }
 
-  private void banMac(final INode node, final Instant banExpires) {
+  private void banMac(final INode node, final @Nullable Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    new BannedMacController().addBannedMac(mac, banExpires);
+    new BannedMacController().addBannedMac(mac, banExpires, getModeratorForNode(modNode));
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
     logger.info(String.format(
         "User was banned from the lobby(Mac ban). "
@@ -86,13 +92,13 @@ public class ModeratorController extends AbstractModeratorController {
     banMac(node, hashedMac, banExpires != null ? banExpires.toInstant() : null);
   }
 
-  private void banMac(final INode node, final String hashedMac, final Instant banExpires) {
+  private void banMac(final INode node, final String hashedMac, final @Nullable Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
     }
     final INode modNode = MessageContext.getSender();
-    new BannedMacController().addBannedMac(hashedMac, banExpires);
+    new BannedMacController().addBannedMac(hashedMac, banExpires, getModeratorForNode(modNode));
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
     logger.info(String.format(
         "User was banned from the lobby(Mac ban). "

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -68,23 +68,7 @@ public class ModeratorController extends AbstractModeratorController {
 
   @Override
   public void banMac(final INode node, final Date banExpires) {
-    banMac(node, banExpires != null ? banExpires.toInstant() : null);
-  }
-
-  private void banMac(final INode node, final @Nullable Instant banExpires) {
-    assertUserIsAdmin();
-    if (isPlayerAdmin(node)) {
-      throw new IllegalStateException("Can't ban an admin");
-    }
-    final INode modNode = MessageContext.getSender();
-    final String mac = getNodeMacAddress(node);
-    new BannedMacController().addBannedMac(mac, banExpires, getModeratorForNode(modNode));
-    final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
-    logger.info(String.format(
-        "User was banned from the lobby(Mac ban). "
-            + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
-        node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
-        modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode), banUntil));
+    banMac(node, getNodeMacAddress(node), banExpires);
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacDao.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacDao.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 
 import javax.annotation.Nullable;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
 
 /**
@@ -17,8 +18,9 @@ public interface BannedMacDao {
    *
    * @param mac The MAC to ban.
    * @param banTill The instant at which the ban will expire or {@ode null} to ban the MAC forever.
+   * @param moderator The moderator executing the ban.
    */
-  void addBannedMac(String mac, @Nullable Instant banTill);
+  void addBannedMac(String mac, @Nullable Instant banTill, Moderator moderator);
 
   /**
    * Indicates the specified MAC is banned.

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameDao.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameDao.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 
 import javax.annotation.Nullable;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
 
 /**
@@ -17,8 +18,9 @@ public interface BannedUsernameDao {
    *
    * @param username The username to ban.
    * @param banTill The instant at which the ban will expire or {@ode null} to ban the username forever.
+   * @param moderator The moderator executing the ban.
    */
-  void addBannedUsername(String username, @Nullable Instant banTill);
+  void addBannedUsername(String username, @Nullable Instant banTill, Moderator moderator);
 
   /**
    * Indicates the specified username is banned.


### PR DESCRIPTION
Partially addresses [this feature request](https://forums.triplea-game.org/topic/440/toolbox-feature-request).

#### Functional changes

The username, IP address, and hashed MAC address of the moderator that executes a username or MAC address ban is recorded along with the corresponding ban record in the database to provide an audit trail.

#### Refactoring changes

The second commit removes some duplicate code between two `banMac()` overloads.  It is best viewed in isolation to see its effect.

#### Testing

In addition to the integration tests, I manually tested all admin commands in the UI for banning a user by username or MAC address using a client from this branch.  I also ran the same tests using a 3635 client to ensure an RMI incompatibility was not accidentally introduced.

#### Notes

I was originally going to include the ban reason feature request in this PR, as well.  However, it appears that will require a breaking RMI change.  As we are nearing an incompatible release, I'll wait until that happens before revisiting the ban reason feature.