### PR TITLE
Use minimumSize instead of size for battle frame

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -251,7 +251,7 @@ public class BattlePanel extends ActionPanel {
         battleFrame.setTitle(attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
         battleFrame.getContentPane().removeAll();
         battleFrame.getContentPane().add(battleDisplay);
-        battleFrame.setSize(800, 600);
+        battleFrame.setMinimumSize(new Dimension(800, 600));
         battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
         PBEMDiceRoller.setFocusWindow(battleFrame);
         boolean foundHumanInBattle = false;


### PR DESCRIPTION
Addresses some of: https://forums.triplea-game.org/topic/494/customizable-battle-window

Allows battle frame to keep the size its adjusted to during a gaming session so you don't have to keep adjusting the size. Probably could do more to improve this but its at least an improvement.