### PR TITLE
Fix Regression preventing people from starting the game

### DIFF
--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -33,7 +33,7 @@ public class DelegateExecutionManager {
    * only 1 block can be held (the block is equivalent to the read lock).
    */
   private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-  private final ThreadLocal<Boolean> currentThreadHasReadLock = new ThreadLocal<>();
+  private final ThreadLocal<Boolean> currentThreadHasReadLock = ThreadLocal.withInitial(() -> Boolean.FALSE);
   private volatile boolean isGameOver = false;
 
   public void setGameOver() {
@@ -141,7 +141,7 @@ public class DelegateExecutionManager {
 
   public void leaveDelegateExecution() {
     readWriteLock.readLock().unlock();
-    currentThreadHasReadLock.set(null);
+    currentThreadHasReadLock.set(Boolean.FALSE);
   }
 
   public void enterDelegateExecution() {


### PR DESCRIPTION
This fixes a severe regression on the latest master that prevents you from starting the game.

EDIT: I'm pretty sure this was introduced by  #2944 at [this line](https://github.com/triplea-game/triplea/pull/2944/files#diff-35a2cd1f06dd7ea3ffc3de915625792bL67), because the Boolean object now gets auto-casted to a boolean primitive, and that results in a null pointer if the Boolean is null