### PR TITLE
Replace MD5Crypt implementation with Apache Commons Md5Crypt

### DIFF
--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -1,226 +1,95 @@
 package games.strategy.util;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Random;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.codec.digest.Md5Crypt.md5Crypt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
- * A Java Implementation of the MD5Crypt function.
- * Modified from the GANYMEDE network directory management system
- * released under the GNU General Public License
- * by the University of Texas at Austin
- * http://tools.arlut.utexas.edu/gash2/
- * Original version from :Jonathan Abbey, jonabbey@arlut.utexas.edu
- * Modified by: Vladimir Silva, vladimir_silva@yahoo.com
- * Modification history:
- * 9/2005
- * - Removed dependencies on a MD5 private implementation
- * - Added built-in java.security.MessageDigest (MD5) support
- * - Code cleanup
- * <br>
+ * A collection of methods for using the FreeBSD MD5-crypt password encryption algorithm.
+ *
+ * @see https://www.usenix.org/legacyurl/md5-crypt
+ * @see https://www.systutorials.com/docs/linux/man/n-md5crypt/
  *
  * @deprecated Use SHA512(fast) or BCrypt(secure) in the future instead
  *             (kept for backwards compatibility)
  */
-@Deprecated // MD5 is not secure, use BCrypt or SHA512 (fast instead
-public class MD5Crypt {
+@Deprecated
+public final class MD5Crypt {
   public static final String MAGIC = "$1$";
-  // Character set allowed for the salt string
-  private static final String SALTCHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
-  // Character set of the encrypted password: A-Za-z0-9./
-  private static final String itoa64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  private static final Pattern ENCRYPTED_PASSWORD_PATTERN =
+      Pattern.compile("^" + MAGIC.replace("$", "\\$") + "([\\.\\/a-zA-Z0-9]{1,8})\\$[\\.\\/a-zA-Z0-9]{22}$");
+  private static final byte[] EMPTY_KEY_BYTES = new byte[0];
+
+  private MD5Crypt() {}
 
   /**
-   * Function to return a string from the set: A-Za-z0-9./
+   * Encrypts the specified password using a new random salt.
    *
-   * @param size
-   *        Length of the string
-   * @param v
-   *        value to be converted
-   * @return A string of size (size) from the set A-Za-z0-9./
-   */
-  private static String to64(long v, int size) {
-    final StringBuilder result = new StringBuilder();
-    while (--size >= 0) {
-      result.append(itoa64.charAt((int) (v & 0x3f)));
-      v >>>= 6;
-    }
-    return result.toString();
-  }
-
-  private static void clearbits(final byte[] bits) {
-    for (int i = 0; i < bits.length; i++) {
-      bits[i] = 0;
-    }
-  }
-
-  /**
-   * convert an encoded unsigned byte value
-   * into a int with the unsigned value.
-   */
-  private static int bytes2u(final byte inp) {
-    return inp & 0xff;
-  }
-
-  /**
-   * LINUX/BSD MD5Crypt function.
+   * @param password The password to be encrypted.
    *
-   * @param password
-   *        Password to be encrypted
-   * @return The encrypted password as an MD5 hash
+   * @return The encrypted password.
    */
   public static String crypt(final String password) {
+    checkNotNull(password);
+
     return crypt(password, newSalt());
   }
 
   /**
-   * LINUX/BSD MD5Crypt function.
+   * Encrypts the specified password using the specified salt.
    *
-   * @param salt
-   *        Random string used to initialize the MD5 engine
-   * @param password
-   *        Password to be encrypted
-   * @return The encrypted password as an MD5 hash
+   * @param password The password to be encrypted.
+   * @param salt The salt. May begin with {@link #MAGIC} and end with a {@code $} followed by any number of characters.
+   *        No more than eight characters will be used. If empty, a new random salt will be used.
+   *
+   * @return The encrypted password.
    */
-  public static String crypt(final String password, String salt) {
-    if (password == null) {
-      throw new IllegalArgumentException("Null password!");
+  public static String crypt(final String password, final String salt) {
+    checkNotNull(password);
+    checkNotNull(salt);
+
+    return md5Crypt(password.getBytes(StandardCharsets.UTF_8), MAGIC + normalizeSalt(salt));
+  }
+
+  private static String normalizeSalt(final String salt) {
+    if (salt.isEmpty()) {
+      return newSalt();
     }
-    if (salt == null) {
-      throw new IllegalArgumentException("Null salt!");
-    }
-    /*
-     * Two MD5 hashes are used
-     */
-    final MessageDigest ctx;
-    MessageDigest ctx1;
-    try {
-      ctx = MessageDigest.getInstance("md5");
-      ctx1 = MessageDigest.getInstance("md5");
-    } catch (final NoSuchAlgorithmException ex) {
-      ex.printStackTrace();
-      return null;
-    }
-    /* Refine the Salt first */
-    /* If it starts with the magic string, then skip that */
-    if (salt.startsWith(MAGIC)) {
-      salt = salt.substring(MAGIC.length());
-    }
-    /* It stops at the first '$', max 8 chars */
-    if (salt.indexOf('$') != -1) {
-      salt = salt.substring(0, salt.indexOf('$'));
-    }
-    if (salt.length() > 8) {
-      salt = salt.substring(0, 8);
-    }
-    /*
-     * Transformation set #1:
-     * The password first, since that is what is most unknown
-     * Magic string
-     * Raw salt
-     */
-    ctx.update(password.getBytes());
-    ctx.update(MAGIC.getBytes());
-    ctx.update(salt.getBytes());
-    /* Then just as many characters of the MD5(pw,salt,pw) */
-    ctx1.update(password.getBytes());
-    ctx1.update(salt.getBytes());
-    ctx1.update(password.getBytes());
-    // ctx1.Final();
-    byte[] finalState = ctx1.digest();
-    for (int pl = password.length(); pl > 0; pl -= 16) {
-      ctx.update(finalState, 0, pl > 16 ? 16 : pl);
-    }
-    /*
-     * the original code claimed that finalState was being cleared
-     * to keep dangerous bits out of memory,
-     * but doing this is also required in order to get the right output.
-     */
-    clearbits(finalState);
-    /* Then something really weird... */
-    for (int i = password.length(); i != 0; i >>>= 1) {
-      if ((i & 1) != 0) {
-        ctx.update(finalState, 0, 1);
-      } else {
-        ctx.update(password.getBytes(), 0, 1);
-      }
-    }
-    finalState = ctx.digest();
-    /*
-     * and now, just to make sure things don't run too fast
-     * On a 60 Mhz Pentium this takes 34 msec, so you would
-     * need 30 seconds to build a 1000 entry dictionary...
-     * (The above timings from the C version)
-     */
-    // TODO: we are WAY faster than 60Mhz, this operation is likely nanoseconds.. (not even micro seconds, nano!)
-    for (int i = 0; i < 1000; i++) {
-      try {
-        ctx1 = MessageDigest.getInstance("md5");
-      } catch (final NoSuchAlgorithmException e0) {
-        return null;
-      }
-      if ((i & 1) != 0) {
-        ctx1.update(password.getBytes());
-      } else {
-        ctx1.update(finalState, 0, 16);
-      }
-      if ((i % 3) != 0) {
-        ctx1.update(salt.getBytes());
-      }
-      if ((i % 7) != 0) {
-        ctx1.update(password.getBytes());
-      }
-      if ((i & 1) != 0) {
-        ctx1.update(finalState, 0, 16);
-      } else {
-        ctx1.update(password.getBytes());
-      }
-      // Final();
-      finalState = ctx1.digest();
-    }
-    /* Now make the output string */
-    final StringBuilder result = new StringBuilder();
-    result.append(MAGIC);
-    result.append(salt);
-    result.append("$");
-    /*
-     * Build a 22 byte output string from the set: A-Za-z0-9./
-     */
-    long l = (bytes2u(finalState[0]) << 16) | (bytes2u(finalState[6]) << 8) | bytes2u(finalState[12]);
-    result.append(to64(l, 4));
-    l = (bytes2u(finalState[1]) << 16) | (bytes2u(finalState[7]) << 8) | bytes2u(finalState[13]);
-    result.append(to64(l, 4));
-    l = (bytes2u(finalState[2]) << 16) | (bytes2u(finalState[8]) << 8) | bytes2u(finalState[14]);
-    result.append(to64(l, 4));
-    l = (bytes2u(finalState[3]) << 16) | (bytes2u(finalState[9]) << 8) | bytes2u(finalState[15]);
-    result.append(to64(l, 4));
-    l = (bytes2u(finalState[4]) << 16) | (bytes2u(finalState[10]) << 8) | bytes2u(finalState[5]);
-    result.append(to64(l, 4));
-    l = bytes2u(finalState[11]);
-    result.append(to64(l, 2));
-    /* Don't leave anything around in vm they could use. */
-    clearbits(finalState);
-    return result.toString();
+
+    return String.format("%1.8s",
+        salt.replaceFirst("^" + MAGIC.replace("$", "\\$"), "")
+            .replaceFirst("\\$.*$", "")
+            .replaceAll("[^./a-zA-Z0-9]", "."));
   }
 
   /**
    * Creates a new random salt that can be passed to {@link #crypt(String, String)}.
    *
-   * @return A new random salt; never {@code null}.
+   * @return A new random salt.
    */
   public static String newSalt() {
-    final StringBuilder salt = new StringBuilder();
-    final Random rnd = new Random();
-    // build a random 8 chars salt
-    while (salt.length() < 8) {
-      final int index = (int) (rnd.nextFloat() * SALTCHARS.length());
-      salt.append(SALTCHARS.substring(index, index + 1));
-    }
-    return salt.toString();
+    return getSalt(md5Crypt(EMPTY_KEY_BYTES));
   }
 
-  public static String getSalt(final String encrypted) {
-    final String valNoMagic = encrypted.substring(MAGIC.length());
-    return valNoMagic.substring(0, valNoMagic.indexOf("$"));
+  /**
+   * Gets the salt for the specified encrypted password.
+   *
+   * @param encryptedPassword The encrypted password from a previous call to {@link #crypt(String, String)} whose salt
+   *        is to be returned.
+   *
+   * @return The salt for the specified encrypted password.
+   *
+   * @throws IllegalArgumentException If {@code encryptedPassword} is not an MD5-crypted password.
+   */
+  public static String getSalt(final String encryptedPassword) {
+    checkNotNull(encryptedPassword);
+
+    final Matcher matcher = ENCRYPTED_PASSWORD_PATTERN.matcher(encryptedPassword);
+    checkArgument(matcher.matches(), "'" + encryptedPassword + "' is not an MD5-crypted password");
+    return matcher.group(1);
   }
 }

--- a/src/test/java/games/strategy/util/MD5CryptTest.java
+++ b/src/test/java/games/strategy/util/MD5CryptTest.java
@@ -1,0 +1,138 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public final class MD5CryptTest {
+  private static String crypt(final String password) {
+    return MD5Crypt.crypt(password);
+  }
+
+  private static String crypt(final String password, final String salt) {
+    return MD5Crypt.crypt(password, salt);
+  }
+
+  private static String getSalt(final String encryptedPassword) {
+    return MD5Crypt.getSalt(encryptedPassword);
+  }
+
+  private static String newSalt() {
+    return MD5Crypt.newSalt();
+  }
+
+  @Test
+  public void cryptWithoutSalt_ShouldReturnEncryptedPassword() {
+    Arrays.asList(
+        "",
+        "password",
+        "the quick brown fox",
+        "ABYZabyz0189",
+        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F")
+        .forEach(password -> {
+          final String encryptedPassword = crypt(password);
+          final String salt = getSalt(encryptedPassword);
+          assertThat(
+              String.format("wrong encrypted password for '%s'", password),
+              crypt(password, salt),
+              is(encryptedPassword));
+        });
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldReturnEncryptedPassword() {
+    Arrays.asList(
+        Triple.of("", "ll5ESPtE", "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"),
+        Triple.of("password", "Eim8FgMk", "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1"),
+        Triple.of("the quick brown fox", "XlnQ6h98", "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv."),
+        Triple.of("ABYZabyz0189", "3lvJqBhy", "$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq."),
+        Triple.of(" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F", "wwmV2glD", "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11"))
+        .forEach(t -> {
+          final String password = t.getFirst();
+          final String salt = t.getSecond();
+          final String encryptedPassword = t.getThird();
+          assertThat(
+              String.format("wrong encrypted password for '%s'", password),
+              crypt(password, salt),
+              is(encryptedPassword));
+        });
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldUseNewRandomSaltWhenSaltIsEmpty() {
+    assertThat(getSalt(crypt("password", "")).length(), is(8));
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldIgnoreLeadingMagicInSalt() {
+    assertThat(crypt("password", "$1$Eim8FgMk"), is(crypt("password", "Eim8FgMk")));
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldIgnoreTrailingHashInSalt() {
+    assertThat(crypt("password", "Z$IGNOREME"), is(crypt("password", "Z")));
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldUseNoMoreThanEightCharactersFromSalt() {
+    assertThat(crypt("password", "123456789"), is(crypt("password", "12345678")));
+  }
+
+  @Test
+  public void cryptWithSalt_ShouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
+    assertThat(crypt("password", "ABC!@DEF"), is(crypt("password", "ABC..DEF")));
+  }
+
+  @Test
+  public void getSalt_ShouldReturnSaltWhenEncryptedPasswordIsLegal() {
+    Arrays.asList(
+        Tuple.of("$1$A$KnCRC85Rudn6P3cpfe3LR/", "A"),
+        Tuple.of("$1$AB$4jo772pXjQ9qCwNdBde3d1", "AB"),
+        Tuple.of("$1$ABC$3tP1DHUbEbG4bd67/3fFu/", "ABC"),
+        Tuple.of("$1$ABCD$dQqZjlWf5HeY7rWTLu23s.", "ABCD"),
+        Tuple.of("$1$ABCDE$ACfvKmv8y/KjlzX1R.tBw.", "ABCDE"),
+        Tuple.of("$1$ABCDEF$f.URqvCLElutKgCndKcMI1", "ABCDEF"),
+        Tuple.of("$1$ABCDEFG$mN7iGIbBXdAAjJtrJG2ia1", "ABCDEFG"),
+        Tuple.of("$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1", "ABCDEFGH"))
+        .forEach(t -> {
+          final String encryptedPassword = t.getFirst();
+          final String salt = t.getSecond();
+          assertThat(
+              String.format("wrong salt for '%s'", encryptedPassword),
+              getSalt(encryptedPassword),
+              is(salt));
+        });
+  }
+
+  @Test
+  public void getSalt_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
+    Arrays.asList(
+        "1$A$KnCRC85Rudn6P3cpfe3LR/",
+        "$$AB$4jo772pXjQ9qCwNdBde3d1",
+        "$1ABC$3tP1DHUbEbG4bd67/3fFu/",
+        "$1$$dQqZjlWf5HeY7rWTLu23s.",
+        "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.")
+        .forEach(encryptedPassword -> {
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> getSalt(encryptedPassword),
+              () -> String.format("expected exception for illegal encrypted password '%s'", encryptedPassword));
+        });
+  }
+
+  @Test
+  public void newSalt_ShouldReturnSaltOfLengthEight() {
+    assertThat(newSalt().length(), is(8));
+  }
+
+  @Test
+  public void newSalt_ShouldReturnDifferentSuccessiveSalts() {
+    assertThat(newSalt(), is(not(newSalt())));
+  }
+}


### PR DESCRIPTION
Resolves #2901.

#### Functional changes

* Passwords containing non-ASCII characters are now consistently encrypted on all platforms regardless of default charset.
* :warning: **Breaking change:** A lobby user will no longer be able to login under the following conditions:
    * User is running 1.9.0.0.3635 or earlier.
    * User has at least one non-ASCII character in their password.
    * User created their account or last changed their password on a platform whose default charset is not UTF-8 (e.g. Windows and possibly Mac).
* :warning: **Breaking change:** A network game client will no longer be able to connect to a password-protected game under the following conditions:
    * Client is running 1.9.0.0.3635 or earlier.
    * Host has selected a password with at least one non-ASCII character.
* For consistency with the previous `MD5Crypt` API (i.e. to avoid raising `IllegalArgumentException`s), the new implementation makes the following changes (note that I couldn't find any code that would actually hit these cases):
    * Passing an empty salt to `crypt()` will cause the implementation to silently use a random 8-character salt instead of the empty salt.
    * Passing a salt containing a character outside the set `[./a-zA-Z0-9]` to `crypt()` will cause the implementation to replace each illegal character with a period (`.`).

#### Testing

I added a bunch of characterization tests before changing the implementation to ensure I didn't introduce any regressions.  The only tests that had to be changed were those dealing with the `crypt()` method preconditions mentioned above.