### PR TITLE
Include message when logging an exception quietly

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -42,21 +42,6 @@ public final class ClientLogger {
     enableErrorPopup = true;
   }
 
-  /**
-   * Logs a Throwable to the error console. This method is deprecated, use API version that accepts
-   * an error message.
-   *
-   * @deprecated Use logQuietly(String, Throwable) instead.
-   *             We should always provide more context then just an exception, so this method is deprecated.
-   *             Notably we should always give some details about what happened, what the exception means,
-   *             and also log any parameter values, or any other surrounding context values so
-   *             we can debug more easily.
-   */
-  @Deprecated
-  public static void logQuietly(final Throwable e) {
-    log(developerOutputStream, e);
-  }
-
   public static void logQuietly(final @Nullable String msg) {
     developerOutputStream.println(msg);
   }

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -181,7 +181,7 @@ public class ClientGame extends AbstractGame {
         remoteMessenger.unregisterRemote(ServerGame.getRemoteRandomName(player));
       }
     } catch (final RuntimeException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to shut down client game", e);
     }
     gameData.getGameLoader().shutDown();
   }

--- a/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -28,7 +28,7 @@ public final class GameDataUtils {
       final byte[] bytes = IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data, copyDelegates));
       return IoUtils.readFromMemory(bytes, GameDataManager::loadGame);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to clone game data", e);
       return null;
     }
   }

--- a/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -82,7 +82,7 @@ public class ProcessRunnerUtil {
       t.setDaemon(true);
       t.start();
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to start new process", e);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -179,7 +179,7 @@ public class ServerGame extends AbstractGame {
         } catch (final ConnectionLostException cle) {
           System.out.println("Connection lost to observer while joining: " + newNode.getName());
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to join game", e);
         }
       }, "Waiting on observer to finish joining: " + newNode.getName()).start();
       try {
@@ -191,7 +191,7 @@ public class ServerGame extends AbstractGame {
         nonBlockingObserver.cannotJoinGame(e.getMessage());
       }
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to join game", e);
       nonBlockingObserver.cannotJoinGame(e.getMessage());
     } finally {
       delegateExecutionManager.resumeDelegateExecution();
@@ -268,7 +268,7 @@ public class ServerGame extends AbstractGame {
       }
     } catch (final GameOverException e) {
       if (!isGameOver) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("GameOverException raised, but game is not over", e);
       }
     }
   }
@@ -327,7 +327,7 @@ public class ServerGame extends AbstractGame {
         remoteMessenger.unregisterRemote(getRemoteName(delegate));
       }
     } catch (final RuntimeException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to shut down server game", e);
     } finally {
       delegateExecutionManager.resumeDelegateExecution();
     }
@@ -360,7 +360,7 @@ public class ServerGame extends AbstractGame {
     try (FileOutputStream fout = new FileOutputStream(f)) {
       saveGame(fout);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save game to file: " + f.getAbsolutePath(), e);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -80,7 +80,7 @@ public class LookAndFeel {
           try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
           } catch (final Exception e) {
-            ClientLogger.logQuietly(e);
+            ClientLogger.logQuietly("Failed to set system look and feel", e);
           }
         }
       }

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -48,7 +48,7 @@ class FileSystemAccessStrategy {
         try {
           Files.delete(map.getInstallLocation().toPath());
         } catch (final IOException e) {
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to delete map: " + map.getInstallLocation().getAbsolutePath(), e);
         }
         map.getInstallLocation().delete();
       }

