### PR TITLE
Move JUnit 5 Experiments code

### DIFF
--- a/src/test/java/games/strategy/engine/config/FilePropertyReaderAsPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/FilePropertyReaderAsPropertyReaderTest.java
@@ -6,9 +6,10 @@ import java.io.Writer;
 import java.util.Map;
 import java.util.Properties;
 
-import org.junit.experimental.extensions.TemporaryFolder;
-import org.junit.experimental.extensions.TemporaryFolderExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import games.strategy.test.extensions.TemporaryFolder;
+import games.strategy.test.extensions.TemporaryFolderExtension;
 
 @ExtendWith(TemporaryFolderExtension.class)
 public final class FilePropertyReaderAsPropertyReaderTest extends AbstractPropertyReaderTestCase {

--- a/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
@@ -8,11 +8,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
 
-import org.junit.experimental.extensions.TemporaryFolder;
-import org.junit.experimental.extensions.TemporaryFolderExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import games.strategy.test.extensions.TemporaryFolder;
+import games.strategy.test.extensions.TemporaryFolderExtension;
 
 @ExtendWith(TemporaryFolderExtension.class)
 public final class FilePropertyReaderTest {

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
@@ -25,8 +25,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.experimental.extensions.TemporaryFolder;
-import org.junit.experimental.extensions.TemporaryFolderExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -37,6 +35,8 @@ import org.mockito.Mock;
 import com.example.mockito.MockitoExtension;
 
 import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
+import games.strategy.test.extensions.TemporaryFolder;
+import games.strategy.test.extensions.TemporaryFolderExtension;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 public final class DownloadUtilsTest extends AbstractClientSettingTestCase {

--- a/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
@@ -6,14 +6,14 @@ import static org.hamcrest.Matchers.is;
 import java.io.File;
 import java.util.Optional;
 
-import org.junit.experimental.extensions.TemporaryFolder;
-import org.junit.experimental.extensions.TemporaryFolderExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.google.common.io.Files;
 
+import games.strategy.test.extensions.TemporaryFolder;
+import games.strategy.test.extensions.TemporaryFolderExtension;
 import games.strategy.util.Version;
 
 /**

--- a/src/test/java/games/strategy/test/extensions/TemporaryFolder.java
+++ b/src/test/java/games/strategy/test/extensions/TemporaryFolder.java
@@ -1,12 +1,13 @@
-package org.junit.experimental.extensions;
+package games.strategy.test.extensions;
 
 import java.io.File;
 import java.io.IOException;
 
 /**
+ * Replacement for the JUnit 4 TemporaryFolder.
  * Based off
  * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolder.java
- * Replacement for the JUnit 4 TemporaryFolder.
+ * Originally licensed under EPL-2.0 OR GPL-2.0-or-later.
  */
 public class TemporaryFolder {
   private File rootFolder;

--- a/src/test/java/games/strategy/test/extensions/TemporaryFolderExtension.java
+++ b/src/test/java/games/strategy/test/extensions/TemporaryFolderExtension.java
@@ -1,4 +1,4 @@
-package org.junit.experimental.extensions;
+package games.strategy.test.extensions;
 
 import static java.util.Arrays.stream;
 
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 
 /**
+ * Replacement for the JUnit4 TemporaryFolder Rule.
  * Based off
  * https://raw.githubusercontent.com/rherrmann/junit5-experiments/master/src/main/java/com/codeaffine/junit5/TemporaryFolderExtension.java
- * Replacement for the JUnit4 TemporaryFolder Rule.
+ * Originally licensed under EPL-2.0 OR GPL-2.0-or-later.
  */
 public class TemporaryFolderExtension implements TestInstancePostProcessor, ParameterResolver {
 
@@ -56,6 +57,4 @@ public class TemporaryFolderExtension implements TestInstancePostProcessor, Para
     tempFolders.add(result);
     return result;
   }
-
 }
-


### PR DESCRIPTION
The `TemporaryFolder` and `TemporaryFolderExtension` classes have been modified from their original form in the JUnit 5 Experiments repo so they can work with the final JUnit 5 GA API, so this is effectively custom TripleA code.  In addition, we probably shouldn't be publishing code under the `org.junit` namespace.  Therefore, this PR moves it under the `g.s.test` package.