### PR TITLE
Add OSX protocol handler

### DIFF
--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -596,7 +596,7 @@ return console.askOkCancel(message, true);
                     </serializedBean>
                     <condition />
                   </action>
-                  <action name="" id="220" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to create protocol handler">
+                  <action name="Linux protocol handler" id="220" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to create protocol handler">
                     <serializedBean>
                       <java class="java.beans.XMLDecoder">
                         <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">
@@ -666,6 +666,40 @@ return true;</string>
                       </java>
                     </serializedBean>
                     <condition>Util.isLinux()</condition>
+                  </action>
+                  <action name="OSX protocol handler" id="456" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to create protocol handler">
+                    <serializedBean>
+                      <java class="java.beans.XMLDecoder">
+                        <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">
+                          <void property="script">
+                            <object class="com.install4j.api.beans.ScriptProperty">
+                              <void property="value">
+                                <string>final File installDir = new File((String)context.getVariable("sys.installationDir"));
+final File infoPlist = new File(installDir, "./Contents/Info.plist");
+final java.nio.charset.Charset utf8 = java.nio.charset.StandardCharsets.UTF_8;
+final String fileContent = new String(java.nio.file.Files.readAllBytes(infoPlist.toPath()), utf8);
+final String replacement = ""
++ "&lt;key&gt;CFBundleURLTypes&lt;/key&gt;\n"
++ "&lt;array&gt;\n"
++ "    &lt;dict&gt;\n"
++ "        &lt;key&gt;CFBundleURLName&lt;/key&gt;\n"
++ "        &lt;string&gt;TripleA&lt;/string&gt;\n"
++ "        &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;\n"
++ "        &lt;array&gt;\n"
++ "            &lt;string&gt;triplea&lt;/string&gt;\n"
++ "        &lt;/array&gt;\n"
++ "    &lt;/dict&gt;\n"
++ "&lt;/array&gt;\n";
+final String regex = "\n(?:" + replacement + ")?(?=&lt;!-- I4J_INSERT_DOCTYPE --&gt;)";
+java.nio.file.Files.write(infoPlist.toPath(), fileContent.replaceFirst(regex, "$1" + replacement).getBytes(utf8));
+return true;</string>
+                              </void>
+                            </object>
+                          </void>
+                        </object>
+                      </java>
+                    </serializedBean>
+                    <condition>Util.isMacOS()</condition>
                   </action>
                 </beans>
               </group>
@@ -1682,7 +1716,7 @@ return true;</string>
         <customAttributes />
       </autoUpdate>
     </windows>
-    <macos name="Mac OS X" id="35" customizedId="" mediaFileName="" installDir="${compiler:sys.fullName}" overridePrincipalLanguage="false" jreBitType="all" runPostProcessor="false" postProcessor="" failOnPostProcessorError="false" useLegacyMediaFileIds="false" legacyMediaFileIds="" downloadURL="" includeAllDownloadableComponents="false" includedJRE="build/assets/install4j/macosx-amd64-1.8.0_144.tar.gz" manualJREEntry="true" bundleType="2" jreURL="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/macosx-amd64-1.8.0_144.tar.gz" jreShared="true" directDownload="true" installOnlyIfNecessary="true" requiredVmIdPrefix="" customInstallBaseDir="" contentFilesType="1" installerName="${i18n:InstallerName(${compiler:sys.fullName})}" volumeName="${compiler:sys.shortName}" compressDmg="true" launcherId="33">
+    <macos name="Mac OS X" id="35" customizedId="" mediaFileName="" installDir="${compiler:sys.fullName}" overridePrincipalLanguage="false" jreBitType="all" runPostProcessor="false" postProcessor="" failOnPostProcessorError="false" useLegacyMediaFileIds="false" legacyMediaFileIds="" downloadURL="" includeAllDownloadableComponents="false" includedJRE="build/assets/install4j/macosx-amd64-1.8.0_144.tar.gz" manualJREEntry="true" bundleType="2" jreURL="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/macosx-amd64-1.8.0_144.tar.gz" jreShared="true" directDownload="true" installOnlyIfNecessary="true" requiredVmIdPrefix="" customInstallBaseDir="" contentFilesType="1" installerName="${i18n:InstallerName(${compiler:sys.fullName})}" volumeName="${compiler:sys.shortName}" compressDmg="false" launcherId="33">
       <excludedComponents />
       <includedDownloadableComponents />
       <excludedBeans />

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -71,7 +71,7 @@
 &lt;array&gt;
     &lt;dict&gt;
         &lt;key&gt;CFBundleURLName&lt;/key&gt;