--- a/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
@@ -55,11 +55,11 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
         try {
           serverRemote.changeToGameOptions(GameProperties.writeEditableProperties(properties));
         } catch (final IOException ex) {
-          ClientLogger.logQuietly(ex);
+          ClientLogger.logQuietly("Failed to write game properties", ex);
         }
       }
     } catch (final IOException | ClassCastException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to read game properties", ex);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -48,7 +48,7 @@ public class LocalLauncher extends AbstractLauncher {
     } catch (final MapNotFoundException e) {
       exceptionLoadingGame = e;
     } catch (final Exception ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to start game", ex);
       exceptionLoadingGame = ex;
     } finally {
       gameLoadingWindow.doneWait();

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -239,7 +239,7 @@ public class ServerLauncher extends AbstractLauncher {
               gameSelectorModel.resetGameDataToNull();
             }
           } catch (final Exception e1) {
-            ClientLogger.logQuietly(e1);
+            ClientLogger.logQuietly("Failed to load game", e1);
             gameSelectorModel.resetGameDataToNull();
           }
         } else {
@@ -342,7 +342,7 @@ public class ServerLauncher extends AbstractLauncher {
     try {
       serverGame.saveGame(f);
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save game: " + f.getAbsolutePath(), e);
       if (headless && HeadlessGameServer.getInstance() != null) {
         HeadlessGameServer.getInstance().printThreadDumpsAndStatus();
         // TODO: We seem to be getting this bug once a week (1.8.0.1 and previous versions). Trying a fix for 1.8.0.3,

--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -145,7 +145,7 @@ public final class ClientLoginValidator implements ILoginValidator {
 
       return ErrorMessages.NO_ERROR;
     } catch (final AuthenticationException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Authentication failed", e);
       return ErrorMessages.INVALID_PASSWORD;
     }
   }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -315,7 +315,7 @@ public class ClientModel implements IMessengerErrorListener {
       // up to 60 seconds for a freaking huge game
       data = IoUtils.readFromMemory(gameData, GameDataManager::loadGame);
     } catch (final IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load game", ex);
       return;
     }
     objectStreamFactory.setData(data);

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -102,7 +102,7 @@ public class GameSelectorModel extends Observable {
         message = e.getClass().getName() + "  at  " + e.getStackTrace()[0].toString();
       }
       message = "Exception while parsing: " + file.getName() + " : " + message;
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(message, e);
       if (ui != null) {
         error(message + "\r\nPlease see console for full error log!", ui);
       }
@@ -116,7 +116,7 @@ public class GameSelectorModel extends Observable {
         return newData;
       }
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to load game", e);
     }
     return null;
   }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -376,7 +376,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       try {
         return GameProperties.writeEditableProperties(currentEditableProperties);
       } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to write game properties", e);
       }
       return null;
     }
@@ -427,7 +427,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           }
         });
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to load save game: " + fileName, e);
       }
     }
 
@@ -443,7 +443,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       try {
         headless.loadGameOptions(bytes);
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to load game options", e);
       }
     }
   };

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -53,7 +53,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
         out.writeObject(serializableMap);
       }
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to write game properties to cache: " + cache.getAbsolutePath(), e);
     }
   }
 
@@ -76,7 +76,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
         }
       }
     } catch (final IOException | ClassNotFoundException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to load game properties from cache: " + cache.getAbsolutePath(), e);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -120,7 +120,7 @@ public class InGameLobbyWatcher {
       rm.registerRemote(rhu, RemoteHostUtils.getRemoteHostUtilsName(um.getLocalNode()));
       return new InGameLobbyWatcher(messenger, rm, gameMessenger, parent, oldWatcher);
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to create in-game lobby watcher", e);
       return null;
     }
   }

--- a/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -71,7 +71,7 @@ public class HttpProxy {
         }
       }
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to get system HTTP proxy", e);
     } finally {
       SystemProperties.setJavaNetUseSystemProxies("false");
     }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -63,7 +63,7 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
       gameData = GameParser.parse(url.toString(), input);
       gameDataFullyLoaded = true;
     } catch (final EngineVersionException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Game engine not compatible with: " + url, e);
       throw new GameParseException(e);
     } catch (final GameParseException e) {
       ClientLogger.logError("Could not parse:" + url, e);

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -187,7 +187,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       System.out.println(e.getMessage());
     } catch (final Exception e) {
       System.err.println("Could not parse:" + uri);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Could not parse: " + uri, e);
     }
   }
 

