### PR TITLE
Fix error logging on missing unit image error.

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -7,7 +7,6 @@ import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nullable;
-import javax.swing.SwingUtilities;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -105,10 +104,6 @@ public final class ClientLogger {
   }
 
   private static void showErrorMessage(final String msg) {
-    // FIXME: Temporary fix for #2820: prevent error popup and restore legacy behavior
-    SwingUtilities.invokeLater(ErrorConsole::showConsole);
-    enableErrorPopup = false;
-
     if (GraphicsEnvironment.isHeadless() || !enableErrorPopup) {
       // skip the pop-up if we there is no Swing UI to show the error message.
       // in all cases the error information should have been quiet logged, the error message pop-up is only

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -94,8 +94,7 @@ public class UnitsDrawer implements IDrawable {
         uiContext.getUnitImageFactory().getImage(type, owner, damaged > 0 || bombingUnitDamage > 0, disabled);
 
     if (!img.isPresent()) {
-      ClientLogger
-          .logError("MISSING IMAGE (this unit or image will be invisible): " + type);
+      ClientLogger.logQuietly("MISSING IMAGE (this unit or image will be invisible): " + type);
     }
 
     if (img.isPresent() && enabledFlags) {


### PR DESCRIPTION
Instead of showing unit image warning missing as a popup, log it quietly. TileManager grabs a UI log, any new UI instances that also block would cause a deadlock. This slight downgrade of functionality avoids that, though we restore nicer error logger for the rest of the game.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
