### PR TITLE
Extract class to encapsulate all tool console output

### DIFF
--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -22,11 +22,11 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolConsole;
 
 public class AutoPlacementFinder {
   private static int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
@@ -78,8 +78,8 @@ public class AutoPlacementFinder {
     // ask user where the map is
     final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
-      System.out.println("You need to specify a map name for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to specify a map name for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
     }
     final File file = getMapPropertiesFile(mapDir);
@@ -143,8 +143,8 @@ public class AutoPlacementFinder {
             }
           }
         }
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to initialize from map properties: " + file.getAbsolutePath(), ex);
+      } catch (final Exception e) {
+        ToolConsole.error("Failed to initialize from map properties: " + file.getAbsolutePath(), e);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -178,20 +178,19 @@ public class AutoPlacementFinder {
           }
         }
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to initialize from user input", ex);
+      } catch (final Exception e) {
+        ToolConsole.error("Failed to initialize from user input", e);
       }
     }
     try {
       // makes TripleA read all the text data files for the map.
       mapData = new MapData(mapDir);
-    } catch (final Exception ex) {
+    } catch (final Exception e) {
       JOptionPane.showMessageDialog(null, new JLabel(
           "Could not find map. Make sure it is in finalized location and contains centers.txt and polygons.txt"));
-      System.out.println("Caught Exception.");
-      System.out.println("Could be due to some missing text files.");
-      System.out.println("Or due to the map folder not being in the right location.");
-      ex.printStackTrace();
+      ToolConsole.error("Caught Exception.");
+      ToolConsole.error("Could be due to some missing text files.");
+      ToolConsole.error("Or due to the map folder not being in the right location.", e);
       System.exit(0);
     }
     textOptionPane.show();
@@ -226,8 +225,8 @@ public class AutoPlacementFinder {
       }
       PointFileReaderWriter.writeOneToMany(new FileOutputStream(fileName), placements);
       textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception ex) {
-      ex.printStackTrace();
+    } catch (final Exception e) {
+      ToolConsole.error("Failed to write points file", e);
       textOptionPane.dispose();
       System.exit(0);
     }