--- a/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -80,13 +80,13 @@ public class DefaultPlayerBridge implements IPlayerBridge {
         try {
           remoteName = ServerGame.getRemoteName(delegate);
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
           final String errorMessage =
               "IDelegate IRemote interface class returned null or was not correct interface. CurrentStep: "
                   + currentStep + ", and CurrentDelegate: " + currentDelegate;
           // for some reason, client isn't getting or seeing the errors, so make sure we print it to err
           // too
           System.err.println(errorMessage);
+          ClientLogger.logQuietly(errorMessage, e);
           throw new IllegalStateException(errorMessage, e);
         }
         return getRemoteThatChecksForGameOver(game.getRemoteMessenger().getRemote(remoteName));

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -113,7 +113,7 @@ public class PBEMMessagePoster implements Serializable {
           historyWriter.startEvent("Turn Summary: " + m_turnSummaryRef);
         }
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to post game to forum", e);
       }
     }
     boolean emailSuccess = true;
@@ -127,7 +127,7 @@ public class PBEMMessagePoster implements Serializable {
       } catch (final IOException e) {
         emailSuccess = false;
         m_emailSendStatus = "Failed! Error " + e.getMessage();
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to send game via email", e);
       }
     }
     if (historyWriter != null) {
@@ -228,7 +228,7 @@ public class PBEMMessagePoster implements Serializable {
           }
         } catch (final Exception e) {
           postOk = false;
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to create save game", e);
         }
         posterPbem.setTurnSummary(historyLog.toString());
         try {
@@ -244,7 +244,7 @@ public class PBEMMessagePoster implements Serializable {
           }
         } catch (final Exception e) {
           postOk = false;
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to post save game to forum", e);
         }
         if (postingDelegate != null) {
           postingDelegate.setHasPostedTurnSummary(postOk);

--- a/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -47,7 +47,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
         deleteToken(client, userId, token);
       }
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to post game to forum", e);
       m_turnSummaryRef = e.getMessage();
     }
     return false;

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -71,8 +71,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
             propFiles.add(props);
           }
         } catch (final IOException e) {
-          System.out.println("error reading file:" + file);
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to read dice server properties: " + file.getAbsolutePath(), e);
         }
       }
     }

--- a/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -174,7 +174,7 @@ public class ClipPlayer {
       try {
         setPref = !Arrays.asList(prefs.keys()).contains(SOUND_PREFERENCE_GLOBAL_SWITCH);
       } catch (final BackingStoreException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to get keys for preferences: " + prefs.absolutePath(), e);
       }
     }
     if (setPref) {
@@ -182,7 +182,7 @@ public class ClipPlayer {
       try {
         prefs.flush();
       } catch (final BackingStoreException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
       }
     }
   }
@@ -240,7 +240,7 @@ public class ClipPlayer {
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
   }
 
@@ -425,7 +425,7 @@ public class ClipPlayer {
                       }
                       availableSounds.add(zipSoundUrl);
                     } catch (final Exception e) {
-                      ClientLogger.logQuietly(e);
+                      ClientLogger.logQuietly("Failed to load sound resource: " + zipElement.getName(), e);
                     }
                   }
                 }
