### PR TITLE
Remove HeadlessException handlers

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.startup.ui.editors;
 
 import java.awt.GridBagConstraints;
-import java.awt.HeadlessException;
 import java.awt.Insets;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -177,14 +176,10 @@ public class EmailSenderEditor extends EditorPanel {
         final String finalMessage = message;
         final int finalMessageType = messageType;
         SwingUtilities.invokeLater(() -> {
-          try {
-            GameRunner.showMessageDialog(
-                finalMessage,
-                GameRunner.Title.of("Email Test"),
-                finalMessageType);
-          } catch (final HeadlessException e) {
-            // should never happen in a GUI app
-          }
+          GameRunner.showMessageDialog(
+              finalMessage,
+              GameRunner.Title.of("Email Test"),
+              finalMessageType);
         });
         progressWindow.setVisible(false);
       }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.startup.ui.editors;
 
 import java.awt.Graphics;
 import java.awt.GridBagConstraints;
-import java.awt.HeadlessException;
 import java.awt.Insets;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -148,14 +147,10 @@ public class ForumPosterEditor extends EditorPanel {
       progressWindow.setVisible(false);
       // now that we have a result, marshall it back unto the swing thread
       SwingUtilities.invokeLater(() -> {
-        try {
-          GameRunner.showMessageDialog(
-              bean.getTurnSummaryRef(),
-              GameRunner.Title.of("Test Turn Summary Post"),
-              JOptionPane.INFORMATION_MESSAGE);
-        } catch (final HeadlessException e) {
-          // should never happen in a GUI app
-        }
+        GameRunner.showMessageDialog(
+            bean.getTurnSummaryRef(),
+            GameRunner.Title.of("Test Turn Summary Post"),
+            JOptionPane.INFORMATION_MESSAGE);
       });
     }).start();
   }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -4,7 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.HeadlessException;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
