### PR TITLE
Checkstyle: Fix abbreviation violations in AI classes

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -73,7 +73,7 @@ import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.net.Messengers;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.ProgressWindow;
 import games.strategy.ui.SwingAction;
@@ -262,7 +262,7 @@ public class GameRunner {
 
       SwingComponents.addWindowClosingListener(mainFrame, GameRunner::exitGameIfFinished);
 
-      ProAI.gameOverClearCache();
+      ProAi.gameOverClearCache();
 
       loadGame();
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -20,7 +20,7 @@ import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.engine.framework.ui.GameChooserModel;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.settings.ClientSetting;
 
 public class GameSelectorModel extends Observable {
@@ -220,7 +220,7 @@ public class GameSelectorModel extends Observable {
   public void loadDefaultGame() {
     // clear out ai cached properties (this ended up being the best place to put it, as we have definitely left a game
     // at this point)
-    ProAI.gameOverClearCache();
+    ProAi.gameOverClearCache();
     new Thread(() -> loadDefaultGame(false)).start();
   }
 

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -22,10 +22,10 @@ import games.strategy.sound.DefaultSoundChannel;
 import games.strategy.sound.HeadlessSoundChannel;
 import games.strategy.sound.ISound;
 import games.strategy.sound.SoundPath;
-import games.strategy.triplea.ai.fastAI.FastAI;
-import games.strategy.triplea.ai.proAI.ProAI;
-import games.strategy.triplea.ai.weakAI.DoesNothingAI;
-import games.strategy.triplea.ai.weakAI.WeakAI;
+import games.strategy.triplea.ai.fastAI.FastAi;
+import games.strategy.triplea.ai.proAI.ProAi;
+import games.strategy.triplea.ai.weakAI.DoesNothingAi;
+import games.strategy.triplea.ai.weakAI.WeakAi;
 import games.strategy.triplea.delegate.EditDelegate;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.HeadlessUiContext;
@@ -55,13 +55,13 @@ public class TripleA implements IGameLoader {
     for (final String name : playerNames.keySet()) {
       final String type = playerNames.get(name);
       if (type.equals(WEAK_COMPUTER_PLAYER_TYPE)) {
-        players.add(new WeakAI(name, type));
+        players.add(new WeakAi(name, type));
       } else if (type.equals(FAST_COMPUTER_PLAYER_TYPE)) {
-        players.add(new FastAI(name, type));
+        players.add(new FastAi(name, type));
       } else if (type.equals(PRO_COMPUTER_PLAYER_TYPE)) {
-        players.add(new ProAI(name, type));
+        players.add(new ProAi(name, type));
       } else if (type.equals(DOESNOTHINGAI_COMPUTER_PLAYER_TYPE)) {
-        players.add(new DoesNothingAI(name, type));
+        players.add(new DoesNothingAi(name, type));
       } else if (type.equals(HUMAN_PLAYER_TYPE) || type.equals(CLIENT_PLAYER_TYPE)) {
         final TripleAPlayer player = new TripleAPlayer(name, type);
         players.add(player);

--- a/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -70,11 +70,11 @@ import games.strategy.util.Tuple;
  * through an IDelegate using a change).
  * </p>
  */
-public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAPlayer {
+public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAPlayer {
 
-  private static final Logger logger = Logger.getLogger(AbstractAI.class.getName());
+  private static final Logger logger = Logger.getLogger(AbstractAi.class.getName());
 
-  public AbstractAI(final String name, final String type) {
+  public AbstractAi(final String name, final String type) {
     super(name, type);
   }
 

--- a/src/main/java/games/strategy/triplea/ai/fastAI/FastAi.java
+++ b/src/main/java/games/strategy/triplea/ai/fastAI/FastAi.java
@@ -1,18 +1,18 @@
 package games.strategy.triplea.ai.fastAI;
 
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.ai.proAI.util.ProOddsCalculator;
 import games.strategy.triplea.oddsCalculator.ta.IOddsCalculator;
 
 /**
  * Fast AI.
  */
-public class FastAI extends ProAI {
+public class FastAi extends ProAi {
 
   // Odds estimator
   private static final IOddsCalculator estimator = new FastOddsEstimator();
 
-  public FastAI(final String name, final String type) {
+  public FastAi(final String name, final String type) {
     super(name, type);
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAi.java
@@ -18,11 +18,11 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.ai.AbstractAI;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.proAI.data.ProBattleResult;
 import games.strategy.triplea.ai.proAI.data.ProPurchaseTerritory;
 import games.strategy.triplea.ai.proAI.data.ProTerritory;
-import games.strategy.triplea.ai.proAI.logging.ProLogUI;
+import games.strategy.triplea.ai.proAI.logging.ProLogUi;
 import games.strategy.triplea.ai.proAI.logging.ProLogger;
 import games.strategy.triplea.ai.proAI.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.ai.proAI.simulate.ProSimulateTurnUtils;
@@ -55,19 +55,19 @@ import games.strategy.util.Tuple;
 /**
  * Pro AI.
  */
-public class ProAI extends AbstractAI {
+public class ProAi extends AbstractAi {
 
   // Odds calculator
-  private static final IOddsCalculator concurrentCalc = new ConcurrentOddsCalculator("ProAI");
+  private static final IOddsCalculator concurrentCalc = new ConcurrentOddsCalculator("ProAi");
   protected ProOddsCalculator calc;
 
   // Phases
-  private final ProCombatMoveAI combatMoveAI;
-  private final ProNonCombatMoveAI nonCombatMoveAI;
-  private final ProPurchaseAI purchaseAI;
-  private final ProRetreatAI retreatAI;
-  private final ProScrambleAI scrambleAI;
-  private final ProPoliticsAI politicsAI;
+  private final ProCombatMoveAi combatMoveAi;
+  private final ProNonCombatMoveAi nonCombatMoveAi;
+  private final ProPurchaseAi purchaseAi;
+  private final ProRetreatAi retreatAi;
+  private final ProScrambleAi scrambleAi;
+  private final ProPoliticsAi politicsAi;
 
   // Data shared across phases
   private Map<Territory, ProTerritory> storedCombatMoveMap;
@@ -76,15 +76,15 @@ public class ProAI extends AbstractAI {
   private List<PoliticalActionAttachment> storedPoliticalActions;
   private List<Territory> storedStrafingTerritories;
 
-  public ProAI(final String name, final String type) {
+  public ProAi(final String name, final String type) {
     super(name, type);
     initializeCalc();
-    combatMoveAI = new ProCombatMoveAI(this);
-    nonCombatMoveAI = new ProNonCombatMoveAI(this);
-    purchaseAI = new ProPurchaseAI(this);
-    retreatAI = new ProRetreatAI(this);
-    scrambleAI = new ProScrambleAI(this);
-    politicsAI = new ProPoliticsAI(this);
+    combatMoveAi = new ProCombatMoveAi(this);
+    nonCombatMoveAi = new ProNonCombatMoveAi(this);
+    purchaseAi = new ProPurchaseAi(this);
+    retreatAi = new ProRetreatAi(this);
+    scrambleAi = new ProScrambleAi(this);
+    politicsAi = new ProPoliticsAi(this);
     storedCombatMoveMap = null;
     storedFactoryMoveMap = null;
     storedPurchaseTerritories = null;
@@ -101,19 +101,19 @@ public class ProAI extends AbstractAI {
   }
 
   public static void initialize(final TripleAFrame frame) {
-    ProLogUI.initialize(frame);
+    ProLogUi.initialize(frame);
     ProLogger.info("Initialized Hard AI");
   }
 
   public static void showSettingsWindow() {
     ProLogger.info("Showing Hard AI settings window");
-    ProLogUI.showSettingsWindow();
+    ProLogUi.showSettingsWindow();
   }
 
   public static void gameOverClearCache() {
     // Are static, clear so that we don't keep the data around after a game is exited
     concurrentCalc.setGameData(null);
-    ProLogUI.clearCachedInstances();
+    ProLogUi.clearCachedInstances();
   }
 
   @Override
@@ -135,17 +135,17 @@ public class ProAI extends AbstractAI {
       final PlayerID player) {
     final long start = System.currentTimeMillis();
     BattleCalculator.clearOolCache();
-    ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
+    ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     calc.setData(data);
     if (nonCombat) {
-      nonCombatMoveAI.doNonCombatMove(storedFactoryMoveMap, storedPurchaseTerritories, moveDel);
+      nonCombatMoveAi.doNonCombatMove(storedFactoryMoveMap, storedPurchaseTerritories, moveDel);
       storedFactoryMoveMap = null;
     } else {
       if (storedCombatMoveMap == null) {
-        combatMoveAI.doCombatMove(moveDel);
+        combatMoveAi.doCombatMove(moveDel);
       } else {
-        combatMoveAI.doMove(storedCombatMoveMap, moveDel, data, player);
+        combatMoveAi.doMove(storedCombatMoveMap, moveDel, data, player);
         storedCombatMoveMap = null;
       }
     }
@@ -158,18 +158,18 @@ public class ProAI extends AbstractAI {
       final GameData data, final PlayerID player) {
     final long start = System.currentTimeMillis();
     BattleCalculator.clearOolCache();
-    ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
+    ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     if (pusToSpend <= 0) {
       return;
     }
     if (purchaseForBid) {
       calc.setData(data);
-      storedPurchaseTerritories = purchaseAI.bid(pusToSpend, purchaseDelegate, data);
+      storedPurchaseTerritories = purchaseAi.bid(pusToSpend, purchaseDelegate, data);
     } else {
 
       // Repair factories
-      purchaseAI.repair(pusToSpend, purchaseDelegate, data, player);
+      purchaseAi.repair(pusToSpend, purchaseDelegate, data, player);
 
       // Check if any place territories exist
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories = ProPurchaseUtils.findPurchaseTerritories(player);
@@ -217,13 +217,13 @@ public class ProAI extends AbstractAI {
         ProLogger.info("Simulating phase: " + stepName);
         if (stepName.endsWith("NonCombatMove")) {
           ProData.initializeSimulation(this, dataCopy, playerCopy);
-          final Map<Territory, ProTerritory> factoryMoveMap = nonCombatMoveAI.simulateNonCombatMove(moveDel);
+          final Map<Territory, ProTerritory> factoryMoveMap = nonCombatMoveAi.simulateNonCombatMove(moveDel);
           if (storedFactoryMoveMap == null) {
             storedFactoryMoveMap = ProSimulateTurnUtils.transferMoveMap(factoryMoveMap, data, player);
           }
         } else if (stepName.endsWith("CombatMove") && !stepName.endsWith("AirborneCombatMove")) {
           ProData.initializeSimulation(this, dataCopy, playerCopy);
-          final Map<Territory, ProTerritory> moveMap = combatMoveAI.doCombatMove(moveDel);
+          final Map<Territory, ProTerritory> moveMap = combatMoveAi.doCombatMove(moveDel);
           if (storedCombatMoveMap == null) {
             storedCombatMoveMap = ProSimulateTurnUtils.transferMoveMap(moveMap, data, player);
           }
@@ -232,13 +232,13 @@ public class ProAI extends AbstractAI {
           ProSimulateTurnUtils.simulateBattles(dataCopy, playerCopy, bridge, calc);
         } else if (stepName.endsWith("Place") || stepName.endsWith("EndTurn")) {
           ProData.initializeSimulation(this, dataCopy, player);
-          storedPurchaseTerritories = purchaseAI.purchase(purchaseDelegate, data);
+          storedPurchaseTerritories = purchaseAi.purchase(purchaseDelegate, data);
           break;
         } else if (stepName.endsWith("Politics")) {
           ProData.initializeSimulation(this, dataCopy, player);
           final PoliticsDelegate politicsDelegate = DelegateFinder.politicsDelegate(dataCopy);
           politicsDelegate.setDelegateBridgeAndPlayer(bridge);
-          final List<PoliticalActionAttachment> actions = politicsAI.politicalActions();
+          final List<PoliticalActionAttachment> actions = politicsAi.politicalActions();
           if (storedPoliticalActions == null) {
             storedPoliticalActions = actions;
           }
@@ -253,16 +253,16 @@ public class ProAI extends AbstractAI {
       final PlayerID player) {
     final long start = System.currentTimeMillis();
     BattleCalculator.clearOolCache();
-    ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
+    ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
-    purchaseAI.place(storedPurchaseTerritories, placeDelegate);
+    purchaseAi.place(storedPurchaseTerritories, placeDelegate);
     storedPurchaseTerritories = null;
     ProLogger.info(player.getName() + " time for place=" + (System.currentTimeMillis() - start));
   }
 
   @Override
   protected void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {
-    ProTechAI.tech(techDelegate, data, player);
+    ProTechAi.tech(techDelegate, data, player);
   }
 
   @Override
@@ -295,12 +295,12 @@ public class ProAI extends AbstractAI {
       return null;
     }
     calc.setData(getGameData());
-    return retreatAI.retreatQuery(battleId, battleTerritory, possibleTerritories);
+    return retreatAi.retreatQuery(battleId, battleTerritory, possibleTerritories);
   }
 
   @Override
   public boolean shouldBomberBomb(final Territory territory) {
-    return combatMoveAI.isBombing();
+    return combatMoveAi.isBombing();
   }
 
   // TODO: Consider supporting this functionality
@@ -407,7 +407,7 @@ public class ProAI extends AbstractAI {
     ProLogger.info(player.getName() + " checking scramble to " + scrambleTo + ", attackers=" + attackers.size()
         + ", defenders=" + defenders.size() + ", possibleScramblers=" + possibleScramblers);
     calc.setData(getGameData());
-    return scrambleAI.scrambleUnitsQuery(scrambleTo, possibleScramblers);
+    return scrambleAi.scrambleUnitsQuery(scrambleTo, possibleScramblers);
   }
 
   @Override
@@ -441,9 +441,9 @@ public class ProAI extends AbstractAI {
     initializeData();
 
     if (storedPoliticalActions == null) {
-      politicsAI.politicalActions();
+      politicsAi.politicalActions();
     } else {
-      politicsAI.doActions(storedPoliticalActions);
+      politicsAi.doActions(storedPoliticalActions);
       storedPoliticalActions = null;
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAi.java
@@ -45,11 +45,11 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro combat move AI.
  */
-class ProCombatMoveAI {
+class ProCombatMoveAi {
 
   private static final int MIN_BOMBING_SCORE = 4; // Avoid bombing low production factories with AA
 
-  private final ProAI ai;
+  private final ProAi ai;
   private final ProOddsCalculator calc;
   private GameData data;
   private PlayerID player;
@@ -57,7 +57,7 @@ class ProCombatMoveAI {
   private boolean isDefensive;
   private boolean isBombing;
 
-  ProCombatMoveAI(final ProAI ai) {
+  ProCombatMoveAi(final ProAi ai) {
     this.ai = ai;
     calc = ai.getCalc();
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -25,7 +25,7 @@ import games.strategy.util.IntegerMap;
  */
 public class ProData {
 
-  private static ProAI proAI;
+  private static ProAi proAi;
   private static GameData data;
   private static PlayerID player;
 
@@ -41,17 +41,17 @@ public class ProData {
   public static ProPurchaseOptionMap purchaseOptions = null;
   public static double minCostPerHitPoint = Double.MAX_VALUE;
 
-  public static void initialize(final ProAI proAi) {
+  public static void initialize(final ProAi proAi) {
     hiddenInitialize(proAi, proAi.getGameData(), proAi.getPlayerId(), false);
   }
 
-  public static void initializeSimulation(final ProAI proAi, final GameData data, final PlayerID player) {
+  public static void initializeSimulation(final ProAi proAi, final GameData data, final PlayerID player) {
     hiddenInitialize(proAi, data, player, true);
   }
 
-  private static void hiddenInitialize(final ProAI proAi, final GameData data, final PlayerID player,
+  private static void hiddenInitialize(final ProAi proAi, final GameData data, final PlayerID player,
       final boolean isSimulation) {
-    ProData.proAI = proAi;
+    ProData.proAi = proAi;
     ProData.data = data;
     ProData.player = player;
     ProData.isSimulation = isSimulation;
@@ -70,8 +70,8 @@ public class ProData {
     minCostPerHitPoint = getMinCostPerHitPoint(purchaseOptions.getLandOptions());
   }
 
-  public static ProAI getProAi() {
-    return proAI;
+  public static ProAi getProAi() {
+    return proAi;
   }
 
   public static GameData getData() {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAi.java
@@ -52,7 +52,7 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro non-combat move AI.
  */
-class ProNonCombatMoveAI {
+class ProNonCombatMoveAi {
 
   private final ProOddsCalculator calc;
   private GameData data;
@@ -60,7 +60,7 @@ class ProNonCombatMoveAI {
   private Map<Unit, Territory> unitTerritoryMap;
   private ProTerritoryManager territoryManager;
 
-  ProNonCombatMoveAI(final ProAI ai) {
+  ProNonCombatMoveAi(final ProAi ai) {
     calc = ai.getCalc();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
@@ -26,11 +26,11 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro politics AI.
  */
-class ProPoliticsAI {
+class ProPoliticsAi {
 
   private final ProOddsCalculator calc;
 
-  ProPoliticsAI(final ProAI ai) {
+  ProPoliticsAi(final ProAi ai) {
     calc = ai.getCalc();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAi.java
@@ -52,7 +52,7 @@ import games.strategy.util.IntegerMap;
 /**
  * Pro purchase AI.
  */
-class ProPurchaseAI {
+class ProPurchaseAi {
 
   private final ProOddsCalculator calc;
   private GameData data;
@@ -62,7 +62,7 @@ class ProPurchaseAI {
   private ProTerritoryManager territoryManager;
   private boolean isBid = false;
 
-  ProPurchaseAI(final ProAI ai) {
+  ProPurchaseAi(final ProAi ai) {
     calc = ai.getCalc();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAi.java
@@ -41,11 +41,11 @@ import games.strategy.triplea.delegate.Matches;
  * 2. attacker submerges sub at start or end of battle
  * 3. defender submerges (or moves if Classic rules) sub at start or end of battle
  */
-class ProRetreatAI {
+class ProRetreatAi {
 
   private final ProOddsCalculator calc;
 
-  ProRetreatAI(final ProAI ai) {
+  ProRetreatAi(final ProAi ai) {
     calc = ai.getCalc();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAi.java
@@ -28,11 +28,11 @@ import games.strategy.util.Tuple;
 /**
  * Pro scramble AI.
  */
-class ProScrambleAI {
+class ProScrambleAi {
 
   private final ProOddsCalculator calc;
 
-  ProScrambleAI(final ProAI ai) {
+  ProScrambleAi(final ProAi ai) {
     calc = ai.getCalc();
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAi.java
@@ -35,7 +35,7 @@ import games.strategy.util.PredicateBuilder;
 /**
  * Pro tech AI.
  */
-final class ProTechAI {
+final class ProTechAi {
 
   static void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {
     if (!Properties.getWW2V3TechModel(data)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -10,7 +10,7 @@ import java.util.prefs.Preferences;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.io.IoUtils;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 
 /**
  * Class to manage log settings.
@@ -28,7 +28,7 @@ public class ProLogSettings implements Serializable {
     if (lastSettings == null) {
       ProLogSettings result = new ProLogSettings();
       try {
-        final byte[] pool = Preferences.userNodeForPackage(ProAI.class).getByteArray(PROGRAM_SETTINGS, null);
+        final byte[] pool = Preferences.userNodeForPackage(ProAi.class).getByteArray(PROGRAM_SETTINGS, null);
         if (pool != null) {
           result = IoUtils.readFromMemory(pool, is -> {
             try (ObjectInputStream ois = new ObjectInputStream(is)) {
@@ -59,7 +59,7 @@ public class ProLogSettings implements Serializable {
           outputStream.writeObject(settings);
         }
       });
-      final Preferences prefs = Preferences.userNodeForPackage(ProAI.class);
+      final Preferences prefs = Preferences.userNodeForPackage(ProAi.class);
       prefs.putByteArray(PROGRAM_SETTINGS, bytes);
       try {
         prefs.flush();

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUi.java
@@ -9,7 +9,7 @@ import games.strategy.triplea.ui.TripleAFrame;
 /**
  * Class to manage log window display.
  */
-public class ProLogUI {
+public class ProLogUi {
   private static ProLogWindow settingsWindow = null;
   private static String currentName = "";
   private static int currentRound = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogger.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogger.java
@@ -58,7 +58,7 @@ public class ProLogger {
     if (logDepth.equals(Level.FINER) && level.equals(Level.FINEST)) {
       return;
     }
-    ProLogUI.notifyAiLogMessage(level, addIndentationCompensation(message, level));
+    ProLogUi.notifyAiLogMessage(level, addIndentationCompensation(message, level));
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
@@ -15,7 +15,7 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.sound.HeadlessSoundChannel;
 import games.strategy.sound.ISound;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.delegate.MustFightBattle;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
@@ -25,13 +25,13 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   private final ITripleADisplay display = new HeadlessDisplay();
   private final ISound soundChannel = new HeadlessSoundChannel();
   private final PlayerID player;
-  private final ProAI proAi;
+  private final ProAi proAi;
   private final DelegateHistoryWriter writer = new DelegateHistoryWriter(new ProDummyGameModifiedChannel());
   private final GameData gameData;
   private final CompositeChange allChanges = new CompositeChange();
   private MustFightBattle battle = null;
 
-  public ProDummyDelegateBridge(final ProAI proAi, final PlayerID player, final GameData data) {
+  public ProDummyDelegateBridge(final ProAi proAi, final PlayerID player, final GameData data) {
     this.proAi = proAi;
     gameData = data;
     this.player = player;

--- a/src/main/java/games/strategy/triplea/ai/weakAI/DoesNothingAi.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/DoesNothingAi.java
@@ -6,15 +6,15 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.ai.AbstractAI;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 
-public class DoesNothingAI extends AbstractAI {
-  public DoesNothingAI(final String name, final String type) {
+public class DoesNothingAi extends AbstractAi {
+  public DoesNothingAi(final String name, final String type) {
     super(name, type);
   }
 
@@ -23,7 +23,7 @@ public class DoesNothingAI extends AbstractAI {
       final GameData data, final PlayerID player) {
     // spend whatever we have
     if (!player.getResources().isEmpty()) {
-      (new WeakAI(this.getName(), this.getType())).purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
+      (new WeakAi(this.getName(), this.getType())).purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
     }
     pause();
   }
@@ -44,7 +44,7 @@ public class DoesNothingAI extends AbstractAI {
       final PlayerID player) {
     // place whatever we have
     if (!player.getUnits().isEmpty()) {
-      (new WeakAI(this.getName(), this.getType())).place(placeForBid, placeDelegate, data, player);
+      (new WeakAi(this.getName(), this.getType())).place(placeForBid, placeDelegate, data, player);
     }
     pause();
   }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
@@ -26,7 +26,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
-import games.strategy.triplea.ai.AbstractAI;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.AiUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -46,9 +46,9 @@ import games.strategy.util.Util;
 /**
  * A very weak ai, based on some simple rules.
  */
-public class WeakAI extends AbstractAI {
+public class WeakAi extends AbstractAi {
 
-  public WeakAI(final String name, final String type) {
+  public WeakAi(final String name, final String type) {
     super(name, type);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -18,7 +18,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.net.GUID;
 import games.strategy.triplea.TripleA;
-import games.strategy.triplea.ai.weakAI.WeakAI;
+import games.strategy.triplea.ai.weakAI.WeakAi;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.BattleRecord.BattleResultDescription;
 import games.strategy.triplea.player.ITripleAPlayer;
@@ -324,7 +324,7 @@ abstract class AbstractBattle implements IBattle {
   protected static ITripleAPlayer getRemote(final PlayerID player, final IDelegateBridge bridge) {
     // if its the null player, return a do nothing proxy
     if (player.isNull()) {
-      return new WeakAI(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+      return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
     }
     return (ITripleAPlayer) bridge.getRemotePlayer(player);
   }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -122,7 +122,7 @@ public abstract class AbstractDelegate implements IDelegate {
    * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote:
    * <p>
    * if (player.isNull()) {
-   * return new WeakAI(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+   * return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
    * }
    * return bridge.getRemotePlayer(player);
    * </p>

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -9,7 +9,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleA;
-import games.strategy.triplea.ai.weakAI.WeakAI;
+import games.strategy.triplea.ai.weakAI.WeakAi;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.display.ITripleADisplay;
@@ -119,7 +119,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   protected static ITripleAPlayer getRemotePlayer(final PlayerID player, final IDelegateBridge bridge) {
     // if its the null player, return a do nothing proxy
     if (player.isNull()) {
-      return new WeakAI(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+      return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
     }
     return (ITripleAPlayer) bridge.getRemotePlayer(player);
   }

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -24,7 +24,7 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleA;
-import games.strategy.triplea.ai.weakAI.WeakAI;
+import games.strategy.triplea.ai.weakAI.WeakAi;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
@@ -467,7 +467,7 @@ public class BattleCalculator {
     final GameData data = bridge.getData();
     final boolean isEditMode = BaseEditDelegate.getEditMode(data);
     final ITripleAPlayer tripleaPlayer = player.isNull()
-        ? new WeakAI(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE)
+        ? new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE)
         : (ITripleAPlayer) bridge.getRemotePlayer(player);
     final Map<Unit, Collection<Unit>> dependents = headLess ? Collections.emptyMap() : getDependents(targetsToPickFrom);
     if (isEditMode && !headLess) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -34,7 +34,7 @@ import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.net.GUID;
 import games.strategy.sound.HeadlessSoundChannel;
 import games.strategy.sound.ISound;
-import games.strategy.triplea.ai.AbstractAI;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.AiUtils;
 import games.strategy.triplea.delegate.BattleTracker;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -503,7 +503,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
         final String displayName, final boolean loadedFromSavedGame) {}
   }
 
-  private static class DummyPlayer extends AbstractAI {
+  private static class DummyPlayer extends AbstractAi {
     private final boolean keepAtLeastOneLand;
     // negative = do not retreat
     private final int retreatAfterRound;

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -59,7 +59,7 @@ import games.strategy.sound.HeadlessSoundChannel;
 import games.strategy.sound.ISound;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ResourceLoader;
-import games.strategy.triplea.ai.AbstractAI;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.ICondition;
@@ -721,7 +721,7 @@ public class ObjectivePanel extends AbstractStatPanel {
         final String displayName, final boolean loadedFromSavedGame) {}
   }
 
-  static class ObjectivePanelDummyPlayer extends AbstractAI {
+  static class ObjectivePanelDummyPlayer extends AbstractAi {
     public ObjectivePanelDummyPlayer(final String name, final String type) {
       super(name, type);
     }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -116,7 +116,7 @@ import games.strategy.thread.ThreadPool;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.TripleAUnit;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
@@ -550,7 +550,7 @@ public class TripleAFrame extends MainGameFrame {
       historySyncher.deactivate();
       historySyncher = null;
     }
-    ProAI.gameOverClearCache();
+    ProAi.gameOverClearCache();
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -10,7 +10,7 @@ import games.strategy.debug.DebugUtils;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.performance.EnablePerformanceLoggingCheckBox;
-import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
@@ -22,10 +22,10 @@ class DebugMenu {
     menuBar.add(debugMenu);
 
     final Set<IGamePlayer> players = frame.getLocalPlayers().getLocalPlayers();
-    final boolean areThereProAIs = players.stream().anyMatch(ProAI.class::isInstance);
+    final boolean areThereProAIs = players.stream().anyMatch(ProAi.class::isInstance);
     if (areThereProAIs) {
-      ProAI.initialize(frame);
-      debugMenu.add(SwingAction.of("Show Hard AI Logs", e -> ProAI.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
+      ProAi.initialize(frame);
+      debugMenu.add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
     }
 
     debugMenu.add(new EnablePerformanceLoggingCheckBox());


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in non-serialized classes within the various AI packages.

@ron-murhammer Requesting a review from you simply to confirm I didn't miss any reflective use of `AbstractAI` and its subclasses that would be broken by this change.