@@ -433,7 +433,7 @@ public class ClipPlayer {
               }
             }
           } catch (final Exception e) {
-            ClientLogger.logQuietly(e);
+            ClientLogger.logQuietly("Failed to read sound file: " + decoded, e);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -183,7 +183,7 @@ public class ResourceLoader implements Closeable {
     try {
       loader.close();
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to close resource loader", e);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -157,7 +157,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     try {
       ui.setEditDelegate((IEditDelegate) getPlayerBridge().getRemotePersistentDelegate("edit"));
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to set edit delegate", e);
     }
     SwingUtilities.invokeLater(() -> {
       ui.getEditModeButtonModel().addActionListener(editModeAction);
@@ -222,7 +222,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
     final UserActionAttachment actionChoice = ui.getUserActionChoice(getPlayerId(), firstRun, userActionDelegate);
@@ -255,7 +255,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
 
@@ -290,7 +290,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
 
@@ -343,7 +343,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
     return airCantLand.isEmpty() || ui.getOkToLetAirDie(getPlayerId(), airCantLand, movePhase);
@@ -395,7 +395,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
                   + ", Remote class name: " + getPlayerBridge().getRemoteDelegate().getClass();
               // for some reason the client is not seeing or getting these errors, so print to err too
               System.err.println(errorContext);
-              ClientLogger.logQuietly(e);
+              ClientLogger.logQuietly(errorContext, e);
               throw new IllegalStateException(errorContext, e);
             }
             final String error = purchaseDel.purchaseRepair(repair);
@@ -420,7 +420,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
     final String purchaseError = purchaseDel.purchase(prod);
@@ -492,7 +492,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
     while (true) {
@@ -531,7 +531,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           + getPlayerBridge().getRemoteDelegate().getClass();
       // for some reason the client is not seeing or getting these errors, so print to err too
       System.err.println(errorContext);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly(errorContext, e);
       throw new IllegalStateException(errorContext, e);
     }
     if (!soundPlayedAlreadyEndTurn && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(getPlayerId(), data)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -39,7 +39,7 @@ public class ProLogSettings implements Serializable {
           });
         }
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to load pro AI log settings", ex);
       }
       if (result == null) {
         result = new ProLogSettings();
@@ -64,10 +64,10 @@ public class ProLogSettings implements Serializable {
       try {
         prefs.flush();
       } catch (final BackingStoreException ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), ex);
       }
     } catch (final Exception ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to save pro AI log settings", ex);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2522,7 +2522,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           final IDelegate delegateEndRound = data.getDelegateList().getDelegate("endRound");
           ((EndRoundDelegate) delegateEndRound).signalGameOver(victoryMessage.trim(), t.getPlayers(), bridge);
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to signal game over", e);
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -726,7 +726,7 @@ public class AirBattle extends AbstractBattle {
       try {
         getRemote(firingPlayer, bridge).confirmEnemyCasualties(battleId, "Press space to continue", hitPlayer);
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Error during casualty notification", e);
       }
     }, "Click to continue waiter");
     t.start();

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -247,7 +247,7 @@ public final class TileImageFactory {
       }
       loadingImages.done();
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to load one or more images: " + urlrelief + ", " + urlBase, e);
     }
 
     // This does the blend
@@ -256,7 +256,7 @@ public final class TileImageFactory {
       try {
         reliefFile = loadCompatibleImage(urlBlankRelief);
       } catch (final IOException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to load image: " + urlBlankRelief, e);
       }
     }
     // This fixes the blank land territories

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -193,7 +193,7 @@ class OddsCalculatorPanel extends JPanel {
       // must be shutdown, as it has a thread pool per each instance.
       calculator.shutdown();
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to shut down odds calculator", e);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
@@ -40,7 +40,7 @@ public class InitialSetup {
       new PlayerOrder().saveToFile(printData);
       new PuChart(printData).saveToFile();
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save print generation data", e);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
@@ -57,7 +57,7 @@ class PuInfo {
         resourceWriter.write("\r\n");
       }
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save print generation data general information", e);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -61,7 +61,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
   }
 
@@ -115,7 +115,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
   }
 
@@ -269,7 +269,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       actor.deactivate();
     } catch (final RuntimeException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to deactivate actor", e);
     }
   }
 
@@ -303,7 +303,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), ex);
     }
   }
 
@@ -337,7 +337,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), ex);
     }
   }
 
