### PR TITLE
Add minimum game window size of 200x200 to prevent window from being shrunk down to near nothing.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MainGameFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MainGameFrame.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui;
 
+import java.awt.Dimension;
+
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 
@@ -15,6 +17,8 @@ public abstract class MainGameFrame extends JFrame {
     super(name);
     localPlayers = players;
     setIconImage(GameRunner.getGameIcon(this));
+    // 200 size is pretty arbitrary, goal is to not allow users to shrink window down to nothing.
+    setMinimumSize(new Dimension(200,200));
   }
 
   public abstract IGame getGame();


### PR DESCRIPTION
Should address: https://github.com/triplea-game/triplea/issues/2218

Before: 
can minimize window down to a sliver, see #2218 

After:
min size kicks in:
![new_min](https://user-images.githubusercontent.com/12397753/36392735-889d7310-1561-11e8-95ed-7b6cc86694bb.png)


<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
