### PR TITLE
Extract method to remove duplicate code in MapData getters

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/ui/mapdata/MapDataTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/mapdata/MapDataTest.java
@@ -1,0 +1,44 @@
+package games.strategy.triplea.ui.mapdata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public final class MapDataTest {
+  @Nested
+  public final class GetPropertyTest {
+    private static final int DEFAULT_VALUE = 42;
+    private static final String NAME = "name";
+
+    private final Properties properties = new Properties();
+
+    private int getProperty() {
+      return MapData.getProperty(properties, NAME, () -> DEFAULT_VALUE, Integer::parseInt);
+    }
+
+    @Test
+    public void shouldReturnValueWhenPropertyExists() {
+      properties.setProperty(NAME, "76");
+
+      assertThat(getProperty(), is(76));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenPropertyDoesNotExist() {
+      properties.remove(NAME);
+
+      assertThat(getProperty(), is(DEFAULT_VALUE));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenPropertyExistsButIsMalformed() {
+      properties.setProperty(NAME, "malformed");
+
+      assertThat(getProperty(), is(DEFAULT_VALUE));
+    }
+  }
+}


### PR DESCRIPTION
Several `MapData` getters had implementations that only differed in data.  This PR extracts a new generic method to encapsulate the logic, and modifies the existing methods to use the generic method.