### PR TITLE
Audit lobby mutes

### DIFF
--- a/config/lobby/db/005_audit_mutes
+++ b/config/lobby/db/005_audit_mutes
@@ -1,0 +1,33 @@
+start transaction;
+
+alter table muted_macs
+  add column mod_username varchar(40) not null default '__unknown__',
+  add column mod_ip varchar(45) not null default '0.0.0.0',
+  add column mod_mac char(28) not null default '$1$MH$WarCz.YHukJf1YVqmMBoS0',
+  add constraint muted_macs_mod_mac_check check (char_length(mod_mac)=28);
+
+alter table muted_macs
+  alter column mod_username drop default,
+  alter column mod_ip drop default,
+  alter column mod_mac drop default;
+
+comment on column muted_macs.mod_username is 'The username of the moderator that executed the mute.';
+comment on column muted_macs.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the mute.';
+comment on column muted_macs.mod_mac is 'The hashed MAC address of the moderator that executed the mute.';
+
+alter table muted_usernames
+  add column mod_username varchar(40) not null default '__unknown__',
+  add column mod_ip varchar(45) not null default '0.0.0.0',
+  add column mod_mac char(28) not null default '$1$MH$WarCz.YHukJf1YVqmMBoS0',
+  add constraint muted_usernames_mod_mac_check check (char_length(mod_mac)=28);
+
+alter table muted_usernames
+  alter column mod_username drop default,
+  alter column mod_ip drop default,
+  alter column mod_mac drop default;
+
+comment on column muted_usernames.mod_username is 'The username of the moderator that executed the mute.';
+comment on column muted_usernames.mod_ip is 'The IP address (v4 or v6) of the moderator that executed the mute.';
+comment on column muted_usernames.mod_mac is 'The hashed MAC address of the moderator that executed the mute.';
+
+commit;

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -1,0 +1,105 @@
+package games.strategy.engine.lobby.server.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Random;
+
+import games.strategy.engine.lobby.server.Moderator;
+import games.strategy.util.Util;
+
+/**
+ * Superclass for fixtures that test a moderator service controller.
+ */
+public abstract class AbstractModeratorServiceControllerTestCase {
+  protected final Moderator moderator = newModerator();
+
+  protected AbstractModeratorServiceControllerTestCase() {}
+
+  /**
+   * Creates a new unique moderator.
+   */
+  protected static Moderator newModerator() {
+    return new Moderator(newUsername(), newInetAddress(), newHashedMacAddress());
+  }
+
+  /**
+   * Creates a new unique username.
+   */
+  protected static String newUsername() {
+    return "user_" + Util.createUniqueTimeStamp();
+  }
+
+  private static InetAddress newInetAddress() {
+    final byte[] addr = new byte[4];
+    new Random().nextBytes(addr);
+    try {
+      return InetAddress.getByAddress(addr);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen", e);
+    }
+  }
+
+  /**
+   * Creates a new unique hashed MAC address.
+   */
+  protected static String newHashedMacAddress() {
+    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  }
+
+  /**
+   * Asserts the moderator returned from the specified query is equal to the expected moderator.
+   *
+   * @param expected The expected moderator.
+   * @param moderatorQuerySql The SQL used to query for the moderator. It is expected that this query returns the
+   *        moderator's username in the first column, the moderator's IP address in the second column, and the
+   *        moderator's hashed MAC address in the third column.
+   * @param preparedStatementInitializer Callback to initialize the parameters in the prepared statement used to query
+   *        for the moderator.
+   * @param unknownModeratorMessage The failure message to be used when the requested moderator does not exist.
+   */
+  protected static void assertModeratorEquals(
+      final Moderator expected,
+      final String moderatorQuerySql,
+      final PreparedStatementInitializer preparedStatementInitializer,
+      final String unknownModeratorMessage) {
+    try (Connection conn = Database.getPostgresConnection();
+        PreparedStatement ps = conn.prepareStatement(moderatorQuerySql)) {
+      preparedStatementInitializer.initialize(ps);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          assertEquals(expected.getUsername(), rs.getString(1));
+          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
+          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
+        } else {
+          fail(unknownModeratorMessage);
+        }
+      }
+    } catch (final UnknownHostException e) {
+      fail("malformed moderator IP address", e);
+    } catch (final SQLException e) {
+      fail("moderator query failed", e);
+    }
+  }
+
+  /**
+   * Initializes the parameters of a {@link PreparedStatement}.
+   */
+  @FunctionalInterface
+  protected interface PreparedStatementInitializer {
+    /**
+     * Initializes the parameters of the specified prepared statement.
+     *
+     * @param ps The prepared statement to initialize.
+     *
+     * @throws SQLException If an error occurs while initializing the prepared statement.
+     */
+    void initialize(PreparedStatement ps) throws SQLException;
+  }
+}

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedMacControllerIntegrationTest.java
@@ -4,31 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
-import games.strategy.util.Util;
 
