### PR TITLE
Simplify ClientFileSystemHelper#getRootFolder()

### DIFF
--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -1,17 +1,17 @@
 package games.strategy.engine;
 
+import static games.strategy.engine.config.client.GameEnginePropertyReader.GAME_ENGINE_PROPERTIES_FILE;
+
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URISyntaxException;
+import java.security.CodeSource;
+
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.config.client.GameEnginePropertyReader;
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.io.FileUtils;
 import games.strategy.triplea.settings.ClientSetting;
@@ -21,7 +21,6 @@ import games.strategy.triplea.settings.GameSetting;
  * Provides methods to work with common file locations in a client installation.
  */
 public final class ClientFileSystemHelper {
-
   private ClientFileSystemHelper() {}
 
   /**
@@ -30,66 +29,51 @@ public final class ClientFileSystemHelper {
    * @return Folder that is the 'root' of the tripleA binary installation. This folder and
    *         contents contains the versioned content downloaded and initially installed. This is
    *         in contrast to the user root folder that is not replaced between installations.
+   *
+   * @throws IllegalStateException If the root folder cannot be located.
    */
   public static File getRootFolder() {
-    final String classFilePath = getGameRunnerClassFilePath();
-
-    final String jarFileName = String.format("triplea-%s-all.jar!", ClientContext.engineVersion().getExactVersion());
-    if (classFilePath.contains(jarFileName)) {
-      return getRootFolderRelativeToJar(classFilePath, jarFileName);
-    }
-
-    return getRootFolderRelativeToClassFile(classFilePath);
-  }
-
-  private static String getGameRunnerClassFilePath() {
-    final String runnerClassName = GameRunner.class.getSimpleName() + ".class";
-    final URL url = GameRunner.class.getResource(runnerClassName);
-    final String path = url.getFile();
     try {
-      // Deal with spaces in the file name which would be url encoded
-      return URLDecoder.decode(path, StandardCharsets.UTF_8.name());
-    } catch (final UnsupportedEncodingException e) {
-      throw new AssertionError("platform does not support UTF-8 charset", e);
+      return getFolderContainingFileWithName(getCodeSourceFolder(), GAME_ENGINE_PROPERTIES_FILE);
+    } catch (final IOException e) {
+      throw new IllegalStateException("unable to locate root folder", e);
     }
   }
 
-  private static File getRootFolderRelativeToJar(final String path, final String jarFileName) {
-    final String subString = path.substring(
-        "file:/".length() - (SystemProperties.isWindows() ? 0 : 1),
-        path.indexOf(jarFileName) - 1);
-    final File f = new File(subString).getParentFile();
-    if (!f.exists()) {
-      throw new IllegalStateException("File not found:" + f);
+  private static File getCodeSourceFolder() throws IOException {
+    final @Nullable CodeSource codeSource = ClientFileSystemHelper.class.getProtectionDomain().getCodeSource();
+    if (codeSource == null) {
+      throw new IOException("code source is not available");
     }
-    return f;
+
+    final File codeSourceLocation;
+    try {
+      codeSourceLocation = new File(codeSource.getLocation().toURI());
+    } catch (final URISyntaxException e) {
+      throw new IOException("code source location URI is malformed", e);
+    }
+
+    // code source location is either a jar file (installation) or a folder (dev environment)
+    return codeSourceLocation.isFile() ? codeSourceLocation.getParentFile() : codeSourceLocation;
   }
 
-  private static File getRootFolderRelativeToClassFile(final String path) {
-    File f = new File(path);
-
-    // move up one directory for each package
-    final int moveUpCount = GameRunner.class.getName().split("\\.").length + 1;
-    for (int i = 0; i < moveUpCount; i++) {
-      f = f.getParentFile();
+  @VisibleForTesting
+  static File getFolderContainingFileWithName(final File startFolder, final String fileName) throws IOException {
+    @Nullable
+    File folder;
+    for (folder = startFolder; folder != null; folder = folder.getParentFile()) {
+      final boolean containsFileWithName = FileUtils.listFiles(folder).stream()
+          .filter(File::isFile)
+          .map(File::getName)
+          .anyMatch(fileName::equals);
+      if (containsFileWithName) {
+        return folder;
+      }
     }
 
-    // keep moving up one directory until we find the game_engine properties file that we expect to be at the root
-    while (!folderContainsGamePropsFile(f)) {
-      f = f.getParentFile();
-    }
-
-    if (!f.exists()) {
-      System.err.println("Could not find root folder, does  not exist:" + f);
-      return new File(SystemProperties.getUserDir());
-    }
-    return f;
-  }
-
-  private static boolean folderContainsGamePropsFile(final File folder) {
-    return FileUtils.listFiles(folder).stream()
-        .map(File::getName)
-        .anyMatch(it -> GameEnginePropertyReader.GAME_ENGINE_PROPERTIES_FILE.equals(it));
+    throw new IOException(String.format(
+        "unable to locate file with name '%s' starting from folder '%s'",
+        fileName, startFolder.getAbsolutePath()));
   }
 
   /**

--- a/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -2,18 +2,70 @@ package games.strategy.engine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 
 import com.example.mockito.MockitoExtension;
 
 import games.strategy.triplea.settings.GameSetting;
 
 public final class ClientFileSystemHelperTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  public final class GetFolderContainingFileWithNameTest {
+    @Spy
+    private final File file = new File("filename.ext");
+
+    @Spy
+    private final File parentFolder = new File("parent");
+
+    @Spy
+    private final File startFolder = new File("start");
+
+    private File getFolderContainingFileWithName() throws Exception {
+      return ClientFileSystemHelper.getFolderContainingFileWithName(startFolder, file.getName());
+    }
+
+    @BeforeEach
+    public void setUp() {
+      when(file.isFile()).thenReturn(true);
+      when(startFolder.getParentFile()).thenReturn(parentFolder);
+    }
+
+    @Test
+    public void shouldReturnStartFolderWhenStartFolderContainsFile() throws Exception {
+      when(startFolder.listFiles()).thenReturn(new File[] {file});
+
+      assertThat(getFolderContainingFileWithName(), is(startFolder));
+    }
+
+    @Test
+    public void shouldReturnAncestorFolderWhenAncestorFolderContainsFile() throws Exception {
+      when(startFolder.listFiles()).thenReturn(new File[0]);
+      when(parentFolder.listFiles()).thenReturn(new File[] {file});
+
+      assertThat(getFolderContainingFileWithName(), is(parentFolder));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNoFolderContainsFile() {
+      when(startFolder.listFiles()).thenReturn(new File[0]);
+      when(parentFolder.listFiles()).thenReturn(new File[0]);
+
+      assertThrows(IOException.class, () -> getFolderContainingFileWithName());
+    }
+  }
+
   @ExtendWith(MockitoExtension.class)
   @Nested
   public final class GetUserMapsFolderPathTest {

--- a/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -33,7 +33,7 @@ public final class ClientFileSystemHelperTest {
     private final File startFolder = new File("start");
 
     private File getFolderContainingFileWithName() throws Exception {
-      return ClientFileSystemHelper.getFolderContainingFileWithName(startFolder, file.getName());
+      return ClientFileSystemHelper.getFolderContainingFileWithName(file.getName(), startFolder);
     }
 
     @BeforeEach


### PR DESCRIPTION
Follow-up to a [recommendation](https://github.com/triplea-game/triplea/pull/2735#issuecomment-354006407) in #2735.  I was able to simplify the `ClientFileSystemHelper#getRootFolder()` method by using the `CodeSource` of the active `ProtectionDomain` instead of parsing the resource URL of a particular class on the classpath to distinguish between jar- and folder-based installation shapes.

Using a `CodeSource` has some potential issues when run under a security manager, but since we don't, I've ignored those issues for now.

#### Functional changes

There was one functional change due to an inconsistency in how we handled the case where the root folder could not be located when run from a folder vs. when run from a jar.  Previously, when run from a jar, an `IllegalStateException` would be thrown if the root folder could not be located, resulting in an immediate return to the main menu.  But when run from a folder, the user's current working directory would be returned instead, which when run from an IDE, typically works.

Since we no longer make a distinction between the different installation shapes, I chose to go with the former jar behavior and fail fast (throwing `IllegalStateException`), as that is what would have happened in production.  **Please advise if the current working directory should be returned instead of throwing an exception.**  Note that the return-to-main-menu behavior is still the same in production in this case, the only difference being that the exception message will state that an image could not be found rather than the true root cause that the root folder couldn't be determined.

#### Testing

I tested as many combinations of platform and installation shapes as I could.  If possible, I'd appreciate if others could test those combinations that I am unable to test identified below.  You get bonus points for testing with an installation path containing spaces. :smile:

Can start a new local game when launching the application from the following:

* [x] Linux IDE (Eclipse)
* [x] Linux Gradle `run` task
* [x] Linux portable zip
* [x] Linux installer
* [ ] macOS IDE
* [ ] macOS Gradle `run` task
* [ ] macOS portable zip
* [ ] macOS installer
* [x] Windows IDE (Eclipse)
* [x] Windows Gradle `run` task
* [x] Windows portable zip
* [x] Windows installer (32-bit; 64-bit)