-        &lt;string&gt;TripleA&lt;/string&gt;
+        &lt;string&gt;TripleA Protocol&lt;/string&gt;
         &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;
         &lt;array&gt;
             &lt;string&gt;triplea&lt;/string&gt;
@@ -1692,7 +1692,7 @@ return true;</string>
         <customAttributes />
       </autoUpdate>
     </windows>
-    <macos name="Mac OS X" id="35" customizedId="" mediaFileName="" installDir="${compiler:sys.fullName}" overridePrincipalLanguage="false" jreBitType="all" runPostProcessor="false" postProcessor="" failOnPostProcessorError="false" useLegacyMediaFileIds="false" legacyMediaFileIds="" downloadURL="" includeAllDownloadableComponents="false" includedJRE="build/assets/install4j/macosx-amd64-1.8.0_144.tar.gz" manualJREEntry="true" bundleType="2" jreURL="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/macosx-amd64-1.8.0_144.tar.gz" jreShared="true" directDownload="true" installOnlyIfNecessary="true" requiredVmIdPrefix="" customInstallBaseDir="" contentFilesType="1" installerName="${i18n:InstallerName(${compiler:sys.fullName})}" volumeName="${compiler:sys.shortName}" compressDmg="false" launcherId="33">
+    <macos name="Mac OS X" id="35" customizedId="" mediaFileName="" installDir="${compiler:sys.fullName}" overridePrincipalLanguage="false" jreBitType="all" runPostProcessor="false" postProcessor="" failOnPostProcessorError="false" useLegacyMediaFileIds="false" legacyMediaFileIds="" downloadURL="" includeAllDownloadableComponents="false" includedJRE="build/assets/install4j/macosx-amd64-1.8.0_144.tar.gz" manualJREEntry="true" bundleType="2" jreURL="https://raw.githubusercontent.com/triplea-game/assets/master/install4j/macosx-amd64-1.8.0_144.tar.gz" jreShared="true" directDownload="true" installOnlyIfNecessary="true" requiredVmIdPrefix="" customInstallBaseDir="" contentFilesType="1" installerName="${i18n:InstallerName(${compiler:sys.fullName})}" volumeName="${compiler:sys.shortName}" compressDmg="true" launcherId="33">
       <excludedComponents />
       <includedDownloadableComponents />
       <excludedBeans />

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -66,8 +66,18 @@
       <customScript mode="1" file="">
         <content />
       </customScript>
-      <infoPlist mode="1" file="">
-        <content />
+      <infoPlist mode="3" file="">
+        <content>&lt;key&gt;CFBundleURLTypes&lt;/key&gt;
+&lt;array&gt;
+    &lt;dict&gt;
+        &lt;key&gt;CFBundleURLName&lt;/key&gt;
+        &lt;string&gt;TripleA&lt;/string&gt;
+        &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;
+        &lt;array&gt;
+            &lt;string&gt;triplea&lt;/string&gt;
+        &lt;/array&gt;
+    &lt;/dict&gt;
+&lt;/array&gt;</content>
       </infoPlist>
       <iconImageFiles>
         <file path="./build/assets/icons/triplea_icon_16_16.png" />
@@ -666,40 +676,6 @@ return true;</string>
                       </java>
                     </serializedBean>
                     <condition>Util.isLinux()</condition>
-                  </action>
-                  <action name="OSX protocol handler" id="456" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to create protocol handler">
-                    <serializedBean>
-                      <java class="java.beans.XMLDecoder">
-                        <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">
-                          <void property="script">
-                            <object class="com.install4j.api.beans.ScriptProperty">
-                              <void property="value">
-                                <string>final File installDir = new File((String)context.getVariable("sys.installationDir"));
-final File infoPlist = new File(installDir, "./Contents/Info.plist");
-final java.nio.charset.Charset utf8 = java.nio.charset.StandardCharsets.UTF_8;
-final String fileContent = new String(java.nio.file.Files.readAllBytes(infoPlist.toPath()), utf8);
-final String replacement = ""
-+ "&lt;key&gt;CFBundleURLTypes&lt;/key&gt;\n"
-+ "&lt;array&gt;\n"
-+ "    &lt;dict&gt;\n"
-+ "        &lt;key&gt;CFBundleURLName&lt;/key&gt;\n"
-+ "        &lt;string&gt;TripleA&lt;/string&gt;\n"
-+ "        &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;\n"
-+ "        &lt;array&gt;\n"
-+ "            &lt;string&gt;triplea&lt;/string&gt;\n"
-+ "        &lt;/array&gt;\n"
-+ "    &lt;/dict&gt;\n"
-+ "&lt;/array&gt;\n";
-final String regex = "\n(?:" + replacement + ")?(?=&lt;!-- I4J_INSERT_DOCTYPE --&gt;)";
-java.nio.file.Files.write(infoPlist.toPath(), fileContent.replaceFirst(regex, "$1" + replacement).getBytes(utf8));
-return true;</string>
-                              </void>
-                            </object>
-                          </void>
-                        </object>
-                      </java>
-                    </serializedBean>
-                    <condition>Util.isMacOS()</condition>
                   </action>
                 </beans>
               </group>

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -1082,7 +1082,7 @@ return console.askYesNo(message, true);
                 </serializedBean>
                 <condition />
               </action>
