### PR TITLE
Introduce Interruptibles class

### DIFF
--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -2,6 +2,7 @@ package games.strategy.debug;
 
 import games.strategy.triplea.ui.ErrorHandler;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 /**
  * A debug console window that displays the standard output and standard error streams.
@@ -37,12 +38,12 @@ public final class ErrorConsole extends GenericConsole {
    * If not yet created, initializes the error console.
    */
   public static void createConsole() {
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       console = new ErrorConsole();
       console.displayStandardOutput();
       console.displayStandardError();
       ErrorHandler.registerExceptionHandler();
-    });
+    }));
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -34,6 +34,7 @@ import games.strategy.net.ServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.TimeManager;
 
 /**
@@ -95,7 +96,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   void setChat(final Chat chat) {
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       if (chat != null) {
         chat.removeChatListener(this);
         cleanupKeyMap();
@@ -127,7 +128,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
         text.setEnabled(false);
         updatePlayerList(Collections.emptyList());
       }
-    });
+    }));
   }
 
   public Chat getChat() {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -82,6 +82,7 @@ import games.strategy.ui.ProgressWindow;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.EventThreadJOptionPane;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 import javafx.application.Application;
@@ -565,13 +566,13 @@ public class GameRunner {
    * After the game has been left, call this.
    */
   public static void clientLeftGame() {
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
       // closing of stream while unloading map resources.
       ThreadUtil.sleep(100);
       setupPanelModel.showSelectType();
       showMainFrame();
-    });
+    }));
   }
 
   public static void quitGame() {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -68,6 +68,7 @@ import games.strategy.net.Messengers;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.EventThreadJOptionPane;
+import games.strategy.util.Interruptibles;
 
 /**
  * Represents a network aware game client connecting to another game that is acting as a server.
@@ -127,7 +128,7 @@ public class ClientModel implements IMessengerErrorListener {
     @Override
     public void gameReset() {
       objectStreamFactory.setData(null);
-      SwingAction.invokeAndWaitUninterruptibly(GameRunner::showMainFrame);
+      Interruptibles.await(() -> SwingAction.invokeAndWait(GameRunner::showMainFrame));
     }
 
     @Override

--- a/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -23,6 +23,7 @@ import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.io.FileUtils;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 /**
  * The model for a {@link GameChooser} dialog.
@@ -109,7 +110,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
    * parameter, then show confirmation of deletion.
    */
   private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map, final Optional<String> errorDetails) {
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       String message = "Could not parse map file correctly, would you like to remove it?\n" + map.getAbsolutePath()
           + "\n(You may see this error message again if you keep the file)";
       String title = "Corrup Map File Found";
@@ -131,7 +132,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
         title = "File Removal Result";
         JOptionPane.showMessageDialog(null, message, title, messageType);
       }
-    });
+    }));
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.ui;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.swing.JComponent;
 import javax.swing.JDialog;
