### PR TITLE
Add new resource attribute isDisplayFor

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -732,11 +732,25 @@ public final class GameParser {
     }
   }
 
-  private void parseResources(final Element root) {
-    getChildren("resource", root).stream()
-        .map(e -> e.getAttribute("name"))
-        .map(name -> new Resource(name, data))
-        .forEach(data.getResourceList()::addResource);
+  private void parseResources(final Element root) throws GameParseException {
+    for (final Element element : getChildren("resource", root)) {
+      final String name = element.getAttribute("name");
+      final String isDisplayedFor = element.getAttribute("isDisplayedFor");
+      final List<PlayerID> players = data.getPlayerList().getPlayers();
+      if (isDisplayedFor.equalsIgnoreCase("NONE")) {
+        players.clear();
+      } else if (!isDisplayedFor.isEmpty()) {
+        players.clear();
+        for (final String s : isDisplayedFor.split(":")) {
+          final PlayerID player = data.getPlayerList().getPlayerId(s);
+          if (player == null) {
+            throw new GameParseException("Parse resources could not find player: " + s);
+          }
+          players.add(player);
+        }
+      }
+      data.getResourceList().addResource(new Resource(name, data, players));
+    }
   }
 
   private void parseRelationshipTypes(final Element root) {

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -61,6 +61,8 @@ import games.strategy.util.Version;
  */
 public final class GameParser {
   private static final Class<?>[] SETTER_ARGS = {String.class};
+  private static final String RESOURCE_IS_DISPLAY_FOR_NONE = "NONE";
+
   private final GameData data = new GameData();
   private final Collection<SAXParseException> errorsSax = new ArrayList<>();
   public static final String DTD_FILE_NAME = "game.dtd";
@@ -737,7 +739,7 @@ public final class GameParser {
       final String name = element.getAttribute("name");
       final String isDisplayedFor = element.getAttribute("isDisplayedFor");
       final List<PlayerID> players = data.getPlayerList().getPlayers();
-      if (isDisplayedFor.equalsIgnoreCase("NONE")) {
+      if (isDisplayedFor.equalsIgnoreCase(RESOURCE_IS_DISPLAY_FOR_NONE)) {
         players.clear();
       } else if (!isDisplayedFor.isEmpty()) {
         players.clear();

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -738,11 +738,12 @@ public final class GameParser {
     for (final Element element : getChildren("resource", root)) {
       final String name = element.getAttribute("name");
       final String isDisplayedFor = element.getAttribute("isDisplayedFor");
-      final List<PlayerID> players = data.getPlayerList().getPlayers();
-      if (isDisplayedFor.equalsIgnoreCase(RESOURCE_IS_DISPLAY_FOR_NONE)) {
-        players.clear();
-      } else if (!isDisplayedFor.isEmpty()) {
-        players.clear();
+      if (isDisplayedFor.isEmpty()) {
+        data.getResourceList().addResource(new Resource(name, data, data.getPlayerList().getPlayers()));
+      } else if (isDisplayedFor.equalsIgnoreCase(RESOURCE_IS_DISPLAY_FOR_NONE)) {
+        data.getResourceList().addResource(new Resource(name, data));
+      } else {
+        final List<PlayerID> players = new ArrayList<>();
         for (final String s : isDisplayedFor.split(":")) {
           final PlayerID player = data.getPlayerList().getPlayerId(s);
           if (player == null) {
@@ -750,8 +751,8 @@ public final class GameParser {
           }
           players.add(player);
         }
+        data.getResourceList().addResource(new Resource(name, data, players));
       }
-      data.getResourceList().addResource(new Resource(name, data, players));
     }
   }
 

--- a/src/main/java/games/strategy/engine/data/Resource.java
+++ b/src/main/java/games/strategy/engine/data/Resource.java
@@ -1,7 +1,12 @@
 package games.strategy.engine.data;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Resource extends NamedAttachable {
   private static final long serialVersionUID = 7471431759007499935L;
+
+  private List<PlayerID> players = new ArrayList<>();
 
   /**
    * Creates new Resource.
@@ -14,4 +19,14 @@ public class Resource extends NamedAttachable {
   public Resource(final String name, final GameData data) {
     super(name, data);
   }
+
+  public Resource(final String name, final GameData data, final List<PlayerID> players) {
+    this(name, data);
+    this.players = players;
+  }
+
+  public boolean isDisplayedFor(final PlayerID player) {
+    return players != null ? players.contains(player) : true;
+  }
+
 }

--- a/src/main/java/games/strategy/engine/data/Resource.java
+++ b/src/main/java/games/strategy/engine/data/Resource.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class Resource extends NamedAttachable {
   private static final long serialVersionUID = 7471431759007499935L;
 
-  private List<PlayerID> players = new ArrayList<>();
+  private final List<PlayerID> players;
 
   /**
    * Creates new Resource.

--- a/src/main/java/games/strategy/engine/data/Resource.java
+++ b/src/main/java/games/strategy/engine/data/Resource.java
@@ -17,16 +17,17 @@ public class Resource extends NamedAttachable {
    *        game data
    */
   public Resource(final String name, final GameData data) {
-    super(name, data);
+    this(name, data, new ArrayList<>());
   }
 
   public Resource(final String name, final GameData data, final List<PlayerID> players) {
-    this(name, data);
+    super(name, data);
     this.players = players;
   }
 
   public boolean isDisplayedFor(final PlayerID player) {
-    return players != null ? players.contains(player) : true;
+    // TODO: remove null check on incompatible release
+    return players == null || players.contains(player);
   }
 
 }

--- a/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ui;
 
+import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   private static final long serialVersionUID = -7713792841831042952L;
 
   private final UiContext uiContext;
-  private final List<IStat> resources = new ArrayList<>();
+  private final List<IStat> resourceStats = new ArrayList<>();
   private final List<JLabel> labels = new ArrayList<>();
 
   public ResourceBar(final GameData data, final UiContext uiContext) {
@@ -37,6 +38,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   protected void initLayout() {
     setBorder(new EtchedBorder(EtchedBorder.RAISED));
     labels.stream().forEachOrdered(this::add);
+    this.setPreferredSize(new Dimension(400, 0));
   }
 
   @Override
@@ -51,7 +53,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
       if (resource.getName().equals(Constants.VPS)) {
         continue;
       }
-      resources.add(new ResourceStat(resource));
+      resourceStats.add(new ResourceStat(resource));
       final JLabel label = new JLabel();
       label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 20));
       labels.add(label);
@@ -64,15 +66,17 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
     try {
       final PlayerID player = gameData.getSequence().getStep().getPlayerId();
       if (player != null) {
-        for (int i = 0; i < resources.size(); i++) {
-          final String quantity = resources.get(i).getFormatter().format(resources.get(i).getValue(player, gameData));
+        for (int i = 0; i < resourceStats.size(); i++) {
+          final IStat resourceStat = resourceStats.get(i);
+          final Resource resource = gameData.getResourceList().getResource(resourceStat.getName());
+          final String quantity = resourceStat.getFormatter().format(resourceStat.getValue(player, gameData));
+          labels.get(i).setVisible(resource.isDisplayedFor(player));
           try {
-            labels.get(i).setIcon(uiContext.getResourceImageFactory()
-                .getIcon(gameData.getResourceList().getResource(resources.get(i).getName()), true));
+            labels.get(i).setIcon(uiContext.getResourceImageFactory().getIcon(resource, true));
             labels.get(i).setText(quantity);
-            labels.get(i).setToolTipText(resources.get(i).getName());
+            labels.get(i).setToolTipText(resourceStat.getName());
           } catch (final IllegalStateException e) {
-            labels.get(i).setText(resources.get(i).getName() + " " + quantity);
+            labels.get(i).setText(resourceStat.getName() + " " + quantity);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -12,7 +12,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.events.GameDataChangeListener;
-import games.strategy.engine.stats.IStat;
 import games.strategy.triplea.Constants;
 
 /**
@@ -22,7 +21,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   private static final long serialVersionUID = -7713792841831042952L;
 
   private final UiContext uiContext;
-  private final List<IStat> resourceStats = new ArrayList<>();
+  private final List<ResourceStat> resourceStats = new ArrayList<>();
   private final List<JLabel> labels = new ArrayList<>();
 
   public ResourceBar(final GameData data, final UiContext uiContext) {
@@ -65,16 +64,17 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
       final PlayerID player = gameData.getSequence().getStep().getPlayerId();
       if (player != null) {
         for (int i = 0; i < resourceStats.size(); i++) {
-          final IStat resourceStat = resourceStats.get(i);
-          final Resource resource = gameData.getResourceList().getResource(resourceStat.getName());
+          final ResourceStat resourceStat = resourceStats.get(i);
+          final Resource resource = resourceStat.resource;
+          final JLabel label = labels.get(i);
           final String quantity = resourceStat.getFormatter().format(resourceStat.getValue(player, gameData));
-          labels.get(i).setVisible(resource.isDisplayedFor(player));
+          label.setVisible(resource.isDisplayedFor(player));
           try {
-            labels.get(i).setIcon(uiContext.getResourceImageFactory().getIcon(resource, true));
-            labels.get(i).setText(quantity);
-            labels.get(i).setToolTipText(resourceStat.getName());
+            label.setIcon(uiContext.getResourceImageFactory().getIcon(resource, true));
+            label.setText(quantity);
+            label.setToolTipText(resourceStat.getName());
           } catch (final IllegalStateException e) {
-            labels.get(i).setText(resourceStat.getName() + " " + quantity);
+            label.setText(resourceStat.getName() + " " + quantity);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.ui;
 
-import java.awt.Dimension;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +37,6 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   protected void initLayout() {
     setBorder(new EtchedBorder(EtchedBorder.RAISED));
     labels.stream().forEachOrdered(this::add);
-    this.setPreferredSize(new Dimension(400, 0));
   }
 
   @Override

--- a/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -61,6 +61,7 @@
 	<!ELEMENT resource EMPTY>
 	<!ATTLIST resource 
 		name ID #REQUIRED
+		isDisplayedFor CDATA #IMPLIED
 	>
 
 <!ELEMENT unitList (unit+) >


### PR DESCRIPTION
Addresses portion of https://forums.triplea-game.org/topic/558/fuel-enhancements

**Functional Changes**
- Added new isDisplayFor property for resources which can be "NONE" or list of players (defaults to showing for all players). Primarily used to display/hide certain resources for specific nations. Follows up the changes in #3013 .

**Example**
```
  <resourceList>
    <resource name="techTokens" isDisplayedFor="NONE"/>
    <resource name="PUs" isDisplayedFor="Union"/>
    <resource name="Manpower" isDisplayedFor="Confederate"/>
    <resource name="Supplies" isDisplayedFor="Union:Confederate"/>
    <resource name="Industry"/>
    <resource name="Leadership"/>
  </resourceList>
```