@@ -497,17 +496,17 @@ public class AutoPlacementFinder {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            System.out.println(propertie + ":" + value);
+            ToolConsole.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        System.out.println("Unrecogized:" + arg2);
+        ToolConsole.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          System.out.println("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -519,43 +518,43 @@ public class AutoPlacementFinder {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + folderString);
+        ToolConsole.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
         unitZoomPercent = Double.parseDouble(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
+        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not a decimal percentage: " + zoomString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
         unitWidth = Integer.parseInt(widthString);
-        System.out.println("Unit Width to use: " + unitWidth);
+        ToolConsole.info("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + widthString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
         unitHeight = Integer.parseInt(heightString);
-        System.out.println("Unit Height to use: " + unitHeight);
+        ToolConsole.info("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + heightString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
       placeWidth = (int) (unitZoomPercent * unitWidth);
       placeHeight = (int) (unitZoomPercent * unitHeight);
-      System.out.println("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
+      ToolConsole.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -26,7 +26,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.PointFileReaderWriter;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 public class AutoPlacementFinder {
   private static int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
@@ -78,8 +78,8 @@ public class AutoPlacementFinder {
     // ask user where the map is
     final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
-      ToolConsole.info("You need to specify a map name for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to specify a map name for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
     }
     final File file = getMapPropertiesFile(mapDir);
@@ -144,7 +144,7 @@ public class AutoPlacementFinder {
           }
         }
       } catch (final Exception e) {
-        ToolConsole.error("Failed to initialize from map properties: " + file.getAbsolutePath(), e);
+        ToolLogger.error("Failed to initialize from map properties: " + file.getAbsolutePath(), e);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -179,7 +179,7 @@ public class AutoPlacementFinder {
         }
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Failed to initialize from user input", e);
+        ToolLogger.error("Failed to initialize from user input", e);
       }
     }
     try {
@@ -188,9 +188,9 @@ public class AutoPlacementFinder {
     } catch (final Exception e) {
       JOptionPane.showMessageDialog(null, new JLabel(
           "Could not find map. Make sure it is in finalized location and contains centers.txt and polygons.txt"));
-      ToolConsole.error("Caught Exception.");
-      ToolConsole.error("Could be due to some missing text files.");
-      ToolConsole.error("Or due to the map folder not being in the right location.", e);
+      ToolLogger.error("Caught Exception.");
+      ToolLogger.error("Could be due to some missing text files.");
+      ToolLogger.error("Or due to the map folder not being in the right location.", e);
       System.exit(0);
     }
     textOptionPane.show();
@@ -226,7 +226,7 @@ public class AutoPlacementFinder {
       PointFileReaderWriter.writeOneToMany(new FileOutputStream(fileName), placements);
       textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception e) {
-      ToolConsole.error("Failed to write points file", e);
+      ToolLogger.error("Failed to write points file", e);
       textOptionPane.dispose();
       System.exit(0);
     }
@@ -496,17 +496,17 @@ public class AutoPlacementFinder {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            ToolConsole.info(propertie + ":" + value);
+            ToolLogger.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        ToolConsole.info("Unrecogized:" + arg2);
+        ToolLogger.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolLogger.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -518,43 +518,43 @@ public class AutoPlacementFinder {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + folderString);
+        ToolLogger.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
         unitZoomPercent = Double.parseDouble(zoomString);
-        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
+        ToolLogger.info("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not a decimal percentage: " + zoomString);
+        ToolLogger.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
         unitWidth = Integer.parseInt(widthString);
-        ToolConsole.info("Unit Width to use: " + unitWidth);
+        ToolLogger.info("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + widthString);
+        ToolLogger.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
         unitHeight = Integer.parseInt(heightString);
-        ToolConsole.info("Unit Height to use: " + unitHeight);
+        ToolLogger.info("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + heightString);
+        ToolLogger.error("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
       placeWidth = (int) (unitZoomPercent * unitWidth);
       placeHeight = (int) (unitZoomPercent * unitHeight);
-      ToolConsole.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
+      ToolLogger.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -37,10 +37,10 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolConsole;
 
 public class CenterPicker extends JFrame {
   private static final long serialVersionUID = -5633998810385136625L;
@@ -64,14 +64,14 @@ public class CenterPicker extends JFrame {
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      System.out.println("Map : " + mapName);
+      ToolConsole.info("Map : " + mapName);
       final CenterPicker picker = new CenterPicker(mapName);
       picker.setSize(800, 600);
       picker.setLocationRelativeTo(null);
@@ -91,7 +91,7 @@ public class CenterPicker extends JFrame {
               + "<br><br>RIGHT CLICK on an existing center = delete that center point."
               + "<br><br>When finished, save the centers and exit." + "</html>"));
     } else {
-      System.out.println("No Image Map Selected. Shutting down.");
+      ToolConsole.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -121,8 +121,7 @@ public class CenterPicker extends JFrame {
       try (InputStream is = new FileInputStream(file.getPath())) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        System.out.println("Something wrong with your Polygons file: " + file.getAbsolutePath());
-        e.printStackTrace();
+        ToolConsole.error("Something wrong with your Polygons file: " + file.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
@@ -131,8 +130,7 @@ public class CenterPicker extends JFrame {
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          System.out.println("Something wrong with your Polygons file: " + polyPath);
-          e.printStackTrace();
+          ToolConsole.error("Something wrong with your Polygons file: " + polyPath, e);
           System.exit(0);
         }
       }
@@ -242,9 +240,9 @@ public class CenterPicker extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToOne(out, centers);
       }
-      System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception ex) {
-      ClientLogger.logQuietly("Failed to save centers", ex);
+      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+    } catch (final Exception e) {
+      ToolConsole.error("Failed to save centers", e);
     }
   }
 
@@ -253,7 +251,7 @@ public class CenterPicker extends JFrame {
    * Loads a pre-defined file with map center points.
    */
   private void loadCenters() {
-    System.out.println("Load a center file");
+    ToolConsole.info("Load a center file");
     final String centerName = new FileOpen("Load A Center File", mapFolderLocation, ".txt").getPathString();
     if (centerName == null) {
       return;
@@ -261,7 +259,7 @@ public class CenterPicker extends JFrame {
     try (InputStream in = new FileInputStream(centerName)) {
       centers = PointFileReaderWriter.readOneToOne(in);
     } catch (final IOException e) {
-      ClientLogger.logQuietly("Failed to load centers: " + centerName, e);
+      ToolConsole.error("Failed to load centers: " + centerName, e);
     }
     repaint();
   }
@@ -337,10 +335,10 @@ public class CenterPicker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -350,7 +348,7 @@ public class CenterPicker extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -40,7 +40,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 public class CenterPicker extends JFrame {
   private static final long serialVersionUID = -5633998810385136625L;
@@ -64,14 +64,14 @@ public class CenterPicker extends JFrame {
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      ToolConsole.info("Map : " + mapName);
+      ToolLogger.info("Map : " + mapName);
       final CenterPicker picker = new CenterPicker(mapName);
       picker.setSize(800, 600);
       picker.setLocationRelativeTo(null);
@@ -91,7 +91,7 @@ public class CenterPicker extends JFrame {
               + "<br><br>RIGHT CLICK on an existing center = delete that center point."
               + "<br><br>When finished, save the centers and exit." + "</html>"));
     } else {
-      ToolConsole.info("No Image Map Selected. Shutting down.");
+      ToolLogger.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -121,7 +121,7 @@ public class CenterPicker extends JFrame {
       try (InputStream is = new FileInputStream(file.getPath())) {
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with your Polygons file: " + file.getAbsolutePath(), e);
+        ToolLogger.error("Something wrong with your Polygons file: " + file.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
@@ -130,7 +130,7 @@ public class CenterPicker extends JFrame {
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ToolConsole.error("Something wrong with your Polygons file: " + polyPath, e);
+          ToolLogger.error("Something wrong with your Polygons file: " + polyPath, e);
           System.exit(0);
         }
       }
@@ -240,9 +240,9 @@ public class CenterPicker extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToOne(out, centers);
       }
-      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+      ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception e) {
-      ToolConsole.error("Failed to save centers", e);
+      ToolLogger.error("Failed to save centers", e);
     }
   }
 
@@ -251,7 +251,7 @@ public class CenterPicker extends JFrame {
    * Loads a pre-defined file with map center points.
    */
   private void loadCenters() {
-    ToolConsole.info("Load a center file");
+    ToolLogger.info("Load a center file");
     final String centerName = new FileOpen("Load A Center File", mapFolderLocation, ".txt").getPathString();
     if (centerName == null) {
       return;
@@ -259,7 +259,7 @@ public class CenterPicker extends JFrame {
     try (InputStream in = new FileInputStream(centerName)) {
       centers = PointFileReaderWriter.readOneToOne(in);
     } catch (final IOException e) {
-      ToolConsole.error("Failed to load centers: " + centerName, e);
+      ToolLogger.error("Failed to load centers: " + centerName, e);
     }
     repaint();
   }
@@ -335,10 +335,10 @@ public class CenterPicker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -348,7 +348,7 @@ public class CenterPicker extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -49,7 +49,6 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.io.FileUtils;
 import games.strategy.triplea.ResourceLoader;
@@ -58,6 +57,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import games.strategy.util.Triple;
 import games.strategy.util.Tuple;
+import tools.util.ToolConsole;
 
 /**
  * This is the DecorationPlacer, it will create a text file for you containing the points to place images at. <br>
@@ -122,14 +122,14 @@ public class DecorationPlacer extends JFrame {
 
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      System.out.println("Map : " + mapName);
+      ToolConsole.info("Map : " + mapName);
       final DecorationPlacer picker = new DecorationPlacer(mapName);
       picker.setSize(800, 600);
       picker.setLocationRelativeTo(null);
@@ -176,7 +176,7 @@ public class DecorationPlacer extends JFrame {
               + "</html>"));
       picker.loadImagesAndPoints();
     } else {
-      System.out.println("No Image Map Selected. Shutting down.");
+      ToolConsole.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -198,30 +198,28 @@ public class DecorationPlacer extends JFrame {
             + "centers?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(fileCenters.getPath())) {
-        System.out.println("Centers : " + fileCenters.getPath());
+        ToolConsole.info("Centers : " + fileCenters.getPath());
         centers = PointFileReaderWriter.readOneToOne(is);
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with Centers file");
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ToolConsole.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     } else {
       try {
-        System.out.println("Select the Centers file");
+        ToolConsole.info("Select the Centers file");
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
-          System.out.println("Centers : " + centerPath);
+          ToolConsole.info("Centers : " + centerPath);
           try (InputStream is = new FileInputStream(centerPath)) {
             centers = PointFileReaderWriter.readOneToOne(is);
           }
         } else {
-          System.out.println("You must specify a centers file.");
-          System.out.println("Shutting down.");
+          ToolConsole.info("You must specify a centers file.");
+          ToolConsole.info("Shutting down.");
           System.exit(0);
         }
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with Centers file");
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ToolConsole.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     }
@@ -237,28 +235,26 @@ public class DecorationPlacer extends JFrame {
             + "polygons?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(filePoly.getPath())) {
-        System.out.println("Polygons : " + filePoly.getPath());
+        ToolConsole.info("Polygons : " + filePoly.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        System.out.println("Something wrong with your Polygons file: " + filePoly.getAbsolutePath());
-        e.printStackTrace();
+        ToolConsole.error("Something wrong with your Polygons file: " + filePoly.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
-      System.out.println("Select the Polygons file");
+      ToolConsole.info("Select the Polygons file");
       final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
       if (polyPath != null) {
-        System.out.println("Polygons : " + polyPath);
+        ToolConsole.info("Polygons : " + polyPath);
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          System.out.println("Something wrong with your Polygons file: " + polyPath);
-          e.printStackTrace();
+          ToolConsole.error("Something wrong with your Polygons file: " + polyPath, e);
           System.exit(0);
         }
       } else {
-        System.out.println("You must specify a Polgyon file.");
-        System.out.println("Shutting down.");
+        ToolConsole.info("You must specify a Polgyon file.");
+        ToolConsole.info("Shutting down.");
         System.exit(0);
       }
     }
@@ -469,15 +465,14 @@ public class DecorationPlacer extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
       }
-      System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception ex) {
-      ClientLogger.logQuietly("Failed to save points", ex);
+      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+    } catch (final Exception e) {
+      ToolConsole.error("Failed to save points", e);
     }
-    System.out.println("");
   }
 
   private void selectImagePointType() {
-    System.out.println("Select Which type of image points file are we making?");
+    ToolConsole.info("Select Which type of image points file are we making?");
     final JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
     panel.add(new JLabel("Which type of image points file are we making?"));
@@ -500,7 +495,7 @@ public class DecorationPlacer extends JFrame {
     for (final ImagePointType type : ImagePointType.getTypes()) {
       if (type.toString().equals(choice)) {
         imagePointType = type;
-        System.out.println("Selected Type: " + choice);
+        ToolConsole.info("Selected Type: " + choice);
         break;
       }
     }
@@ -508,7 +503,7 @@ public class DecorationPlacer extends JFrame {
 
   private void topLeftOrBottomLeft() {
     final Object[] options = {"Point is Top Left", "Point is Bottom Left"};
-    System.out.println("Select Show images from top left or bottom left point?");
+    ToolConsole.info("Select Show images from top left or bottom left point?");
     showFromTopLeft = JOptionPane.showOptionDialog(this,
         "Are the images shown from the top left, or from the bottom left point? \r\n"
             + "All images are shown from the top left, except for 'name_place.txt', 'pu_place.txt', and "
@@ -530,7 +525,7 @@ public class DecorationPlacer extends JFrame {
     final Object[] miscOrNamesOptions = {"Folder Full of Images", "Text File Full of Points"};
     final Object[] pointsAreNamesOptions = {"Points end in .png", "Points do NOT end in .png"};
     final Object[] fillAllOptions = {"Fill In All Territories", "Let Me Select Territories"};
-    System.out.println("Select Folder full of images OR Text file full of points?");
+    ToolConsole.info("Select Folder full of images OR Text file full of points?");
     if (JOptionPane.showOptionDialog(this,
         "Are you doing a folder full of different images (decorations.txt [misc] and name_place.txt [territoryNames]) "
             + "\r\n"
@@ -552,7 +547,7 @@ public class DecorationPlacer extends JFrame {
       // while everything else (like pu_place.txt (PUs folder)) will use either a static image or a dynamically chosen
       // image based on some
       // in game property in the game data.
-      System.out.println("Points end in .png OR they do not?");
+      ToolConsole.info("Points end in .png OR they do not?");
       fillCurrentImagePointsBasedOnImageFolder(JOptionPane.showOptionDialog(this,
           "Does the text file use the exact image file name, including the .png extension (decorations.txt) \r\n"
               + "Or does the text file not use the full file name with no extension, just a territory name "
@@ -568,7 +563,7 @@ public class DecorationPlacer extends JFrame {
       // load all territories? things like pu_place.txt should have all or most territories, while things like
       // blockade.txt and
       // kamikaze_place.txt and capitols.txt will only have a small number of territories
-      System.out.println("Select Fill in all territories OR let you select them?");
+      ToolConsole.info("Select Fill in all territories OR let you select them?");
       fillCurrentImagePointsBasedOnTextFile(JOptionPane.showOptionDialog(this,
           "Are you going to do a point for every single territory (pu_place.txt) \r\n"
               + "Or are you going to do just a few territories (capitols.txt, convoy.txt, vc.txt, etc, most others) ? "
@@ -579,13 +574,12 @@ public class DecorationPlacer extends JFrame {
           null, fillAllOptions, fillAllOptions[(imagePointType.isFillAll() ? 0 : 1)]) != JOptionPane.NO_OPTION);
     }
     cheapMutex = false;
-    System.out.println("");
     repaint();
     JOptionPane.showMessageDialog(this, new JLabel(imagePointType.getInstructions()));
   }
 
   private static void loadImageFolder() {
-    System.out.println("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
+    ToolConsole.info("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
     File folder = new File(mapFolderLocation, imagePointType.getFolderName());
     if (!folder.exists()) {
       folder = mapFolderLocation;
@@ -600,7 +594,7 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void loadImagePointTextFile() {
-    System.out.println("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
+    ToolConsole.info("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
     final FileOpen centerName = new FileOpen("Load an Image Points Text File", mapFolderLocation,
         new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
     currentImagePointsTextFile = centerName.getFile();
@@ -608,8 +602,7 @@ public class DecorationPlacer extends JFrame {
       try (InputStream in = new FileInputStream(centerName.getPathString())) {
         currentPoints = PointFileReaderWriter.readOneToMany(in);
       } catch (final IOException e) {
-        System.out.println("Failed to load image points: " + centerName.getPathString());
-        e.printStackTrace();
+        ToolConsole.error("Failed to load image points: " + centerName.getPathString(), e);
         System.exit(0);
       }
     } else {
@@ -644,13 +637,13 @@ public class DecorationPlacer extends JFrame {
       for (final Entry<String, Point> entry : centers.entrySet()) {
         List<Point> points = currentPoints.get(entry.getKey());
         if (points == null) {
-          System.out.println("Did NOT find point for: " + entry.getKey());
+          ToolConsole.info("Did NOT find point for: " + entry.getKey());
           points = new ArrayList<>();
           final Point p = new Point(entry.getValue().x - (width / 2),
               entry.getValue().y + addY + ((showFromTopLeft ? -1 : 1) * (height / 2)));
           points.add(p);
         } else {
-          System.out.println("Found point for: " + entry.getKey());
+          ToolConsole.info("Found point for: " + entry.getKey());
         }
         currentImagePoints.put(entry.getKey(), Tuple.of(staticImageForPlacing, points));
       }
@@ -682,14 +675,14 @@ public class DecorationPlacer extends JFrame {
         points = new ArrayList<>();
         Point p = centers.get(possibleTerritoryName);
         if (p == null) {
-          System.out.println("Did NOT find point for: " + possibleTerritoryName);
+          ToolConsole.info("Did NOT find point for: " + possibleTerritoryName);
           points.add(new Point(50, 50));
         } else {
           p = new Point(p.x - (image.getWidth(null) / 2),
               p.y + addY + ((showFromTopLeft ? -1 : 1) * (image.getHeight(null) / 2)));
           points.add(p);
           allTerritories.remove(possibleTerritoryName);
-          System.out.println("Found point for: " + possibleTerritoryName);
+          ToolConsole.info("Found point for: " + possibleTerritoryName);
         }
       } else {
         allTerritories.remove(possibleTerritoryName);
@@ -699,7 +692,7 @@ public class DecorationPlacer extends JFrame {
     }
     if (!allTerritories.isEmpty() && imagePointType == ImagePointType.name_place) {
       JOptionPane.showMessageDialog(this, new JLabel("Territory images not found in folder: " + allTerritories));
-      System.out.println(allTerritories);
+      ToolConsole.info("Territory images not found in folder: " + allTerritories);
     }
   }
 
@@ -806,10 +799,10 @@ public class DecorationPlacer extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -819,7 +812,7 @@ public class DecorationPlacer extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -57,7 +57,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import games.strategy.util.Triple;
 import games.strategy.util.Tuple;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * This is the DecorationPlacer, it will create a text file for you containing the points to place images at. <br>
@@ -122,14 +122,14 @@ public class DecorationPlacer extends JFrame {
 
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      ToolConsole.info("Map : " + mapName);
+      ToolLogger.info("Map : " + mapName);
       final DecorationPlacer picker = new DecorationPlacer(mapName);
       picker.setSize(800, 600);
       picker.setLocationRelativeTo(null);
@@ -176,7 +176,7 @@ public class DecorationPlacer extends JFrame {
               + "</html>"));
       picker.loadImagesAndPoints();
     } else {
-      ToolConsole.info("No Image Map Selected. Shutting down.");
+      ToolLogger.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -198,28 +198,28 @@ public class DecorationPlacer extends JFrame {
             + "centers?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(fileCenters.getPath())) {
-        ToolConsole.info("Centers : " + fileCenters.getPath());
+        ToolLogger.info("Centers : " + fileCenters.getPath());
         centers = PointFileReaderWriter.readOneToOne(is);
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with Centers file", e);
+        ToolLogger.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     } else {
       try {
-        ToolConsole.info("Select the Centers file");
+        ToolLogger.info("Select the Centers file");
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
-          ToolConsole.info("Centers : " + centerPath);
+          ToolLogger.info("Centers : " + centerPath);
           try (InputStream is = new FileInputStream(centerPath)) {
             centers = PointFileReaderWriter.readOneToOne(is);
           }
         } else {
-          ToolConsole.info("You must specify a centers file.");
-          ToolConsole.info("Shutting down.");
+          ToolLogger.info("You must specify a centers file.");
+          ToolLogger.info("Shutting down.");
           System.exit(0);
         }
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with Centers file", e);
+        ToolLogger.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     }
@@ -235,26 +235,26 @@ public class DecorationPlacer extends JFrame {
             + "polygons?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(filePoly.getPath())) {
-        ToolConsole.info("Polygons : " + filePoly.getPath());
+        ToolLogger.info("Polygons : " + filePoly.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with your Polygons file: " + filePoly.getAbsolutePath(), e);
+        ToolLogger.error("Something wrong with your Polygons file: " + filePoly.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
-      ToolConsole.info("Select the Polygons file");
+      ToolLogger.info("Select the Polygons file");
       final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
       if (polyPath != null) {
-        ToolConsole.info("Polygons : " + polyPath);
+        ToolLogger.info("Polygons : " + polyPath);
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ToolConsole.error("Something wrong with your Polygons file: " + polyPath, e);
+          ToolLogger.error("Something wrong with your Polygons file: " + polyPath, e);
           System.exit(0);
         }
       } else {
-        ToolConsole.info("You must specify a Polgyon file.");
-        ToolConsole.info("Shutting down.");
+        ToolLogger.info("You must specify a Polgyon file.");
+        ToolLogger.info("Shutting down.");
         System.exit(0);
       }
     }
@@ -465,14 +465,14 @@ public class DecorationPlacer extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
       }
-      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+      ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception e) {
-      ToolConsole.error("Failed to save points", e);
+      ToolLogger.error("Failed to save points", e);
     }
   }
 
   private void selectImagePointType() {
-    ToolConsole.info("Select Which type of image points file are we making?");
+    ToolLogger.info("Select Which type of image points file are we making?");
     final JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
     panel.add(new JLabel("Which type of image points file are we making?"));
@@ -495,7 +495,7 @@ public class DecorationPlacer extends JFrame {
     for (final ImagePointType type : ImagePointType.getTypes()) {
       if (type.toString().equals(choice)) {
         imagePointType = type;
-        ToolConsole.info("Selected Type: " + choice);
+        ToolLogger.info("Selected Type: " + choice);
         break;
       }
     }
@@ -503,7 +503,7 @@ public class DecorationPlacer extends JFrame {
 
   private void topLeftOrBottomLeft() {
     final Object[] options = {"Point is Top Left", "Point is Bottom Left"};
-    ToolConsole.info("Select Show images from top left or bottom left point?");
+    ToolLogger.info("Select Show images from top left or bottom left point?");
     showFromTopLeft = JOptionPane.showOptionDialog(this,
         "Are the images shown from the top left, or from the bottom left point? \r\n"
             + "All images are shown from the top left, except for 'name_place.txt', 'pu_place.txt', and "
@@ -525,7 +525,7 @@ public class DecorationPlacer extends JFrame {
     final Object[] miscOrNamesOptions = {"Folder Full of Images", "Text File Full of Points"};
     final Object[] pointsAreNamesOptions = {"Points end in .png", "Points do NOT end in .png"};
     final Object[] fillAllOptions = {"Fill In All Territories", "Let Me Select Territories"};
-    ToolConsole.info("Select Folder full of images OR Text file full of points?");
+    ToolLogger.info("Select Folder full of images OR Text file full of points?");
     if (JOptionPane.showOptionDialog(this,
         "Are you doing a folder full of different images (decorations.txt [misc] and name_place.txt [territoryNames]) "
             + "\r\n"
@@ -547,7 +547,7 @@ public class DecorationPlacer extends JFrame {
       // while everything else (like pu_place.txt (PUs folder)) will use either a static image or a dynamically chosen
       // image based on some
       // in game property in the game data.
-      ToolConsole.info("Points end in .png OR they do not?");
+      ToolLogger.info("Points end in .png OR they do not?");
       fillCurrentImagePointsBasedOnImageFolder(JOptionPane.showOptionDialog(this,
           "Does the text file use the exact image file name, including the .png extension (decorations.txt) \r\n"
               + "Or does the text file not use the full file name with no extension, just a territory name "
@@ -563,7 +563,7 @@ public class DecorationPlacer extends JFrame {
       // load all territories? things like pu_place.txt should have all or most territories, while things like
       // blockade.txt and
       // kamikaze_place.txt and capitols.txt will only have a small number of territories
-      ToolConsole.info("Select Fill in all territories OR let you select them?");
+      ToolLogger.info("Select Fill in all territories OR let you select them?");
       fillCurrentImagePointsBasedOnTextFile(JOptionPane.showOptionDialog(this,
           "Are you going to do a point for every single territory (pu_place.txt) \r\n"
               + "Or are you going to do just a few territories (capitols.txt, convoy.txt, vc.txt, etc, most others) ? "
@@ -579,7 +579,7 @@ public class DecorationPlacer extends JFrame {
   }
 
   private static void loadImageFolder() {
-    ToolConsole.info("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
+    ToolLogger.info("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
     File folder = new File(mapFolderLocation, imagePointType.getFolderName());
     if (!folder.exists()) {
       folder = mapFolderLocation;
@@ -594,7 +594,7 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void loadImagePointTextFile() {
-    ToolConsole.info("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
+    ToolLogger.info("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
     final FileOpen centerName = new FileOpen("Load an Image Points Text File", mapFolderLocation,
         new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
     currentImagePointsTextFile = centerName.getFile();
@@ -602,7 +602,7 @@ public class DecorationPlacer extends JFrame {
       try (InputStream in = new FileInputStream(centerName.getPathString())) {
         currentPoints = PointFileReaderWriter.readOneToMany(in);
       } catch (final IOException e) {
-        ToolConsole.error("Failed to load image points: " + centerName.getPathString(), e);
+        ToolLogger.error("Failed to load image points: " + centerName.getPathString(), e);
         System.exit(0);
       }
     } else {
@@ -637,13 +637,13 @@ public class DecorationPlacer extends JFrame {
       for (final Entry<String, Point> entry : centers.entrySet()) {
         List<Point> points = currentPoints.get(entry.getKey());
         if (points == null) {
-          ToolConsole.info("Did NOT find point for: " + entry.getKey());
+          ToolLogger.info("Did NOT find point for: " + entry.getKey());
           points = new ArrayList<>();
           final Point p = new Point(entry.getValue().x - (width / 2),
               entry.getValue().y + addY + ((showFromTopLeft ? -1 : 1) * (height / 2)));
           points.add(p);
         } else {
-          ToolConsole.info("Found point for: " + entry.getKey());
+          ToolLogger.info("Found point for: " + entry.getKey());
         }
         currentImagePoints.put(entry.getKey(), Tuple.of(staticImageForPlacing, points));
       }
@@ -675,14 +675,14 @@ public class DecorationPlacer extends JFrame {
         points = new ArrayList<>();
         Point p = centers.get(possibleTerritoryName);
         if (p == null) {
-          ToolConsole.info("Did NOT find point for: " + possibleTerritoryName);
+          ToolLogger.info("Did NOT find point for: " + possibleTerritoryName);
           points.add(new Point(50, 50));
         } else {
           p = new Point(p.x - (image.getWidth(null) / 2),
               p.y + addY + ((showFromTopLeft ? -1 : 1) * (image.getHeight(null) / 2)));
           points.add(p);
           allTerritories.remove(possibleTerritoryName);
-          ToolConsole.info("Found point for: " + possibleTerritoryName);
+          ToolLogger.info("Found point for: " + possibleTerritoryName);
         }
       } else {
         allTerritories.remove(possibleTerritoryName);
@@ -692,7 +692,7 @@ public class DecorationPlacer extends JFrame {
     }
     if (!allTerritories.isEmpty() && imagePointType == ImagePointType.name_place) {
       JOptionPane.showMessageDialog(this, new JLabel("Territory images not found in folder: " + allTerritories));
-      ToolConsole.info("Territory images not found in folder: " + allTerritories);
+      ToolLogger.info("Territory images not found in folder: " + allTerritories);
     }
   }
 
@@ -799,10 +799,10 @@ public class DecorationPlacer extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -812,7 +812,7 @@ public class DecorationPlacer extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/JTextAreaOptionPane.java
+++ b/src/main/java/tools/image/JTextAreaOptionPane.java
@@ -13,7 +13,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * A text area that can show updates scrolling by.
@@ -51,7 +51,7 @@ class JTextAreaOptionPane {
     // editor.setContentType("text/html");
     editor.setText(initialEditorText);
     if (this.logToSystemOut) {
-      ToolConsole.info(initialEditorText);
+      ToolLogger.info(initialEditorText);
     }
     editor.setCaretPosition(0);
     windowFrame.setPreferredSize(new Dimension(editorSizeX, editorSizeY));
@@ -90,7 +90,7 @@ class JTextAreaOptionPane {
 
   void append(final String text) {
     if (logToSystemOut) {
-      ToolConsole.info(text);
+      ToolLogger.info(text);
     }
     editor.append(text);
     editor.setCaretPosition(editor.getText().length());

--- a/src/main/java/tools/image/JTextAreaOptionPane.java
+++ b/src/main/java/tools/image/JTextAreaOptionPane.java
@@ -13,6 +13,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.WindowConstants;
 
+import tools.util.ToolConsole;
+
 /**
  * A text area that can show updates scrolling by.
  */
@@ -49,7 +51,7 @@ class JTextAreaOptionPane {
     // editor.setContentType("text/html");
     editor.setText(initialEditorText);
     if (this.logToSystemOut) {
-      System.out.println(initialEditorText);
+      ToolConsole.info(initialEditorText);
     }
     editor.setCaretPosition(0);
     windowFrame.setPreferredSize(new Dimension(editorSizeX, editorSizeY));
@@ -88,7 +90,7 @@ class JTextAreaOptionPane {
 
   void append(final String text) {
     if (logToSystemOut) {
-      System.out.print(text);
+      ToolConsole.info(text);
     }
     editor.append(text);
     editor.setCaretPosition(editor.getText().length());

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -47,7 +47,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * old comments
@@ -85,14 +85,14 @@ public class PolygonGrabber extends JFrame {
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      ToolConsole.info("Map : " + mapName);
+      ToolLogger.info("Map : " + mapName);
       final PolygonGrabber grabber = new PolygonGrabber(mapName);
       grabber.setSize(800, 600);
       grabber.setLocationRelativeTo(null);
@@ -114,7 +114,7 @@ public class PolygonGrabber extends JFrame {
               + "<br><br>RIGHT CLICK = save or replace those borders for that territory."
               + "<br><br>When finished, save the polygons and exit." + "</html>"));
     } else {
-      ToolConsole.info("No Image Map Selected. Shutting down.");
+      ToolLogger.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -142,27 +142,27 @@ public class PolygonGrabber extends JFrame {
             + "names?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(file.getPath())) {
-        ToolConsole.info("Centers : " + file.getPath());
+        ToolLogger.info("Centers : " + file.getPath());
         centers = PointFileReaderWriter.readOneToOne(is);
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with Centers file", e);
+        ToolLogger.error("Something wrong with Centers file", e);
       }
     } else {
       try {
-        ToolConsole.info("Select the Centers file");
+        ToolLogger.info("Select the Centers file");
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
-          ToolConsole.info("Centers : " + centerPath);
+          ToolLogger.info("Centers : " + centerPath);
           try (InputStream is = new FileInputStream(centerPath)) {
             centers = PointFileReaderWriter.readOneToOne(is);
           }
         } else {
-          ToolConsole.info("You must specify a centers file.");
-          ToolConsole.info("Shutting down.");
+          ToolLogger.info("You must specify a centers file.");
+          ToolLogger.info("Shutting down.");
           System.exit(0);
         }
       } catch (final IOException e) {
-        ToolConsole.error("Something wrong with Centers file", e);
+        ToolLogger.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     }
@@ -219,7 +219,7 @@ public class PolygonGrabber extends JFrame {
       g.drawImage(bufferedImage, 0, 0, null);
       for (final String territoryName : centers.keySet()) {
         final Point center = centers.get(territoryName);
-        ToolConsole.info("Detecting Polygon for:" + territoryName);
+        ToolLogger.info("Detecting Polygon for:" + territoryName);
         final Polygon p = findPolygon(center.x, center.y);
         // test if the poly contains the center point (this often fails when there is an island right above (because
         // findPolygon will grab
@@ -369,9 +369,9 @@ public class PolygonGrabber extends JFrame {
       try (OutputStream out = new FileOutputStream(polyName)) {
         PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
       }
-      ToolConsole.info("Data written to :" + new File(polyName).getCanonicalPath());
+      ToolLogger.info("Data written to :" + new File(polyName).getCanonicalPath());
     } catch (final Exception e) {
-      ToolConsole.error("file save name: " + polyName, e);
+      ToolLogger.error("file save name: " + polyName, e);
     }
   }
 
@@ -380,7 +380,7 @@ public class PolygonGrabber extends JFrame {
    * Loads a pre-defined file with map polygon points.
    */
   private void loadPolygons() {
-    ToolConsole.info("Load a polygon file");
+    ToolLogger.info("Load a polygon file");
     final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
     if (polyName == null) {
       return;
@@ -388,7 +388,7 @@ public class PolygonGrabber extends JFrame {
     try (InputStream in = new FileInputStream(polyName)) {
       polygons = PointFileReaderWriter.readOneToManyPolygons(in);
     } catch (final IOException e) {
-      ToolConsole.error("Failed to load polygons: " + polyName, e);
+      ToolLogger.error("Failed to load polygons: " + polyName, e);
       System.exit(0);
     }
     repaint();
@@ -412,7 +412,7 @@ public class PolygonGrabber extends JFrame {
     if (rightMouse && current != null) { // right click and list of polys is not empty
       doneCurrentGroup();
     } else if (pointInCurrentPolygon(point)) { // point clicked is already highlighted
-      ToolConsole.info("rejecting");
+      ToolLogger.info("rejecting");
       return;
     } else if (ctrlDown) {
       if (current == null) {
@@ -471,7 +471,7 @@ public class PolygonGrabber extends JFrame {
     } else if (option > 0) {
       current = null;
     } else {
-      ToolConsole.info("something very invalid");
+      ToolLogger.info("something very invalid");
     }
   }
 
@@ -708,7 +708,7 @@ public class PolygonGrabber extends JFrame {
       ypoints[i] = item.y;
       i++;
     }
-    ToolConsole.info("Done finding polygon. total points;" + xpoints.length);
+    ToolLogger.info("Done finding polygon. total points;" + xpoints.length);
     return new Polygon(xpoints, ypoints, xpoints.length);
   }
 
@@ -733,10 +733,10 @@ public class PolygonGrabber extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -746,7 +746,7 @@ public class PolygonGrabber extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -44,10 +44,10 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolConsole;
 
 /**
  * old comments
@@ -85,14 +85,14 @@ public class PolygonGrabber extends JFrame {
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
       mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
-      System.out.println("Map : " + mapName);
+      ToolConsole.info("Map : " + mapName);
       final PolygonGrabber grabber = new PolygonGrabber(mapName);
       grabber.setSize(800, 600);
       grabber.setLocationRelativeTo(null);
@@ -114,7 +114,7 @@ public class PolygonGrabber extends JFrame {
               + "<br><br>RIGHT CLICK = save or replace those borders for that territory."
               + "<br><br>When finished, save the polygons and exit." + "</html>"));
     } else {
-      System.out.println("No Image Map Selected. Shutting down.");
+      ToolConsole.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -142,29 +142,27 @@ public class PolygonGrabber extends JFrame {
             + "names?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(file.getPath())) {
-        System.out.println("Centers : " + file.getPath());
+        ToolConsole.info("Centers : " + file.getPath());
         centers = PointFileReaderWriter.readOneToOne(is);
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with Centers file");
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ToolConsole.error("Something wrong with Centers file", e);
       }
     } else {
       try {
-        System.out.println("Select the Centers file");
+        ToolConsole.info("Select the Centers file");
         final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
-          System.out.println("Centers : " + centerPath);
+          ToolConsole.info("Centers : " + centerPath);
           try (InputStream is = new FileInputStream(centerPath)) {
             centers = PointFileReaderWriter.readOneToOne(is);
           }
         } else {
-          System.out.println("You must specify a centers file.");
-          System.out.println("Shutting down.");
+          ToolConsole.info("You must specify a centers file.");
+          ToolConsole.info("Shutting down.");
           System.exit(0);
         }
-      } catch (final IOException ex1) {
-        System.out.println("Something wrong with Centers file");
-        ex1.printStackTrace();
+      } catch (final IOException e) {
+        ToolConsole.error("Something wrong with Centers file", e);
         System.exit(0);
       }
     }
@@ -221,7 +219,7 @@ public class PolygonGrabber extends JFrame {
       g.drawImage(bufferedImage, 0, 0, null);
       for (final String territoryName : centers.keySet()) {
         final Point center = centers.get(territoryName);
-        System.out.println("Detecting Polygon for:" + territoryName);
+        ToolConsole.info("Detecting Polygon for:" + territoryName);
         final Polygon p = findPolygon(center.x, center.y);
         // test if the poly contains the center point (this often fails when there is an island right above (because
         // findPolygon will grab
@@ -371,9 +369,9 @@ public class PolygonGrabber extends JFrame {
       try (OutputStream out = new FileOutputStream(polyName)) {
         PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
       }
-      System.out.println("Data written to :" + new File(polyName).getCanonicalPath());
-    } catch (final Exception ex) {
-      ClientLogger.logQuietly("file save name: " + polyName, ex);
+      ToolConsole.info("Data written to :" + new File(polyName).getCanonicalPath());
+    } catch (final Exception e) {
+      ToolConsole.error("file save name: " + polyName, e);
     }
   }
 
@@ -382,7 +380,7 @@ public class PolygonGrabber extends JFrame {
    * Loads a pre-defined file with map polygon points.
    */
   private void loadPolygons() {
-    System.out.println("Load a polygon file");
+    ToolConsole.info("Load a polygon file");
     final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
     if (polyName == null) {
       return;
@@ -390,8 +388,7 @@ public class PolygonGrabber extends JFrame {
     try (InputStream in = new FileInputStream(polyName)) {
       polygons = PointFileReaderWriter.readOneToManyPolygons(in);
     } catch (final IOException e) {
-      System.out.println("Failed to load polygons: " + polyName);
-      e.printStackTrace();
+      ToolConsole.error("Failed to load polygons: " + polyName, e);
       System.exit(0);
     }
     repaint();
@@ -415,7 +412,7 @@ public class PolygonGrabber extends JFrame {
     if (rightMouse && current != null) { // right click and list of polys is not empty
       doneCurrentGroup();
     } else if (pointInCurrentPolygon(point)) { // point clicked is already highlighted
-      System.out.println("rejecting");
+      ToolConsole.info("rejecting");
       return;
     } else if (ctrlDown) {
       if (current == null) {
@@ -474,7 +471,7 @@ public class PolygonGrabber extends JFrame {
     } else if (option > 0) {
       current = null;
     } else {
-      System.out.println("something very invalid");
+      ToolConsole.info("something very invalid");
     }
   }
 
@@ -711,7 +708,7 @@ public class PolygonGrabber extends JFrame {
       ypoints[i] = item.y;
       i++;
     }
-    System.out.println("Done finding polygon. total points;" + xpoints.length);
+    ToolConsole.info("Done finding polygon. total points;" + xpoints.length);
     return new Polygon(xpoints, ypoints, xpoints.length);
   }
 
@@ -736,10 +733,10 @@ public class PolygonGrabber extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -749,7 +746,7 @@ public class PolygonGrabber extends JFrame {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -24,6 +24,7 @@ import javax.swing.JOptionPane;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 import tools.map.making.ImageIoCompletionWatcher;
+import tools.util.ToolConsole;
 
 /**
  * Utility for breaking an image into seperate smaller images.
@@ -58,8 +59,8 @@ public class ReliefImageBreaker {
       mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
-      System.out.println("You need to select a folder to save the tiles in for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to select a folder to save the tiles in for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -74,8 +75,8 @@ public class ReliefImageBreaker {
     // ask user to input image location
     final Image map = loadImage();
     if (map == null) {
-      System.out.println("You need to select a map image for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to select a map image for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
     }
     // ask user wether it is sea zone only or not
@@ -84,15 +85,15 @@ public class ReliefImageBreaker {
     // ask user where the map is
     final String mapDir = getMapDirectory();
     if (mapDir == null || mapDir.equals("")) {
-      System.out.println("You need to specify a map name for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to specify a map name for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
     }
     try {
       mapData = new MapData(mapDir);
       // files for the map.
-    } catch (final NullPointerException npe) {
-      System.out.println("Bad data given or missing text files, shutting down");
+    } catch (final NullPointerException e) {
+      ToolConsole.error("Bad data given or missing text files, shutting down", e);
       System.exit(0);
     }
     for (final String territoryName : mapData.getTerritories()) {
@@ -105,7 +106,7 @@ public class ReliefImageBreaker {
       }
       processImage(territoryName, map);
     }
-    System.out.println("All Finished!");
+    ToolConsole.info("All Finished!");
     System.exit(0);
   }
 
@@ -146,7 +147,7 @@ public class ReliefImageBreaker {
    * @return java.awt.Image img the loaded image
    */
   private static Image loadImage() {
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
@@ -186,7 +187,7 @@ public class ReliefImageBreaker {
       outFileName += ".png";
     }
     ImageIO.write(relief, "png", new File(outFileName));
-    System.out.println("wrote " + outFileName);
+    ToolConsole.info("wrote " + outFileName);
   }
 
   /**
@@ -231,10 +232,10 @@ public class ReliefImageBreaker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -244,7 +245,7 @@ public class ReliefImageBreaker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -24,7 +24,7 @@ import javax.swing.JOptionPane;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 import tools.map.making.ImageIoCompletionWatcher;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * Utility for breaking an image into seperate smaller images.
@@ -59,8 +59,8 @@ public class ReliefImageBreaker {
       mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
-      ToolConsole.info("You need to select a folder to save the tiles in for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to select a folder to save the tiles in for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -75,8 +75,8 @@ public class ReliefImageBreaker {
     // ask user to input image location
     final Image map = loadImage();
     if (map == null) {
-      ToolConsole.info("You need to select a map image for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to select a map image for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
     }
     // ask user wether it is sea zone only or not
@@ -85,15 +85,15 @@ public class ReliefImageBreaker {
     // ask user where the map is
     final String mapDir = getMapDirectory();
     if (mapDir == null || mapDir.equals("")) {
-      ToolConsole.info("You need to specify a map name for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to specify a map name for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
     }
     try {
       mapData = new MapData(mapDir);
       // files for the map.
     } catch (final NullPointerException e) {
-      ToolConsole.error("Bad data given or missing text files, shutting down", e);
+      ToolLogger.error("Bad data given or missing text files, shutting down", e);
       System.exit(0);
     }
     for (final String territoryName : mapData.getTerritories()) {
@@ -106,7 +106,7 @@ public class ReliefImageBreaker {
       }
       processImage(territoryName, map);
     }
-    ToolConsole.info("All Finished!");
+    ToolLogger.info("All Finished!");
     System.exit(0);
   }
 
@@ -147,7 +147,7 @@ public class ReliefImageBreaker {
    * @return java.awt.Image img the loaded image
    */
   private static Image loadImage() {
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
@@ -187,7 +187,7 @@ public class ReliefImageBreaker {
       outFileName += ".png";
     }
     ImageIO.write(relief, "png", new File(outFileName));
-    ToolConsole.info("wrote " + outFileName);
+    ToolLogger.info("wrote " + outFileName);
   }
 
   /**
@@ -232,10 +232,10 @@ public class ReliefImageBreaker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -245,7 +245,7 @@ public class ReliefImageBreaker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -18,6 +18,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import games.strategy.triplea.ui.screen.TileManager;
+import tools.util.ToolConsole;
 
 /**
  * Utility for breaking an image into seperate smaller images.
@@ -60,8 +61,8 @@ public class TileImageBreaker {
       mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
-      System.out.println("You need to select a folder to save the tiles in for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to select a folder to save the tiles in for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -80,8 +81,8 @@ public class TileImageBreaker {
     // ask user to input image location
     final Image map = loadImage();
     if (map == null) {
-      System.out.println("You need to select a map image for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to select a map image for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -121,7 +122,7 @@ public class TileImageBreaker {
    * @return java.awt.Image img the loaded image
    */
   private static Image loadImage() {
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
@@ -158,10 +159,10 @@ public class TileImageBreaker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -171,7 +172,7 @@ public class TileImageBreaker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -18,7 +18,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import games.strategy.triplea.ui.screen.TileManager;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * Utility for breaking an image into seperate smaller images.
@@ -61,8 +61,8 @@ public class TileImageBreaker {
       mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
-      ToolConsole.info("You need to select a folder to save the tiles in for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to select a folder to save the tiles in for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -81,8 +81,8 @@ public class TileImageBreaker {
     // ask user to input image location
     final Image map = loadImage();
     if (map == null) {
-      ToolConsole.info("You need to select a map image for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to select a map image for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -122,7 +122,7 @@ public class TileImageBreaker {
    * @return java.awt.Image img the loaded image
    */
   private static Image loadImage() {
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
@@ -159,10 +159,10 @@ public class TileImageBreaker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -172,7 +172,7 @@ public class TileImageBreaker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -25,10 +25,10 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ui.screen.TileManager;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolConsole;
 
 /**
  * For taking a folder of basetiles and putting them back together into an image.
@@ -59,8 +59,8 @@ public class TileImageReconstructor {
       mapFolderLocation = baseTileLocationSelection.getFile().getParentFile();
     }
     if (baseTileLocation == null) {
-      System.out.println("You need to select a folder where the basetiles are for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to select a folder where the basetiles are for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -81,8 +81,8 @@ public class TileImageReconstructor {
         });
     imageSaveLocation = imageSaveLocationSelection.getPathString();
     if (imageSaveLocation == null) {
-      System.out.println("You need to choose a name and location for your image file for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("You need to choose a name and location for your image file for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -103,8 +103,8 @@ public class TileImageReconstructor {
       }
     }
     if (sizeX <= 0 || sizeY <= 0) {
-      System.out.println("Map dimensions must be greater than zero for this to work");
-      System.out.println("Shutting down");
+      ToolConsole.info("Map dimensions must be greater than zero for this to work");
+      ToolConsole.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -112,19 +112,18 @@ public class TileImageReconstructor {
         "Do not draw polgyons.txt file onto your image?\r\n(Default = 'yes' = do not draw)",
         "Do Not Also Draw Polygons?", JOptionPane.YES_NO_OPTION) == JOptionPane.NO_OPTION) {
       try {
-        System.out.println("Load a polygon file");
+        ToolConsole.info("Load a polygon file");
         final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyName != null) {
           try (InputStream in = new FileInputStream(polyName)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(in);
           } catch (final IOException e) {
-            System.out.println("Failed to load polygons: " + polyName);
-            e.printStackTrace();
+            ToolConsole.error("Failed to load polygons: " + polyName, e);
             System.exit(0);
           }
         }
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to load polygons", ex);
+      } catch (final Exception e) {
+        ToolConsole.error("Failed to load polygons", e);
       }
     }
     createMap();
@@ -166,7 +165,7 @@ public class TileImageReconstructor {
     try {
       ImageIO.write(mapImage, "png", new File(imageSaveLocation));
     } catch (final IOException e) {
-      ClientLogger.logQuietly("Failed to save image: " + imageSaveLocation, e);
+      ToolConsole.error("Failed to save image: " + imageSaveLocation, e);
     }
     textOptionPane.appendNewLine("Wrote " + imageSaveLocation);
     textOptionPane.appendNewLine("\r\nAll Finished!");
@@ -197,10 +196,10 @@ public class TileImageReconstructor {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -210,7 +209,7 @@ public class TileImageReconstructor {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -28,7 +28,7 @@ import javax.swing.filechooser.FileFilter;
 import games.strategy.triplea.ui.screen.TileManager;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * For taking a folder of basetiles and putting them back together into an image.
@@ -59,8 +59,8 @@ public class TileImageReconstructor {
       mapFolderLocation = baseTileLocationSelection.getFile().getParentFile();
     }
     if (baseTileLocation == null) {
-      ToolConsole.info("You need to select a folder where the basetiles are for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to select a folder where the basetiles are for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -81,8 +81,8 @@ public class TileImageReconstructor {
         });
     imageSaveLocation = imageSaveLocationSelection.getPathString();
     if (imageSaveLocation == null) {
-      ToolConsole.info("You need to choose a name and location for your image file for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("You need to choose a name and location for your image file for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -103,8 +103,8 @@ public class TileImageReconstructor {
       }
     }
     if (sizeX <= 0 || sizeY <= 0) {
-      ToolConsole.info("Map dimensions must be greater than zero for this to work");
-      ToolConsole.info("Shutting down");
+      ToolLogger.info("Map dimensions must be greater than zero for this to work");
+      ToolLogger.info("Shutting down");
       System.exit(0);
       return;
     }
@@ -112,18 +112,18 @@ public class TileImageReconstructor {
         "Do not draw polgyons.txt file onto your image?\r\n(Default = 'yes' = do not draw)",
         "Do Not Also Draw Polygons?", JOptionPane.YES_NO_OPTION) == JOptionPane.NO_OPTION) {
       try {
-        ToolConsole.info("Load a polygon file");
+        ToolLogger.info("Load a polygon file");
         final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyName != null) {
           try (InputStream in = new FileInputStream(polyName)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(in);
           } catch (final IOException e) {
-            ToolConsole.error("Failed to load polygons: " + polyName, e);
+            ToolLogger.error("Failed to load polygons: " + polyName, e);
             System.exit(0);
           }
         }
       } catch (final Exception e) {
-        ToolConsole.error("Failed to load polygons", e);
+        ToolLogger.error("Failed to load polygons", e);
       }
     }
     createMap();
@@ -165,7 +165,7 @@ public class TileImageReconstructor {
     try {
       ImageIO.write(mapImage, "png", new File(imageSaveLocation));
     } catch (final IOException e) {
-      ToolConsole.error("Failed to save image: " + imageSaveLocation, e);
+      ToolLogger.error("Failed to save image: " + imageSaveLocation, e);
     }
     textOptionPane.appendNewLine("Wrote " + imageSaveLocation);
     textOptionPane.appendNewLine("\r\nAll Finished!");
@@ -196,10 +196,10 @@ public class TileImageReconstructor {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -209,7 +209,7 @@ public class TileImageReconstructor {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/XmlUpdater.java
+++ b/src/main/java/tools/image/XmlUpdater.java
@@ -18,7 +18,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import games.strategy.io.IoUtils;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 public class XmlUpdater {
   private static File mapFolderLocation = null;
@@ -31,7 +31,7 @@ public class XmlUpdater {
     handleCommandLineArgs(args);
     final File gameXmlFile = new FileOpen("Select xml file", mapFolderLocation, ".xml").getFile();
     if (gameXmlFile == null) {
-      ToolConsole.info("No file selected");
+      ToolLogger.info("No file selected");
       return;
     }
     final InputStream source = XmlUpdater.class.getResourceAsStream("gameupdate.xslt");
@@ -58,7 +58,7 @@ public class XmlUpdater {
     try (OutputStream outStream = new FileOutputStream(gameXmlFile)) {
       outStream.write(resultBytes);
     }
-    ToolConsole.info("Successfully updated:" + gameXmlFile);
+    ToolLogger.info("Successfully updated:" + gameXmlFile);
   }
 
   private static String getValue(final String arg) {
@@ -82,10 +82,10 @@ public class XmlUpdater {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -95,7 +95,7 @@ public class XmlUpdater {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/image/XmlUpdater.java
+++ b/src/main/java/tools/image/XmlUpdater.java
@@ -18,6 +18,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import games.strategy.io.IoUtils;
+import tools.util.ToolConsole;
 
 public class XmlUpdater {
   private static File mapFolderLocation = null;
@@ -30,7 +31,7 @@ public class XmlUpdater {
     handleCommandLineArgs(args);
     final File gameXmlFile = new FileOpen("Select xml file", mapFolderLocation, ".xml").getFile();
     if (gameXmlFile == null) {
-      System.out.println("No file selected");
+      ToolConsole.info("No file selected");
       return;
     }
     final InputStream source = XmlUpdater.class.getResourceAsStream("gameupdate.xslt");
@@ -57,7 +58,7 @@ public class XmlUpdater {
     try (OutputStream outStream = new FileOutputStream(gameXmlFile)) {
       outStream.write(resultBytes);
     }
-    System.out.println("Successfully updated:" + gameXmlFile);
+    ToolConsole.info("Successfully updated:" + gameXmlFile);
   }
 
   private static String getValue(final String arg) {
@@ -81,10 +82,10 @@ public class XmlUpdater {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -94,7 +95,7 @@ public class XmlUpdater {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -27,12 +27,12 @@ import java.util.regex.Pattern;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.ui.Util;
 import games.strategy.util.AlphanumComparator;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolConsole;
 
 /**
  * Utility to find connections between polygons
@@ -66,7 +66,7 @@ public class ConnectionFinder {
             + "<br>The connections file can and Should Be Deleted when finished, because it is Not Needed and not read "
             + "by the engine. "
             + "</html>"));
-    System.out.println("Select polygons.txt");
+    ToolConsole.info("Select polygons.txt");
     File polyFile = null;
     if (mapFolderLocation != null && mapFolderLocation.exists()) {
       polyFile = new File(mapFolderLocation, "polygons.txt");
@@ -78,7 +78,7 @@ public class ConnectionFinder {
       polyFile = new FileOpen("Select The polygons.txt file", mapFolderLocation, ".txt").getFile();
     }
     if (polyFile == null || !polyFile.exists()) {
-      System.out.println("No polygons.txt Selected. Shutting down.");
+      ToolConsole.info("No polygons.txt Selected. Shutting down.");
       System.exit(0);
     }
     if (mapFolderLocation == null && polyFile != null) {
@@ -96,8 +96,8 @@ public class ConnectionFinder {
         }
         territoryAreas.put(territoryName, listOfAreas);
       }
-    } catch (final IOException ex) {
-      ClientLogger.logQuietly("Failed to load polygons: " + polyFile.getAbsolutePath(), ex);
+    } catch (final IOException e) {
+      ToolConsole.error("Failed to load polygons: " + polyFile.getAbsolutePath(), e);
       System.exit(0);
     }
     if (!dimensionsSet) {
@@ -135,7 +135,7 @@ public class ConnectionFinder {
       }
     }
     final Map<String, Collection<String>> connections = new HashMap<>();
-    System.out.println("Now Scanning for Connections");
+    ToolConsole.info("Now Scanning for Connections");
     // sort so that they are in alphabetic order (makes xml's prettier and easier to update in future)
     final List<String> allTerritories =
         mapOfPolygons == null ? new ArrayList<>() : new ArrayList<>(mapOfPolygons.keySet());
@@ -181,11 +181,10 @@ public class ConnectionFinder {
           "connections.txt", mapFolderLocation).getPathString();
       final StringBuilder connectionsString = convertToXml(connections);
       if (fileName == null) {
-        System.out.println();
         if (territoryDefinitions != null) {
-          System.out.println(territoryDefinitions.toString());
+          ToolConsole.info(territoryDefinitions.toString());
         }
-        System.out.println(connectionsString.toString());
+        ToolConsole.info(connectionsString.toString());
       } else {
         try (OutputStream out = new FileOutputStream(fileName)) {
           if (territoryDefinitions != null) {
@@ -193,10 +192,10 @@ public class ConnectionFinder {
           }
           out.write(String.valueOf(connectionsString).getBytes());
         }
-        System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
+        ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
       }
-    } catch (final Exception ex) {
-      ex.printStackTrace();
+    } catch (final Exception e) {
+      ToolConsole.error("Failed to write connections", e);
     }
   } // end main
 
@@ -389,7 +388,7 @@ public class ConnectionFinder {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
       if (arg.startsWith(LINE_THICKNESS)) {
@@ -413,7 +412,7 @@ public class ConnectionFinder {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -32,7 +32,7 @@ import games.strategy.util.AlphanumComparator;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * Utility to find connections between polygons
@@ -66,7 +66,7 @@ public class ConnectionFinder {
             + "<br>The connections file can and Should Be Deleted when finished, because it is Not Needed and not read "
             + "by the engine. "
             + "</html>"));
-    ToolConsole.info("Select polygons.txt");
+    ToolLogger.info("Select polygons.txt");
     File polyFile = null;
     if (mapFolderLocation != null && mapFolderLocation.exists()) {
       polyFile = new File(mapFolderLocation, "polygons.txt");
@@ -78,7 +78,7 @@ public class ConnectionFinder {
       polyFile = new FileOpen("Select The polygons.txt file", mapFolderLocation, ".txt").getFile();
     }
     if (polyFile == null || !polyFile.exists()) {
-      ToolConsole.info("No polygons.txt Selected. Shutting down.");
+      ToolLogger.info("No polygons.txt Selected. Shutting down.");
       System.exit(0);
     }
     if (mapFolderLocation == null && polyFile != null) {
@@ -97,7 +97,7 @@ public class ConnectionFinder {
         territoryAreas.put(territoryName, listOfAreas);
       }
     } catch (final IOException e) {
-      ToolConsole.error("Failed to load polygons: " + polyFile.getAbsolutePath(), e);
+      ToolLogger.error("Failed to load polygons: " + polyFile.getAbsolutePath(), e);
       System.exit(0);
     }
     if (!dimensionsSet) {
@@ -135,7 +135,7 @@ public class ConnectionFinder {
       }
     }
     final Map<String, Collection<String>> connections = new HashMap<>();
-    ToolConsole.info("Now Scanning for Connections");
+    ToolLogger.info("Now Scanning for Connections");
     // sort so that they are in alphabetic order (makes xml's prettier and easier to update in future)
     final List<String> allTerritories =
         mapOfPolygons == null ? new ArrayList<>() : new ArrayList<>(mapOfPolygons.keySet());
@@ -182,9 +182,9 @@ public class ConnectionFinder {
       final StringBuilder connectionsString = convertToXml(connections);
       if (fileName == null) {
         if (territoryDefinitions != null) {
-          ToolConsole.info(territoryDefinitions.toString());
+          ToolLogger.info(territoryDefinitions.toString());
         }
-        ToolConsole.info(connectionsString.toString());
+        ToolLogger.info(connectionsString.toString());
       } else {
         try (OutputStream out = new FileOutputStream(fileName)) {
           if (territoryDefinitions != null) {
@@ -192,10 +192,10 @@ public class ConnectionFinder {
           }
           out.write(String.valueOf(connectionsString).getBytes());
         }
-        ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+        ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
       }
     } catch (final Exception e) {
-      ToolConsole.error("Failed to write connections", e);
+      ToolLogger.error("Failed to write connections", e);
     }
   } // end main
 
@@ -388,7 +388,7 @@ public class ConnectionFinder {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
       if (arg.startsWith(LINE_THICKNESS)) {
@@ -412,7 +412,7 @@ public class ConnectionFinder {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/map/making/ImageShrinker.java
+++ b/src/main/java/tools/map/making/ImageShrinker.java
@@ -17,6 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import tools.image.FileOpen;
+import tools.util.ToolConsole;
 
 /**
  * Takes an image and shrinks it. Used for making small images.
@@ -64,7 +65,7 @@ public class ImageShrinker {
       encoder.setOutput(out);
       encoder.write(null, new IIOImage(thumbImage, null, null), param);
     }
-    System.out.println("Image successfully written to " + file.getPath());
+    ToolConsole.info("Image successfully written to " + file.getPath());
     System.exit(0);
   }
 
@@ -89,10 +90,10 @@ public class ImageShrinker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + value);
+        ToolConsole.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      System.out.println("Only argument allowed is the map directory.");
+      ToolConsole.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -102,7 +103,7 @@ public class ImageShrinker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          System.out.println("Could not find directory: " + value);
+          ToolConsole.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/map/making/ImageShrinker.java
+++ b/src/main/java/tools/map/making/ImageShrinker.java
@@ -17,7 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import tools.image.FileOpen;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * Takes an image and shrinks it. Used for making small images.
@@ -65,7 +65,7 @@ public class ImageShrinker {
       encoder.setOutput(out);
       encoder.write(null, new IIOImage(thumbImage, null, null), param);
     }
-    ToolConsole.info("Image successfully written to " + file.getPath());
+    ToolLogger.info("Image successfully written to " + file.getPath());
     System.exit(0);
   }
 
@@ -90,10 +90,10 @@ public class ImageShrinker {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + value);
+        ToolLogger.info("Could not find directory: " + value);
       }
     } else if (args.length > 1) {
-      ToolConsole.info("Only argument allowed is the map directory.");
+      ToolLogger.info("Only argument allowed is the map directory.");
     }
     // might be set by -D
     if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
@@ -103,7 +103,7 @@ public class ImageShrinker {
         if (mapFolder.exists()) {
           mapFolderLocation = mapFolder;
         } else {
-          ToolConsole.info("Could not find directory: " + value);
+          ToolLogger.info("Could not find directory: " + value);
         }
       }
     }

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -25,7 +25,6 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.net.OpenFileUtility;
@@ -40,6 +39,7 @@ import tools.image.PolygonGrabber;
 import tools.image.ReliefImageBreaker;
 import tools.image.TileImageBreaker;
 import tools.image.TileImageReconstructor;
+import tools.util.ToolConsole;
 
 /**
  * A frame that will run the different map making utilities we have.
@@ -348,15 +348,15 @@ public class MapCreator extends JFrame {
     panel2.add(placementPickerButton);
     panel2.add(Box.createVerticalStrut(30));
     final JButton tileBreakerButton = new JButton("Run the Tile Image Breaker");
-    tileBreakerButton.addActionListener(SwingAction.of("Run the Tile Image Breaker", e -> {
+    tileBreakerButton.addActionListener(SwingAction.of("Run the Tile Image Breaker", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(TileImageBreaker.class);
       } else {
         new Thread(() -> {
           try {
             TileImageBreaker.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run tile image breaker", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run tile image breaker", e);
           }
         }).start();
       }
@@ -364,15 +364,15 @@ public class MapCreator extends JFrame {
     panel2.add(tileBreakerButton);
     panel2.add(Box.createVerticalStrut(30));
     final JButton decorationPlacerButton = new JButton("Run the Decoration Placer");
-    decorationPlacerButton.addActionListener(SwingAction.of("Run the Decoration Placer", e -> {
+    decorationPlacerButton.addActionListener(SwingAction.of("Run the Decoration Placer", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(DecorationPlacer.class);
       } else {
         new Thread(() -> {
           try {
             DecorationPlacer.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run decoration placer", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run decoration placer", e);
           }
         }).start();
       }
@@ -390,15 +390,15 @@ public class MapCreator extends JFrame {
     panel3.add(new JLabel("Sorry but for now the only XML creator is Wisconsin's 'Part 2' of his map maker."));
     panel3.add(Box.createVerticalStrut(30));
     final JButton connectionFinderButton = new JButton("Run the Connection Finder");
-    connectionFinderButton.addActionListener(SwingAction.of("Run the Connection Finder", e -> {
+    connectionFinderButton.addActionListener(SwingAction.of("Run the Connection Finder", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(ConnectionFinder.class);
       } else {
         new Thread(() -> {
           try {
             ConnectionFinder.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run connection finder", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run connection finder", e);
           }
         }).start();
       }
@@ -415,15 +415,15 @@ public class MapCreator extends JFrame {
     panel4.add(new JLabel("Other or Optional Utilities:"));
     panel4.add(Box.createVerticalStrut(30));
     final JButton reliefBreakerButton = new JButton("Run the Relief Image Breaker");
-    reliefBreakerButton.addActionListener(SwingAction.of("Run the Relief Image Breaker", e -> {
+    reliefBreakerButton.addActionListener(SwingAction.of("Run the Relief Image Breaker", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(ReliefImageBreaker.class);
       } else {
         new Thread(() -> {
           try {
             ReliefImageBreaker.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run relief image breaker", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run relief image breaker", e);
           }
         }).start();
       }
@@ -431,15 +431,15 @@ public class MapCreator extends JFrame {
     panel4.add(reliefBreakerButton);
     panel4.add(Box.createVerticalStrut(30));
     final JButton imageShrinkerButton = new JButton("Run the Image Shrinker");
-    imageShrinkerButton.addActionListener(SwingAction.of("Run the Image Shrinker", e -> {
+    imageShrinkerButton.addActionListener(SwingAction.of("Run the Image Shrinker", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(ImageShrinker.class);
       } else {
         new Thread(() -> {
           try {
             ImageShrinker.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run image shrinker", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run image shrinker", e);
           }
         }).start();
       }
@@ -447,15 +447,15 @@ public class MapCreator extends JFrame {
     panel4.add(imageShrinkerButton);
     panel4.add(Box.createVerticalStrut(30));
     final JButton tileImageReconstructorButton = new JButton("Run the Tile Image Reconstructor");
-    tileImageReconstructorButton.addActionListener(SwingAction.of("Run the Tile Image Reconstructor", e -> {
+    tileImageReconstructorButton.addActionListener(SwingAction.of("Run the Tile Image Reconstructor", event -> {
       if (runUtilitiesAsSeperateProcesses) {
         runUtility(TileImageReconstructor.class);
       } else {
         new Thread(() -> {
           try {
             TileImageReconstructor.main(new String[0]);
-          } catch (final Exception exception) {
-            ClientLogger.logQuietly("Failed to run tile image reconstructor", exception);
+          } catch (final Exception e) {
+            ToolConsole.error("Failed to run tile image reconstructor", e);
           }
         }).start();
       }

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -39,7 +39,7 @@ import tools.image.PolygonGrabber;
 import tools.image.ReliefImageBreaker;
 import tools.image.TileImageBreaker;
 import tools.image.TileImageReconstructor;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * A frame that will run the different map making utilities we have.
@@ -356,7 +356,7 @@ public class MapCreator extends JFrame {
           try {
             TileImageBreaker.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run tile image breaker", e);
+            ToolLogger.error("Failed to run tile image breaker", e);
           }
         }).start();
       }
@@ -372,7 +372,7 @@ public class MapCreator extends JFrame {
           try {
             DecorationPlacer.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run decoration placer", e);
+            ToolLogger.error("Failed to run decoration placer", e);
           }
         }).start();
       }
@@ -398,7 +398,7 @@ public class MapCreator extends JFrame {
           try {
             ConnectionFinder.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run connection finder", e);
+            ToolLogger.error("Failed to run connection finder", e);
           }
         }).start();
       }
@@ -423,7 +423,7 @@ public class MapCreator extends JFrame {
           try {
             ReliefImageBreaker.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run relief image breaker", e);
+            ToolLogger.error("Failed to run relief image breaker", e);
           }
         }).start();
       }
@@ -439,7 +439,7 @@ public class MapCreator extends JFrame {
           try {
             ImageShrinker.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run image shrinker", e);
+            ToolLogger.error("Failed to run image shrinker", e);
           }
         }).start();
       }
@@ -455,7 +455,7 @@ public class MapCreator extends JFrame {
           try {
             TileImageReconstructor.main(new String[0]);
           } catch (final Exception e) {
-            ToolConsole.error("Failed to run tile image reconstructor", e);
+            ToolLogger.error("Failed to run tile image reconstructor", e);
           }
         }).start();
       }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -51,7 +51,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.util.Tuple;
 import tools.image.FileOpen;
 import tools.image.FileSave;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * This is the MapPropertiesMaker, it will create a map.properties file for you. <br>
@@ -82,7 +82,7 @@ public class MapPropertiesMaker extends JFrame {
     // map.properties file for
     // you. " + "</html>"));
     if (mapFolderLocation == null) {
-      ToolConsole.info("Select the map folder");
+      ToolLogger.info("Select the map folder");
       final String path = new FileSave("Where is your map's folder?", null, mapFolderLocation).getPathString();
       if (path != null) {
         final File mapFolder = new File(path);
@@ -98,7 +98,7 @@ public class MapPropertiesMaker extends JFrame {
       maker.setLocationRelativeTo(null);
       maker.setVisible(true);
     } else {
-      ToolConsole.info("No Map Folder Selected. Shutting down.");
+      ToolLogger.info("No Map Folder Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -254,7 +254,7 @@ public class MapPropertiesMaker extends JFrame {
       label.addMouseListener(new MouseListener() {
         @Override
         public void mouseClicked(final MouseEvent e) {
-          ToolConsole.info(label.getBackground().toString());
+          ToolLogger.info(label.getBackground().toString());
           final Color color = JColorChooser.showDialog(label, "Choose color", label.getBackground());
           mapProperties.getColorMap().put(label.getText(), color);
           MapPropertiesMaker.this.createPlayerColorChooser();
@@ -312,7 +312,7 @@ public class MapPropertiesMaker extends JFrame {
 
   private void loadProperties() {
     final Properties properties = new Properties();
-    ToolConsole.info("Load a properties file");
+    ToolLogger.info("Load a properties file");
     final String centerName =
         new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
     if (centerName == null) {
@@ -321,7 +321,7 @@ public class MapPropertiesMaker extends JFrame {
     try (InputStream in = new FileInputStream(centerName)) {
       properties.load(in);
     } catch (final IOException e) {
-      ToolConsole.error("Failed to load map properties: " + centerName, e);
+      ToolLogger.error("Failed to load map properties: " + centerName, e);
     }
     for (final Method setter : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");
@@ -347,10 +347,10 @@ public class MapPropertiesMaker extends JFrame {
           Writer out = new OutputStreamWriter(sink)) {
         out.write(stringToWrite);
       }
-      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
-      ToolConsole.info(stringToWrite);
+      ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
+      ToolLogger.info(stringToWrite);
     } catch (final Exception e) {
-      ToolConsole.error("Failed to save map properties", e);
+      ToolLogger.error("Failed to save map properties", e);
     }
   }
 
@@ -364,7 +364,7 @@ public class MapPropertiesMaker extends JFrame {
       try {
         outString.append(outMethod.invoke(mapProperties));
       } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-        ToolConsole.error("Failed to invoke method reflectively: " + outMethod.getName(), e);
+        ToolLogger.error("Failed to invoke method reflectively: " + outMethod.getName(), e);
       }
     }
     return outString.toString();
@@ -391,17 +391,17 @@ public class MapPropertiesMaker extends JFrame {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            ToolConsole.info(propertie + ":" + value);
+            ToolLogger.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        ToolConsole.info("Unrecogized:" + arg2);
+        ToolLogger.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolLogger.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -414,7 +414,7 @@ public class MapPropertiesMaker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + folderString);
+        ToolLogger.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
@@ -423,9 +423,9 @@ public class MapPropertiesMaker extends JFrame {
         final double unitZoomPercent = Double.parseDouble(zoomString);
         // mapProperties.setUNITS_SCALE(unit_zoom_percent);
         mapProperties.setUnitsScale(zoomString);
-        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
+        ToolLogger.info("Unit Zoom Percent to use: " + unitZoomPercent);
       } catch (final Exception e) {
-        ToolConsole.error("Not a decimal percentage: " + zoomString);
+        ToolLogger.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
@@ -434,9 +434,9 @@ public class MapPropertiesMaker extends JFrame {
         final int unitWidth = Integer.parseInt(widthString);
         mapProperties.setUnitsWidth(unitWidth);
         mapProperties.setUnitsCounterOffsetWidth(unitWidth / 4);
-        ToolConsole.info("Unit Width to use: " + unitWidth);
+        ToolLogger.info("Unit Width to use: " + unitWidth);
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + widthString);
+        ToolLogger.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
@@ -445,9 +445,9 @@ public class MapPropertiesMaker extends JFrame {
         final int unitHeight = Integer.parseInt(heightString);
         mapProperties.setUnitsHeight(unitHeight);
         mapProperties.setUnitsCounterOffsetHeight(unitHeight);
-        ToolConsole.info("Unit Height to use: " + unitHeight);
+        ToolLogger.info("Unit Height to use: " + unitHeight);
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + heightString);
+        ToolLogger.error("Not an integer: " + heightString);
       }
     }
   }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -44,7 +44,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.ui.DoubleTextField;
 import games.strategy.ui.IntTextField;
@@ -52,6 +51,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.util.Tuple;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolConsole;
 
 /**
  * This is the MapPropertiesMaker, it will create a map.properties file for you. <br>
@@ -82,7 +82,7 @@ public class MapPropertiesMaker extends JFrame {
     // map.properties file for
     // you. " + "</html>"));
     if (mapFolderLocation == null) {
-      System.out.println("Select the map folder");
+      ToolConsole.info("Select the map folder");
       final String path = new FileSave("Where is your map's folder?", null, mapFolderLocation).getPathString();
       if (path != null) {
         final File mapFolder = new File(path);
@@ -98,7 +98,7 @@ public class MapPropertiesMaker extends JFrame {
       maker.setLocationRelativeTo(null);
       maker.setVisible(true);
     } else {
-      System.out.println("No Map Folder Selected. Shutting down.");
+      ToolConsole.info("No Map Folder Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -254,7 +254,7 @@ public class MapPropertiesMaker extends JFrame {
       label.addMouseListener(new MouseListener() {
         @Override
         public void mouseClicked(final MouseEvent e) {
-          System.out.println(label.getBackground());
+          ToolConsole.info(label.getBackground().toString());
           final Color color = JColorChooser.showDialog(label, "Choose color", label.getBackground());
           mapProperties.getColorMap().put(label.getText(), color);
           MapPropertiesMaker.this.createPlayerColorChooser();
@@ -312,7 +312,7 @@ public class MapPropertiesMaker extends JFrame {
 
   private void loadProperties() {
     final Properties properties = new Properties();
-    System.out.println("Load a properties file");
+    ToolConsole.info("Load a properties file");
     final String centerName =
         new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
     if (centerName == null) {
@@ -321,7 +321,7 @@ public class MapPropertiesMaker extends JFrame {
     try (InputStream in = new FileInputStream(centerName)) {
       properties.load(in);
     } catch (final IOException e) {
-      ClientLogger.logQuietly("Failed to load map properties: " + centerName, e);
+      ToolConsole.error("Failed to load map properties: " + centerName, e);
     }
     for (final Method setter : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");
@@ -347,12 +347,10 @@ public class MapPropertiesMaker extends JFrame {
           Writer out = new OutputStreamWriter(sink)) {
         out.write(stringToWrite);
       }
-      System.out.println("");
-      System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
-      System.out.println("");
-      System.out.println(stringToWrite);
+      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+      ToolConsole.info(stringToWrite);
     } catch (final Exception e) {
-      ClientLogger.logQuietly("Failed to save map properties", e);
+      ToolConsole.error("Failed to save map properties", e);
     }
   }
 
@@ -366,7 +364,7 @@ public class MapPropertiesMaker extends JFrame {
       try {
         outString.append(outMethod.invoke(mapProperties));
       } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-        ClientLogger.logQuietly("Failed to invoke method reflectively: " + outMethod.getName(), e);
+        ToolConsole.error("Failed to invoke method reflectively: " + outMethod.getName(), e);
       }
     }
     return outString.toString();
@@ -393,17 +391,17 @@ public class MapPropertiesMaker extends JFrame {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            System.out.println(propertie + ":" + value);
+            ToolConsole.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        System.out.println("Unrecogized:" + arg2);
+        ToolConsole.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          System.out.println("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -416,7 +414,7 @@ public class MapPropertiesMaker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + folderString);
+        ToolConsole.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
@@ -425,9 +423,9 @@ public class MapPropertiesMaker extends JFrame {
         final double unitZoomPercent = Double.parseDouble(zoomString);
         // mapProperties.setUNITS_SCALE(unit_zoom_percent);
         mapProperties.setUnitsScale(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
-      } catch (final Exception ex) {
-        System.err.println("Not a decimal percentage: " + zoomString);
+        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
+      } catch (final Exception e) {
+        ToolConsole.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
@@ -436,9 +434,9 @@ public class MapPropertiesMaker extends JFrame {
         final int unitWidth = Integer.parseInt(widthString);
         mapProperties.setUnitsWidth(unitWidth);
         mapProperties.setUnitsCounterOffsetWidth(unitWidth / 4);
-        System.out.println("Unit Width to use: " + unitWidth);
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + widthString);
+        ToolConsole.info("Unit Width to use: " + unitWidth);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
@@ -447,9 +445,9 @@ public class MapPropertiesMaker extends JFrame {
         final int unitHeight = Integer.parseInt(heightString);
         mapProperties.setUnitsHeight(unitHeight);
         mapProperties.setUnitsCounterOffsetHeight(unitHeight);
-        System.out.println("Unit Height to use: " + unitHeight);
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + heightString);
+        ToolConsole.info("Unit Height to use: " + unitHeight);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + heightString);
       }
     }
   }

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -30,7 +30,7 @@ import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.data.properties.StringProperty;
 import games.strategy.util.PropertyUtil;
 import games.strategy.util.Tuple;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 /**
  * This will take ANY object, and then look at every method that begins with 'set[name]' and if there also exists a
@@ -112,10 +112,10 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     final Object value = getValue();
     final Object[] args = {value};
     try {
-      ToolConsole.info(setter + "   to   " + value);
+      ToolLogger.info(setter + "   to   " + value);
       setter.invoke(object, args);
     } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-      ToolConsole.error("Failed to invoke setter reflectively: " + setter.getName(), e);
+      ToolLogger.error("Failed to invoke setter reflectively: " + setter.getName(), e);
     }
   }
 
@@ -135,7 +135,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       try {
         currentValue = field.get(object);
       } catch (final IllegalArgumentException | IllegalAccessException e) {
-        ToolConsole.error("Failed to get field value reflectively: " + field.getName(), e);
+        ToolLogger.error("Failed to get field value reflectively: " + field.getName(), e);
         continue;
       }
       try {
@@ -143,7 +143,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
             new MapPropertyWrapper<>(propertyName, null, currentValue, setter);
         properties.add(wrapper);
       } catch (final Exception e) {
-        ToolConsole.error("Failed to create map property wrapper", e);
+        ToolLogger.error("Failed to create map property wrapper", e);
       }
     }
     properties.sort(Comparator.comparing(MapPropertyWrapper::getName));

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.properties.AEditableProperty;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.CollectionProperty;
@@ -31,6 +30,7 @@ import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.data.properties.StringProperty;
 import games.strategy.util.PropertyUtil;
 import games.strategy.util.Tuple;
+import tools.util.ToolConsole;
 
 /**
  * This will take ANY object, and then look at every method that begins with 'set[name]' and if there also exists a
@@ -112,10 +112,10 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     final Object value = getValue();
     final Object[] args = {value};
     try {
-      System.out.println(setter + "   to   " + value);
+      ToolConsole.info(setter + "   to   " + value);
       setter.invoke(object, args);
     } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
-      ClientLogger.logQuietly("Failed to invoke setter reflectively: " + setter.getName(), e);
+      ToolConsole.error("Failed to invoke setter reflectively: " + setter.getName(), e);
     }
   }
 
@@ -135,7 +135,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       try {
         currentValue = field.get(object);
       } catch (final IllegalArgumentException | IllegalAccessException e) {
-        ClientLogger.logQuietly("Failed to get field value reflectively: " + field.getName(), e);
+        ToolConsole.error("Failed to get field value reflectively: " + field.getName(), e);
         continue;
       }
       try {
@@ -143,7 +143,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
             new MapPropertyWrapper<>(propertyName, null, currentValue, setter);
         properties.add(wrapper);
       } catch (final Exception e) {
-        ClientLogger.logQuietly("Failed to create map property wrapper", e);
+        ToolConsole.error("Failed to create map property wrapper", e);
       }
     }
     properties.sort(Comparator.comparing(MapPropertyWrapper::getName));

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -44,7 +44,6 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.SwingAction;
@@ -52,6 +51,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolConsole;
 
 public class PlacementPicker extends JFrame {
   private static final long serialVersionUID = 953019978051420881L;
@@ -119,7 +119,7 @@ public class PlacementPicker extends JFrame {
             + "<br><br>To show all placements, or see the overflow direction, or see which territories you have not "
             + "yet completed enough, "
             + "<br>placements for, turn on the mode options in the 'edit' menu. " + "</html>"));
-    System.out.println("Select the map");
+    ToolConsole.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
@@ -131,7 +131,7 @@ public class PlacementPicker extends JFrame {
       picker.setLocationRelativeTo(null);
       picker.setVisible(true);
     } else {
-      System.out.println("No Image Map Selected. Shutting down.");
+      ToolConsole.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -211,8 +211,8 @@ public class PlacementPicker extends JFrame {
             }
           }
         }
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to initialize from map properties", ex);
+      } catch (final Exception e) {
+        ToolConsole.error("Failed to initialize from map properties", e);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -246,8 +246,8 @@ public class PlacementPicker extends JFrame {
           }
         }
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to initialize from user input", ex);
+      } catch (final Exception e) {
+        ToolConsole.error("Failed to initialize from user input", e);
       }
     }
     File file = null;
@@ -261,27 +261,25 @@ public class PlacementPicker extends JFrame {
         "A polygons.txt file was found in the map's folder, do you want to use the file to supply the territories?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(file.getPath())) {
-        System.out.println("Polygons : " + file.getPath());
+        ToolConsole.info("Polygons : " + file.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        System.out.println("Failed to load polygons: " + file.getAbsolutePath());
-        e.printStackTrace();
+        ToolConsole.error("Failed to load polygons: " + file.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
-      System.out.println("Select the Polygons file");
+      ToolConsole.info("Select the Polygons file");
       final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
       if (polyPath != null) {
-        System.out.println("Polygons : " + polyPath);
+        ToolConsole.info("Polygons : " + polyPath);
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          System.out.println("Failed to load polygons: " + polyPath);
-          e.printStackTrace();
+          ToolConsole.error("Failed to load polygons: " + polyPath, e);
           System.exit(0);
         }
       } else {
-        System.out.println("Polygons file not given. Will run regardless");
+        ToolConsole.info("Polygons file not given. Will run regardless");
       }
     }
     createImage(mapName);
@@ -490,9 +488,9 @@ public class PlacementPicker extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
       }
-      System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception ex) {
-      ClientLogger.logQuietly("fileName = " + fileName, ex);
+      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+    } catch (final Exception e) {
+      ToolConsole.error("fileName = " + fileName, e);
     }
   }
 
@@ -501,7 +499,7 @@ public class PlacementPicker extends JFrame {
    * Loads a pre-defined file with map placement points.
    */
   private void loadPlacements() {
-    System.out.println("Load a placement file");
+    ToolConsole.info("Load a placement file");
     final String placeName = new FileOpen("Load A Placement File", mapFolderLocation, ".txt").getPathString();
     if (placeName == null) {
       return;
@@ -509,8 +507,7 @@ public class PlacementPicker extends JFrame {
     try (InputStream in = new FileInputStream(placeName)) {
       placements = PointFileReaderWriter.readOneToMany(in);
     } catch (final IOException e) {
-      System.out.println("Failed to load placements: " + placeName);
-      e.printStackTrace();
+      ToolConsole.error("Failed to load placements: " + placeName, e);
       System.exit(0);
     }
     repaint();
@@ -553,7 +550,7 @@ public class PlacementPicker extends JFrame {
         }
         placements.put(currentCountry, currentPlacements);
         currentPlacements = new ArrayList<>();
-        System.out.println("done:" + currentCountry);
+        ToolConsole.info("done:" + currentCountry);
       }
     } else if (rightMouse) {
       if (currentPlacements != null && !currentPlacements.isEmpty()) {
@@ -629,17 +626,17 @@ public class PlacementPicker extends JFrame {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            System.out.println(propertie + ":" + value);
+            ToolConsole.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        System.out.println("Unrecogized:" + arg2);
+        ToolConsole.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          System.out.println("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -651,43 +648,43 @@ public class PlacementPicker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        System.out.println("Could not find directory: " + folderString);
+        ToolConsole.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
         unitZoomPercent = Double.parseDouble(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
+        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not a decimal percentage: " + zoomString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
         unitWidth = Integer.parseInt(widthString);
-        System.out.println("Unit Width to use: " + unitWidth);
+        ToolConsole.info("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + widthString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
         unitHeight = Integer.parseInt(heightString);
-        System.out.println("Unit Height to use: " + unitHeight);
+        ToolConsole.info("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + heightString);
+      } catch (final Exception e) {
+        ToolConsole.error("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
       placeWidth = (int) (unitZoomPercent * unitWidth);
       placeHeight = (int) (unitZoomPercent * unitHeight);
-      System.out.println("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
+      ToolConsole.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -51,7 +51,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
-import tools.util.ToolConsole;
+import tools.util.ToolLogger;
 
 public class PlacementPicker extends JFrame {
   private static final long serialVersionUID = 953019978051420881L;
@@ -119,7 +119,7 @@ public class PlacementPicker extends JFrame {
             + "<br><br>To show all placements, or see the overflow direction, or see which territories you have not "
             + "yet completed enough, "
             + "<br>placements for, turn on the mode options in the 'edit' menu. " + "</html>"));
-    ToolConsole.info("Select the map");
+    ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
     if (mapFolderLocation == null && mapSelection.getFile() != null) {
@@ -131,7 +131,7 @@ public class PlacementPicker extends JFrame {
       picker.setLocationRelativeTo(null);
       picker.setVisible(true);
     } else {
-      ToolConsole.info("No Image Map Selected. Shutting down.");
+      ToolLogger.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
   } // end main
@@ -212,7 +212,7 @@ public class PlacementPicker extends JFrame {
           }
         }
       } catch (final Exception e) {
-        ToolConsole.error("Failed to initialize from map properties", e);
+        ToolLogger.error("Failed to initialize from map properties", e);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -247,7 +247,7 @@ public class PlacementPicker extends JFrame {
         }
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Failed to initialize from user input", e);
+        ToolLogger.error("Failed to initialize from user input", e);
       }
     }
     File file = null;
@@ -261,25 +261,25 @@ public class PlacementPicker extends JFrame {
         "A polygons.txt file was found in the map's folder, do you want to use the file to supply the territories?",
         "File Suggestion", 1) == 0) {
       try (InputStream is = new FileInputStream(file.getPath())) {
-        ToolConsole.info("Polygons : " + file.getPath());
+        ToolLogger.info("Polygons : " + file.getPath());
         polygons = PointFileReaderWriter.readOneToManyPolygons(is);
       } catch (final IOException e) {
-        ToolConsole.error("Failed to load polygons: " + file.getAbsolutePath(), e);
+        ToolLogger.error("Failed to load polygons: " + file.getAbsolutePath(), e);
         System.exit(0);
       }
     } else {
-      ToolConsole.info("Select the Polygons file");
+      ToolLogger.info("Select the Polygons file");
       final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
       if (polyPath != null) {
-        ToolConsole.info("Polygons : " + polyPath);
+        ToolLogger.info("Polygons : " + polyPath);
         try (InputStream is = new FileInputStream(polyPath)) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          ToolConsole.error("Failed to load polygons: " + polyPath, e);
+          ToolLogger.error("Failed to load polygons: " + polyPath, e);
           System.exit(0);
         }
       } else {
-        ToolConsole.info("Polygons file not given. Will run regardless");
+        ToolLogger.info("Polygons file not given. Will run regardless");
       }
     }
     createImage(mapName);
@@ -488,9 +488,9 @@ public class PlacementPicker extends JFrame {
       try (OutputStream out = new FileOutputStream(fileName)) {
         PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
       }
-      ToolConsole.info("Data written to :" + new File(fileName).getCanonicalPath());
+      ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception e) {
-      ToolConsole.error("fileName = " + fileName, e);
+      ToolLogger.error("fileName = " + fileName, e);
     }
   }
 
@@ -499,7 +499,7 @@ public class PlacementPicker extends JFrame {
    * Loads a pre-defined file with map placement points.
    */
   private void loadPlacements() {
-    ToolConsole.info("Load a placement file");
+    ToolLogger.info("Load a placement file");
     final String placeName = new FileOpen("Load A Placement File", mapFolderLocation, ".txt").getPathString();
     if (placeName == null) {
       return;
@@ -507,7 +507,7 @@ public class PlacementPicker extends JFrame {
     try (InputStream in = new FileInputStream(placeName)) {
       placements = PointFileReaderWriter.readOneToMany(in);
     } catch (final IOException e) {
-      ToolConsole.error("Failed to load placements: " + placeName, e);
+      ToolLogger.error("Failed to load placements: " + placeName, e);
       System.exit(0);
     }
     repaint();
@@ -550,7 +550,7 @@ public class PlacementPicker extends JFrame {
         }
         placements.put(currentCountry, currentPlacements);
         currentPlacements = new ArrayList<>();
-        ToolConsole.info("done:" + currentCountry);
+        ToolLogger.info("done:" + currentCountry);
       }
     } else if (rightMouse) {
       if (currentPlacements != null && !currentPlacements.isEmpty()) {
@@ -626,17 +626,17 @@ public class PlacementPicker extends JFrame {
           if (arg.equals(propertie)) {
             final String value = getValue(arg2);
             System.setProperty(propertie, value);
-            ToolConsole.info(propertie + ":" + value);
+            ToolLogger.info(propertie + ":" + value);
             found = true;
             break;
           }
         }
       }
       if (!found) {
-        ToolConsole.info("Unrecogized:" + arg2);
+        ToolLogger.info("Unrecogized:" + arg2);
         if (!usagePrinted) {
           usagePrinted = true;
-          ToolConsole.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
+          ToolLogger.info("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
               + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
               + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
         }
@@ -648,43 +648,43 @@ public class PlacementPicker extends JFrame {
       if (mapFolder.exists()) {
         mapFolderLocation = mapFolder;
       } else {
-        ToolConsole.info("Could not find directory: " + folderString);
+        ToolLogger.info("Could not find directory: " + folderString);
       }
     }
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
         unitZoomPercent = Double.parseDouble(zoomString);
-        ToolConsole.info("Unit Zoom Percent to use: " + unitZoomPercent);
+        ToolLogger.info("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not a decimal percentage: " + zoomString);
+        ToolLogger.error("Not a decimal percentage: " + zoomString);
       }
     }
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
         unitWidth = Integer.parseInt(widthString);
-        ToolConsole.info("Unit Width to use: " + unitWidth);
+        ToolLogger.info("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + widthString);
+        ToolLogger.error("Not an integer: " + widthString);
       }
     }
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
         unitHeight = Integer.parseInt(heightString);
-        ToolConsole.info("Unit Height to use: " + unitHeight);
+        ToolLogger.info("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
       } catch (final Exception e) {
-        ToolConsole.error("Not an integer: " + heightString);
+        ToolLogger.error("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
       placeWidth = (int) (unitZoomPercent * unitWidth);
       placeHeight = (int) (unitZoomPercent * unitHeight);
-      ToolConsole.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
+      ToolLogger.info("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }

--- a/src/main/java/tools/util/ToolConsole.java
+++ b/src/main/java/tools/util/ToolConsole.java
@@ -1,0 +1,39 @@
+package tools.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A collection of methods for use by support tools to write messages to the console.
+ */
+public final class ToolConsole {
+  private ToolConsole() {}
+
+  /**
+   * Writes the specified error message to the console.
+   */
+  public static void error(final String message) {
+    checkNotNull(message);
+
+    System.err.println(message);
+  }
+
+  /**
+   * Writes the specified error message and exception to the console.
+   */
+  public static void error(final String message, final Throwable t) {
+    checkNotNull(message);
+    checkNotNull(t);
+
+    error(message);
+    t.printStackTrace(System.err);
+  }
+
+  /**
+   * Writes the specified informational message to the console.
+   */
+  public static void info(final String message) {
+    checkNotNull(message);
+
+    System.out.println(message);
+  }
+}

--- a/src/main/java/tools/util/ToolLogger.java
+++ b/src/main/java/tools/util/ToolLogger.java
@@ -3,13 +3,13 @@ package tools.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A collection of methods for use by support tools to write messages to the console.
+ * Provides methods for support tools to write log messages.
  */
-public final class ToolConsole {
-  private ToolConsole() {}
+public final class ToolLogger {
+  private ToolLogger() {}
 
   /**
-   * Writes the specified error message to the console.
+   * Logs the specified error message.
    */
   public static void error(final String message) {
     checkNotNull(message);
@@ -18,7 +18,7 @@ public final class ToolConsole {
   }
 
   /**
-   * Writes the specified error message and exception to the console.
+   * Logs the specified error message with an associated exception.
    */
   public static void error(final String message, final Throwable t) {
     checkNotNull(message);
@@ -29,7 +29,7 @@ public final class ToolConsole {
   }
 
   /**
-   * Writes the specified informational message to the console.
+   * Logs the specified informational message.
    */
   public static void info(final String message) {
     checkNotNull(message);


### PR DESCRIPTION
Follow-up to a [discussion](https://github.com/triplea-game/triplea/pull/2902#discussion_r163992121) in #2902.

Tool code shouldn't use `ClientLogger` because `logError()` doesn't operate as expected in the separate processes used to run tools.  (In order to use `ClientLogger` correctly, tools would have to initialize it similar to what's done in `GameRunner`, and even then there would be a separate error console from the client's error console.)  In addition to `ClientLogger`, tool code makes many calls to `System.out` and `System.err` methods, resulting in a hodgepodge of different mechanisms to write to the console.

This PR extracts the new `ToolConsole` class, which encapsulates all access to the console for tools similar to what `ClientLogger` does for the TripleA client.  All `ClientLogger`, `System.out`, and `System.err` usage within tool code was replaced with `ToolConsole` methods.

Happy to entertain suggestions to rename the new package, class, and methods.