### PR TITLE
Map parsing loop fix

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -292,7 +292,7 @@ public class GameRunner {
   private static void loadGame() {
     try {
       newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
-        gameSelectorModel.loadDefaultGame(false);
+        gameSelectorModel.loadDefaultGame();
         final String fileName = System.getProperty(TRIPLEA_GAME, "");
         if (fileName.length() > 0) {
           gameSelectorModel.load(new File(fileName), mainFrame);

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -292,7 +292,7 @@ public class GameRunner {
   private static void loadGame() {
     try {
       newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
-        gameSelectorModel.loadDefaultGame();
+        gameSelectorModel.loadDefaultGameSameThread();
         final String fileName = System.getProperty(TRIPLEA_GAME, "");
         if (fileName.length() > 0) {
           gameSelectorModel.load(new File(fileName), mainFrame);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -62,7 +62,7 @@ public class LocalLauncher extends AbstractLauncher {
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused
       // by closing of stream while unloading map resources.
       Interruptibles.sleep(100);
-      gameSelectorModel.loadDefaultGame();
+      gameSelectorModel.loadDefaultGameNewThread();
       SwingUtilities.invokeLater(() -> JOptionPane.getFrameForComponent(parent).setVisible(true));
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -243,7 +243,7 @@ public class ServerLauncher extends AbstractLauncher {
             gameSelectorModel.resetGameDataToNull();
           }
         } else {
-          gameSelectorModel.loadDefaultGame();
+          gameSelectorModel.loadDefaultGameNewThread();
         }
         if (parent != null) {
           SwingUtilities.invokeLater(() -> JOptionPane.getFrameForComponent(parent).setVisible(true));

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -265,7 +265,6 @@ public class GameSelectorModel extends Observable {
   }
 
   private static void resetToFactoryDefault() {
-    // we don't refresh the game chooser model because we have just removed a bad map from it
     ClientSetting.DEFAULT_GAME_URI_PREF.save(ClientSetting.DEFAULT_GAME_URI_PREF.defaultValue);
     ClientSetting.flush();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -289,7 +289,6 @@ public class GameSelectorModel extends Observable {
       } catch (final GameParseException e) {
         model.removeEntry(selectedGame);
         resetToFactoryDefault();
-        loadDefaultGame();
         return null;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -232,8 +232,7 @@ public class GameSelectorModel extends Observable {
     // was using running a game within its root folder, we shouldn't open it)
     GameChooserEntry selectedGame;
     final String user = ClientFileSystemHelper.getUserRootFolder().toURI().toString();
-    if (userPreferredDefaultGameUri != null && userPreferredDefaultGameUri.length() > 0
-        && userPreferredDefaultGameUri.contains(user)) {
+    if (!userPreferredDefaultGameUri.isEmpty() && userPreferredDefaultGameUri.contains(user)) {
       // if the user has a preferred URI, then we load it, and don't bother parsing or doing anything with the whole
       // game model list
       try {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -217,14 +217,21 @@ public class GameSelectorModel extends Observable {
     super.clearChanged();
   }
 
-  public void loadDefaultGame() {
+  /**
+   * Clears AI game over cache and loads default game in a new thread.
+   */
+  public void loadDefaultGameNewThread() {
     // clear out ai cached properties (this ended up being the best place to put it, as we have definitely left a game
     // at this point)
     ProAi.gameOverClearCache();
-    new Thread(this::loadDefaultGameTask).start();
+    new Thread(this::loadDefaultGameSameThread).start();
   }
 
-  private void loadDefaultGameTask() {
+  /**
+   * Runs the load default game logic in same thread. Default game is the one that we loaded
+   * on startup.
+   */
+  public void loadDefaultGameSameThread() {
     final String userPreferredDefaultGameUri = ClientSetting.DEFAULT_GAME_URI_PREF.value();
 
     // we don't want to load a game file by default that is not within the map folders we can load. (ie: if a previous
@@ -250,7 +257,7 @@ public class GameSelectorModel extends Observable {
           selectedGame.fullyParseGameData();
         } catch (final GameParseException e) {
           resetToFactoryDefault();
-          loadDefaultGame();
+          loadDefaultGameSameThread();
           return;
         }
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -380,10 +380,12 @@ public class GameSelectorPanel extends JPanel implements Observer {
             }
             model.load(entry);
           });
-          setOriginalPropertiesMap(model.getGameData());
-          // only for new games, not saved games, we set the default options, and set them only once
-          // (the first time it is loaded)
-          gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
+          if(model.getGameData() != null) {
+            setOriginalPropertiesMap(model.getGameData());
+            // only for new games, not saved games, we set the default options, and set them only once
+            // (the first time it is loaded)
+            gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
+          }
         }
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -39,6 +39,9 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 import swinglib.JButtonBuilder;
 
+/**
+ * Left hand side panel of the launcher screen that has various info, like selected game and engine version.
+ */
 public class GameSelectorPanel extends JPanel implements Observer {
   private static final long serialVersionUID = -4598107601238030020L;
 
@@ -380,7 +383,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
             }
             model.load(entry);
           });
-          if(model.getGameData() != null) {
+          if (model.getGameData() != null) {
             setOriginalPropertiesMap(model.getGameData());
             // only for new games, not saved games, we set the default options, and set them only once
             // (the first time it is loaded)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -383,6 +383,9 @@ public class GameSelectorPanel extends JPanel implements Observer {
             }
             model.load(entry);
           });
+          // warning: NPE check is not to protect against concurrency, another thread could still null out game data.
+          // The NPE check is to protect against the case where there are errors loading game, in which case
+          // we'll have a null game data.
           if (model.getGameData() != null) {
             setOriginalPropertiesMap(model.getGameData());
             // only for new games, not saved games, we set the default options, and set them only once


### PR DESCRIPTION
Should fix: https://github.com/triplea-game/triplea/issues/2708

### Overview

408e97d has fix, the other commits are some cleanups to help enable the fix.
Basic idea is that 'loadDefaultGame' calls something that falls back to 'loadDefaultGame'. Removing this fallback breaks the infinite loop. We should still have the behavior where if a game was successfully loaded on launch that will be the default, and we still have code to fall back to that in `GameSelectorModel`


### Testing Notes:
Hand tested : |
I introduced a game parser error as described in #2708 to simulate a bad map parse for default map and was able to repro the infinite loop. With the fix applied you just get one error message instead of repeating errors.

### After fix screenshot:
Instead of falling back to a default map, we'll fall back to an empty map in this case:
![after](https://user-images.githubusercontent.com/12397753/36389781-45240fc4-1555-11e8-8ea9-f2f514745820.png)
In the screenshot, notice in the top left there is no map selection. When the dialog is closed that will remain the case. Before the fix, the dialog would keep re-appearing as the backend is caught in an infinite loading loop.


