### PR TITLE
Improve ErrorMessage UI and fix close bug

### DIFF
--- a/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -8,6 +8,7 @@ import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 import swinglib.JButtonBuilder;
+import swinglib.JLabelBuilder;
 import swinglib.JPanelBuilder;
 
 /**
@@ -35,18 +36,25 @@ public enum ErrorMessage {
     windowReference.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
     windowReference.add(JPanelBuilder.builder()
         .borderLayout()
-        .addCenter(
-            errorMessage,
-            JPanelBuilder.Padding.of(20))
-        .addSouth(JPanelBuilder.builder()
-            .flowLayout()
+        .borderEmpty(10)
+        .addCenter(JPanelBuilder.builder()
             .horizontalBoxLayout()
+            .addHorizontalGlue()
+            .add(JLabelBuilder.builder().errorIcon().build())
+            .addHorizontalStrut(10)
+            .add(errorMessage)
+            .addHorizontalGlue()
+            .build())
+        .addSouth(JPanelBuilder.builder()
+            .horizontalBoxLayout()
+            .borderEmpty(20, 0, 0, 0)
+            .addHorizontalGlue()
             .add(JButtonBuilder.builder()
-                .title("Ok")
+                .okTitle()
                 .actionListener(() -> windowReference.setVisible(false))
                 .selected(true)
                 .build())
-            .addHorizontalStrut(10)
+            .addHorizontalStrut(5)
             .add(JButtonBuilder.builder()
                 .title("Show Details")
                 .toolTip("Shows the error console window with full error details.")
@@ -56,6 +64,7 @@ public enum ErrorMessage {
                   ErrorConsole.showConsole();
                 })
                 .build())
+            .addHorizontalGlue()
             .build())
         .build());
   }
@@ -66,7 +75,6 @@ public enum ErrorMessage {
    * visible the frame.
    */
   public void init() {}