@@ -354,7 +354,7 @@ public abstract class AbstractUiContext implements UiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), ex);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -26,7 +26,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -219,12 +218,8 @@ public class BattlePanel extends ActionPanel {
 
   public void listBattle(final GUID battleId, final List<String> steps) {
     if (!SwingUtilities.isEventDispatchThread()) {
-      try {
-        // recursive call
-        SwingUtilities.invokeLater(() -> listBattle(battleId, steps));
-      } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
-      }
+      // recursive call
+      SwingUtilities.invokeLater(() -> listBattle(battleId, steps));
       return;
     }
     removeAll();

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -143,7 +143,7 @@ public class CommentPanel extends JPanel {
             doc.insertString(doc.getLength(), prefix, bold);
             doc.insertString(doc.getLength(), m.group(1) + "\n", normal);
           } catch (final BadLocationException e1) {
-            ClientLogger.logQuietly(e1);
+            ClientLogger.logQuietly("Failed to add history node", e1);
           }
         }
       } finally {
@@ -193,7 +193,7 @@ public class CommentPanel extends JPanel {
             doc.insertString(doc.getLength(), prefix, bold);
             doc.insertString(doc.getLength(), m.group(1) + "\n", normal);
           } catch (final BadLocationException e) {
-            ClientLogger.logQuietly(e);
+            ClientLogger.logQuietly("Failed to add history", e);
           }
         }
       }
@@ -217,7 +217,7 @@ public class CommentPanel extends JPanel {
           doc.insertString(doc.getLength(), error + "\n", italic);
         }
       } catch (final BadLocationException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to add comment", e);
       }
       final BoundedRangeModel scrollModel = scrollPane.getVerticalScrollBar().getModel();
       scrollModel.setValue(scrollModel.getMaximum());
@@ -250,7 +250,7 @@ public class CommentPanel extends JPanel {
         }
       }
     } catch (final BadLocationException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to trim lines", e);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -273,12 +273,14 @@ class EditPanel extends ActionPanel {
           return;
         }
         final Set<TechAdvance> advance = new HashSet<>();
+        // FIXME: This try-catch block appears to be guarding against a ClassCastException.
+        // It should be removed and the underlying problem fixed.
         try {
           for (final Object selection : techList.getSelectedValuesList()) {
             advance.add((TechAdvance) selection);
           }
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to copy all selected tech advances", e);
         }
         final String result = EditPanel.this.frame.getEditDelegate().addTechAdvance(player, advance);
         if (result != null) {
@@ -336,12 +338,14 @@ class EditPanel extends ActionPanel {
           return;
         }
         final Set<TechAdvance> advance = new HashSet<>();
+        // FIXME: This try-catch block appears to be guarding against a ClassCastException.
+        // It should be removed and the underlying problem fixed.
         try {
           for (final Object selection : techList.getSelectedValuesList()) {
             advance.add((TechAdvance) selection);
           }
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
+          ClientLogger.logQuietly("Failed to copy all selected tech advances", e);
         }
         final String result = EditPanel.this.frame.getEditDelegate().removeTechAdvance(player, advance);
         if (result != null) {

--- a/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -110,7 +110,7 @@ public class HeadedUiContext extends AbstractUiContext {
           cursor = toolkit.createCustomCursor(image, hotSpot, data.getGameName() + " Cursor");
         }
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to create cursor from: " + cursorUrl, e);
       }
     }
     stopWatch.done();
@@ -228,7 +228,7 @@ public class HeadedUiContext extends AbstractUiContext {
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1501,7 +1501,7 @@ public class TripleAFrame extends MainGameFrame {
           }
         });
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to process game data change", e);
       }
     }
   };
@@ -1758,7 +1758,7 @@ public class TripleAFrame extends MainGameFrame {
               JOptionPane.showMessageDialog(TripleAFrame.this, "Game Saved", "Game Saved",
                   JOptionPane.INFORMATION_MESSAGE);
             } catch (final IOException e) {
-              ClientLogger.logQuietly(e);
+              ClientLogger.logQuietly("Failed to save game: " + f.getAbsolutePath(), e);
             }
           }
         } finally {

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -171,7 +171,7 @@ public class MapData implements Closeable {
       }
       initializeContains();
     } catch (final IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load map properties", ex);
     }
   }
 
@@ -244,7 +244,7 @@ public class MapData implements Closeable {
     try {
       return Double.parseDouble(mapProperties.getProperty(PROPERTY_UNITS_SCALE));
     } catch (final NumberFormatException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to parse map property: " + PROPERTY_UNITS_SCALE, e);
       return 1.0;
     }
   }
