### PR TITLE
Fix ConsumesUnits TUV Calc Adding Consumed Unit Value Twice

### DIFF
--- a/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -81,11 +81,12 @@ public class TuvUtils {
     }
 
     // Override with XML TUV or consumesUnit sum
+    final IntegerMap<UnitType> result = new IntegerMap<>(costs);
     for (final UnitType unitType : costs.keySet()) {
-      costs.put(unitType, getTotalTuv(unitType, costs, new HashSet<>()));
+      result.put(unitType, getTotalTuv(unitType, costs, new HashSet<>()));
     }
 
-    return costs;
+    return result;
   }
 
   /**

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -240,6 +240,13 @@ public class GameDataTestUtil {
   }
 
   /**
+   * Returns a germanFortification UnitType object for the specified GameData object.
+   */
+  public static UnitType germanFortification(final GameData data) {
+    return unitType("germanFortification", data);
+  }
+
+  /**
    * Returns a truck UnitType object for the specified GameData object.
    */
   public static UnitType truck(final GameData data) {

--- a/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
@@ -35,6 +35,13 @@ public class TuvUtilsTest {
   }
 
   @Test
+  public void testCostsForTuvWithConsumesUnitChain() {
+    final PlayerID germans = GameDataTestUtil.germany(gameData);
+    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);
+    assertEquals(12, result.getInt(GameDataTestUtil.germanFortification(gameData)));
+  }
+
+  @Test
   public void testCostsForTuvWithXmlPropertySet() {
     final PlayerID germans = GameDataTestUtil.germany(gameData);
     final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(germans, gameData);


### PR DESCRIPTION
Need to create a separate result list so not to override the purchase cost list. Otherwise if the cost is updated by 1 consumesUnits unit which is then consumed by another it adds that value twice. 

Testing
- TWW Fortification was showing 17 TUV before and now properly shows 12 TUV after