### PR TITLE
Fix unused allocated object warnings in TripleAMenuBar

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -4,7 +4,6 @@ import java.awt.event.KeyEvent;
 import java.util.Set;
 
 import javax.swing.JMenu;
-import javax.swing.JMenuBar;
 
 import games.strategy.debug.DebugUtils;
 import games.strategy.debug.ErrorConsole;
@@ -13,23 +12,24 @@ import games.strategy.performance.EnablePerformanceLoggingCheckBox;
 import games.strategy.triplea.ai.proAI.ProAi;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.ui.SwingAction;
-import games.strategy.ui.SwingComponents;
 
-class DebugMenu {
+final class DebugMenu extends JMenu {
+  private static final long serialVersionUID = -4876915214715298132L;
 
-  DebugMenu(final JMenuBar menuBar, final TripleAFrame frame) {
-    final JMenu debugMenu = SwingComponents.newJMenu("Debug", SwingComponents.KeyboardCode.D);
-    menuBar.add(debugMenu);
+  DebugMenu(final TripleAFrame frame) {
+    super("Debug");
+
+    setMnemonic(KeyEvent.VK_D);
 
     final Set<IGamePlayer> players = frame.getLocalPlayers().getLocalPlayers();
     final boolean areThereProAIs = players.stream().anyMatch(ProAi.class::isInstance);
     if (areThereProAIs) {
       ProAi.initialize(frame);
-      debugMenu.add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
+      add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
     }
 
-    debugMenu.add(new EnablePerformanceLoggingCheckBox());
-    debugMenu.add(SwingAction.of("Show Console", e -> {
+    add(new EnablePerformanceLoggingCheckBox());
+    add(SwingAction.of("Show Console", e -> {
       ErrorConsole.showConsole();
       ErrorConsole.getConsole().append(DebugUtils.getMemory());
     })).setMnemonic(KeyEvent.VK_C);

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -53,33 +53,35 @@ import games.strategy.ui.SwingAction;
 import games.strategy.util.FileNameUtils;
 import games.strategy.util.LocalizeHtml;
 
-class ExportMenu {
+final class ExportMenu extends JMenu {
+  private static final long serialVersionUID = 8416990293444575737L;
 
   private final TripleAFrame frame;
   private final GameData gameData;
   private final UiContext uiContext;
   private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy_MM_dd");
 
-  ExportMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {
+  ExportMenu(final TripleAFrame frame) {
+    super("Export");
+
     this.frame = frame;
     gameData = frame.getGame().getData();
     uiContext = frame.getUiContext();
 
-    final JMenu menuGame = new JMenu("Export");
-    menuGame.setMnemonic(KeyEvent.VK_E);
-    menuBar.add(menuGame);
-    addExportXml(menuGame);
-    addExportStats(menuGame);
-    addExportStatsFull(menuGame);
-    addExportSetupCharts(menuGame);
-    addExportUnitStats(menuGame);
-    addSaveScreenshot(menuGame);
+    setMnemonic(KeyEvent.VK_E);
+
+    addExportXml();
+    addExportStats();
+    addExportStatsFull();
+    addExportSetupCharts();
+    addExportUnitStats();
+    addSaveScreenshot();
   }
 
   // TODO: create a second menu option for parsing current attachments
-  private void addExportXml(final JMenu parentMenu) {
+  private void addExportXml() {
     final Action exportXml = SwingAction.of("Export game.xml File (Beta)", e -> exportXmlFile());
-    parentMenu.add(exportXml).setMnemonic(KeyEvent.VK_X);
+    add(exportXml).setMnemonic(KeyEvent.VK_X);
   }
 
   private void exportXmlFile() {
@@ -111,8 +113,7 @@ class ExportMenu {
     }
   }
 
-
-  private void addSaveScreenshot(final JMenu parentMenu) {
+  private void addSaveScreenshot() {
     final Action abstractAction = SwingAction.of("Export Map Snapshot", e -> {
       // get current history node. if we are in history view, get the selected node.
       final HistoryPanel historyPanel = frame.getHistoryPanel();
@@ -124,17 +125,17 @@ class ExportMenu {
       }
       ScreenshotExporter.exportScreenshot(frame, gameData, curNode);
     });
-    parentMenu.add(abstractAction).setMnemonic(KeyEvent.VK_E);
+    add(abstractAction).setMnemonic(KeyEvent.VK_E);
   }
 
-  private void addExportStatsFull(final JMenu parentMenu) {
+  private void addExportStatsFull() {
     final Action showDiceStats = SwingAction.of("Export Full Game Stats", e -> createAndSaveStats(true));
-    parentMenu.add(showDiceStats).setMnemonic(KeyEvent.VK_F);
+    add(showDiceStats).setMnemonic(KeyEvent.VK_F);
   }
 
-  private void addExportStats(final JMenu parentMenu) {
+  private void addExportStats() {
     final Action showDiceStats = SwingAction.of("Export Short Game Stats", e -> createAndSaveStats(false));
-    parentMenu.add(showDiceStats).setMnemonic(KeyEvent.VK_S);
+    add(showDiceStats).setMnemonic(KeyEvent.VK_S);
   }
 
   private void createAndSaveStats(final boolean showPhaseStats) {
@@ -375,7 +376,7 @@ class ExportMenu {
     }
   }
 
-  private void addExportUnitStats(final JMenu parentMenu) {
+  private void addExportUnitStats() {
     final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Unit Charts", e -> {
       final JFileChooser chooser = new JFileChooser();
       chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
@@ -394,14 +395,12 @@ class ExportMenu {
       } catch (final IOException e1) {
         ClientLogger.logQuietly("Failed to write unit stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
       }
-
     }));
     menuFileExport.setMnemonic(KeyEvent.VK_U);
-    parentMenu.add(menuFileExport);
+    add(menuFileExport);
   }
 
-
-  private void addExportSetupCharts(final JMenu parentMenu) {
+  private void addExportSetupCharts() {
     final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Setup Charts", e -> {
       final JFrame frame = new JFrame("Export Setup Charts");
       frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -421,10 +420,8 @@ class ExportMenu {
       frame.setLocationRelativeTo(frame);
       frame.setVisible(true);
       uiContext.addShutdownWindow(frame);
-
     }));
     menuFileExport.setMnemonic(KeyEvent.VK_C);
-    parentMenu.add(menuFileExport);
-
+    add(menuFileExport);
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -21,28 +21,28 @@ import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.history.HistoryLog;
 import games.strategy.ui.SwingAction;
 
-class FileMenu {
+final class FileMenu extends JMenu {
+  private static final long serialVersionUID = -3855695429784752428L;
 
   private final GameData gameData;
   private final TripleAFrame frame;
   private final IGame game;
 
-  FileMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {
+  FileMenu(final TripleAFrame frame) {
+    super("File");
+
     this.frame = frame;
     game = frame.getGame();
     gameData = frame.getGame().getData();
 
-    final JMenu fileMenu = new JMenu("File");
-    fileMenu.setMnemonic(KeyEvent.VK_F);
-    fileMenu.add(createSaveMenu());
+    setMnemonic(KeyEvent.VK_F);
 
+    add(createSaveMenu());
     if (PBEMMessagePoster.gameDataHasPlayByEmailOrForumMessengers(gameData)) {
-      fileMenu.add(addPostPbem());
+      add(addPostPbem());
     }
-
-    fileMenu.addSeparator();
-    addExitMenu(fileMenu);
-    menuBar.add(fileMenu);
+    addSeparator();
+    addExitMenu();
   }
 
   private JMenuItem createSaveMenu() {
@@ -85,7 +85,7 @@ class FileMenu {
     return menuPbem;
   }
 
-  void addExitMenu(final JMenu parentMenu) {
+  private void addExitMenu() {
     final boolean isMac = SystemProperties.isMac();
     final JMenuItem leaveGameMenuExit = new JMenuItem(SwingAction.of("Leave Game", e -> frame.leaveGame()));
     leaveGameMenuExit.setMnemonic(KeyEvent.VK_L);
@@ -97,7 +97,7 @@ class FileMenu {
       leaveGameMenuExit.setAccelerator(
           KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
     }
-    parentMenu.add(leaveGameMenuExit);
+    add(leaveGameMenuExit);
     // Mac OS X automatically creates a Quit menu item under the TripleA menu,
     // so all we need to do is register that menu item with triplea's shutdown mechanism
     if (isMac) {
@@ -105,8 +105,7 @@ class FileMenu {
     } else { // On non-Mac operating systems, we need to manually create an Exit menu item
       final JMenuItem menuFileExit = new JMenuItem(SwingAction.of("Exit Program", e -> frame.shutdown()));
       menuFileExit.setMnemonic(KeyEvent.VK_E);
-      parentMenu.add(menuFileExit);
+      add(menuFileExit);
     }
   }
-
 }

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -37,67 +37,61 @@ import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.VerifiedRandomNumbersDialog;
 import games.strategy.ui.IntTextField;
 import games.strategy.ui.SwingAction;
-import games.strategy.ui.SwingComponents;
 
-class GameMenu {
+final class GameMenu extends JMenu {
+  private static final long serialVersionUID = -6273782490069588052L;
 
   private final TripleAFrame frame;
   private final UiContext uiContext;
   private final GameData gameData;
   private final IGame game;
 
-  GameMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {
+  GameMenu(final TripleAFrame frame) {
+    super("Game");
+
     this.frame = frame;
     game = frame.getGame();
     gameData = frame.getGame().getData();
     uiContext = frame.getUiContext();
 
-    menuBar.add(createGameMenu());
+    setMnemonic(KeyEvent.VK_G);
+
+    addEditMode();
+    addSeparator();
+    add(SwingAction.of("Engine Settings", e -> ClientSetting.showSettingsWindow()));
+    SoundOptions.addGlobalSoundSwitchMenu(this);
+    SoundOptions.addToMenu(this);
+    addSeparator();
+    add(frame.getShowGameAction()).setMnemonic(KeyEvent.VK_G);
+    add(frame.getShowHistoryAction()).setMnemonic(KeyEvent.VK_H);
+    add(frame.getShowMapOnlyAction()).setMnemonic(KeyEvent.VK_M);
+    addSeparator();
+    addGameOptionsMenu();
+    addShowVerifiedDice();
+    addPoliticsMenu();
+    addNotificationSettings();
+    addShowDiceStats();
+    addRollDice();
+    addBattleCalculatorMenu();
   }
 
-  private JMenu createGameMenu() {
-    final JMenu menuGame = SwingComponents.newJMenu("Game", SwingComponents.KeyboardCode.G);
-    addEditMode(menuGame);
-
-    menuGame.addSeparator();
-    menuGame.add(SwingAction.of("Engine Settings", e -> ClientSetting.showSettingsWindow()));
-    SoundOptions.addGlobalSoundSwitchMenu(menuGame);
-    SoundOptions.addToMenu(menuGame);
-    menuGame.addSeparator();
-    menuGame.add(frame.getShowGameAction()).setMnemonic(KeyEvent.VK_G);
-    menuGame.add(frame.getShowHistoryAction()).setMnemonic(KeyEvent.VK_H);
-    menuGame.add(frame.getShowMapOnlyAction()).setMnemonic(KeyEvent.VK_M);
-
-    menuGame.addSeparator();
-    addGameOptionsMenu(menuGame);
-    addShowVerifiedDice(menuGame);
-    addPoliticsMenu(menuGame);
-    addNotificationSettings(menuGame);
-    addShowDiceStats(menuGame);
-    addRollDice(menuGame);
-    addBattleCalculatorMenu(menuGame);
-    return menuGame;
-  }
-
-  private void addEditMode(final JMenu parentMenu) {
+  private void addEditMode() {
     final JCheckBoxMenuItem editMode = new JCheckBoxMenuItem("Enable Edit Mode");
     editMode.setModel(frame.getEditModeButtonModel());
-    parentMenu.add(editMode).setMnemonic(KeyEvent.VK_E);
+    add(editMode).setMnemonic(KeyEvent.VK_E);
   }
 
-
-
-  private void addShowVerifiedDice(final JMenu parentMenu) {
+  private void addShowVerifiedDice() {
     final Action showVerifiedDice = SwingAction.of("Show Verified Dice",
         e -> new VerifiedRandomNumbersDialog(frame.getRootPane()).setVisible(true));
     if (game instanceof ClientGame) {
-      parentMenu.add(showVerifiedDice).setMnemonic(KeyEvent.VK_V);
+      add(showVerifiedDice).setMnemonic(KeyEvent.VK_V);
     }
   }
 
-  protected void addGameOptionsMenu(final JMenu menuGame) {
+  private void addGameOptionsMenu() {
     if (!gameData.getProperties().getEditableProperties().isEmpty()) {
-      menuGame.add(SwingAction.of("Map Options", e -> {
+      add(SwingAction.of("Map Options", e -> {
         final PropertiesUi ui = new PropertiesUi(gameData.getProperties().getEditableProperties(), false);
         JOptionPane.showMessageDialog(frame, ui, "Map Options", JOptionPane.PLAIN_MESSAGE);
       })).setMnemonic(KeyEvent.VK_O);
@@ -108,8 +102,8 @@ class GameMenu {
    * Add a Politics Panel button to the game menu, this panel will show the
    * current political landscape as a reference, no actions on this panel.
    */
-  private void addPoliticsMenu(final JMenu menuGame) {
-    menuGame.add(SwingAction.of("Show Politics Panel", e -> {
+  private void addPoliticsMenu() {
+    add(SwingAction.of("Show Politics Panel", e -> {
       final PoliticalStateOverview ui = new PoliticalStateOverview(gameData, uiContext, false);
       final JScrollPane scroll = new JScrollPane(ui);
       scroll.setBorder(BorderFactory.createEmptyBorder());
@@ -124,11 +118,10 @@ class GameMenu {
               (scroll.getPreferredSize().height > availHeight ? availHeight : scroll.getPreferredSize().height)));
 
       JOptionPane.showMessageDialog(frame, scroll, "Politics Panel", JOptionPane.PLAIN_MESSAGE);
-
     })).setMnemonic(KeyEvent.VK_P);
   }
 
-  private void addNotificationSettings(final JMenu parentMenu) {
+  private void addNotificationSettings() {
     final JMenu notificationMenu = new JMenu();
     notificationMenu.setMnemonic(KeyEvent.VK_U);
     notificationMenu.setText("User Notifications");
@@ -168,11 +161,11 @@ class GameMenu {
     notificationMenu.add(showTriggeredNotifications);
     notificationMenu.add(showTriggerChanceSuccessful);
     notificationMenu.add(showTriggerChanceFailure);
-    parentMenu.add(notificationMenu);
+    add(notificationMenu);
   }
 
-  private void addShowDiceStats(final JMenu parentMenu) {
-    parentMenu.add(SwingAction.of("Show Dice Stats", e -> {
+  private void addShowDiceStats() {
+    add(SwingAction.of("Show Dice Stats", e -> {
       final IRandomStats randomStats =
           (IRandomStats) game.getRemoteMessenger().getRemote(IRandomStats.RANDOM_STATS_REMOTE_NAME);
       final RandomStatsDetails stats = randomStats.getRandomStats(gameData.getDiceSides());
@@ -181,7 +174,7 @@ class GameMenu {
     })).setMnemonic(KeyEvent.VK_D);
   }
 
-  private void addRollDice(final JMenu parentMenu) {
+  private void addRollDice() {
     final JMenuItem rollDiceBox = new JMenuItem("Roll Dice");
     rollDiceBox.setMnemonic(KeyEvent.VK_R);
     rollDiceBox.addActionListener(e -> {
@@ -199,7 +192,7 @@ class GameMenu {
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 20), 0, 0));
       panel.add(diceSidesText, new GridBagConstraints(2, 1, 1, 1, 0, 0, GridBagConstraints.WEST,
           GridBagConstraints.BOTH, new Insets(0, 20, 0, 10), 0, 0));
-      JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(parentMenu), panel, "Roll Dice",
+      JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(this), panel, "Roll Dice",
           JOptionPane.OK_OPTION, JOptionPane.INFORMATION_MESSAGE, null, new String[] {"OK"}, "OK");
       try {
         final int numberOfDice = Integer.parseInt(numberOfText.getText());
@@ -225,12 +218,12 @@ class GameMenu {
         // ignore malformed input
       }
     });
-    parentMenu.add(rollDiceBox);
+    add(rollDiceBox);
   }
 
-  private void addBattleCalculatorMenu(final JMenu menuGame) {
+  private void addBattleCalculatorMenu() {
     final Action showBattleMenu = SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null));
-    final JMenuItem showBattleMenuItem = menuGame.add(showBattleMenu);
+    final JMenuItem showBattleMenuItem = add(showBattleMenu);
     showBattleMenuItem.setMnemonic(KeyEvent.VK_B);
     showBattleMenuItem.setAccelerator(
         KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -20,7 +20,6 @@ import javax.swing.JEditorPane;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
-import javax.swing.JMenuBar;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -43,29 +42,33 @@ import games.strategy.ui.SwingComponents;
 import games.strategy.util.LocalizeHtml;
 import swinglib.JLabelBuilder;
 
-public class HelpMenu {
+/**
+ * The help menu.
+ */
+public final class HelpMenu extends JMenu {
+  private static final long serialVersionUID = 4070541434144687452L;
 
   private final UiContext uiContext;
   private final GameData gameData;
 
-  HelpMenu(final JMenuBar menuBar, final UiContext uiContext, final GameData gameData) {
+  HelpMenu(final UiContext uiContext, final GameData gameData) {
+    super("Help");
+
     this.uiContext = uiContext;
     this.gameData = gameData;
 
-    final JMenu helpMenu = new JMenu("Help");
-    helpMenu.setMnemonic(KeyEvent.VK_H);
-    menuBar.add(helpMenu);
+    setMnemonic(KeyEvent.VK_H);
 
-    addMoveHelpMenu(helpMenu);
-    addUnitHelpMenu(helpMenu);
-    addGameNotesMenu(helpMenu);
-    addAboutMenu(helpMenu);
-    addReportBugsMenu(helpMenu);
+    addMoveHelpMenu();
+    addUnitHelpMenu();
+    addGameNotesMenu();
+    addAboutMenu();
+    addReportBugsMenu();
   }
 
-  private static void addMoveHelpMenu(final JMenu parentMenu) {
+  private void addMoveHelpMenu() {
     final String moveSelectionHelpTitle = "Movement/Selection Help";
-    parentMenu.add(SwingAction.of(moveSelectionHelpTitle, e -> {
+    add(SwingAction.of(moveSelectionHelpTitle, e -> {
       // html formatted string
       final String hints = "<b> Selecting Units</b><br>" + "Left click on a unit stack to select 1 unit.<br>"
           + "ALT-Left click on a unit stack to select 10 units of that type in the stack.<br>"
@@ -167,9 +170,9 @@ public class HelpMenu {
 
 
 
-  private void addUnitHelpMenu(final JMenu parentMenu) {
+  private void addUnitHelpMenu() {
     final String unitHelpTitle = "Unit Help";
-    parentMenu.add(SwingAction.of(unitHelpTitle, e -> {
+    add(SwingAction.of(unitHelpTitle, e -> {
       final JEditorPane editorPane = new JEditorPane();
       editorPane.setEditable(false);
       editorPane.setContentType("text/html");
@@ -218,10 +221,9 @@ public class HelpMenu {
     })).setMnemonic(KeyEvent.VK_U);
   }
 
-
   public static final JEditorPane gameNotesPane = new JEditorPane();
 
-  private void addGameNotesMenu(final JMenu parentMenu) {
+  private void addGameNotesMenu() {
     // allow the game developer to write notes that appear in the game
     // displays whatever is in the notes field in html
     final String notesProperty = gameData.getProperties().get("notes", "");
@@ -232,7 +234,7 @@ public class HelpMenu {
       gameNotesPane.setText(notes);
       gameNotesPane.setForeground(Color.BLACK);
       final String gameNotesTitle = "Game Notes";
-      parentMenu.add(SwingAction.of(gameNotesTitle, e -> SwingUtilities.invokeLater(() -> {
+      add(SwingAction.of(gameNotesTitle, e -> SwingUtilities.invokeLater(() -> {
         final JScrollPane scroll = new JScrollPane(gameNotesPane);
         scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
         final JDialog dialog = new JDialog((JFrame) null, gameNotesTitle);
@@ -270,7 +272,7 @@ public class HelpMenu {
     }
   }
 
-  private void addAboutMenu(final JMenu parentMenu) {
+  private void addAboutMenu() {
     final String text = "<html>"
         + "<h2>" + gameData.getGameName() + "</h2>"
         + "<b>Engine Version:</b> " + ClientContext.engineVersion().getExactVersion() + "<br>"
@@ -296,8 +298,8 @@ public class HelpMenu {
         .build();
 
     if (!SystemProperties.isMac()) {
-      parentMenu.addSeparator();
-      parentMenu.add(SwingAction.of("About", e -> JOptionPane.showMessageDialog(null, label,
+      addSeparator();
+      add(SwingAction.of("About", e -> JOptionPane.showMessageDialog(null, label,
           "About " + gameData.getGameName(), JOptionPane.PLAIN_MESSAGE))).setMnemonic(KeyEvent.VK_A);
     } else { // On Mac OS X, put the About menu where Mac users expect it to be
       Application.getApplication().setAboutHandler(paramAboutEvent -> JOptionPane.showMessageDialog(null, label,
@@ -305,8 +307,8 @@ public class HelpMenu {
     }
   }
 
-  private static void addReportBugsMenu(final JMenu parentMenu) {
-    parentMenu.add(SwingAction.of("Send Bug Report",
+  private void addReportBugsMenu() {
+    add(SwingAction.of("Send Bug Report",
         e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES))).setMnemonic(KeyEvent.VK_B);
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -39,7 +39,10 @@ import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 
-public class LobbyMenu extends JMenuBar {
+/**
+ * The lobby client menu bar.
+ */
+public final class LobbyMenu extends JMenuBar {
   private static final long serialVersionUID = 4980621864542042057L;
   private static final String HASHED_MAC_PREFIX = games.strategy.util.MD5Crypt.MAGIC + "MH$";
 
@@ -284,7 +287,6 @@ public class LobbyMenu extends JMenuBar {
     helpPageLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
     parentMenu.add(helpPageLink);
 
-
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
     lobbyRules.addActionListener(
         e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
@@ -293,7 +295,6 @@ public class LobbyMenu extends JMenuBar {
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
     parentMenu.add(warClub);
-
   }
 
   private void addChatTimeMenu(final JMenu parentMenu) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -21,33 +21,37 @@ import games.strategy.net.HeadlessServerMessenger;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.TripleAFrame;
 
-public class TripleAMenuBar extends JMenuBar {
+/**
+ * The game client menu bar.
+ */
+public final class TripleAMenuBar extends JMenuBar {
   private static final long serialVersionUID = -1447295944297939539L;
-  protected final TripleAFrame frame;
+
+  private final TripleAFrame frame;
 
   public TripleAMenuBar(final TripleAFrame frame) {
     this.frame = frame;
-    new FileMenu(this, frame);
-    new ViewMenu(this, frame);
-    new GameMenu(this, frame);
-    new ExportMenu(this, frame);
+
+    add(new FileMenu(frame));
+    add(new ViewMenu(frame));
+    add(new GameMenu(frame));
+    add(new ExportMenu(frame));
 
     final Optional<InGameLobbyWatcherWrapper> watcher = frame.getInGameLobbyWatcher();
-    if (watcher.isPresent() && watcher.get().isActive()) {
-      createLobbyMenu(this, watcher.get());
-    }
+    watcher.filter(InGameLobbyWatcherWrapper::isActive).ifPresent(this::createLobbyMenu);
     if (!(frame.getGame().getMessenger() instanceof HeadlessServerMessenger)) {
-      new NetworkMenu(this, watcher, frame);
+      add(new NetworkMenu(watcher, frame));
     }
-    new WebHelpMenu(this);
-    new DebugMenu(this, frame);
-    new HelpMenu(this, frame.getUiContext(), frame.getGame().getData());
+
+    add(new WebHelpMenu());
+    add(new DebugMenu(frame));
+    add(new HelpMenu(frame.getUiContext(), frame.getGame().getData()));
   }
 
-  private void createLobbyMenu(final JMenuBar menuBar, final InGameLobbyWatcherWrapper watcher) {
+  private void createLobbyMenu(final InGameLobbyWatcherWrapper watcher) {
     final JMenu lobby = new JMenu("Lobby");
     lobby.setMnemonic(KeyEvent.VK_L);
-    menuBar.add(lobby);
+    add(lobby);
     lobby.add(new EditGameCommentAction(watcher, frame));
     lobby.add(new RemoveGameFromLobbyAction(watcher));
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -25,7 +25,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
-import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -54,7 +53,9 @@ import games.strategy.triplea.ui.screen.UnitsDrawer;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
 import games.strategy.ui.SwingAction;
 
-class ViewMenu {
+final class ViewMenu extends JMenu {
+  private static final long serialVersionUID = -4703734404422047487L;
+
   private JCheckBoxMenuItem showMapDetails;
   private JCheckBoxMenuItem showMapBlends;
 
@@ -62,53 +63,52 @@ class ViewMenu {
   private final TripleAFrame frame;
   private final UiContext uiContext;
 
-  ViewMenu(final JMenuBar menuBar, final TripleAFrame frame) {
+  ViewMenu(final TripleAFrame frame) {
+    super("View");
+
     this.frame = frame;
     this.uiContext = frame.getUiContext();
     gameData = frame.getGame().getData();
 
+    setMnemonic(KeyEvent.VK_V);
 
-    final JMenu menuView = new JMenu("View");
-    menuView.setMnemonic(KeyEvent.VK_V);
-    menuBar.add(menuView);
-    addZoomMenu(menuView);
-    addUnitSizeMenu(menuView);
-    addLockMap(menuView);
-    addShowUnits(menuView);
-    addUnitNationDrawMenu(menuView);
+    addZoomMenu();
+    addUnitSizeMenu();
+    addLockMap();
+    addShowUnits();
+    addUnitNationDrawMenu();
     if (uiContext.getMapData().useTerritoryEffectMarkers()) {
-      addShowTerritoryEffects(menuView);
+      addShowTerritoryEffects();
     }
-    addMapSkinsMenu(menuView);
-    addShowMapDetails(menuView);
-    addShowMapBlends(menuView);
-    addDrawTerritoryBordersAgain(menuView);
-    addMapFontAndColorEditorMenu(menuView);
-    addChatTimeMenu(menuView);
-    addShowCommentLog(menuView);
-    // The menuItem to turn TabbedProduction on or off
-    addTabbedProduction(menuView);
-    addShowGameUuid(menuView);
+    addMapSkinsMenu();
+    addShowMapDetails();
+    addShowMapBlends();
+    addDrawTerritoryBordersAgain();
+    addMapFontAndColorEditorMenu();
+    addChatTimeMenu();
+    addShowCommentLog();
+    addTabbedProduction();
+    addShowGameUuid();
 
     showMapDetails.setEnabled(uiContext.getMapData().getHasRelief());
   }
 
-  private void addShowCommentLog(final JMenu parentMenu) {
+  private void addShowCommentLog() {
     final JCheckBoxMenuItem showCommentLog = new JCheckBoxMenuItem("Show Comment Log");
     showCommentLog.setModel(frame.getShowCommentLogButtonModel());
-    parentMenu.add(showCommentLog).setMnemonic(KeyEvent.VK_L);
+    add(showCommentLog).setMnemonic(KeyEvent.VK_L);
   }
 
-  private static void addTabbedProduction(final JMenu parentMenu) {
+  private void addTabbedProduction() {
     final JCheckBoxMenuItem tabbedProduction = new JCheckBoxMenuItem("Show Production Tabs");
     tabbedProduction.setMnemonic(KeyEvent.VK_P);
     tabbedProduction.setSelected(PurchasePanel.isTabbedProduction());
     tabbedProduction.addActionListener(e -> PurchasePanel.setTabbedProduction(tabbedProduction.isSelected()));
-    parentMenu.add(tabbedProduction);
+    add(tabbedProduction);
   }
 
-  private void addShowGameUuid(final JMenu menuView) {
-    menuView.add(SwingAction.of("Game UUID", e -> {
+  private void addShowGameUuid() {
+    add(SwingAction.of("Game UUID", e -> {
       final String id = (String) gameData.getProperties().get(GameData.GAME_UUID);
       final JTextField text = new JTextField();
       text.setText(id);
@@ -118,12 +118,12 @@ class ViewMenu {
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
       panel.add(text, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.BOTH,
           new Insets(0, 0, 0, 0), 0, 0));
-      JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(menuView), panel, "Game UUID",
+      JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(this), panel, "Game UUID",
           JOptionPane.OK_OPTION, JOptionPane.INFORMATION_MESSAGE, null, new String[] {"OK"}, "OK");
     })).setMnemonic(KeyEvent.VK_U);
   }
 
-  private void addZoomMenu(final JMenu menuGame) {
+  private void addZoomMenu() {
     final Action mapZoom = SwingAction.of("Map Zoom", e -> {
       final SpinnerNumberModel model = new SpinnerNumberModel();
       model.setMaximum(100);
@@ -168,10 +168,10 @@ class ViewMenu {
       frame.setScale(value.doubleValue());
 
     });
-    menuGame.add(mapZoom).setMnemonic(KeyEvent.VK_Z);
+    add(mapZoom).setMnemonic(KeyEvent.VK_Z);
   }
 
-  private void addUnitSizeMenu(final JMenu parentMenu) {
+  private void addUnitSizeMenu() {
     final NumberFormat decimalFormat = new DecimalFormat("00.##");
     // This is the action listener used
     class UnitSizeAction extends AbstractAction {
@@ -239,13 +239,13 @@ class ViewMenu {
     unitSizeMenu.add(radioItem66);
     unitSizeMenu.add(radioItem56);
     unitSizeMenu.add(radioItem50);
-    parentMenu.add(unitSizeMenu);
+    add(unitSizeMenu);
   }
 
-  private void addMapSkinsMenu(final JMenu menuGame) {
+  private void addMapSkinsMenu() {
     final JMenu mapSubMenu = new JMenu("Map Skins");
     mapSubMenu.setMnemonic(KeyEvent.VK_K);
-    menuGame.add(mapSubMenu);
+    add(mapSubMenu);
     final ButtonGroup mapButtonGroup = new ButtonGroup();
     final Map<String, String> skins = AbstractUiContext.getSkins(frame.getGame().getData());
     mapSubMenu.setEnabled(skins.size() > 1);
@@ -270,7 +270,7 @@ class ViewMenu {
     }
   }
 
-  private void addShowMapDetails(final JMenu menuGame) {
+  private void addShowMapDetails() {
     showMapDetails = new JCheckBoxMenuItem("Show Map Details");
     showMapDetails.setMnemonic(KeyEvent.VK_D);
     showMapDetails.setSelected(TileImageFactory.getShowReliefImages());
@@ -282,10 +282,10 @@ class ViewMenu {
       new Thread(() -> frame.getMapPanel().updateCountries(gameData.getMap().getTerritories()),
           "Triplea : Show map details thread").start();
     });
-    menuGame.add(showMapDetails);
+    add(showMapDetails);
   }
 
-  private void addShowMapBlends(final JMenu menuGame) {
+  private void addShowMapBlends() {
     showMapBlends = new JCheckBoxMenuItem("Show Map Blends");
     showMapBlends.setMnemonic(KeyEvent.VK_B);
     if (uiContext.getMapData().getHasRelief() && showMapDetails.isEnabled() && showMapDetails.isSelected()) {
@@ -307,10 +307,10 @@ class ViewMenu {
         frame.getMapPanel().updateCountries(gameData.getMap().getTerritories());
       }, "Triplea : Show map Blends thread").start();
     });
-    menuGame.add(showMapBlends);
+    add(showMapBlends);
   }
 
-  private void addShowUnits(final JMenu parentMenu) {
+  private void addShowUnits() {
     final JCheckBoxMenuItem showUnitsBox = new JCheckBoxMenuItem("Show Units");
     showUnitsBox.setMnemonic(KeyEvent.VK_U);
     showUnitsBox.setSelected(true);
@@ -319,10 +319,10 @@ class ViewMenu {
       uiContext.setShowUnits(tfselected);
       frame.getMapPanel().resetMap();
     });
-    parentMenu.add(showUnitsBox);
+    add(showUnitsBox);
   }
 
-  private void addDrawTerritoryBordersAgain(final JMenu parentMenu) {
+  private void addDrawTerritoryBordersAgain() {
     final JMenu drawBordersMenu = new JMenu();
     drawBordersMenu.setMnemonic(KeyEvent.VK_O);
     drawBordersMenu.setText("Draw Borders On Top");
@@ -379,10 +379,10 @@ class ViewMenu {
     drawBordersMenu.add(noneButton);
     drawBordersMenu.add(mediumButton);
     drawBordersMenu.add(highButton);
-    parentMenu.add(drawBordersMenu);
+    add(drawBordersMenu);
   }
 
-  private void addMapFontAndColorEditorMenu(final JMenu parentMenu) {
+  private void addMapFontAndColorEditorMenu() {
     final Action mapFontOptions = SwingAction.of("Edit Map Font and Color", e -> {
       final List<IEditableProperty> properties = new ArrayList<>();
       final NumberProperty fontsize =
@@ -429,12 +429,11 @@ class ViewMenu {
         MapImage.setPropertyUnitHitDamageColor((Color) hitDamageColor.getValue());
         frame.getMapPanel().resetMap();
       }
-
     });
-    parentMenu.add(mapFontOptions).setMnemonic(KeyEvent.VK_C);
+    add(mapFontOptions).setMnemonic(KeyEvent.VK_C);
   }
 
-  private void addShowTerritoryEffects(final JMenu parentMenu) {
+  private void addShowTerritoryEffects() {
     final JCheckBoxMenuItem territoryEffectsBox = new JCheckBoxMenuItem("Show TerritoryEffects");
     territoryEffectsBox.setMnemonic(KeyEvent.VK_T);
     territoryEffectsBox.addActionListener(e -> {
@@ -442,19 +441,19 @@ class ViewMenu {
       uiContext.setShowTerritoryEffects(tfselected);
       frame.getMapPanel().resetMap();
     });
-    parentMenu.add(territoryEffectsBox);
+    add(territoryEffectsBox);
     territoryEffectsBox.setSelected(true);
   }
 
-  private void addLockMap(final JMenu parentMenu) {
+  private void addLockMap() {
     final JCheckBoxMenuItem lockMapBox = new JCheckBoxMenuItem("Lock Map");
     lockMapBox.setMnemonic(KeyEvent.VK_M);
     lockMapBox.setSelected(uiContext.getLockMap());
     lockMapBox.addActionListener(e -> uiContext.setLockMap(lockMapBox.isSelected()));
-    parentMenu.add(lockMapBox);
+    add(lockMapBox);
   }
 
-  private void addUnitNationDrawMenu(final JMenu parentMenu) {
+  private void addUnitNationDrawMenu() {
     final JMenu unitSizeMenu = new JMenu();
     unitSizeMenu.setMnemonic(KeyEvent.VK_N);
     unitSizeMenu.setText("Flag Display Mode");
@@ -480,7 +479,7 @@ class ViewMenu {
         UnitsDrawer.UnitFlagDrawMode.NEXT_TO, setting, prefs));
     unitSizeMenu.add(createFlagDrawModeRadionButtonItem("Large", unitFlagSettingGroup,
         UnitsDrawer.UnitFlagDrawMode.BELOW, setting, prefs));
-    parentMenu.add(unitSizeMenu);
+    add(unitSizeMenu);
   }
 
   private JRadioButtonMenuItem createFlagDrawModeRadionButtonItem(final String text, final ButtonGroup group,
@@ -501,12 +500,12 @@ class ViewMenu {
     return buttonItem;
   }
 
-  private void addChatTimeMenu(final JMenu parentMenu) {
+  private void addChatTimeMenu() {
     final JCheckBoxMenuItem chatTimeBox = new JCheckBoxMenuItem("Show Chat Times");
     chatTimeBox.setMnemonic(KeyEvent.VK_T);
     chatTimeBox.addActionListener(e -> frame.setShowChatTime(chatTimeBox.isSelected()));
     chatTimeBox.setSelected(false);
-    parentMenu.add(chatTimeBox);
+    add(chatTimeBox);
     chatTimeBox.setEnabled(GameRunner.getChat().isPresent());
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -8,44 +8,47 @@ import javax.swing.JMenuItem;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingComponents;
 
-class WebHelpMenu {
-  WebHelpMenu(final TripleAMenuBar menuBar) {
-    final JMenu web = new JMenu("Web");
-    web.setMnemonic(KeyEvent.VK_W);
-    menuBar.add(web);
-    addWebMenu(web);
+final class WebHelpMenu extends JMenu {
+  private static final long serialVersionUID = -1940188637908722947L;
+
+  WebHelpMenu() {
+    super("Web");
+
+    setMnemonic(KeyEvent.VK_W);
+
+    addWebMenu();
   }
 
-  private static void addWebMenu(final JMenu parentMenu) {
+  private void addWebMenu() {
     final JMenuItem hostingLink = new JMenuItem("How to Host");
     hostingLink.setMnemonic(KeyEvent.VK_H);
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
-    parentMenu.add(hostingLink);
+    add(hostingLink);
 
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
     lobbyRules.setMnemonic(KeyEvent.VK_L);
     lobbyRules.addActionListener(
         e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
-    parentMenu.add(lobbyRules);
+    add(lobbyRules);
 
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
     warClub.setMnemonic(KeyEvent.VK_W);
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
-    parentMenu.add(warClub);
+    add(warClub);
 
     final JMenuItem donateLink = new JMenuItem("Donate");
     donateLink.setMnemonic(KeyEvent.VK_O);
     donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
-    parentMenu.add(donateLink);
+    add(donateLink);
 
     final JMenuItem helpLink = new JMenuItem("Help");
     helpLink.setMnemonic(KeyEvent.VK_G);
     helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
-    parentMenu.add(helpLink);
+    add(helpLink);
 
     final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
     ruleBookLink.setMnemonic(KeyEvent.VK_K);
     ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
-    parentMenu.add(ruleBookLink);
+    add(ruleBookLink);
   }
 }


### PR DESCRIPTION
Static analysis identified several "the allocated object is never used" warnings within `TripleAMenuBar`.  The allocated objects are used to create the various `JMenu`s on the menu bar.  However, they are indeed used but through a level of indirection due to how the menus are created.

Previously, the various `*Menu` classes were responsible for adding the `JMenu` they create to the `TripleAMenuBar`, which was passed as a parameter to the constructor.  This PR reverses that by

1. having the `*Menu` classes extend `JMenu` directly, and
1. having `TripleAMenuBar` add the `JMenu`s it creates directly to itself.

I also did a bit of unrelated refactoring in `NetworkMenu` to remove some duplication.