### PR TITLE
Remove unnecessary calls to log exceptions

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -203,8 +203,7 @@ public class ClientGame extends AbstractGame {
     try (FileOutputStream fout = new FileOutputStream(f)) {
       fout.write(bytes);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -16,7 +16,6 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.swing.JOptionPane;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.engine.data.GameData;
@@ -127,8 +126,7 @@ public final class GameDataManager {
         instance.initialize(name, displayName);
         data.getDelegateList().addDelegate(instance);
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
-        throw new IOException(e.getMessage());
+        throw new IOException(e);
       }
       final String next = (String) input.readObject();
       if (next.equals(DELEGATE_DATA_NEXT)) {

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -151,7 +151,6 @@ public class ServerGame extends AbstractGame {
       try {
         return IoUtils.writeToMemory(this::saveGame);
       } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
         throw new IllegalStateException(e);
       }
     };

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -361,7 +361,6 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       try {
         return IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
       } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
         throw new IllegalStateException(e);
       }
     }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -150,8 +150,7 @@ class EndPoint {
       method = implementor.getClass().getMethod(call.getMethodName(), call.getArgTypes());
       method.setAccessible(true);
     } catch (final NoSuchMethodException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
     MessageContext.setSenderNodeForThread(messageOriginator);
     try {

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -15,7 +15,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESKeySpec;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.RemoteName;
@@ -69,8 +68,7 @@ public class Vault {
       secretKeyFactory = SecretKeyFactory.getInstance(ALGORITHM);
       keyGen = KeyGenerator.getInstance(ALGORITHM);
     } catch (final NoSuchAlgorithmException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException("Nothing known about algorithm:" + ALGORITHM);
+      throw new IllegalStateException("Nothing known about algorithm:" + ALGORITHM, e);
     }
   }
 
@@ -130,8 +128,7 @@ public class Vault {
       cipher = Cipher.getInstance(ALGORITHM);
       cipher.init(Cipher.ENCRYPT_MODE, key);
     } catch (final NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
     // join the data and known value into one array
     final byte[] dataAndCheck = joinDataAndKnown(data);
@@ -139,8 +136,7 @@ public class Vault {
     try {
       encrypted = cipher.doFinal(dataAndCheck);
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
     // tell the world
     getRemoteBroadcaster().addLockedValue(id, encrypted);
@@ -257,8 +253,7 @@ public class Vault {
         cipher = Cipher.getInstance(ALGORITHM);
         cipher.init(Cipher.DECRYPT_MODE, key);
       } catch (final NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException e) {
-        ClientLogger.logQuietly(e);
-        throw new IllegalStateException(e.getMessage());
+        throw new IllegalStateException(e);
       }
       final byte[] encrypted = unverifiedValues.remove(id);
       final byte[] decrypted;

--- a/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -7,8 +7,6 @@ import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Set;
 
-import games.strategy.debug.ClientLogger;
-
 public class HeadlessServerMessenger implements IServerMessenger {
 
   private final INode node;
@@ -17,8 +15,7 @@ public class HeadlessServerMessenger implements IServerMessenger {
     try {
       node = new Node("dummy", InetAddress.getLocalHost(), 0);
     } catch (final UnknownHostException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -149,8 +149,7 @@ public class ResourceLoader implements Closeable {
         }
       }
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
     return paths;
   }
@@ -169,8 +168,7 @@ public class ResourceLoader implements Closeable {
       try {
         urls[i] = f.toURI().toURL();
       } catch (final MalformedURLException e) {
-        ClientLogger.logQuietly(e);
-        throw new IllegalStateException(e.getMessage());
+        throw new IllegalStateException(e);
       }
     }
     resourceLocationTracker = new ResourceLocationTracker(mapName, urls);

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.PlayerID;
@@ -170,8 +169,7 @@ public abstract class TechAdvance extends NamedAttachable {
       constructor = clazz.getConstructor(preDefinedTechConstructorParameter);
       ta = constructor.newInstance(data);
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(s + " is not a valid technology or could not be instantiated");
+      throw new IllegalStateException(s + " is not a valid technology or could not be instantiated", e);
     }
     if (ta == null) {
       throw new IllegalStateException(s + " is not a valid technology or could not be instantiated");

--- a/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import javax.imageio.ImageIO;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ResourceLoader;
 
 public class ImageFactory {
@@ -41,8 +40,7 @@ public class ImageFactory {
       try {
         image = ImageIO.read(url);
       } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
-        throw new IllegalStateException(e.getMessage());
+        throw new IllegalStateException(e);
       }
       images.put(key, image);
     }

--- a/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -11,7 +11,6 @@ import java.util.prefs.Preferences;
 
 import javax.imageio.ImageIO;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.ui.Util;
@@ -29,8 +28,7 @@ public class MapImage {
     try {
       return ImageIO.read(mapFileUrl);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -726,8 +726,7 @@ public class MapData implements Closeable {
     try {
       return Optional.of(ImageIO.read(url));
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
-      throw new IllegalStateException(e.getMessage());
+      throw new IllegalStateException(e);
     }
   }
 


### PR DESCRIPTION
Part of an effort to remove calls to the deprecated `ClientLogger#logQuietly(Throwable)` method.

Code that catches an exception, logs it, and throws a new exception with the original exception message, such as:

```java
  } catch (final Exception e) {
    ClientLogger.logQuietly(e);
    throw new IllegalStateException(e.getMessage());
  }
```

should simply include the original exception as the cause of the new exception:

```java
  } catch (final Exception e) {
    throw new IllegalStateException(e);
  }
```

The exception handler that actually processes the exception should make the decision as to whether it should be logged or not.