@@ -10,6 +11,7 @@ import javax.swing.JScrollPane;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 /**
  * Wrapper for properties selection window.
@@ -26,7 +28,8 @@ public class PropertiesSelector {
    */
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
-    return SwingAction.invokeAndWaitUninterruptibly(() -> showDialog(parent, title, properties, buttonOptions))
+    final Supplier<Object> action = () -> showDialog(parent, title, properties, buttonOptions);
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
         .orElse(JOptionPane.UNINITIALIZED_VALUE);
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -29,6 +29,7 @@ import javax.swing.SpinnerNumberModel;
 
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 /**
  * GUI class used to display logging window and logging settings.
@@ -388,7 +389,7 @@ class ProLogWindow extends JDialog {
   }
 
   void notifyNewRound(final int roundNumber, final String name) {
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       final JPanel newPanel = new JPanel();
       final JScrollPane newScrollPane = new JScrollPane();
       final JTextArea newTextArea = new JTextArea();
@@ -402,7 +403,7 @@ class ProLogWindow extends JDialog {
       newPanel.add(newScrollPane);
       logHolderTabbedPane.addTab(Integer.toString(roundNumber) + "-" + name, newPanel);
       currentLogTextArea = newTextArea;
-    });
+    }));
     // Now remove round logging that has 'expired'.
     // Note that this method will also trim all but the first and last log panels if logging is turned off
     // (We always keep first round's log panel, and we keep last because the user might turn logging back on in the
@@ -419,7 +420,7 @@ class ProLogWindow extends JDialog {
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }
-      SwingAction.invokeAndWaitUninterruptibly(() -> {
+      Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
         for (int i = 0; i < logHolderTabbedPane.getTabCount(); i++) {
           // Remember, we never remove last tab, in case user turns logging back on in the middle of a round
           if (i != 0 && i < logHolderTabbedPane.getTabCount() - maxHistoryRounds) {
@@ -428,7 +429,7 @@ class ProLogWindow extends JDialog {
             i--;
           }
         }
-      });
+      }));
     }
   }
 }

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -8,7 +8,6 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -118,54 +117,6 @@ public final class SwingAction {
       final Throwable cause = e.getCause();
       Throwables.throwIfUnchecked(cause);
       throw new AssertionError("unexpected checked exception", cause);
-    }
-  }
-
-  /**
-   * Synchronously executes the specified action on the Swing event dispatch thread. If interrupted while waiting for
-   * the action to complete, this method will set the thread's interrupted status and return immediately.
-   *
-   * <p>
-   * This method may safely be called from any thread, including the Swing event dispatch thread.
-   * </p>
-   *
-   * @param action The action to execute.
-   *
-   * @throws RuntimeException If the action throws an unchecked exception.
-   */
-  public static void invokeAndWaitUninterruptibly(final Runnable action) {
-    checkNotNull(action);
-
-    invokeAndWaitUninterruptibly(() -> {
-      action.run();
-      return null;
-    });
-  }
-
-  /**
-   * Synchronously executes the specified action on the Swing event dispatch thread and returns the value it supplies.
-   * If interrupted while waiting for the action to complete, this method will set the thread's interrupted status and
-   * return immediately.
-   *
-   * <p>
-   * This method may safely be called from any thread, including the Swing event dispatch thread.
-   * </p>
-   *
-   * @param action The action to execute.
-   *
-   * @return The value supplied by the action or empty if the thread was interrupted. If the action supplies
-   *         {@code null}, it will be indistinguishable from the interrupted case.
-   *
-   * @throws RuntimeException If the action throws an unchecked exception.
-   */
-  public static <T> Optional<T> invokeAndWaitUninterruptibly(final Supplier<T> action) {
-    checkNotNull(action);
-
-    try {
-      return Optional.ofNullable(invokeAndWait(action));
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return Optional.empty();
     }
   }
 

--- a/src/main/java/games/strategy/util/Interruptibles.java
+++ b/src/main/java/games/strategy/util/Interruptibles.java
@@ -1,0 +1,113 @@
+package games.strategy.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A collection of methods that assist working with operations that may be interrupted but it is typically awkward to
+ * deal with {@link InterruptedException} in the calling context.
+ */
+public final class Interruptibles {
+  private Interruptibles() {}
+
+  /**
+   * Executes and awaits the completion of the specified operation that produces no result. If the current thread is
+   * interrupted before the operation completes, the thread will be re-interrupted, and this method will return
+   * {@code true}. This method re-throws any unchecked exception thrown by {@code runnable}.
+   *
+   * @param runnable The operation to execute and await.
+   *
+   * @return {@code true} if the current thread was interrupted while waiting for the operation to complete; otherwise
+   *         {@code false}.
+   */
+  public static boolean await(final InterruptibleRunnable runnable) {
+    checkNotNull(runnable);
+
+    return awaitResult(() -> {
+      runnable.run();
+      return null;
+    }).interrupted;
+  }
+
+  /**
+   * Executes and awaits the completion of the specified operation that produces a result. If the current thread is
+   * interrupted before the operation completes, the thread will be re-interrupted, and this method will return a
+   * {@link Result} whose {@code interrupted} field is {@code true}. This method re-throws any unchecked exception
+   * thrown by {@code supplier}.
+   *
+   * @param supplier The operation to execute and await.
+   *
+   * @return If the operation completed without interruption, {@code interrupted} will be {@code false} and
+   *         {@code result} will contain the operation's result (a {@code null} result is modeled as an empty result);
+   *         if the operation was interrupted, {@code interrupted} will be {@code true} and {@code result} will be
+   *         empty.
+   */
+  public static <T> Result<T> awaitResult(final InterruptibleSupplier<T> supplier) {
+    checkNotNull(supplier);
+
+    try {
+      return new Result<>(Optional.ofNullable(supplier.get()), false);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return new Result<>(Optional.empty(), true);
+    }
+  }
+
+  /**
+   * An interruptible action that does not supply a result.
+   */
+  @FunctionalInterface
+  public interface InterruptibleRunnable {
+    /**
+     * Invokes the action.
+     *
+     * @throws InterruptedException If the current thread is interrupted while waiting for the action to complete.
+     */
+    void run() throws InterruptedException;
+  }
+
+  /**
+   * An interruptible supplier of results.
+   *
+   * @param <T> The type of the result.
+   */
+  @FunctionalInterface
+  public interface InterruptibleSupplier<T> {
+    /**
+     * Gets the result.
+     *
+     * @return The result.
+     *
+     * @throws InterruptedException If the current thread is interrupted while waiting for the supplier to complete.
+     */
+    @Nullable
+    T get() throws InterruptedException;
+  }
+
+  /**
+   * The result of an interruptible operation that returns a result.
+   *
+   * @param <T> The result of the operation.
+   */
+  @Immutable
+  public static final class Result<T> {
+    /**
+     * Indicates the operation was interrupted; {@code result} is meaningless.
+     */
+    public final boolean interrupted;
+
+    /**
+     * The result of the operation or empty if the operation did not supply a result.
+     */
+    public final Optional<T> result;
+
+    private Result(final Optional<T> result, final boolean interrupted) {
+      this.interrupted = interrupted;
+      this.result = result;
+    }
+  }
+}

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -1,6 +1,7 @@
 package games.strategy.test;
 
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 /**
  * A Utility class for test classes.
@@ -18,7 +19,7 @@ public final class TestUtil {
    */
   public static void waitForSwingThreads() {
     // add a no-op action to the end of the swing event queue, and then wait for it
-    SwingAction.invokeAndWaitUninterruptibly(() -> {
-    });
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
+    }));
   }
 }

