### PR TITLE
Add @Nullable annotations for ban and mute method parameters

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
@@ -2,6 +2,8 @@ package games.strategy.engine.lobby.server;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.message.IRemote;
 import games.strategy.net.INode;
 
@@ -19,42 +21,56 @@ public interface IModeratorController extends IRemote {
 
   /**
    * Ban the username of the given INode.
+   *
+   * @param banExpires {@code null} for a permanent ban.
    */
-  void banUsername(INode node, Date banExpires);
+  void banUsername(INode node, @Nullable Date banExpires);
 
   /**
+   * @param banExpires {@code null} for a permanent ban.
+   *
    * @deprecated Kept to maintain backwards compatibility.
    *             Remove with next incompatible release.
    */
   @Deprecated
-  default void banIp(final INode node, final Date banExpires) {}
+  default void banIp(final INode node, final @Nullable Date banExpires) {}
 
   /**
    * Ban the mac of the given INode.
+   *
+   * @param banExpires {@code null} for a permanent ban.
    */
-  void banMac(INode node, Date banExpires);
+  void banMac(INode node, @Nullable Date banExpires);
 
   /**
    * Ban the mac.
+   *
+   * @param banExpires {@code null} for a permanent ban.
    */
-  void banMac(INode node, String hashedMac, Date banExpires);
+  void banMac(INode node, String hashedMac, @Nullable Date banExpires);
 
   /**
    * Mute the username of the given INode.
+   *
+   * @param muteExpires {@code null} for a permanent mute.
    */
-  void muteUsername(INode node, Date muteExpires);
+  void muteUsername(INode node, @Nullable Date muteExpires);
 
   /**
+   * @param muteExpires {@code null} for a permanent mute.
+   *
    * @deprecated Kept to maintain backwards compatibility.
    *             Remove with next incompatible release.
    */
   @Deprecated
-  default void muteIp(final INode node, final Date muteExpires) {}
+  default void muteIp(final INode node, final @Nullable Date muteExpires) {}
 
   /**
    * Mute the mac of the given INode.
+   *
+   * @param muteExpires {@code null} for a permanent mute.
    */
-  void muteMac(INode node, Date muteExpires);
+  void muteMac(INode node, @Nullable Date muteExpires);
 
   /**
    * Get list of people in the game.

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -23,11 +23,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void banUsername(final INode node, final Date banExpires) {
+  public void banUsername(final INode node, final @Nullable Date banExpires) {
     banUsername(node, banExpires != null ? banExpires.toInstant() : null);
   }
 
-  private void banUsername(final INode node, final Instant banExpires) {
+  private void banUsername(final INode node, final @Nullable Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
@@ -67,12 +67,12 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void banMac(final INode node, final Date banExpires) {
+  public void banMac(final INode node, final @Nullable Date banExpires) {
     banMac(node, getNodeMacAddress(node), banExpires);
   }
 
   @Override
-  public void banMac(final INode node, final String hashedMac, final Date banExpires) {
+  public void banMac(final INode node, final String hashedMac, final @Nullable Date banExpires) {
     banMac(node, hashedMac, banExpires != null ? banExpires.toInstant() : null);
   }
 
@@ -92,11 +92,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void muteUsername(final INode node, final Date muteExpires) {
+  public void muteUsername(final INode node, final @Nullable Date muteExpires) {
     muteUsername(node, muteExpires != null ? muteExpires.toInstant() : null);
   }
 
-  private void muteUsername(final INode node, final Instant muteExpires) {
+  private void muteUsername(final INode node, final @Nullable Instant muteExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't mute an admin");
@@ -115,11 +115,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void muteMac(final INode node, final Date muteExpires) {
+  public void muteMac(final INode node, final @Nullable Date muteExpires) {
     muteMac(node, muteExpires != null ? muteExpires.toInstant() : null);
   }
 
-  private void muteMac(final INode node, final Instant muteExpires) {
+  private void muteMac(final INode node, final @Nullable Instant muteExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't mute an admin");

--- a/src/main/java/games/strategy/engine/lobby/server/NullModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/NullModeratorController.java
@@ -2,6 +2,8 @@ package games.strategy.engine.lobby.server;
 
 import java.util.Date;
 
+import javax.annotation.Nullable;
+
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
@@ -15,12 +17,12 @@ public class NullModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void banMac(final INode node, final String hashedMac, final Date banExpires) {
+  public void banMac(final INode node, final String hashedMac, final @Nullable Date banExpires) {
     // nothing
   }
 
   @Override
-  public void banMac(final INode node, final Date banExpires) {
+  public void banMac(final INode node, final @Nullable Date banExpires) {
     // nothing
   }
 
@@ -68,17 +70,17 @@ public class NullModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void banUsername(final INode node, final Date banExpires) {
+  public void banUsername(final INode node, final @Nullable Date banExpires) {
     // nothing
   }
 
   @Override
-  public void muteUsername(final INode node, final Date muteExpires) {
+  public void muteUsername(final INode node, final @Nullable Date muteExpires) {
     // nothing
   }
 
   @Override
-  public void muteMac(final INode node, final Date muteExpires) {
+  public void muteMac(final INode node, final @Nullable Date muteExpires) {
     // nothing
   }
 


### PR DESCRIPTION
Follow-up to a suggestion from #2828.  This PR simply annotates `IModeratorController` ban/mute method parameters that are nullable (the ban/mute durations, where a `null` value indicates a permanent ban/mute).