### PR TITLE
Headless server + available games simplifications

### DIFF
--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -37,9 +37,9 @@ public class AvailableGames {
   private final Set<String> availableMapFolderOrZipNames = Collections.synchronizedSet(new HashSet<>());
 
   AvailableGames() {
-    Arrays.asList(Optional.ofNullable(ClientFileSystemHelper.getUserMapsFolder().listFiles())
+    Arrays.stream(Optional.ofNullable(ClientFileSystemHelper.getUserMapsFolder().listFiles())
         .orElse(new File[0]))
-        .parallelStream()
+        .parallel()
         .forEach(map -> {
           if (map.isDirectory()) {
             populateFromDirectory(map, availableGames, availableMapFolderOrZipNames);

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -150,6 +150,7 @@ public class AvailableGames {
 
 
   }
+
   private static Optional<GameData> parse(final URI uri) {
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -44,18 +44,6 @@ public class AvailableGames {
     return new HashSet<>(availableGames.keySet());
   }
 
-  Set<String> getAvailableMapFolderOrZipNames() {
-    return Collections.unmodifiableSet(availableMapFolderOrZipNames);
-  }
-
-  /**
-   * Can return null.
-   */
-  public GameData getGameData(final String gameName) {
-    return Optional.ofNullable(availableGames.get(gameName))
-        .map(AvailableGames::getGameDataFromXml)
-        .orElse(null);
-  }
 
   /**
    * Returns the path to the file associated with the specified game.
@@ -163,6 +151,15 @@ public class AvailableGames {
     return false;
   }
 
+  /**
+   * Can return null.
+   */
+  public GameData getGameData(final String gameName) {
+    return Optional.ofNullable(availableGames.get(gameName))
+        .map(AvailableGames::getGameDataFromXml)
+        .orElse(null);
+  }
+
   private static GameData getGameDataFromXml(final URI uri) {
     if (uri == null) {
       return null;
@@ -177,5 +174,10 @@ public class AvailableGames {
       }
     }
     return null;
+  }
+
+  public boolean containsMapName(final String mapNameProperty) {
+    return availableMapFolderOrZipNames.contains(mapNameProperty)
+        || availableMapFolderOrZipNames.contains(mapNameProperty + "-master");
   }
 }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -34,35 +34,11 @@ public class AvailableGames {
   private static final Logger logger = Logger.getLogger(AvailableGames.class.getName());
 
   private static final String ZIP_EXTENSION = ".zip";
-  private final Map<String, URI> availableGames = new TreeMap<>();
-  private final Set<String> availableMapFolderOrZipNames = new HashSet<>();
+  private final Map<String, URI> availableGames = Collections.synchronizedMap(new TreeMap<>());
+  private final Set<String> availableMapFolderOrZipNames = Collections.synchronizedSet(new HashSet<>());
 
   AvailableGames() {
-    populateAvailableGames(
-        Collections.synchronizedMap(availableGames),
-        Collections.synchronizedSet(availableMapFolderOrZipNames));
-  }
-
-  Set<String> getGameNames() {
-    return new HashSet<>(availableGames.keySet());
-  }
-
-
-  /**
-   * Returns the path to the file associated with the specified game.
-   *
-   * <p>
-   * The "path" is actually a URI in string form.
-   * </p>
-   *
-   * @param gameName The name of the game whose file path is to be retrieved; may be {@code null}.
-   *
-   * @return The path to the game file; or {@code null} if the game is not available.
-   */
-  String getGameFilePath(final String gameName) {
-    return Optional.ofNullable(availableGames.get(gameName))
-        .map(Object::toString)
-        .orElse(null);
+    populateAvailableGames(availableGames, availableMapFolderOrZipNames);
   }
 
   private static void populateAvailableGames(
@@ -152,6 +128,28 @@ public class AvailableGames {
       }
     }
     return false;
+  }
+
+  Set<String> getGameNames() {
+    return new HashSet<>(availableGames.keySet());
+  }
+
+
+  /**
+   * Returns the path to the file associated with the specified game.
+   *
+   * <p>
+   * The "path" is actually a URI in string form.
+   * </p>
+   *
+   * @param gameName The name of the game whose file path is to be retrieved; may be {@code null}.
+   *
+   * @return The path to the game file; or {@code null} if the game is not available.
+   */
+  String getGameFilePath(final String gameName) {
+    return Optional.ofNullable(availableGames.get(gameName))
+        .map(Object::toString)
+        .orElse(null);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
@@ -81,16 +80,12 @@ public class AvailableGames {
         if (entry.getName().contains("games/") && entry.getName().toLowerCase().endsWith(".xml")) {
           final URL url = loader.getResource(entry.getName());
           if (url != null) {
-            try {
-              final boolean added = addToAvailableGames(
-                  new URI(url.toString().replace(" ", "%20")),
-                  availableGames);
-              if (added && map.getName().length() > 4) {
-                availableMapFolderOrZipNames
-                    .add(map.getName().substring(0, map.getName().length() - ZIP_EXTENSION.length()));
-              }
-            } catch (final URISyntaxException e) {
-              // only happens when URI couldn't be build and therefore no entry was added. That's fine
+            final boolean added = addToAvailableGames(
+                URI.create(url.toString().replace(" ", "%20")),
+                availableGames);
+            if (added && map.getName().length() > 4) {
+              availableMapFolderOrZipNames
+                  .add(map.getName().substring(0, map.getName().length() - ZIP_EXTENSION.length()));
             }
           }
         }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Executors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import javax.annotation.Nonnull;
+
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
@@ -57,7 +59,9 @@ public class AvailableGames {
    * Can return null.
    */
   public GameData getGameData(final String gameName) {
-    return getGameDataFromXml(availableGames.get(gameName));
+    return Optional.ofNullable(availableGames.get(gameName))
+        .map(AvailableGames::getGameDataFromXml)
+        .orElse(null);
   }
 
   /**
@@ -174,12 +178,10 @@ public class AvailableGames {
   }
 
 
-  private static boolean addToAvailableGames(final URI uri, final Map<String, URI> availableGames,
-      final Set<String> mapNamePropertyList) {
-    if (uri == null) {
-      return false;
-    }
-
+  private static boolean addToAvailableGames(
+      @Nonnull final URI uri,
+      @Nonnull final Map<String, URI> availableGames,
+      @Nonnull final Set<String> mapNamePropertyList) {
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -38,13 +38,6 @@ public class AvailableGames {
   private final Set<String> availableMapFolderOrZipNames = Collections.synchronizedSet(new HashSet<>());
 
   AvailableGames() {
-    populateAvailableGames(availableGames, availableMapFolderOrZipNames);
-  }
-
-  private static void populateAvailableGames(
-      final Map<String, URI> availableGames,
-      final Set<String> availableMapFolderOrZipNames) {
-
     Arrays.asList(Optional.ofNullable(ClientFileSystemHelper.getUserMapsFolder().listFiles())
         .orElse(new File[0]))
         .parallelStream()

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -70,7 +70,6 @@ public class HeadlessGameServer {
   private boolean shutDown = false;
 
   private HeadlessGameServer() {
-    super();
     if (instance != null) {
       throw new IllegalStateException("Instance already exists");
     }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -117,9 +117,12 @@ public class HeadlessGameServer {
         System.out.println("Loading GameData failed for: " + fileName);
         return;
       }
+
+
       final String mapNameProperty = data.getProperties().get(Constants.MAP_NAME, "");
-      final Set<String> availableMaps = availableGames.getAvailableMapFolderOrZipNames();
-      if (!availableMaps.contains(mapNameProperty) && !availableMaps.contains(mapNameProperty + "-master")) {
+
+
+      if(!availableGames.containsMapName(mapNameProperty)) {
         System.out.println("Game mapName not in available games listing: " + mapNameProperty);
         return;
       }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -632,15 +632,11 @@ public class HeadlessGameServer {
     }
   }
 
-  SetupPanelModel getSetupPanelModel() {
-    return setupPanelModel;
-  }
-
-  ServerModel getServerModel() {
+  private ServerModel getServerModel() {
     return getServerModel(setupPanelModel);
   }
 
-  static ServerModel getServerModel(final SetupPanelModel setupPanelModel) {
+  private static ServerModel getServerModel(final SetupPanelModel setupPanelModel) {
     if (setupPanelModel == null) {
       return null;
     }
@@ -673,6 +669,12 @@ public class HeadlessGameServer {
     }
   }
 
+  /**
+   * Launches a bot server. Most properties are passed via command line-like arguments.
+   */
+  /*
+   * TODO: get properties from a configuration file instead of CLI.
+   */
   public static void main(final String[] args) {
     ClientSetting.initialize();
 

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -102,7 +102,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
       return ZipProcessingResult.ERROR;
     }
 
-    addNewGameChooserEntry(URI.create(url.toString().replace(" ", "%20")))
+    createGameChooserEntry(URI.create(url.toString().replace(" ", "%20")))
         .ifPresent(entries::add);
     return ZipProcessingResult.SUCCESS;
   }
@@ -143,7 +143,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
    * @param uri
    *        URI of the new entry
    */
-  private static Optional<GameChooserEntry> addNewGameChooserEntry(final URI uri) {
+  private static Optional<GameChooserEntry> createGameChooserEntry(final URI uri) {
     try {
       return Optional.of(createEntry(uri));
     } catch (final EngineVersionException e) {
@@ -185,7 +185,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
     if (games.listFiles() != null) {
       for (final File game : games.listFiles()) {
         if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
-          addNewGameChooserEntry(game.toURI()).ifPresent(entries::add);
+          createGameChooserEntry(game.toURI()).ifPresent(entries::add);
         }
       }
     }


### PR DESCRIPTION
A sequence of refactorings in Headless server code, 'available games module':
- used optional/streaming to replace null checks and executor service
- moved methods within file
- other misc cleanups, an NPE fix for example

-----

Review note: each commit is pretty self contained, reviewing commit-by-commit might be the best way to understand the individual changes