### PR TITLE
Checkstyle: Update thresholds via pull request

### DIFF
--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -90,8 +90,8 @@ create_remote_branch() {
   local -r branch_name=$1
 
   echo "Creating branch '$branch_name' in '$TRAVIS_REPO_SLUG' at SHA '$TRAVIS_COMMIT'..."
-  local -r create_ref_request="{ \
-    \"ref\": \"refs/heads/$branch_name\", \
+  local -r create_ref_request="{
+    \"ref\": \"refs/heads/$branch_name\",
     \"sha\": \"$TRAVIS_COMMIT\"
   }"
   curl \
@@ -109,15 +109,15 @@ update_remote_file() {
   local -r old_hash=$2
 
   echo "Updating '$GRADLE_PROPERTIES' in '$TRAVIS_REPO_SLUG' on branch '$branch_name'..."
-  local -r update_file_request="{ \
-    \"message\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\", \
-    \"committer\": { \
-      \"name\": \"tripleabuilderbot\", \
-      \"email\": \"tripleabuilderbot@gmail.com\" \
-    }, \
-    \"branch\": \"$branch_name\", \
-    \"content\": \"$(base64 -w 0 $GRADLE_PROPERTIES)\", \
-    \"sha\": \"$old_hash\" \
+  local -r update_file_request="{
+    \"message\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\",
+    \"committer\": {
+      \"name\": \"tripleabuilderbot\",
+      \"email\": \"tripleabuilderbot@gmail.com\"
+    },
+    \"branch\": \"$branch_name\",
+    \"content\": \"$(base64 -w 0 $GRADLE_PROPERTIES)\",
+    \"sha\": \"$old_hash\"
   }"
   curl \
       --silent \
@@ -133,8 +133,8 @@ create_remote_pull_request() {
   local -r branch_name=$1
 
   echo "Creating new pull request in '$TRAVIS_REPO_SLUG' for branch '$branch_name'..."
-  local -r create_pr_request="{ \
-    \"title\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\", \
+  local -r create_pr_request="{
+    \"title\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\",
     \"head\": \"$branch_name\",
     \"base\": \"master\",
     \"body\": \"**Note to reviewer:** Please delete the PR branch after merging.\",

--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -36,6 +36,10 @@ should_skip_build() {
     echo "  ...skipping because this repo is not permitted."
     skip=$TRUE
   fi
+  if [[ "$TRIPLEA_RELEASE" != "true" ]]; then
+    echo "  ...skipping because this is not the release build."
+    skip=$TRUE
+  fi
   return $skip
 }
 
@@ -74,15 +78,44 @@ has_local_thresholds_changed() {
 }
 
 update_remote_thresholds() {
-  echo "Pushing '$GRADLE_PROPERTIES' changes to '$TRAVIS_REPO_SLUG:$TRAVIS_BRANCH'..."
   local -r old_hash=$1
-  local -r update_request="{ \
+  local -r branch_name="checkstyle_update_thresholds_after_build_${TRAVIS_BUILD_NUMBER}"
+
+  create_remote_branch "$branch_name"
+  update_remote_file "$branch_name" "$old_hash"
+  create_remote_pull_request "$branch_name"
+}
+
+create_remote_branch() {
+  local -r branch_name=$1
+
+  echo "Creating branch '$branch_name' in '$TRAVIS_REPO_SLUG' at SHA '$TRAVIS_COMMIT'..."
+  local -r create_ref_request="{ \
+    \"ref\": \"refs/heads/$branch_name\", \
+    \"sha\": \"$TRAVIS_COMMIT\"
+  }"
+  curl \
+      --silent \
+      --show-error \
+      -X POST \
+      --header "Accept: application/vnd.github.v3+json" \
+      --data "$create_ref_request" \
+      --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
+      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs"
+}
+
+update_remote_file() {
+  local -r branch_name=$1
+  local -r old_hash=$2
+
+  echo "Updating '$GRADLE_PROPERTIES' in '$TRAVIS_REPO_SLUG' on branch '$branch_name'..."
+  local -r update_file_request="{ \
     \"message\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\", \
     \"committer\": { \
       \"name\": \"tripleabuilderbot\", \
       \"email\": \"tripleabuilderbot@gmail.com\" \
     }, \
-    \"branch\": \"$TRAVIS_BRANCH\", \
+    \"branch\": \"$branch_name\", \
     \"content\": \"$(base64 -w 0 $GRADLE_PROPERTIES)\", \
     \"sha\": \"$old_hash\" \
   }"
@@ -91,9 +124,30 @@ update_remote_thresholds() {
       --show-error \
       -X PUT \
       --header "Accept: application/vnd.github.v3+json" \
-      --data "$update_request" \
+      --data "$update_file_request" \
       --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
       "https://api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES"
+}
+
+create_remote_pull_request() {
+  local -r branch_name=$1
+
+  echo "Creating new pull request in '$TRAVIS_REPO_SLUG' for branch '$branch_name'..."
+  local -r create_pr_request="{ \
+    \"title\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\", \
+    \"head\": \"$branch_name\",
+    \"base\": \"master\",
+    \"body\": \"**Note to reviewer:** Please delete the PR branch after merging.\",
+    \"maintainer_can_modify\": true
+  }"
+  curl \
+      --silent \
+      --show-error \
+      -X POST \
+      --header "Accept: application/vnd.github.v3+json" \
+      --data "$create_pr_request" \
+      --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
+      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls"
 }
 
 main

--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -83,25 +83,18 @@ update_remote_thresholds() {
 
   create_remote_branch "$branch_name"
   update_remote_file "$branch_name" "$old_hash"
-  create_remote_pull_request "$branch_name"
+  create_pull_request "$branch_name"
 }
 
 create_remote_branch() {
   local -r branch_name=$1
 
   echo "Creating branch '$branch_name' in '$TRAVIS_REPO_SLUG' at SHA '$TRAVIS_COMMIT'..."
-  local -r create_ref_request="{
+  local -r request_data="{
     \"ref\": \"refs/heads/$branch_name\",
     \"sha\": \"$TRAVIS_COMMIT\"
   }"
-  curl \
-      --silent \
-      --show-error \
-      -X POST \
-      --header "Accept: application/vnd.github.v3+json" \
-      --data "$create_ref_request" \
-      --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
-      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs"
+  call_github_api "POST" "git/refs" "$request_data"
 }
 
 update_remote_file() {
@@ -109,7 +102,7 @@ update_remote_file() {
   local -r old_hash=$2
 
   echo "Updating '$GRADLE_PROPERTIES' in '$TRAVIS_REPO_SLUG' on branch '$branch_name'..."
-  local -r update_file_request="{
+  local -r request_data="{
     \"message\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\",
     \"committer\": {
       \"name\": \"tripleabuilderbot\",
@@ -119,35 +112,36 @@ update_remote_file() {
     \"content\": \"$(base64 -w 0 $GRADLE_PROPERTIES)\",
     \"sha\": \"$old_hash\"
   }"
-  curl \
-      --silent \
-      --show-error \
-      -X PUT \
-      --header "Accept: application/vnd.github.v3+json" \
-      --data "$update_file_request" \
-      --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
-      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES"
+  call_github_api "PUT" "contents/$GRADLE_PROPERTIES" "$request_data"
 }
 
-create_remote_pull_request() {
+create_pull_request() {
   local -r branch_name=$1
 
   echo "Creating new pull request in '$TRAVIS_REPO_SLUG' for branch '$branch_name'..."
-  local -r create_pr_request="{
+  local -r request_data="{
     \"title\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\",
     \"head\": \"$branch_name\",
     \"base\": \"master\",
     \"body\": \"**Note to reviewer:** Please delete the PR branch after merging.\",
     \"maintainer_can_modify\": true
   }"
+  call_github_api "POST" "pulls" "$request_data"
+}
+
+call_github_api() {
+  local -r method=$1
+  local -r uri_path=$2
+  local -r data=$3
+
   curl \
       --silent \
       --show-error \
-      -X POST \
+      --request "$method" \
       --header "Accept: application/vnd.github.v3+json" \
-      --data "$create_pr_request" \
+      --data "$data" \
       --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
-      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls"
+      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/$uri_path"
 }
 
 main


### PR DESCRIPTION
Fixes #2931.

When the Checkstyle thresholds change, we previously would update _gradle.properties_ and push a new commit directly to `master`.  Due to `master` branch protection, which was enabled recently, this is no longer possible.

This PR changes the _update_checkstyle_thresholds_ script to do the following when it detects the Checkstyle thresholds have changed:

1. Create a new branch based on `master` with the name `checkstyle_update_thresholds_after_build_XXXX`, where `XXXX` is the Travis build number.
1. Update _gradle.properties_ with the latest Checkstyle thresholds on the branch created in (1) (this creates a new commit on that branch and is effectively the same thing the previous script did).
1. Create a new PR to merge the branch created in (1) into `master`.

#### Testing

I tested this on my fork and it appears to work as expected.  I had to disable some of the checks that are used to ensure the script only runs under the proper conditions in order to test in my fork.  So we won't know if it works 100% until these changes are merged.

#### Notes

Previously we made one call to the GitHub API; now we make three.  Each of these three calls makes a change to the repo, which triggers a new build in Travis:

1. Creating new branch.
1. Creating new commit on new branch.
1. Creating PR.

The first two builds are superfluous.  Unfortunately, I'm not aware of a way to prevent Travis from running those first two builds.  I'm not overly concerned at this time because, as I mentioned elsewhere, our Checkstyle fixes are becoming less frequent.