--- a/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -12,9 +12,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.time.Duration;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -117,90 +115,6 @@ public class SwingActionTest {
     SwingUtilities.invokeAndWait(() -> assertThrows(
         IllegalStateException.class,
         () -> SwingAction.invokeAndWait(SUPPLIER_THROWING_EXCEPTION)));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithRunnable_ShouldInvokeActionWhenCalledOffEdt(
-      @Mock final Runnable action) {
-    SwingAction.invokeAndWaitUninterruptibly(action);
-
-    verify(action).run();
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithRunnable_ShouldInvokeActionWhenCalledOnEdt(
-      @Mock final Runnable action) throws Exception {
-    SwingUtilities.invokeAndWait(() -> SwingAction.invokeAndWaitUninterruptibly(action));
-
-    verify(action).run();
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithRunnable_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> SwingAction.invokeAndWaitUninterruptibly(RUNNABLE_THROWING_EXCEPTION));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithRunnable_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt()
-      throws Exception {
-    SwingUtilities.invokeAndWait(() -> assertThrows(
-        IllegalStateException.class,
-        () -> SwingAction.invokeAndWaitUninterruptibly(RUNNABLE_THROWING_EXCEPTION)));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithSupplier_ShouldReturnActionResultWhenCalledOffEdt() {
-    assertEquals(Optional.of(VALUE), SwingAction.invokeAndWaitUninterruptibly(() -> VALUE));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithSupplier_ShouldReturnActionResultWhenCalledOnEdt() throws Exception {
-    SwingUtilities.invokeAndWait(
-        () -> assertEquals(Optional.of(VALUE), SwingAction.invokeAndWaitUninterruptibly(() -> VALUE)));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithSupplier_ShouldReturnEmptyResultWhenInterrupted() throws Exception {
-    final CountDownLatch threadReadyLatch = new CountDownLatch(1);
-    final CountDownLatch testCompleteLatch = new CountDownLatch(1);
-    final AtomicReference<Optional<Object>> result = new AtomicReference<>();
-
-    final Thread thread = new Thread(() -> {
-      result.set(SwingAction.invokeAndWaitUninterruptibly(() -> {
-        threadReadyLatch.countDown();
-        try {
-          testCompleteLatch.await();
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          fail("unexpected interruption on EDT");
-        }
-        return VALUE;
-      }));
-    });
-    thread.start();
-    threadReadyLatch.await();
-    thread.interrupt();
-    thread.join();
-    testCompleteLatch.countDown();
-
-    assertEquals(Optional.empty(), result.get());
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithSupplier_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
-    assertThrows(
-        IllegalStateException.class,
-        () -> SwingAction.invokeAndWaitUninterruptibly(SUPPLIER_THROWING_EXCEPTION));
-  }
-
-  @Test
-  public void testInvokeAndWaitUninterruptiblyWithSupplier_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt()
-      throws Exception {
-    SwingUtilities.invokeAndWait(() -> assertThrows(
-        IllegalStateException.class,
-        () -> SwingAction.invokeAndWaitUninterruptibly(SUPPLIER_THROWING_EXCEPTION)));
   }
 
   @Test

--- a/src/test/java/games/strategy/util/InterruptiblesTest.java
+++ b/src/test/java/games/strategy/util/InterruptiblesTest.java
@@ -1,0 +1,93 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+
+import com.example.mockito.MockitoExtension;
+
+import games.strategy.util.Interruptibles.InterruptibleRunnable;
+
+@ExtendWith(MockitoExtension.class)
+public final class InterruptiblesTest {
+  @AfterEach
+  public void resetTestThreadInterruptionStatusSoItDoesNotCrossTestBoundaries() {
+    Thread.interrupted();
+  }
+
+  @Nested
+  public final class AwaitTest {
+    @Test
+    public void shouldReturnFalseWhenNotInterrupted(@Mock final InterruptibleRunnable runnable) throws Exception {
+      final boolean interrupted = Interruptibles.await(runnable);
+
+      verify(runnable).run();
+      assertThat(interrupted, is(false));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenInterrupted() {
+      final boolean interrupted = Interruptibles.await(() -> {
+        throw new InterruptedException();
+      });
+
+      assertThat(interrupted, is(true));
+      assertThat(Thread.currentThread().isInterrupted(), is(true));
+    }
+
+    @Test
+    public void shouldRethrowRunnableUncheckedException() {
+      assertThrows(IllegalStateException.class, () -> Interruptibles.await(() -> {
+        throw new IllegalStateException();
+      }));
+    }
+  }
+
+  @Nested
+  public final class AwaitResultTest {
+    @Test
+    public void shouldReturnUninterruptedSupplierNonNullResultWhenNotInterrupted() {
+      final Object value = new Object();
+
+      final Interruptibles.Result<Object> result = Interruptibles.awaitResult(() -> value);
+
+      assertThat(result.interrupted, is(false));
+      assertThat(result.result, is(Optional.of(value)));
+    }
+
+    @Test
+    public void shouldReturnUninterruptedSupplierNullResultWhenNotInterrupted() {
+      final Interruptibles.Result<Object> result = Interruptibles.awaitResult(() -> null);
+
+      assertThat(result.interrupted, is(false));
+      assertThat(result.result, is(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnInterruptedEmptyResultWhenInterrupted() {
+      final Interruptibles.Result<Object> result = Interruptibles.awaitResult(() -> {
+        throw new InterruptedException();
+      });
+
+      assertThat(result.interrupted, is(true));
+      assertThat(result.result, is(Optional.empty()));
+      assertThat(Thread.currentThread().isInterrupted(), is(true));
+    }
+
+    @Test
+    public void shouldRethrowSupplierUncheckedException() {
+      assertThrows(IllegalStateException.class, () -> Interruptibles.awaitResult(() -> {
+        throw new IllegalStateException();
+      }));
+    }
+  }
+}


### PR DESCRIPTION
The `Interruptibles` class executes and awaits interruptible operations for callers where
handling `InterruptedException` may be awkward.  It encapsulates catching `InterruptedException` and re-interrupting the thread.

This class should be viewed as a complement to Guava's `Uninterruptibles` class.  I see specialized interruptible methods being added to this class in the future written in terms of the existing generic methods.  For example, `ThreadUtil#sleep()` will probably be moved here.

#### Functional changes

None.

#### Refactoring changes

* Replaced the `SwingAction#invokeAndWaitUninterruptibly()` methods with an appropriate call to `Interruptibles` wrapping the existing `SwingAction` operation.
    * The advantage of the `Interruptibles` approach in the `SwingAction#invokeAndWaitUninterruptibly(Supplier<T>)` case is that one can now distinguish between interruption and the supplier simply returning `null`.  This was previously not possible because both cases returned an empty `Optional`.
* Some code was reformatted to extract the `SwingAction` lambdas to a local variable in order to ensure readability, where needed.  Otherwise, the Eclipse formatter can force a non-intuitive indentation.  For example, expect to see the following style of code wherever the body of `action` doesn't fit on a single line:

```java
final Supplier<String> action = () -> {
  // ...
};
return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
    .map( /* ... */ )
    .orElse( /* ... */ );
```

#### Notes

Reviewing with whitespace changes ignored is recommended.