### PR TITLE
Use one label for ErrorMessage icon and text

### DIFF
--- a/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -30,7 +30,7 @@ public enum ErrorMessage {
   INSTANCE;
 
   private final JFrame windowReference = new JFrame("TripleA Error");
-  private final JLabel errorMessage = new JLabel();
+  private final JLabel errorMessage = JLabelBuilder.builder().errorIcon().iconTextGap(10).build();
   private final AtomicBoolean isVisible = new AtomicBoolean(false);
 
   ErrorMessage() {
@@ -48,8 +48,6 @@ public enum ErrorMessage {
         .addCenter(JPanelBuilder.builder()
             .horizontalBoxLayout()
             .addHorizontalGlue()
-            .add(JLabelBuilder.builder().errorIcon().build())
-            .addHorizontalStrut(10)
             .add(errorMessage)
             .addHorizontalGlue()
             .build())

--- a/src/main/java/swinglib/JLabelBuilder.java
+++ b/src/main/java/swinglib/JLabelBuilder.java
@@ -27,6 +27,7 @@ public class JLabelBuilder {
 
   private String text;
   private @Nullable Icon icon;
+  private @Nullable Integer iconTextGap;
   private Alignment alignment;
   private Dimension maxSize;
   private int maxTextLength = Integer.MAX_VALUE;
@@ -60,6 +61,10 @@ public class JLabelBuilder {
       label.setIcon(icon);
     }
 
+    if (iconTextGap != null) {
+      label.setIconTextGap(iconTextGap);
+    }
+
     if (alignment != null) {
       switch (alignment) {
         case LEFT:
@@ -85,6 +90,11 @@ public class JLabelBuilder {
 
   public JLabelBuilder errorIcon() {
     icon = UIManager.getIcon("OptionPane.errorIcon");
+    return this;
+  }
+
+  public JLabelBuilder iconTextGap(final int iconTextGap) {
+    this.iconTextGap = iconTextGap;
     return this;
   }
 

--- a/src/test/java/swinglib/JLabelBuilderTest.java
+++ b/src/test/java/swinglib/JLabelBuilderTest.java
@@ -30,6 +30,16 @@ public class JLabelBuilderTest {
   }
 
   @Test
+  public void iconTextGap() {
+    final int value = 42;
+    final JLabel label = JLabelBuilder.builder()
+        .text("value")
+        .iconTextGap(value)
+        .build();
+    MatcherAssert.assertThat(label.getIconTextGap(), is(value));
+  }
+
+  @Test
   public void textOrIconIsRequired() {
     assertThrows(IllegalStateException.class, JLabelBuilder.builder()::build);
   }


### PR DESCRIPTION
Follow up from an observation in [#2911](https://github.com/triplea-game/triplea/pull/2911#discussion_r164274243).