### PR TITLE
Remove ClientLogger usage from tests

### DIFF
--- a/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.util.ThreadUtil;
 
 public class MessengerIntegrationTest {
@@ -55,27 +54,9 @@ public class MessengerIntegrationTest {
 
   @AfterEach
   public void tearDown() {
-    try {
-      if (serverMessenger != null) {
-        serverMessenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
-    try {
-      if (client1Messenger != null) {
-        client1Messenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
-    try {
-      if (client2Messenger != null) {
-        client2Messenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
+    MessengerTestUtils.shutDownQuietly(serverMessenger);
+    MessengerTestUtils.shutDownQuietly(client1Messenger);
+    MessengerTestUtils.shutDownQuietly(client2Messenger);
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -7,7 +7,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Properties;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.gamePlayer.IRemotePlayer;
 import games.strategy.engine.history.DelegateHistoryWriter;
@@ -53,7 +52,7 @@ public class TestDelegateBridge implements ITestDelegateBridge {
     try {
       when(messenger.getLocalNode()).thenReturn(new Node("dummy", InetAddress.getLocalHost(), 0));
     } catch (final UnknownHostException e) {
-      ClientLogger.logQuietly(e);
+      throw new IllegalStateException("test cannot run without network interface", e);
     }
     when(messenger.isServer()).thenReturn(true);
     final ChannelMessenger channelMessenger =

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.RemoteName;
@@ -18,6 +17,7 @@ import games.strategy.net.ClientMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
+import games.strategy.net.MessengerTestUtils;
 import games.strategy.net.ServerMessenger;
 import games.strategy.util.ThreadUtil;
 
@@ -44,20 +44,8 @@ public class ChannelMessengerTest {
 
   @AfterEach
   public void tearDown() {
-    try {
-      if (serverMessenger != null) {
-        serverMessenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
-    try {
-      if (clientMessenger != null) {
-        clientMessenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
+    MessengerTestUtils.shutDownQuietly(serverMessenger);
+    MessengerTestUtils.shutDownQuietly(clientMessenger);
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.ConnectionLostException;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.MessageContext;
@@ -66,13 +64,7 @@ public class RemoteMessengerTest {
         return null;
       }
     }).when(serverMessenger).removeConnection(any());
-    final Node dummyNode;
-    try {
-      dummyNode = new Node("dummy", InetAddress.getLocalHost(), 0);
-    } catch (final UnknownHostException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e);
-    }
+    final Node dummyNode = new Node("dummy", InetAddress.getLocalHost(), 0);
     when(serverMessenger.getLocalNode()).thenReturn(dummyNode);
     when(serverMessenger.getServerNode()).thenReturn(dummyNode);
     when(serverMessenger.isServer()).thenReturn(true);

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -8,19 +8,18 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
+import games.strategy.net.MessengerTestUtils;
 import games.strategy.net.Node;
 import games.strategy.net.ServerMessenger;
 
@@ -52,30 +51,14 @@ public class VaultTest {
 
   @AfterEach
   public void tearDown() {
-    try {
-      if (serverMessenger != null) {
-        serverMessenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
-    try {
-      if (clientMessenger != null) {
-        clientMessenger.shutDown();
-      }
-    } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-    }
+    MessengerTestUtils.shutDownQuietly(serverMessenger);
+    MessengerTestUtils.shutDownQuietly(clientMessenger);
   }
 
   @Test
-  public void testLocal() throws NotUnlockedException {
+  public void testLocal() throws Exception {
     final IServerMessenger messenger = mock(IServerMessenger.class);
-    try {
-      when(messenger.getLocalNode()).thenReturn(new Node("dummy", InetAddress.getLocalHost(), 0));
-    } catch (final UnknownHostException e) {
-      ClientLogger.logQuietly(e);
-    }
+    when(messenger.getLocalNode()).thenReturn(new Node("dummy", InetAddress.getLocalHost(), 0));
     final UnifiedMessenger unifiedMessenger = new UnifiedMessenger(messenger);
     final ChannelMessenger channelMessenger = new ChannelMessenger(unifiedMessenger);
     // RemoteMessenger remoteMessenger = new RemoteMessenger(unifiedMessenger);

--- a/src/test/java/games/strategy/net/MessengerTestUtils.java
+++ b/src/test/java/games/strategy/net/MessengerTestUtils.java
@@ -1,0 +1,25 @@
+package games.strategy.net;
+
+import javax.annotation.Nullable;
+
+/**
+ * A collection of methods useful for writing tests that use instances of {@link IMessenger}.
+ */
+public final class MessengerTestUtils {
+  private MessengerTestUtils() {}
+
+  /**
+   * Shuts down the specified messenger unconditionally. Any exception will be written to stdout.
+   *
+   * @param messenger The messenger to shut down; if {@code null}, this method does nothing.
+   */
+  public static void shutDownQuietly(final @Nullable IMessenger messenger) {
+    if (messenger != null) {
+      try {
+        messenger.shutDown();
+      } catch (final Exception e) {
+        e.printStackTrace(System.out);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is part of an effort to get rid of the deprecation warnings related to the `ClientLogger#logQuietly(Throwable)` method.  These changes remove all `ClientLogger` usage from test code (except for calls to `disableErrorPopupForTesting()` and `resetErrorPopupForTesting()`).

In some cases, the exceptions that were being swallowed and logged should be allowed to raise a test error.

For the cases that quietly shut down an `IMessenger`, I extracted the new `MessengerTestUtils#shutDownQuietly()` method.  I kept the logging behavior, although this is questionable given that the output of an automated test is typically ignored.  However, I replaced `ClientLogger#logQuietly()` with a direct call to `Throwable#printStackTrace()` because I don't think it's appropriate for arbitrary test code to make use of `ClientLogger`, which has very specific semantics.