@@ -259,7 +259,7 @@ public class MapData implements Closeable {
     try {
       return Integer.parseInt(mapProperties.getProperty(PROPERTY_UNITS_WIDTH));
     } catch (final NumberFormatException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to parse map property: " + PROPERTY_UNITS_WIDTH, e);
       return UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
     }
   }
@@ -274,7 +274,7 @@ public class MapData implements Closeable {
     try {
       return Integer.parseInt(mapProperties.getProperty(PROPERTY_UNITS_HEIGHT));
     } catch (final NumberFormatException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to parse map property: " + PROPERTY_UNITS_HEIGHT, e);
       return UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
     }
   }
@@ -290,7 +290,7 @@ public class MapData implements Closeable {
     try {
       return Integer.parseInt(mapProperties.getProperty(PROPERTY_UNITS_COUNTER_OFFSET_WIDTH));
     } catch (final NumberFormatException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to parse map property: " + PROPERTY_UNITS_COUNTER_OFFSET_WIDTH, e);
       return getDefaultUnitWidth() / 4;
     }
   }
@@ -306,7 +306,7 @@ public class MapData implements Closeable {
     try {
       return Integer.parseInt(mapProperties.getProperty(PROPERTY_UNITS_COUNTER_OFFSET_HEIGHT));
     } catch (final NumberFormatException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to parse map property: " + PROPERTY_UNITS_COUNTER_OFFSET_HEIGHT, e);
       return getDefaultUnitHeight();
     }
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -104,12 +104,10 @@ class ExportMenu {
     } finally {
       gameData.releaseReadLock();
     }
-    try {
-      try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
-        writer.write(xmlFile);
-      }
+    try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
+      writer.write(xmlFile);
     } catch (final IOException e1) {
-      ClientLogger.logQuietly(e1);
+      ClientLogger.logQuietly("Failed to write XML: " + chooser.getSelectedFile().getAbsolutePath(), e1);
     }
   }
 
@@ -373,7 +371,7 @@ class ExportMenu {
     try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
       writer.write(text.toString());
     } catch (final IOException e1) {
-      ClientLogger.logQuietly(e1);
+      ClientLogger.logQuietly("Failed to write stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
     }
   }
 
@@ -394,7 +392,7 @@ class ExportMenu {
             HelpMenu.getUnitStatsTable(gameData, uiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
       } catch (final IOException e1) {
-        ClientLogger.logQuietly(e1);
+        ClientLogger.logQuietly("Failed to write unit stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
       }
 
     }));

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -21,7 +21,6 @@ import javax.swing.SwingUtilities;
 
 import com.google.common.base.Strings;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.lobby.client.login.CreateUpdateAccountPanel;
 import games.strategy.engine.lobby.client.login.LobbyLoginPreferences;
@@ -159,15 +158,19 @@ public class LobbyMenu extends JMenuBar {
           "Please consult other admins before banning longer than 1 day.", date -> {
             final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
                 .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
-            try {
-              controller.banUsername(new Node(name, InetAddress.getByName("0.0.0.0"), 0), date);
-            } catch (final UnknownHostException ex) {
-              ClientLogger.logQuietly(ex);
-            }
+            controller.banUsername(newDummyNode(name), date);
           });
     });
     item.setEnabled(true);
     parentMenu.add(item);
+  }
+
+  private static INode newDummyNode(final String name) {
+    try {
+      return new Node(name, InetAddress.getByAddress(new byte[] {0, 0, 0, 0}), 0);
+    } catch (final UnknownHostException e) {
+      throw new AssertionError("should never happen");
+    }
   }
 
   private void addBanMacAddressMenu(final JMenu parentMenu) {
@@ -198,12 +201,7 @@ public class LobbyMenu extends JMenuBar {
           "Please consult other admins before banning longer than 1 day.", date -> {
             final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
                 .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
-            try {
-              controller.banMac(
-                  new Node("None (Admin menu originated ban)", InetAddress.getByName("0.0.0.0"), 0), mac, date);
-            } catch (final UnknownHostException ex) {
-              ClientLogger.logQuietly(ex);
-            }
+            controller.banMac(newDummyNode("None (Admin menu originated ban)"), mac, date);
           });
     });
     item.setEnabled(true);
