### PR TITLE
Error Prone: Fix obsolete JDK API usage violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -107,6 +107,7 @@ public class GameData implements Serializable {
   private transient volatile boolean testLockIsHeld = false;
   private final List<Tuple<IAttachment, ArrayList<Tuple<String, String>>>> attachmentOrderAndValues =
       new ArrayList<>();
+  // TODO: change to Map/HashMap upon next incompatible release
   private final Hashtable<String, TerritoryEffect> territoryEffectList = new Hashtable<>();
   private final BattleRecordsList battleRecordsList = new BattleRecordsList(this);
 
@@ -463,7 +464,7 @@ public class GameData implements Serializable {
     return relationships;
   }
 
-  public Hashtable<String, TerritoryEffect> getTerritoryEffectList() {
+  public Map<String, TerritoryEffect> getTerritoryEffectList() {
     return territoryEffectList;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -3,10 +3,11 @@ package games.strategy.engine.data.properties;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Vector;
 
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+
+import games.strategy.ui.SwingComponents;
 
 /**
  * A property that uses a list for selecting the value.
@@ -53,7 +54,7 @@ public class ComboProperty<T> extends AEditableProperty {
 
   @Override
   public JComponent getEditorComponent() {
-    final JComboBox<T> box = new JComboBox<>(new Vector<>(possibleValues));
+    final JComboBox<T> box = new JComboBox<>(SwingComponents.newComboBoxModel(possibleValues));
     box.setSelectedItem(value);
     box.addActionListener(e -> value = box.getItemAt(box.getSelectedIndex()));
     return box;

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -382,10 +382,10 @@ public class DownloadMapsWindow extends JFrame {
 
     final JLabel mapSizeLabel = new JLabel(" ");
 
-    final DefaultListModel<String> model = SwingComponents.newJListModel(maps, map -> map.getMapName());
-
-
     if (maps.size() > 0) {
+      final DefaultListModel<String> model = new DefaultListModel<>();
+      maps.stream().map(DownloadFileDescription::getMapName).forEach(model::addElement);
+
       final DownloadFileDescription mapToSelect = determineCurrentMapSelection(maps, selectedMap);
       final JList<String> gamesList = createGameSelectionList(mapToSelect, maps, descriptionPane, model);
       gamesList.addListSelectionListener(createDescriptionPanelUpdatingSelectionListener(
@@ -423,8 +423,7 @@ public class DownloadMapsWindow extends JFrame {
   private static JList<String> createGameSelectionList(final DownloadFileDescription selectedMap,
       final List<DownloadFileDescription> maps, final JEditorPane descriptionPanel,
       final DefaultListModel<String> model) {
-
-    final JList<String> gamesList = SwingComponents.newJList(model);
+    final JList<String> gamesList = new JList<>(model);
     final int selectedIndex = maps.indexOf(selectedMap);
     gamesList.setSelectedIndex(selectedIndex);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -29,6 +29,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 public class ExecutionStack implements Serializable {
   private static final long serialVersionUID = -8675285470515074530L;
   private IExecutable m_current;
+  // TODO: change to Deque/ArrayDeque upon next incompatible release
   private final Stack<IExecutable> m_stack = new Stack<>();
 
   void execute(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -20,12 +20,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Hashtable;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -76,6 +75,7 @@ import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.ui.IntTextField;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
+import games.strategy.ui.SwingComponents;
 import games.strategy.ui.WidgetChangedListener;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
@@ -332,7 +332,7 @@ class OddsCalculatorPanel extends JPanel {
       final List<String> selected = territoryEffectsJList.getSelectedValuesList();
       data.acquireReadLock();
       try {
-        final Hashtable<String, TerritoryEffect> allTerritoryEffects = data.getTerritoryEffectList();
+        final Map<String, TerritoryEffect> allTerritoryEffects = data.getTerritoryEffectList();
         for (final String selection : selected) {
           if (selection.equals(NO_EFFECTS)) {
             territoryEffects.clear();
@@ -652,17 +652,17 @@ class OddsCalculatorPanel extends JPanel {
       if (doesPlayerHaveUnitsOnMap(PlayerID.NULL_PLAYERID, data)) {
         playerList.add(PlayerID.NULL_PLAYERID);
       }
-      attackerCombo = new JComboBox<>(new Vector<>(playerList));
-      defenderCombo = new JComboBox<>(new Vector<>(playerList));
-      swapSidesCombo = new JComboBox<>(new Vector<>(playerList));
-      final Hashtable<String, TerritoryEffect> allTerritoryEffects = data.getTerritoryEffectList();
+      attackerCombo = new JComboBox<>(SwingComponents.newComboBoxModel(playerList));
+      defenderCombo = new JComboBox<>(SwingComponents.newComboBoxModel(playerList));
+      swapSidesCombo = new JComboBox<>(SwingComponents.newComboBoxModel(playerList));
+      final Map<String, TerritoryEffect> allTerritoryEffects = data.getTerritoryEffectList();
       if (allTerritoryEffects == null || allTerritoryEffects.isEmpty()) {
         territoryEffectsJList = null;
       } else {
-        final Vector<String> effectNames = new Vector<>();
+        final List<String> effectNames = new ArrayList<>();
         effectNames.add(NO_EFFECTS);
         effectNames.addAll(allTerritoryEffects.keySet());
-        territoryEffectsJList = new JList<>(effectNames);
+        territoryEffectsJList = new JList<>(SwingComponents.newListModel(effectNames));
         territoryEffectsJList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         territoryEffectsJList.setLayoutOrientation(JList.VERTICAL);
         // equal to the amount of space left (number of remaining items on the right)

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -426,8 +425,8 @@ public class BattleDisplay extends JPanel {
       imagePanel.add(retreatTerritory);
       imagePanel.setBorder(new EmptyBorder(10, 10, 10, 0));
       this.add(imagePanel, BorderLayout.EAST);
-      final Vector<Territory> listElements = new Vector<>(possible);
-      list = new JList<>(listElements);
+      final List<Territory> listElements = new ArrayList<>(possible);
+      list = new JList<>(SwingComponents.newListModel(listElements));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       if (listElements.size() >= 1) {
         list.setSelectedIndex(0);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -6,13 +6,13 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.Vector;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -46,6 +46,7 @@ import games.strategy.triplea.delegate.dataObjects.CasualtyList;
 import games.strategy.triplea.delegate.dataObjects.FightBattleDetails;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
+import games.strategy.ui.SwingComponents;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.Interruptibles;
 import swinglib.JPanelBuilder;
@@ -528,11 +529,11 @@ public class BattlePanel extends ActionPanel {
       final String unitName = unit.getType().getName() + " in " + unitTerritory;
       final JLabel label = new JLabel("Which territory should " + unitName + " bombard?");
       this.add(label, BorderLayout.NORTH);
-      final Vector<Object> listElements = new Vector<>(territories);
+      final List<Object> listElements = new ArrayList<>(territories);
       if (noneAvailable) {
         listElements.add(0, "None");
       }
-      list = new JList<>(listElements);
+      list = new JList<>(SwingComponents.newListModel(listElements));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       if (listElements.size() >= 1) {
         list.setSelectedIndex(0);

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Vector;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -62,6 +61,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.ui.SwingComponents;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Triple;
@@ -249,10 +249,10 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final Vector<TechAdvance> techs;
+        final Collection<TechAdvance> techs;
         getData().acquireReadLock();
         try {
-          techs = new Vector<>(TechnologyDelegate.getAvailableTechs(player, data));
+          techs = TechnologyDelegate.getAvailableTechs(player, data);
         } finally {
           getData().releaseReadLock();
         }
@@ -260,7 +260,7 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final JList<TechAdvance> techList = new JList<>(techs);
+        final JList<TechAdvance> techList = new JList<>(SwingComponents.newListModel(techs));
         techList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         techList.setLayoutOrientation(JList.VERTICAL);
         techList.setVisibleRowCount(10);
@@ -296,10 +296,10 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final Vector<TechAdvance> techs;
+        final Collection<TechAdvance> techs;
         getData().acquireReadLock();
         try {
-          techs = new Vector<>(TechTracker.getCurrentTechAdvances(player, data));
+          techs = TechTracker.getCurrentTechAdvances(player, data);
           // there is no way to "undo" these two techs, so do not allow them to be removed
           final Iterator<TechAdvance> iter = techs.iterator();
           while (iter.hasNext()) {
@@ -316,7 +316,7 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final JList<TechAdvance> techList = new JList<>(techs);
+        final JList<TechAdvance> techList = new JList<>(SwingComponents.newListModel(techs));
         techList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         techList.setLayoutOrientation(JList.VERTICAL);
         techList.setVisibleRowCount(10);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Vector;
 
 import javax.swing.Action;
 import javax.swing.JButton;
@@ -34,6 +33,7 @@ import games.strategy.triplea.delegate.dataObjects.TechRoll;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
 import games.strategy.ui.SwingAction;
+import games.strategy.ui.SwingComponents;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
@@ -107,7 +107,7 @@ public class TechPanel extends ActionPanel {
         JOptionPane.showMessageDialog(TechPanel.this, "No more available tech advances");
         return;
       }
-      final JList<TechAdvance> list = new JList<>(new Vector<>(available));
+      final JList<TechAdvance> list = new JList<>(SwingComponents.newListModel(available));
       final JPanel panel = new JPanel();
       panel.setLayout(new BorderLayout());
       panel.add(list, BorderLayout.CENTER);
@@ -160,7 +160,7 @@ public class TechPanel extends ActionPanel {
       JOptionPane.showMessageDialog(TechPanel.this, "No more available tech advances");
       return;
     }
-    final JList<TechnologyFrontier> list = new JList<TechnologyFrontier>(new Vector<>(techCategories)) {
+    final JList<TechnologyFrontier> list = new JList<TechnologyFrontier>(SwingComponents.newListModel(techCategories)) {
       private static final long serialVersionUID = 35094445315520702L;
 
       @Override
@@ -212,15 +212,16 @@ public class TechPanel extends ActionPanel {
       if (techCategories.isEmpty()) {
         return;
       }
-      final JList<TechnologyFrontier> list = new JList<TechnologyFrontier>(new Vector<>(techCategories)) {
-        private static final long serialVersionUID = -8415987764855418565L;
+      final JList<TechnologyFrontier> list =
+          new JList<TechnologyFrontier>(SwingComponents.newListModel(techCategories)) {
+            private static final long serialVersionUID = -8415987764855418565L;
 
-        @Override
-        public String getToolTipText(final MouseEvent e) {
-          final int index = locationToIndex(e.getPoint());
-          return (-1 < index) ? getTechListToolTipText(getModel().getElementAt(index)) : null;
-        }
-      };
+            @Override
+            public String getToolTipText(final MouseEvent e) {
+              final int index = locationToIndex(e.getPoint());
+              return (-1 < index) ? getTechListToolTipText(getModel().getElementAt(index)) : null;
+            }
+          };
       final JPanel panel = new JPanel();
       panel.setLayout(new BorderLayout());
       panel.add(list, BorderLayout.CENTER);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -4,7 +4,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.util.Vector;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -16,6 +15,7 @@ import javax.swing.JScrollPane;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.dataObjects.TechResults;
+import games.strategy.ui.SwingComponents;
 
 public class TechResultsDisplay extends JPanel {
   private static final long serialVersionUID = -8303376983862918107L;
@@ -27,7 +27,7 @@ public class TechResultsDisplay extends JPanel {
     if (msg.getHits() != 0) {
       add(new JLabel("Technologies discovered:"), new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.WEST,
           GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
-      final JList<String> list = new JList<>(new Vector<>(msg.getAdvances()));
+      final JList<String> list = new JList<>(SwingComponents.newListModel(msg.getAdvances()));
       add(list, new GridBagConstraints(0, 2, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
           new Insets(0, 0, 5, 0), 0, 0));
       list.setBackground(this.getBackground());

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -902,7 +901,7 @@ public class TripleAFrame extends MainGameFrame {
     final AtomicReference<Unit> selected = new AtomicReference<>();
     final String message = "Select bombing target in " + territory.getName();
     final Supplier<Tuple<JPanel, JList<Unit>>> action = () -> {
-      final JList<Unit> list = new JList<>(new Vector<>(potentialTargets));
+      final JList<Unit> list = new JList<>(SwingComponents.newListModel(potentialTargets));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       list.setSelectedIndex(0);
       list.setCellRenderer(new UnitRenderer());
@@ -998,7 +997,7 @@ public class TripleAFrame extends MainGameFrame {
     messageAndDialogThreadPool.waitForAll();
     final Supplier<Tuple<JPanel, JList<Territory>>> action = () -> {
       mapPanel.centerOn(currentTerritory);
-      final JList<Territory> list = new JList<>(new Vector<>(candidates));
+      final JList<Territory> list = new JList<>(SwingComponents.newListModel(candidates));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       list.setSelectedIndex(0);
       final JPanel panel = new JPanel();
@@ -1368,7 +1367,7 @@ public class TripleAFrame extends MainGameFrame {
     mapPanel.centerOn(from);
 
     final Supplier<Territory> action = () -> {
-      final JList<Territory> list = new JList<>(new Vector<>(candidates));
+      final JList<Territory> list = new JList<>(SwingComponents.newListModel(candidates));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
       list.setSelectedIndex(0);
       final JPanel panel = new JPanel();

--- a/game-core/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/game-core/src/main/java/games/strategy/ui/SwingComponents.java
@@ -17,21 +17,20 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
 
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
+import javax.swing.ComboBoxModel;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
-import javax.swing.JList;
 import javax.swing.JMenu;
 import javax.swing.JOptionPane;
 import javax.swing.JRadioButton;
@@ -39,6 +38,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
+import javax.swing.ListModel;
 import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
@@ -276,14 +276,34 @@ public class SwingComponents {
     });
   }
 
-  public static <T> DefaultListModel<String> newJListModel(final List<T> maps, final Function<T, String> mapper) {
-    final DefaultListModel<String> model = new DefaultListModel<>();
-    maps.stream().map(mapper).forEach(model::addElement);
-    return model;
+  /**
+   * Creates a new combo box model containing a copy of the specified collection of values.
+   *
+   * @param values The values used to populate the combo box model.
+   *
+   * @return A new combo box model.
+   */
+  public static <T> ComboBoxModel<T> newComboBoxModel(final Collection<T> values) {
+    checkNotNull(values);
+
+    final DefaultComboBoxModel<T> comboBoxModel = new DefaultComboBoxModel<>();
+    values.forEach(comboBoxModel::addElement);
+    return comboBoxModel;
   }
 
-  public static JList<String> newJList(final DefaultListModel<String> listModel) {
-    return new JList<>(listModel);
+  /**
+   * Creates a new list model containing a copy of the specified collection of values.
+   *
+   * @param values The values used to populate the list model.
+   *
+   * @return A new list model.
+   */
+  public static <T> ListModel<T> newListModel(final Collection<T> values) {
+    checkNotNull(values);
+
+    final DefaultListModel<T> listModel = new DefaultListModel<>();
+    values.forEach(listModel::addElement);
+    return listModel;
   }
 
   public static JEditorPane newHtmlJEditorPane() {


### PR DESCRIPTION
This PR fixes violations of the Error Prone JdkObsolete rule.

Most of these were due to the use of `Vector` because the `DefaultComboBoxModel` and `DefaultListModel` constructors only accept arrays and `Vector`s.  I extracted two helper methods to `SwingComponents` to encapsulate wrapping a `Collection` in both of the Swing models.  These two implementations could probably have been optimized with custom `ComboBoxModel` and `ListModel` types, but instead I chose to preserve existing behavior (i.e. using an underlying `Vector`) just in case there was some cross-thread access going on someplace.

There were two cases I couldn't fix without breaking compatibility.  For those, I simply added TODOs to be addressed upon the next incompatible release.