### PR TITLE
Update battle calc unit ordering

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -581,7 +581,7 @@ public final class Matches {
     return obj -> UnitAttachment.get(obj.getType()).getAttackingLimit() != null;
   }
 
-  private static Predicate<UnitType> unitTypeCanNotMoveDuringCombatMove() {
+  public static Predicate<UnitType> unitTypeCanNotMoveDuringCombatMove() {
     return type -> UnitAttachment.get(type).getCanNotMoveDuringCombatMove();
   }
 
@@ -1132,7 +1132,7 @@ public final class Matches {
     return u -> unitTypeCanMove(u.getOwner()).test(u.getType());
   }
 
-  private static Predicate<UnitType> unitTypeCanMove(final PlayerID player) {
+  public static Predicate<UnitType> unitTypeCanMove(final PlayerID player) {
     return obj -> UnitAttachment.get(obj).getMovement(player) > 0;
   }
 


### PR DESCRIPTION
Addresses https://forums.triplea-game.org/topic/553/improve-battle-calc-unit-ordering

**Functional Changes**
- Changes battle calc unit type ordering from (land, air, AA, bombard) to (land, air, can't combat move, bombard) as these grouping make more sense across all maps
- Also update unit type ordering to respect the unit type ordering from production frontier XML so that within the groups above units are then displayed in the order they appear in the production frontier

**Note:** This should have 0 changes to most simple maps and I tested it on v2, v3, and global which show no change. This is mainly to address maps with complex unit sets especially if they use "AA attacks" for targeting specific units and aren't just AA guns.