### PR TITLE
PointFileReaderWriter: Require caller to close streams

### DIFF
--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -197,12 +197,14 @@ public class ResourceLoader implements Closeable {
    * @param inputPath
    *        (The name of a resource is a '/'-separated path name that identifies the resource. Do not use '\' or
    *        File.separator)
+   *
+   * @return The resource URL or {@code null} if the resource does not exist.
    */
-  public URL getResource(final String inputPath) {
+  public @Nullable URL getResource(final String inputPath) {
     final String path = resourceLocationTracker.getMapPrefix() + inputPath;
     return getMatchingResources(path).stream().findFirst().orElse(
-        getMatchingResources(inputPath).stream().findFirst().orElseGet(
-            () -> null));
+        getMatchingResources(inputPath).stream().findFirst().orElse(
+            null));
   }
 
   private List<URL> getMatchingResources(final String path) {

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringTokenizer;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
@@ -212,9 +214,12 @@ public class ResourceLoader implements Closeable {
   }
 
   /**
-   * Ensure that you close the InputStream returned by this method when you are done using it.
+   * @return An input stream for the specified resource or {@code null} if the resource does not exist. The caller is
+   *         responsible for closing the returned input stream.
+   *
+   * @throws IllegalStateException If the specified resource exists but the input stream cannot be opened.
    */
-  public InputStream getResourceAsStream(final String path) {
+  public @Nullable InputStream getResourceAsStream(final String path) {
     final URL url = getResource(path);
     if (url == null) {
       return null;

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -133,34 +133,32 @@ public class MapData implements Closeable {
   public MapData(final ResourceLoader loader) {
     resourceLoader = loader;
     try {
-      final String prefix = "";
+      place = readPointsOneToMany(optionalResource(PLACEMENT_FILE));
+      territoryEffects = readPointsOneToMany(optionalResource(TERRITORY_EFFECT_FILE));
 
-      place = readPointsOneToMany(optionalResource(prefix + PLACEMENT_FILE));
-      territoryEffects = readPointsOneToMany(optionalResource(prefix + TERRITORY_EFFECT_FILE));
-
-      if (loader.getResourceAsStream(prefix + POLYGON_FILE) == null) {
+      if (loader.getResourceAsStream(POLYGON_FILE) == null) {
         throw new IllegalStateException(
-            "Error in resource loading. Unable to load expected resource: " + prefix + POLYGON_FILE + ", the error"
+            "Error in resource loading. Unable to load expected resource: " + POLYGON_FILE + ", the error"
                 + " is that either we did not find the correct path to load. Check the resource loader to make"
                 + " sure the map zip or dir was added. Failing that, the path in this error message should be available"
                 + " relative to the map folder, or relative to the root of the map zip");
       }
 
-      polys = readPolygonsOneToMany(requiredResource(prefix + POLYGON_FILE));
-      centers = readPointsOneToOne(requiredResource(prefix + CENTERS_FILE));
-      vcPlace = readPointsOneToOne(optionalResource(prefix + VC_MARKERS));
-      convoyPlace = readPointsOneToOne(optionalResource(prefix + CONVOY_MARKERS));
-      commentPlace = readPointsOneToOne(optionalResource(prefix + COMMENT_MARKERS));
-      blockadePlace = readPointsOneToOne(optionalResource(prefix + BLOCKADE_MARKERS));
-      capitolPlace = readPointsOneToOne(optionalResource(prefix + CAPITAL_MARKERS));
-      puPlace = readPointsOneToOne(optionalResource(prefix + PU_PLACE_FILE));
-      namePlace = readPointsOneToOne(optionalResource(prefix + TERRITORY_NAME_PLACE_FILE));
-      kamikazePlace = readPointsOneToOne(optionalResource(prefix + KAMIKAZE_FILE));
+      polys = readPolygonsOneToMany(requiredResource(POLYGON_FILE));
+      centers = readPointsOneToOne(requiredResource(CENTERS_FILE));
+      vcPlace = readPointsOneToOne(optionalResource(VC_MARKERS));
+      convoyPlace = readPointsOneToOne(optionalResource(CONVOY_MARKERS));
+      commentPlace = readPointsOneToOne(optionalResource(COMMENT_MARKERS));
+      blockadePlace = readPointsOneToOne(optionalResource(BLOCKADE_MARKERS));
+      capitolPlace = readPointsOneToOne(optionalResource(CAPITAL_MARKERS));
+      puPlace = readPointsOneToOne(optionalResource(PU_PLACE_FILE));
+      namePlace = readPointsOneToOne(optionalResource(TERRITORY_NAME_PLACE_FILE));
+      kamikazePlace = readPointsOneToOne(optionalResource(KAMIKAZE_FILE));
       mapProperties = new Properties();
       decorations = loadDecorations();
       territoryNameImages = territoryNameImages();
       try {
-        final URL url = loader.getResource(prefix + MAP_PROPERTIES);
+        final URL url = loader.getResource(MAP_PROPERTIES);
         if (url == null) {
           throw new IllegalStateException("No map.properties file defined");
         }

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -146,7 +146,7 @@ public class MapData implements Closeable {
                 + " relative to the map folder, or relative to the root of the map zip");
       }
 
-      polys = PointFileReaderWriter.readOneToManyPolygons(loader.getResourceAsStream(prefix + POLYGON_FILE));
+      polys = readPolygonsOneToManyRequired(prefix + POLYGON_FILE);
       centers = readPointsOneToOneRequired(prefix + CENTERS_FILE);
       vcPlace = readPointsOneToOneOptional(prefix + VC_MARKERS);
       convoyPlace = readPointsOneToOneOptional(prefix + CONVOY_MARKERS);
@@ -178,17 +178,21 @@ public class MapData implements Closeable {
   }
 
   private Map<String, Point> readPointsOneToOneOptional(final String path) throws IOException {
-    return readPointsOneToOne(() -> {
-      return Optional.ofNullable(resourceLoader.getResourceAsStream(path))
-          .orElseGet(() -> new ByteArrayInputStream(new byte[0]));
-    });
+    return readPointsOneToOne(() -> optionalResourceAsStream(path));
+  }
+
+  private InputStream optionalResourceAsStream(final String path) {
+    return Optional.ofNullable(resourceLoader.getResourceAsStream(path))
+        .orElseGet(() -> new ByteArrayInputStream(new byte[0]));
   }
 
   private Map<String, Point> readPointsOneToOneRequired(final String path) throws IOException {
-    return readPointsOneToOne(() -> {
-      return Optional.ofNullable(resourceLoader.getResourceAsStream(path))
-          .orElseThrow(() -> new FileNotFoundException(path));
-    });
+    return readPointsOneToOne(() -> requiredResourceAsStream(path));
+  }
+
+  private InputStream requiredResourceAsStream(final String path) throws IOException {
+    return Optional.ofNullable(resourceLoader.getResourceAsStream(path))
+        .orElseThrow(() -> new FileNotFoundException(path));
   }
 
   private static Map<String, Point> readPointsOneToOne(final InputStreamFactory inputStreamFactory) throws IOException {
@@ -198,16 +202,24 @@ public class MapData implements Closeable {
   }
 
   private Map<String, List<Point>> readPointsOneToManyOptional(final String path) throws IOException {
-    return readPointsOneToMany(() -> {
-      return Optional.ofNullable(resourceLoader.getResourceAsStream(path))
-          .orElseGet(() -> new ByteArrayInputStream(new byte[0]));
-    });
+    return readPointsOneToMany(() -> optionalResourceAsStream(path));
   }
 
   private static Map<String, List<Point>> readPointsOneToMany(final InputStreamFactory inputStreamFactory)
       throws IOException {
     try (InputStream is = inputStreamFactory.newInputStream()) {
       return PointFileReaderWriter.readOneToMany(is);
+    }
+  }
+
+  private Map<String, List<Polygon>> readPolygonsOneToManyRequired(final String path) throws IOException {
+    return readPolygonsOneToMany(() -> requiredResourceAsStream(path));
+  }
+
+  private static Map<String, List<Polygon>> readPolygonsOneToMany(final InputStreamFactory inputStreamFactory)
+      throws IOException {
+    try (InputStream is = inputStreamFactory.newInputStream()) {
+      return PointFileReaderWriter.readOneToManyPolygons(is);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 
 import games.strategy.debug.ClientLogger;
@@ -146,14 +147,14 @@ public class MapData implements Closeable {
 
       polys = PointFileReaderWriter.readOneToManyPolygons(loader.getResourceAsStream(prefix + POLYGON_FILE));
       centers = PointFileReaderWriter.readOneToOneCenters(loader.getResourceAsStream(prefix + CENTERS_FILE));
-      vcPlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + VC_MARKERS));
-      convoyPlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + CONVOY_MARKERS));
-      commentPlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + COMMENT_MARKERS));
-      blockadePlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + BLOCKADE_MARKERS));
-      capitolPlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + CAPITAL_MARKERS));
-      puPlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + PU_PLACE_FILE));
-      namePlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + TERRITORY_NAME_PLACE_FILE));
-      kamikazePlace = PointFileReaderWriter.readOneToOne(loader.getResourceAsStream(prefix + KAMIKAZE_FILE));
+      vcPlace = readPointsOneToOne(prefix + VC_MARKERS);
+      convoyPlace = readPointsOneToOne(prefix + CONVOY_MARKERS);
+      commentPlace = readPointsOneToOne(prefix + COMMENT_MARKERS);
+      blockadePlace = readPointsOneToOne(prefix + BLOCKADE_MARKERS);
+      capitolPlace = readPointsOneToOne(prefix + CAPITAL_MARKERS);
+      puPlace = readPointsOneToOne(prefix + PU_PLACE_FILE);
+      namePlace = readPointsOneToOne(prefix + TERRITORY_NAME_PLACE_FILE);
+      kamikazePlace = readPointsOneToOne(prefix + KAMIKAZE_FILE);
       mapProperties = new Properties();
       decorations = loadDecorations();
       territoryNameImages = territoryNameImages();
