### PR TITLE
[Do not merge] Remove master suffix requirement (partially)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -168,7 +168,6 @@ public final class AvailableGames {
   }
 
   public boolean containsMapName(final String mapNameProperty) {
-    return availableMapFolderOrZipNames.contains(mapNameProperty)
-        || availableMapFolderOrZipNames.contains(mapNameProperty + "-master");
+    return availableMapFolderOrZipNames.contains(mapNameProperty);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -115,8 +115,7 @@ public class DownloadFileDescription {
 
   /** File reference for where to install the file. */
   File getInstallLocation() {
-    final String masterSuffix = (getMapZipFileName().toLowerCase().endsWith("master.zip")) ? "-master" : "";
-    final String normalizedMapName = getMapName().toLowerCase().replace(' ', '_') + masterSuffix + ".zip";
+    final String normalizedMapName = getMapName().toLowerCase().replace(' ', '_') + ".zip";
     return new File(ClientFileSystemHelper.getUserMapsFolder() + File.separator + normalizedMapName);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -89,6 +89,7 @@ public class ResourceLoader implements Closeable {
     final String normalizedMapName = normalizeMapName(mapName);
     return Arrays.asList(
         new File(userMapsFolder, mapName + ".zip"),
+        new File(userMapsFolder, normalizedMapName + "-master.zip"), 
         new File(userMapsFolder, normalizedMapName + ".zip"));
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -89,7 +89,6 @@ public class ResourceLoader implements Closeable {
     final String normalizedMapName = normalizeMapName(mapName);
     return Arrays.asList(
         new File(userMapsFolder, mapName + ".zip"),
-        new File(userMapsFolder, normalizedMapName + "-master.zip"),
         new File(userMapsFolder, normalizedMapName + ".zip"));
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -13,7 +13,7 @@ class ResourceLocationTracker {
    */
   static final String MASTER_ZIP_MAGIC_PREFIX = "-master/map/";
 
-  static final String MASTER_ZIP_IDENTIFYING_SUFFIX = "-master.zip";
+  static final String ZIP_IDENTIFYING_SUFFIX = ".zip";
 
   private final String mapPrefix;
 
@@ -25,16 +25,16 @@ class ResourceLocationTracker {
    *        loaded from a zip or a directory, and if zip, if it matches any particular naming.
    */
   ResourceLocationTracker(final String mapName, final URL[] resourcePaths) {
-    final boolean isUsingMasterZip = Arrays.stream(resourcePaths)
+    final boolean isUsingZip = Arrays.stream(resourcePaths)
         .map(Object::toString)
-        .anyMatch(path -> path.endsWith(MASTER_ZIP_IDENTIFYING_SUFFIX));
+        .anyMatch(path -> path.endsWith(ZIP_IDENTIFYING_SUFFIX));
 
 
     // map skins will have the full path name as their map name.
-    if (mapName.endsWith("-master.zip")) {
+    if (mapName.endsWith(".zip")) {
       mapPrefix = mapName.substring(0, mapName.length() - "-master.zip".length()) + MASTER_ZIP_MAGIC_PREFIX;
     } else {
-      mapPrefix = isUsingMasterZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";
+      mapPrefix = isUsingZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -250,7 +250,7 @@ public abstract class AbstractUiContext implements UiContext {
     final Map<String, String> skinsByDisplayName = new HashMap<>();
     for (final File f : FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder())) {
       if (mapSkinNameMatchesMapName(f.getName(), mapName)) {
-        final String displayName = f.getName().replace(mapName + "-", "").replace("-master", "").replace(".zip", "");
+        final String displayName = f.getName().replace(mapName + "-", "").replace(".zip", "");
         skinsByDisplayName.put(displayName, f.getName());
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -250,7 +250,7 @@ public abstract class AbstractUiContext implements UiContext {
     final Map<String, String> skinsByDisplayName = new HashMap<>();
     for (final File f : FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder())) {
       if (mapSkinNameMatchesMapName(f.getName(), mapName)) {
-        final String displayName = f.getName().replace(mapName + "-", "").replace(".zip", "");
+        final String displayName = f.getName().replace(mapName + "-", "").replace("-master", "").replace(".zip", "");
         skinsByDisplayName.put(displayName, f.getName());
       }
     }

--- a/game-core/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
@@ -26,7 +26,7 @@ public class ResourceLocationTrackerTest {
   public void masterZipsGetSpecialPrefixBasedOnTheMapName() throws Exception {
     final String fakeMapName = "fakeMapName";
     final ResourceLocationTracker testObj = new ResourceLocationTracker(fakeMapName,
-        new URL[] {new URL("file://pretend" + ResourceLocationTracker.MASTER_ZIP_IDENTIFYING_SUFFIX)});
+        new URL[] {new URL("file://pretend" + ResourceLocationTracker.ZIP_IDENTIFYING_SUFFIX)});
     assertThat(testObj.getMapPrefix(), is(fakeMapName + ResourceLocationTracker.MASTER_ZIP_MAGIC_PREFIX));
   }
 


### PR DESCRIPTION
The initial goal was to change the engine to just not download map zips with the -master suffix, however I noticed that github creates downloadable zip files containing a folder with the same name as the zip.
This PR works, new map files are being downloaded as just <mapname>.zip without the master suffix, and old map files with the master suffix are still being recognized and playable, however as you might have expected already there are a couple of flaws with this_
1. The old "master suffix map files" aren't displayed in the download maps window, simply because the code just checks if the file that the map would be downloaded to already exists and if it does, the map is listed as existent.
2. Old map files are not being deleted when new files are being downloaded with the new naming scheme. This creates duplicate maps which is not good.
3. If we ever wanted to change the system to point at a specific github revision, the folder inside the zip would still be named <mapname>-<SHA1>, which doesn't solve the root issue of this. This problem could however be solved by just unzipping and rezipping the downloaded zip and just removing the uneccessary top level folder, which we probably want to do anyways.

In any case it seems like we need to fundamentally redesign how maps are being downloaded I opened #3030  to discuss this further.