### PR TITLE
Error Prone: Fix reference equality violations

### DIFF
--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -64,7 +64,7 @@ public class DelegateExecutionManager {
   }
 
   private boolean currentThreadHasReadLock() {
-    return currentThreadHasReadLock.get() == Boolean.TRUE;
+    return currentThreadHasReadLock.get();
   }
 
   /**

--- a/src/main/java/games/strategy/net/GUID.java
+++ b/src/main/java/games/strategy/net/GUID.java
@@ -63,7 +63,7 @@ public final class GUID implements Externalizable {
     if (other == this) {
       return true;
     }
-    return this.id == other.id && (other.prefix == this.prefix || other.prefix.equals(this.prefix));
+    return this.id == other.id && Objects.equals(this.prefix, other.prefix);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -533,7 +534,7 @@ public class WeakAi extends AbstractAi {
     Collections.shuffle(enemyOwned);
     Collections.sort(enemyOwned, (o1, o2) -> {
       // -1 means o1 goes first. 1 means o2 goes first. zero means they are equal.
-      if (o1 == o2 || (o1 == null && o2 == null)) {
+      if (Objects.equals(o1, o2)) {
         return 0;
       }
       if (o1 == null) {
@@ -541,9 +542,6 @@ public class WeakAi extends AbstractAi {
       }
       if (o2 == null) {
         return -1;
-      }
-      if (o1.equals(o2)) {
-        return 0;
       }
       final TerritoryAttachment ta1 = TerritoryAttachment.get(o1);
       final TerritoryAttachment ta2 = TerritoryAttachment.get(o2);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
@@ -1417,13 +1418,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   protected Comparator<Territory> getBestProducerComparator(final Territory to, final Collection<Unit> units,
       final PlayerID player) {
     return (t1, t2) -> {
-      if (t1 == t2 || t1.equals(t2)) {
+      if (Objects.equals(t1, t2)) {
         return 0;
       }
       // producing to territory comes first
-      if (to == t1 || to.equals(t1)) {
+      if (Objects.equals(to, t1)) {
         return -1;
-      } else if (to == t2 || to.equals(t2)) {
+      } else if (Objects.equals(to, t2)) {
         return 1;
       }
       final int left1 = getMaxUnitsToBePlacedFrom(t1, units, to, player);
@@ -1461,7 +1462,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   protected Comparator<Unit> getHardestToPlaceWithRequiresUnitsRestrictions(final boolean sortConstructionsToFront) {
     return (u1, u2) -> {
-      if (u1 == u2 || u1.equals(u2)) {
+      if (Objects.equals(u1, u2)) {
         return 0;
       }
       final UnitAttachment ua1 = UnitAttachment.get(u1.getType());

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -45,11 +45,11 @@ public class DiceImageFactory {
     for (int i = 0; i <= diceSides; i++) {
       Image img = null;
       if (resourceLoader != null) {
-        if (color == Color.black) {
+        if (Color.BLACK.equals(color)) {
           img = imageFactory.getImage("dice/" + i + ".png", false);
-        } else if (color == Color.red) {
+        } else if (Color.RED.equals(color)) {
           img = imageFactory.getImage("dice/" + i + "_hit.png", false);
-        } else if (color == IGNORED) {
+        } else if (IGNORED.equals(color)) {
           img = imageFactory.getImage("dice/" + i + "_ignored.png", false);
         }
       }

--- a/src/test/java/games/strategy/net/GuidTest.java
+++ b/src/test/java/games/strategy/net/GuidTest.java
@@ -9,7 +9,7 @@ public final class GuidTest {
   @Test
   public void shouldBeEquatableAndHashable() {
     EqualsVerifier.forClass(GUID.class)
-        .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
+        .suppress(Warning.NONFINAL_FIELDS)
         .verify();
   }
 }


### PR DESCRIPTION
This PR fixes some low-hanging violations of the Error Prone ReferenceEquality rule.

In most cases, the reference equality check was paired with a standard `Object#equals()` call to handle the condition when one object might be `null` to avoid an NPE when calling `equals()`.  I replaced those expressions with a call to `Objects#equals()`.

The other cases were reference equality checks against _presumed_ singleton static fields (e.g. `Color#black`).  I replaced those checks with a call to `Object#equals()`.