### PR TITLE
Checkstyle: Fix abbreviation violations in Properties

### DIFF
--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -6,12 +6,15 @@ import games.strategy.engine.data.PlayerID;
 /**
  * Provides typed access to the properties of GameData.
  */
-public class Properties implements Constants {
+public final class Properties implements Constants {
+  private Properties() {}
+
   // These should always default to false, if boolean, and if not should default to whatever is the "default" behavior
   // of TripleA.
   // If you want something to default to "true", when change the wording of the constant to make it a negative of
   // itself, then default to
   // false. (ex: "Do not do something", false; instead of "Do something", true;)
+
   public static int getNeutralCharge(final GameData data) {
     return data.getProperties().get(NEUTRAL_CHARGE_PROPERTY, 0);
   }
@@ -127,14 +130,14 @@ public class Properties implements Constants {
   /*
    * Are AA casualties chosen randomly
    */
-  public static boolean getRandomAACasualties(final GameData data) {
+  public static boolean getRandomAaCasualties(final GameData data) {
     return data.getProperties().get(RANDOM_AA_CASUALTIES, false);
   }
 
   /*
    * Are AA casualties chosen randomly
    */
-  public static boolean getRollAAIndividually(final GameData data) {
+  public static boolean getRollAaIndividually(final GameData data) {
     return data.getProperties().get(ROLL_AA_INDIVIDUALLY, false);
   }
 
@@ -142,7 +145,7 @@ public class Properties implements Constants {
    * Limit the damage caused by each bomber on rockets and Strategic Bomb Raids to
    * production of territory
    */
-  public static boolean getLimitRocketAndSBRDamageToProduction(final GameData data) {
+  public static boolean getLimitRocketAndSbrDamageToProduction(final GameData data) {
     return data.getProperties().get(LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION, false);
   }
 
@@ -150,7 +153,7 @@ public class Properties implements Constants {
    * Limit the TOTAL damage caused by Bombers in a turn to territory's
    * production
    */
-  public static boolean getLimitSBRDamagePerTurn(final GameData data) {
+  public static boolean getLimitSbrDamagePerTurn(final GameData data) {
     return data.getProperties().get(LIMIT_SBR_DAMAGE_PER_TURN, false);
   }
 
@@ -166,14 +169,14 @@ public class Properties implements Constants {
    * Limit the TOTAL PUs lost to Bombers/Rockets in a turn to territory's
    * production.
    */
-  public static boolean getPUCap(final GameData data) {
+  public static boolean getPuCap(final GameData data) {
     return data.getProperties().get(PU_CAP, false);
   }
 
   /**
    * Reduce Victory Points by Strategic Bombing.
    */
-  public static boolean getSBRVictoryPoint(final GameData data) {
+  public static boolean getSbrVictoryPoints(final GameData data) {
     return data.getProperties().get(SBR_VICTORY_POINTS, false);
   }
 
@@ -222,7 +225,7 @@ public class Properties implements Constants {
   /**
    * Restricted from blitz through territories with factories/AA.
    */
-  public static boolean getBlitzThroughFactoriesAndAARestricted(final GameData data) {
+  public static boolean getBlitzThroughFactoriesAndAaRestricted(final GameData data) {
     return data.getProperties().get(BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED, false);
   }
 
@@ -342,11 +345,11 @@ public class Properties implements Constants {
   /**
    * AA restricted to Attacked Territory Only.
    */
-  public static boolean getAATerritoryRestricted(final GameData data) {
+  public static boolean getAaTerritoryRestricted(final GameData data) {
     return data.getProperties().get(AA_TERRITORY_RESTRICTED, false);
   }
 
-  public static boolean getMultipleAAPerTerritory(final GameData data) {
+  public static boolean getMultipleAaPerTerritory(final GameData data) {
     return data.getProperties().get(MULTIPLE_AA_PER_TERRITORY, false);
   }
 
@@ -358,11 +361,11 @@ public class Properties implements Constants {
     return data.getProperties().get(TRIGGERS, false);
   }
 
-  public static boolean getAlwaysOnAA(final GameData data) {
+  public static boolean getAlwaysOnAa(final GameData data) {
     return data.getProperties().get(ALWAYS_ON_AA_PROPERTY, false);
   }
 
-  public static boolean getLHTRCarrierProductionRules(final GameData data) {
+  public static boolean getLhtrCarrierProductionRules(final GameData data) {
     return data.getProperties().get(LHTR_CARRIER_PRODUCTION_RULES, false);
   }
 
@@ -401,63 +404,63 @@ public class Properties implements Constants {
     return data.getProperties().get(TWO_HITPOINT_UNITS_REQUIRE_REPAIR_FACILITIES, false);
   }
 
-  public static boolean getChoose_AA_Casualties(final GameData data) {
+  public static boolean getChooseAaCasualties(final GameData data) {
     return data.getProperties().get(CHOOSE_AA, false);
   }
 
-  public static boolean getSubmersible_Subs(final GameData data) {
+  public static boolean getSubmersibleSubs(final GameData data) {
     return data.getProperties().get(SUBMERSIBLE_SUBS, false);
   }
 
-  public static boolean getUse_Destroyers_And_Artillery(final GameData data) {
+  public static boolean getUseDestroyersAndArtillery(final GameData data) {
     return data.getProperties().get(USE_DESTROYERS_AND_ARTILLERY, false);
   }
 
-  public static boolean getUse_Shipyards(final GameData data) {
+  public static boolean getUseShipyards(final GameData data) {
     return data.getProperties().get(USE_SHIPYARDS, false);
   }
 
-  public static boolean getLow_Luck(final GameData data) {
+  public static boolean getLowLuck(final GameData data) {
     return data.getProperties().get(LOW_LUCK, false);
   }
 
-  public static boolean getLL_AA_ONLY(final GameData data) {
+  public static boolean getLowLuckAaOnly(final GameData data) {
     return data.getProperties().get(LL_AA_ONLY, false);
   }
 
-  public static boolean getLL_TECH_ONLY(final GameData data) {
+  public static boolean getLowLuckTechOnly(final GameData data) {
     return data.getProperties().get(LL_TECH_ONLY, false);
   }
 
-  public static boolean getLL_DAMAGE_ONLY(final GameData data) {
+  public static boolean getLowLuckDamageOnly(final GameData data) {
     return data.getProperties().get(LL_DAMAGE_ONLY, false);
   }
 
-  public static boolean getKamikaze_Airplanes(final GameData data) {
+  public static boolean getKamikazeAirplanes(final GameData data) {
     return data.getProperties().get(KAMIKAZE, false);
   }
 
-  public static boolean getLHTR_Heavy_Bombers(final GameData data) {
+  public static boolean getLhtrHeavyBombers(final GameData data) {
     return data.getProperties().get(LHTR_HEAVY_BOMBERS, false);
   }
 
-  public static int getSuper_Sub_Defense_Bonus(final GameData data) {
+  public static int getSuperSubDefenseBonus(final GameData data) {
     return data.getProperties().get(SUPER_SUB_DEFENSE_BONUS, 0);
   }
 
-  public static boolean getScramble_Rules_In_Effect(final GameData data) {
+  public static boolean getScrambleRulesInEffect(final GameData data) {
     return data.getProperties().get(SCRAMBLE_RULES_IN_EFFECT, false);
   }
 
-  public static boolean getScrambled_Units_Return_To_Base(final GameData data) {
+  public static boolean getScrambledUnitsReturnToBase(final GameData data) {
     return data.getProperties().get(SCRAMBLED_UNITS_RETURN_TO_BASE, false);
   }
 
-  public static boolean getScramble_To_Sea_Only(final GameData data) {
+  public static boolean getScrambleToSeaOnly(final GameData data) {
     return data.getProperties().get(SCRAMBLE_TO_SEA_ONLY, false);
   }
 
-  public static boolean getScramble_From_Island_Only(final GameData data) {
+  public static boolean getScrambleFromIslandOnly(final GameData data) {
     return data.getProperties().get(SCRAMBLE_FROM_ISLAND_ONLY, false);
   }
 
@@ -465,7 +468,7 @@ public class Properties implements Constants {
     return data.getProperties().get(SCRAMBLE_TO_ANY_AMPHIBIOUS_ASSAULT, false);
   }
 
-  public static int getPU_Multiplier(final GameData data) {
+  public static int getPuMultiplier(final GameData data) {
     return data.getProperties().get(PU_MULTIPLIER, 1);
   }
 
@@ -566,7 +569,7 @@ public class Properties implements Constants {
     return data.getProperties().get(KAMIKAZE_SUICIDE_ATTACKS_DONE_BY_CURRENT_TERRITORY_OWNER, false);
   }
 
-  public static boolean getForceAAattacksForLastStepOfFlyOver(final GameData data) {
+  public static boolean getForceAaAttacksForLastStepOfFlyOver(final GameData data) {
     return data.getProperties().get(FORCE_AA_ATTACKS_FOR_LAST_STEP_OF_FLY_OVER, false);
   }
 
@@ -667,6 +670,4 @@ public class Properties implements Constants {
   public static boolean getControlAllCanalsBetweenTerritoriesToPass(final GameData data) {
     return data.getProperties().get(CONTROL_ALL_CANALS_BETWEEN_TERRITORIES_TO_PASS, false);
   }
-
-  private Properties() {}
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAi.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAi.java
@@ -350,7 +350,7 @@ public class ProAi extends AbstractAi {
         defenders.removeAll(defaultCasualties.getKilled());
         final double strengthDifference = ProBattleUtils.estimateStrengthDifference(battlesite, attackers, defenders);
         int minStrengthDifference = 60;
-        if (!Properties.getLow_Luck(data)) {
+        if (!Properties.getLowLuck(data)) {
           minStrengthDifference = 55;
         }
         if (strengthDifference > minStrengthDifference) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -56,7 +56,7 @@ public class ProData {
     ProData.player = player;
     ProData.isSimulation = isSimulation;
 
-    if (!Properties.getLow_Luck(data)) {
+    if (!Properties.getLowLuck(data)) {
       winPercentage = 90;
       minWinPercentage = 65;
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -293,13 +293,13 @@ public class ProTerritoryManager {
   private static void findScrambleOptions(final PlayerID player, final Map<Territory, ProTerritory> moveMap) {
     final GameData data = ProData.getData();
 
-    if (!Properties.getScramble_Rules_In_Effect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data)) {
       return;
     }
 
     // Find scramble properties
-    final boolean fromIslandOnly = Properties.getScramble_From_Island_Only(data);
-    final boolean toSeaOnly = Properties.getScramble_To_Sea_Only(data);
+    final boolean fromIslandOnly = Properties.getScrambleFromIslandOnly(data);
+    final boolean toSeaOnly = Properties.getScrambleToSeaOnly(data);
     final int maxScrambleDistance = StreamSupport.stream(data.getUnitTypeList().spliterator(), false)
         .map(UnitAttachment::get)
         .filter(UnitAttachment::getCanScramble)

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -137,7 +137,7 @@ public class ProUtils {
         production += TerritoryAttachment.getProduction(place);
       }
     }
-    production *= Properties.getPU_Multiplier(data);
+    production *= Properties.getPuMultiplier(data);
     return production;
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1310,7 +1310,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           final List<UnitType> allBombers =
               CollectionUtils.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsStrategicBomber());
           final int heavyBomberDiceRollsTotal = Properties.getHeavyBomberDiceRolls(data);
-          final boolean heavyBombersLhtr = Properties.getLHTR_Heavy_Bombers(data);
+          final boolean heavyBombersLhtr = Properties.getLhtrHeavyBombers(data);
           for (final UnitType bomber : allBombers) {
             // TODO: The bomber dice rolls get set when the xml is parsed.
             // we subtract the base rolls to get the bonus

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2396,7 +2396,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         for (int i = 0; i < eachMultiple; ++i) {
           int toAdd = t.getResourceCount();
           if (t.getResource().equals(Constants.PUS)) {
-            toAdd *= Properties.getPU_Multiplier(data);
+            toAdd *= Properties.getPuMultiplier(data);
           }
           int total = player.getResources().getQuantity(t.getResource()) + toAdd;
           if (total < 0) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1612,7 +1612,7 @@ public class UnitAttachment extends DefaultAttachment {
     int defenseValue =
         m_defense + TechAbilityAttachment.getDefenseBonus((UnitType) this.getAttachedTo(), player, getData());
     if (defenseValue > 0 && m_isSub && TechTracker.hasSuperSubs(player)) {
-      final int bonus = Properties.getSuper_Sub_Defense_Bonus(getData());
+      final int bonus = Properties.getSuperSubDefenseBonus(getData());
       defenseValue += bonus;
     }
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
@@ -2744,7 +2744,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (max == Integer.MAX_VALUE && (ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly())) {
       // under certain rules (classic rules) there can only be 1 aa gun in a territory.
       if (!(Properties.getWW2V2(data) || Properties.getWW2V3(data)
-          || Properties.getMultipleAAPerTerritory(data))) {
+          || Properties.getMultipleAaPerTerritory(data))) {
         max = 1;
       }
     }
@@ -3165,10 +3165,10 @@ public class UnitAttachment extends DefaultAttachment {
       if (getIsAAforCombatOnly() && getIsAAforBombingThisUnitOnly() && getIsAAforFlyOverOnly()) {
         stats.append(getTypeAA()).append(", ");
       } else if (getIsAAforCombatOnly() && getIsAAforFlyOverOnly()
-          && !Properties.getAATerritoryRestricted(getData())) {
+          && !Properties.getAaTerritoryRestricted(getData())) {
         stats.append(getTypeAA()).append(" for Combat & Move Through, ");
       } else if (getIsAAforBombingThisUnitOnly() && getIsAAforFlyOverOnly()
-          && !Properties.getAATerritoryRestricted(getData())) {
+          && !Properties.getAaTerritoryRestricted(getData())) {
         stats.append(getTypeAA()).append(" for Raids & Move Through, ");
       } else if (getIsAAforCombatOnly()) {
         stats.append(getTypeAA()).append(" for Combat, ");
@@ -3222,10 +3222,10 @@ public class UnitAttachment extends DefaultAttachment {
     } else if (getCanBeDamaged()) {
       stats.append("can be Attacked By Raids, ");
     }
-    if (getIsAirBase() && Properties.getScramble_Rules_In_Effect(getData())) {
+    if (getIsAirBase() && Properties.getScrambleRulesInEffect(getData())) {
       stats.append("can Allow Scrambling, ");
     }
-    if (getCanScramble() && Properties.getScramble_Rules_In_Effect(getData())) {
+    if (getCanScramble() && Properties.getScrambleRulesInEffect(getData())) {
       stats.append("can Scramble ").append(getMaxScrambleDistance() > 0 ? getMaxScrambleDistance() : 1)
           .append(" Distance, ");
     }
@@ -3317,7 +3317,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (getIsSuicideOnHit()) {
       stats.append("SuicideOnHit Unit, ");
     }
-    if (getIsAir() && (getIsKamikaze() || Properties.getKamikaze_Airplanes(getData()))) {
+    if (getIsAir() && (getIsKamikaze() || Properties.getKamikazeAirplanes(getData()))) {
       stats.append("can use All Movement To Attack Target, ");
     }
     if ((getIsInfantry() || getIsLandTransportable()) && playerHasMechInf(player)) {
@@ -3438,7 +3438,7 @@ public class UnitAttachment extends DefaultAttachment {
           && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
-              || Properties.getMultipleAAPerTerritory(getData()))) {
+              || Properties.getMultipleAaPerTerritory(getData()))) {
         stats.append("max of 1 ").append(getMovementLimit().getSecond()).append(" moving per territory, ");
       } else if (getMovementLimit().getFirst() < 10000) {
         stats.append("max of ").append(getMovementLimit().getFirst()).append(" ").append(getMovementLimit().getSecond())
@@ -3450,7 +3450,7 @@ public class UnitAttachment extends DefaultAttachment {
           && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
-              || Properties.getMultipleAAPerTerritory(getData()))) {
+              || Properties.getMultipleAaPerTerritory(getData()))) {
         stats.append("max of 1 ").append(getAttackingLimit().getSecond()).append(" attacking per territory, ");
       } else if (getAttackingLimit().getFirst() < 10000) {
         stats.append("max of ").append(getAttackingLimit().getFirst()).append(" ")
@@ -3462,7 +3462,7 @@ public class UnitAttachment extends DefaultAttachment {
           && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
-              || Properties.getMultipleAAPerTerritory(getData()))) {
+              || Properties.getMultipleAaPerTerritory(getData()))) {
         stats.append("max of 1 ").append(getPlacementLimit().getSecond()).append(" placed per territory, ");
       } else if (getPlacementLimit().getFirst() < 10000) {
         stats.append("max of ").append(getPlacementLimit().getFirst()).append(" ")

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -50,11 +50,11 @@ class AAInMoveUtil implements Serializable {
   }
 
   private boolean isAlwaysOnAaEnabled() {
-    return Properties.getAlwaysOnAA(getData());
+    return Properties.getAlwaysOnAa(getData());
   }
 
   private boolean isAaTerritoryRestricted() {
-    return Properties.getAATerritoryRestricted(getData());
+    return Properties.getAaTerritoryRestricted(getData());
   }
 
   private ITripleAPlayer getRemotePlayer(final PlayerID id) {
@@ -207,7 +207,7 @@ class AAInMoveUtil implements Serializable {
         territoriesWhereAaWillFire.add(current);
       }
     }
-    if (Properties.getForceAAattacksForLastStepOfFlyOver(data)) {
+    if (Properties.getForceAaAttacksForLastStepOfFlyOver(data)) {
       if (route.getEnd().getUnits().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(route.getEnd());
       }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -81,7 +81,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       int toAdd = getProduction(territories);
       final int blockadeLoss = getBlockadeProductionLoss(player, data, bridge, endTurnReport);
       toAdd -= blockadeLoss;
-      toAdd *= Properties.getPU_Multiplier(data);
+      toAdd *= Properties.getPuMultiplier(data);
       int total = player.getResources().getQuantity(pus) + toAdd;
       final String transcriptText;
       if (blockadeLoss == 0) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -734,7 +734,7 @@ public class AirMovementValidator {
   }
 
   private static boolean isKamikazeAircraft(final GameData data) {
-    return Properties.getKamikaze_Airplanes(data);
+    return Properties.getKamikazeAirplanes(data);
   }
 
   private static boolean areNeutralsPassableByAir(final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -27,7 +27,7 @@ public class AirThatCantLandUtil {
   }
 
   public static boolean isLhtrCarrierProduction(final GameData data) {
-    return Properties.getLHTRCarrierProductionRules(data);
+    return Properties.getLhtrCarrierProductionRules(data);
   }
 
   public static boolean isLandExistingFightersOnNewCarriers(final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -112,7 +112,7 @@ public class BattleCalculator {
           dice.getHits(), allowMultipleHitsPerUnit);
     }
 
-    if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
+    if (Properties.getLowLuck(data) || Properties.getLowLuckAaOnly(data)) {
       return getLowLuckAaCasualties(defending, planes, defendingAa, dice, bridge, allowMultipleHitsPerUnit);
     }
 
@@ -985,21 +985,21 @@ public class BattleCalculator {
    * @return Random AA Casualties - casualties randomly assigned.
    */
   private static boolean isRandomAaCasualties(final GameData data) {
-    return Properties.getRandomAACasualties(data);
+    return Properties.getRandomAaCasualties(data);
   }
 
   /**
    * @return Roll AA Individually - roll against each aircraft.
    */
   private static boolean isRollAaIndividually(final GameData data) {
-    return Properties.getRollAAIndividually(data);
+    return Properties.getRollAaIndividually(data);
   }
 
   /**
    * @return Choose AA - attacker selects casualties.
    */
   private static boolean isChooseAa(final GameData data) {
-    return Properties.getChoose_AA_Casualties(data);
+    return Properties.getChooseAaCasualties(data);
   }
 
   /**
@@ -1021,7 +1021,7 @@ public class BattleCalculator {
    */
   public static int getUnitPowerForSorting(final Unit current, final boolean defending, final GameData data,
       final Collection<TerritoryEffect> territoryEffects) {
-    final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
     final UnitAttachment ua = UnitAttachment.get(current.getType());
     final int rolls = (defending) ? ua.getDefenseRolls(current.getOwner()) : ua.getAttackRolls(current.getOwner());
     int strengthWithoutSupport = 0;

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -610,11 +610,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     // first, figure out all the territories where scrambling units could scramble to
     // then ask the defending player if they wish to scramble units there, and actually move the units there
     final GameData data = getData();
-    if (!Properties.getScramble_Rules_In_Effect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data)) {
       return;
     }
-    final boolean fromIslandOnly = Properties.getScramble_From_Island_Only(data);
-    final boolean toSeaOnly = Properties.getScramble_To_Sea_Only(data);
+    final boolean fromIslandOnly = Properties.getScrambleFromIslandOnly(data);
+    final boolean toSeaOnly = Properties.getScrambleToSeaOnly(data);
     final boolean toAnyAmphibious = Properties.getScrambleToAnyAmphibiousAssault(data);
     final boolean toSbr = Properties.getCanScrambleIntoAirBattles(data);
     int maxScrambleDistance = 0;
@@ -946,10 +946,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private void scramblingCleanup() {
     // return scrambled units to their original territories, or let them move 1 or x to a new territory.
     final GameData data = getData();
-    if (!Properties.getScramble_Rules_In_Effect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data)) {
       return;
     }
-    final boolean mustReturnToBase = Properties.getScrambled_Units_Return_To_Base(data);
+    final boolean mustReturnToBase = Properties.getScrambledUnitsReturnToBase(data);
     for (final Territory t : data.getMap().getTerritories()) {
       int carrierCostOfCurrentTerr = 0;
       final Collection<Unit> wasScrambled = t.getUnits().getMatches(Matches.unitWasScrambled());
@@ -996,7 +996,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private static void resetMaxScrambleCount(final IDelegateBridge bridge) {
     // reset the tripleaUnit property for all airbases that were used
     final GameData data = bridge.getData();
-    if (!Properties.getScramble_Rules_In_Effect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data)) {
       return;
     }
     final CompositeChange change = new CompositeChange();
@@ -1347,7 +1347,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final CompositeChange change = new CompositeChange();
     int hits = 0;
     int[] rolls = null;
-    if (Properties.getLow_Luck(data)) {
+    if (Properties.getLowLuck(data)) {
       int power = 0;
       for (final Entry<Resource, Integer> entry : numberOfAttacks.entrySet()) {
         final Resource r = entry.getKey();

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -392,7 +392,7 @@ public class BattleTracker implements Serializable {
       presentFromStartTilEnd.removeAll(unitsNotUnloadedTilEndOfRoute);
     }
     final boolean canConquerMiddleSteps = presentFromStartTilEnd.stream().anyMatch(Matches.unitIsNotAir());
-    final boolean scramblingEnabled = Properties.getScramble_Rules_In_Effect(data);
+    final boolean scramblingEnabled = Properties.getScrambleRulesInEffect(data);
     final Predicate<Territory> conquerable = Matches.territoryIsEmptyOfCombatUnits(data, id)
         .and(Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id)
             .or(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)));

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -151,7 +151,7 @@ public class DiceRoll implements Externalizable {
     final Triple<Integer, Integer, Boolean> triple = getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
         null, null, defending, defendingAa, validAttackingUnitsForThisRoll, data, false);
     final int totalPower = triple.getFirst();
-    if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
+    if (Properties.getLowLuck(data) || Properties.getLowLuckAaOnly(data)) {
       final String annotation = "Roll " + typeAa + " in " + location.getName();
       hits += getLowLuckHits(bridge, sortedDice, totalPower, chosenDiceSizeForAll, defendingAa.get(0).getOwner(),
           annotation);
@@ -367,7 +367,7 @@ public class DiceRoll implements Externalizable {
       final IDelegateBridge bridge, final IBattle battle, final String annotation,
       final Collection<TerritoryEffect> territoryEffects, final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
     // Decide whether to use low luck rules or normal rules.
-    if (Properties.getLow_Luck(bridge.getData())) {
+    if (Properties.getLowLuck(bridge.getData())) {
       return rollDiceLowLuck(units, defending, player, bridge, battle, annotation, territoryEffects,
           allEnemyUnitsAliveOrWaitingToDie);
     }
@@ -520,8 +520,8 @@ public class DiceRoll implements Externalizable {
   private static Tuple<Integer, Integer> getTotalPowerAndRolls(
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
     final int diceSides = data.getDiceSides();
-    final boolean lowLuck = Properties.getLow_Luck(data);
-    final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(data);
+    final boolean lowLuck = Properties.getLowLuck(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
     // bonus is normally 1 for most games
     final int extraRollBonus = Math.max(1, data.getDiceSides() / 6);
     int totalPower = 0;
@@ -849,7 +849,7 @@ public class DiceRoll implements Externalizable {
       }
     }
     final GameData data = bridge.getData();
-    final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
     final List<Unit> units = new ArrayList<>(unitsList);
     final int rollCount = AirBattle.getAirBattleRolls(unitsList, defending);
     if (rollCount == 0) {
@@ -882,7 +882,7 @@ public class DiceRoll implements Externalizable {
       totalPower += Math.min(Math.max(totalStrength, 0), data.getDiceSides());
     }
 
-    if (Properties.getLow_Luck(data)) {
+    if (Properties.getLowLuck(data)) {
       // Get number of hits
       hitCount = totalPower / data.getDiceSides();
       random = new int[0];
@@ -972,7 +972,7 @@ public class DiceRoll implements Externalizable {
       return new DiceRoll(new ArrayList<>(), 0, 0);
     }
     final int[] random = bridge.getRandom(data.getDiceSides(), rollCount, player, DiceType.COMBAT, annotation);
-    final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
     final List<Die> dice = new ArrayList<>();
     int hitCount = 0;
     int diceIndex = 0;

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -185,7 +185,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
         continue;
       }
       if (resource.getName().equals(Constants.PUS)) {
-        toAdd *= Properties.getPU_Multiplier(getData());
+        toAdd *= Properties.getPuMultiplier(getData());
       }
       int total = player.getResources().getQuantity(resource) + toAdd;
       if (total < 0) {
@@ -256,7 +256,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
         continue;
       }
       int toAdd = rule.getObjectiveValue();
-      toAdd *= Properties.getPU_Multiplier(data);
+      toAdd *= Properties.getPuMultiplier(data);
       toAdd *= rule.getEachMultiple();
       int total = player.getResources().getQuantity(Constants.PUS) + toAdd;
       if (total < 0) {

--- a/src/main/java/games/strategy/triplea/delegate/ImprovedShipyardsAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/ImprovedShipyardsAdvance.java
@@ -30,7 +30,7 @@ public final class ImprovedShipyardsAdvance extends TechAdvance {
   @Override
   public void perform(final PlayerID id, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getUse_Shipyards(data)) {
+    if (!Properties.getUseShipyards(data)) {
       return;
     }
     final ProductionFrontier current = id.getProductionFrontier();

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -230,7 +230,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initDestroyerArtillery(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final boolean addArtilleryAndDestroyers = Properties.getUse_Destroyers_And_Artillery(data);
+    final boolean addArtilleryAndDestroyers = Properties.getUseDestroyersAndArtillery(data);
     if (!isWW2V2(data) && addArtilleryAndDestroyers) {
       final CompositeChange change = new CompositeChange();
       final ProductionRule artillery = data.getProductionRuleList().getProductionRule("buyArtillery");
@@ -265,7 +265,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initShipyards(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final boolean useShipyards = Properties.getUse_Shipyards(data);
+    final boolean useShipyards = Properties.getUseShipyards(data);
     if (useShipyards) {
       final CompositeChange change = new CompositeChange();
       final ProductionFrontier frontierShipyards =

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1288,7 +1288,7 @@ public final class Matches {
           .of(enemyUnit(player, data).negate())
           // WW2V2, cant blitz through factories and aa guns
           // WW2V1, you can
-          .orIf(!Properties.getWW2V2(data) && !Properties.getBlitzThroughFactoriesAndAARestricted(data),
+          .orIf(!Properties.getWW2V2(data) && !Properties.getBlitzThroughFactoriesAndAaRestricted(data),
               unitIsInfrastructure())
           .build();
       return t.getUnits().allMatch(blitzableUnits);

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -561,7 +561,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       return errorMsg.append(result.getDisallowedUnitWarning(0)).append(numErrorsMsg).toString();
     }
     boolean isKamikaze = false;
-    final boolean getKamikazeAir = Properties.getKamikaze_Airplanes(data);
+    final boolean getKamikazeAir = Properties.getKamikazeAirplanes(data);
     Collection<Unit> kamikazeUnits = new ArrayList<>();
 
     // confirm kamikaze moves, and remove them from unresolved units

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -960,7 +960,7 @@ public class MoveValidator {
       }
       final Collection<Unit> transports = TransportUtils.mapTransports(route, units, null).values();
       final boolean isScramblingOrKamikazeAttacksEnabled =
-          Properties.getScramble_Rules_In_Effect(data) || Properties.getUseKamikazeSuicideAttacks(data);
+          Properties.getScrambleRulesInEffect(data) || Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
       final Predicate<Unit> enemySubmarineMatch = Matches.unitIsEnemyOf(data, player).and(Matches.unitIsSub());
@@ -1556,7 +1556,7 @@ public class MoveValidator {
   }
 
   private static boolean isSubmersibleSubsAllowed(final GameData data) {
-    return Properties.getSubmersible_Subs(data);
+    return Properties.getSubmersibleSubs(data);
   }
 
   private static boolean isIgnoreTransportInMovement(final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -133,7 +133,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canSubsSubmerge() {
-    return Properties.getSubmersible_Subs(m_data);
+    return Properties.getSubmersibleSubs(m_data);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -59,7 +59,7 @@ public class RocketsFireHelper {
   }
 
   private static boolean isPuCap(final GameData data) {
-    return Properties.getPUCap(data);
+    return Properties.getPuCap(data);
   }
 
   private static boolean isLimitRocketDamagePerTurn(final GameData data) {
@@ -67,7 +67,7 @@ public class RocketsFireHelper {
   }
 
   private static boolean isLimitRocketDamageToProduction(final GameData data) {
-    return Properties.getLimitRocketAndSBRDamageToProduction(data);
+    return Properties.getLimitRocketAndSbrDamageToProduction(data);
   }
 
   static void fireRockets(final IDelegateBridge bridge, final PlayerID player) {
@@ -248,7 +248,7 @@ public class RocketsFireHelper {
     final boolean doNotUseBombingBonus =
         !Properties.getUseBombingMaxDiceSidesAndBonus(data) || rockets == null;
     int cost = 0;
-    if (!Properties.getLL_DAMAGE_ONLY(data)) {
+    if (!Properties.getLowLuckDamageOnly(data)) {
       if (doNotUseBombingBonus || rockets == null) {
         // no low luck, and no bonus, so just roll based on the map's dice sides
         final int[] rolls = bridge.getRandom(data.getDiceSides(), numberOfAttacks, player, DiceType.BOMBING,
@@ -399,7 +399,7 @@ public class RocketsFireHelper {
       bridge.getHistoryWriter().startEvent("Rocket attack in " + attackedTerritory.getName() + " does " + cost
           + " damage to " + targets.iterator().next());
     } else {
-      cost *= Properties.getPU_Multiplier(data);
+      cost *= Properties.getPuMultiplier(data);
       getRemote(bridge).reportMessage("Rocket attack in " + attackedTerritory.getName() + " costs:" + cost,
           "Rocket attack in " + attackedTerritory.getName() + " costs:" + cost);
       // Trying to remove more PUs than the victim has is A Bad Thing[tm]

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -449,19 +449,19 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private boolean isLimitSbrDamageToProduction() {
-    return Properties.getLimitRocketAndSBRDamageToProduction(m_data);
+    return Properties.getLimitRocketAndSbrDamageToProduction(m_data);
   }
 
   private static boolean isLimitSbrDamagePerTurn(final GameData data) {
-    return Properties.getLimitSBRDamagePerTurn(data);
+    return Properties.getLimitSbrDamagePerTurn(data);
   }
 
   private static boolean isPuCap(final GameData data) {
-    return Properties.getPUCap(data);
+    return Properties.getPuCap(data);
   }
 
   private boolean isSbrVictoryPoints() {
-    return Properties.getSBRVictoryPoint(m_data);
+    return Properties.getSbrVictoryPoints(m_data);
   }
 
   private boolean isPacificTheater() {
@@ -597,7 +597,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             !Properties.getUseBombingMaxDiceSidesAndBonus(m_data);
         final String annotation = m_attacker.getName() + " rolling to allocate cost of strategic bombing raid against "
             + m_defender.getName() + " in " + m_battleSite.getName();
-        if (!Properties.getLL_DAMAGE_ONLY(m_data)) {
+        if (!Properties.getLowLuckDamageOnly(m_data)) {
           if (doNotUseBombingBonus) {
             // no low luck, and no bonus, so just roll based on the map's dice sides
             m_dice = bridge.getRandom(m_data.getDiceSides(), rollCount, m_attacker, DiceType.BOMBING, annotation);
@@ -703,7 +703,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       }
       int damageLimit = TerritoryAttachment.getProduction(m_battleSite);
       int cost = 0;
-      final boolean lhtrBombers = Properties.getLHTR_Heavy_Bombers(m_data);
+      final boolean lhtrBombers = Properties.getLhtrHeavyBombers(m_data);
       int index = 0;
       final boolean limitDamage = isWW2V2() || isLimitSbrDamageToProduction();
       final List<Die> dice = new ArrayList<>();
@@ -814,7 +814,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       } else {
         // Record PUs lost
         DelegateFinder.moveDelegate(m_data).pusLost(m_battleSite, cost);
-        cost *= Properties.getPU_Multiplier(m_data);
+        cost *= Properties.getPuMultiplier(m_data);
         getDisplay(bridge).bombingResults(m_battleID, dice, cost);
         if (cost > 0) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BOMBING_STRATEGIC, m_attacker);

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -169,7 +169,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   private boolean isLowLuckTechOnly() {
-    return Properties.getLL_TECH_ONLY(getData());
+    return Properties.getLowLuckTechOnly(getData());
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -690,7 +690,7 @@ class OddsCalculatorPanel extends JPanel {
     numRuns.setMin(1);
     numRuns.setMax(20000);
 
-    final int simulationCount = Properties.getLow_Luck(data)
+    final int simulationCount = Properties.getLowLuck(data)
         ? ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK.intValue()
         : ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE.intValue();
     numRuns.setValue(simulationCount);

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -71,7 +71,7 @@ public class PlacePanel extends AbstractMovePanel {
   }
 
   private boolean isLhtrCarrierProductionRules() {
-    return Properties.getLHTRCarrierProductionRules(getData());
+    return Properties.getLhtrCarrierProductionRules(getData());
   }
 
   private final MapSelectionListener placeMapSelectionListener = new DefaultMapSelectionListener() {

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -453,7 +453,7 @@ public class StatPanel extends AbstractStatPanel {
           production += TerritoryAttachment.getProduction(place);
         }
       }
-      production *= Properties.getPU_Multiplier(data);
+      production *= Properties.getPuMultiplier(data);
       return production;
     }
   }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in the `g.s.triplea.Properties` class.  Some of the method names made me suspicious that they might be called via reflection, but I couldn't find any reflective usage.