### PR TITLE
Undo bombing change should set previous bombing not HP damage

### DIFF
--- a/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
+++ b/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
@@ -29,8 +29,8 @@ public class BombingUnitDamageChange extends Change {
     }
     this.hits = hits.copy();
     undoHits = new IntegerMap<>();
-    for (final Unit item : this.hits.keySet()) {
-      undoHits.put(item, item.getHits());
+    for (final Unit unit : this.hits.keySet()) {
+      undoHits.put(unit, ((TripleAUnit) unit).getUnitDamage());
     }
   }
 
@@ -50,5 +50,10 @@ public class BombingUnitDamageChange extends Change {
   @Override
   public Change invert() {
     return new BombingUnitDamageChange(undoHits, hits);
+  }
+
+  @Override
+  public String toString() {
+    return "Bombing unit damage change. Hits:" + hits + " undoHits:" + undoHits;
   }
 }


### PR DESCRIPTION
Appears to be a bug that has been around for a long time.

Functional Changes
- When bombing damage change is undone, it reverts to the previous bombing damage now instead of trying to revert to previous unit HP damage

Test
- Any game where an infrastructure unit already had damage and then was destroyed by bombing, you can click through the history before its destroyed it'll actually show as undamaged. Now after this change it'll show the proper amount of damage it had before being destroyed.
- Also using the new whenCapturedSustainDamage and undoing a combat move, you can now see the unit goes back to its previous damage not full health

@veqryn It appears this bug goes back to the original implementation: https://github.com/triplea-game/triplea/commit/ce0155172f10d33df69ed1de3f7d2337947277fc. I'm 99% sure that this should set the undo to the unitDamage not Hits but just in case you want to take a look.