### PR TITLE
Allow SwingAction#invokeAndWait(Runnable) to re-throw exceptions

### DIFF
--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -37,7 +37,7 @@ public final class ErrorConsole extends GenericConsole {
    * If not yet created, initializes the error console.
    */
   public static void createConsole() {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       console = new ErrorConsole();
       console.displayStandardOutput();
       console.displayStandardError();

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -95,7 +95,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   void setChat(final Chat chat) {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       if (chat != null) {
         chat.removeChatListener(this);
         cleanupKeyMap();

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -118,7 +118,7 @@ public class GameRunner {
    * No args will launch a client, additional args can be supplied to specify additional behavior.
    * Warning: game engine code invokes this method to spawn new game clients.
    */
-  public static void main(final String[] args) {
+  public static void main(final String[] args) throws InterruptedException{
     LoggingConfiguration.initialize();
     ClientSetting.initialize();
 
@@ -550,7 +550,7 @@ public class GameRunner {
    * After the game has been left, call this.
    */
   public static void clientLeftGame() {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
       // closing of stream while unloading map resources.
       ThreadUtil.sleep(100);
@@ -562,5 +562,4 @@ public class GameRunner {
   public static void quitGame() {
     mainFrame.dispatchEvent(new WindowEvent(mainFrame, WindowEvent.WINDOW_CLOSING));
   }
-
 }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -127,7 +127,7 @@ public class ClientModel implements IMessengerErrorListener {
     @Override
     public void gameReset() {
       objectStreamFactory.setData(null);
-      SwingAction.invokeAndWait(GameRunner::showMainFrame);
+      SwingAction.invokeAndWaitUninterruptibly(GameRunner::showMainFrame);
     }
 
     @Override

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -109,7 +109,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
    * parameter, then show confirmation of deletion.
    */
   private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map, final Optional<String> errorDetails) {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       String message = "Could not parse map file correctly, would you like to remove it?\n" + map.getAbsolutePath()
           + "\n(You may see this error message again if you keep the file)";
       String title = "Corrup Map File Found";

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -89,7 +89,8 @@ public class TripleA implements IGameLoader {
   }
 
   @Override
-  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) {
+  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless)
+      throws InterruptedException {
     this.game = game;
     if (game.getData().getDelegateList().getDelegate("edit") == null) {
       // An evil hack: instead of modifying the XML, force an EditDelegate by adding one here

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -388,7 +388,7 @@ class ProLogWindow extends JDialog {
   }
 
   void notifyNewRound(final int roundNumber, final String name) {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       final JPanel newPanel = new JPanel();
       final JScrollPane newScrollPane = new JScrollPane();
       final JTextArea newTextArea = new JTextArea();
@@ -419,7 +419,7 @@ class ProLogWindow extends JDialog {
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }
-      SwingAction.invokeAndWait(() -> {
+      SwingAction.invokeAndWaitUninterruptibly(() -> {
         for (int i = 0; i < logHolderTabbedPane.getTabCount(); i++) {
           // Remember, we never remove last tab, in case user turns logging back on in the middle of a round
           if (i != 0 && i < logHolderTabbedPane.getTabCount() - maxHistoryRounds) {

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -231,7 +231,7 @@ public class BattlePanel extends ActionPanel {
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
       final PlayerID attacker, final PlayerID defender,
       final boolean isAmphibious, final BattleType battleType, final Collection<Unit> amphibiousLandAttackers) {
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
       if (battleDisplay != null) {
         cleanUpBattleWindow();
         currentBattleDisplayed = null;

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 public final class Util {
   public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
@@ -33,9 +32,12 @@ public final class Util {
   }
 
   public static <T> T runInSwingEventThread(final Task<T> task) {
-    final AtomicReference<T> results = new AtomicReference<>();
-    SwingAction.invokeAndWait(() -> results.set(task.run()));
-    return results.get();
+    try {
+      return SwingAction.invokeAndWait(task::run);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
+    }
   }
 
   private static final Component component = new Component() {

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -74,7 +74,7 @@ public class MapCreator extends JFrame {
   /**
    * Entry point for the map-making utilities application.
    */
-  public static void main(final String[] args) {
+  public static void main(final String[] args) throws InterruptedException {
     ClientSetting.initialize();
 
     SwingAction.invokeAndWait(() -> {

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -18,7 +18,7 @@ public final class TestUtil {
    */
   public static void waitForSwingThreads() {
     // add a no-op action to the end of the swing event queue, and then wait for it
-    SwingAction.invokeAndWait(() -> {
+    SwingAction.invokeAndWaitUninterruptibly(() -> {
     });
   }
 }


### PR DESCRIPTION
Follow-up to #2926.

Primarily changes the behavior of `SwingAction#invokeAndWait(Runnable)` to not swallow exceptions.  Thus, similar to `invokeAndWait(Supplier<T>)`, it re-throws unchecked exceptions and `InterruptedException`.

For those cases where callers _really_ don't need to handle `InterruptedException`, I added the convenience method `invokeAndWaitUninterruptibly(Runnable)`, which handles `InterruptedException` by re-interrupting the thread before returning to the caller.

When updating affected call sites, if it made sense to handle `InterruptedException` or to allow it to propagate up the call stack, I left `invokeAndWait(Runnable)` in place and made the necessary surrounding modifications.  Otherwise, I replaced `invokeAndWait(Runnable)` with `invokeAndWaitUninterruptibly(Runnable)`.  There were a few cases where using `invokeAndWait(Supplier<T>)` made more sense than using `invokeAndWait(Runnable)` with `AtomicReference`s.

It is recommended to review this PR with whitespace changes ignored (`?w=1`).