### PR TITLE
Remove hard-coded Battle Display action button colors

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -55,7 +54,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -594,10 +592,6 @@ public class BattleDisplay extends JPanel {
     add(diceAndSteps, BorderLayout.CENTER);
     add(actionButton, BorderLayout.SOUTH);
     actionButton.setEnabled(false);
-    if (!SystemProperties.isMac()) {
-      actionButton.setBackground(Color.lightGray.darker());
-      actionButton.setForeground(Color.white);
-    }
     setDefaultWidths(defenderTable);
     setDefaultWidths(attackerTable);
 


### PR DESCRIPTION
Fixes #3018.

As discussed in that issue, the code that hard-codes the colors on the Battle Display's action button goes all the way back to 2003 (5f160f3e3), while the code that excludes Mac from the hard-coded colors was added in 2006 (6f1fc81cd).  There's probably no longer a reason that we shouldn't just let the L&F manage the colors of this button.

If we want to make the button stand out (which was the original intention of 5f160f3e3), we could do something like increase the font size or the font weight.

#### Substance

##### Before

![battle-display-substance-before](https://user-images.githubusercontent.com/4826349/36357570-ddd208bc-14cd-11e8-9a88-9fae7776af04.png)

##### After

![battle-display-substance-after](https://user-images.githubusercontent.com/4826349/36357571-e2868da6-14cd-11e8-90e5-e7350a66c867.png)

#### Nimbus

##### Before

![battle-display-nimbus-before](https://user-images.githubusercontent.com/4826349/36357576-ed7350b4-14cd-11e8-9494-a214a52f31f9.png)

##### After

![battle-display-nimbus-after](https://user-images.githubusercontent.com/4826349/36357578-f2711b78-14cd-11e8-8cd6-b8397c30bd6f.png)

