### PR TITLE
Remove unused method parameters

### DIFF
--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -238,8 +238,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     unmuteMacTimer.schedule(getMacUnmuteTask(mac), checkTime.toEpochMilli() - System.currentTimeMillis());
   }
 
-  // TODO: remove 'ip' parameter if can confirm no backwards compat issues
-  public void notifyPlayerLogin(final String uniquePlayerName, final String ip, final String mac) {
+  public void notifyPlayerLogin(final String uniquePlayerName, final String mac) {
     synchronized (cachedListLock) {
       cachedMacAddresses.put(uniquePlayerName, mac);
       if (isLobby()) {

--- a/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -97,8 +97,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           send(new InetSocketAddress[] {(InetSocketAddress) channel.socket().getRemoteSocketAddress(),
               serverMessenger.getLocalNode().getSocketAddress()});
           // Login succeeded, so notify the ServerMessenger about the login with the name, mac, etc.
-          serverMessenger.notifyPlayerLogin(remoteName, channel.socket().getInetAddress().getHostAddress(),
-              remoteMac);
+          serverMessenger.notifyPlayerLogin(remoteName, remoteMac);
           // We are good
           return Action.UNQUARANTINE;
         case ACK_ERROR:

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -216,7 +216,7 @@ public class BattlePanel extends ActionPanel {
     return battleFrame;
   }
 
-  public void listBattle(final GUID battleId, final List<String> steps) {
+  public void listBattle(final List<String> steps) {
     SwingAction.invokeNowOrLater(() -> {
       removeAll();
       if (battleDisplay != null) {

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -42,7 +42,7 @@ public class TripleADisplay implements ITripleADisplay {
 
   @Override
   public void listBattleSteps(final GUID battleId, final List<String> steps) {
-    ui.getBattlePanel().listBattle(battleId, steps);
+    ui.getBattlePanel().listBattle(steps);
   }
 
   @Override


### PR DESCRIPTION
Confirmed that `ServerMessenger#notifyPlayerLogin()` does not appear to be called reflectively, so the TODO referencing possible backwards compatibility issues shouldn't apply.