### PR TITLE
Add Enter/Esc key listeners to lobby login/create/update dialogs

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
@@ -23,6 +23,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 
 import games.strategy.engine.lobby.server.userDB.DBUser;
+import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
 
 /**
@@ -127,8 +128,16 @@ public final class CreateUpdateAccountPanel extends JPanel {
   }
 
   private void setupListeners() {
-    cancelButton.addActionListener(e -> dialog.setVisible(false));
+    cancelButton.addActionListener(e -> close());
     okButton.addActionListener(e -> okPressed());
+
+    SwingComponents.addEnterKeyListener(this, this::okPressed);
+  }
+
+  private void close() {
+    if (dialog != null) {
+      dialog.setVisible(false);
+    }
   }
 
   private void okPressed() {
@@ -158,7 +167,7 @@ public final class CreateUpdateAccountPanel extends JPanel {
     }
 
     returnValue = ReturnValue.OK;
-    dialog.setVisible(false);
+    close();
   }
 
   /**
@@ -172,6 +181,7 @@ public final class CreateUpdateAccountPanel extends JPanel {
   public ReturnValue show(final Window parent) {
     dialog = new JDialog(JOptionPane.getFrameForComponent(parent), title, true);
     dialog.getContentPane().add(this);
+    SwingComponents.addEscapeKeyListener(dialog, this::close);
     dialog.pack();
     dialog.setLocationRelativeTo(parent);
     dialog.setVisible(true);

--- a/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -94,12 +94,18 @@ final class LoginPanel extends JPanel {
     logon.addActionListener(e -> logonPressed());
     createAccount.addActionListener(e -> {
       returnValue = ReturnValue.CREATE_ACCOUNT;
-      dialog.setVisible(false);
+      close();
     });
-    cancel.addActionListener(e -> dialog.setVisible(false));
+    cancel.addActionListener(e -> close());
     anonymousLogin.addActionListener(e -> updateComponents());
 
     SwingComponents.addEnterKeyListener(this, this::logonPressed);
+  }
+
+  private void close() {
+    if (dialog != null) {
+      dialog.setVisible(false);
+    }
   }
 
   private void logonPressed() {
@@ -117,7 +123,7 @@ final class LoginPanel extends JPanel {
     }
 
     returnValue = ReturnValue.LOGON;
-    dialog.setVisible(false);
+    close();
   }
 
   private void updateComponents() {
@@ -143,6 +149,7 @@ final class LoginPanel extends JPanel {
   ReturnValue show(final Window parent) {
     dialog = new JDialog(JOptionPane.getFrameForComponent(parent), "Login", true);
     dialog.getContentPane().add(this);
+    SwingComponents.addEscapeKeyListener(dialog, this::close);
     dialog.pack();
     dialog.setLocationRelativeTo(parent);
     dialog.setVisible(true);


### PR DESCRIPTION
The lobby Login dialog already has an <kbd>Enter</kbd> listener that triggers the Login button action.  This PR adds the following additional key listeners:

* <kbd>Esc</kbd> listener for the Login dialog that closes the dialog.
* <kbd>Enter</kbd> listener for the Create/Update Account dialog that triggers the OK button action.
* <kbd>Esc</kbd> listener for the Create/Update Account dialog that closes the dialog.