### PR TITLE
Replace Util#runInSwingEventThread() with SwingAction

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -26,12 +26,8 @@ public class PropertiesSelector {
    */
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
-    try {
-      return SwingAction.invokeAndWait(() -> showDialog(parent, title, properties, buttonOptions));
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return JOptionPane.UNINITIALIZED_VALUE;
-    }
+    return SwingAction.invokeAndWaitUninterruptibly(() -> showDialog(parent, title, properties, buttonOptions))
+        .orElse(JOptionPane.UNINITIALIZED_VALUE);
   }
 
   private static Object showDialog(final JComponent parent, final String title,

--- a/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -60,17 +60,14 @@ public class PbemDiceRoller implements IRandomSource {
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) throws IllegalStateException {
-    try {
-      return SwingAction.invokeAndWait(() -> {
-        final HttpDiceRollerDialog dialog =
-            new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
-        dialog.roll();
-        return dialog.getDiceRoll();
-      });
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return new int[0];
-    }
+    return SwingAction
+        .invokeAndWaitUninterruptibly(() -> {
+          final HttpDiceRollerDialog dialog =
+              new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
+          dialog.roll();
+          return dialog.getDiceRoll();
+        })
+        .orElseGet(() -> new int[0]);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -40,8 +40,10 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -153,7 +155,6 @@ import games.strategy.triplea.util.TuvUtils;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
-import games.strategy.ui.Util;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.IntegerMap;
@@ -884,7 +885,9 @@ public class TripleAFrame extends MainGameFrame {
     return choice == JOptionPane.OK_OPTION;
   }
 
-  public Unit getStrategicBombingRaidTarget(final Territory territory, final Collection<Unit> potentialTargets,
+  public @Nullable Unit getStrategicBombingRaidTarget(
+      final Territory territory,
+      final Collection<Unit> potentialTargets,
       final Collection<Unit> bombers) {
     if (potentialTargets.size() == 1 || messageAndDialogThreadPool == null) {
       return potentialTargets.iterator().next();
@@ -892,7 +895,7 @@ public class TripleAFrame extends MainGameFrame {
     messageAndDialogThreadPool.waitForAll();
     final AtomicReference<Unit> selected = new AtomicReference<>();
     final String message = "Select bombing target in " + territory.getName();
-    final Tuple<JPanel, JList<Unit>> comps = Util.runInSwingEventThread(() -> {
+    final Supplier<Tuple<JPanel, JList<Unit>>> action = () -> {
       final JList<Unit> list = new JList<>(new Vector<>(potentialTargets));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       list.setSelectedIndex(0);
@@ -905,16 +908,20 @@ public class TripleAFrame extends MainGameFrame {
       final JScrollPane scroll = new JScrollPane(list);
       panel.add(scroll, BorderLayout.CENTER);
       return Tuple.of(panel, list);
-    });
-    final JPanel panel = comps.getFirst();
-    final JList<?> list = comps.getSecond();
-    final String[] options = {"OK"};
-    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
-        JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
-    if (selection == 0) {
-      selected.set((Unit) list.getSelectedValue());
-    }
-    return selected.get();
+    };
+    return SwingAction.invokeAndWaitUninterruptibly(action)
+        .map(comps -> {
+          final JPanel panel = comps.getFirst();
+          final JList<?> list = comps.getSecond();
+          final String[] options = {"OK"};
+          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
+              JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
+          if (selection == 0) {
+            selected.set((Unit) list.getSelectedValue());
+          }
+          return selected.get();
+        })
+        .orElse(null);
   }
 
   /**
@@ -959,16 +966,21 @@ public class TripleAFrame extends MainGameFrame {
       return new int[numDice];
     }
     messageAndDialogThreadPool.waitForAll();
-    final DiceChooser chooser =
-        Util.runInSwingEventThread(() -> new DiceChooser(getUiContext(), numDice, hitAt, hitOnlyIfEquals, diceSides));
-    do {
-      EventThreadJOptionPane.showMessageDialog(null, chooser, title, JOptionPane.PLAIN_MESSAGE,
-          getUiContext().getCountDownLatchHandler());
-    } while (chooser.getDice() == null);
-    return chooser.getDice();
+    return SwingAction
+        .invokeAndWaitUninterruptibly(() -> new DiceChooser(getUiContext(), numDice, hitAt, hitOnlyIfEquals, diceSides))
+        .map(chooser -> {
+          do {
+            EventThreadJOptionPane.showMessageDialog(null, chooser, title, JOptionPane.PLAIN_MESSAGE,
+                getUiContext().getCountDownLatchHandler());
+          } while (chooser.getDice() == null);
+          return chooser.getDice();
+        })
+        .orElseGet(() -> new int[numDice]);
   }
 
-  public Territory selectTerritoryForAirToLand(final Collection<Territory> candidates, final Territory currentTerritory,
+  public @Nullable Territory selectTerritoryForAirToLand(
+      final Collection<Territory> candidates,
+      final Territory currentTerritory,
       final String unitMessage) {
     if (candidates == null || candidates.isEmpty()) {
       return null;
@@ -977,7 +989,7 @@ public class TripleAFrame extends MainGameFrame {
       return candidates.iterator().next();
     }
     messageAndDialogThreadPool.waitForAll();
-    final Tuple<JPanel, JList<Territory>> comps = Util.runInSwingEventThread(() -> {
+    final Supplier<Tuple<JPanel, JList<Territory>>> action = () -> {
       mapPanel.centerOn(currentTerritory);
       final JList<Territory> list = new JList<>(new Vector<>(candidates));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -992,15 +1004,20 @@ public class TripleAFrame extends MainGameFrame {
       panel.add(text, BorderLayout.NORTH);
       panel.add(scroll, BorderLayout.CENTER);
       return Tuple.of(panel, list);
-    });
-    final JPanel panel = comps.getFirst();
-    final JList<?> list = comps.getSecond();
-    final String[] options = {"OK"};
-    final String title = "Select territory for air units to land, current territory is " + currentTerritory.getName();
-    EventThreadJOptionPane.showOptionDialog(this, panel, title, JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
-        null, options, null, getUiContext().getCountDownLatchHandler());
-    final Territory selected = (Territory) list.getSelectedValue();
-    return selected;
+    };
+    return SwingAction.invokeAndWaitUninterruptibly(action)
+        .map(comps -> {
+          final JPanel panel = comps.getFirst();
+          final JList<?> list = comps.getSecond();
+          final String[] options = {"OK"};
+          final String title =
+              "Select territory for air units to land, current territory is " + currentTerritory.getName();
+          EventThreadJOptionPane.showOptionDialog(this, panel, title, JOptionPane.OK_CANCEL_OPTION,
+              JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
+          final Territory selected = (Territory) list.getSelectedValue();
+          return selected;
+        })
+        .orElse(null);
   }
 
   public Tuple<Territory, Set<Unit>> pickTerritoryAndUnits(final PlayerID player,

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -8,6 +8,7 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -135,10 +136,36 @@ public final class SwingAction {
   public static void invokeAndWaitUninterruptibly(final Runnable action) {
     checkNotNull(action);
 
+    invokeAndWaitUninterruptibly(() -> {
+      action.run();
+      return null;
+    });
+  }
+
+  /**
+   * Synchronously executes the specified action on the Swing event dispatch thread and returns the value it supplies.
+   * If interrupted while waiting for the action to complete, this method will set the thread's interrupted status and
+   * return immediately.
+   *
+   * <p>
+   * This method may safely be called from any thread, including the Swing event dispatch thread.
+   * </p>
+   *
+   * @param action The action to execute.
+   *
+   * @return The value supplied by the action or empty if the thread was interrupted. If the action supplies
+   *         {@code null}, it will be indistinguishable from the interrupted case.
+   *
+   * @throws RuntimeException If the action throws an unchecked exception.
+   */
+  public static <T> Optional<T> invokeAndWaitUninterruptibly(final Supplier<T> action) {
+    checkNotNull(action);
+
     try {
-      invokeAndWait(action);
+      return Optional.ofNullable(invokeAndWait(action));
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -24,21 +24,7 @@ import java.util.Optional;
 public final class Util {
   public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
 
-  // all we have is static methods
   private Util() {}
-
-  public interface Task<T> {
-    T run();
-  }
-
-  public static <T> T runInSwingEventThread(final Task<T> task) {
-    try {
-      return SwingAction.invokeAndWait(task::run);
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return null;
-    }
-  }
 
   private static final Component component = new Component() {
     private static final long serialVersionUID = 1800075529163275600L;

--- a/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -174,6 +174,7 @@ public class SwingActionTest {
           testCompleteLatch.await();
         } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
+          fail("unexpected interruption on EDT");
         }
         return VALUE;
       }));


### PR DESCRIPTION
`Util#runInSwingEventThread()` was basically a pass-through to `SwingAction#invokeAndWait()` that always returned `null` in the event an `InterruptedException` was raised.  This PR:

* Adds the new `SwingAction#invokeAndWaitUninterruptibly(Supplier<T>)` overload.
* Replaces all calls to `Util#runInSwingEventThread()` with `SwingAction#invokeAndWaitUninterruptibly(Supplier<T>)`.
* Replaces existing calls to `SwingAction#invokeAndWait(Supplier<T>)` that have a trivial `InterruptedException` handler with `SwingAction#invokeAndWaitUninterruptibly(Supplier<T>)`.

In one of the replaced calls (`TripleAFrame#selectFixedDice()`), I observed that `null` was not a valid return value and corrected that.  In all other cases, I left things as they were and continue to return `null` upon interruption.

It is recommended to review this PR with whitespace changes ignored.