### PR TITLE
Improve Settings window layout

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static games.strategy.engine.framework.ArgParser.CliProperties.DO_NOT_CHECK_FOR_UPDATES;
 import static games.strategy.engine.framework.ArgParser.CliProperties.GAME_HOST_CONSOLE;
 import static games.strategy.engine.framework.ArgParser.CliProperties.LOBBY_GAME_COMMENTS;
@@ -44,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
+import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -168,6 +170,19 @@ public class GameRunner {
     frame.setLocationRelativeTo(null);
 
     return frame;
+  }
+
+  /**
+   * Creates a new modeless dialog with the specified title whose parent is the main frame window.
+   *
+   * @param title The dialog title.
+   *
+   * @return A new modeless dialog.
+   */
+  public static JDialog newDialog(final String title) {
+    checkNotNull(title);
+
+    return new JDialog(mainFrame, title);
   }
 
   public static FileDialog newFileDialog() {

--- a/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -11,7 +11,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.prefs.Preferences;
 
-import javax.swing.Box;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -301,7 +300,7 @@ final class SelectionComponentFactory {
         return JPanelBuilder.builder()
             .horizontalBoxLayout()
             .add(field)
-            .add(Box.createHorizontalStrut(10))
+            .addHorizontalStrut(5)
             .add(button)
             .build();
       }

--- a/src/main/java/swinglib/JScrollPaneBuilder.java
+++ b/src/main/java/swinglib/JScrollPaneBuilder.java
@@ -4,8 +4,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.awt.Component;
+import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.swing.JScrollPane;
+import javax.swing.border.Border;
 
 /**
  * A builder for incrementally creating instances of {@link JScrollPane}.
@@ -23,6 +26,7 @@ import javax.swing.JScrollPane;
  * </pre>
  */
 public final class JScrollPaneBuilder {
+  private @Nullable Border border;
   private Component view;
 
   private JScrollPaneBuilder() {}
@@ -32,14 +36,36 @@ public final class JScrollPaneBuilder {
   }
 
   /**
+   * Sets the scroll pane border.
+   *
+   * @param border The border.
+   */
+  public JScrollPaneBuilder border(final Border border) {
+    checkNotNull(border);
+
+    this.border = border;
+    return this;
+  }
+
+  /**
+   * Conditionally sets the scroll pane border.
+   *
+   * @param border The border; if empty, the current border will not be changed.
+   */
+  public JScrollPaneBuilder border(final Optional<Border> border) {
+    checkNotNull(border);
+
+    border.ifPresent(this::border);
+    return this;
+  }
+
+  /**
    * Sets the component to display in the scroll pane's viewport.
    *
    * @param view The component to display in the scroll pane's viewport.
-   *
-   * @throws NullPointerException If {@code view} is {@code null}.
    */
   public JScrollPaneBuilder view(final Component view) {
-    checkNotNull(view, "view must not be null");
+    checkNotNull(view);
 
     this.view = view;
     return this;
@@ -55,6 +81,12 @@ public final class JScrollPaneBuilder {
   public JScrollPane build() {
     checkState(view != null, "view must be specified");
 
-    return new JScrollPane(view);
+    final JScrollPane scrollPane = new JScrollPane(view);
+
+    if (border != null) {
+      scrollPane.setBorder(border);
+    }
+
+    return scrollPane;
   }
 }

--- a/src/test/java/swinglib/JScrollPaneBuilderTest.java
+++ b/src/test/java/swinglib/JScrollPaneBuilderTest.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Component;
 
+import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
+import javax.swing.border.Border;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,15 +19,21 @@ public final class JScrollPaneBuilderTest {
   private final JScrollPaneBuilder builder = JScrollPaneBuilder.builder();
 
   @Test
-  public void view_ShouldThrowExceptionWhenViewIsNull() {
-    final Exception e = assertThrows(NullPointerException.class, () -> builder.view(null));
+  public void build_ShouldThrowExceptionWhenViewUnspecified() {
+    final Exception e = assertThrows(IllegalStateException.class, () -> builder.build());
     assertThat(e.getMessage(), containsString("view"));
   }
 
   @Test
-  public void build_ShouldThrowExceptionWhenViewUnspecified() {
-    final Exception e = assertThrows(IllegalStateException.class, () -> builder.build());
-    assertThat(e.getMessage(), containsString("view"));
+  public void build_ShouldSetBorderWhenProvided() {
+    final Border border = BorderFactory.createEmptyBorder();
+
+    final JScrollPane scrollPane = builder
+        .view(new JLabel())
+        .border(border)
+        .build();
+
+    assertThat(scrollPane.getBorder(), is(sameInstance(border)));
   }
 
   @Test


### PR DESCRIPTION
This PR contains several improvements to the layout of the Settings window:

* Add margins between all components
* Vertically align tab controls from top rather than from center
* Move buttons outside of tab pane so there is only one set for the entire window (this results in a visual improvement for L&Fs that draw a border around the tab pane)
* Center window relative to main frame instead of appearing at screen coordinate (0,0)
* Center settings change confirmation dialog relative to window instead of being centered relative to screen

#### Substance

##### Before

![settings-window-battle-sim-substance-before](https://user-images.githubusercontent.com/4826349/35788842-01eb8b38-0a06-11e8-8336-3430d39d4cf9.png)

![settings-window-testing-substance-before](https://user-images.githubusercontent.com/4826349/35788850-06a0d7d2-0a06-11e8-9344-7bab997a67b9.png)

##### After

![settings-window-battle-sim-substance-after](https://user-images.githubusercontent.com/4826349/35788856-0be80940-0a06-11e8-9f41-0b1dd4daa717.png)

![settings-window-testing-substance-after](https://user-images.githubusercontent.com/4826349/35788858-1037bdce-0a06-11e8-94ac-6a915c6e4c59.png)

#### Nimbus

##### Before

![settings-window-battle-sim-nimbus-before](https://user-images.githubusercontent.com/4826349/35788861-15742890-0a06-11e8-9d47-28316b4ac982.png)

![settings-window-testing-nimbus-before](https://user-images.githubusercontent.com/4826349/35788864-19b4da80-0a06-11e8-919f-6e5577970bcc.png)

##### After

![settings-window-battle-sim-nimbus-after](https://user-images.githubusercontent.com/4826349/35788866-1ec97102-0a06-11e8-81ec-a2295612c48f.png)

![settings-window-testing-nimbus-after](https://user-images.githubusercontent.com/4826349/35788869-22bc6c60-0a06-11e8-8a5b-916cf2d9e176.png)