### PR TITLE
Add check so disabled units can't move

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -179,6 +179,10 @@ public class MoveValidator {
     for (final Unit unit : units) {
       if (TripleAUnit.get(unit).getSubmerged()) {
         result.addDisallowedUnit("Cannot move submerged units", unit);
+        continue;
+      }
+      if (Matches.unitIsDisabled().test(unit)) {
+        result.addDisallowedUnit("Cannot move disabled units", unit);
       }
     }
     // make sure all units are actually in the start territory

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -179,9 +179,7 @@ public class MoveValidator {
     for (final Unit unit : units) {
       if (TripleAUnit.get(unit).getSubmerged()) {
         result.addDisallowedUnit("Cannot move submerged units", unit);
-        continue;
-      }
-      if (Matches.unitIsDisabled().test(unit)) {
+      } else if (Matches.unitIsDisabled().test(unit)) {
         result.addDisallowedUnit("Cannot move disabled units", unit);
       }
     }


### PR DESCRIPTION
Add check so disabled units can't be moved.

Tested
- Latest TWW 2.8 has trains that can be bombed and disabled which shouldn't be able to be moved