### PR TITLE
Add unit property and logic for whenCapturedSustainsDamage

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -215,6 +215,7 @@ public class UnitAttachment extends DefaultAttachment {
   private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsDamagedChangesInto = new HashMap<>();
   private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsRepairedChangesInto = new HashMap<>();
   private Map<String, Tuple<String, IntegerMap<UnitType>>> m_whenCapturedChangesInto = new LinkedHashMap<>();
+  private int m_whenCapturedSustainsDamage = 0;
   private List<PlayerID> m_canBeCapturedOnEnteringBy = new ArrayList<>();
   private List<PlayerID> m_canBeGivenByTerritoryTo = new ArrayList<>();
   // a set of information for dealing with special abilities or
@@ -566,6 +567,24 @@ public class UnitAttachment extends DefaultAttachment {
 
   public void resetWhenCapturedChangesInto() {
     m_whenCapturedChangesInto = new LinkedHashMap<>();
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setWhenCapturedSustainsDamage(final String s) {
+    m_whenCapturedSustainsDamage = getInt(s);
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setWhenCapturedSustainsDamage(final Integer s) {
+    m_whenCapturedSustainsDamage = s;
+  }
+
+  public int getWhenCapturedSustainsDamage() {
+    return m_whenCapturedSustainsDamage;
+  }
+
+  public void resetWhenCapturedSustainsDamage() {
+    m_whenCapturedSustainsDamage = 0;
   }
 
   /**
@@ -3064,6 +3083,7 @@ public class UnitAttachment extends DefaultAttachment {
         + (m_whenCapturedChangesInto != null
             ? (m_whenCapturedChangesInto.size() == 0 ? "empty" : m_whenCapturedChangesInto.toString())
             : "null")
+        + " whenCapturedSustainsDamage:" + m_whenCapturedSustainsDamage
         + "  whenHitPointsDamagedChangesInto:"
         + (m_whenHitPointsDamagedChangesInto != null
             ? (m_whenHitPointsDamagedChangesInto.size() == 0 ? "empty" : m_whenHitPointsDamagedChangesInto.toString())

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -735,6 +735,10 @@ public class BattleTracker implements Serializable {
     markWasInCombat(arrivedUnits, bridge, changeTracker);
   }
 
+  /**
+   * Called when a territory is conquered to determine if remaining enemy units should be
+   * captured, destroyed, or take damage.
+   */
   public static void captureOrDestroyUnits(final Territory territory, final PlayerID id, final PlayerID newOwner,
       final IDelegateBridge bridge, final UndoableMove changeTracker) {
     final GameData data = bridge.getData();

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2056,6 +2056,10 @@ public final class Matches {
     return u -> !UnitAttachment.get(u.getType()).getWhenCapturedChangesInto().isEmpty();
   }
 
+  static Predicate<Unit> unitWhenCapturedSustainsDamage() {
+    return u -> UnitAttachment.get(u.getType()).getWhenCapturedSustainsDamage() > 0;
+  }
+
   public static <T extends AbstractUserActionAttachment> Predicate<T> abstractUserActionAttachmentCanBeAttempted(
       final HashMap<ICondition, Boolean> testedConditions) {
     return uaa -> uaa.hasAttemptsLeft() && uaa.canPerform(testedConditions);


### PR DESCRIPTION
Addresses https://forums.triplea-game.org/topic/567/inflict-bombing-damage-on-capture

**Functional Changes**
- Adds new unit option whenCapturedSustainsDamage which can be used to add damage to units like factories/rails/etc when they are captured by an enemy

**Tested**
- Add the following to the rail unit which has 6 max hp, maxOperationalDamage of 2, and canDieFromReachingMaxDamage is true in TWW:
`<option name="whenCapturedSustainsDamage" value="3"/>`
- Tested conquering territory with undamaged rail that then has 3 damage and is disabled
- Tested conquering territory with rail that has 3 damage and rail is destroyed
- Tested conquering territory with rail that has 4 damage and rail is destroyed