### PR TITLE
Add Player Resource Bar

### DIFF
--- a/src/main/java/games/strategy/engine/data/ResourceList.java
+++ b/src/main/java/games/strategy/engine/data/ResourceList.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.data;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ResourceList extends GameDataComponent {
   private static final long serialVersionUID = -8812702449627698253L;
-  private final Map<String, Resource> m_resourceList = new HashMap<>();
+  private final Map<String, Resource> m_resourceList = new LinkedHashMap<>();
 
   public ResourceList(final GameData data) {
     super(data);

--- a/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -81,6 +81,8 @@ public class ResourceImageFactory {
 
   /**
    * Return a icon image.
+   *
+   * @throws IllegalStateException if image can't be found
    */
   public ImageIcon getIcon(final Resource type, final boolean large) {
     final String fullName = type.getName() + (large ? "_large" : "");

--- a/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -47,12 +47,12 @@ public class EconomyPanel extends AbstractStatPanel {
     private String[][] collectedData;
 
     public ResourceTableModel() {
-      setResourceCollums();
+      setResourceColumns();
       gameData.addDataChangeListener(this);
       isDirty = true;
     }
 
-    private void setResourceCollums() {
+    private void setResourceColumns() {
       final List<IStat> statList = new ArrayList<>();
       for (final Resource resource : gameData.getResourceList().getResources()) {
         if (resource.getName().equals(Constants.TECH_TOKENS) || resource.getName().equals(Constants.VPS)) {

--- a/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -1,0 +1,87 @@
+package games.strategy.triplea.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.border.EtchedBorder;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.events.GameDataChangeListener;
+import games.strategy.engine.stats.IStat;
+import games.strategy.triplea.Constants;
+
+/**
+ * Panel used to display the current players resources.
+ */
+public class ResourceBar extends AbstractStatPanel implements GameDataChangeListener {
+  private static final long serialVersionUID = -7713792841831042952L;
+
+  private final UiContext uiContext;
+  private IStat[] statsResource;
+  private final List<JLabel> labels = new ArrayList<>();
+
+  public ResourceBar(final GameData data, final UiContext uiContext) {
+    super(data);
+    this.uiContext = uiContext;
+    setResources();
+    initLayout();
+    gameData.addDataChangeListener(this);
+  }
+
+  @Override
+  protected void initLayout() {
+    setBorder(new EtchedBorder(EtchedBorder.RAISED));
+    labels.stream().forEachOrdered(label -> add(label));
+  }
+
+  @Override
+  public void setGameData(final GameData data) {
+    gameData.removeDataChangeListener(this);
+    gameData = data;
+    gameData.addDataChangeListener(this);
+  }
+
+  private void setResources() {
+    final List<IStat> statList = new ArrayList<>();
+    for (final Resource resource : gameData.getResourceList().getResources()) {
+      if (resource.getName().equals(Constants.VPS)) {
+        continue;
+      }
+      statList.add(new ResourceStat(resource));
+      final JLabel label = new JLabel();
+      label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 20));
+      labels.add(label);
+    }
+    statsResource = statList.toArray(new IStat[statList.size()]);
+  }
+
+  @Override
+  public void gameDataChanged(final Change change) {
+    gameData.acquireReadLock();
+    try {
+      final PlayerID player = gameData.getSequence().getStep().getPlayerId();
+      if (player != null) {
+        new ArrayList<>();
+        for (int i = 0; i < statsResource.length; i++) {
+          final String quantity = statsResource[i].getFormatter().format(statsResource[i].getValue(player, gameData));
+          try {
+            labels.get(i).setIcon(uiContext.getResourceImageFactory()
+                .getIcon(gameData.getResourceList().getResource(statsResource[i].getName()), true));
+            labels.get(i).setText(quantity);
+            labels.get(i).setToolTipText(statsResource[i].getName());
+          } catch (final IllegalStateException e) {
+            labels.get(i).setText(statsResource[i].getName() + " " + quantity);
+          }
+        }
+      }
+    } finally {
+      gameData.releaseReadLock();
+    }
+  }
+
+}

--- a/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -22,7 +22,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   private static final long serialVersionUID = -7713792841831042952L;
 
   private final UiContext uiContext;
-  private IStat[] statsResource;
+  private final List<IStat> resources = new ArrayList<>();
   private final List<JLabel> labels = new ArrayList<>();
 
   public ResourceBar(final GameData data, final UiContext uiContext) {
@@ -36,7 +36,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   @Override
   protected void initLayout() {
     setBorder(new EtchedBorder(EtchedBorder.RAISED));
-    labels.stream().forEachOrdered(label -> add(label));
+    labels.stream().forEachOrdered(this::add);
   }
 
   @Override
@@ -47,17 +47,15 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   }
 
   private void setResources() {
-    final List<IStat> statList = new ArrayList<>();
     for (final Resource resource : gameData.getResourceList().getResources()) {
       if (resource.getName().equals(Constants.VPS)) {
         continue;
       }
-      statList.add(new ResourceStat(resource));
+      resources.add(new ResourceStat(resource));
       final JLabel label = new JLabel();
       label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 20));
       labels.add(label);
     }
-    statsResource = statList.toArray(new IStat[statList.size()]);
   }
 
   @Override
@@ -66,16 +64,15 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
     try {
       final PlayerID player = gameData.getSequence().getStep().getPlayerId();
       if (player != null) {
-        new ArrayList<>();
-        for (int i = 0; i < statsResource.length; i++) {
-          final String quantity = statsResource[i].getFormatter().format(statsResource[i].getValue(player, gameData));
+        for (int i = 0; i < resources.size(); i++) {
+          final String quantity = resources.get(i).getFormatter().format(resources.get(i).getValue(player, gameData));
           try {
             labels.get(i).setIcon(uiContext.getResourceImageFactory()
-                .getIcon(gameData.getResourceList().getResource(statsResource[i].getName()), true));
+                .getIcon(gameData.getResourceList().getResource(resources.get(i).getName()), true));
             labels.get(i).setText(quantity);
-            labels.get(i).setToolTipText(statsResource[i].getName());
+            labels.get(i).setToolTipText(resources.get(i).getName());
           } catch (final IllegalStateException e) {
-            labels.get(i).setText(statsResource[i].getName() + " " + quantity);
+            labels.get(i).setText(resources.get(i).getName() + " " + quantity);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -172,6 +172,7 @@ public class TripleAFrame extends MainGameFrame {
   private final MapPanel mapPanel;
   private final MapPanelSmallView smallView;
   private final JLabel message = new JLabel("No selection");
+  private final ResourceBar resourceBar;
   private final JLabel status = new JLabel("");
   private final JLabel step = new JLabel("xxxxxx");
   private final JLabel round = new JLabel("xxxxxx");
@@ -290,7 +291,8 @@ public class TripleAFrame extends MainGameFrame {
     gameSouthPanel.setLayout(new BorderLayout());
     message.setBorder(new EtchedBorder(EtchedBorder.RAISED));
     message.setPreferredSize(message.getPreferredSize());
-    message.setText("some text to set a reasonable preferred size");
+    message.setText("some text to set a reasonable preferred size for territory name and resources");
+    resourceBar = new ResourceBar(data, uiContext);
     status.setText("some text to set a reasonable preferred size for movement error messages");
     message.setPreferredSize(message.getPreferredSize());
     status.setPreferredSize(message.getPreferredSize());
@@ -299,9 +301,11 @@ public class TripleAFrame extends MainGameFrame {
     final JPanel bottomMessagePanel = new JPanel();
     bottomMessagePanel.setLayout(new GridBagLayout());
     bottomMessagePanel.setBorder(BorderFactory.createEmptyBorder());
-    bottomMessagePanel.add(message, new GridBagConstraints(0, 0, 1, 1, .35, 1, GridBagConstraints.WEST,
+    bottomMessagePanel.add(message, new GridBagConstraints(0, 0, 1, 1, .40, 1, GridBagConstraints.WEST,
         GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-    bottomMessagePanel.add(status, new GridBagConstraints(1, 0, 1, 1, .65, 1, GridBagConstraints.CENTER,
+    bottomMessagePanel.add(resourceBar, new GridBagConstraints(1, 0, 1, 1, .30, 1, GridBagConstraints.CENTER,
+        GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+    bottomMessagePanel.add(status, new GridBagConstraints(2, 0, 1, 1, .30, 1, GridBagConstraints.EAST,
         GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
     gameSouthPanel.add(bottomMessagePanel, BorderLayout.CENTER);
     status.setBorder(new EtchedBorder(EtchedBorder.RAISED));
@@ -1428,6 +1432,7 @@ public class TripleAFrame extends MainGameFrame {
       lastStepPlayer = currentStepPlayer;
       currentStepPlayer = player;
     }
+    resourceBar.gameDataChanged(null);
     // if the game control has passed to someone else and we are not just showing the map
     // show the history
     if (player != null && !player.isNull()) {


### PR DESCRIPTION
Address first part of https://forums.triplea-game.org/topic/558/fuel-enhancements

Functional Changes
- Shows current player's resource amounts along the bottom bar. Displays proper icon if available otherwise the resource name.

Tested
- Opened around 10-15 popular maps to ensure it works. Best map to test is probably Civil War since it has a number of resources and already includes custom resource icons in the map zip.

Example
![image](https://user-images.githubusercontent.com/1427689/36338023-27fb6dee-136a-11e8-916d-913d6d39fbe5.png)
