### PR TITLE
Fix filter used to extract players in an alliance

### DIFF
--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -78,7 +78,7 @@ public class AllianceTracker implements Serializable {
    */
   public Set<PlayerID> getPlayersInAlliance(final String allianceName) {
     return alliances.entries().stream()
-        .filter(e -> e.getValue().contains(allianceName))
+        .filter(e -> e.getValue().equals(allianceName))
         .map(Map.Entry::getKey)
         .collect(Collectors.toSet());
   }

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -1,10 +1,15 @@
 package games.strategy.engine.data;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -35,5 +40,22 @@ public class AllianceTrackerTest {
     assertTrue(relationshipTracker.isAllied(bush, castro));
   }
 
-  // TODO create test suite for Alliance/Relationships/Politics
+  @Test
+  public void getPlayersInAlliance_ShouldDifferentiateAllianceNamesThatAreSubstringsOfOtherAllianceNames() {
+    final PlayerID player1 = new PlayerID("Player1", gameData);
+    final PlayerID player2 = new PlayerID("Player2", gameData);
+    final PlayerID player3 = new PlayerID("Player3", gameData);
+    final PlayerID player4 = new PlayerID("Player4", gameData);
+    final String alliance1Name = "Alliance"; // NOTE: alliance1 name is a substring of alliance2 name
+    final String alliance2Name = "AntiAlliance";
+    final AllianceTracker allianceTracker = new AllianceTracker(ImmutableMultimap.<PlayerID, String>builder()
+        .put(player1, alliance1Name)
+        .put(player2, alliance1Name)
+        .put(player3, alliance2Name)
+        .put(player4, alliance2Name)
+        .build());
+
+    assertThat(allianceTracker.getPlayersInAlliance(alliance1Name), is(ImmutableSet.of(player1, player2)));
+    assertThat(allianceTracker.getPlayersInAlliance(alliance2Name), is(ImmutableSet.of(player3, player4)));
+  }
 }

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -46,8 +46,8 @@ public class AllianceTrackerTest {
     final PlayerID player2 = new PlayerID("Player2", gameData);
     final PlayerID player3 = new PlayerID("Player3", gameData);
     final PlayerID player4 = new PlayerID("Player4", gameData);
-    final String alliance1Name = "Alliance"; // NOTE: alliance1 name is a substring of alliance2 name
-    final String alliance2Name = "AntiAlliance";
+    final String alliance1Name = "Alliance";
+    final String alliance2Name = "Anti" + alliance1Name;
     final AllianceTracker allianceTracker = new AllianceTracker(ImmutableMultimap.<PlayerID, String>builder()
         .put(player1, alliance1Name)
         .put(player2, alliance1Name)


### PR DESCRIPTION
Fixes #2961.

The filter used in `AllianceTracker#getPlayersInAlliance()` mistakenly matched substrings when comparing alliance names rather than the alliance name as a whole.  The call to `String#contains()` appears to be an accidental carryover due to the original `Iterator`-based code receiving map entries of type `Map.Entry<PlayerID, Collection<String>>`.  The Guava `Multimap` stream flattens the multimap so that the streamed entries are of type `Map.Entry<PlayerID, String>`, thus `Object#equals()` is the appropriate filter condition.

#### Testing

The new unit test passes with the original `Iterator` code, fails with the code prior to this PR, and passes with the code in this PR.  I also verified the 270BC politics panel appears as it did prior to #2681.