-
 
   /**
    * Displays the error dialog window with a given message. This is no-op if the window is already visible.

--- a/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -1,6 +1,8 @@
 package games.strategy.debug;
 
 import java.awt.Dialog;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.JFrame;
@@ -34,6 +36,12 @@ public enum ErrorMessage {
   ErrorMessage() {
     windowReference.setAlwaysOnTop(true);
     windowReference.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
+    windowReference.addWindowListener(new WindowAdapter() {
+      @Override
+      public void windowClosing(final WindowEvent e) {
+        hide();
+      }
+    });
     windowReference.add(JPanelBuilder.builder()
         .borderLayout()
         .borderEmpty(10)
@@ -51,7 +59,7 @@ public enum ErrorMessage {
             .addHorizontalGlue()
             .add(JButtonBuilder.builder()
                 .okTitle()
-                .actionListener(() -> windowReference.setVisible(false))
+                .actionListener(this::hide)
                 .selected(true)
                 .build())
             .addHorizontalStrut(5)
@@ -59,14 +67,18 @@ public enum ErrorMessage {
                 .title("Show Details")
                 .toolTip("Shows the error console window with full error details.")
                 .actionListener(() -> {
-                  windowReference.setVisible(false);
-                  isVisible.set(false);
+                  hide();
                   ErrorConsole.showConsole();
                 })
                 .build())
             .addHorizontalGlue()
             .build())
         .build());
+  }
+
+  private void hide() {
+    windowReference.setVisible(false);
+    isVisible.set(false);
   }
 
   /**

--- a/src/main/java/swinglib/JButtonBuilder.java
+++ b/src/main/java/swinglib/JButtonBuilder.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.Font;
 
 import javax.swing.JButton;
+import javax.swing.UIManager;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -69,6 +70,13 @@ public class JButtonBuilder {
     Preconditions.checkArgument(!Strings.nullToEmpty(title).trim().isEmpty());
     this.title = title;
     return this;
+  }
+
+  /**
+   * Sets the button title to the system's OK button text.
+   */
+  public JButtonBuilder okTitle() {
+    return title(UIManager.getString("OptionPane.okButtonText"));
   }
 
   /**

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -2,8 +2,11 @@ package swinglib;
 
 import java.awt.Dimension;
 
+import javax.annotation.Nullable;
+import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 
 import com.google.common.base.Ascii;
@@ -23,6 +26,7 @@ import com.google.common.base.Preconditions;
 public class JLabelBuilder {
 
   private String text;
+  private @Nullable Icon icon;
   private Alignment alignment;
   private Dimension maxSize;
   private int maxTextLength = Integer.MAX_VALUE;
@@ -37,14 +41,24 @@ public class JLabelBuilder {
 
   /**
    * Constructs a Swing JLabel using current builder values.
-   * Values that must be set: text
+   * Values that must be set: text or icon
    */
   public JLabel build() {
-    Preconditions.checkNotNull(text);
-    Preconditions.checkState(!text.trim().isEmpty());
+    Preconditions.checkState(text != null || icon != null);
 
-    final String truncated = Ascii.truncate(text, maxTextLength, "...");
+    final String truncated;
+    if (text != null) {
+      Preconditions.checkState(!text.trim().isEmpty());
+      truncated = Ascii.truncate(text, maxTextLength, "...");
+    } else {
+      truncated = "";
+    }
+
     final JLabel label = new JLabel(truncated);
+
+    if (icon != null) {
+      label.setIcon(icon);
+    }
 
     if (alignment != null) {
       switch (alignment) {
@@ -67,6 +81,11 @@ public class JLabelBuilder {
     }
 
     return label;
+  }
+
+  public JLabelBuilder errorIcon() {
+    icon = UIManager.getIcon("OptionPane.errorIcon");
+    return this;
   }
 
   public JLabelBuilder leftAlign() {

--- a/src/main/java/swinglib/JPanelBuilder.java
+++ b/src/main/java/swinglib/JPanelBuilder.java
@@ -15,13 +15,13 @@ import java.util.Collection;
 import java.util.function.Supplier;
 
 import javax.imageio.ImageIO;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.Border;
-import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 
@@ -256,7 +256,11 @@ public class JPanelBuilder {
   }
 
   public JPanelBuilder borderEmpty(final int borderWidth) {
-    border = new EmptyBorder(borderWidth, borderWidth, borderWidth, borderWidth);
+    return borderEmpty(borderWidth, borderWidth, borderWidth, borderWidth);
+  }
+
+  public JPanelBuilder borderEmpty(final int top, final int left, final int bottom, final int right) {
+    border = BorderFactory.createEmptyBorder(top, left, bottom, right);
     return this;
   }
 

--- a/src/test/java/swinglib/JLabelBuilderTest.java
+++ b/src/test/java/swinglib/JLabelBuilderTest.java
@@ -30,8 +30,8 @@ public class JLabelBuilderTest {
   }
 
   @Test
-  public void textIsRequired() {
-    assertThrows(NullPointerException.class, JLabelBuilder.builder()::build);
+  public void textOrIconIsRequired() {
+    assertThrows(IllegalStateException.class, JLabelBuilder.builder()::build);
   }
 
   @Test

--- a/src/test/java/swinglib/JPanelBuilderTest.java
+++ b/src/test/java/swinglib/JPanelBuilderTest.java
@@ -28,22 +28,6 @@ public class JPanelBuilderTest {
   }
 
   @Test
-  public void testBorder() {
-    final int borderWidth = 3;
-    final JPanel panel = JPanelBuilder.builder()
-        .borderEmpty(borderWidth)
-        .build();
-
-    assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
-
-    final Insets borderInsets = ((EmptyBorder) panel.getBorder()).getBorderInsets();
-    assertThat(borderInsets.top, is(borderWidth));
-    assertThat(borderInsets.bottom, is(borderWidth));
-    assertThat(borderInsets.left, is(borderWidth));
-    assertThat(borderInsets.right, is(borderWidth));
-  }
-
-  @Test
   public void horizontalAlignmentCenter() {
     final JPanel panel = JPanelBuilder.builder()
         .horizontalAlignmentCenter()
@@ -97,7 +81,7 @@ public class JPanelBuilderTest {
   }
 
   @Test
-  public void emptyBorder() {
+  public void emptyBorderWithSingleWidth() {
     final int borderWidth = 100;
     final JPanel panel = JPanelBuilder.builder()
         .borderEmpty(borderWidth)
@@ -110,6 +94,20 @@ public class JPanelBuilderTest {
     assertThat(insets.right, is(borderWidth));
   }
 
+  @Test
+  public void emptyBorderWithIndependentWidths() {
+    final JPanel panel = JPanelBuilder.builder()
+        .borderEmpty(1, 2, 3, 4)
+        .build();
+
+    assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
+
+    final Insets insets = panel.getBorder().getBorderInsets(panel);
+    assertThat(insets.top, is(1));
+    assertThat(insets.left, is(2));
+    assertThat(insets.bottom, is(3));
+    assertThat(insets.right, is(4));
+  }
 
   @Test
   public void addLabel() {


### PR DESCRIPTION
This PR primarily improves the UI of the `ErrorMessage` class in the following ways:

* Include an error icon.
* Use standard border and component spacing.
* Use standard text for OK button.

#### Nimbus

##### Before

![error-dialog-before-nimbus](https://user-images.githubusercontent.com/4826349/35469092-9e5a4e12-02fb-11e8-9677-6f2734b5cb69.png)

##### After

![error-dialog-after-nimbus](https://user-images.githubusercontent.com/4826349/35469095-a80472f8-02fb-11e8-826d-ac9ffb146a6c.png)

#### Substance

##### Before

![error-dialog-before-substance](https://user-images.githubusercontent.com/4826349/35469097-b04673b2-02fb-11e8-9606-20a03546309f.png)

##### After

![error-dialog-after-substance](https://user-images.githubusercontent.com/4826349/35469098-b5d89e0e-02fb-11e8-9918-bad459e6436b.png)

---

The second commit also fixes a bug that prevented `ErrorMessage` from being re-opened after it was closed using either the OK button or the system close command ('X').
