### PR TITLE
Add XML Resource Property isDisplayedFor

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Resource.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Resource.java
@@ -1,7 +1,12 @@
 package games.strategy.engine.data;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Resource extends NamedAttachable {
   private static final long serialVersionUID = 7471431759007499935L;
+
+  private final List<PlayerID> players;
 
   /**
    * Creates new Resource.
@@ -12,6 +17,17 @@ public class Resource extends NamedAttachable {
    *        game data
    */
   public Resource(final String name, final GameData data) {
-    super(name, data);
+    this(name, data, new ArrayList<>());
   }
+
+  public Resource(final String name, final GameData data, final List<PlayerID> players) {
+    super(name, data);
+    this.players = players;
+  }
+
+  public boolean isDisplayedFor(final PlayerID player) {
+    // TODO: remove null check on incompatible release
+    return players == null || players.contains(player);
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -12,7 +12,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.events.GameDataChangeListener;
-import games.strategy.engine.stats.IStat;
 import games.strategy.triplea.Constants;
 
 /**
@@ -22,7 +21,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
   private static final long serialVersionUID = -7713792841831042952L;
 
   private final UiContext uiContext;
-  private final List<IStat> resources = new ArrayList<>();
+  private final List<ResourceStat> resourceStats = new ArrayList<>();
   private final List<JLabel> labels = new ArrayList<>();
 
   public ResourceBar(final GameData data, final UiContext uiContext) {
@@ -51,7 +50,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
       if (resource.getName().equals(Constants.VPS)) {
         continue;
       }
-      resources.add(new ResourceStat(resource));
+      resourceStats.add(new ResourceStat(resource));
       final JLabel label = new JLabel();
       label.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 20));
       labels.add(label);
@@ -64,15 +63,18 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
     try {
       final PlayerID player = gameData.getSequence().getStep().getPlayerId();
       if (player != null) {
-        for (int i = 0; i < resources.size(); i++) {
-          final String quantity = resources.get(i).getFormatter().format(resources.get(i).getValue(player, gameData));
+        for (int i = 0; i < resourceStats.size(); i++) {
+          final ResourceStat resourceStat = resourceStats.get(i);
+          final Resource resource = resourceStat.resource;
+          final JLabel label = labels.get(i);
+          final String quantity = resourceStat.getFormatter().format(resourceStat.getValue(player, gameData));
+          label.setVisible(resource.isDisplayedFor(player));
           try {
-            labels.get(i).setIcon(uiContext.getResourceImageFactory()
-                .getIcon(gameData.getResourceList().getResource(resources.get(i).getName()), true));
-            labels.get(i).setText(quantity);
-            labels.get(i).setToolTipText(resources.get(i).getName());
+            label.setIcon(uiContext.getResourceImageFactory().getIcon(resource, true));
+            label.setText(quantity);
+            label.setToolTipText(resourceStat.getName());
           } catch (final IllegalStateException e) {
-            labels.get(i).setText(resources.get(i).getName() + " " + quantity);
+            label.setText(resourceStat.getName() + " " + quantity);
           }
         }
       }

--- a/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -61,6 +61,7 @@
 	<!ELEMENT resource EMPTY>
 	<!ATTLIST resource 
 		name ID #REQUIRED
+		isDisplayedFor CDATA #IMPLIED
 	>
 
 <!ELEMENT unitList (unit+) >


### PR DESCRIPTION
Addresses portion of https://forums.triplea-game.org/topic/558/fuel-enhancements

**Functional Changes**
- Added new isDisplayFor property for resources which can be "NONE" or list of players (defaults to showing for all players). Primarily used to display/hide certain resources for specific nations. Follows up the changes in #3013 .

**Example**
```
  <resourceList>
    <resource name="techTokens" isDisplayedFor="NONE"/>
    <resource name="PUs" isDisplayedFor="Union"/>
    <resource name="Manpower" isDisplayedFor="Confederate"/>
    <resource name="Supplies" isDisplayedFor="Union:Confederate"/>
    <resource name="Industry"/>
    <resource name="Leadership"/>
  </resourceList>
```