### PR TITLE
Remove killed units when retreating to ensure proper TUV for battle calc

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1275,6 +1275,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!defender) {
       units = new HashSet<>(units);
       units.addAll(m_battleSite.getUnits().getMatches(Matches.unitIsOwnedBy(m_attacker)));
+      units.removeAll(m_killed);
     }
     if (subs) {
       units = CollectionUtils.getMatches(units, Matches.unitIsSub());


### PR DESCRIPTION
Addresses #2960 

This bug was introduced in #1827 where infra units needed added back into the list of potential retreating units. Due to how the BC counts the attackers as coming from the territory that the battle is in, it caused the BC to think it could retreat killed units which made the TUV calcs incorrect.

Testing
- Tested several maps by setting retreat after round to positive integers and the TUV appears correct now
- Tested that infra units still retreat on maps like Feudal Japan
