### PR TITLE
Error Prone: Fix default charset violations in test code

### DIFF
--- a/src/test/java/games/strategy/debug/LogReaderTest.java
+++ b/src/test/java/games/strategy/debug/LogReaderTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
@@ -28,7 +29,7 @@ public class LogReaderTest {
   public void testStreamSplittingArray() throws Exception {
     final LogReader reader = new LogReader(stream, area, Boolean.TRUE::booleanValue, console);
     final String testString = "Some Test String";
-    final byte[] testByteArray = testString.getBytes();
+    final byte[] testByteArray = testString.getBytes(Charset.defaultCharset());
     reader.getStream().write(testByteArray);
     verify(stream).write(testByteArray, 0, testByteArray.length);
     SwingUtilities.invokeAndWait(() -> verify(area).append(testString));
@@ -48,15 +49,17 @@ public class LogReaderTest {
   public void testWriteInvisible() throws Exception {
     final LogReader reader = new LogReader(stream, area, Boolean.FALSE::booleanValue, console);
     final String testString = "Some Test String";
-    reader.getStream().write(testString.getBytes());
+    reader.getStream().write(testString.getBytes(Charset.defaultCharset()));
     SwingUtilities.invokeAndWait(() -> verify(area).append(testString));
   }
 
   @Test
   public void testConsolePopup() throws Exception {
     final String testString = "Some Test String";
-    new LogReader(stream, area, Boolean.TRUE::booleanValue, console).getStream().write(testString.getBytes());
-    new LogReader(stream, area, Boolean.FALSE::booleanValue, console).getStream().write(testString.getBytes());
+    new LogReader(stream, area, Boolean.TRUE::booleanValue, console).getStream()
+        .write(testString.getBytes(Charset.defaultCharset()));
+    new LogReader(stream, area, Boolean.FALSE::booleanValue, console).getStream()
+        .write(testString.getBytes(Charset.defaultCharset()));
     SwingUtilities.invokeAndWait(() -> {
       verify(console).setVisible(true);
       verify(console, times(0)).setVisible(false);

--- a/src/test/java/games/strategy/engine/config/FilePropertyReaderAsPropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/FilePropertyReaderAsPropertyReaderTest.java
@@ -1,8 +1,9 @@
 package games.strategy.engine.config;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Properties;
 
@@ -18,7 +19,7 @@ public final class FilePropertyReaderAsPropertyReaderTest extends AbstractProper
   @Override
   protected PropertyReader createPropertyReader(final Map<String, String> properties) throws Exception {
     final File file = temporaryFolder.newFile(getClass().getName());
-    try (Writer writer = new FileWriter(file)) {
+    try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
       final Properties props = new Properties();
       properties.forEach(props::setProperty);
       props.store(writer, null);

--- a/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
@@ -5,8 +5,9 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public final class FilePropertyReaderTest {
   @BeforeEach
   public void setup() throws Exception {
     final File file = temporaryFolder.newFile(getClass().getName());
-    try (Writer writer = new FileWriter(file)) {
+    try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
       writer.write("a=b\n");
       writer.write(" 1 = 2 \n");
       writer.write("whitespace =      \n");

--- a/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
@@ -4,7 +4,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,6 @@ public class LobbyPropertyFileParserTest {
     testProps1.errorMessage = TestData.errorMessage;
     testProps1.message = TestData.message;
     testProps1.version = TestData.version0;
-
 
     final TestProps testProps2 = new TestProps();
     testProps2.host = TestData.host;
@@ -41,7 +42,6 @@ public class LobbyPropertyFileParserTest {
         testProps1, testProps2, testPropsMatch
     };
   }
-
 
   /**
    * Just one set of values in a config file with no verson. The props we return should be a pretty
@@ -68,7 +68,7 @@ public class LobbyPropertyFileParserTest {
 
   private static File createTempFile(final TestProps... testProps) throws Exception {
     final File f = File.createTempFile("testing", ".tmp");
-    try (FileWriter writer = new FileWriter(f)) {
+    try (Writer writer = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
       for (final TestProps testProp : Arrays.asList(testProps)) {
         writer.write(testProp.toYaml());
       }
@@ -105,7 +105,6 @@ public class LobbyPropertyFileParserTest {
     String version1 = "1.0.0.0";
     String clientCurrentVersion = "2.0.0.0";
   }
-
 
   /**
    * Simple struct-like object to keep our test data together and form a YAML more easily.

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.map.download;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.hamcrest.Matchers;
@@ -13,7 +14,6 @@ import games.strategy.io.IoUtils;
 public class DownloadFileParserTest {
   private static final String GAME_NAME = "myGame";
 
-
   @Test
   public void testParseMap() throws Exception {
     final List<DownloadFileDescription> games = parse(buildTestData());
@@ -22,7 +22,6 @@ public class DownloadFileParserTest {
     assertThat(desc.getUrl(), is("http://example.com/games/game.zip"));
     assertThat(desc.getDescription(), Matchers.containsString("Some notes"));
     assertThat(desc.getMapName(), is(GAME_NAME));
-
 
     assertThat(desc.isMap(), is(true));
     assertThat(desc.isMapSkin(), is(false));
@@ -58,37 +57,36 @@ public class DownloadFileParserTest {
   }
 
   private static byte[] buildTestData() {
-    String xml = "";
-    xml += "- url: http://example.com/games/game.zip\n";
-    xml += "  mapName: " + GAME_NAME + "\n";
-    xml += "  version: 1\n";
-    xml += createTypeTag(DownloadFileDescription.DownloadType.MAP);
-    xml += "  description: |\n";
-    xml += "     <pre>Some notes about the game, simple html allowed.\n";
-    xml += "     </pre>\n";
-    xml += "- url: http://example.com/games/mod.zip\n";
-    xml += "  mapName: modName\n";
-    xml += "  version: 1\n";
-    // missing map type defaults to map
-    xml += "  description: |\n";
-    xml += "      map mod\n";
-    xml += "- url: http://example.com/games/skin.zip\n";
-    xml += "  mapName: skin\n";
-    xml += "  version: 1\n";
-    xml += createTypeTag(DownloadFileDescription.DownloadType.MAP_SKIN);
-    xml += "  description: |\n";
-    xml += "      map skin\n";
-    xml += "- url: http://example.com/games/tool.zip\n";
-    xml += "  mapName: mapToolName\n";
-    xml += "  version: 1\n";
-    xml += createTypeTag(DownloadFileDescription.DownloadType.MAP_TOOL);
-    xml += "  description: |\n";
-    xml += "       <pre>\n";
-    xml += "       this is a map tool";
-    xml += "    </pre>\n";
-    return xml.getBytes();
+    final String xml = ""
+        + "- url: http://example.com/games/game.zip\n"
+        + "  mapName: " + GAME_NAME + "\n"
+        + "  version: 1\n"
+        + createTypeTag(DownloadFileDescription.DownloadType.MAP)
+        + "  description: |\n"
+        + "     <pre>Some notes about the game, simple html allowed.\n"
+        + "     </pre>\n"
+        + "- url: http://example.com/games/mod.zip\n"
+        + "  mapName: modName\n"
+        + "  version: 1\n"
+        // missing map type defaults to map
+        + "  description: |\n"
+        + "      map mod\n"
+        + "- url: http://example.com/games/skin.zip\n"
+        + "  mapName: skin\n"
+        + "  version: 1\n"
+        + createTypeTag(DownloadFileDescription.DownloadType.MAP_SKIN)
+        + "  description: |\n"
+        + "      map skin\n"
+        + "- url: http://example.com/games/tool.zip\n"
+        + "  mapName: mapToolName\n"
+        + "  version: 1\n"
+        + createTypeTag(DownloadFileDescription.DownloadType.MAP_TOOL)
+        + "  description: |\n"
+        + "       <pre>\n"
+        + "       this is a map tool"
+        + "    </pre>\n";
+    return xml.getBytes(StandardCharsets.UTF_8);
   }
-
 
   @Test
   public void testMapTypeDefaultsToMap() throws Exception {
@@ -100,12 +98,12 @@ public class DownloadFileParserTest {
   }
 
   private static byte[] createSimpleGameXmlWithNoTypeTag() {
-    String xml = "";
-    xml += "- url: http://example.com/games/mod.zip\n";
-    xml += "  mapName: " + GAME_NAME + "\n";
-    xml += "  version: 1\n";
-    xml += "  description: |\n";
-    xml += "      description\n";
-    return xml.getBytes();
+    final String xml = ""
+        + "- url: http://example.com/games/mod.zip\n"
+        + "  mapName: " + GAME_NAME + "\n"
+        + "  version: 1\n"
+        + "  description: |\n"
+        + "      description\n";
+    return xml.getBytes(StandardCharsets.UTF_8);
   }
 }

--- a/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ public class FileSystemStrategyTest {
     final String text = DownloadFileProperties.VERSION_PROPERTY + " = 1.2";
     mapFile = temporaryFolder.newFile(getClass().getName());
     final File propFile = temporaryFolder.newFile(mapFile.getName() + ".properties");
-    Files.write(text.getBytes(), propFile);
+    Files.write(text.getBytes(StandardCharsets.UTF_8), propFile);
   }
 
   @Test
@@ -48,5 +49,4 @@ public class FileSystemStrategyTest {
   public void testMapFileFound() {
     assertThat(testObj.getMapVersion(mapFile.getAbsolutePath()), is(Optional.of(new Version(1, 2))));
   }
-
 }


### PR DESCRIPTION
Includes two additional string concatenation simplifications.

**NOTE:** It's unlikely, but these tests may fail when run on a platform where UTF-8 is not the default charset.  This is because the tests write in UTF-8 and the corresponding production code under test most likely reads in the default charset (Error Prone violations to be fixed in a future PR).  I don't think any of the tests use non-ASCII characters, but if someone could run these tests locally on Windows or Mac before merging, it would be appreciated.