@@ -225,11 +223,7 @@ public class LobbyMenu extends JMenuBar {
       }
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
-      try {
-        controller.banUsername(new Node(name, InetAddress.getByName("0.0.0.0"), 0), Date.from(Instant.EPOCH));
-      } catch (final UnknownHostException ex) {
-        ClientLogger.logQuietly(ex);
-      }
+      controller.banUsername(newDummyNode(name), Date.from(Instant.EPOCH));
     });
     item.setEnabled(true);
     parentMenu.add(item);
@@ -261,12 +255,7 @@ public class LobbyMenu extends JMenuBar {
       }
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
-      try {
-        controller.banMac(new Node("None (Admin menu originated unban)", InetAddress.getByName("0.0.0.0"), 0), mac,
-            Date.from(Instant.EPOCH));
-      } catch (final UnknownHostException ex) {
-        ClientLogger.logQuietly(ex);
-      }
+      controller.banMac(newDummyNode("None (Admin menu originated unban)"), mac, Date.from(Instant.EPOCH));
     });
     item.setEnabled(true);
     parentMenu.add(item);

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -200,7 +200,8 @@ public class PointFileReaderWriter {
         current = reader.readLine();
       }
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to read polygons", e);
+      // FIXME: o_O Should not exit process from "library" code
       System.exit(0);
     } finally {
       try {

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -144,7 +144,7 @@ public class AutoPlacementFinder {
           }
         }
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to initialize from map properties: " + file.getAbsolutePath(), ex);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -179,7 +179,7 @@ public class AutoPlacementFinder {
         }
         placeDimensionsSet = true;
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to initialize from user input", ex);
       }
     }
     try {

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -242,7 +242,7 @@ public class CenterPicker extends JFrame {
       }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to save centers", ex);
     }
   }
 
@@ -261,7 +261,7 @@ public class CenterPicker extends JFrame {
       centers = PointFileReaderWriter.readOneToOne(in);
       repaint();
     } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load centers", ex);
     }
   }
 

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -468,7 +468,7 @@ public class DecorationPlacer extends JFrame {
       }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to save points", ex);
     }
     System.out.println("");
   }
@@ -609,7 +609,7 @@ public class DecorationPlacer extends JFrame {
         currentPoints = new HashMap<>();
       }
     } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load points", ex);
     }
   }
 

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -394,7 +394,7 @@ public class PolygonGrabber extends JFrame {
       ClientLogger.logQuietly("file name = " + polyName, ex);
     } catch (final HeadlessException ex) {
       // TODO: remove HeadlessException (fix anti-pattern control flow via exception handling with proper control flow)
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load polygons", ex);
     }
   }
 

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -118,7 +118,7 @@ public class TileImageReconstructor {
           polygons = PointFileReaderWriter.readOneToManyPolygons(in);
         }
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to load polygons", ex);
       }
     }
     createMap();
@@ -160,7 +160,7 @@ public class TileImageReconstructor {
     try {
       ImageIO.write(mapImage, "png", new File(imageSaveLocation));
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save image: " + imageSaveLocation, e);
     }
     textOptionPane.appendNewLine("Wrote " + imageSaveLocation);
     textOptionPane.appendNewLine("\r\nAll Finished!");

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -97,7 +97,7 @@ public class ConnectionFinder {
         territoryAreas.put(territoryName, listOfAreas);
       }
     } catch (final IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load polygons: " + polyFile.getAbsolutePath(), ex);
     }
     if (!dimensionsSet) {
       final String lineWidth = JOptionPane.showInputDialog(null,

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -356,7 +356,7 @@ public class MapCreator extends JFrame {
           try {
             TileImageBreaker.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run tile image breaker", exception);
           }
         }).start();
       }
