### PR TITLE
Remove System#exit() calls from PointFileReaderWriter

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -165,7 +165,7 @@ public class MapData implements Closeable {
 
       initializeContains();
     } catch (final IOException ex) {
-      ClientLogger.logQuietly("Failed to load map properties", ex);
+      ClientLogger.logQuietly("Failed to initialize map data", ex);
     }
   }
 

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -22,8 +22,6 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.io.input.CloseShieldInputStream;
 
-import games.strategy.debug.ClientLogger;
-
 /**
  * Utility to read and write files in the form of
  * String -> a list of points, or string-> list of polygons.
@@ -137,7 +135,7 @@ public final class PointFileReaderWriter {
   /**
    * Returns a map of the form String -> Collection of points.
    */
-  public static Map<String, List<Point>> readOneToMany(final InputStream stream) {
+  public static Map<String, List<Point>> readOneToMany(final InputStream stream) throws IOException {
     checkNotNull(stream);
 
     final HashMap<String, List<Point>> mapping = new HashMap<>();
@@ -151,10 +149,6 @@ public final class PointFileReaderWriter {
         }
         current = reader.readLine();
       }
-    } catch (final IOException e) {
-      ClientLogger.logError("Failed to read one-to-many points file", e);
-      // FIXME: o_O Should not exit process from "library" code
-      System.exit(0);
     }
     return mapping;
   }
@@ -162,7 +156,7 @@ public final class PointFileReaderWriter {
   /**
    * Returns a map of the form String -> Collection of polygons.
    */
-  public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) {
+  public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
     final HashMap<String, List<Polygon>> mapping = new HashMap<>();
     try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
@@ -174,10 +168,6 @@ public final class PointFileReaderWriter {
         }
         current = reader.readLine();
       }
