### PR TITLE
Update Logic to Consider endTurnNoPU and Add Income to Resource Bar

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -13,6 +13,8 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
+import games.strategy.util.IntegerMap;
 
 /**
  * Panel used to display the current players resources.
@@ -63,6 +65,7 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
     try {
       final PlayerID player = gameData.getSequence().getStep().getPlayerId();
       if (player != null) {
+        final IntegerMap<Resource> resourceIncomes = AbstractEndTurnDelegate.findEstimatedIncome(player, gameData);
         for (int i = 0; i < resourceStats.size(); i++) {
           final ResourceStat resourceStat = resourceStats.get(i);
           final Resource resource = resourceStat.resource;
@@ -71,10 +74,10 @@ public class ResourceBar extends AbstractStatPanel implements GameDataChangeList
           label.setVisible(resource.isDisplayedFor(player));
           try {
             label.setIcon(uiContext.getResourceImageFactory().getIcon(resource, true));
-            label.setText(quantity);
+            label.setText(quantity + " (+" + resourceIncomes.getInt(resource) + ")");
             label.setToolTipText(resourceStat.getName());
           } catch (final IllegalStateException e) {
-            label.setText(resourceStat.getName() + " " + quantity);
+            label.setText(resourceStat.getName() + " " + quantity + " (+" + resourceIncomes.getInt(resource) + ")");
           }
         }
       }


### PR DESCRIPTION
Addresses next point of https://forums.triplea-game.org/topic/558/fuel-enhancements

Functional Changes
- Add estimated income to resource bar:
![image](https://user-images.githubusercontent.com/1427689/36365812-d1508580-1510-11e8-9939-d77f9ff66970.png)
- For now, this only takes into account income from territories, units, and NOs. It ignores blockades, war bonds, triggers, relationship upkeep, and bonus income.

Tested
- Tested various maps including Civil War, revised, global