### PR TITLE
Check for air and land transports during non-blitz check

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -346,7 +346,9 @@ public class MoveValidator {
             .getUnitTypesThatLostBlitz((wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
         for (final Unit unit : nonBlitzingUnits) {
           // TODO: Need to actually test if the unit is being air transported or land transported
-          if (Matches.unitIsAirTransportable().test(unit) || Matches.unitIsLandTransportable().test(unit)) {
+          if ((Matches.unitIsAirTransportable().test(unit) && units.stream().anyMatch(Matches.unitIsAirTransport()))
+              || (Matches.unitIsLandTransportable().test(unit)
+                  && units.stream().anyMatch(Matches.unitIsLandTransport()))) {
             continue;
           }
           final TripleAUnit taUnit = (TripleAUnit) unit;


### PR DESCRIPTION
Tighten up non-blitzing units check for air/land transported units by ensuring that there is also the appropriate transports in the unit group. This is not a 100% fix but is an easy change the makes it cover more cases.

Tested
- Latest TWW 2.8 has tanks/mech that have isLandTransportable which is allowing them to skip the blitz check. With this change they will no longer skip the blitz check since isLandTransport units only work in non-combat.