### PR TITLE
Ensure Ordering Based on XML for Political Action Roundels

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -3,7 +3,7 @@ package games.strategy.triplea.attachments;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -116,7 +116,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    * @return a set of all other players involved in this PoliticalAction.
    */
   public Set<PlayerID> getOtherPlayers() {
-    final HashSet<PlayerID> otherPlayers = new HashSet<>();
+    final Set<PlayerID> otherPlayers = new LinkedHashSet<>();
     for (final String relationshipChange : m_relationshipChange) {
       final String[] s = relationshipChange.split(":");
       otherPlayers.add(getData().getPlayerList().getPlayerId(s[0]));


### PR DESCRIPTION
Addresses #2966 

**Testing**
- After the fix the roundels always appear in the order based on the relationship changes in the political action attachment

**Result**
![image](https://user-images.githubusercontent.com/1427689/36066116-f817440e-0e69-11e8-9b92-43c597497ba0.png)
