### PR TITLE
Offload access log timestamp insertion to database

### DIFF
--- a/config/lobby/db/007_add_access_log
+++ b/config/lobby/db/007_add_access_log
@@ -1,7 +1,7 @@
 start transaction;
 
 create table access_log (
-  access_time timestamptz not null,
+  access_time timestamptz not null default now(),
   username varchar(40) not null,
   ip inet not null,
   mac char(28) not null check (char_length(mac)=28),

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/AccessLogControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/AccessLogControllerIntegrationTest.java
@@ -2,13 +2,12 @@ package games.strategy.engine.lobby.server.db;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.Timestamp;
-import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,34 +20,31 @@ public final class AccessLogControllerIntegrationTest {
 
   @Test
   public void insert_ShouldInsertNewRecord() throws Exception {
-    final Instant instant = Instant.now();
     final User user = TestUserUtils.newUser();
 
     for (final UserType userType : UserType.values()) {
-      accessLogController.insert(instant, user, userType);
+      accessLogController.insert(user, userType);
 
-      thenAccessLogRecordShouldExist(instant, user, userType);
+      thenAccessLogRecordShouldExist(user, userType);
     }
   }
 
-  private static void thenAccessLogRecordShouldExist(final Instant instant, final User user, final UserType userType)
-      throws Exception {
-    final String sql = ""
-        + "select count(*) from access_log "
-        + "where access_time=? and username=? and ip=?::inet and mac=? and registered=?";
+  private static void thenAccessLogRecordShouldExist(final User user, final UserType userType) throws Exception {
+    final String sql = "select access_time from access_log where username=? and ip=?::inet and mac=? and registered=?";
     try (Connection conn = Database.getPostgresConnection();
         PreparedStatement ps = conn.prepareStatement(sql)) {
-      ps.setTimestamp(1, Timestamp.from(instant));
-      ps.setString(2, user.getUsername());
-      ps.setString(3, user.getInetAddress().getHostAddress());
-      ps.setString(4, user.getHashedMacAddress());
-      ps.setBoolean(5, userType == UserType.REGISTERED);
+      ps.setString(1, user.getUsername());
+      ps.setString(2, user.getInetAddress().getHostAddress());
+      ps.setString(3, user.getHashedMacAddress());
+      ps.setBoolean(4, userType == UserType.REGISTERED);
       try (ResultSet rs = ps.executeQuery()) {
-        if (rs.next()) {
-          assertThat(rs.getInt(1), is(1));
-        } else {
-          fail("access log record does not exist");
-        }
+        assertThat("record should exist", rs.next(), is(true));
+        assertThat("access_time column should have a default value", rs.getTimestamp(1), is(not(nullValue())));
+        assertThat(
+            "only one record should exist "
+                + "(possible aliasing from another test run due to no control over access_time value)",
+            rs.next(),
+            is(false));
       }
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/server/db/AccessLogController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/AccessLogController.java
@@ -5,8 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
 
 import games.strategy.engine.lobby.server.User;
 import games.strategy.engine.lobby.server.login.UserType;
@@ -16,23 +14,17 @@ import games.strategy.engine.lobby.server.login.UserType;
  */
 public final class AccessLogController implements AccessLogDao {
   @Override
-  public void insert(final Instant instant, final User user, final UserType userType) throws SQLException {
-    checkNotNull(instant);
+  public void insert(final User user, final UserType userType) throws SQLException {
     checkNotNull(user);
     checkNotNull(userType);
 
-    final String sql = ""
-        + "insert into access_log "
-        + "  (access_time, username, ip, mac, registered) "
-        + "  values "
-        + "  (?, ?, ?::inet, ?, ?)";
+    final String sql = "insert into access_log (username, ip, mac, registered) values (?, ?::inet, ?, ?)";
     try (Connection conn = Database.getPostgresConnection();
         PreparedStatement ps = conn.prepareStatement(sql)) {
-      ps.setTimestamp(1, Timestamp.from(instant));
-      ps.setString(2, user.getUsername());
-      ps.setString(3, user.getInetAddress().getHostAddress());
-      ps.setString(4, user.getHashedMacAddress());
-      ps.setBoolean(5, userType == UserType.REGISTERED);
+      ps.setString(1, user.getUsername());
+      ps.setString(2, user.getInetAddress().getHostAddress());
+      ps.setString(3, user.getHashedMacAddress());
+      ps.setBoolean(4, userType == UserType.REGISTERED);
       ps.execute();
       conn.commit();
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/AccessLogDao.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/AccessLogDao.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.server.db;
 
 import java.sql.SQLException;
-import java.time.Instant;
 
 import games.strategy.engine.lobby.server.User;
 import games.strategy.engine.lobby.server.login.UserType;
@@ -13,11 +12,10 @@ public interface AccessLogDao {
   /**
    * Inserts a new record in the access log table.
    *
-   * @param instant The instant of the access.
    * @param user The user who accessed the lobby.
    * @param userType The type of the user who accessed the lobby.
    *
    * @throws SQLException If an error occurs while logging the access.
    */
-  void insert(Instant instant, User user, UserType userType) throws SQLException;
+  void insert(User user, UserType userType) throws SQLException;
 }

--- a/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
@@ -1,11 +1,9 @@
 package games.strategy.engine.lobby.server.login;
 
-import java.time.Instant;
-
 import games.strategy.engine.lobby.server.User;
 
 interface AccessLog {
-  void logFailedAuthentication(Instant instant, User user, UserType userType, String errorMessage);
+  void logFailedAuthentication(User user, UserType userType, String errorMessage);
 
-  void logSuccessfulAuthentication(Instant instant, User user, UserType userType);
+  void logSuccessfulAuthentication(User user, UserType userType);
 }

--- a/src/main/java/games/strategy/engine/lobby/server/login/CompositeAccessLog.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/CompositeAccessLog.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.server.login;
 
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -30,14 +29,9 @@ final class CompositeAccessLog implements AccessLog {
   }
 
   @Override
-  public void logFailedAuthentication(
-      final Instant instant,
-      final User user,
-      final UserType userType,
-      final String errorMessage) {
-    logger.info(String.format("Failed authentication by %s user at [%s]: name: %s, IP: %s, MAC: %s, error: %s",
+  public void logFailedAuthentication(final User user, final UserType userType, final String errorMessage) {
+    logger.info(String.format("Failed authentication by %s user: name: %s, IP: %s, MAC: %s, error: %s",
         userType.toString().toLowerCase(),
-        instant,
         user.getUsername(),
         user.getInetAddress().getHostAddress(),
         user.getHashedMacAddress(),
@@ -45,16 +39,15 @@ final class CompositeAccessLog implements AccessLog {
   }
 
   @Override
-  public void logSuccessfulAuthentication(final Instant instant, final User user, final UserType userType) {
-    logger.info(String.format("Successful authentication by %s user at [%s]: name: %s, IP: %s, MAC: %s",
+  public void logSuccessfulAuthentication(final User user, final UserType userType) {
+    logger.info(String.format("Successful authentication by %s user: name: %s, IP: %s, MAC: %s",
         userType.toString().toLowerCase(),
-        instant,
         user.getUsername(),
         user.getInetAddress().getHostAddress(),
         user.getHashedMacAddress()));
 
     try {
-      accessLogDao.insert(instant, user, userType);
+      accessLogDao.insert(user, userType);
     } catch (final SQLException e) {
       logger.log(Level.SEVERE, "failed to record successful authentication in database", e);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -3,7 +3,6 @@ package games.strategy.engine.lobby.server.login;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,9 +197,9 @@ public final class LobbyLoginValidator implements ILoginValidator {
 
   private void logAuthenticationResult(final User user, final UserType userType, final @Nullable String errorMessage) {
     if (errorMessage == null) {
-      accessLog.logSuccessfulAuthentication(Instant.now(), user, userType);
+      accessLog.logSuccessfulAuthentication(user, userType);
     } else {
-      accessLog.logFailedAuthentication(Instant.now(), user, userType, errorMessage);
+      accessLog.logFailedAuthentication(user, userType, errorMessage);
     }
   }
 

--- a/src/test/java/games/strategy/engine/lobby/server/login/CompositeAccessLogTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/CompositeAccessLogTest.java
@@ -4,8 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.time.Instant;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,25 +23,23 @@ public final class CompositeAccessLogTest {
   @InjectMocks
   private CompositeAccessLog compositeAccessLog;
 
-  private final Instant instant = Instant.now();
-
   private final User user = TestUserUtils.newUser();
 
   @Test
   public void logFailedAuthentication_ShouldNotAddDatabaseAccessLogRecord() throws Exception {
     for (final UserType userType : UserType.values()) {
-      compositeAccessLog.logFailedAuthentication(instant, user, userType, "error message");
+      compositeAccessLog.logFailedAuthentication(user, userType, "error message");
 
-      verify(accessLogDao, never()).insert(any(Instant.class), any(User.class), any(UserType.class));
+      verify(accessLogDao, never()).insert(any(User.class), any(UserType.class));
     }
   }
 
   @Test
   public void logSuccessfulAuthentication_ShouldAddDatabaseAccessLogRecord() throws Exception {
     for (final UserType userType : UserType.values()) {
-      compositeAccessLog.logSuccessfulAuthentication(instant, user, userType);
+      compositeAccessLog.logSuccessfulAuthentication(user, userType);
 
-      verify(accessLogDao).insert(instant, user, userType);
+      verify(accessLogDao).insert(user, userType);
     }
   }
 }

--- a/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -185,11 +184,11 @@ public final class LobbyLoginValidatorTest {
     }
 
     final void thenAccessLogShouldReceiveFailedAuthentication(final UserType userType) {
-      verify(accessLog).logFailedAuthentication(any(Instant.class), eq(user), eq(userType), anyString());
+      verify(accessLog).logFailedAuthentication(eq(user), eq(userType), anyString());
     }
 
     final void thenAccessLogShouldReceiveSuccessfulAuthentication(final UserType userType) {
-      verify(accessLog).logSuccessfulAuthentication(any(Instant.class), eq(user), eq(userType));
+      verify(accessLog).logSuccessfulAuthentication(eq(user), eq(userType));
     }
 
     final void thenAuthenticationShouldFail() {


### PR DESCRIPTION
(**NOTE:** This PR shouldn't be merged until #2987 is fully approved since it uses the same technique to retroactively change a database migration script.)

In #2977, I argued against having the database automatically populate the `access_log` table's `access_time` column value for the following reasons:

1. It would be harder to test because there is no natural primary key for this table, so without knowing all column values, there is a small possibility of aliasing when querying for an inserted record.
1. There are multiple access log sinks (database and `Logger`), and they both should share the same timestamp in case the two sinks were ever cross-referenced.

It turns out I didn't think through (2) well enough.  While, yes, we can include the timestamp in the `Logger` output, the `Logger` itself is going to annotate the log message with its own timestamp, for a net result of two timestamps per log record.  That seems redundant, even if one of them represents the accurate authentication time (which for all reasonable cases will be identical to the timestamp supplied by the `Logger`).  So this is, at best, a weak argument.

When I argued (1), I believe I was using hard-coded values in the tests for all columns, which would have made aliasing a real possibility if the test didn't know what value of `access_time` to query for when checking for success.  However, since then, I changed the test to generate random values for the `username`, `ip`, and `mac` columns for each test run.  So the likelihood of aliasing (and thus a flaky test) should now be highly unlikely.

Therefore, this PR implements the original recommendation to simply use a default value of `now()` for the `access_time` column and have the DAO not be concerned about it.