### PR TITLE
Ensure ErrorMessage is always initialized on EDT

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -123,14 +123,17 @@ public class GameRunner {
     ClientSetting.initialize();
 
     if (!ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
-      ErrorConsole.createConsole();
+      SwingAction.invokeAndWait(() -> {
+        LookAndFeel.setupLookAndFeel();
+        ErrorConsole.createConsole();
+        ErrorMessage.INSTANCE.init();
+      });
     }
+
     if (!new ArgParser(COMMAND_LINE_ARGS).handleCommandLineArgs(args)) {
       usage();
       return;
     }
-
-    LookAndFeel.setupLookAndFeel();
 
     if (HttpProxy.isUsingSystemProxy()) {
       HttpProxy.updateSystemProxy();
@@ -145,7 +148,6 @@ public class GameRunner {
       SwingUtilities.invokeLater(() -> {
         setupPanelModel.showSelectType();
         mainFrame = newMainFrame();
-        ErrorMessage.INSTANCE.init();
       });
 
       showMainFrame();

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -1,9 +1,12 @@
 package games.strategy.engine.framework.lookandfeel;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 import org.pushingpixels.substance.api.skin.SubstanceAutumnLookAndFeel;
@@ -38,10 +41,16 @@ import org.pushingpixels.substance.api.skin.SubstanceTwilightLookAndFeel;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.ui.SwingAction;
 
-public class LookAndFeel {
+/**
+ * Provides methods for working with the Swing Look-And-Feel.
+ */
+public final class LookAndFeel {
+  private LookAndFeel() {}
 
+  /**
+   * Returns a collection of the available Look-And-Feels.
+   */
   public static List<String> getLookAndFeelAvailableList() {
     final List<String> substanceLooks = new ArrayList<>();
     for (final UIManager.LookAndFeelInfo look : UIManager.getInstalledLookAndFeels()) {
@@ -65,26 +74,30 @@ public class LookAndFeel {
     return substanceLooks;
   }
 
+  /**
+   * Sets the user's preferred Look-And-Feel. If not available, the system Look-And-Feel will be used.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
+   */
   public static void setupLookAndFeel() {
-    SwingAction.invokeAndWait(() -> {
-      try {
-        UIManager.setLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
-        // FYI if you are getting a null pointer exception in Substance, like this:
-        // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
-        // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
-        // Then it is because you included the swingx substance library without including swingx.
-        // You can solve by including both swingx libraries or removing both,
-        // or by setting the look and feel twice in a row.
-      } catch (final Throwable t) {
-        if (!SystemProperties.isMac()) {
-          try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-          } catch (final Exception e) {
-            ClientLogger.logQuietly("Failed to set system look and feel", e);
-          }
+    checkState(SwingUtilities.isEventDispatchThread());
+
+    try {
+      UIManager.setLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
+      // FYI if you are getting a null pointer exception in Substance, like this:
+      // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
+      // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
+      // Then it is because you included the swingx substance library without including swingx.
+      // You can solve by including both swingx libraries or removing both,
+      // or by setting the look and feel twice in a row.
+    } catch (final Throwable t) {
+      if (!SystemProperties.isMac()) {
+        try {
+          UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (final Exception e) {
+          ClientLogger.logQuietly("Failed to set system look and feel", e);
         }
       }
-    });
+    }
   }
-
 }

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -84,12 +84,6 @@ public final class LookAndFeel {
 
     try {
       UIManager.setLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
-      // FYI if you are getting a null pointer exception in Substance, like this:
-      // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
-      // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
-      // Then it is because you included the swingx substance library without including swingx.
-      // You can solve by including both swingx libraries or removing both,
-      // or by setting the look and feel twice in a row.
     } catch (final Throwable t) {
       if (!SystemProperties.isMac()) {
         try {

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
@@ -27,13 +27,13 @@ public class ErrorHandler implements Thread.UncaughtExceptionHandler, ErrorHandl
    * Method used to handle errors. Called auto-magically by sun property
    */
   @Override
-  public void handle(final Throwable throwable) {
+  public void handle(final Throwable t) {
+    final String msg = "Error: " + (t.getLocalizedMessage() != null ? t.getLocalizedMessage() : t);
     if (GraphicsEnvironment.isHeadless()) {
-      final String msg = "Error: " + throwable.getMessage();
       System.err.println(msg);
-      throwable.printStackTrace();
+      t.printStackTrace();
     } else {
-      ClientLogger.logError("Error: " + throwable.getMessage(), throwable);
+      ClientLogger.logError(msg, t);
     }
   }
 

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -30,6 +30,7 @@ import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 import tools.image.AutoPlacementFinder;
 import tools.image.CenterPicker;
@@ -71,10 +72,15 @@ public class MapCreator extends JFrame {
     return new String[] {TRIPLEA_MAP_FOLDER, TRIPLEA_UNIT_ZOOM, TRIPLEA_UNIT_WIDTH, TRIPLEA_UNIT_HEIGHT};
   }
 
+  /**
+   * Entry point for the map-making utilities application.
+   */
   public static void main(final String[] args) {
-    LookAndFeel.setupLookAndFeel();
+    ClientSetting.initialize();
 
     SwingAction.invokeAndWait(() -> {
+      LookAndFeel.setupLookAndFeel();
+
       final MapCreator creator = new MapCreator();
       creator.setSize(800, 600);
       creator.setLocationRelativeTo(null);


### PR DESCRIPTION
Fixes #2919.

#### Functional changes

* Initialize `ErrorMessage` as early as possible in `GameRunner#main()` to ensure initialization runs on the EDT.  If `ClientLogger#logError()` is called before `ErrorMessage` is initialized, the initialization will occur on the calling thread (possibly not the EDT), which will trigger another exception when, for example, the Substance L&F is used.
* Initialize L&F before `ErrorConsole` is initialized.  This has the side effect of rendering the console using the user's preferred L&F rather than the system L&F.  I suspect this is the way things used to be, and the `LookAndFeel#setupLookAndFeel()` call was probably inadvertently moved sometime in the past year.
* Initialize `ClientSettings` in `MapCreator` before the L&F is set.  This has the side effect of running the map-making tools using the user's preferred L&F rather than the system L&F.  Again, I think this is the way the map-making tools behaved in the past.

#### Refactoring changes

* Require `LookAndFeel#setupLookAndFeel()` to be called on the EDT rather than delegating to the EDT internally.  This just makes the call sites cleaner as they are already delegating to the EDT.
* Added some missing Javadocs.

#### Testing

Re-ran the scenario described in #2919 and verified `ErrorMessage` is displayed as expected and its error message is not `null`.