### PR TITLE
Include testCompileOnly configuration in integTest compile classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ sourceSets {
         java.srcDir 'src/integ_test/java'
         resources.srcDir 'src/integ_test/resources'
 
-        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
+        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testCompileOnly + configurations.testRuntime
         runtimeClasspath = output + compileClasspath + configurations.junitPlatform
     }
 }


### PR DESCRIPTION
~This PR reverts #2854.  With that change, the warnings described in #2524 once again appear when building via Gradle.~

~Strange since the JUnit team itself uses `compileOnly` for this dependency.  I suspect it may have something to do with how Error Prone runs during compilation.  (I thought Error Prone was integrated as a compiler extension, but maybe it just runs as a separate process after the compiler, which would explain why the API Guardian annotations would have to be on the runtime classpath for Error Prone to see them.)~

<hr>

After #2854, the warnings described in #2524 once again appear when building the integration tests from Gradle.  The root cause is due to not including the `testCompileOnly` configuration in the `integTest` source set's compile classpath.