### PR TITLE
Remove unused "triplea.engine.version.bin" CLI property

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -152,7 +152,6 @@ public final class ArgParser {
     public static final String LOBBY_GAME_SUPPORT_EMAIL = "triplea.lobby.game.supportEmail";
     public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
     public static final String LOBBY_GAME_RECONNECTION = "triplea.lobby.game.reconnection";
-    public static final String ENGINE_VERSION_BIN = "triplea.engine.version.bin";
     public static final String DO_NOT_CHECK_FOR_UPDATES = "triplea.doNotCheckForUpdates";
 
     public static final String TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME = "triplea.server.startGameSyncWaitTime";

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework;
 
 import static games.strategy.engine.framework.ArgParser.CliProperties.DO_NOT_CHECK_FOR_UPDATES;
-import static games.strategy.engine.framework.ArgParser.CliProperties.ENGINE_VERSION_BIN;
 import static games.strategy.engine.framework.ArgParser.CliProperties.GAME_HOST_CONSOLE;
 import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_HOSTED_BY;
@@ -110,7 +109,7 @@ public class GameRunner {
       TRIPLEA_GAME, TRIPLEA_MAP_DOWNLOAD, TRIPLEA_SERVER, TRIPLEA_CLIENT,
       TRIPLEA_HOST, TRIPLEA_PORT, TRIPLEA_NAME, SERVER_PASSWORD,
       TRIPLEA_STARTED, LOBBY_PORT, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
-      ENGINE_VERSION_BIN, DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER));
+      DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER));
 
 
   /**
@@ -138,25 +137,6 @@ public class GameRunner {
 
     final Version engineVersion = ClientContext.engineVersion();
     System.out.println("TripleA engine version " + engineVersion.getExactVersion());
-
-    final String version = System.getProperty(ENGINE_VERSION_BIN);
-    if (version != null && version.length() > 0) {
-      final Version testVersion;
-      try {
-        testVersion = new Version(version);
-        // if successful we don't do anything
-        System.out.println(ENGINE_VERSION_BIN + ":" + version);
-        if (!engineVersion.equals(testVersion)) {
-          System.out.println("Current Engine version in use: " + engineVersion);
-        }
-      } catch (final Exception e) {
-        System.setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
-        System.out.println(ENGINE_VERSION_BIN + ":" + engineVersion);
-      }
-    } else {
-      System.setProperty(ENGINE_VERSION_BIN, engineVersion.toString());
-      System.out.println(ENGINE_VERSION_BIN + ":" + engineVersion);
-    }
 
     if (ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
       Application.launch(TripleA.class, args);

--- a/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.framework;
 
-import static games.strategy.engine.framework.ArgParser.CliProperties.ENGINE_VERSION_BIN;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,7 +12,6 @@ import java.util.Scanner;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.system.SystemProperties;
-import games.strategy.util.Version;
 
 /**
  * To hold various static utility methods for running a java program.
@@ -61,16 +58,6 @@ public class ProcessRunnerUtil {
       final File icons = new File(ClientFileSystemHelper.getRootFolder(), "icons/triplea_icon.png");
       if (icons.exists()) {
         commands.add("-Xdock:icon=" + icons.getAbsolutePath() + "");
-      }
-    }
-    final String version = System.getProperty(ENGINE_VERSION_BIN);
-    if (version != null && version.length() > 0) {
-      final Version testVersion;
-      try {
-        testVersion = new Version(version);
-        commands.add("-D" + ENGINE_VERSION_BIN + "=" + testVersion.toString());
-      } catch (final Exception e) {
-        // nothing
       }
     }
   }


### PR DESCRIPTION
As discussed in #2809, this property appears to no longer be used after the removal of the Old Jar feature in a7f85cf87.  I searched the various lobby scripts for usage of this property but couldn't find any.