-public class BannedMacControllerIntegrationTest {
-
+public final class BannedMacControllerIntegrationTest extends AbstractModeratorServiceControllerTestCase {
   private final BannedMacController controller = spy(new BannedMacController());
   private final String hashedMac = newHashedMacAddress();
-  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testBanMacForever() {
@@ -86,7 +75,7 @@ public class BannedMacControllerIntegrationTest {
   public void testBanMacUpdatesModerator() {
     banMacForSeconds(Long.MAX_VALUE, moderator);
 
-    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    final Moderator otherModerator = newModerator();
     banMacForSeconds(Long.MAX_VALUE, otherModerator);
 
     assertModeratorForBannedMacEquals(otherModerator);
@@ -102,38 +91,11 @@ public class BannedMacControllerIntegrationTest {
     return banEnd;
   }
 
-  private static InetAddress newInetAddress() {
-    final byte[] addr = new byte[4];
-    new Random().nextBytes(addr);
-    try {
-      return InetAddress.getByAddress(addr);
-    } catch (final UnknownHostException e) {
-      throw new AssertionError("should never happen", e);
-    }
-  }
-
-  private static String newHashedMacAddress() {
-    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
-  }
-
   private void assertModeratorForBannedMacEquals(final Moderator expected) {
-    final String sql = "select mod_username, mod_ip, mod_mac from banned_macs where mac=?";
-    try (Connection con = Database.getPostgresConnection();
-        PreparedStatement ps = con.prepareStatement(sql)) {
-      ps.setString(1, hashedMac);
-      try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          assertEquals(expected.getUsername(), rs.getString(1));
-          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
-          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
-        } else {
-          fail("unknown banned hashed MAC address: " + hashedMac);
-        }
-      }
-    } catch (final UnknownHostException e) {
-      fail("malformed moderator IP address", e);
-    } catch (final SQLException e) {
-      fail("moderator query failed", e);
-    }
+    assertModeratorEquals(
+        expected,
+        "select mod_username, mod_ip, mod_mac from banned_macs where mac=?",
+        ps -> ps.setString(1, hashedMac),
+        "unknown banned hashed MAC address: " + hashedMac);
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/BannedUsernameControllerIntegrationTest.java
@@ -4,31 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Tuple;
-import games.strategy.util.Util;
 
-public class BannedUsernameControllerIntegrationTest {
-
+public final class BannedUsernameControllerIntegrationTest extends AbstractModeratorServiceControllerTestCase {
   private final BannedUsernameController controller = spy(new BannedUsernameController());
-  private final String username = Util.createUniqueTimeStamp();
-  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
+  private final String username = newUsername();
 
   @Test
   public void testBanUsernameForever() {
@@ -86,7 +75,7 @@ public class BannedUsernameControllerIntegrationTest {
   public void testBanUsernameUpdatesModerator() {
     banUsernameForSeconds(Long.MAX_VALUE, moderator);
 
-    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    final Moderator otherModerator = newModerator();
     banUsernameForSeconds(Long.MAX_VALUE, otherModerator);
 
     assertModeratorForBannedUsernameEquals(otherModerator);
@@ -102,38 +91,11 @@ public class BannedUsernameControllerIntegrationTest {
     return banEnd;
   }
 
-  private static InetAddress newInetAddress() {
-    final byte[] addr = new byte[4];
-    new Random().nextBytes(addr);
-    try {
-      return InetAddress.getByAddress(addr);
-    } catch (final UnknownHostException e) {
-      throw new AssertionError("should never happen", e);
-    }
-  }
-
-  private static String newHashedMacAddress() {
-    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
-  }
-
   private void assertModeratorForBannedUsernameEquals(final Moderator expected) {
-    final String sql = "select mod_username, mod_ip, mod_mac from banned_usernames where username=?";
-    try (Connection con = Database.getPostgresConnection();
-        PreparedStatement ps = con.prepareStatement(sql)) {
-      ps.setString(1, username);
-      try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          assertEquals(expected.getUsername(), rs.getString(1));
-          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
-          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
-        } else {
-          fail("unknown banned username: " + username);
-        }
-      }
-    } catch (final UnknownHostException e) {
-      fail("malformed moderator IP address", e);
-    } catch (final SQLException e) {
-      fail("moderator query failed", e);
-    }
+    assertModeratorEquals(
+        expected,
+        "select mod_username, mod_ip, mod_mac from banned_usernames where username=?",
+        ps -> ps.setString(1, username),
+        "unknown banned username: " + username);
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -3,30 +3,19 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.server.Moderator;
-import games.strategy.util.Util;
 
-public class MutedMacControllerIntegrationTest {
-
+public final class MutedMacControllerIntegrationTest extends AbstractModeratorServiceControllerTestCase {
   private final MutedMacController controller = spy(new MutedMacController());
   private final String hashedMac = newHashedMacAddress();
-  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testMuteMacForever() {
@@ -76,7 +65,7 @@ public class MutedMacControllerIntegrationTest {
   public void testMuteMacUpdatesModerator() {
     muteMacForSeconds(Long.MAX_VALUE, moderator);
 
-    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    final Moderator otherModerator = newModerator();
     muteMacForSeconds(Long.MAX_VALUE, otherModerator);
 
     assertModeratorForMutedMacEquals(otherModerator);
@@ -92,38 +81,11 @@ public class MutedMacControllerIntegrationTest {
     return muteEnd;
   }
 
-  private static InetAddress newInetAddress() {
-    final byte[] addr = new byte[4];
-    new Random().nextBytes(addr);
-    try {
-      return InetAddress.getByAddress(addr);
-    } catch (final UnknownHostException e) {
-      throw new AssertionError("should never happen", e);
-    }
-  }
-
-  private static String newHashedMacAddress() {
-    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
-  }
-
   private void assertModeratorForMutedMacEquals(final Moderator expected) {
-    final String sql = "select mod_username, mod_ip, mod_mac from muted_macs where mac=?";
-    try (Connection con = Database.getPostgresConnection();
-        PreparedStatement ps = con.prepareStatement(sql)) {
-      ps.setString(1, hashedMac);
-      try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          assertEquals(expected.getUsername(), rs.getString(1));
-          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
-          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
-        } else {
-          fail("unknown muted hashed MAC address: " + hashedMac);
-        }
-      }
-    } catch (final UnknownHostException e) {
-      fail("malformed moderator IP address", e);
-    } catch (final SQLException e) {
-      fail("moderator query failed", e);
-    }
+    assertModeratorEquals(
+        expected,
+        "select mod_username, mod_ip, mod_mac from muted_macs where mac=?",
+        ps -> ps.setString(1, hashedMac),
+        "unknown muted hashed MAC address: " + hashedMac);
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -3,20 +3,30 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Util;
 
 public class MutedMacControllerIntegrationTest {
 
   private final MutedMacController controller = spy(new MutedMacController());
-  private final String hashedMac = games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  private final String hashedMac = newHashedMacAddress();
+  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testMuteMacForever() {
@@ -62,9 +72,58 @@ public class MutedMacControllerIntegrationTest {
     assertEquals(Optional.of(muteUntil), controller.getMacUnmuteTime(hashedMac));
   }
 
+  @Test
+  public void testMuteMacUpdatesModerator() {
+    muteMacForSeconds(Long.MAX_VALUE, moderator);
+
+    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    muteMacForSeconds(Long.MAX_VALUE, otherModerator);
+
+    assertModeratorForMutedMacEquals(otherModerator);
+  }
+
   private Instant muteMacForSeconds(final long length) {
+    return muteMacForSeconds(length, moderator);
+  }
+
+  private Instant muteMacForSeconds(final long length, final Moderator moderator) {
     final Instant muteEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addMutedMac(hashedMac, muteEnd);
+    controller.addMutedMac(hashedMac, muteEnd, moderator);
     return muteEnd;
+  }
+
+  private static InetAddress newInetAddress() {
+    final byte[] addr = new byte[4];
+    new Random().nextBytes(addr);
+    try {
+      return InetAddress.getByAddress(addr);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen", e);
+    }
+  }
+
+  private static String newHashedMacAddress() {
+    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  }
+
+  private void assertModeratorForMutedMacEquals(final Moderator expected) {
+    final String sql = "select mod_username, mod_ip, mod_mac from muted_macs where mac=?";
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, hashedMac);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          assertEquals(expected.getUsername(), rs.getString(1));
+          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
+          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
+        } else {
+          fail("unknown muted hashed MAC address: " + hashedMac);
+        }
+      }
+    } catch (final UnknownHostException e) {
+      fail("malformed moderator IP address", e);
+    } catch (final SQLException e) {
+      fail("moderator query failed", e);
+    }
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
@@ -3,20 +3,30 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.server.Moderator;
 import games.strategy.util.Util;
 
 public class MutedUsernameControllerIntegrationTest {
 
   private final MutedUsernameController controller = spy(new MutedUsernameController());
   private final String username = Util.createUniqueTimeStamp();
+  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
 
   @Test
   public void testMuteUsernameForever() {
@@ -40,7 +50,7 @@ public class MutedUsernameControllerIntegrationTest {
     final Instant muteUntil = muteUsernameForSeconds(100L);
     assertTrue(controller.isUsernameMuted(username));
     assertEquals(Optional.of(muteUntil), controller.getUsernameUnmuteTime(username));
-    controller.addMutedUsername(username, Instant.now().minusSeconds(10L));
+    muteUsernameForSeconds(-10L);
     assertFalse(controller.isUsernameMuted(username));
     assertEquals(Optional.empty(), controller.getUsernameUnmuteTime(username));
   }
@@ -62,9 +72,58 @@ public class MutedUsernameControllerIntegrationTest {
     assertEquals(Optional.of(muteUntil), controller.getUsernameUnmuteTime(username));
   }
 
+  @Test
+  public void testMuteUsernameUpdatesModerator() {
+    muteUsernameForSeconds(Long.MAX_VALUE, moderator);
+
+    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    muteUsernameForSeconds(Long.MAX_VALUE, otherModerator);
+
+    assertModeratorForMutedUsernameEquals(otherModerator);
+  }
+
   private Instant muteUsernameForSeconds(final long length) {
+    return muteUsernameForSeconds(length, moderator);
+  }
+
+  private Instant muteUsernameForSeconds(final long length, final Moderator moderator) {
     final Instant muteEnd = length == Long.MAX_VALUE ? null : Instant.now().plusSeconds(length);
-    controller.addMutedUsername(username, muteEnd);
+    controller.addMutedUsername(username, muteEnd, moderator);
     return muteEnd;
+  }
+
+  private static InetAddress newInetAddress() {
+    final byte[] addr = new byte[4];
+    new Random().nextBytes(addr);
+    try {
+      return InetAddress.getByAddress(addr);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen", e);
+    }
+  }
+
+  private static String newHashedMacAddress() {
+    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
+  }
+
+  private void assertModeratorForMutedUsernameEquals(final Moderator expected) {
+    final String sql = "select mod_username, mod_ip, mod_mac from muted_usernames where username=?";
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, username);
+      try (ResultSet rs = ps.executeQuery()) {
+        if (rs.next()) {
+          assertEquals(expected.getUsername(), rs.getString(1));
+          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
+          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
+        } else {
+          fail("unknown muted username: " + username);
+        }
+      }
+    } catch (final UnknownHostException e) {
+      fail("malformed moderator IP address", e);
+    } catch (final SQLException e) {
+      fail("moderator query failed", e);
+    }
   }
 }

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/MutedUsernameControllerIntegrationTest.java
@@ -3,30 +3,19 @@ package games.strategy.engine.lobby.server.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.Random;
 
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.server.Moderator;
-import games.strategy.util.Util;
 
-public class MutedUsernameControllerIntegrationTest {
-
+public final class MutedUsernameControllerIntegrationTest extends AbstractModeratorServiceControllerTestCase {
   private final MutedUsernameController controller = spy(new MutedUsernameController());
-  private final String username = Util.createUniqueTimeStamp();
-  private final Moderator moderator = new Moderator("mod", newInetAddress(), newHashedMacAddress());
+  private final String username = newUsername();
 
   @Test
   public void testMuteUsernameForever() {
@@ -76,7 +65,7 @@ public class MutedUsernameControllerIntegrationTest {
   public void testMuteUsernameUpdatesModerator() {
     muteUsernameForSeconds(Long.MAX_VALUE, moderator);
 
-    final Moderator otherModerator = new Moderator("otherMod", newInetAddress(), newHashedMacAddress());
+    final Moderator otherModerator = newModerator();
     muteUsernameForSeconds(Long.MAX_VALUE, otherModerator);
 
     assertModeratorForMutedUsernameEquals(otherModerator);
@@ -92,38 +81,11 @@ public class MutedUsernameControllerIntegrationTest {
     return muteEnd;
   }
 
-  private static InetAddress newInetAddress() {
-    final byte[] addr = new byte[4];
-    new Random().nextBytes(addr);
-    try {
-      return InetAddress.getByAddress(addr);
-    } catch (final UnknownHostException e) {
-      throw new AssertionError("should never happen", e);
-    }
-  }
-
-  private static String newHashedMacAddress() {
-    return games.strategy.util.MD5Crypt.crypt(Util.createUniqueTimeStamp(), "MH");
-  }
-
   private void assertModeratorForMutedUsernameEquals(final Moderator expected) {
-    final String sql = "select mod_username, mod_ip, mod_mac from muted_usernames where username=?";
-    try (Connection con = Database.getPostgresConnection();
-        PreparedStatement ps = con.prepareStatement(sql)) {
-      ps.setString(1, username);
-      try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          assertEquals(expected.getUsername(), rs.getString(1));
-          assertEquals(expected.getInetAddress(), InetAddress.getByName(rs.getString(2)));
-          assertEquals(expected.getHashedMacAddress(), rs.getString(3));
-        } else {
-          fail("unknown muted username: " + username);
-        }
-      }
-    } catch (final UnknownHostException e) {
-      fail("malformed moderator IP address", e);
-    } catch (final SQLException e) {
-      fail("moderator query failed", e);
-    }
+    assertModeratorEquals(
+        expected,
+        "select mod_username, mod_ip, mod_mac from muted_usernames where username=?",
+        ps -> ps.setString(1, username),
+        "unknown muted username: " + username);
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -104,7 +104,7 @@ public class ModeratorController extends AbstractModeratorController {
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final String realName = getRealName(node);
-    new MutedUsernameController().addMutedUsername(realName, muteExpires);
+    new MutedUsernameController().addMutedUsername(realName, muteExpires, getModeratorForNode(modNode));
     serverMessenger.notifyUsernameMutingOfPlayer(realName, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
     logger.info(String.format(
@@ -126,7 +126,7 @@ public class ModeratorController extends AbstractModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    new MutedMacController().addMutedMac(mac, muteExpires);
+    new MutedMacController().addMutedMac(mac, muteExpires, getModeratorForNode(modNode));
     serverMessenger.notifyMacMutingOfPlayer(mac, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
     logger.info(String.format(

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.lobby.server.db;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -8,8 +10,12 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
+import games.strategy.engine.lobby.server.Moderator;
+
 /**
- * Utilitiy class to create/read/delete muted usernames (there is no update).
+ * Utility class to create/read/delete muted usernames (there is no update).
  */
 public class MutedUsernameController extends TimedController {
   /**
@@ -18,22 +24,38 @@ public class MutedUsernameController extends TimedController {
    * <p>
    * If this username is already muted, this call will update the mute_end.
    * </p>
+   *
+   * @param username The username to mute.
+   * @param muteTill The instant at which the mute will expire or {@code null} to mute the username forever.
+   * @param moderator The moderator executing the mute.
    */
-  public void addMutedUsername(final String username, final Instant muteTill) {
-    if (muteTill == null || muteTill.isAfter(now())) {
+  public void addMutedUsername(final String username, final @Nullable Instant muteTill, final Moderator moderator) {
+    checkNotNull(moderator);
 
-      try (Connection con = Database.getPostgresConnection();
-          PreparedStatement ps = con.prepareStatement("insert into muted_usernames (username, mute_till) values (?, ?)"
-              + " on conflict (username) do update set mute_till=excluded.mute_till")) {
-        ps.setString(1, username);
-        ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
-        ps.execute();
-        con.commit();
-      } catch (final SQLException sqle) {
-        throw new IllegalStateException("Error inserting muted username:" + username, sqle);
-      }
-    } else {
+    if (muteTill != null && muteTill.isBefore(now())) {
       removeMutedUsername(username);
+      return;
+    }
+
+    final String sql = ""
+        + "insert into muted_usernames "
+        + "  (username, mute_till, mod_username, mod_ip, mod_mac) values (?, ?, ?, ?, ?) "
+        + "on conflict (username) do update set "
+        + "  mute_till=excluded.mute_till, "
+        + "  mod_username=excluded.mod_username, "
+        + "  mod_ip=excluded.mod_ip, "
+        + "  mod_mac=excluded.mod_mac";
+    try (Connection con = Database.getPostgresConnection();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, username);
+      ps.setTimestamp(2, muteTill != null ? Timestamp.from(muteTill) : null);
+      ps.setString(3, moderator.getUsername());
+      ps.setString(4, moderator.getInetAddress().getHostAddress());
+      ps.setString(5, moderator.getHashedMacAddress());
+      ps.execute();
+      con.commit();
+    } catch (final SQLException sqle) {
+      throw new IllegalStateException("Error inserting muted username:" + username, sqle);
     }
   }
 


### PR DESCRIPTION
Partially addresses [this feature request](https://forums.triplea-game.org/topic/440/toolbox-feature-request).  This PR is identical to #2828 except that it audits mutes rather than bans.

#### Functional changes

The username, IP address, and hashed MAC address of the moderator that executes a username or MAC address mute is recorded along with the corresponding ban record in the database to provide an audit trail.

#### Refactoring changes

The second commit extracts a test fixture superclass to remove some duplication between the various ban/mute integration tests.  It is best viewed in isolation to see its effect.

#### Testing

In addition to the integration tests, I manually tested all admin commands in the UI for muting a user by username or MAC address using a client from this branch.  I also ran the same tests using a 3635 client to ensure an RMI incompatibility was not accidentally introduced.