@@ -172,6 +173,12 @@ public class MapData implements Closeable {
       initializeContains();
     } catch (final IOException ex) {
       ClientLogger.logQuietly("Failed to load map properties", ex);
+    }
+  }
+
+  private Map<String, Point> readPointsOneToOne(final String path) throws IOException {
+    try (@Nullable InputStream is = resourceLoader.getResourceAsStream(path)) {
+      return PointFileReaderWriter.readOneToOne(is);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -35,7 +35,6 @@ import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
-import games.strategy.util.UrlStreams;
 
 /**
  * contains data about the territories useful for drawing.
@@ -157,18 +156,13 @@ public class MapData implements Closeable {
       mapProperties = new Properties();
       decorations = loadDecorations();
       territoryNameImages = territoryNameImages();
-      try {
-        final URL url = loader.getResource(MAP_PROPERTIES);
-        if (url == null) {
-          throw new IllegalStateException("No map.properties file defined");
-        }
-        final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-        if (inputStream.isPresent()) {
-          mapProperties.load(inputStream.get());
-        }
+
+      try (InputStream inputStream = requiredResource(MAP_PROPERTIES).newInputStream()) {
+        mapProperties.load(inputStream);
       } catch (final Exception e) {
-        System.out.println("Error reading map.properties:" + e);
+        ClientLogger.logQuietly("Error reading map.properties", e);
       }
+
       initializeContains();
     } catch (final IOException ex) {
       ClientLogger.logQuietly("Failed to load map properties", ex);

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -180,28 +180,35 @@ public class MapData implements Closeable {
   }
 
   private static Map<String, Point> readPointsOneToOne(final InputStreamFactory inputStreamFactory) throws IOException {
-    try (InputStream is = inputStreamFactory.newInputStream()) {
-      return PointFileReaderWriter.readOneToOne(is);
-    }
+    return runWithInputStream(inputStreamFactory, PointFileReaderWriter::readOneToOne);
   }
 
   private static Map<String, List<Point>> readPointsOneToMany(final InputStreamFactory inputStreamFactory)
       throws IOException {
-    try (InputStream is = inputStreamFactory.newInputStream()) {
-      return PointFileReaderWriter.readOneToMany(is);
-    }
+    return runWithInputStream(inputStreamFactory, PointFileReaderWriter::readOneToMany);
   }
 
   private static Map<String, List<Polygon>> readPolygonsOneToMany(final InputStreamFactory inputStreamFactory)
       throws IOException {
+    return runWithInputStream(inputStreamFactory, PointFileReaderWriter::readOneToManyPolygons);
+  }
+
+  private static <R> R runWithInputStream(
+      final InputStreamFactory inputStreamFactory,
+      final InputStreamReader<R> reader) throws IOException {
     try (InputStream is = inputStreamFactory.newInputStream()) {
-      return PointFileReaderWriter.readOneToManyPolygons(is);
+      return reader.read(is);
     }
   }
 
   @FunctionalInterface
   private interface InputStreamFactory {
     InputStream newInputStream() throws IOException;
+  }
+
+  @FunctionalInterface
+  private interface InputStreamReader<R> {
+    R read(InputStream is) throws IOException;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -136,7 +136,7 @@ public class MapData implements Closeable {
       place = readPointsOneToMany(optionalResource(PLACEMENT_FILE));
       territoryEffects = readPointsOneToMany(optionalResource(TERRITORY_EFFECT_FILE));
 
-      if (loader.getResourceAsStream(POLYGON_FILE) == null) {
+      if (loader.getResource(POLYGON_FILE) == null) {
         throw new IllegalStateException(
             "Error in resource loading. Unable to load expected resource: " + POLYGON_FILE + ", the error"
                 + " is that either we did not find the correct path to load. Check the resource loader to make"

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -1,5 +1,7 @@
 package games.strategy.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.Point;
 import java.awt.Polygon;
 import java.io.IOException;
@@ -32,13 +34,9 @@ public final class PointFileReaderWriter {
 
   /**
    * Returns a map of the form String -> Point.
-   *
-   * @param stream The stream from which to read the point file. If {@code null}, an empty map will be returned.
    */
-  public static Map<String, Point> readOneToOne(final @Nullable InputStream stream) throws IOException {
-    if (stream == null) {
-      return Collections.emptyMap();
-    }
+  public static Map<String, Point> readOneToOne(final InputStream stream) throws IOException {
+    checkNotNull(stream);
 
     final Map<String, Point> mapping = new HashMap<>();
     try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -160,12 +160,13 @@ public final class PointFileReaderWriter {
   }
 
   /**
-   * Returns a map of the form String -> Collection of points.
+   * Returns a map of the form String -> Collection of polygons.
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) {
     final HashMap<String, List<Polygon>> mapping = new HashMap<>();
-    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+    try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
+      @Nullable
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -177,14 +178,6 @@ public final class PointFileReaderWriter {
       ClientLogger.logQuietly("Failed to read polygons", e);
       // FIXME: o_O Should not exit process from "library" code
       System.exit(0);
-    } finally {
-      try {
-        if (stream != null) {
-          stream.close();
-        }
-      } catch (final IOException e) {
-        ClientLogger.logError("Failed to close polygon reader stream", e);
-      }
     }
     return mapping;
   }

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -12,7 +12,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -138,10 +137,8 @@ public final class PointFileReaderWriter {
   /**
    * Returns a map of the form String -> Collection of points.
    */
-  public static Map<String, List<Point>> readOneToMany(final @Nullable InputStream stream) {
-    if (stream == null) {
-      return Collections.emptyMap();
-    }
+  public static Map<String, List<Point>> readOneToMany(final InputStream stream) {
+    checkNotNull(stream);
 
     final HashMap<String, List<Point>> mapping = new HashMap<>();
     try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -17,6 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import javax.annotation.Nullable;
+
+import org.apache.commons.io.input.CloseShieldInputStream;
+
 import games.strategy.debug.ClientLogger;
 
 /**
@@ -28,15 +32,18 @@ public final class PointFileReaderWriter {
 
   /**
    * Returns a map of the form String -> Point.
+   *
+   * @param stream The stream from which to read the point file. If {@code null}, an empty map will be returned.
    */
-  public static Map<String, Point> readOneToOne(final InputStream stream) throws IOException {
+  public static Map<String, Point> readOneToOne(final @Nullable InputStream stream) throws IOException {
     if (stream == null) {
       return Collections.emptyMap();
     }
-    final Map<String, Point> mapping = new HashMap<>();
 
-    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+    final Map<String, Point> mapping = new HashMap<>();
+    try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
+      @Nullable
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -44,8 +51,6 @@ public final class PointFileReaderWriter {
         }
         current = reader.readLine();
       }
-    } finally {
-      stream.close();
     }
     return mapping;
   }

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -20,12 +20,11 @@ import java.util.StringTokenizer;
 import games.strategy.debug.ClientLogger;
 
 /**
- * Utiltity to read and write files in the form of
+ * Utility to read and write files in the form of
  * String -> a list of points, or string-> list of polygons.
  */
-public class PointFileReaderWriter {
-  /** Creates a new instance of PointFileReader. */
-  public PointFileReaderWriter() {}
+public final class PointFileReaderWriter {
+  private PointFileReaderWriter() {}
 
   /**
    * Returns a map of the form String -> Point.
@@ -310,5 +309,4 @@ public class PointFileReaderWriter {
     }
     mapping.put(name, points);
   }
-  // TODO add write methods
 }

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -53,27 +53,6 @@ public final class PointFileReaderWriter {
     return mapping;
   }
 
-  /**
-   * Returns a map of the form String -> Point.
-   */
-  public static Map<String, Point> readOneToOneCenters(final InputStream stream) throws IOException {
-    final Map<String, Point> mapping = new HashMap<>();
-
-    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
-        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
-      String current = reader.readLine();
-      while (current != null) {
-        if (current.trim().length() != 0) {
-          readSingle(current, mapping);
-        }
-        current = reader.readLine();
-      }
-    } finally {
-      stream.close();
-    }
-    return mapping;
-  }
-
   private static void readSingle(final String line, final Map<String, Point> mapping) throws IOException {
     final StringTokenizer tokens = new StringTokenizer(line, "", false);
     final String name = tokens.nextToken("(").trim();

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -119,8 +119,8 @@ public class CenterPicker extends JFrame {
         "A polygons.txt file was found in the map's folder, do you want to use the file to supply the territories "
             + "names?",
         "File Suggestion", 1) == 0) {
-      try {
-        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
+      try (InputStream is = new FileInputStream(file.getPath())) {
+        polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file: " + ex1);
         ex1.printStackTrace();
@@ -129,7 +129,9 @@ public class CenterPicker extends JFrame {
       try {
         final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
-          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          try (InputStream is = new FileInputStream(polyPath)) {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          }
         }
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file: " + ex1);

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -257,8 +258,9 @@ public class CenterPicker extends JFrame {
       if (centerName == null) {
         return;
       }
-      final FileInputStream in = new FileInputStream(centerName);
-      centers = PointFileReaderWriter.readOneToOne(in);
+      try (InputStream in = new FileInputStream(centerName)) {
+        centers = PointFileReaderWriter.readOneToOne(in);
+      }
       repaint();
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly("Failed to load centers", ex);

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -196,9 +197,9 @@ public class DecorationPlacer extends JFrame {
         "A centers.txt file was found in the map's folder, do you want to use the file to supply the territories "
             + "centers?",
         "File Suggestion", 1) == 0) {
-      try {
+      try (InputStream is = new FileInputStream(fileCenters.getPath())) {
         System.out.println("Centers : " + fileCenters.getPath());
-        centers = PointFileReaderWriter.readOneToOne(new FileInputStream(fileCenters.getPath()));
+        centers = PointFileReaderWriter.readOneToOne(is);
       } catch (final IOException ex1) {
         System.out.println("Something wrong with Centers file");
         ex1.printStackTrace();
@@ -210,7 +211,9 @@ public class DecorationPlacer extends JFrame {
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
-          centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
+          try (InputStream is = new FileInputStream(centerPath)) {
+            centers = PointFileReaderWriter.readOneToOne(is);
+          }
         } else {
           System.out.println("You must specify a centers file.");
           System.out.println("Shutting down.");

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -606,8 +606,9 @@ public class DecorationPlacer extends JFrame {
           new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
       currentImagePointsTextFile = centerName.getFile();
       if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
-        final FileInputStream in = new FileInputStream(centerName.getPathString());
-        currentPoints = PointFileReaderWriter.readOneToMany(in);
+        try (InputStream in = new FileInputStream(centerName.getPathString())) {
+          currentPoints = PointFileReaderWriter.readOneToMany(in);
+        }
       } else {
         currentPoints = new HashMap<>();
       }

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -236,9 +236,9 @@ public class DecorationPlacer extends JFrame {
         "A polygons.txt file was found in the map's folder, do you want to use the file to supply the territories "
             + "polygons?",
         "File Suggestion", 1) == 0) {
-      try {
+      try (InputStream is = new FileInputStream(filePoly.getPath())) {
         System.out.println("Polygons : " + filePoly.getPath());
-        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(filePoly.getPath()));
+        polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file");
         ex1.printStackTrace();
@@ -250,7 +250,9 @@ public class DecorationPlacer extends JFrame {
         final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
-          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          try (InputStream is = new FileInputStream(polyPath)) {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          }
         } else {
           System.out.println("You must specify a Polgyon file.");
           System.out.println("Shutting down.");

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -20,7 +20,6 @@ import java.awt.event.MouseMotionAdapter;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -390,10 +389,11 @@ public class PolygonGrabber extends JFrame {
       if (polyName == null) {
         return;
       }
-      final FileInputStream in = new FileInputStream(polyName);
-      polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+      try (InputStream in = new FileInputStream(polyName)) {
+        polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+      }
       repaint();
-    } catch (final FileNotFoundException ex) {
+    } catch (final IOException ex) {
       ClientLogger.logQuietly("file name = " + polyName, ex);
     } catch (final HeadlessException ex) {
       // TODO: remove HeadlessException (fix anti-pattern control flow via exception handling with proper control flow)

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -142,9 +143,9 @@ public class PolygonGrabber extends JFrame {
         "A centers.txt file was found in the map's folder, do you want to use the file to supply the territories "
             + "names?",
         "File Suggestion", 1) == 0) {
-      try {
+      try (InputStream is = new FileInputStream(file.getPath())) {
         System.out.println("Centers : " + file.getPath());
-        centers = PointFileReaderWriter.readOneToOne(new FileInputStream(file.getPath()));
+        centers = PointFileReaderWriter.readOneToOne(is);
       } catch (final IOException ex1) {
         System.out.println("Something wrong with Centers file");
         ex1.printStackTrace();
@@ -155,7 +156,9 @@ public class PolygonGrabber extends JFrame {
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
-          centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
+          try (InputStream is = new FileInputStream(centerPath)) {
+            centers = PointFileReaderWriter.readOneToOne(is);
+          }
         } else {
           System.out.println("You must specify a centers file.");
           System.out.println("Shutting down.");

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -13,6 +13,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,8 +115,9 @@ public class TileImageReconstructor {
         System.out.println("Load a polygon file");
         final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyName != null) {
-          final FileInputStream in = new FileInputStream(polyName);
-          polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+          try (InputStream in = new FileInputStream(polyName)) {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+          }
         }
       } catch (final Exception ex) {
         ClientLogger.logQuietly("Failed to load polygons", ex);

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -85,8 +86,7 @@ public class ConnectionFinder {
     }
     final Map<String, List<Area>> territoryAreas = new HashMap<>();
     Map<String, List<Polygon>> mapOfPolygons = null;
-    try {
-      final FileInputStream in = new FileInputStream(polyFile);
+    try (InputStream in = new FileInputStream(polyFile)) {
       mapOfPolygons = PointFileReaderWriter.readOneToManyPolygons(in);
       for (final String territoryName : mapOfPolygons.keySet()) {
         final List<Polygon> listOfPolygons = mapOfPolygons.get(territoryName);

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -261,9 +261,9 @@ public class PlacementPicker extends JFrame {
     if (file.exists() && JOptionPane.showConfirmDialog(new JPanel(),
         "A polygons.txt file was found in the map's folder, do you want to use the file to supply the territories?",
         "File Suggestion", 1) == 0) {
-      try {
+      try (InputStream is = new FileInputStream(file.getPath())) {
         System.out.println("Polygons : " + file.getPath());
-        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
+        polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException ex1) {
         ex1.printStackTrace();
       }
@@ -273,7 +273,9 @@ public class PlacementPicker extends JFrame {
         final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
-          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          try (InputStream is = new FileInputStream(polyPath)) {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          }
         } else {
           System.out.println("Polygons file not given. Will run regardless");
         }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -503,8 +504,9 @@ public class PlacementPicker extends JFrame {
       if (placeName == null) {
         return;
       }
-      final FileInputStream in = new FileInputStream(placeName);
-      placements = PointFileReaderWriter.readOneToMany(in);
+      try (InputStream in = new FileInputStream(placeName)) {
+        placements = PointFileReaderWriter.readOneToMany(in);
+      }
       repaint();
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly("Failed to load placements", ex);

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -10,7 +10,9 @@ import java.awt.Point;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Nested;
@@ -51,6 +53,39 @@ public final class PointFileReaderWriterTest {
           "United Kingdom", new Point(1865, 475),
           "Germany", new Point(2470, 667),
           "Eastern United States", new Point(715, 655))));
+    }
+  }
+
+  @Nested
+  public final class ReadOneToManyTest {
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final InputStream is = spy(new ByteArrayInputStream(new byte[0]));
+
+      PointFileReaderWriter.readOneToMany(is);
+
+      verify(is, never()).close();
+    }
+
+    @Test
+    public void shouldReturnEmptyMapWhenStreamIsNull() {
+      assertThat(PointFileReaderWriter.readOneToMany(null), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldReadMultiplePointsPerName() throws Exception {
+      final String content = ""
+          + "Belarus  (3042,544)  (3092,544)  (2991,542)\n"
+          + "54 Sea Zone  (6071,2696)  (6123,2695)\n"
+          + "Philippines (5267,2091)\n";
+
+      final Map<String, List<Point>> pointListsByName =
+          IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToMany);
+
+      assertThat(pointListsByName, is(ImmutableMap.of(
+          "Belarus", Arrays.asList(new Point(3042, 544), new Point(3092, 544), new Point(2991, 542)),
+          "54 Sea Zone", Arrays.asList(new Point(6071, 2696), new Point(6123, 2695)),
+          "Philippines", Arrays.asList(new Point(5267, 2091)))));
     }
   }
 }

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -1,0 +1,56 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.awt.Point;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import games.strategy.io.IoUtils;
+
+public final class PointFileReaderWriterTest {
+  @Nested
+  public final class ReadOneToOneTest {
+    @Test
+    public void shouldReturnEmptyMapWhenStreamIsNull() throws Exception {
+      assertThat(PointFileReaderWriter.readOneToOne(null), is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final InputStream is = spy(new ByteArrayInputStream(new byte[0]));
+
+      PointFileReaderWriter.readOneToOne(is);
+
+      verify(is, never()).close();
+    }
+
+    @Test
+    public void shouldReadOnePointPerName() throws Exception {
+      final String content = ""
+          + "United Kingdom (1865,475)\n"
+          + "Germany (2470,667)\n"
+          + "Eastern United States (715,655)\n";
+
+      final Map<String, Point> pointsByName =
+          IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToOne);
+
+      assertThat(pointsByName, is(ImmutableMap.of(
+          "United Kingdom", new Point(1865, 475),
+          "Germany", new Point(2470, 667),
+          "Eastern United States", new Point(715, 655))));
+    }
+  }
+}

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -1,12 +1,15 @@
 package games.strategy.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.awt.Point;
+import java.awt.Polygon;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -14,11 +17,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.common.primitives.Ints;
 
 import games.strategy.io.IoUtils;
 
@@ -42,17 +48,17 @@ public final class PointFileReaderWriterTest {
     @Test
     public void shouldReadOnePointPerName() throws Exception {
       final String content = ""
-          + "United Kingdom (1865,475)\n"
-          + "Germany (2470,667)\n"
-          + "Eastern United States (715,655)\n";
+          + "United Kingdom (1011,1021)\n"
+          + "Germany (2011,2021)\n"
+          + "Eastern United States (3011,3021)\n";
 
       final Map<String, Point> pointsByName =
           IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToOne);
 
       assertThat(pointsByName, is(ImmutableMap.of(
-          "United Kingdom", new Point(1865, 475),
-          "Germany", new Point(2470, 667),
-          "Eastern United States", new Point(715, 655))));
+          "United Kingdom", new Point(1011, 1021),
+          "Germany", new Point(2011, 2021),
+          "Eastern United States", new Point(3011, 3021))));
     }
   }
 
@@ -75,17 +81,71 @@ public final class PointFileReaderWriterTest {
     @Test
     public void shouldReadMultiplePointsPerName() throws Exception {
       final String content = ""
-          + "Belarus  (3042,544)  (3092,544)  (2991,542)\n"
-          + "54 Sea Zone  (6071,2696)  (6123,2695)\n"
-          + "Philippines (5267,2091)\n";
+          + "Belarus  (1011,1021)  (1012,1022)  (1013,1023)\n"
+          + "54 Sea Zone  (2011,2021)  (2012,2022)\n"
+          + "Philippines (3011,3021)\n";
 
       final Map<String, List<Point>> pointListsByName =
           IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToMany);
 
       assertThat(pointListsByName, is(ImmutableMap.of(
-          "Belarus", Arrays.asList(new Point(3042, 544), new Point(3092, 544), new Point(2991, 542)),
-          "54 Sea Zone", Arrays.asList(new Point(6071, 2696), new Point(6123, 2695)),
-          "Philippines", Arrays.asList(new Point(5267, 2091)))));
+          "Belarus", Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)),
+          "54 Sea Zone", Arrays.asList(new Point(2011, 2021), new Point(2012, 2022)),
+          "Philippines", Arrays.asList(new Point(3011, 3021)))));
+    }
+  }
+
+  @Nested
+  public final class ReadOneToManyPolygonsTest {
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final InputStream is = spy(new ByteArrayInputStream(new byte[0]));
+
+      PointFileReaderWriter.readOneToManyPolygons(is);
+
+      verify(is, never()).close();
+    }
+
+    @Test
+    public void shouldReturnEmptyMapWhenStreamIsEmpty() throws Exception {
+      assertThat(
+          IoUtils.readFromMemory(new byte[0], PointFileReaderWriter::readOneToManyPolygons),
+          is(Collections.emptyMap()));
+    }
+
+    @Test
+    public void shouldReadMultiplePolygonsPerName() throws Exception {
+      final String content = ""
+          + "Belarus  <  (1011,1021) (1012,1022) (1013,1023) >\n"
+          + "54 Sea Zone  <  (2011,2021) (2012,2022) (2013,2023) >  <  (2111,2121) (2112,2122) (2113,2123) >\n"
+          + "Philippines  <  (3011,3021) (3012,3022) (3013,3023) >  <  (3111,3121) (3112,3122) >  <  (3211,3221) >\n";
+
+      final Map<String, List<Polygon>> polygonListsByName = IoUtils.readFromMemory(
+          content.getBytes(StandardCharsets.UTF_8),
+          PointFileReaderWriter::readOneToManyPolygons);
+
+      assertThat(polygonListsByName, is(aMapWithSize(3)));
+      assertThat(polygonListsByName, hasKey("Belarus"));
+      assertThat(points(polygonListsByName.get("Belarus")), is(Arrays.asList(
+          Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)))));
+      assertThat(polygonListsByName, hasKey("54 Sea Zone"));
+      assertThat(points(polygonListsByName.get("54 Sea Zone")), is(Arrays.asList(
+          Arrays.asList(new Point(2011, 2021), new Point(2012, 2022), new Point(2013, 2023)),
+          Arrays.asList(new Point(2111, 2121), new Point(2112, 2122), new Point(2113, 2123)))));
+      assertThat(polygonListsByName, hasKey("Philippines"));
+      assertThat(points(polygonListsByName.get("Philippines")), is(Arrays.asList(
+          Arrays.asList(new Point(3011, 3021), new Point(3012, 3022), new Point(3013, 3023)),
+          Arrays.asList(new Point(3111, 3121), new Point(3112, 3122)),
+          Arrays.asList(new Point(3211, 3221)))));
+    }
+
+    private List<List<Point>> points(final List<Polygon> polygons) {
+      return polygons.stream()
+          .map(polygon -> {
+            return Streams.zip(Ints.asList(polygon.xpoints).stream(), Ints.asList(polygon.ypoints).stream(), Point::new)
+                .collect(Collectors.toList());
+          })
+          .collect(Collectors.toList());
     }
   }
 }

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -68,8 +68,8 @@ public final class PointFileReaderWriterTest {
     }
 
     @Test
-    public void shouldReturnEmptyMapWhenStreamIsNull() {
-      assertThat(PointFileReaderWriter.readOneToMany(null), is(Collections.emptyMap()));
+    public void shouldReturnEmptyMapWhenStreamIsEmpty() throws Exception {
+      assertThat(IoUtils.readFromMemory(new byte[0], PointFileReaderWriter::readOneToMany), is(Collections.emptyMap()));
     }
 
     @Test

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -24,17 +24,17 @@ public final class PointFileReaderWriterTest {
   @Nested
   public final class ReadOneToOneTest {
     @Test
-    public void shouldReturnEmptyMapWhenStreamIsNull() throws Exception {
-      assertThat(PointFileReaderWriter.readOneToOne(null), is(Collections.emptyMap()));
-    }
-
-    @Test
     public void shouldNotCloseStream() throws Exception {
       final InputStream is = spy(new ByteArrayInputStream(new byte[0]));
 
       PointFileReaderWriter.readOneToOne(is);
 
       verify(is, never()).close();
+    }
+
+    @Test
+    public void shouldReturnEmptyMapWhenStreamIsEmpty() throws Exception {
+      assertThat(IoUtils.readFromMemory(new byte[0], PointFileReaderWriter::readOneToOne), is(Collections.emptyMap()));
     }
 
     @Test


### PR DESCRIPTION
`PointFileReaderWriter` uses a resource-management idiom that is different from the rest of our code: it takes ownership of the `InputStream` passed to its methods and closes the stream before they return.  This can lead to confusion because the calling code appears to leak the stream it creates.  For consistency, this PR modifies the code such that the code that creates the stream is responsible for closing it.

#### Functional changes

None.

#### Refactoring changes

* `PointFileReaderWriter` methods no longer close their `InputStream` parameter.
* All affected `PointFileReaderWriter` methods were changed to require a non-`null` input stream.  This puts the burden on the caller to handle the "missing resource" case.
* Point/polygon resource initialization in `MapData` was modified to make it explicit which resources are optional and which are required.  This detail was previously buried in the specific `PointFileReaderWriter` method being called.
* Fixed a few leaked streams in `MapData` unrelated to `PointFileReaderWriter`.
* Added some `@Nullable` annotations and updated Javadocs where appropriate.
* Some other minor cleanups (see commit list).

#### Testing

Several characterization tests were added to detect regressions in `PointFileReaderWriter`.  The changes in `MapData` were tested by starting a new game using various maps.

#### Notes

It's probably easier to review the changes all at once, as there is a lot of iteration between the individual commits.