-    } catch (final IOException e) {
-      ClientLogger.logQuietly("Failed to read polygons", e);
-      // FIXME: o_O Should not exit process from "library" code
-      System.exit(0);
     }
     return mapping;
   }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -122,7 +122,8 @@ public class CenterPicker extends JFrame {
       try (InputStream is = new FileInputStream(file.getPath())) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ClientLogger.logQuietly("Something wrong with your Polygons file: " + file.getAbsolutePath(), e);
+        System.out.println("Something wrong with your Polygons file: " + file.getAbsolutePath());
+        e.printStackTrace();
         System.exit(0);
       }
     } else {
@@ -131,7 +132,8 @@ public class CenterPicker extends JFrame {
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ClientLogger.logQuietly("Something wrong with your Polygons file: " + polyPath, e);
+          System.out.println("Something wrong with your Polygons file: " + polyPath);
+          e.printStackTrace();
           System.exit(0);
         }
       }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -121,21 +121,19 @@ public class CenterPicker extends JFrame {
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(file.getPath())) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with your Polygons file: " + ex1);
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ClientLogger.logQuietly("Something wrong with your Polygons file: " + file.getAbsolutePath(), e);
+        System.exit(0);
       }
     } else {
-      try {
-        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
-        if (polyPath != null) {
-          try (InputStream is = new FileInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-          }
+      final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
+      if (polyPath != null) {
+        try (InputStream is = new FileInputStream(polyPath)) {
+          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+        } catch (final IOException e) {
+          ClientLogger.logQuietly("Something wrong with your Polygons file: " + polyPath, e);
+          System.exit(0);
         }
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with your Polygons file: " + ex1);
-        ex1.printStackTrace();
       }
     }
     createImage(mapName);

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -241,7 +241,8 @@ public class DecorationPlacer extends JFrame {
         System.out.println("Polygons : " + filePoly.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ClientLogger.logQuietly("Something wrong with your Polygons file: " + filePoly.getAbsolutePath(), e);
+        System.out.println("Something wrong with your Polygons file: " + filePoly.getAbsolutePath());
+        e.printStackTrace();
         System.exit(0);
       }
     } else {
@@ -252,7 +253,8 @@ public class DecorationPlacer extends JFrame {
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ClientLogger.logQuietly("Something wrong with your Polygons file: " + polyPath, e);
+          System.out.println("Something wrong with your Polygons file: " + polyPath);
+          e.printStackTrace();
           System.exit(0);
         }
       } else {
@@ -608,7 +610,8 @@ public class DecorationPlacer extends JFrame {
         try (InputStream in = new FileInputStream(centerName.getPathString())) {
           currentPoints = PointFileReaderWriter.readOneToMany(in);
         } catch (final IOException e) {
-          ClientLogger.logQuietly("Failed to load image points: " + centerName.getPathString(), e);
+          System.out.println("Failed to load image points: " + centerName.getPathString());
+          e.printStackTrace();
           System.exit(0);
         }
       } else {

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -240,28 +240,24 @@ public class DecorationPlacer extends JFrame {
       try (InputStream is = new FileInputStream(filePoly.getPath())) {
         System.out.println("Polygons : " + filePoly.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with your Polygons file");
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ClientLogger.logQuietly("Something wrong with your Polygons file: " + filePoly.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
-      try {
-        System.out.println("Select the Polygons file");
-        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
-        if (polyPath != null) {
-          System.out.println("Polygons : " + polyPath);
-          try (InputStream is = new FileInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-          }
-        } else {
-          System.out.println("You must specify a Polgyon file.");
-          System.out.println("Shutting down.");
+      System.out.println("Select the Polygons file");
+      final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
+      if (polyPath != null) {
+        System.out.println("Polygons : " + polyPath);
+        try (InputStream is = new FileInputStream(polyPath)) {
+          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+        } catch (final IOException e) {
+          ClientLogger.logQuietly("Something wrong with your Polygons file: " + polyPath, e);
           System.exit(0);
         }
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with your Polygons file");
-        ex1.printStackTrace();
+      } else {
+        System.out.println("You must specify a Polgyon file.");
+        System.out.println("Shutting down.");
         System.exit(0);
       }
     }
@@ -611,12 +607,15 @@ public class DecorationPlacer extends JFrame {
       if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
         try (InputStream in = new FileInputStream(centerName.getPathString())) {
           currentPoints = PointFileReaderWriter.readOneToMany(in);
+        } catch (final IOException e) {
+          ClientLogger.logQuietly("Failed to load image points: " + centerName.getPathString(), e);
+          System.exit(0);
         }
       } else {
         currentPoints = new HashMap<>();
       }
-    } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly("Failed to load points", ex);
+    } catch (final HeadlessException e) {
+      ClientLogger.logQuietly("Failed to load image points", e);
     }
   }
 

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -392,7 +392,8 @@ public class PolygonGrabber extends JFrame {
       try (InputStream in = new FileInputStream(polyName)) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(in);
       } catch (final IOException e) {
-        ClientLogger.logQuietly("Failed to load polygons: " + polyName, e);
+        System.out.println("Failed to load polygons: " + polyName);
+        e.printStackTrace();
         System.exit(0);
       }
       repaint();

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -391,10 +391,11 @@ public class PolygonGrabber extends JFrame {
       }
       try (InputStream in = new FileInputStream(polyName)) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+      } catch (final IOException e) {
+        ClientLogger.logQuietly("Failed to load polygons: " + polyName, e);
+        System.exit(0);
       }
       repaint();
-    } catch (final IOException ex) {
-      ClientLogger.logQuietly("file name = " + polyName, ex);
     } catch (final HeadlessException ex) {
       // TODO: remove HeadlessException (fix anti-pattern control flow via exception handling with proper control flow)
       ClientLogger.logQuietly("Failed to load polygons", ex);

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -118,7 +118,8 @@ public class TileImageReconstructor {
           try (InputStream in = new FileInputStream(polyName)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(in);
           } catch (final IOException e) {
-            ClientLogger.logQuietly("Failed to load polygons: " + polyName, e);
+            System.out.println("Failed to load polygons: " + polyName);
+            e.printStackTrace();
             System.exit(0);
           }
         }

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -117,6 +117,9 @@ public class TileImageReconstructor {
         if (polyName != null) {
           try (InputStream in = new FileInputStream(polyName)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+          } catch (final IOException e) {
+            ClientLogger.logQuietly("Failed to load polygons: " + polyName, e);
+            System.exit(0);
           }
         }
       } catch (final Exception ex) {

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -98,6 +98,7 @@ public class ConnectionFinder {
       }
     } catch (final IOException ex) {
       ClientLogger.logQuietly("Failed to load polygons: " + polyFile.getAbsolutePath(), ex);
+      System.exit(0);
     }
     if (!dimensionsSet) {
       final String lineWidth = JOptionPane.showInputDialog(null,

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -265,7 +265,8 @@ public class PlacementPicker extends JFrame {
         System.out.println("Polygons : " + file.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ClientLogger.logQuietly("Failed to load polygons: " + file.getAbsolutePath(), e);
+        System.out.println("Failed to load polygons: " + file.getAbsolutePath());
+        e.printStackTrace();
         System.exit(0);
       }
     } else {
@@ -276,7 +277,8 @@ public class PlacementPicker extends JFrame {
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ClientLogger.logQuietly("Failed to load polygons: " + polyPath, e);
+          System.out.println("Failed to load polygons: " + polyPath);
+          e.printStackTrace();
           System.exit(0);
         }
       } else {
@@ -509,7 +511,8 @@ public class PlacementPicker extends JFrame {
       try (InputStream in = new FileInputStream(placeName)) {
         placements = PointFileReaderWriter.readOneToMany(in);
       } catch (final IOException e) {
-        ClientLogger.logQuietly("Failed to load placements: " + placeName, e);
+        System.out.println("Failed to load placements: " + placeName);
+        e.printStackTrace();
         System.exit(0);
       }
       repaint();

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -264,23 +264,23 @@ public class PlacementPicker extends JFrame {
       try (InputStream is = new FileInputStream(file.getPath())) {
         System.out.println("Polygons : " + file.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-      } catch (final IOException ex1) {
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ClientLogger.logQuietly("Failed to load polygons: " + file.getAbsolutePath(), e);
+        System.exit(0);
       }
     } else {
-      try {
-        System.out.println("Select the Polygons file");
-        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
-        if (polyPath != null) {
-          System.out.println("Polygons : " + polyPath);
-          try (InputStream is = new FileInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
-          }
-        } else {
-          System.out.println("Polygons file not given. Will run regardless");
+      System.out.println("Select the Polygons file");
+      final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
+      if (polyPath != null) {
+        System.out.println("Polygons : " + polyPath);
+        try (InputStream is = new FileInputStream(polyPath)) {
+          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+        } catch (final IOException e) {
+          ClientLogger.logQuietly("Failed to load polygons: " + polyPath, e);
+          System.exit(0);
         }
-      } catch (final IOException ex1) {
-        ex1.printStackTrace();
+      } else {
+        System.out.println("Polygons file not given. Will run regardless");
       }
     }
     createImage(mapName);
@@ -508,10 +508,13 @@ public class PlacementPicker extends JFrame {
       }
       try (InputStream in = new FileInputStream(placeName)) {
         placements = PointFileReaderWriter.readOneToMany(in);
+      } catch (final IOException e) {
+        ClientLogger.logQuietly("Failed to load placements: " + placeName, e);
+        System.exit(0);
       }
       repaint();
-    } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly("Failed to load placements", ex);
+    } catch (final HeadlessException e) {
+      ClientLogger.logQuietly("Failed to load placements", e);
     }
   }
 


### PR DESCRIPTION
This PR removes two calls to `System#exit()` in two different `PointFileReaderWriter` methods.  This class is library code and should not terminate the process upon an error.

The TripleA client (via `MapData`) now handles exceptions thrown by all `PointFileReaderWriter#readXXX()` methods consistently.

However, I preserved the application termination behavior in tool code because it wasn't clear to me if not exiting the application upon an error would introduce other problems.  Fixing the error handling behavior in the tool code appears to be a huge task and will probably require a few PRs in and of itself.

It's recommended to review this PR with whitespace changes ignored (`?w=1`).