### PR TITLE
Extract method to encapsulate File#listFiles() usage

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -6,10 +6,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -17,6 +13,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.config.client.GameEnginePropertyReader;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.io.FileUtils;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSetting;
 
@@ -90,11 +87,9 @@ public final class ClientFileSystemHelper {
   }
 
   private static boolean folderContainsGamePropsFile(final File folder) {
-    final File[] files = folder.listFiles();
-
-    final List<String> fileNames = (files == null) ? Collections.emptyList()
-        : Arrays.stream(files).map(File::getName).collect(Collectors.toList());
-    return fileNames.contains(GameEnginePropertyReader.GAME_ENGINE_PROPERTIES_FILE);
+    return FileUtils.listFiles(folder).stream()
+        .map(File::getName)
+        .anyMatch(it -> GameEnginePropertyReader.GAME_ENGINE_PROPERTIES_FILE.equals(it));
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -23,6 +22,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
+import games.strategy.io.FileUtils;
 import games.strategy.util.UrlStreams;
 
 /**
@@ -34,9 +34,7 @@ public class AvailableGames {
   private final Set<String> availableMapFolderOrZipNames = Collections.synchronizedSet(new HashSet<>());
 
   AvailableGames() {
-    Arrays.stream(Optional.ofNullable(ClientFileSystemHelper.getUserMapsFolder().listFiles())
-        .orElse(new File[0]))
-        .parallel()
+    FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).parallelStream()
         .forEach(map -> {
           if (map.isDirectory()) {
             populateFromDirectory(map, availableGames, availableMapFolderOrZipNames);
@@ -51,17 +49,11 @@ public class AvailableGames {
       final Map<String, URI> availableGames,
       final Set<String> availableMapFolderOrZipNames) {
     final File games = new File(mapDir, "games");
-    if (!games.exists()) {
-      // no games in this map dir
-      return;
-    }
-    if (games.listFiles() != null) {
-      for (final File game : games.listFiles()) {
-        if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
-          final boolean added = addToAvailableGames(game.toURI(), availableGames);
-          if (added) {
-            availableMapFolderOrZipNames.add(mapDir.getName());
-          }
+    for (final File game : FileUtils.listFiles(games)) {
+      if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
+        final boolean added = addToAvailableGames(game.toURI(), availableGames);
+        if (added) {
+          availableMapFolderOrZipNames.add(mapDir.getName());
         }
       }
     }

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Optional;
@@ -22,6 +21,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.io.FileUtils;
 import games.strategy.ui.SwingAction;
 
 /**
@@ -53,10 +53,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
 
   static Set<GameChooserEntry> parseMapFiles() {
     final Set<GameChooserEntry> parsedMapSet = new HashSet<>();
-
-    Arrays.asList(Optional.ofNullable(ClientFileSystemHelper.getUserMapsFolder().listFiles())
-        .orElse(new File[0]))
-        .parallelStream()
+    FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).parallelStream()
         .forEach(map -> {
           if (map.isDirectory()) {
             parsedMapSet.addAll(populateFromDirectory(map));
@@ -177,16 +174,9 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
 
     final File parentFolder = mapFolder.exists() ? mapFolder : mapDir;
     final File games = new File(parentFolder, "games");
-
-    if (!games.exists()) {
-      // no games in this map dir
-      return entries;
-    }
-    if (games.listFiles() != null) {
-      for (final File game : games.listFiles()) {
-        if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
-          createGameChooserEntry(game.toURI()).ifPresent(entries::add);
-        }
+    for (final File game : FileUtils.listFiles(games)) {
+      if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
+        createGameChooserEntry(game.toURI()).ifPresent(entries::add);
       }
     }
     return entries;

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -42,6 +42,7 @@ import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.IBean;
 import games.strategy.engine.framework.system.HttpProxy;
+import games.strategy.io.FileUtils;
 
 /**
  * A pbem dice roller that reads its configuration from a properties file.
@@ -61,8 +62,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       throw new IllegalStateException("No dice server folder:" + f);
     }
     final List<Properties> propFiles = new ArrayList<>();
-    final File[] files = f.listFiles();
-    for (final File file : files) {
+    for (final File file : FileUtils.listFiles(f)) {
       if (!file.isDirectory() && file.getName().endsWith(".properties")) {
         try {
           final Properties props = new Properties();

--- a/src/main/java/games/strategy/io/FileUtils.java
+++ b/src/main/java/games/strategy/io/FileUtils.java
@@ -1,0 +1,34 @@
+package games.strategy.io;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.Nullable;
+
+/**
+ * A collection of useful methods related to files.
+ */
+public final class FileUtils {
+  private FileUtils() {}
+
+  /**
+   * Returns a collection of abstract pathnames denoting the files and directories in the specified directory.
+   *
+   * @param directory The directory whose files are to be listed.
+   *
+   * @return An immutable collection of files. If {@code directory} does not denote a directory, the collection will be
+   *         empty.
+   *
+   * @see File#listFiles()
+   */
+  public static Collection<File> listFiles(final File directory) {
+    checkNotNull(directory);
+
+    final @Nullable File[] files = directory.listFiles();
+    return files != null ? Collections.unmodifiableList(Arrays.asList(files)) : Collections.emptyList();
+  }
+}

--- a/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -26,6 +26,7 @@ import java.util.zip.ZipFile;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.io.FileUtils;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.util.UrlStreams;
 import javazoom.jl.player.AudioDevice;
@@ -447,7 +448,7 @@ public class ClipPlayer {
       }
     }
     if (thisSoundFile.isDirectory()) {
-      for (final File soundFile : thisSoundFile.listFiles()) {
+      for (final File soundFile : FileUtils.listFiles(thisSoundFile)) {
         if (isSoundFileNamed(soundFile)) {
           try {
             final URL individualSoundUrl = soundFile.toURI().toURL();

--- a/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -18,6 +18,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.LocalPlayers;
+import games.strategy.io.FileUtils;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.util.CountDownLatchHandler;
@@ -247,11 +248,7 @@ public abstract class AbstractUiContext implements UiContext {
 
   private static Map<String, String> getSkins(final String mapName) {
     final Map<String, String> skinsByDisplayName = new HashMap<>();
-    final File[] files = ClientFileSystemHelper.getUserMapsFolder().listFiles();
-    if (files == null) {
-      return skinsByDisplayName;
-    }
-    for (final File f : files) {
+    for (final File f : FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder())) {
       if (mapSkinNameMatchesMapName(f.getName(), mapName)) {
         final String displayName = f.getName().replace(mapName + "-", "").replace("-master", "").replace(".zip", "");
         skinsByDisplayName.put(displayName, f.getName());

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -51,6 +51,7 @@ import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.io.FileUtils;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
@@ -664,7 +665,7 @@ public class DecorationPlacer extends JFrame {
     final int addY = (imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
         : (imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
     final List<String> allTerritories = new ArrayList<>(centers.keySet());
-    for (final File file : currentImageFolderLocation.listFiles()) {
+    for (final File file : FileUtils.listFiles(currentImageFolderLocation)) {
       if (!file.getPath().endsWith(".png") && !file.getPath().endsWith(".gif")) {
         continue;
       }

--- a/src/test/java/games/strategy/io/FileUtilsTest.java
+++ b/src/test/java/games/strategy/io/FileUtilsTest.java
@@ -1,0 +1,41 @@
+package games.strategy.io;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.experimental.extensions.MockitoExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+
+public final class FileUtilsTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class ListFilesTest {
+    @Spy
+    private final File directory = new File("");
+
+    @Test
+    public void shouldReturnFileCollectionWhenTargetIsDirectory() {
+      final File file1 = new File("file1");
+      final File file2 = new File("file2");
+      final File file3 = new File("file3");
+      when(directory.listFiles()).thenReturn(new File[] {file1, file2, file3});
+
+      assertThat(FileUtils.listFiles(directory), contains(file1, file2, file3));
+    }
+
+    @Test
+    public void shouldReturnEmptyCollectionWhenTargetIsNotDirectory() {
+      when(directory.listFiles()).thenReturn(null);
+
+      assertThat(FileUtils.listFiles(directory), is(empty()));
+    }
+  }
+}


### PR DESCRIPTION
`File#listFiles()` is annoying because it can return `null` if the target file is not a directory.  This leads to a lot of additional boilerplate around the use of this method.  In addition, some of the `null` checks introduced TOCTOUs because the result of the first check wasn't cached.  There are also some cases where a `null` check isn't performed, and an NPE will be thrown under the right conditions.

This PR introduces a new method to encapsulate the `null`-handling details, and replaces all usage of `File#listFiles()` with the new method.