-              <action name="" id="176" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to unregister the protocol handler">
+              <action name="Remove Windows Protocol Handler" id="176" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to unregister the protocol handler">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
@@ -1103,7 +1103,7 @@ return console.askYesNo(message, true);
                 </serializedBean>
                 <condition>Util.isWindows() &amp;&amp; ((String)WinRegistry.getValue(RegistryRoot.HKEY_CURRENT_USER, "Software\\Classes\\triplea\\shell\\open\\command", "")).equalsIgnoreCase("\"" + context.getVariable("sys.installationDir") + "\\TripleA.exe\" \"%1\"")</condition>
               </action>
-              <action name="" id="221" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to remove protocol handler">
+              <action name="Remove Linux protocol handler" id="221" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="1" multiExec="false" failureStrategy="1" errorMessage="Failed to remove protocol handler">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">


### PR DESCRIPTION
Should fix #2976 No guarantees at all, ~I'm not even sure if this entry is being added to the right file.~
@DanVanAtta could you please test this according to this scheme?:
1. Install TripleA and ovewrite the previous version, leave everything default.
2. Verify the protocol handler works
3. Uninstall TripleA
4. Verify the protocol handler doesn't work and no error is being displayed, other than "safari can't open the specified address" and the plist file was deleted.
5. Install TripleA
6. Verify the protocol handler works
7. Install TripleA on a different path, so 2 versions exist simultaneosly
8. Verify the protocol handler still works (I don't know if you get an option to choose between versions)
9. Uninstall one version of TripleA
10. Verify the protocol Handler still works
11. Uninstall the other version of TripleA
12. Verify the protocol handler no longer works and all files have been deleted.

~I don't think I need to manually revert changes to the file, I suppose the files are per installation, and not per protocol, different to windows and linux (and much easier too).
If I'm wrong with this, here's the file that _should_ at least in theory revert the changes:~
```diff
diff --git a/build.install4j b/build.install4j
index 76c8188..0b1cc94 100644
--- a/build.install4j
+++ b/build.install4j
@@ -1146,6 +1146,39 @@ return true;</string>
                 </serializedBean>
                 <condition>Util.isLinux()</condition>
               </action>
+              <action name="" id="458" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="0" multiExec="false" failureStrategy="1" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">
+                      <void property="script">
+                        <object class="com.install4j.api.beans.ScriptProperty">
+                          <void property="value">
+                            <string>final File installDir = new File((String)context.getVariable("sys.installationDir"));
+final File infoPlist = new File(installDir, "./Contents/Info.plist");
+final java.nio.charset.Charset utf8 = java.nio.charset.StandardCharsets.UTF_8;
+final String fileContent = new String(java.nio.file.Files.readAllBytes(infoPlist.toPath()), utf8);
+final String replacement = ""
++ "&lt;key&gt;CFBundleURLTypes&lt;/key&gt;\n"
++ "&lt;array&gt;\n"
++ "    &lt;dict&gt;\n"
++ "        &lt;key&gt;CFBundleURLName&lt;/key&gt;\n"
++ "        &lt;string&gt;TripleA&lt;/string&gt;\n"
++ "        &lt;key&gt;CFBundleURLSchemes&lt;/key&gt;\n"
++ "        &lt;array&gt;\n"
++ "            &lt;string&gt;triplea&lt;/string&gt;\n"
++ "        &lt;/array&gt;\n"
++ "    &lt;/dict&gt;\n"
++ "&lt;/array&gt;\n";
+java.nio.file.Files.write(infoPlist.toPath(), fileContent.replace(replacement, "").getBytes(utf8));
+return true;</string>
+                          </void>
+                        </object>
+                      </void>
+                    </object>
+                  </java>
+                </serializedBean>
+                <condition>Util.isMacOS()</condition>
+              </action>
             </actions>
             <formComponents>
               <formComponent name="" id="286" customizedId="" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent" enabled="true" commentSet="false" comment="" insetTop="" insetLeft="" insetBottom="" insetRight="" resetInitOnPrevious="false" useExternalParametrization="false" externalParametrizationName="" externalParametrizationMode="all">
```

EDIT: I just noticed there's a simple way to add custom fragments to the plist file 🙄 
This way I'm able to drop a lot of code...