### PR TITLE
PointFileReaderWriter: Require caller to close streams

### DIFF
--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import java.util.StringTokenizer;
 import javax.annotation.Nullable;
 
 import org.apache.commons.io.input.CloseShieldInputStream;
+import org.apache.commons.io.output.CloseShieldOutputStream;
 
 /**
  * Utility to read and write files in the form of
@@ -62,7 +64,18 @@ public final class PointFileReaderWriter {
     mapping.put(name, p);
   }
 
-  public static void writeOneToOne(final OutputStream sink, final Map<String, Point> mapping) throws Exception {
+  /**
+   * Writes the specified one-to-one mapping between names and points to the specified stream.
+   *
+   * @param sink The stream to which the name-to-point mappings will be written.
+   * @param mapping The name-to-point mapping to be written.
+   *
+   * @throws IOException If an I/O error occurs while writing to the stream.
+   */
+  public static void writeOneToOne(final OutputStream sink, final Map<String, Point> mapping) throws IOException {
+    checkNotNull(sink);
+    checkNotNull(mapping);
+
     final StringBuilder out = new StringBuilder();
     final Iterator<String> keyIter = mapping.keySet().iterator();
     while (keyIter.hasNext()) {
@@ -77,8 +90,19 @@ public final class PointFileReaderWriter {
     write(out, sink);
   }
 
+  /**
+   * Writes the specified one-to-many mapping between names and polygons to the specified stream.
+   *
+   * @param sink The stream to which the name-to-polygons mappings will be written.
+   * @param mapping The name-to-polygons mapping to be written.
+   *
+   * @throws IOException If an I/O error occurs while writing to the stream.
+   */
   public static void writeOneToManyPolygons(final OutputStream sink, final Map<String, List<Polygon>> mapping)
-      throws Exception {
+      throws IOException {
+    checkNotNull(sink);
+    checkNotNull(mapping);
+
     final StringBuilder out = new StringBuilder();
     final Iterator<String> keyIter = mapping.keySet().iterator();
     while (keyIter.hasNext()) {
@@ -102,16 +126,25 @@ public final class PointFileReaderWriter {
   }
 
   private static void write(final StringBuilder buf, final OutputStream sink) throws IOException {
-    final OutputStreamWriter out = new OutputStreamWriter(sink);
-    out.write(buf.toString());
-    out.flush();
+    try (Writer out = new OutputStreamWriter(new CloseShieldOutputStream(sink))) {
+      out.write(buf.toString());
+    }
   }
 
-  public static void writeOneToMany(final OutputStream sink, Map<String, Collection<Point>> mapping) throws Exception {
+  /**
+   * Writes the specified one-to-many mapping between names and points to the specified stream.
+   *
+   * @param sink The stream to which the name-to-points mappings will be written.
+   * @param mapping The name-to-points mapping to be written.
+   *
+   * @throws IOException If an I/O error occurs while writing to the stream.
+   */
+  public static void writeOneToMany(final OutputStream sink, final Map<String, List<Point>> mapping)
+      throws IOException {
+    checkNotNull(sink);
+    checkNotNull(mapping);
+
     final StringBuilder out = new StringBuilder();
-    if (mapping == null) {
-      mapping = new HashMap<>();
-    }
     final Iterator<String> keyIter = mapping.keySet().iterator();
     while (keyIter.hasNext()) {
       final String name = keyIter.next();

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -171,7 +171,7 @@ public final class PointFileReaderWriter {
   public static Map<String, List<Point>> readOneToMany(final InputStream stream) throws IOException {
     checkNotNull(stream);
 
-    final HashMap<String, List<Point>> mapping = new HashMap<>();
+    final Map<String, List<Point>> mapping = new HashMap<>();
     try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       @Nullable
@@ -190,7 +190,9 @@ public final class PointFileReaderWriter {
    * Returns a map of the form String -> Collection of polygons.
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
-    final HashMap<String, List<Polygon>> mapping = new HashMap<>();
+    checkNotNull(stream);
+
+    final Map<String, List<Polygon>> mapping = new HashMap<>();
     try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       @Nullable
@@ -205,7 +207,7 @@ public final class PointFileReaderWriter {
     return mapping;
   }
 
-  private static void readMultiplePolygons(final String line, final HashMap<String, List<Polygon>> mapping)
+  private static void readMultiplePolygons(final String line, final Map<String, List<Polygon>> mapping)
       throws IOException {
     try {
       // this loop is executed a lot when loading games
@@ -213,7 +215,7 @@ public final class PointFileReaderWriter {
       final String name = line.substring(0, line.indexOf('<')).trim();
       int index = name.length();
       final List<Polygon> polygons = new ArrayList<>(64);
-      final ArrayList<Point> points = new ArrayList<>();
+      final List<Point> points = new ArrayList<>();
       final int length = line.length();
       while (index < length) {
         char current = line.charAt(index);
@@ -270,7 +272,7 @@ public final class PointFileReaderWriter {
     }
   }
 
-  private static void createPolygonFromPoints(final Collection<Polygon> polygons, final ArrayList<Point> points) {
+  private static void createPolygonFromPoints(final Collection<Polygon> polygons, final List<Point> points) {
     final int[] pointsX = new int[points.size()];
     final int[] pointsY = new int[points.size()];
     for (int i = 0; i < points.size(); i++) {
@@ -281,7 +283,7 @@ public final class PointFileReaderWriter {
     polygons.add(new Polygon(pointsX, pointsY, pointsX.length));
   }
 
-  private static void readMultiple(final String line, final HashMap<String, List<Point>> mapping) throws IOException {
+  private static void readMultiple(final String line, final Map<String, List<Point>> mapping) throws IOException {
     final StringTokenizer tokens = new StringTokenizer(line, "");
     final String name = tokens.nextToken("(").trim();
     if (mapping.containsKey(name)) {

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -7,6 +7,8 @@ import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,8 +75,7 @@ public class AutoPlacementFinder {
    * Will calculate the placements on the map automatically.
    */
   static void calculate() {
-    // create hash map of placements
-    final Map<String, Collection<Point>> placements = new HashMap<>();
+    final Map<String, List<Point>> placements = new HashMap<>();
     // ask user where the map is
     final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
@@ -215,18 +216,17 @@ public class AutoPlacementFinder {
     } // while
     textOptionPane.appendNewLine("\r\nAll Finished!");
     textOptionPane.countDown();
-    try {
-      final String fileName =
-          new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
-      if (fileName == null) {
-        textOptionPane.appendNewLine("You chose not to save, Shutting down");
-        textOptionPane.dispose();
-        System.exit(0);
-      }
-      PointFileReaderWriter.writeOneToMany(new FileOutputStream(fileName), placements);
+    final String fileName = new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
+    if (fileName == null) {
+      textOptionPane.appendNewLine("You chose not to save, Shutting down");
+      textOptionPane.dispose();
+      System.exit(0);
+    }
+    try (OutputStream os = new FileOutputStream(fileName)) {
+      PointFileReaderWriter.writeOneToMany(os, placements);
       textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception e) {
-      ToolLogger.error("Failed to write points file", e);
+    } catch (final IOException e) {
+      ToolLogger.error("Failed to write points file: " + fileName, e);
       textOptionPane.dispose();
       System.exit(0);
     }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -231,18 +231,16 @@ public class CenterPicker extends JFrame {
    * Saves the centers to disk.
    */
   private void saveCenters() {
-    try {
-      final String fileName =
-          new FileSave("Where To Save centers.txt ?", "centers.txt", mapFolderLocation).getPathString();
-      if (fileName == null) {
-        return;
-      }
-      try (OutputStream out = new FileOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToOne(out, centers);
-      }
+    final String fileName =
+        new FileSave("Where To Save centers.txt ?", "centers.txt", mapFolderLocation).getPathString();
+    if (fileName == null) {
+      return;
+    }
+    try (OutputStream out = new FileOutputStream(fileName)) {
+      PointFileReaderWriter.writeOneToOne(out, centers);
       ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception e) {
-      ToolLogger.error("Failed to save centers", e);
+    } catch (final IOException e) {
+      ToolLogger.error("Failed to save centers: " + fileName, e);
     }
   }
 

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -456,18 +456,16 @@ public class DecorationPlacer extends JFrame {
       entry.getValue().getSecond().addAll(pointSet);
       currentPoints.put(entry.getKey(), entry.getValue().getSecond());
     }
-    try {
-      final String fileName = new FileSave("Where To Save Image Points Text File?", JFileChooser.FILES_ONLY,
-          currentImagePointsTextFile, mapFolderLocation).getPathString();
-      if (fileName == null) {
-        return;
-      }
-      try (OutputStream out = new FileOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
-      }
+    final String fileName = new FileSave("Where To Save Image Points Text File?", JFileChooser.FILES_ONLY,
+        currentImagePointsTextFile, mapFolderLocation).getPathString();
+    if (fileName == null) {
+      return;
+    }
+    try (OutputStream out = new FileOutputStream(fileName)) {
+      PointFileReaderWriter.writeOneToMany(out, currentPoints);
       ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception e) {
-      ToolLogger.error("Failed to save points", e);
+    } catch (final IOException e) {
+      ToolLogger.error("Failed to save points: " + fileName, e);
     }
   }
 

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -362,16 +362,14 @@ public class PolygonGrabber extends JFrame {
   private void savePolygons() {
     final String polyName =
         new FileSave("Where To Save Polygons.txt ?", "polygons.txt", mapFolderLocation).getPathString();
-    try {
-      if (polyName == null) {
-        return;
-      }
-      try (OutputStream out = new FileOutputStream(polyName)) {
-        PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
-      }
+    if (polyName == null) {
+      return;
+    }
+    try (OutputStream out = new FileOutputStream(polyName)) {
+      PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
       ToolLogger.info("Data written to :" + new File(polyName).getCanonicalPath());
-    } catch (final Exception e) {
-      ToolLogger.error("file save name: " + polyName, e);
+    } catch (final IOException e) {
+      ToolLogger.error("Failed to save polygons: " + polyName, e);
     }
   }
 

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -481,16 +481,14 @@ public class PlacementPicker extends JFrame {
   private void savePlacements() {
     final String fileName =
         new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
-    try {
-      if (fileName == null) {
-        return;
-      }
-      try (OutputStream out = new FileOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
-      }
+    if (fileName == null) {
+      return;
+    }
+    try (OutputStream out = new FileOutputStream(fileName)) {
+      PointFileReaderWriter.writeOneToMany(out, placements);
       ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
-    } catch (final Exception e) {
-      ToolLogger.error("fileName = " + fileName, e);
+    } catch (final IOException e) {
+      ToolLogger.error("Failed to write placements: " + fileName, e);
     }
   }
 

--- a/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.verify;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +31,15 @@ import com.google.common.primitives.Ints;
 import games.strategy.io.IoUtils;
 
 public final class PointFileReaderWriterTest {
+  private static <R> R readFromString(final IoUtils.InputStreamFunction<R> function, final String content)
+      throws Exception {
+    return IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), function);
+  }
+
+  private static String writeToString(final IoUtils.OutputStreamConsumer consumer) throws Exception {
+    return new String(IoUtils.writeToMemory(consumer), StandardCharsets.UTF_8);
+  }
+
   @Nested
   public final class ReadOneToOneTest {
     @Test
@@ -52,8 +63,7 @@ public final class PointFileReaderWriterTest {
           + "Germany (2011,2021)\n"
           + "Eastern United States (3011,3021)\n";
 
-      final Map<String, Point> pointsByName =
-          IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToOne);
+      final Map<String, Point> pointsByName = readFromString(PointFileReaderWriter::readOneToOne, content);
 
       assertThat(pointsByName, is(ImmutableMap.of(
           "United Kingdom", new Point(1011, 1021),
@@ -85,8 +95,7 @@ public final class PointFileReaderWriterTest {
           + "54 Sea Zone  (2011,2021)  (2012,2022)\n"
           + "Philippines (3011,3021)\n";
 
-      final Map<String, List<Point>> pointListsByName =
-          IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), PointFileReaderWriter::readOneToMany);
+      final Map<String, List<Point>> pointListsByName = readFromString(PointFileReaderWriter::readOneToMany, content);
 
       assertThat(pointListsByName, is(ImmutableMap.of(
           "Belarus", Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)),
@@ -120,9 +129,8 @@ public final class PointFileReaderWriterTest {
           + "54 Sea Zone  <  (2011,2021) (2012,2022) (2013,2023) >  <  (2111,2121) (2112,2122) (2113,2123) >\n"
           + "Philippines  <  (3011,3021) (3012,3022) (3013,3023) >  <  (3111,3121) (3112,3122) >  <  (3211,3221) >\n";
 
-      final Map<String, List<Polygon>> polygonListsByName = IoUtils.readFromMemory(
-          content.getBytes(StandardCharsets.UTF_8),
-          PointFileReaderWriter::readOneToManyPolygons);
+      final Map<String, List<Polygon>> polygonListsByName =
+          readFromString(PointFileReaderWriter::readOneToManyPolygons, content);
 
       assertThat(polygonListsByName, is(aMapWithSize(3)));
       assertThat(polygonListsByName, hasKey("Belarus"));
@@ -146,6 +154,100 @@ public final class PointFileReaderWriterTest {
                 .collect(Collectors.toList());
           })
           .collect(Collectors.toList());
+    }
+  }
+
+  @Nested
+  public final class WriteOneToOneTest {
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final OutputStream os = spy(new ByteArrayOutputStream());
+
+      PointFileReaderWriter.writeOneToOne(os, Collections.emptyMap());
+
+      verify(os, never()).close();
+    }
+
+    @Test
+    public void shouldWriteOnePointPerName() throws Exception {
+      final Map<String, Point> pointsByName = ImmutableMap.of(
+          "United Kingdom", new Point(1011, 1021),
+          "Germany", new Point(2011, 2021),
+          "Eastern United States", new Point(3011, 3021));
+
+      final String content = writeToString(os -> PointFileReaderWriter.writeOneToOne(os, pointsByName));
+
+      assertThat(content, is(""
+          + "United Kingdom  (1011,1021)\r\n"
+          + "Germany  (2011,2021)\r\n"
+          + "Eastern United States  (3011,3021)"));
+    }
+  }
+
+  @Nested
+  public final class WriteOneToManyTest {
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final OutputStream os = spy(new ByteArrayOutputStream());
+
+      PointFileReaderWriter.writeOneToMany(os, Collections.emptyMap());
+
+      verify(os, never()).close();
+    }
+
+    @Test
+    public void shouldWriteMultiplePointsPerName() throws Exception {
+      final Map<String, List<Point>> pointListsByName = ImmutableMap.of(
+          "Belarus", Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)),
+          "54 Sea Zone", Arrays.asList(new Point(2011, 2021), new Point(2012, 2022)),
+          "Philippines", Arrays.asList(new Point(3011, 3021)));
+
+      final String content = writeToString(os -> PointFileReaderWriter.writeOneToMany(os, pointListsByName));
+
+      assertThat(content, is(""
+          + "Belarus  (1011,1021)  (1012,1022)  (1013,1023)\r\n"
+          + "54 Sea Zone  (2011,2021)  (2012,2022)\r\n"
+          + "Philippines  (3011,3021)"));
+    }
+  }
+
+  @Nested
+  public final class WriteOneToManyPolygonsTest {
+    @Test
+    public void shouldNotCloseStream() throws Exception {
+      final OutputStream os = spy(new ByteArrayOutputStream());
+
+      PointFileReaderWriter.writeOneToManyPolygons(os, Collections.emptyMap());
+
+      verify(os, never()).close();
+    }
+
+    @Test
+    public void shouldWriteMultiplePolygonsPerName() throws Exception {
+      final Map<String, List<Polygon>> polygonListsByName = ImmutableMap.of(
+          "Belarus", Arrays.asList(
+              polygon(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023))),
+          "54 Sea Zone", Arrays.asList(
+              polygon(new Point(2011, 2021), new Point(2012, 2022), new Point(2013, 2023)),
+              polygon(new Point(2111, 2121), new Point(2112, 2122), new Point(2113, 2123))),
+          "Philippines", Arrays.asList(
+              polygon(new Point(3011, 3021), new Point(3012, 3022), new Point(3013, 3023)),
+              polygon(new Point(3111, 3121), new Point(3112, 3122)),
+              polygon(new Point(3211, 3221))));
+
+      final String content = writeToString(os -> PointFileReaderWriter.writeOneToManyPolygons(os, polygonListsByName));
+
+      assertThat(content, is(""
+          + "Belarus  <  (1011,1021) (1012,1022) (1013,1023) > \r\n"
+          + "54 Sea Zone  <  (2011,2021) (2012,2022) (2013,2023) >  <  (2111,2121) (2112,2122) (2113,2123) > \r\n"
+          + "Philippines  <  (3011,3021) (3012,3022) (3013,3023) >  <  (3111,3121) (3112,3122) >  <  (3211,3221) > "));
+    }
+
+    private Polygon polygon(final Point... points) {
+      return new Polygon(
+          Arrays.stream(points).mapToInt(it -> it.x).toArray(),
+          Arrays.stream(points).mapToInt(it -> it.y).toArray(),
+          points.length);
     }
   }
 }


### PR DESCRIPTION
Companion to #2889 but for the `writeXXX()` methods.

`PointFileReaderWriter` uses a resource-management idiom that is different from the rest of our code: it takes ownership of the `OutputStream` passed to its methods and closes the stream before they return.  This can lead to confusion because the calling code appears to leak the stream it creates.  For consistency, this PR modifies the code such that the code that creates the stream is responsible for closing it.

#### Functional changes

None.

#### Refactoring changes

* `PointFileReaderWriter` methods no longer close their `OutputStream` parameter.
* Handling a `null` mapping in `writeOneToMany()` was never realized by any of the current callers, so it was replaced with a `checkNotNull` precondition.
* The signature of `writeOneToMany()` was changed to use a `mapping` parameter of type `Map<String, List<Point>>` instead of `Map<String, Collection<Point>>` for symmetry with `readOneToMany()` (as well as consistency with all other read/write methods in this class).  This allowed the removal of a few unnecessary copies in callers that were created simply to workaround the invariance of the generic collections.
* Replaced several concrete types with interface types where possible (e.g. `HashMap` -> `Map`).

#### Testing

Several characterization tests were added to detect regressions in `PointFileReaderWriter`.

#### Notes

Please view with whitespace changes ignored (`?w=1`).