### PR TITLE
Encapsulate hashed MAC address implementation details

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -13,6 +13,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
+import games.strategy.net.MacFinder;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Version;
 
@@ -27,11 +28,6 @@ import games.strategy.util.Version;
  */
 public final class ClientLoginValidator implements ILoginValidator {
   static final String PASSWORD_REQUIRED_PROPERTY = "Password Required";
-  @VisibleForTesting
-  static final int MAC_ADDRESS_LENGTH = 28;
-  @VisibleForTesting
-  static final String MAC_MAGIC_STRING_PREFIX = games.strategy.util.Md5Crypt.MAGIC + "MH$";
-
 
   @VisibleForTesting
   interface ErrorMessages {
@@ -44,16 +40,6 @@ public final class ClientLoginValidator implements ILoginValidator {
 
   private final IServerMessenger serverMessenger;
   private String password;
-
-  /**
-   * Returns true if the parameter value is the correct length of a md5 hashed value,
-   * and if also it starts with the correct string value.
-   */
-  public static boolean isValidMac(final String value) {
-    return value.length() == MAC_ADDRESS_LENGTH
-        && value.startsWith(MAC_MAGIC_STRING_PREFIX)
-        && value.matches("[0-9a-zA-Z$./]+");
-  }
 
   public ClientLoginValidator(final IServerMessenger serverMessenger) {
     this.serverMessenger = serverMessenger;
@@ -115,7 +101,7 @@ public final class ClientLoginValidator implements ILoginValidator {
 
     if (hashedMac == null) {
       return ErrorMessages.UNABLE_TO_OBTAIN_MAC;
-    } else if (!isValidMac(hashedMac)) {
+    } else if (!MacFinder.isValidHashedMacAddress(hashedMac)) {
       return ErrorMessages.INVALID_MAC;
     } else if (serverMessenger.isMacMiniBanned(hashedMac)) {
       return ErrorMessages.YOU_HAVE_BEEN_BANNED;

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -17,6 +17,7 @@ import games.strategy.engine.message.MessageContext;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
+import games.strategy.net.MacFinder;
 import games.strategy.net.Messengers;
 
 public class ModeratorController extends AbstractModeratorController {
@@ -326,7 +327,7 @@ public class ModeratorController extends AbstractModeratorController {
     builder.append("\r\nHashed Mac: ");
     if (UNKNOWN_HASHED_MAC_ADDRESS.equals(mac)) {
       builder.append("(Unknown)");
-    } else if (mac.startsWith(games.strategy.util.Md5Crypt.MAGIC + "MH$")) {
+    } else if (MacFinder.isValidHashedMacAddress(mac)) {
       builder.append(mac.substring(6));
     } else {
       builder.append(mac + " (Invalid)");

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -328,7 +328,7 @@ public class ModeratorController extends AbstractModeratorController {
     if (UNKNOWN_HASHED_MAC_ADDRESS.equals(mac)) {
       builder.append("(Unknown)");
     } else if (MacFinder.isValidHashedMacAddress(mac)) {
-      builder.append(mac.substring(6));
+      builder.append(MacFinder.trimHashedMacAddressPrefix(mac));
     } else {
       builder.append(mac + " (Invalid)");
     }

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -32,6 +32,7 @@ import games.strategy.engine.lobby.server.db.UserController;
 import games.strategy.engine.lobby.server.db.UserDao;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
+import games.strategy.net.MacFinder;
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
@@ -162,9 +163,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
         return ErrorMessages.THATS_NOT_A_NICE_NAME;
       }
     }
-    if (user.getHashedMacAddress().length() != 28
-        || !user.getHashedMacAddress().startsWith(games.strategy.util.Md5Crypt.MAGIC + "MH$")
-        || !user.getHashedMacAddress().matches("[0-9a-zA-Z$./]+")) {
+    if (!MacFinder.isValidHashedMacAddress(user.getHashedMacAddress())) {
       // Must have been tampered with
       return ErrorMessages.INVALID_MAC;
     }

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.framework.startup.login.ClientLoginValidator;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.message.HubInvoke;
@@ -68,8 +67,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
       final IObjectStreamFactory streamFact, final IConnectionLogin login)
       throws IOException {
     Preconditions.checkNotNull(mac);
-    Preconditions.checkArgument(ClientLoginValidator.isValidMac(mac),
-        "Not a valid mac: " + mac + ", length: " + mac.length());
+    Preconditions.checkArgument(MacFinder.isValidHashedMacAddress(mac), "Not a valid mac: " + mac);
     socketChannel = SocketChannel.open();
     socketChannel.configureBlocking(false);
     final InetSocketAddress remote = new InetSocketAddress(host, port);

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -21,17 +21,23 @@ import com.google.common.primitives.Bytes;
 
 import games.strategy.debug.ClientLogger;
 
+/**
+ * Provides access to the MAC address of the local node.
+ */
 public final class MacFinder {
+  private static final String HASHED_MAC_ADDRESS_SALT = "MH";
+
   private MacFinder() {}
 
   /**
    * Should result in something like this: $1$MH$345ntXD4G3AKpAeHZdaGe3.
+   *
+   * @throws IllegalArgumentException If the MAC address is not available.
    */
   public static String getHashedMacAddress() {
     final String mac = getMacAddress();
     if (mac == null) {
-      throw new IllegalArgumentException(
-          "You have an invalid MAC address or TripleA can't find your mac address");
+      throw new IllegalArgumentException("You have an invalid MAC address or TripleA can't find your mac address");
     }
     return getHashedMacAddress(mac);
   }
@@ -53,7 +59,7 @@ public final class MacFinder {
   }
 
   private static String getHashedMacAddress(final String macAddress) {
-    return games.strategy.util.Md5Crypt.crypt(macAddress, "MH");
+    return games.strategy.util.Md5Crypt.crypt(macAddress, HASHED_MAC_ADDRESS_SALT);
   }
 
   private static String getMacAddress() {
@@ -267,5 +273,22 @@ public final class MacFinder {
       }
     }
     return null;
+  }
+
+  /**
+   * Indicates the specified value is a valid hashed MAC address.
+   *
+   * @param value The value to test.
+   *
+   * @return {@code true} if the specified value is a valid hashed MAC address; otherwise {@code false}.
+   */
+  public static boolean isValidHashedMacAddress(final String value) {
+    checkNotNull(value);
+
+    try {
+      return HASHED_MAC_ADDRESS_SALT.equals(games.strategy.util.Md5Crypt.getSalt(value));
+    } catch (final IllegalArgumentException e) {
+      return false;
+    }
   }
 }

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -291,4 +291,19 @@ public final class MacFinder {
       return false;
     }
   }
+
+  /**
+   * Removes the prefix from the specified hashed MAC address.
+   *
+   * @param hashedMacAddress The hashed MAC address whose prefix is to be removed.
+   *
+   * @return The hashed MAC address without its prefix.
+   *
+   * @throws IllegalArgumentException If {@code hashedMacAddress} is not a valid hashed MAC address.
+   */
+  public static String trimHashedMacAddressPrefix(final String hashedMacAddress) {
+    checkNotNull(hashedMacAddress);
+
+    return games.strategy.util.Md5Crypt.getHash(hashedMacAddress);
+  }
 }

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -33,6 +33,7 @@ import games.strategy.engine.lobby.server.ModeratorController;
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.INode;
+import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.UrlConstants;
@@ -44,7 +45,6 @@ import games.strategy.ui.SwingComponents;
  */
 public final class LobbyMenu extends JMenuBar {
   private static final long serialVersionUID = 4980621864542042057L;
-  private static final String HASHED_MAC_PREFIX = games.strategy.util.Md5Crypt.MAGIC + "MH$";
 
   private final LobbyFrame lobbyFrame;
 
@@ -185,18 +185,8 @@ public final class LobbyMenu extends JMenuBar {
       if (mac == null || mac.length() < 1) {
         return;
       }
-      final String error;
-      if (mac.length() != 28) {
-        error = "Must be 28 characters long";
-      } else if (!mac.startsWith(HASHED_MAC_PREFIX)) {
-        error = "Must start with: " + HASHED_MAC_PREFIX;
-      } else if (!mac.matches("[0-9a-zA-Z$./]+")) {
-        error = "Must use only these characters: 0-9a-zA-Z$./";
-      } else {
-        error = null;
-      }
-      if (error != null) {
-        JOptionPane.showMessageDialog(lobbyFrame, "The hashed Mac Address you entered is invalid (" + error + ").",
+      if (!MacFinder.isValidHashedMacAddress(mac)) {
+        JOptionPane.showMessageDialog(lobbyFrame, "The hashed Mac Address you entered is invalid.",
             "Invalid Hashed Mac", JOptionPane.ERROR_MESSAGE);
         return;
       }
@@ -241,18 +231,8 @@ public final class LobbyMenu extends JMenuBar {
       if (mac == null || mac.length() < 1) {
         return;
       }
-      final String error;
-      if (mac.length() != 28) {
-        error = "Must be 28 characters long";
-      } else if (!mac.startsWith(HASHED_MAC_PREFIX)) {
-        error = "Must start with: " + HASHED_MAC_PREFIX;
-      } else if (!mac.matches("[0-9a-zA-Z$./]+")) {
-        error = "Must use only these characters: 0-9a-zA-Z$./";
-      } else {
-        error = null;
-      }
-      if (error != null) {
-        JOptionPane.showMessageDialog(lobbyFrame, "The hashed Mac Address you entered is invalid (" + error + ").",
+      if (!MacFinder.isValidHashedMacAddress(mac)) {
+        JOptionPane.showMessageDialog(lobbyFrame, "The hashed Mac Address you entered is invalid.",
             "Invalid Hashed Mac", JOptionPane.ERROR_MESSAGE);
         return;
       }

--- a/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/src/main/java/games/strategy/util/Md5Crypt.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 public final class Md5Crypt {
   public static final String MAGIC = "$1$";
   private static final Pattern ENCRYPTED_PASSWORD_PATTERN =
-      Pattern.compile("^" + MAGIC.replace("$", "\\$") + "([\\.\\/a-zA-Z0-9]{1,8})\\$[\\.\\/a-zA-Z0-9]{22}$");
+      Pattern.compile("^" + MAGIC.replace("$", "\\$") + "([\\.\\/a-zA-Z0-9]{1,8})\\$([\\.\\/a-zA-Z0-9]{22})$");
   private static final byte[] EMPTY_KEY_BYTES = new byte[0];
 
   private Md5Crypt() {}
@@ -73,6 +73,24 @@ public final class Md5Crypt {
    */
   public static String newSalt() {
     return getSalt(md5Crypt(EMPTY_KEY_BYTES));
+  }
+
+  /**
+   * Gets the hash for the specified encrypted password.
+   *
+   * @param encryptedPassword The encrypted password from a previous call to {@link #crypt(String, String)} whose hash
+   *        is to be returned.
+   *
+   * @return The hash for the specified encrypted password.
+   *
+   * @throws IllegalArgumentException If {@code encryptedPassword} is not an MD5-crypted password.
+   */
+  public static String getHash(final String encryptedPassword) {
+    checkNotNull(encryptedPassword);
+
+    final Matcher matcher = ENCRYPTED_PASSWORD_PATTERN.matcher(encryptedPassword);
+    checkArgument(matcher.matches(), "'" + encryptedPassword + "' is not an MD5-crypted password");
+    return matcher.group(2);
   }
 
   /**

--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.net.SocketAddress;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,7 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
 import com.example.mockito.MockitoExtension;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.framework.startup.login.ClientLoginValidator.ErrorMessages;
@@ -23,29 +20,6 @@ import games.strategy.engine.framework.startup.login.ClientLoginValidator.ErrorM
 public final class ClientLoginValidatorTest {
   private static final String PASSWORD = "password";
   private static final String OTHER_PASSWORD = "otherPassword";
-
-  @Nested
-  public final class MacValidationTest {
-    private static final String MAGIC_MAC_START = ClientLoginValidator.MAC_MAGIC_STRING_PREFIX;
-
-    @Test
-    public void invalidMacs() {
-      final Collection<String> macs = Arrays.asList(
-          MAGIC_MAC_START + "no spaces allowed",
-          MAGIC_MAC_START + "tooShort",
-          MAGIC_MAC_START + "#%@symbol",
-          Strings.repeat("0", ClientLoginValidator.MAC_ADDRESS_LENGTH));
-      macs.forEach(invalidValue -> assertThat(ClientLoginValidator.isValidMac(invalidValue), is(false)));
-    }
-
-    @Test
-    public void validMac() {
-      final int remainingPaddingLength = ClientLoginValidator.MAC_ADDRESS_LENGTH - MAGIC_MAC_START.length();
-      final String valid = MAGIC_MAC_START + Strings.repeat("0", remainingPaddingLength);
-
-      assertThat(ClientLoginValidator.isValidMac(valid), is(true));
-    }
-  }
 
   @Nested
   public final class GetChallengePropertiesTest {

--- a/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/src/test/java/games/strategy/net/MacFinderTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 public final class MacFinderTest {
@@ -28,19 +30,18 @@ public final class MacFinderTest {
   }
 
   @Test
-  public void isValidHashedMacAddress_ShouldReturnFalseWhenLengthIsInvalid() {
-    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189."), is(false));
-    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189./1"), is(false));
+  public void isValidHashedMacAddress_ShouldReturnFalseWhenNotValidMd5CryptedValue() {
+    Arrays.asList(
+        "$1$MH$ABCDWXYZabcdwxyz0189.",
+        "$1$MH$ABCDWXYZabcdwxyz0189./1",
+        "1$MH$ABCDWXYZabcdwxyz0189./1",
+        "$1$MH$ABCDWXYZabcdwxyz0189._")
+        .forEach(hashedMacAddress -> assertThat(MacFinder.isValidHashedMacAddress(hashedMacAddress), is(false)));
   }
 
   @Test
-  public void isValidHashedMacAddress_ShouldReturnFalseWhenDoesNotHaveExpectedPrefix() {
-    assertThat(MacFinder.isValidHashedMacAddress("1$MH$ABCDWXYZabcdwxyz0189./1"), is(false));
-  }
-
-  @Test
-  public void isValidHashedMacAddress_ShouldReturnFalseWhenContainsInvalidCharacters() {
-    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189._"), is(false));
+  public void isValidHashedMacAddress_ShouldReturnFalseWhenDoesNotHaveExpectedSalt() {
+    assertThat(MacFinder.isValidHashedMacAddress("$1$SALT$ABCDWXYZabcdwxyz0189./"), is(false));
   }
 
   @Test

--- a/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/src/test/java/games/strategy/net/MacFinderTest.java
@@ -21,4 +21,25 @@ public final class MacFinderTest {
     assertThat(hashedMacAddress.length(), is(28));
     assertThat(hashedMacAddress, startsWith("$1$MH$"));
   }
+
+  @Test
+  public void isValidHashedMacAddress_ShouldReturnTrueWhenValid() {
+    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189./"), is(true));
+  }
+
+  @Test
+  public void isValidHashedMacAddress_ShouldReturnFalseWhenLengthIsInvalid() {
+    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189."), is(false));
+    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189./1"), is(false));
+  }
+
+  @Test
+  public void isValidHashedMacAddress_ShouldReturnFalseWhenDoesNotHaveExpectedPrefix() {
+    assertThat(MacFinder.isValidHashedMacAddress("1$MH$ABCDWXYZabcdwxyz0189./1"), is(false));
+  }
+
+  @Test
+  public void isValidHashedMacAddress_ShouldReturnFalseWhenContainsInvalidCharacters() {
+    assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189._"), is(false));
+  }
 }

--- a/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/src/test/java/games/strategy/net/MacFinderTest.java
@@ -42,4 +42,14 @@ public final class MacFinderTest {
   public void isValidHashedMacAddress_ShouldReturnFalseWhenContainsInvalidCharacters() {
     assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189._"), is(false));
   }
+
+  @Test
+  public void trimHashedMacAddressPrefix_ShouldReturnHashedMacAddressWithoutPrefixWhenValid() {
+    assertThat(MacFinder.trimHashedMacAddressPrefix("$1$MH$ABCDWXYZabcdwxyz0189./"), is("ABCDWXYZabcdwxyz0189./"));
+  }
+
+  @Test
+  public void trimHashedMacAddressPrefix_ShouldThrowExceptionWhenInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> MacFinder.trimHashedMacAddressPrefix("invalid"));
+  }
 }

--- a/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -18,6 +18,10 @@ public final class Md5CryptTest {
     return Md5Crypt.crypt(password, salt);
   }
 
+  private static String getHash(final String encryptedPassword) {
+    return Md5Crypt.getHash(encryptedPassword);
+  }
+
   private static String getSalt(final String encryptedPassword) {
     return Md5Crypt.getSalt(encryptedPassword);
   }
@@ -90,6 +94,43 @@ public final class Md5CryptTest {
   }
 
   @Test
+  public void getHash_ShouldReturnHashWhenEncryptedPasswordIsLegal() {
+    Arrays.asList(
+        Tuple.of("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0", "KsXRew.PuhVQTNMKSXQZx0"),
+        Tuple.of("$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1", "Y7Rv7y5WCc7rARI/g7xgH1"),
+        Tuple.of("$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv.", "iIDgBB73DNCK/RwmzU0kv."),
+        Tuple.of("$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq.", "ZjNcN3vfMfRdNcDyzQbQq."),
+        Tuple.of("$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11", "J5dZUS3L8DAMUim4wdL/11"))
+        .forEach(t -> {
+          final String encryptedPassword = t.getFirst();
+          final String hash = t.getSecond();
+          assertThat(
+              String.format("wrong hash for '%s'", encryptedPassword),
+              getHash(encryptedPassword),
+              is(hash));
+        });
+  }
+
+  @Test
+  public void getHash_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
+    Arrays.asList(
+        "1$A$KnCRC85Rudn6P3cpfe3LR/",
+        "$$AB$4jo772pXjQ9qCwNdBde3d1",
+        "$1ABC$3tP1DHUbEbG4bd67/3fFu/",
+        "$1$$dQqZjlWf5HeY7rWTLu23s.",
+        "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw_",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw..")
+        .forEach(encryptedPassword -> {
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> getHash(encryptedPassword),
+              () -> String.format("expected exception for illegal encrypted password '%s'", encryptedPassword));
+        });
+  }
+
+  @Test
   public void getSalt_ShouldReturnSaltWhenEncryptedPasswordIsLegal() {
     Arrays.asList(
         Tuple.of("$1$A$KnCRC85Rudn6P3cpfe3LR/", "A"),
@@ -117,7 +158,10 @@ public final class Md5CryptTest {
         "$$AB$4jo772pXjQ9qCwNdBde3d1",
         "$1ABC$3tP1DHUbEbG4bd67/3fFu/",
         "$1$$dQqZjlWf5HeY7rWTLu23s.",
-        "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.")
+        "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw_",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw",
+        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw..")
         .forEach(encryptedPassword -> {
           assertThrows(
               IllegalArgumentException.class,


### PR DESCRIPTION
I noticed that hashed MAC address validation was duplicated all over the place.  This PR simply brings all hashed MAC address implementation details into the `MacFinder` class, which is where this information originates.