### PR TITLE
Fix map feedback URL generation algorithm

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import com.google.common.base.MoreObjects;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.triplea.UrlConstants;
 import games.strategy.util.Version;
 
 /**
@@ -107,9 +108,9 @@ public class DownloadFileDescription {
 
   /** Translates the stored URL into a github new issue link. */
   String getFeedbackUrl() {
-    return (url.contains("github.com") && url.contains("/releases/"))
-        ? url.substring(0, url.indexOf("/releases/")) + "/issues/new"
-        : "";
+    return (url.contains("github.com") && url.contains("/archive/"))
+        ? url.substring(0, url.indexOf("/archive/")) + "/issues/new"
+        : UrlConstants.GITHUB_ISSUES.toString();
   }
 
   /** File reference for where to install the file. */

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -8,6 +8,7 @@ import java.io.File;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
 
@@ -77,29 +78,23 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  public void testGetFeedbackUrl() {
-    final String commonPrefix = "http://github.com/triplea-maps/world_war_ii_revised/";
-    String inputUrl = commonPrefix + "releases/download/0.1/abc.zip";
-    String expected = commonPrefix + "issues/new";
-
-    DownloadFileDescription testObj = testObjFromUrl(inputUrl);
-    assertThat(testObj.getFeedbackUrl(), is(expected));
-
-
-    inputUrl = "http://randomWebsite/releases/abc.zip";
-    expected = "";
-
-    testObj = testObjFromUrl(inputUrl);
-    assertThat("Missing 'github.com' in the URL should return empty", testObj.getFeedbackUrl(), is(expected));
-
-
-    inputUrl = "http://github.com/random/abc.zip";
-    expected = "";
-
-    testObj = testObjFromUrl(inputUrl);
-    assertThat("Missing 'releases' in the URL, should return empty", testObj.getFeedbackUrl(), is(expected));
+  public void testGetFeedbackUrl_ShouldReturnMapIssueTrackerUrlWhenDownloadUrlIsGitHubArchive() {
+    assertThat(
+        testObjFromUrl("https://github.com/org/repo/archive/master.zip").getFeedbackUrl(),
+        is("https://github.com/org/repo/issues/new"));
   }
 
+  @Test
+  public void testGetFeedbackUrl_ShouldReturnGeneralIssueTrackerUrlWhenDownloadUrlIsNotGitHubArchive() {
+    assertThat(
+        "when URL does not contain 'github.com'",
+        testObjFromUrl("https://somewhere-else.com/org/repo/archive/master.zip").getFeedbackUrl(),
+        is(UrlConstants.GITHUB_ISSUES.toString()));
+    assertThat(
+        "when URL does not contain '/archive/'",
+        testObjFromUrl("https://github.com/org/repo/releases/download/1.0/repo.zip").getFeedbackUrl(),
+        is(UrlConstants.GITHUB_ISSUES.toString()));
+  }
 
   @Test
   public void testGetInstallLocation() {


### PR DESCRIPTION
Fixes #2896.

The `DownloadFileDescription#getFeedbackUrl()` method assumed maps are still published via GitHub releases instead of as GitHub zipballs.  Therefore, the Give Map Feedback command broke a little over a year ago when the map release mechanism changed.

I updated the algorithm to scan for a GitHub zipball instead of a GitHub release.  I also changed the URL used in the event the map URL is not a GitHub zipball from an empty string to the main TripleA issue tracker.  I thought this was better than having the empty string trigger an error in the UI.  Please advise if the previous behavior is preferable or if a different URL should be used.