### PR TITLE
Remove @API Guardian from test runtime classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,11 +115,12 @@ dependencies {
     runtime remoteFile('https://github.com/kirill-grouchnikov/substance/raw/master/drop/7.1.01/trident-1.4.jar')
 
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.3.3'
-    testCompile 'org.apiguardian:apiguardian-api:1.0.0'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
     testCompile 'org.mockito:mockito-core:2.13.0'
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
+
+    testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
 
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.2'
     testRuntime 'org.junit.platform:junit-platform-launcher:1.0.2'


### PR DESCRIPTION
This JUnit 5 dependency is only required at test compile time.