@@ -254,19 +253,17 @@ public class CenterPicker extends JFrame {
    * Loads a pre-defined file with map center points.
    */
   private void loadCenters() {
-    try {
-      System.out.println("Load a center file");
-      final String centerName = new FileOpen("Load A Center File", mapFolderLocation, ".txt").getPathString();
-      if (centerName == null) {
-        return;
-      }
-      try (InputStream in = new FileInputStream(centerName)) {
-        centers = PointFileReaderWriter.readOneToOne(in);
-      }
-      repaint();
-    } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly("Failed to load centers", ex);
+    System.out.println("Load a center file");
+    final String centerName = new FileOpen("Load A Center File", mapFolderLocation, ".txt").getPathString();
+    if (centerName == null) {
+      return;
     }
+    try (InputStream in = new FileInputStream(centerName)) {
+      centers = PointFileReaderWriter.readOneToOne(in);
+    } catch (final IOException e) {
+      ClientLogger.logQuietly("Failed to load centers: " + centerName, e);
+    }
+    repaint();
   }
 
   /**

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -5,7 +5,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
-import java.awt.HeadlessException;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
@@ -601,24 +600,20 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void loadImagePointTextFile() {
-    try {
-      System.out.println("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
-      final FileOpen centerName = new FileOpen("Load an Image Points Text File", mapFolderLocation,
-          new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
-      currentImagePointsTextFile = centerName.getFile();
-      if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
-        try (InputStream in = new FileInputStream(centerName.getPathString())) {
-          currentPoints = PointFileReaderWriter.readOneToMany(in);
-        } catch (final IOException e) {
-          System.out.println("Failed to load image points: " + centerName.getPathString());
-          e.printStackTrace();
-          System.exit(0);
-        }
-      } else {
-        currentPoints = new HashMap<>();
+    System.out.println("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
+    final FileOpen centerName = new FileOpen("Load an Image Points Text File", mapFolderLocation,
+        new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
+    currentImagePointsTextFile = centerName.getFile();
+    if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
+      try (InputStream in = new FileInputStream(centerName.getPathString())) {
+        currentPoints = PointFileReaderWriter.readOneToMany(in);
+      } catch (final IOException e) {
+        System.out.println("Failed to load image points: " + centerName.getPathString());
+        e.printStackTrace();
+        System.exit(0);
       }
-    } catch (final HeadlessException e) {
-      ClientLogger.logQuietly("Failed to load image points", e);
+    } else {
+      currentPoints = new HashMap<>();
     }
   }
 

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -4,7 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.HeadlessException;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
@@ -385,22 +384,17 @@ public class PolygonGrabber extends JFrame {
   private void loadPolygons() {
     System.out.println("Load a polygon file");
     final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
-    try {
-      if (polyName == null) {
-        return;
-      }
-      try (InputStream in = new FileInputStream(polyName)) {
-        polygons = PointFileReaderWriter.readOneToManyPolygons(in);
-      } catch (final IOException e) {
-        System.out.println("Failed to load polygons: " + polyName);
-        e.printStackTrace();
-        System.exit(0);
-      }
-      repaint();
-    } catch (final HeadlessException ex) {
-      // TODO: remove HeadlessException (fix anti-pattern control flow via exception handling with proper control flow)
-      ClientLogger.logQuietly("Failed to load polygons", ex);
+    if (polyName == null) {
+      return;
     }
+    try (InputStream in = new FileInputStream(polyName)) {
+      polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+    } catch (final IOException e) {
+      System.out.println("Failed to load polygons: " + polyName);
+      e.printStackTrace();
+      System.exit(0);
+    }
+    repaint();
   }
 
   /**
@@ -461,7 +455,7 @@ public class PolygonGrabber extends JFrame {
    * Does something with respect to check if the name
    * of a territory is valid or not.
    */
-  private void doneCurrentGroup() throws HeadlessException {
+  private void doneCurrentGroup() {
     final JTextField text = new JTextField();
     guessCountryName(text, centers.entrySet());
     final int option = JOptionPane.showConfirmDialog(this, text);

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -7,7 +7,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.HeadlessException;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
@@ -313,18 +312,16 @@ public class MapPropertiesMaker extends JFrame {
 
   private void loadProperties() {
     final Properties properties = new Properties();
-    try {
-      System.out.println("Load a properties file");
-      final String centerName =
-          new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
-      if (centerName == null) {
-        return;
-      }
-      try (InputStream in = new FileInputStream(centerName)) {
-        properties.load(in);
-      }
-    } catch (final HeadlessException | IOException ex) {
-      ClientLogger.logQuietly("Failed to load map properties", ex);
+    System.out.println("Load a properties file");
+    final String centerName =
+        new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
+    if (centerName == null) {
+      return;
+    }
+    try (InputStream in = new FileInputStream(centerName)) {
+      properties.load(in);
+    } catch (final IOException e) {
+      ClientLogger.logQuietly("Failed to load map properties: " + centerName, e);
     }
     for (final Method setter : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -4,7 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.HeadlessException;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
@@ -504,21 +503,17 @@ public class PlacementPicker extends JFrame {
   private void loadPlacements() {
     System.out.println("Load a placement file");
     final String placeName = new FileOpen("Load A Placement File", mapFolderLocation, ".txt").getPathString();
-    try {
-      if (placeName == null) {
-        return;
-      }
-      try (InputStream in = new FileInputStream(placeName)) {
-        placements = PointFileReaderWriter.readOneToMany(in);
-      } catch (final IOException e) {
-        System.out.println("Failed to load placements: " + placeName);
-        e.printStackTrace();
-        System.exit(0);
-      }
-      repaint();
-    } catch (final HeadlessException e) {
-      ClientLogger.logQuietly("Failed to load placements", e);
+    if (placeName == null) {
+      return;
     }
+    try (InputStream in = new FileInputStream(placeName)) {
+      placements = PointFileReaderWriter.readOneToMany(in);
+    } catch (final IOException e) {
+      System.out.println("Failed to load placements: " + placeName);
+      e.printStackTrace();
+      System.exit(0);
+    }
+    repaint();
   }
 
   /**


### PR DESCRIPTION
The affected code is all part of one or another GUI application (TripleA client or map making tool).  If a `HeadlessException` occurs, we should allow it to terminate the thread.

In the map making tools, it's possible these were dual console/GUI applications in the past, and the `HeadlessException` handlers were hacks to workaround running them in console mode. ¯\\\_(ツ)\_/¯

It is suggested to review this PR with whitespace changes ignored (`?w=1`).

#### Testing

I performed both a PBEM test email and PBF test post to ensure there was no hidden `HeadlessException` getting thrown during these operations that we weren't aware of.  No issues observed.