### PR TITLE
Use SwingAction#invokeXXX() methods where appropriate

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -243,7 +243,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   @Override
   public void addMessageWithSound(final String message, final String from, final boolean thirdperson,
       final String sound) {
-    final Runnable runner = () -> {
+    SwingAction.invokeNowOrLater(() -> {
       if (from == null || chat == null || chat.getServerNode() == null || chat.getServerNode().getName() == null) {
         // someone likely disconnected from the game.
         return;
@@ -270,12 +270,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
         scrollModel.setValue(scrollModel.getMaximum());
       });
       ClipPlayer.play(sound);
-    };
-    if (SwingUtilities.isEventDispatchThread()) {
-      runner.run();
-    } else {
-      SwingUtilities.invokeLater(runner);
-    }
+    });
   }
 
   private void addChatMessage(final String originalMessage, final String from, final boolean thirdperson) {

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -95,41 +95,39 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   void setChat(final Chat chat) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingAction.invokeAndWait(() -> setChat(chat));
-      return;
-    }
-    if (chat != null) {
-      chat.removeChatListener(this);
-      cleanupKeyMap();
-    }
-    this.chat = chat;
-    if (chat != null) {
-      setupKeyMap();
-      chat.addChatListener(this);
-      send.setEnabled(true);
-      text.setEnabled(true);
-      synchronized (chat.getMutex()) {
-        text.setText("");
-        for (final ChatMessage message : chat.getChatHistory()) {
-          if (message.getFrom().equals(chat.getServerNode().getName())) {
-            if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
-              addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
-                  "ADMIN_CHAT_CONTROL", false);
-              continue;
-            } else if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
-              addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
-              continue;
-            }
-          }
-          addChatMessage(message.getMessage(), message.getFrom(), message.isMyMessage());
-        }
+    SwingAction.invokeAndWait(() -> {
+      if (chat != null) {
+        chat.removeChatListener(this);
+        cleanupKeyMap();
       }
-    } else {
-      send.setEnabled(false);
-      text.setEnabled(false);
-      updatePlayerList(Collections.emptyList());
-    }
+      this.chat = chat;
+      if (chat != null) {
+        setupKeyMap();
+        chat.addChatListener(this);
+        send.setEnabled(true);
+        text.setEnabled(true);
+        synchronized (chat.getMutex()) {
+          text.setText("");
+          for (final ChatMessage message : chat.getChatHistory()) {
+            if (message.getFrom().equals(chat.getServerNode().getName())) {
+              if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
+                addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
+                    "ADMIN_CHAT_CONTROL", false);
+                continue;
+              } else if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
+                addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
+                continue;
+              }
+            }
+            addChatMessage(message.getMessage(), message.getFrom(), message.isMyMessage());
+          }
+        }
+      } else {
+        send.setEnabled(false);
+        text.setEnabled(false);
+        updatePlayerList(Collections.emptyList());
+      }
+    });
   }
 
   public Chat getChat() {

--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -28,7 +28,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.ListCellRenderer;
-import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 import games.strategy.net.INode;
@@ -219,20 +218,14 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
 
   @Override
   public synchronized void updatePlayerList(final Collection<INode> players) {
-    final Runnable runner = () -> {
+    SwingAction.invokeNowOrLater(() -> {
       listModel.clear();
       for (final INode name : players) {
         if (!hiddenPlayers.contains(name.getName())) {
           listModel.addElement(name);
         }
       }
-    };
-    // invoke in the swing event thread
-    if (SwingUtilities.isEventDispatchThread()) {
-      runner.run();
-    } else {
-      SwingUtilities.invokeLater(runner);
-    }
+    });
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -550,15 +550,13 @@ public class GameRunner {
    * After the game has been left, call this.
    */
   public static void clientLeftGame() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingAction.invokeAndWait(GameRunner::clientLeftGame);
-      return;
-    }
-    // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
-    // closing of stream while unloading map resources.
-    ThreadUtil.sleep(100);
-    setupPanelModel.showSelectType();
-    showMainFrame();
+    SwingAction.invokeAndWait(() -> {
+      // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
+      // closing of stream while unloading map resources.
+      ThreadUtil.sleep(100);
+      setupPanelModel.showSelectType();
+      showMainFrame();
+    });
   }
 
   public static void quitGame() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -20,7 +20,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
@@ -37,6 +36,7 @@ import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.ui.SwingAction;
 import swinglib.JButtonBuilder;
 
 public class GameSelectorPanel extends JPanel implements Observer {
@@ -75,23 +75,21 @@ public class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void updateGameData() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(this::updateGameData);
-      return;
-    }
-    nameText.setText(model.getGameName());
-    versionText.setText(model.getGameVersion());
-    roundText.setText(model.getGameRound());
-    String fileName = model.getFileName();
-    if (fileName != null && fileName.length() > 1) {
-      try {
-        fileName = URLDecoder.decode(fileName, "UTF-8");
-      } catch (final IllegalArgumentException | UnsupportedEncodingException e) { // ignore
+    SwingAction.invokeNowOrLater(() -> {
+      nameText.setText(model.getGameName());
+      versionText.setText(model.getGameVersion());
+      roundText.setText(model.getGameRound());
+      String fileName = model.getFileName();
+      if (fileName != null && fileName.length() > 1) {
+        try {
+          fileName = URLDecoder.decode(fileName, "UTF-8");
+        } catch (final IllegalArgumentException | UnsupportedEncodingException e) { // ignore
+        }
       }
-    }
-    fileNameText.setText(getFormattedFileNameText(fileName,
-        Math.max(22, 3 + nameText.getText().length() + nameLabel.getText().length())));
-    fileNameText.setToolTipText(fileName);
+      fileNameText.setText(getFormattedFileNameText(fileName,
+          Math.max(22, 3 + nameText.getText().length() + nameLabel.getText().length())));
+      fileNameText.setToolTipText(fileName);
+    });
   }
 
   /**
@@ -305,21 +303,19 @@ public class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void setWidgetActivation() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> setWidgetActivation());
-      return;
-    }
-    final boolean canSelectGameData = canSelectLocalGameData();
-    final boolean canChangeHostBotGameData = canChangeHostBotGameData();
-    loadSavedGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
-    loadNewGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
-    // Disable game options if there are none.
-    if (canChangeHostBotGameData || (canSelectGameData && model.getGameData() != null
-        && model.getGameData().getProperties().getEditableProperties().size() > 0)) {
-      gameOptions.setEnabled(true);
-    } else {
-      gameOptions.setEnabled(false);
-    }
+    SwingAction.invokeNowOrLater(() -> {
+      final boolean canSelectGameData = canSelectLocalGameData();
+      final boolean canChangeHostBotGameData = canChangeHostBotGameData();
+      loadSavedGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
+      loadNewGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
+      // Disable game options if there are none.
+      if (canChangeHostBotGameData || (canSelectGameData && model.getGameData() != null
+          && model.getGameData().getProperties().getEditableProperties().size() > 0)) {
+        gameOptions.setEnabled(true);
+      } else {
+        gameOptions.setEnabled(false);
+      }
+    });
   }
 
   private boolean canSelectLocalGameData() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -5,13 +5,12 @@ import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 
-import javax.swing.SwingUtilities;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.launcher.LauncherFactory;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.pbem.PBEMMessagePoster;
+import games.strategy.ui.SwingAction;
 
 /** Setup panel when hosting a local game. */
 public class LocalSetupPanel extends SetupPanel implements Observer {
@@ -70,11 +69,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
 
   @Override
   public void update(final Observable o, final Object arg) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> layoutPlayerComponents(this, playerTypes, gameSelectorModel.getGameData()));
-      return;
-    }
-    layoutPlayerComponents(this, playerTypes, gameSelectorModel.getGameData());
+    SwingAction.invokeNowOrLater(() -> layoutPlayerComponents(this, playerTypes, gameSelectorModel.getGameData()));
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -18,7 +18,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 
@@ -27,6 +26,7 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
+import games.strategy.ui.SwingAction;
 
 /**
  * When the game launches, the MainFrame is loaded which will contain
@@ -200,12 +200,10 @@ public class MainPanel extends JPanel implements Observer {
   }
 
   private void setWidgetActivation() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> setWidgetActivation());
-      return;
-    }
-    gameTypePanelModel.setWidgetActivation();
-    playButton.setEnabled(gameSetupPanel != null && gameSetupPanel.canGameStart());
+    SwingAction.invokeNowOrLater(() -> {
+      gameTypePanelModel.setWidgetActivation();
+      playButton.setEnabled(gameSetupPanel != null && gameSetupPanel.canGameStart());
+    });
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -53,6 +53,7 @@ import games.strategy.engine.random.InternalDiceServer;
 import games.strategy.engine.random.PbemDiceRoller;
 import games.strategy.engine.random.PropertiesDiceRoller;
 import games.strategy.triplea.pbem.AxisAndAlliesForumPoster;
+import games.strategy.ui.SwingAction;
 
 /**
  * A panel for setting up Play by Email/Forum.
@@ -329,16 +330,10 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
    */
   @Override
   public void update(final Observable o, final Object arg) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> {
-        loadAll();
-        layoutComponents();
-      });
-      return;
-    }
-
-    loadAll();
-    layoutComponents();
+    SwingAction.invokeNowOrLater(() -> {
+      loadAll();
+      layoutComponents();
+    });
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -7,7 +7,6 @@ import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
@@ -28,13 +27,9 @@ public class PropertiesSelector {
    */
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      final AtomicReference<Object> buttonRef = new AtomicReference<>();
-      SwingAction.invokeAndWait(() -> buttonRef.set(showDialog(parent, title, properties, buttonOptions)));
-      return buttonRef.get();
-    }
-
-    return showDialog(parent, title, properties, buttonOptions);
+    final AtomicReference<Object> buttonRef = new AtomicReference<>();
+    SwingAction.invokeAndWait(() -> buttonRef.set(showDialog(parent, title, properties, buttonOptions)));
+    return buttonRef.get();
   }
 
   private static Object showDialog(final JComponent parent, final String title,

--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.ui;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JComponent;
 import javax.swing.JDialog;
@@ -27,9 +26,12 @@ public class PropertiesSelector {
    */
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
-    final AtomicReference<Object> buttonRef = new AtomicReference<>();
-    SwingAction.invokeAndWait(() -> buttonRef.set(showDialog(parent, title, properties, buttonOptions)));
-    return buttonRef.get();
+    try {
+      return SwingAction.invokeAndWait(() -> showDialog(parent, title, properties, buttonOptions));
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return JOptionPane.UNINITIALIZED_VALUE;
+    }
   }
 
   private static Object showDialog(final JComponent parent, final String title,

--- a/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -62,15 +62,14 @@ public class PbemDiceRoller implements IRandomSource {
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) throws IllegalStateException {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      final AtomicReference<int[]> result = new AtomicReference<>();
-      SwingAction.invokeAndWait(() -> result.set(getRandom(max, count, annotation)));
-      return result.get();
-    }
-    final HttpDiceRollerDialog dialog =
-        new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
-    dialog.roll();
-    return dialog.getDiceRoll();
+    final AtomicReference<int[]> result = new AtomicReference<>();
+    SwingAction.invokeAndWait(() -> {
+      final HttpDiceRollerDialog dialog =
+          new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
+      dialog.roll();
+      result.set(dialog.getDiceRoll());
+    });
+    return result.get();
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -8,7 +8,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.net.SocketException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -59,17 +58,19 @@ public class PbemDiceRoller implements IRandomSource {
     dialog.roll();
   }
 
-
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) throws IllegalStateException {
-    final AtomicReference<int[]> result = new AtomicReference<>();
-    SwingAction.invokeAndWait(() -> {
-      final HttpDiceRollerDialog dialog =
-          new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
-      dialog.roll();
-      result.set(dialog.getDiceRoll());
-    });
-    return result.get();
+    try {
+      return SwingAction.invokeAndWait(() -> {
+        final HttpDiceRollerDialog dialog =
+            new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
+        dialog.roll();
+        return dialog.getDiceRoll();
+      });
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return new int[0];
+    }
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -217,16 +217,13 @@ public class BattlePanel extends ActionPanel {
   }
 
   public void listBattle(final GUID battleId, final List<String> steps) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      // recursive call
-      SwingUtilities.invokeLater(() -> listBattle(battleId, steps));
-      return;
-    }
-    removeAll();
-    if (battleDisplay != null) {
-      getMap().centerOn(battleDisplay.getBattleLocation());
-      battleDisplay.listBattle(steps);
-    }
+    SwingAction.invokeNowOrLater(() -> {
+      removeAll();
+      if (battleDisplay != null) {
+        getMap().centerOn(battleDisplay.getBattleLocation());
+        battleDisplay.listBattle(steps);
+      }
+    });
   }
 
   public void showBattle(final GUID battleId, final Territory location,

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -20,7 +20,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.JTextPane;
 import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
 import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 import javax.swing.text.BadLocationException;
@@ -120,7 +119,7 @@ public class CommentPanel extends JPanel {
   }
 
   private void readHistoryTreeEvent(final TreeModelEvent e) {
-    final Runnable runner = () -> {
+    SwingAction.invokeNowOrLater(() -> {
       data.acquireReadLock();
       try {
         final Document doc = text.getDocument();
@@ -149,13 +148,7 @@ public class CommentPanel extends JPanel {
       } finally {
         data.releaseReadLock();
       }
-    };
-    // invoke in the swing event thread
-    if (SwingUtilities.isEventDispatchThread()) {
-      runner.run();
-    } else {
-      SwingUtilities.invokeLater(runner);
-    }
+    });
   }
 
   private void setupKeyMap() {
@@ -202,7 +195,7 @@ public class CommentPanel extends JPanel {
 
   /** thread safe. */
   public void addMessage(final String message) {
-    final Runnable runner = () -> {
+    SwingAction.invokeNowOrLater(() -> {
       try {
         final Document doc = text.getDocument();
         // save history entry
@@ -221,13 +214,7 @@ public class CommentPanel extends JPanel {
       }
       final BoundedRangeModel scrollModel = scrollPane.getVerticalScrollBar().getModel();
       scrollModel.setValue(scrollModel.getMaximum());
-    };
-    // invoke in the swing event thread
-    if (SwingUtilities.isEventDispatchThread()) {
-      runner.run();
-    } else {
-      SwingUtilities.invokeLater(runner);
-    }
+    });
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -10,12 +10,12 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.image.DiceImageFactory;
+import games.strategy.ui.SwingAction;
 
 public class DicePanel extends JPanel {
   private static final long serialVersionUID = -7544999867518263506L;
@@ -41,24 +41,22 @@ public class DicePanel extends JPanel {
   }
 
   public void setDiceRoll(final DiceRoll diceRoll) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> setDiceRoll(diceRoll));
-      return;
-    }
-    removeAll();
-    for (int i = 1; i <= data.getDiceSides(); i++) {
-      final List<Die> dice = diceRoll.getRolls(i);
-      if (dice.isEmpty()) {
-        continue;
+    SwingAction.invokeNowOrLater(() -> {
+      removeAll();
+      for (int i = 1; i <= data.getDiceSides(); i++) {
+        final List<Die> dice = diceRoll.getRolls(i);
+        if (dice.isEmpty()) {
+          continue;
+        }
+        add(new JLabel("Rolled at " + (i) + ":"));
+        add(create(diceRoll.getRolls(i)));
       }
-      add(new JLabel("Rolled at " + (i) + ":"));
-      add(create(diceRoll.getRolls(i)));
-    }
-    add(Box.createVerticalGlue());
-    add(new JLabel("Total hits:" + diceRoll.getHits()));
-    validate();
-    invalidate();
-    repaint();
+      add(Box.createVerticalGlue());
+      add(new JLabel("Total hits:" + diceRoll.getHits()));
+      validate();
+      invalidate();
+      repaint();
+    });
   }
 
   private JComponent create(final List<Die> dice) {

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1858,40 +1858,36 @@ public class TripleAFrame extends MainGameFrame {
     validate();
   }
 
-
-
   private void setWidgetActivation() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> setWidgetActivation());
-      return;
-    }
-    if (showHistoryAction != null) {
-      showHistoryAction.setEnabled(!(inHistory || uiContext.getShowMapOnly()));
-    }
-    if (showGameAction != null) {
-      showGameAction.setEnabled(!inGame);
-    }
-    if (showMapOnlyAction != null) {
-      // We need to check and make sure there are no local human players
-      boolean foundHuman = false;
-      for (final IGamePlayer gamePlayer : localPlayers.getLocalPlayers()) {
-        if (gamePlayer instanceof TripleAPlayer) {
-          foundHuman = true;
+    SwingAction.invokeNowOrLater(() -> {
+      if (showHistoryAction != null) {
+        showHistoryAction.setEnabled(!(inHistory || uiContext.getShowMapOnly()));
+      }
+      if (showGameAction != null) {
+        showGameAction.setEnabled(!inGame);
+      }
+      if (showMapOnlyAction != null) {
+        // We need to check and make sure there are no local human players
+        boolean foundHuman = false;
+        for (final IGamePlayer gamePlayer : localPlayers.getLocalPlayers()) {
+          if (gamePlayer instanceof TripleAPlayer) {
+            foundHuman = true;
+          }
+        }
+        if (!foundHuman) {
+          showMapOnlyAction.setEnabled(inGame || inHistory);
+        } else {
+          showMapOnlyAction.setEnabled(false);
         }
       }
-      if (!foundHuman) {
-        showMapOnlyAction.setEnabled(inGame || inHistory);
-      } else {
-        showMapOnlyAction.setEnabled(false);
+      if (editModeButtonModel != null) {
+        if (editDelegate == null || uiContext.getShowMapOnly()) {
+          editModeButtonModel.setEnabled(false);
+        } else {
+          editModeButtonModel.setEnabled(true);
+        }
       }
-    }
-    if (editModeButtonModel != null) {
-      if (editDelegate == null || uiContext.getShowMapOnly()) {
-        editModeButtonModel.setEnabled(false);
-      } else {
-        editModeButtonModel.setEnabled(true);
-      }
-    }
+    });
   }
 
   // setEditDelegate is called by TripleAPlayer at the start and end of a turn

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -38,7 +38,8 @@ import games.strategy.debug.ClientLogger;
  * SwingAction.of(e -> doSomething());
  * </pre>
  */
-public class SwingAction {
+public final class SwingAction {
+  private SwingAction() {}
 
   /**
    * Creates a Swing 'Action' object around a given name and action listener. Example:
@@ -86,6 +87,26 @@ public class SwingAction {
       ClientLogger.logError("Failed while invoking a swing UI action", e);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Synchronously executes the specified action if called from the Swing event dispatch thread. Otherwise,
+   * asynchronously executes the specified action on the Swing event dispatch thread.
+   *
+   * <p>
+   * This method may safely be called from any thread, including the Swing event dispatch thread.
+   * </p>
+   *
+   * @param action The action to execute.
+   */
+  public static void invokeNowOrLater(final Runnable action) {
+    checkNotNull(action);
+
+    if (SwingUtilities.isEventDispatchThread()) {
+      action.run();
+    } else {
+      SwingUtilities.invokeLater(action);
     }
   }
 

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.swing.SwingUtilities;
-
 public final class Util {
   public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
 
@@ -35,9 +33,6 @@ public final class Util {
   }
 
   public static <T> T runInSwingEventThread(final Task<T> task) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      return task.run();
-    }
     final AtomicReference<T> results = new AtomicReference<>();
     SwingAction.invokeAndWait(() -> results.set(task.run()));
     return results.get();

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -23,7 +23,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
 
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
@@ -148,19 +147,12 @@ public class MapCreator extends JFrame {
   }
 
   private void setWidgetActivation() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(new Runnable() {
-        @Override
-        public void run() {
-          setWidgetActivation();
-        }
-      });
-      return;
-    }
-    mainPanel.validate();
-    mainPanel.repaint();
-    this.validate();
-    this.repaint();
+    SwingAction.invokeNowOrLater(() -> {
+      mainPanel.validate();
+      mainPanel.repaint();
+      this.validate();
+      this.repaint();
+    });
   }
 
   private void createPart1Panel() {

--- a/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -55,11 +55,8 @@ public class SwingActionTest {
   @Test
   public void testInvokeNowOrLater() {
     final CountDownLatch latch = new CountDownLatch(1);
-    final Runnable action = () -> {
-      latch.countDown();
-    };
 
-    SwingAction.invokeNowOrLater(action);
+    SwingAction.invokeNowOrLater(latch::countDown);
 
     assertTimeoutPreemptively(Duration.ofSeconds(5L), () -> latch.await());
   }

--- a/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -1,6 +1,7 @@
 package games.strategy.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
 import javax.swing.Action;
@@ -47,5 +50,17 @@ public class SwingActionTest {
       SwingAction.invokeAndWait(action);
       verify(action, times(2)).run();
     });
+  }
+
+  @Test
+  public void testInvokeNowOrLater() {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final Runnable action = () -> {
+      latch.countDown();
+    };
+
+    SwingAction.invokeNowOrLater(action);
+
+    assertTimeoutPreemptively(Duration.ofSeconds(5L), () -> latch.await());
   }
 }


### PR DESCRIPTION
There's a lot of conditionally-recursive calls like this in our codebase:

```java
void doSomething() {
  if (!SwingUtilities.isEventDispatchThread()) {
    SwingUtilities.invokeXXX(() -> doSomething());
    return;
  }
  // ... do something ...
}
```

where `invokeXXX()` is either `invokeAndWait()` or `invokeLater()`.

This PR first extracts the `SwingAction#invokeNowOrLater()` method, which is the complement to `SwingAction#invokeAndWait()` for `SwingUtilities#invokeLater()`.  It then replaces the above pattern with `SwingAction` usage as follows:

```java
void doSomething() {
  SwingAction.invokeXXX(() -> {
    // ... do something ...
  });
}
```

Similar patterns are also replaced with equivalent `SwingAction` usage.

It is recommended to review this PR with whitespace changes ignored (`?w=1`).

#### Issues for review

I wasn't sure if it would be confusing if I called the new `SwingAction` method `invokeLater()` instead of `invokeNowOrLater()`.  However, I'm open to changing it to the former if the latter is deemed equally confusing.