### PR TITLE
Re-interrupt current thread after catching InterruptedException

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -452,7 +452,7 @@ public class GameRunner {
     try {
       tracker.waitForAll();
     } catch (final InterruptedException ex) {
-      ClientLogger.logQuietly(ex);
+      Thread.currentThread().interrupt();
     }
     return img;
   }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -166,6 +166,7 @@ public class ServerGame extends AbstractGame {
         return;
       }
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       nonBlockingObserver.cannotJoinGame(e.getMessage());
       return;
     }
@@ -187,7 +188,7 @@ public class ServerGame extends AbstractGame {
           nonBlockingObserver.cannotJoinGame("Taking too long to join.");
         }
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
         nonBlockingObserver.cannotJoinGame(e.getMessage());
       }
     } catch (final Exception e) {
@@ -260,7 +261,7 @@ public class ServerGame extends AbstractGame {
             // that the game is over.
             delegateExecutionStoppedLatch.await();
           } catch (final InterruptedException e) {
-            // ignore
+            Thread.currentThread().interrupt();
           }
         } else {
           runStep(false);
@@ -305,7 +306,7 @@ public class ServerGame extends AbstractGame {
         }
       }
     } catch (final InterruptedException e) {
-      ClientLogger.logQuietly(e);
+      Thread.currentThread().interrupt();
     }
     // shutdown
     try {
@@ -370,6 +371,7 @@ public class ServerGame extends AbstractGame {
         throw new IOException("Could not lock delegate execution");
       }
     } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
       throw new IOException(ie.getMessage());
     }
     try {

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -208,7 +208,7 @@ public class ServerLauncher extends AbstractLauncher {
               }
             }
           } catch (final InterruptedException e) {
-            ClientLogger.logQuietly(e);
+            Thread.currentThread().interrupt();
           }
           stopGame();
         } catch (final Exception e) {
@@ -391,7 +391,7 @@ public class ServerLauncher extends AbstractLauncher {
       try {
         latch.await();
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
 
@@ -400,7 +400,7 @@ public class ServerLauncher extends AbstractLauncher {
       try {
         didNotTimeOut = latch.await(timeout, timeUnit);
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
       return didNotTimeOut;
     }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -103,7 +103,7 @@ public class ClientModel implements IMessengerErrorListener {
       try {
         latch.await(GameRunner.MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME, TimeUnit.SECONDS);
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
 
@@ -137,7 +137,7 @@ public class ClientModel implements IMessengerErrorListener {
       try {
         latch.await(GameRunner.MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME, TimeUnit.SECONDS);
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
   };

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -582,7 +582,8 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     if (removeConnectionsLatch != null) {
       try {
         removeConnectionsLatch.await(6, TimeUnit.SECONDS);
-      } catch (final InterruptedException e) { // no worries
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     }
     // will be handled elsewhere

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -129,6 +129,7 @@ public final class BackgroundTaskRunner {
         } catch (final ExecutionException e) {
           exceptionRef.set(e.getCause());
         } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
           exceptionRef.set(e);
         }
       }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -55,7 +55,7 @@ class EndPoint {
         try {
           numberMutex.wait();
         } catch (final InterruptedException e) {
-          ClientLogger.logQuietly(e);
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -124,7 +124,7 @@ public class UnifiedMessenger {
     try {
       latch.await();
     } catch (final InterruptedException e) {
-      logger.log(Level.WARNING, e.getMessage());
+      Thread.currentThread().interrupt();
     }
 
     synchronized (pendingLock) {

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -316,7 +316,7 @@ public class Vault {
             waitForLock.wait(waitTime);
           }
         } catch (final InterruptedException e) {
-          // not a big deal
+          Thread.currentThread().interrupt();
         }
       }
     }
@@ -339,7 +339,7 @@ public class Vault {
         try {
           waitForLock.wait(leftToWait);
         } catch (final InterruptedException e) {
-          // not a big deal
+          Thread.currentThread().interrupt();
         }
         leftToWait = startTime + timeout - System.currentTimeMillis();
       }

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -104,6 +104,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
     try {
       initLatch.await();
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       connectionRefusedError = e;
       try {
         socketChannel.close();

--- a/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -109,7 +109,7 @@ public class ClientQuarantineConversation extends QuarantineConversation {
             try {
               doneShowLatch.await();
             } catch (final InterruptedException e) {
-              // ignore
+              Thread.currentThread().interrupt();
             }
             if (isClosed) {
               return Action.NONE;

--- a/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/src/main/java/games/strategy/net/nio/Decoder.java
@@ -62,6 +62,7 @@ class Decoder {
         try {
           data = reader.take();
         } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
           continue;
         }
         if (data == null || !running) {

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.data.PlayerID;
@@ -134,7 +133,7 @@ public class TripleA implements IGameLoader {
           frame.toFront();
         });
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
 

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.SwingUtilities;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.data.PlayerID;
@@ -37,6 +35,7 @@ import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.ui.display.TripleADisplay;
+import games.strategy.ui.SwingAction;
 
 @MapSupport
 public class TripleA implements IGameLoader {
@@ -117,26 +116,21 @@ public class TripleA implements IGameLoader {
       // technically not needed because we won't have any "local human players" in a headless game.
       connectPlayers(players, null);
     } else {
-      try {
-        SwingUtilities.invokeAndWait(() -> {
-          final TripleAFrame frame;
-          frame = new TripleAFrame(game, localPlayers);
-          display = new TripleADisplay(frame);
-          game.addDisplay(display);
-          soundChannel = new DefaultSoundChannel(localPlayers);
-          game.addSoundChannel(soundChannel);
-          frame.setSize(700, 400);
-          frame.setVisible(true);
-          ClipPlayer.play(SoundPath.CLIP_GAME_START);
-          connectPlayers(players, frame);
-          frame.setExtendedState(Frame.MAXIMIZED_BOTH);
-          frame.toFront();
-        });
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      SwingAction.invokeAndWait(() -> {
+        final TripleAFrame frame;
+        frame = new TripleAFrame(game, localPlayers);
+        display = new TripleADisplay(frame);
+        game.addDisplay(display);
+        soundChannel = new DefaultSoundChannel(localPlayers);
+        game.addSoundChannel(soundChannel);
+        frame.setSize(700, 400);
+        frame.setVisible(true);
+        ClipPlayer.play(SoundPath.CLIP_GAME_START);
+        connectPlayers(players, frame);
+        frame.setExtendedState(Frame.MAXIMIZED_BOTH);
+        frame.toFront();
+      });
     }
-
   }
 
   private static void connectPlayers(final Set<IGamePlayer> players, final TripleAFrame frame) {

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -735,7 +735,7 @@ public class AirBattle extends AbstractBattle {
       bridge.leaveDelegateExecution();
       t.join();
     } catch (final InterruptedException e) {
-      // ignore
+      Thread.currentThread().interrupt();
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -189,7 +189,7 @@ public class Fire implements IExecutable {
       bridge.leaveDelegateExecution();
       t.join();
     } catch (final InterruptedException e) {
-      // ignore
+      Thread.currentThread().interrupt();
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2193,7 +2193,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         bridge.leaveDelegateExecution();
         t.join();
       } catch (final InterruptedException e) {
-        // ignore
+        Thread.currentThread().interrupt();
       } finally {
         bridge.enterDelegateExecution();
       }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -520,7 +520,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       bridge.leaveDelegateExecution();
       t.join();
     } catch (final InterruptedException e) {
-      // ignore
+      Thread.currentThread().interrupt();
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/src/main/java/games/strategy/triplea/image/ImageRef.java
+++ b/src/main/java/games/strategy/triplea/image/ImageRef.java
@@ -5,8 +5,6 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 
-import games.strategy.debug.ClientLogger;
-
 /**
  * We keep a soft reference to the image to allow it to be garbage collected.
  * Also, the image may not have finished watching when we are created, but the
@@ -21,7 +19,7 @@ class ImageRef {
         try {
           referenceQueue.remove();
         } catch (final InterruptedException e) {
-          ClientLogger.logQuietly(e);
+          Thread.currentThread().interrupt();
         }
       }
     }, "Tile Image Factory Soft Reference Reclaimer");

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -275,6 +275,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
           final AggregateResults result = future.get();
           results.addResults(result.getResults());
         } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
           interruptExceptions.add(e);
         } catch (final ExecutionException e) {
           final String cause = e.getCause().getLocalizedMessage();

--- a/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -74,6 +74,7 @@ public abstract class ActionPanel extends JPanel {
     try {
       latch.await();
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       release();
     }
     // cross a memory barrier

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -50,7 +50,6 @@ import javax.swing.border.EtchedBorder;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -404,7 +403,7 @@ public class BattleDisplay extends JPanel {
     try {
       latch.await();
     } catch (final InterruptedException e1) {
-      e1.printStackTrace();
+      Thread.currentThread().interrupt();
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(latch);
     }
@@ -531,7 +530,7 @@ public class BattleDisplay extends JPanel {
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
-      ClientLogger.logQuietly(ex);
+      Thread.currentThread().interrupt();
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -845,6 +845,7 @@ public class MapPanel extends ImageScrollerLargeView {
         try {
           tile = undrawnTiles.poll(2000, TimeUnit.MILLISECONDS);
         } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
           continue;
         }
         if (tile == null) {

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1026,7 +1026,7 @@ public class TripleAFrame extends MainGameFrame {
       try {
         latch1.await();
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
     actionButtons.changeToPickTerritoryAndUnits(player);
@@ -1045,7 +1045,7 @@ public class TripleAFrame extends MainGameFrame {
       try {
         latch2.await();
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
+        Thread.currentThread().interrupt();
       }
     }
     if (actionButtons != null && actionButtons.getCurrent() != null) {
@@ -1133,7 +1133,7 @@ public class TripleAFrame extends MainGameFrame {
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
-      // ignore interrupted exception
+      Thread.currentThread().interrupt();
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
@@ -1225,7 +1225,7 @@ public class TripleAFrame extends MainGameFrame {
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
-      // ignore interrupted exception
+      Thread.currentThread().interrupt();
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
@@ -1304,7 +1304,7 @@ public class TripleAFrame extends MainGameFrame {
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
-      ex.printStackTrace();
+      Thread.currentThread().interrupt();
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -448,8 +448,8 @@ public class SwingComponents {
         } catch (final ExecutionException e) {
           promise.completeExceptionally(e.getCause());
         } catch (final InterruptedException e) {
-          promise.completeExceptionally(e);
           Thread.currentThread().interrupt();
+          promise.completeExceptionally(e);
         }
       }
     };

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -54,7 +54,7 @@ public final class Util {
       tracker.waitForAll();
       tracker.removeImage(anImage);
     } catch (final InterruptedException ignored) {
-      // ignore interrupted
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -142,6 +142,7 @@ public final class EventThreadJOptionPane {
         latch.await();
         done = true;
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
         latchHandler.interruptLatch(latch);
       }
     }

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -21,7 +21,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 import tools.map.making.ImageIoCompletionWatcher;
@@ -157,8 +156,7 @@ public class ReliefImageBreaker {
         tracker.waitForAll();
         return img;
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly("interrupted while loading images", e);
-        return loadImage();
+        Thread.currentThread().interrupt();
       }
     }
     return null;

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -17,7 +17,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ui.screen.TileManager;
 
 /**
@@ -132,8 +131,7 @@ public class TileImageBreaker {
         tracker.waitForAll();
         return img;
       } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
-        return loadImage();
+        Thread.currentThread().interrupt();
       }
     }
     return null;

--- a/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
+++ b/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
@@ -17,7 +17,7 @@ public class ImageIoCompletionWatcher implements ImageObserver {
     try {
       countDownLatch.await();
     } catch (final InterruptedException e) {
-      // Ignore interrupted exception
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/test/java/games/strategy/thread/ThreadPoolTest.java
+++ b/src/test/java/games/strategy/thread/ThreadPoolTest.java
@@ -79,7 +79,7 @@ public class ThreadPoolTest {
       try {
         thread.join();
       } catch (final InterruptedException e) {
-        // ignore interrupted exception
+        Thread.currentThread().interrupt();
       }
     }
   }
@@ -111,7 +111,7 @@ public class ThreadPoolTest {
       try {
         Thread.sleep(0, 1);
       } catch (final InterruptedException e) {
-        throw new IllegalStateException(e);
+        Thread.currentThread().interrupt();
       }
       done = true;
     }


### PR DESCRIPTION
This PR started as an attempt to remove some unnecessary calls to the deprecated `ClientLogger#logQuietly(Throwable)` method.  Then I realized we still have a lot `InterruptedException` handlers that do not re-interrupt the current thread if they do not re-throw the exception, as discussed in #1448.

This PR adds the statement `Thread.currentThread().interrupt()` to every `InterruptedException` handler in which such a statement wasn't already present.  It also removes unnecessary logging of `InterruptedException` and comments that were against the advice of #1448.