@@ -372,7 +372,7 @@ public class MapCreator extends JFrame {
           try {
             DecorationPlacer.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run decoration placer", exception);
           }
         }).start();
       }
@@ -398,7 +398,7 @@ public class MapCreator extends JFrame {
           try {
             ConnectionFinder.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run connection finder", exception);
           }
         }).start();
       }
@@ -423,7 +423,7 @@ public class MapCreator extends JFrame {
           try {
             ReliefImageBreaker.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run relief image breaker", exception);
           }
         }).start();
       }
@@ -439,7 +439,7 @@ public class MapCreator extends JFrame {
           try {
             ImageShrinker.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run image shrinker", exception);
           }
         }).start();
       }
@@ -455,7 +455,7 @@ public class MapCreator extends JFrame {
           try {
             TileImageReconstructor.main(new String[0]);
           } catch (final Exception exception) {
-            ClientLogger.logQuietly(exception);
+            ClientLogger.logQuietly("Failed to run tile image reconstructor", exception);
           }
         }).start();
       }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -319,10 +320,11 @@ public class MapPropertiesMaker extends JFrame {
       if (centerName == null) {
         return;
       }
-      final FileInputStream in = new FileInputStream(centerName);
-      properties.load(in);
+      try (InputStream in = new FileInputStream(centerName)) {
+        properties.load(in);
+      }
     } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load map properties", ex);
     }
     for (final Method setter : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");
@@ -353,7 +355,7 @@ public class MapPropertiesMaker extends JFrame {
       System.out.println("");
       System.out.println(stringToWrite);
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to save map properties", e);
     }
   }
 
@@ -367,7 +369,7 @@ public class MapPropertiesMaker extends JFrame {
       try {
         outString.append(outMethod.invoke(mapProperties));
       } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to invoke method reflectively: " + outMethod.getName(), e);
       }
     }
     return outString.toString();

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -114,7 +114,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       System.out.println(setter + "   to   " + value);
       setter.invoke(object, args);
     } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-      ClientLogger.logQuietly(e);
+      ClientLogger.logQuietly("Failed to invoke setter reflectively: " + setter.getName(), e);
     }
   }
 
@@ -133,11 +133,8 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       final Object currentValue;
       try {
         currentValue = field.get(object);
-      } catch (final IllegalArgumentException e) {
-        ClientLogger.logQuietly(e);
-        continue;
-      } catch (final IllegalAccessException e) {
-        ClientLogger.logQuietly(e);
+      } catch (final IllegalArgumentException | IllegalAccessException e) {
+        ClientLogger.logQuietly("Failed to get field value reflectively: " + field.getName(), e);
         continue;
       }
       try {
@@ -145,7 +142,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
             new MapPropertyWrapper<>(propertyName, null, currentValue, setter);
         properties.add(wrapper);
       } catch (final Exception e) {
-        ClientLogger.logQuietly(e);
+        ClientLogger.logQuietly("Failed to create map property wrapper", e);
       }
     }
     properties.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -212,7 +212,7 @@ public class PlacementPicker extends JFrame {
           }
         }
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to initialize from map properties", ex);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -247,7 +247,7 @@ public class PlacementPicker extends JFrame {
         }
         placeDimensionsSet = true;
       } catch (final Exception ex) {
-        ClientLogger.logQuietly(ex);
+        ClientLogger.logQuietly("Failed to initialize from user input", ex);
       }
     }
     File file = null;
@@ -507,7 +507,7 @@ public class PlacementPicker extends JFrame {
       placements = PointFileReaderWriter.readOneToMany(in);
       repaint();
     } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly(ex);
+      ClientLogger.logQuietly("Failed to load placements", ex);
     }
   }
 


### PR DESCRIPTION
This PR includes a message at every call site where an exception is logged quietly.  This allows for the removal of the deprecated `ClientLogger#logQuietly(Throwable)` overload.