### PR TITLE
Iterate over entrySet() instead of keySet()

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -164,9 +164,9 @@ public class Chat {
    *        map from node to tag
    */
   private void assignNodeTags(final Map<INode, Tag> chatters) {
-    for (final INode node : chatters.keySet()) {
-      final Tag tag = chatters.get(node);
-      addToNotesMap(node, tag);
+    for (final Map.Entry<INode, Tag> iNodeTagEntry : chatters.entrySet()) {
+      final Tag tag = iNodeTagEntry.getValue();
+      addToNotesMap(iNodeTagEntry.getKey(), tag);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -110,10 +110,10 @@ public class CompositeRouteFinder {
    */
   private int getTerScore(final Territory ter) {
     int bestMatchingScore = Integer.MAX_VALUE;
-    for (final Predicate<Territory> match : matches.keySet()) {
-      final int score = matches.get(match);
+    for (final Map.Entry<Predicate<Territory>, Integer> predicateIntegerEntry : matches.entrySet()) {
+      final int score = predicateIntegerEntry.getValue();
       if (score < bestMatchingScore) { // If this is a 'better' match
-        if (match.test(ter)) {
+        if ((predicateIntegerEntry.getKey()).test(ter)) {
           bestMatchingScore = score;
         }
       }

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -60,9 +60,9 @@ public class PlayerManager {
 
   public Set<String> getPlayedBy(final INode playerNode) {
     final Set<String> players = new HashSet<>();
-    for (final String player : playerMapping.keySet()) {
-      if (playerMapping.get(player).equals(playerNode)) {
-        players.add(player);
+    for (final Map.Entry<String, INode> stringINodeEntry : playerMapping.entrySet()) {
+      if (stringINodeEntry.getValue().equals(playerNode)) {
+        players.add(stringINodeEntry.getKey());
       }
     }
     return players;
@@ -81,9 +81,9 @@ public class PlayerManager {
   public PlayerID getRemoteOpponent(final INode localNode, final GameData data) {
     // find a local player
     PlayerID local = null;
-    for (final String player : playerMapping.keySet()) {
-      if (playerMapping.get(player).equals(localNode)) {
-        local = data.getPlayerList().getPlayerId(player);
+    for (final Map.Entry<String, INode> stringINodeEntry : playerMapping.entrySet()) {
+      if (stringINodeEntry.getValue().equals(localNode)) {
+        local = data.getPlayerList().getPlayerId(stringINodeEntry.getKey());
         break;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -46,12 +46,12 @@ class PlayerOwnerChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    for (final GUID id : m_new.keySet()) {
-      final Unit unit = data.getUnits().get(id);
-      if (!m_old.get(id).equals(unit.getOwner().getName())) {
-        throw new IllegalStateException("Wrong owner, expecting" + m_old.get(id) + " but got " + unit.getOwner());
+    for (final Map.Entry<GUID, String> guidStringEntry : m_new.entrySet()) {
+      final Unit unit = data.getUnits().get(guidStringEntry.getKey());
+      if (!m_old.get(guidStringEntry.getKey()).equals(unit.getOwner().getName())) {
+        throw new IllegalStateException("Wrong owner, expecting" + m_old.get(guidStringEntry.getKey()) + " but got " + unit.getOwner());
       }
-      final String owner = m_new.get(id);
+      final String owner = guidStringEntry.getValue();
       final PlayerID player = data.getPlayerList().getPlayerId(owner);
       unit.setOwner(player);
     }

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -163,8 +163,8 @@ public class GameDataExporter {
   }
 
   private void printEditableProperties(final Map<String, IEditableProperty> edProperties) {
-    for (final String property : edProperties.keySet()) {
-      printEditableProperty(edProperties.get(property));
+    for (final Map.Entry<String, IEditableProperty> stringIEditablePropertyEntry : edProperties.entrySet()) {
+      printEditableProperty(stringIEditablePropertyEntry.getValue());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -92,8 +92,8 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     if (players == null || players.isEmpty()) {
       return false;
     }
-    for (final String player : players.keySet()) {
-      if (players.get(player) == null) {
+    for (final Map.Entry<String, String> stringStringEntry : players.entrySet()) {
+      if (stringStringEntry.getValue() == null) {
         return false;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -321,10 +321,10 @@ public class ClientModel implements IMessengerErrorListener {
     }
     objectStreamFactory.setData(data);
     final Map<String, String> playerMapping = new HashMap<>();
-    for (final String player : playersToNodes.keySet()) {
-      final String playedBy = playersToNodes.get(player);
+    for (final Map.Entry<String, String> stringStringEntry : playersToNodes.entrySet()) {
+      final String playedBy = stringStringEntry.getValue();
       if (playedBy.equals(messenger.getLocalNode().getName())) {
-        playerMapping.put(player, IGameLoader.CLIENT_PLAYER_TYPE);
+        playerMapping.put(stringStringEntry.getKey(), IGameLoader.CLIENT_PLAYER_TYPE);
       }
     }
     final Set<IGamePlayer> playerSet = data.getGameLoader().createPlayers(playerMapping);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.swing.Action;
 import javax.swing.BoxLayout;
@@ -65,12 +64,12 @@ public class ClientSetupPanel extends SetupPanel {
       disableable.clear();
     }
     playerRows = new ArrayList<>();
-    final Set<String> playerNames = playerNamesAndAlliancesInTurnOrder.keySet();
-    for (final String name : playerNames) {
-      final PlayerRow playerRow = new PlayerRow(name, playerNamesAndAlliancesInTurnOrder.get(name),
-          IGameLoader.CLIENT_PLAYER_TYPE, enabledPlayers.get(name));
+    for (final Map.Entry<String, Collection<String>> stringCollectionEntry : playerNamesAndAlliancesInTurnOrder
+        .entrySet()) {
+      final PlayerRow playerRow = new PlayerRow(stringCollectionEntry.getKey(), stringCollectionEntry.getValue(),
+          IGameLoader.CLIENT_PLAYER_TYPE, enabledPlayers.get(stringCollectionEntry.getKey()));
       playerRows.add(playerRow);
-      playerRow.update(players.get(name), disableable.contains(name));
+      playerRow.update(players.get(stringCollectionEntry.getKey()), disableable.contains(stringCollectionEntry.getKey()));
     }
     layoutComponents();
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -53,8 +53,8 @@ class LobbyGameTableModel extends AbstractTableModel {
 
     final Map<GUID, GameDescription> games =
         ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();
-    for (final GUID id : games.keySet()) {
-      updateGame(id, games.get(id));
+    for (final Map.Entry<GUID, GameDescription> guidGameDescriptionEntry : games.entrySet()) {
+      updateGame(guidGameDescriptionEntry.getKey(), guidGameDescriptionEntry.getValue());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -52,18 +52,18 @@ public class TripleA implements IGameLoader {
   @Override
   public Set<IGamePlayer> createPlayers(final Map<String, String> playerNames) {
     final Set<IGamePlayer> players = new HashSet<>();
-    for (final String name : playerNames.keySet()) {
-      final String type = playerNames.get(name);
+    for (final Map.Entry<String, String> stringStringEntry : playerNames.entrySet()) {
+      final String type = stringStringEntry.getValue();
       if (type.equals(WEAK_COMPUTER_PLAYER_TYPE)) {
-        players.add(new WeakAi(name, type));
+        players.add(new WeakAi(stringStringEntry.getKey(), type));
       } else if (type.equals(FAST_COMPUTER_PLAYER_TYPE)) {
-        players.add(new FastAi(name, type));
+        players.add(new FastAi(stringStringEntry.getKey(), type));
       } else if (type.equals(PRO_COMPUTER_PLAYER_TYPE)) {
-        players.add(new ProAi(name, type));
+        players.add(new ProAi(stringStringEntry.getKey(), type));
       } else if (type.equals(DOESNOTHINGAI_COMPUTER_PLAYER_TYPE)) {
-        players.add(new DoesNothingAi(name, type));
+        players.add(new DoesNothingAi(stringStringEntry.getKey(), type));
       } else if (type.equals(HUMAN_PLAYER_TYPE) || type.equals(CLIENT_PLAYER_TYPE)) {
-        final TripleAPlayer player = new TripleAPlayer(name, type);
+        final TripleAPlayer player = new TripleAPlayer(stringStringEntry.getKey(), type);
         players.add(player);
       } else {
         throw new IllegalStateException("Player type not recognized:" + type);

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
@@ -93,9 +93,10 @@ class ProPoliticsAi {
 
       // Find attack options per war action
       final Map<PoliticalActionAttachment, Double> attackPercentageMap = new HashMap<>();
-      for (final PoliticalActionAttachment action : enemyMap.keySet()) {
+      for (final Map.Entry<PoliticalActionAttachment, List<PlayerID>> politicalActionAttachmentListEntry : enemyMap
+          .entrySet()) {
         int count = 0;
-        final List<PlayerID> enemyPlayers = enemyMap.get(action);
+        final List<PlayerID> enemyPlayers = politicalActionAttachmentListEntry.getValue();
         for (final ProTerritory patd : attackOptions) {
           if (Matches.isTerritoryOwnedBy(enemyPlayers).test(patd.getTerritory())
               || Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(enemyPlayers)).test(patd.getTerritory())) {
@@ -103,7 +104,7 @@ class ProPoliticsAi {
           }
         }
         final double attackPercentage = count / (attackOptions.size() + 1.0);
-        attackPercentageMap.put(action, attackPercentage);
+        attackPercentageMap.put(politicalActionAttachmentListEntry.getKey(), attackPercentage);
         ProLogger.trace(enemyPlayers + ", count=" + count + ", attackPercentage=" + attackPercentage);
       }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
@@ -29,8 +29,8 @@ public class ProMyMoveOptions {
 
   ProMyMoveOptions(final ProMyMoveOptions myMoveOptions) {
     this();
-    for (final Territory t : myMoveOptions.territoryMap.keySet()) {
-      territoryMap.put(t, new ProTerritory(myMoveOptions.territoryMap.get(t)));
+    for (final Map.Entry<Territory, ProTerritory> territoryProTerritoryEntry : myMoveOptions.territoryMap.entrySet()) {
+      territoryMap.put(territoryProTerritoryEntry.getKey(), new ProTerritory(territoryProTerritoryEntry.getValue()));
     }
     unitMoveMap.putAll(myMoveOptions.unitMoveMap);
     transportMoveMap.putAll(myMoveOptions.transportMoveMap);

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -55,12 +55,12 @@ public class ProOtherMoveOptions {
     final Map<Territory, ProTerritory> result = new HashMap<>();
     final List<PlayerID> players = ProUtils.getOtherPlayersInTurnOrder(player);
     for (final Map<Territory, ProTerritory> moveMap : moveMaps) {
-      for (final Territory t : moveMap.keySet()) {
+      for (final Map.Entry<Territory, ProTerritory> territoryProTerritoryEntry : moveMap.entrySet()) {
 
         // Get current player
         final PlayerID movePlayer;
-        final Set<Unit> currentUnits = new HashSet<>(moveMap.get(t).getMaxUnits());
-        currentUnits.addAll(moveMap.get(t).getMaxAmphibUnits());
+        final Set<Unit> currentUnits = new HashSet<>(territoryProTerritoryEntry.getValue().getMaxUnits());
+        currentUnits.addAll(territoryProTerritoryEntry.getValue().getMaxAmphibUnits());
         if (!currentUnits.isEmpty()) {
           movePlayer = currentUnits.iterator().next().getOwner();
         } else {
@@ -69,27 +69,27 @@ public class ProOtherMoveOptions {
 
         // Skip if checking allied moves and their turn doesn't come before territory owner's
         if (ProData.getData().getRelationshipTracker().isAllied(player, movePlayer)
-            && !ProUtils.isPlayersTurnFirst(players, movePlayer, t.getOwner())) {
+            && !ProUtils.isPlayersTurnFirst(players, movePlayer, (territoryProTerritoryEntry.getKey()).getOwner())) {
           continue;
         }
 
         // Add to max move map if its empty or its strength is greater than existing
-        if (!result.containsKey(t)) {
-          result.put(t, moveMap.get(t));
+        if (!result.containsKey(territoryProTerritoryEntry.getKey())) {
+          result.put(territoryProTerritoryEntry.getKey(), territoryProTerritoryEntry.getValue());
         } else {
-          final Set<Unit> maxUnits = new HashSet<>(result.get(t).getMaxUnits());
-          maxUnits.addAll(result.get(t).getMaxAmphibUnits());
+          final Set<Unit> maxUnits = new HashSet<>(result.get(territoryProTerritoryEntry.getKey()).getMaxUnits());
+          maxUnits.addAll(result.get(territoryProTerritoryEntry.getKey()).getMaxAmphibUnits());
           double maxStrength = 0;
           if (!maxUnits.isEmpty()) {
-            maxStrength = ProBattleUtils.estimateStrength(t, new ArrayList<>(maxUnits), new ArrayList<>(), isAttacker);
+            maxStrength = ProBattleUtils.estimateStrength(territoryProTerritoryEntry.getKey(), new ArrayList<>(maxUnits), new ArrayList<>(), isAttacker);
           }
           final double currentStrength =
-              ProBattleUtils.estimateStrength(t, new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
+              ProBattleUtils.estimateStrength(territoryProTerritoryEntry.getKey(), new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
           final boolean currentHasLandUnits = currentUnits.stream().anyMatch(Matches.unitIsLand());
           final boolean maxHasLandUnits = maxUnits.stream().anyMatch(Matches.unitIsLand());
-          if ((currentHasLandUnits && ((!maxHasLandUnits && !t.isWater()) || currentStrength > maxStrength))
-              || ((!maxHasLandUnits || t.isWater()) && currentStrength > maxStrength)) {
-            result.put(t, moveMap.get(t));
+          if ((currentHasLandUnits && ((!maxHasLandUnits && !(territoryProTerritoryEntry.getKey()).isWater()) || currentStrength > maxStrength))
+              || ((!maxHasLandUnits || (territoryProTerritoryEntry.getKey()).isWater()) && currentStrength > maxStrength)) {
+            result.put(territoryProTerritoryEntry.getKey(), territoryProTerritoryEntry.getValue());
           }
         }
       }
@@ -102,13 +102,13 @@ public class ProOtherMoveOptions {
 
     final Map<Territory, List<ProTerritory>> result = new HashMap<>();
     for (final Map<Territory, ProTerritory> moveMap : moveMapList) {
-      for (final Territory t : moveMap.keySet()) {
-        if (!result.containsKey(t)) {
+      for (final Map.Entry<Territory, ProTerritory> territoryProTerritoryEntry : moveMap.entrySet()) {
+        if (!result.containsKey(territoryProTerritoryEntry.getKey())) {
           final List<ProTerritory> list = new ArrayList<>();
-          list.add(moveMap.get(t));
-          result.put(t, list);
+          list.add(territoryProTerritoryEntry.getValue());
+          result.put(territoryProTerritoryEntry.getKey(), list);
         } else {
-          result.get(t).add(moveMap.get(t));
+          result.get(territoryProTerritoryEntry.getKey()).add(territoryProTerritoryEntry.getValue());
         }
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -247,8 +247,8 @@ public class ProTerritory {
   }
 
   public void putAllAmphibAttackMap(final Map<Unit, List<Unit>> amphibAttackMap) {
-    for (final Unit u : amphibAttackMap.keySet()) {
-      putAmphibAttackMap(u, amphibAttackMap.get(u));
+    for (final Map.Entry<Unit, List<Unit>> unitListEntry : amphibAttackMap.entrySet()) {
+      putAmphibAttackMap(unitListEntry.getKey(), unitListEntry.getValue());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -115,38 +115,39 @@ public class ProTerritoryManager {
 
     // Determine if territory can be successfully attacked with max possible attackers
     final List<Territory> territoriesToRemove = new ArrayList<>();
-    for (final Territory t : attackMap.keySet()) {
-      final ProTerritory patd = attackMap.get(t);
+    for (final Map.Entry<Territory, ProTerritory> territoryProTerritoryEntry : attackMap.entrySet()) {
+      final ProTerritory patd = territoryProTerritoryEntry.getValue();
 
       // Check if I can win without amphib units and ignore AA since max units might have lots of planes
       List<Unit> defenders = CollectionUtils.getMatches(patd.getMaxEnemyDefenders(player, data),
           ProMatches.unitIsEnemyAndNotAa(player, data));
       if (isIgnoringRelationships) {
-        defenders = new ArrayList<>(t.getUnits().getUnits());
+        defenders = new ArrayList<>((territoryProTerritoryEntry.getKey()).getUnits().getUnits());
       }
-      patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, patd.getMaxUnits(), defenders, new HashSet<>()));
+      patd.setMaxBattleResult(calc.estimateAttackBattleResults(territoryProTerritoryEntry.getKey(), patd.getMaxUnits(), defenders, new HashSet<>()));
 
       // Add in amphib units if I can't win without them
       if (patd.getMaxBattleResult().getWinPercentage() < ProData.winPercentage && !patd.getMaxAmphibUnits().isEmpty()) {
         final Set<Unit> combinedUnits = new HashSet<>(patd.getMaxUnits());
         combinedUnits.addAll(patd.getMaxAmphibUnits());
-        patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, new ArrayList<>(combinedUnits), defenders,
+        patd.setMaxBattleResult(calc.estimateAttackBattleResults(territoryProTerritoryEntry.getKey(), new ArrayList<>(combinedUnits), defenders,
             patd.getMaxBombardUnits()));
         patd.setNeedAmphibUnits(true);
       }
 
       // Check strafing and using allied attack if enemy capital/factory
       boolean isEnemyCapitalOrFactory = false;
-      final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (!t.getOwner().isNull()
-          && ((ta != null && ta.isCapital()) || ProMatches.territoryHasInfraFactoryAndIsLand().test(t))) {
+      final TerritoryAttachment ta = TerritoryAttachment.get(territoryProTerritoryEntry.getKey());
+      if (!(territoryProTerritoryEntry.getKey()).getOwner().isNull()
+          && ((ta != null && ta.isCapital()) || ProMatches.territoryHasInfraFactoryAndIsLand().test(
+          territoryProTerritoryEntry.getKey()))) {
         isEnemyCapitalOrFactory = true;
       }
       if (patd.getMaxBattleResult().getWinPercentage() < ProData.minWinPercentage && isEnemyCapitalOrFactory
-          && alliedAttackOptions.getMax(t) != null) {
+          && alliedAttackOptions.getMax(territoryProTerritoryEntry.getKey()) != null) {
 
         // Check for allied attackers
-        final ProTerritory alliedAttack = alliedAttackOptions.getMax(t);
+        final ProTerritory alliedAttack = alliedAttackOptions.getMax(territoryProTerritoryEntry.getKey());
         final Set<Unit> alliedUnits = new HashSet<>(alliedAttack.getMaxUnits());
         alliedUnits.addAll(alliedAttack.getMaxAmphibUnits());
         if (!alliedUnits.isEmpty()) {
@@ -154,12 +155,14 @@ public class ProTerritoryManager {
           // Make sure allies' capital isn't next to territory
           final PlayerID alliedPlayer = alliedUnits.iterator().next().getOwner();
           final Territory capital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(alliedPlayer, data);
-          if (capital != null && !data.getMap().getNeighbors(capital).contains(t)) {
+          if (capital != null && !data.getMap().getNeighbors(capital).contains(
+              territoryProTerritoryEntry.getKey())) {
 
             // Get max enemy defenders
             final Set<Unit> additionalEnemyDefenders = new HashSet<>();
             final List<PlayerID> players = ProUtils.getOtherPlayersInTurnOrder(player);
-            for (final ProTerritory enemyDefendOption : enemyDefendOptions.getAll(t)) {
+            for (final ProTerritory enemyDefendOption : enemyDefendOptions.getAll(
+                territoryProTerritoryEntry.getKey())) {
               final Set<Unit> enemyUnits = new HashSet<>(enemyDefendOption.getMaxUnits());
               enemyUnits.addAll(enemyDefendOption.getMaxAmphibUnits());
               if (!enemyUnits.isEmpty()) {
@@ -174,7 +177,7 @@ public class ProTerritoryManager {
             final Set<Unit> enemyDefendersBeforeStrafe = new HashSet<>(defenders);
             enemyDefendersBeforeStrafe.addAll(additionalEnemyDefenders);
             final ProBattleResult result =
-                calc.estimateAttackBattleResults(t, new ArrayList<>(alliedUnits),
+                calc.estimateAttackBattleResults(territoryProTerritoryEntry.getKey(), new ArrayList<>(alliedUnits),
                     new ArrayList<>(enemyDefendersBeforeStrafe), alliedAttack.getMaxBombardUnits());
             if (result.getWinPercentage() < ProData.winPercentage) {
               patd.setStrafing(true);
@@ -182,16 +185,17 @@ public class ProTerritoryManager {
               // Try to strafe to allow allies to conquer territory
               final Set<Unit> combinedUnits = new HashSet<>(patd.getMaxUnits());
               combinedUnits.addAll(patd.getMaxAmphibUnits());
-              final ProBattleResult strafeResult = calc.callBattleCalculator(t, new ArrayList<>(combinedUnits),
+              final ProBattleResult strafeResult = calc.callBattleCalculator(
+                  territoryProTerritoryEntry.getKey(), new ArrayList<>(combinedUnits),
                   defenders, patd.getMaxBombardUnits(), true);
 
               // Check allied result with strafe
               final Set<Unit> enemyDefendersAfterStrafe = new HashSet<>(strafeResult.getAverageDefendersRemaining());
               enemyDefendersAfterStrafe.addAll(additionalEnemyDefenders);
-              patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, new ArrayList<>(alliedUnits),
+              patd.setMaxBattleResult(calc.estimateAttackBattleResults(territoryProTerritoryEntry.getKey(), new ArrayList<>(alliedUnits),
                   new ArrayList<>(enemyDefendersAfterStrafe), alliedAttack.getMaxBombardUnits()));
 
-              ProLogger.debug("Checking strafing territory: " + t + ", alliedPlayer="
+              ProLogger.debug("Checking strafing territory: " + territoryProTerritoryEntry.getKey() + ", alliedPlayer="
                   + alliedUnits.iterator().next().getOwner().getName() + ", maxWin%="
                   + patd.getMaxBattleResult().getWinPercentage() + ", maxAttackers=" + alliedUnits.size()
                   + ", maxDefenders=" + enemyDefendersAfterStrafe.size());
@@ -203,7 +207,7 @@ public class ProTerritoryManager {
       if (patd.getMaxBattleResult().getWinPercentage() < ProData.minWinPercentage
           || (patd.isStrafing() && (patd.getMaxBattleResult().getWinPercentage() < ProData.winPercentage
               || !patd.getMaxBattleResult().isHasLandUnitRemaining()))) {
-        territoriesToRemove.add(t);
+        territoriesToRemove.add(territoryProTerritoryEntry.getKey());
       }
     }
 
@@ -335,13 +339,13 @@ public class ProTerritoryManager {
     }
 
     // Find potential max units that can be scrambled to each territory
-    for (final Territory to : scrambleTerrs.keySet()) {
-      for (final Territory from : scrambleTerrs.get(to)) {
+    for (final Map.Entry<Territory, HashSet<Territory>> territoryHashSetEntry : scrambleTerrs.entrySet()) {
+      for (final Territory from : territoryHashSetEntry.getValue()) {
 
         // Find potential scramble units from territory
         final Collection<Unit> airbases = from.getUnits().getMatches(airbasesCanScramble);
         final int maxCanScramble = getMaxScrambleCount(airbases);
-        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
+        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, territoryHashSetEntry.getKey(), Matches.territoryIsNotImpassable());
         List<Unit> canScrambleAir = from.getUnits().getMatches(Matches.unitIsEnemyOf(data, player)
             .and(Matches.unitCanScramble())
             .and(Matches.unitIsNotDisabled())
@@ -353,14 +357,14 @@ public class ProTerritoryManager {
           if (maxCanScramble < canScrambleAir.size()) {
             Collections.sort(canScrambleAir, (o1, o2) -> {
               final double strength1 =
-                  ProBattleUtils.estimateStrength(to, Collections.singletonList(o1), new ArrayList<>(), false);
+                  ProBattleUtils.estimateStrength(territoryHashSetEntry.getKey(), Collections.singletonList(o1), new ArrayList<>(), false);
               final double strength2 =
-                  ProBattleUtils.estimateStrength(to, Collections.singletonList(o2), new ArrayList<>(), false);
+                  ProBattleUtils.estimateStrength(territoryHashSetEntry.getKey(), Collections.singletonList(o2), new ArrayList<>(), false);
               return Double.compare(strength2, strength1);
             });
             canScrambleAir = canScrambleAir.subList(0, maxCanScramble);
           }
-          moveMap.get(to).getMaxScrambleUnits().addAll(canScrambleAir);
+          moveMap.get(territoryHashSetEntry.getKey()).getMaxScrambleUnits().addAll(canScrambleAir);
         }
       }
     }
@@ -745,9 +749,9 @@ public class ProTerritoryManager {
       final Map<Unit, Set<Territory>> unitMoveMap2 = new HashMap<>();
       findNavalMoveOptions(player, myUnitTerritories, new HashMap<>(), unitMoveMap2, new HashMap<>(),
           Matches.territoryIsWater(), enemyTerritories, false, true);
-      for (final Unit u : unitMoveMap2.keySet()) {
-        if (Matches.unitIsCarrier().test(u)) {
-          possibleCarrierTerritories.addAll(unitMoveMap2.get(u));
+      for (final Map.Entry<Unit, Set<Territory>> unitSetEntry : unitMoveMap2.entrySet()) {
+        if (Matches.unitIsCarrier().test(unitSetEntry.getKey())) {
+          possibleCarrierTerritories.addAll(unitSetEntry.getValue());
         }
       }
       for (final Territory t : data.getMap().getTerritories()) {
@@ -970,13 +974,13 @@ public class ProTerritoryManager {
     for (final ProTransport proTransportData : transportMapList) {
       final Map<Territory, Set<Territory>> transportMap = proTransportData.getTransportMap();
       final List<Territory> transportTerritoriesToRemove = new ArrayList<>();
-      for (final Territory t : transportMap.keySet()) {
-        final Set<Territory> transportMoveTerritories = transportMap.get(t);
-        final Set<Territory> landMoveTerritories = landRoutesMap.get(t);
+      for (final Map.Entry<Territory, Set<Territory>> territorySetEntry : transportMap.entrySet()) {
+        final Set<Territory> transportMoveTerritories = territorySetEntry.getValue();
+        final Set<Territory> landMoveTerritories = landRoutesMap.get(territorySetEntry.getKey());
         if (landMoveTerritories != null) {
           transportMoveTerritories.removeAll(landMoveTerritories);
           if (transportMoveTerritories.isEmpty()) {
-            transportTerritoriesToRemove.add(t);
+            transportTerritoriesToRemove.add(territorySetEntry.getKey());
           }
         }
       }
@@ -989,13 +993,13 @@ public class ProTerritoryManager {
     for (final ProTransport proTransportData : transportMapList) {
       final Map<Territory, Set<Territory>> transportMap = proTransportData.getTransportMap();
       final Unit transport = proTransportData.getTransport();
-      for (final Territory moveTerritory : transportMap.keySet()) {
+      for (final Map.Entry<Territory, Set<Territory>> territorySetEntry : transportMap.entrySet()) {
 
         // Get units to transport
-        final Set<Territory> territoriesCanLoadFrom = transportMap.get(moveTerritory);
+        final Set<Territory> territoriesCanLoadFrom = territorySetEntry.getValue();
         List<Unit> alreadyAddedToMaxAmphibUnits = new ArrayList<>();
-        if (moveMap.containsKey(moveTerritory)) {
-          alreadyAddedToMaxAmphibUnits = moveMap.get(moveTerritory).getMaxAmphibUnits();
+        if (moveMap.containsKey(territorySetEntry.getKey())) {
+          alreadyAddedToMaxAmphibUnits = moveMap.get(territorySetEntry.getKey()).getMaxAmphibUnits();
         }
         List<Unit> amphibUnits = ProTransportUtils.getUnitsToTransportFromTerritories(player, transport,
             territoriesCanLoadFrom, alreadyAddedToMaxAmphibUnits);
@@ -1005,12 +1009,12 @@ public class ProTerritoryManager {
         }
 
         // Add amphib units to attack map
-        if (moveMap.containsKey(moveTerritory)) {
-          moveMap.get(moveTerritory).addMaxAmphibUnits(amphibUnits);
+        if (moveMap.containsKey(territorySetEntry.getKey())) {
+          moveMap.get(territorySetEntry.getKey()).addMaxAmphibUnits(amphibUnits);
         } else {
-          final ProTerritory moveTerritoryData = new ProTerritory(moveTerritory);
+          final ProTerritory moveTerritoryData = new ProTerritory(territorySetEntry.getKey());
           moveTerritoryData.addMaxAmphibUnits(amphibUnits);
-          moveMap.put(moveTerritory, moveTerritoryData);
+          moveMap.put(territorySetEntry.getKey(), moveTerritoryData);
         }
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
@@ -99,57 +99,59 @@ public class ProSimulateTurnUtils {
 
     final Map<Territory, ProTerritory> result = new HashMap<>();
     final List<Unit> usedUnits = new ArrayList<>();
-    for (final Territory fromTerritory : moveMap.keySet()) {
-      final Territory toTerritory = toData.getMap().getTerritory(fromTerritory.getName());
+    for (final Entry<Territory, ProTerritory> territoryProTerritoryEntry : moveMap.entrySet()) {
+      final Territory toTerritory = toData.getMap().getTerritory((territoryProTerritoryEntry.getKey()).getName());
       final ProTerritory patd = new ProTerritory(toTerritory);
       result.put(toTerritory, patd);
-      final Map<Unit, List<Unit>> amphibAttackMap = moveMap.get(fromTerritory).getAmphibAttackMap();
-      final Map<Unit, Boolean> isTransportingMap = moveMap.get(fromTerritory).getIsTransportingMap();
-      final Map<Unit, Territory> transportTerritoryMap = moveMap.get(fromTerritory).getTransportTerritoryMap();
-      final Map<Unit, Territory> bombardMap = moveMap.get(fromTerritory).getBombardTerritoryMap();
-      ProLogger.debug("Transferring " + fromTerritory + " to " + toTerritory);
+      final Map<Unit, List<Unit>> amphibAttackMap = territoryProTerritoryEntry.getValue().getAmphibAttackMap();
+      final Map<Unit, Boolean> isTransportingMap = territoryProTerritoryEntry.getValue().getIsTransportingMap();
+      final Map<Unit, Territory> transportTerritoryMap = territoryProTerritoryEntry.getValue().getTransportTerritoryMap();
+      final Map<Unit, Territory> bombardMap = territoryProTerritoryEntry.getValue().getBombardTerritoryMap();
+      ProLogger.debug("Transferring " + territoryProTerritoryEntry.getKey() + " to " + toTerritory);
       final List<Unit> amphibUnits = new ArrayList<>();
-      for (final Unit transport : amphibAttackMap.keySet()) {
+      for (final Entry<Unit, List<Unit>> unitListEntry : amphibAttackMap.entrySet()) {
         final Unit toTransport;
         final List<Unit> toUnits = new ArrayList<>();
-        if (isTransportingMap.get(transport)) {
-          toTransport = transferLoadedTransport(transport, amphibAttackMap.get(transport), unitTerritoryMap, usedUnits,
+        if (isTransportingMap.get(unitListEntry.getKey())) {
+          toTransport = transferLoadedTransport(unitListEntry.getKey(), unitListEntry.getValue(), unitTerritoryMap, usedUnits,
               toData, player);
           toUnits.addAll(TransportTracker.transporting(toTransport));
         } else {
-          toTransport = transferUnit(transport, unitTerritoryMap, usedUnits, toData, player);
-          for (final Unit u : amphibAttackMap.get(transport)) {
+          toTransport = transferUnit(unitListEntry.getKey(), unitTerritoryMap, usedUnits, toData, player);
+          for (final Unit u : unitListEntry.getValue()) {
             final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
             toUnits.add(toUnit);
           }
         }
         patd.addUnits(toUnits);
         patd.putAmphibAttackMap(toTransport, toUnits);
-        amphibUnits.addAll(amphibAttackMap.get(transport));
-        if (transportTerritoryMap.get(transport) != null) {
+        amphibUnits.addAll(unitListEntry.getValue());
+        if (transportTerritoryMap.get(unitListEntry.getKey()) != null) {
           patd.getTransportTerritoryMap().put(toTransport,
-              toData.getMap().getTerritory(transportTerritoryMap.get(transport).getName()));
+              toData.getMap().getTerritory(transportTerritoryMap.get(unitListEntry.getKey()).getName()));
         }
-        ProLogger.trace("---Transferring transport=" + transport + " with units=" + amphibAttackMap.get(transport)
-            + " unloadTerritory=" + transportTerritoryMap.get(transport) + " to transport=" + toTransport
+        ProLogger.trace("---Transferring transport=" + unitListEntry.getKey() + " with units=" + unitListEntry
+            .getValue()
+            + " unloadTerritory=" + transportTerritoryMap.get(unitListEntry.getKey()) + " to transport=" + toTransport
             + " with units=" + toUnits + " unloadTerritory=" + patd.getTransportTerritoryMap().get(toTransport));
       }
-      for (final Unit u : moveMap.get(fromTerritory).getUnits()) {
+      for (final Unit u : territoryProTerritoryEntry.getValue().getUnits()) {
         if (!amphibUnits.contains(u)) {
           final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
           patd.addUnit(toUnit);
           ProLogger.trace("---Transferring unit " + u + " to " + toUnit);
         }
       }
-      for (final Unit u : moveMap.get(fromTerritory).getBombers()) {
+      for (final Unit u : territoryProTerritoryEntry.getValue().getBombers()) {
         final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
         patd.getBombers().add(toUnit);
         ProLogger.trace("---Transferring bomber " + u + " to " + toUnit);
       }
-      for (final Unit u : bombardMap.keySet()) {
-        final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
-        patd.getBombardTerritoryMap().put(toUnit, toData.getMap().getTerritory(bombardMap.get(u).getName()));
-        ProLogger.trace("---Transferring bombard=" + u + ", bombardFromTerritory=" + bombardMap.get(u) + " to bomard="
+      for (final Entry<Unit, Territory> unitTerritoryEntry : bombardMap.entrySet()) {
+        final Unit toUnit = transferUnit(unitTerritoryEntry.getKey(), unitTerritoryMap, usedUnits, toData, player);
+        patd.getBombardTerritoryMap().put(toUnit, toData.getMap().getTerritory(unitTerritoryEntry.getValue().getName()));
+        ProLogger.trace("---Transferring bombard=" + unitTerritoryEntry.getKey()
+            + ", bombardFromTerritory=" + unitTerritoryEntry.getValue() + " to bomard="
             + toUnit + ", bombardFromTerritory=" + patd.getBombardTerritoryMap().get(toUnit));
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -138,8 +138,9 @@ public class ProBattleUtils {
       for (final Territory nearbyTerritory : nearbyTerritoriesForAllied) {
         alliedUnits.addAll(nearbyTerritory.getUnits().getMatches(Matches.isUnitAllied(player, data)));
       }
-      for (final Territory purchaseTerritory : purchaseTerritories.keySet()) {
-        for (final ProPlaceTerritory ppt : purchaseTerritories.get(purchaseTerritory).getCanPlaceTerritories()) {
+      for (final Map.Entry<Territory, ProPurchaseTerritory> territoryProPurchaseTerritoryEntry : purchaseTerritories
+          .entrySet()) {
+        for (final ProPlaceTerritory ppt : territoryProPurchaseTerritoryEntry.getValue().getCanPlaceTerritories()) {
           if (nearbyTerritoriesForAllied.contains(ppt.getTerritory())) {
             alliedUnits.addAll(ppt.getPlaceUnits());
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -107,8 +107,9 @@ public class ProPurchaseUtils {
           currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);
         }
         currentlyBuilt += CollectionUtils.countMatches(unitsToPlace, unitTypeOwnedBy);
-        for (final Territory t : purchaseTerritories.keySet()) {
-          for (final ProPlaceTerritory placeTerritory : purchaseTerritories.get(t).getCanPlaceTerritories()) {
+        for (final Map.Entry<Territory, ProPurchaseTerritory> territoryProPurchaseTerritoryEntry : purchaseTerritories
+            .entrySet()) {
+          for (final ProPlaceTerritory placeTerritory : territoryProPurchaseTerritoryEntry.getValue().getCanPlaceTerritories()) {
             currentlyBuilt += CollectionUtils.countMatches(placeTerritory.getPlaceUnits(), unitTypeOwnedBy);
           }
         }
@@ -134,17 +135,17 @@ public class ProPurchaseUtils {
     }
     final Map<ProPurchaseOption, Double> purchasePercentages = new LinkedHashMap<>();
     double upperBound = 0.0;
-    for (final ProPurchaseOption ppo : purchaseEfficiencies.keySet()) {
-      final double chance = purchaseEfficiencies.get(ppo) / totalEfficiency * 100;
+    for (final Map.Entry<ProPurchaseOption, Double> proPurchaseOptionDoubleEntry : purchaseEfficiencies.entrySet()) {
+      final double chance = proPurchaseOptionDoubleEntry.getValue() / totalEfficiency * 100;
       upperBound += chance;
-      purchasePercentages.put(ppo, upperBound);
-      ProLogger.trace(ppo.getUnitType().getName() + ", probability=" + chance + ", upperBound=" + upperBound);
+      purchasePercentages.put(proPurchaseOptionDoubleEntry.getKey(), upperBound);
+      ProLogger.trace((proPurchaseOptionDoubleEntry.getKey()).getUnitType().getName() + ", probability=" + chance + ", upperBound=" + upperBound);
     }
     final double randomNumber = Math.random() * 100;
     ProLogger.trace("Random number: " + randomNumber);
-    for (final ProPurchaseOption ppo : purchasePercentages.keySet()) {
-      if (randomNumber <= purchasePercentages.get(ppo)) {
-        return Optional.of(ppo);
+    for (final Map.Entry<ProPurchaseOption, Double> proPurchaseOptionDoubleEntry : purchasePercentages.entrySet()) {
+      if (randomNumber <= proPurchaseOptionDoubleEntry.getValue()) {
+        return Optional.of(proPurchaseOptionDoubleEntry.getKey());
       }
     }
     return Optional.of(purchasePercentages.keySet().iterator().next());
@@ -349,8 +350,9 @@ public class ProPurchaseUtils {
     if (purchaseTerritories == null) {
       return placeUnits;
     }
-    for (final Territory purchaseTerritory : purchaseTerritories.keySet()) {
-      for (final ProPlaceTerritory ppt : purchaseTerritories.get(purchaseTerritory).getCanPlaceTerritories()) {
+    for (final Map.Entry<Territory, ProPurchaseTerritory> territoryProPurchaseTerritoryEntry : purchaseTerritories
+        .entrySet()) {
+      for (final ProPlaceTerritory ppt : territoryProPurchaseTerritoryEntry.getValue().getCanPlaceTerritories()) {
         if (t.equals(ppt.getTerritory())) {
           placeUnits.addAll(ppt.getPlaceUnits());
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weakAI/WeakAi.java
@@ -862,12 +862,13 @@ public class WeakAi extends AbstractAi {
       int i = 0;
       while (currentProduction < maxUnits && i < 2) {
         for (final RepairRule rrule : repairRules) {
-          for (final Unit fixUnit : unitsThatCanProduceNeedingRepair.keySet()) {
-            if (fixUnit == null || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
+          for (final Map.Entry<Unit, Territory> unitTerritoryEntry : unitsThatCanProduceNeedingRepair.entrySet()) {
+            if (unitTerritoryEntry.getKey() == null || !(unitTerritoryEntry.getKey())
+                .getType().equals(rrule.getResults().keySet().iterator().next())) {
               continue;
             }
             if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
-                .test(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
+                .test(unitTerritoryEntry.getValue())) {
               continue;
             }
             // we will repair the first territories in the list as much as we can, until we fulfill the condition, then
@@ -876,10 +877,11 @@ public class WeakAi extends AbstractAi {
             if (currentProduction >= maxUnits) {
               continue;
             }
-            final TripleAUnit taUnit = (TripleAUnit) fixUnit;
+            final TripleAUnit taUnit = (TripleAUnit) unitTerritoryEntry.getKey();
             diff = taUnit.getUnitDamage();
-            final int unitProductionAllowNegative = TripleAUnit.getHowMuchCanUnitProduce(fixUnit,
-                unitsThatCanProduceNeedingRepair.get(fixUnit), player, data, false, true) - diff;
+            final int unitProductionAllowNegative = TripleAUnit.getHowMuchCanUnitProduce(
+                unitTerritoryEntry.getKey(),
+                unitTerritoryEntry.getValue(), player, data, false, true) - diff;
             if (i == 0) {
               if (unitProductionAllowNegative < 0) {
                 diff = Math.min(diff, (maxUnits - currentProduction) - unitProductionAllowNegative);
@@ -895,7 +897,7 @@ public class WeakAi extends AbstractAi {
                 currentProduction += diff + unitProductionAllowNegative;
               }
               repairMap.add(rrule, diff);
-              repair.put(fixUnit, repairMap);
+              repair.put(unitTerritoryEntry.getKey(), repairMap);
               leftToSpend -= diff;
               purchaseDelegate.purchaseRepair(repair);
               repair.clear();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -262,8 +262,8 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
 
   protected boolean checkTurns(final GameData data) {
     final int turn = data.getSequence().getRound();
-    for (final int t : m_turns.keySet()) {
-      if (turn >= t && turn <= m_turns.get(t)) {
+    for (final Map.Entry<Integer, Integer> integerIntegerEntry : m_turns.entrySet()) {
+      if (turn >= integerIntegerEntry.getKey() && turn <= integerIntegerEntry.getValue()) {
         return true;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -789,8 +789,8 @@ public class BattleTracker implements Serializable {
         final Map<String, Tuple<String, IntegerMap<UnitType>>> map =
             UnitAttachment.get(u.getType()).getWhenCapturedChangesInto();
         final PlayerID currentOwner = u.getOwner();
-        for (final String value : map.keySet()) {
-          final String[] s = value.split(":");
+        for (final Map.Entry<String, Tuple<String, IntegerMap<UnitType>>> stringTupleEntry : map.entrySet()) {
+          final String[] s = (stringTupleEntry.getKey()).split(":");
           if (!(s[0].equals("any") || data.getPlayerList().getPlayerId(s[0]).equals(currentOwner))) {
             continue;
           }
@@ -800,7 +800,7 @@ public class BattleTracker implements Serializable {
           }
           final CompositeChange changes = new CompositeChange();
           final Collection<Unit> toAdd = new ArrayList<>();
-          final Tuple<String, IntegerMap<UnitType>> toCreate = map.get(value);
+          final Tuple<String, IntegerMap<UnitType>> toCreate = stringTupleEntry.getValue();
           final boolean translateAttributes = toCreate.getFirst().equalsIgnoreCase("true");
           for (final UnitType ut : toCreate.getSecond().keySet()) {
             toAdd.addAll(ut.create(toCreate.getSecond().getInt(ut), newOwner));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -445,13 +445,17 @@ public class DiceRoll implements Externalizable {
         new IntegerMap<>(supportLeftEnemy);
     final Map<UnitSupportAttachment, LinkedIntegerMap<Unit>> supportUnitsLeftFriendlyRolls =
         new HashMap<>();
-    for (final UnitSupportAttachment usa : supportUnitsLeftFriendly.keySet()) {
-      supportUnitsLeftFriendlyRolls.put(usa, new LinkedIntegerMap<>(supportUnitsLeftFriendly.get(usa)));
+    for (final Entry<UnitSupportAttachment, LinkedIntegerMap<Unit>> unitSupportAttachmentLinkedIntegerMapEntry : supportUnitsLeftFriendly
+        .entrySet()) {
+      supportUnitsLeftFriendlyRolls.put(unitSupportAttachmentLinkedIntegerMapEntry.getKey(), new LinkedIntegerMap<>(
+          unitSupportAttachmentLinkedIntegerMapEntry.getValue()));
     }
     final Map<UnitSupportAttachment, LinkedIntegerMap<Unit>> supportUnitsLeftEnemyRolls =
         new HashMap<>();
-    for (final UnitSupportAttachment usa : supportUnitsLeftEnemy.keySet()) {
-      supportUnitsLeftEnemyRolls.put(usa, new LinkedIntegerMap<>(supportUnitsLeftEnemy.get(usa)));
+    for (final Entry<UnitSupportAttachment, LinkedIntegerMap<Unit>> unitSupportAttachmentLinkedIntegerMapEntry : supportUnitsLeftEnemy
+        .entrySet()) {
+      supportUnitsLeftEnemyRolls.put(unitSupportAttachmentLinkedIntegerMapEntry.getKey(), new LinkedIntegerMap<>(
+          unitSupportAttachmentLinkedIntegerMapEntry.getValue()));
     }
     final int diceSides = data.getDiceSides();
     for (final Unit current : unitsGettingPowerFor) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -66,11 +66,11 @@ public class FinishedBattle extends AbstractBattle {
   public Change addAttackChange(final Route route, final Collection<Unit> units,
       final HashMap<Unit, HashSet<Unit>> targets) {
     final Map<Unit, Collection<Unit>> addedTransporting = TransportTracker.transporting(units);
-    for (final Unit unit : addedTransporting.keySet()) {
-      if (m_dependentUnits.get(unit) != null) {
-        m_dependentUnits.get(unit).addAll(addedTransporting.get(unit));
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : addedTransporting.entrySet()) {
+      if (m_dependentUnits.get(unitCollectionEntry.getKey()) != null) {
+        m_dependentUnits.get(unitCollectionEntry.getKey()).addAll(unitCollectionEntry.getValue());
       } else {
-        m_dependentUnits.put(unit, addedTransporting.get(unit));
+        m_dependentUnits.put(unitCollectionEntry.getKey(), unitCollectionEntry.getValue());
       }
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
@@ -119,8 +119,8 @@ public class FinishedBattle extends AbstractBattle {
         m_isAmphibious = !m_amphibiousAttackFrom.isEmpty();
       }
     }
-    for (final Unit dependence : m_dependentUnits.keySet()) {
-      final Collection<Unit> dependent = m_dependentUnits.get(dependence);
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : m_dependentUnits.entrySet()) {
+      final Collection<Unit> dependent = unitCollectionEntry.getValue();
       dependent.removeAll(units);
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1471,8 +1471,8 @@ public final class Matches {
       final Map<Unit, Collection<Unit>> carrierMustMoveWith =
           MoveValidator.carrierMustMoveWith(units, units, data, currentPlayer);
       if (carrierMustMoveWith != null) {
-        for (final Unit unit : carrierMustMoveWith.keySet()) {
-          if (carrierMustMoveWith.get(unit).contains(dependent)) {
+        for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : carrierMustMoveWith.entrySet()) {
+          if (unitCollectionEntry.getValue().contains(dependent)) {
             return true;
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -458,8 +458,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
 
     // Check if any repaired units change into different unit types
-    for (final Territory territory : damagedMap.keySet()) {
-      repairedChangeInto(damagedMap.get(territory), territory, bridge);
+    for (final Entry<Territory, Set<Unit>> territorySetEntry : damagedMap.entrySet()) {
+      repairedChangeInto(territorySetEntry.getValue(), territorySetEntry.getKey(), bridge);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -388,21 +388,22 @@ public class MovePerformer implements Serializable {
     // load the transports
     if (route.isLoad() || paratroopsLanding) {
       // mark transports as having transported
-      for (final Unit load : transporting.keySet()) {
-        final Unit transport = transporting.get(load);
-        if (!TransportTracker.transporting(transport).contains(load)) {
-          final Change change = TransportTracker.loadTransportChange((TripleAUnit) transport, load);
+      for (final Entry<Unit, Unit> unitUnitEntry : transporting.entrySet()) {
+        final Unit transport = unitUnitEntry.getValue();
+        if (!TransportTracker.transporting(transport).contains(unitUnitEntry.getKey())) {
+          final Change change = TransportTracker.loadTransportChange((TripleAUnit) transport,
+              unitUnitEntry.getKey());
           m_currentMove.addChange(change);
           m_currentMove.load(transport);
           bridge.addChange(change);
         }
       }
       if (transporting.isEmpty()) {
-        for (final Unit airTransport : dependentAirTransportableUnits.keySet()) {
-          for (final Unit unit : dependentAirTransportableUnits.get(airTransport)) {
-            final Change change = TransportTracker.loadTransportChange((TripleAUnit) airTransport, unit);
+        for (final Entry<Unit, Collection<Unit>> unitCollectionEntry : dependentAirTransportableUnits.entrySet()) {
+          for (final Unit unit : unitCollectionEntry.getValue()) {
+            final Change change = TransportTracker.loadTransportChange((TripleAUnit) unitCollectionEntry.getKey(), unit);
             m_currentMove.addChange(change);
-            m_currentMove.load(airTransport);
+            m_currentMove.load(unitCollectionEntry.getKey());
             bridge.addChange(change);
           }
         }
@@ -415,8 +416,8 @@ public class MovePerformer implements Serializable {
       // if there are multiple units on a single transport, the transport will be in units list multiple times
       if (transporting.isEmpty()) {
         units.addAll(dependentAirTransportableUnits.keySet());
-        for (final Unit airTransport : dependentAirTransportableUnits.keySet()) {
-          units.addAll(dependentAirTransportableUnits.get(airTransport));
+        for (final Entry<Unit, Collection<Unit>> unitCollectionEntry : dependentAirTransportableUnits.entrySet()) {
+          units.addAll(unitCollectionEntry.getValue());
         }
       }
       // any pending battles in the unloading zone?

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -547,9 +547,9 @@ public class MoveValidator {
       }
 
       // Ensure all air transports are included
-      for (final Unit airTransport : newDependents.keySet()) {
-        if (!units.contains(airTransport)) {
-          for (final Unit unit : newDependents.get(airTransport)) {
+      for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : newDependents.entrySet()) {
+        if (!units.contains(unitCollectionEntry.getKey())) {
+          for (final Unit unit : unitCollectionEntry.getValue()) {
             if (units.contains(unit)) {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
@@ -1206,11 +1206,11 @@ public class MoveValidator {
       // airTransports);
       final Map<Unit, Unit> airTransportsAndParatroops =
           TransportUtils.mapTransportsToLoad(paratroopsRequiringTransport, airTransports);
-      for (final Unit paratroop : airTransportsAndParatroops.keySet()) {
-        if (Matches.unitHasMoved().test(paratroop)) {
-          result.addDisallowedUnit("Cannot paratroop units that have already moved", paratroop);
+      for (final Map.Entry<Unit, Unit> unitUnitEntry : airTransportsAndParatroops.entrySet()) {
+        if (Matches.unitHasMoved().test(unitUnitEntry.getKey())) {
+          result.addDisallowedUnit("Cannot paratroop units that have already moved", unitUnitEntry.getKey());
         }
-        final Unit transport = airTransportsAndParatroops.get(paratroop);
+        final Unit transport = unitUnitEntry.getValue();
         if (Matches.unitHasMoved().test(transport)) {
           result.addDisallowedUnit("Cannot move then transport paratroops", transport);
         }
@@ -1319,13 +1319,13 @@ public class MoveValidator {
 
   private static void addToMapping(final Map<Unit, Collection<Unit>> mapping,
       final Map<Unit, Collection<Unit>> newMapping) {
-    for (final Unit key : newMapping.keySet()) {
-      if (mapping.containsKey(key)) {
-        final Collection<Unit> heldUnits = mapping.get(key);
-        heldUnits.addAll(newMapping.get(key));
-        mapping.put(key, heldUnits);
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : newMapping.entrySet()) {
+      if (mapping.containsKey(unitCollectionEntry.getKey())) {
+        final Collection<Unit> heldUnits = mapping.get(unitCollectionEntry.getKey());
+        heldUnits.addAll(unitCollectionEntry.getValue());
+        mapping.put(unitCollectionEntry.getKey(), heldUnits);
       } else {
-        mapping.put(key, newMapping.get(key));
+        mapping.put(unitCollectionEntry.getKey(), unitCollectionEntry.getValue());
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -200,18 +200,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Map<Unit, Collection<Unit>> dependencies = TransportTracker.transporting(units);
     if (!isAlliedAirIndependent()) {
       dependencies.putAll(MoveValidator.carrierMustMoveWith(units, units, m_data, m_attacker));
-      for (final Unit carrier : dependencies.keySet()) {
-        final UnitAttachment ua = UnitAttachment.get(carrier.getType());
+      for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : dependencies.entrySet()) {
+        final UnitAttachment ua = UnitAttachment.get((unitCollectionEntry.getKey()).getType());
         if (ua.getCarrierCapacity() == -1) {
           continue;
         }
-        final Collection<Unit> fighters = dependencies.get(carrier);
+        final Collection<Unit> fighters = unitCollectionEntry.getValue();
         // Dependencies count both land and air units. Land units could be allied or owned, while air is just allied
         // since owned already launched at beginning of turn
         fighters.retainAll(CollectionUtils.getMatches(fighters, Matches.unitIsAir()));
         for (final Unit fighter : fighters) {
           // Set transportedBy for fighter
-          change.add(ChangeFactory.unitPropertyChange(fighter, carrier, TripleAUnit.TRANSPORTED_BY));
+          change.add(ChangeFactory.unitPropertyChange(fighter, unitCollectionEntry.getKey(), TripleAUnit.TRANSPORTED_BY));
         }
         // remove transported fighters from battle display
         m_attackingUnits.removeAll(fighters);
@@ -235,12 +235,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
-    for (final Unit holder : dependencies.keySet()) {
-      final Collection<Unit> transporting = dependencies.get(holder);
-      if (m_dependentUnits.get(holder) != null) {
-        m_dependentUnits.get(holder).addAll(transporting);
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : dependencies.entrySet()) {
+      final Collection<Unit> transporting = unitCollectionEntry.getValue();
+      if (m_dependentUnits.get(unitCollectionEntry.getKey()) != null) {
+        m_dependentUnits.get(unitCollectionEntry.getKey()).addAll(transporting);
       } else {
-        m_dependentUnits.put(holder, new LinkedHashSet<>(transporting));
+        m_dependentUnits.put(unitCollectionEntry.getKey(), new LinkedHashSet<>(transporting));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -49,11 +49,11 @@ public class NonFightingBattle extends DependentBattle {
   public Change addAttackChange(final Route route, final Collection<Unit> units,
       final HashMap<Unit, HashSet<Unit>> targets) {
     final Map<Unit, Collection<Unit>> addedTransporting = TransportTracker.transporting(units);
-    for (final Unit unit : addedTransporting.keySet()) {
-      if (m_dependentUnits.get(unit) != null) {
-        m_dependentUnits.get(unit).addAll(addedTransporting.get(unit));
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : addedTransporting.entrySet()) {
+      if (m_dependentUnits.get(unitCollectionEntry.getKey()) != null) {
+        m_dependentUnits.get(unitCollectionEntry.getKey()).addAll(unitCollectionEntry.getValue());
       } else {
-        m_dependentUnits.put(unit, addedTransporting.get(unit));
+        m_dependentUnits.put(unitCollectionEntry.getKey(), unitCollectionEntry.getValue());
       }
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
@@ -166,12 +166,12 @@ public class NonFightingBattle extends DependentBattle {
    * Add dependent Units. Uninformative comment to suppress checkstyle warning.
    */
   public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
-    for (final Unit holder : dependencies.keySet()) {
-      final Collection<Unit> transporting = dependencies.get(holder);
-      if (m_dependentUnits.get(holder) != null) {
-        m_dependentUnits.get(holder).addAll(transporting);
+    for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : dependencies.entrySet()) {
+      final Collection<Unit> transporting = unitCollectionEntry.getValue();
+      if (m_dependentUnits.get(unitCollectionEntry.getKey()) != null) {
+        m_dependentUnits.get(unitCollectionEntry.getKey()).addAll(transporting);
       } else {
-        m_dependentUnits.put(holder, new LinkedHashSet<>(transporting));
+        m_dependentUnits.put(unitCollectionEntry.getKey(), new LinkedHashSet<>(transporting));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -283,13 +283,14 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
 
   private static IntegerMap<Unit> getUnitRepairs(final Map<Unit, IntegerMap<RepairRule>> repairRules) {
     final IntegerMap<Unit> repairMap = new IntegerMap<>();
-    for (final Unit u : repairRules.keySet()) {
-      final IntegerMap<RepairRule> rules = repairRules.get(u);
+    for (final Entry<Unit, IntegerMap<RepairRule>> unitIntegerMapEntry : repairRules.entrySet()) {
+      final IntegerMap<RepairRule> rules = unitIntegerMapEntry.getValue();
       final TreeSet<RepairRule> repRules = new TreeSet<>(repairRuleComparator);
       repRules.addAll(rules.keySet());
       for (final RepairRule repairRule : repRules) {
-        final int quantity = rules.getInt(repairRule) * repairRule.getResults().getInt(u.getType());
-        repairMap.add(u, quantity);
+        final int quantity = rules.getInt(repairRule) * repairRule.getResults().getInt((unitIntegerMapEntry
+            .getKey()).getType());
+        repairMap.add(unitIntegerMapEntry.getKey(), quantity);
       }
     }
     return repairMap;
@@ -309,11 +310,10 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
 
   private IntegerMap<Resource> getRepairCosts(final Map<Unit, IntegerMap<RepairRule>> repairRules,
       final PlayerID player) {
-    final Collection<Unit> units = repairRules.keySet();
     final IntegerMap<Resource> costs = new IntegerMap<>();
-    for (final Unit u : units) {
-      for (final RepairRule rule : repairRules.get(u).keySet()) {
-        costs.addMultiple(rule.getCosts(), repairRules.get(u).getInt(rule));
+    for (final Entry<Unit, IntegerMap<RepairRule>> unitIntegerMapEntry : repairRules.entrySet()) {
+      for (final RepairRule rule : unitIntegerMapEntry.getValue().keySet()) {
+        costs.addMultiple(rule.getCosts(), unitIntegerMapEntry.getValue().getInt(rule));
       }
     }
     final double discount = TechAbilityAttachment.getRepairDiscount(player, getData());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -133,9 +133,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private Unit getTarget(final Unit attacker) {
-    for (final Unit target : m_targets.keySet()) {
-      if (m_targets.get(target).contains(attacker)) {
-        return target;
+    for (final Entry<Unit, HashSet<Unit>> unitHashSetEntry : m_targets.entrySet()) {
+      if (unitHashSetEntry.getValue().contains(attacker)) {
+        return unitHashSetEntry.getKey();
       }
     }
     throw new IllegalStateException("Unit " + attacker.getType().getName() + " has no target");
@@ -148,13 +148,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     if (targets == null) {
       return ChangeFactory.EMPTY_CHANGE;
     }
-    for (final Unit target : targets.keySet()) {
-      HashSet<Unit> currentAttackers = m_targets.get(target);
+    for (final Entry<Unit, HashSet<Unit>> unitHashSetEntry : targets.entrySet()) {
+      HashSet<Unit> currentAttackers = m_targets.get(unitHashSetEntry.getKey());
       if (currentAttackers == null) {
         currentAttackers = new HashSet<>();
       }
-      currentAttackers.addAll(targets.get(target));
-      m_targets.put(target, currentAttackers);
+      currentAttackers.addAll(unitHashSetEntry.getValue());
+      m_targets.put(unitHashSetEntry.getKey(), currentAttackers);
     }
     return ChangeFactory.EMPTY_CHANGE;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -146,36 +146,37 @@ public class BattleRecords implements Serializable {
   }
 
   public void addRecord(final BattleRecords other) {
-    for (final PlayerID p : other.m_records.keySet()) {
-      final HashMap<GUID, BattleRecord> currentRecord = m_records.get(p);
+    for (final Entry<PlayerID, HashMap<GUID, BattleRecord>> playerIDHashMapEntry : other.m_records.entrySet()) {
+      final HashMap<GUID, BattleRecord> currentRecord = m_records.get(playerIDHashMapEntry.getKey());
       if (currentRecord != null) {
         // this only comes up if we use edit mode to create an attack for a player who's already had their turn and
         // therefore already has
         // their record.
-        final HashMap<GUID, BattleRecord> additionalRecords = other.m_records.get(p);
+        final HashMap<GUID, BattleRecord> additionalRecords = playerIDHashMapEntry.getValue();
         for (final Entry<GUID, BattleRecord> entry : additionalRecords.entrySet()) {
           final GUID guid = entry.getKey();
           final BattleRecord br = entry.getValue();
           if (currentRecord.containsKey(guid)) {
-            throw new IllegalStateException("Should not be adding battle record for player " + p.getName()
+            throw new IllegalStateException("Should not be adding battle record for player " + (playerIDHashMapEntry
+                .getKey()).getName()
                 + " when they are already on the record. " + "Trying to add: " + br.toString());
           }
           currentRecord.put(guid, br);
         }
-        m_records.put(p, currentRecord);
+        m_records.put(playerIDHashMapEntry.getKey(), currentRecord);
       } else {
-        m_records.put(p, other.m_records.get(p));
+        m_records.put(playerIDHashMapEntry.getKey(), playerIDHashMapEntry.getValue());
       }
     }
   }
 
   public void removeRecord(final BattleRecords other) {
-    for (final PlayerID p : other.m_records.keySet()) {
-      final HashMap<GUID, BattleRecord> currentRecord = m_records.get(p);
+    for (final Entry<PlayerID, HashMap<GUID, BattleRecord>> playerIDHashMapEntry : other.m_records.entrySet()) {
+      final HashMap<GUID, BattleRecord> currentRecord = m_records.get(playerIDHashMapEntry.getKey());
       if (currentRecord == null) {
         throw new IllegalStateException("Trying to remove a player records but records do not exist");
       }
-      final HashMap<GUID, BattleRecord> toRemoveRecords = other.m_records.get(p);
+      final HashMap<GUID, BattleRecord> toRemoveRecords = playerIDHashMapEntry.getValue();
       for (final Entry<GUID, BattleRecord> entry : toRemoveRecords.entrySet()) {
         final GUID guid = entry.getKey();
         if (!currentRecord.containsKey(guid)) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -68,8 +68,8 @@ class CountryChart {
         countryFileWriter.write(currentTerritory.getName());
         final List<Map<UnitType, Integer>> currentList = infoMap.get(currentTerritory);
         for (final Map<UnitType, Integer> currentMap : currentList) {
-          for (final UnitType unitTypeHere : currentMap.keySet()) {
-            final int here = currentMap.get(unitTypeHere);
+          for (final Map.Entry<UnitType, Integer> unitTypeIntegerEntry : currentMap.entrySet()) {
+            final int here = unitTypeIntegerEntry.getValue();
             countryFileWriter.write("," + here);
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
@@ -48,8 +48,8 @@ class PuInfo {
         for (final PlayerID currentPlayer : gameData.getPlayerList()) {
           resourceWriter.write(currentPlayer.getName());
           final Map<Resource, Integer> resourceMap = infoMap.get(currentPlayer);
-          for (final Resource currentResource : resourceMap.keySet()) {
-            final int amountResource = resourceMap.get(currentResource);
+          for (final Map.Entry<Resource, Integer> resourceIntegerEntry : resourceMap.entrySet()) {
+            final int amountResource = resourceIntegerEntry.getValue();
             resourceWriter.write("," + amountResource);
           }
           resourceWriter.write("\r\n");

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -619,9 +619,9 @@ public class MovePanel extends AbstractMovePanel {
     // First, load capable transports
     final Map<Unit, Unit> unitsToCapableTransports =
         TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, capableTransports);
-    for (final Unit unit : unitsToCapableTransports.keySet()) {
-      final Unit transport = unitsToCapableTransports.get(unit);
-      final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+    for (final Map.Entry<Unit, Unit> unitUnitEntry : unitsToCapableTransports.entrySet()) {
+      final Unit transport = unitUnitEntry.getValue();
+      final int unitCost = UnitAttachment.get((unitUnitEntry.getKey()).getType()).getTransportCost();
       availableCapacityMap.add(transport, (-1 * unitCost));
       defaultSelections.add(transport);
     }
@@ -630,9 +630,9 @@ public class MovePanel extends AbstractMovePanel {
     // Next, load allied transports
     final Map<Unit, Unit> unitsToAlliedTransports =
         TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, alliedTransports);
-    for (final Unit unit : unitsToAlliedTransports.keySet()) {
-      final Unit transport = unitsToAlliedTransports.get(unit);
-      final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+    for (final Map.Entry<Unit, Unit> unitUnitEntry : unitsToAlliedTransports.entrySet()) {
+      final Unit transport = unitUnitEntry.getValue();
+      final int unitCost = UnitAttachment.get((unitUnitEntry.getKey()).getType()).getTransportCost();
       availableCapacityMap.add(transport, (-1 * unitCost));
       defaultSelections.add(transport);
       useAlliedTransports = true;
@@ -645,9 +645,9 @@ public class MovePanel extends AbstractMovePanel {
     if (getSelectedEndpointTerritory() == null) {
       final Map<Unit, Unit> unitsToIncapableTransports =
           TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, incapableTransports);
-      for (final Unit unit : unitsToIncapableTransports.keySet()) {
-        final Unit transport = unitsToIncapableTransports.get(unit);
-        final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
+      for (final Map.Entry<Unit, Unit> unitUnitEntry : unitsToIncapableTransports.entrySet()) {
+        final Unit transport = unitUnitEntry.getValue();
+        final int unitCost = UnitAttachment.get((unitUnitEntry.getKey()).getType()).getTransportCost();
         availableCapacityMap.add(transport, (-1 * unitCost));
         defaultSelections.add(transport);
       }
@@ -848,8 +848,8 @@ public class MovePanel extends AbstractMovePanel {
           final Collection<Unit> unitsToLoad =
               CollectionUtils.getMatches(route.getStart().getUnits().getUnits(), unitsToLoadMatch);
           unitsToLoad.removeAll(selectedUnits);
-          for (final Unit u : dependentUnits.keySet()) {
-            unitsToLoad.removeAll(dependentUnits.get(u));
+          for (final Map.Entry<Unit, Collection<Unit>> unitCollectionEntry : dependentUnits.entrySet()) {
+            unitsToLoad.removeAll(unitCollectionEntry.getValue());
           }
           // Get the potential air transports to load
           final Predicate<Unit> candidateAirTransportsMatch = Matches.unitIsAirTransport()
@@ -945,10 +945,10 @@ public class MovePanel extends AbstractMovePanel {
         final String action = "load";
         loadedUnits = userChooseUnits(defaultSelections, unitsToLoadMatch, unitsToLoad, title, action);
         final Map<Unit, Unit> mapping = TransportUtils.mapTransportsToLoad(loadedUnits, airTransportsToLoad);
-        for (final Unit unit : mapping.keySet()) {
+        for (final Map.Entry<Unit, Unit> unitUnitEntry : mapping.entrySet()) {
           final Collection<Unit> unitsColl = new ArrayList<>();
-          unitsColl.add(unit);
-          final Unit airTransport = mapping.get(unit);
+          unitsColl.add(unitUnitEntry.getKey());
+          final Unit airTransport = unitUnitEntry.getValue();
           if (dependentUnits.containsKey(airTransport)) {
             unitsColl.addAll(dependentUnits.get(airTransport));
           }

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -3,8 +3,8 @@ package games.strategy.triplea.ui;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeSet;
 
 import javax.swing.BoxLayout;
@@ -63,18 +63,18 @@ public class SimpleUnitPanel extends JPanel {
   public void setUnitsFromRepairRuleMap(final HashMap<Unit, IntegerMap<RepairRule>> units, final PlayerID player,
       final GameData data) {
     removeAll();
-    final Set<Unit> entries = units.keySet();
-    for (final Unit unit : entries) {
-      final IntegerMap<RepairRule> rules = units.get(unit);
+    for (final Map.Entry<Unit, IntegerMap<RepairRule>> unitIntegerMapEntry : units.entrySet()) {
+      final IntegerMap<RepairRule> rules = unitIntegerMapEntry.getValue();
       final TreeSet<RepairRule> repairRules = new TreeSet<>(repairRuleComparator);
       repairRules.addAll(rules.keySet());
       for (final RepairRule repairRule : repairRules) {
         final int quantity = rules.getInt(repairRule);
         if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           // check to see if the repair rule matches the damaged unit
-          if (unit.getType().equals((repairRule.getResults().keySet().iterator().next()))) {
-            addUnits(player, quantity, unit.getType(), Matches.unitHasTakenSomeBombingUnitDamage().test(unit),
-                Matches.unitIsDisabled().test(unit));
+          if ((unitIntegerMapEntry.getKey()).getType().equals((repairRule.getResults().keySet().iterator().next()))) {
+            addUnits(player, quantity, (unitIntegerMapEntry.getKey()).getType(), Matches.unitHasTakenSomeBombingUnitDamage().test(
+                unitIntegerMapEntry.getKey()),
+                Matches.unitIsDisabled().test(unitIntegerMapEntry.getKey()));
           }
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1182,21 +1182,22 @@ public class TripleAFrame extends MainGameFrame {
       final JPanel panel2 = new JPanel();
       panel2.setBorder(BorderFactory.createEmptyBorder());
       panel2.setLayout(new FlowLayout());
-      for (final Territory from : possibleScramblers.keySet()) {
+      for (final Entry<Territory, Tuple<Collection<Unit>, Collection<Unit>>> territoryTupleEntry : possibleScramblers
+          .entrySet()) {
         final JPanel panelChooser = new JPanel();
         panelChooser.setLayout(new BoxLayout(panelChooser, BoxLayout.Y_AXIS));
         panelChooser.setBorder(BorderFactory.createLineBorder(getBackground()));
-        final JLabel whereFrom = new JLabel("From: " + from.getName());
+        final JLabel whereFrom = new JLabel("From: " + (territoryTupleEntry.getKey()).getName());
         whereFrom.setHorizontalAlignment(SwingConstants.LEFT);
         whereFrom.setFont(new Font("Arial", Font.BOLD, 12));
         panelChooser.add(whereFrom);
         panelChooser.add(new JLabel(" "));
-        final Collection<Unit> possible = possibleScramblers.get(from).getSecond();
+        final Collection<Unit> possible = territoryTupleEntry.getValue().getSecond();
         final int maxAllowed =
-            Math.min(BattleDelegate.getMaxScrambleCount(possibleScramblers.get(from).getFirst()), possible.size());
+            Math.min(BattleDelegate.getMaxScrambleCount(territoryTupleEntry.getValue().getFirst()), possible.size());
         final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
         chooser.setMaxAndShowMaxButton(maxAllowed);
-        choosers.add(Tuple.of(from, chooser));
+        choosers.add(Tuple.of(territoryTupleEntry.getKey(), chooser));
         panelChooser.add(chooser);
         final JScrollPane chooserScrollPane = new JScrollPane(panelChooser);
         panel2.add(chooserScrollPane);

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -398,9 +398,9 @@ public class HistoryLog extends JFrame {
     if (verbose) {
       logWriter.println("Combat Hit Differential Summary :");
       logWriter.println();
-      for (final String player : hitDifferentialMap.keySet()) {
-        logWriter.println(moreIndent + player + " : "
-            + String.format("%.2f", hitDifferentialMap.get(player)));
+      for (final Map.Entry<String, Double> stringDoubleEntry : hitDifferentialMap.entrySet()) {
+        logWriter.println(moreIndent + stringDoubleEntry.getKey() + " : "
+            + String.format("%.2f", stringDoubleEntry.getValue()));
       }
     }
     logWriter.println();

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -262,8 +262,8 @@ public class MapData implements Closeable {
   private Map<Image, List<Point>> loadDecorations() throws IOException {
     final Map<Image, List<Point>> decorations = new HashMap<>();
     final Map<String, List<Point>> points = readPointsOneToMany(optionalResource(DECORATIONS_FILE));
-    for (final String name : points.keySet()) {
-      loadImage("misc/" + name).ifPresent(img -> decorations.put(img, points.get(name)));
+    for (final Map.Entry<String, List<Point>> stringListEntry : points.entrySet()) {
+      loadImage("misc/" + stringListEntry.getKey()).ifPresent(img -> decorations.put(img, stringListEntry.getValue()));
     }
     return decorations;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -249,16 +249,16 @@ final class ViewMenu extends JMenu {
     final ButtonGroup mapButtonGroup = new ButtonGroup();
     final Map<String, String> skins = AbstractUiContext.getSkins(frame.getGame().getData());
     mapSubMenu.setEnabled(skins.size() > 1);
-    for (final String key : skins.keySet()) {
-      final JMenuItem mapMenuItem = new JRadioButtonMenuItem(key);
+    for (final Map.Entry<String, String> stringStringEntry : skins.entrySet()) {
+      final JMenuItem mapMenuItem = new JRadioButtonMenuItem(stringStringEntry.getKey());
       mapButtonGroup.add(mapMenuItem);
       mapSubMenu.add(mapMenuItem);
-      if (skins.get(key).equals(AbstractUiContext.getMapDir())) {
+      if (stringStringEntry.getValue().equals(AbstractUiContext.getMapDir())) {
         mapMenuItem.setSelected(true);
       }
       mapMenuItem.addActionListener(e -> {
         try {
-          frame.updateMap(skins.get(key));
+          frame.updateMap(stringStringEntry.getValue());
           if (uiContext.getMapData().getHasRelief()) {
             showMapDetails.setSelected(true);
           }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -196,10 +196,12 @@ public class TileManager {
         }
         // add the decorations
         final Map<Image, List<Point>> decorations = mapData.getDecorations();
-        for (final Image img : decorations.keySet()) {
-          for (final Point p : decorations.get(img)) {
-            final DecoratorDrawable drawable = new DecoratorDrawable(p, img);
-            final Rectangle bounds = new Rectangle(p.x, p.y, img.getWidth(null), img.getHeight(null));
+        for (final Map.Entry<Image, List<Point>> imageListEntry : decorations.entrySet()) {
+          for (final Point p : imageListEntry.getValue()) {
+            final DecoratorDrawable drawable = new DecoratorDrawable(p, imageListEntry.getKey());
+            final Rectangle bounds = new Rectangle(p.x, p.y, (imageListEntry.getKey()).getWidth(null), (imageListEntry
+                .getKey())
+                .getHeight(null));
             for (final Tile t : getTiles(bounds)) {
               t.addDrawable(drawable);
             }

--- a/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -125,14 +125,14 @@ public class TuvUtils {
         differentCosts.put(ut, listTemp);
       }
     }
-    for (final UnitType ut : differentCosts.keySet()) {
+    for (final Entry<UnitType, List<Integer>> unitTypeListEntry : differentCosts.entrySet()) {
       int totalCosts = 0;
-      final List<Integer> costsForType = differentCosts.get(ut);
+      final List<Integer> costsForType = unitTypeListEntry.getValue();
       for (final int cost : costsForType) {
         totalCosts += cost;
       }
       final int averagedCost = (int) Math.round(((double) totalCosts / (double) costsForType.size()));
-      costs.put(ut, averagedCost);
+      costs.put(unitTypeListEntry.getKey(), averagedCost);
     }
     return costs;
   }
@@ -211,9 +211,9 @@ public class TuvUtils {
       }
       // since our production frontier may not cover all the units we control, and not the enemy units,
       // we will add any unit types not in our list, based on the list for everyone
-      for (final UnitType ut : average.keySet()) {
-        if (!current.keySet().contains(ut)) {
-          current.put(ut, average.get(ut));
+      for (final Entry<UnitType, ResourceCollection> unitTypeResourceCollectionEntry : average.entrySet()) {
+        if (!current.keySet().contains(unitTypeResourceCollectionEntry.getKey())) {
+          current.put(unitTypeResourceCollectionEntry.getKey(), unitTypeResourceCollectionEntry.getValue());
         }
       }
     }

--- a/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-core/src/main/java/tools/image/CenterPicker.java
@@ -216,10 +216,10 @@ public class CenterPicker extends JFrame {
       public void paint(final Graphics g) {
         g.drawImage(image, 0, 0, this);
         g.setColor(Color.red);
-        for (final String centerName : centers.keySet()) {
-          final Point item = centers.get(centerName);
+        for (final Entry<String, Point> stringPointEntry : centers.entrySet()) {
+          final Point item = stringPointEntry.getValue();
           g.fillOval(item.x, item.y, 15, 15);
-          g.drawString(centerName, item.x + 17, item.y + 13);
+          g.drawString(stringPointEntry.getKey(), item.x + 17, item.y + 13);
         }
       }
     };

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -217,9 +217,9 @@ public class PolygonGrabber extends JFrame {
           bufferedImage.getHeight(null), BufferedImage.TYPE_INT_ARGB);
       final Graphics g = imageCopy.getGraphics();
       g.drawImage(bufferedImage, 0, 0, null);
-      for (final String territoryName : centers.keySet()) {
-        final Point center = centers.get(territoryName);
-        ToolLogger.info("Detecting Polygon for:" + territoryName);
+      for (final Entry<String, Point> stringPointEntry : centers.entrySet()) {
+        final Point center = stringPointEntry.getValue();
+        ToolLogger.info("Detecting Polygon for:" + stringPointEntry.getKey());
         final Polygon p = findPolygon(center.x, center.y);
         // test if the poly contains the center point (this often fails when there is an island right above (because
         // findPolygon will grab
@@ -251,7 +251,7 @@ public class PolygonGrabber extends JFrame {
         }
         final List<Polygon> polys = new ArrayList<>();
         polys.add(p);
-        polygons.put(territoryName, polys);
+        polygons.put(stringPointEntry.getKey(), polys);
       }
       g.dispose();
       imageCopy.flush();

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -88,13 +88,13 @@ public class ConnectionFinder {
     Map<String, List<Polygon>> mapOfPolygons = null;
     try (InputStream in = new FileInputStream(polyFile)) {
       mapOfPolygons = PointFileReaderWriter.readOneToManyPolygons(in);
-      for (final String territoryName : mapOfPolygons.keySet()) {
-        final List<Polygon> listOfPolygons = mapOfPolygons.get(territoryName);
+      for (final Map.Entry<String, List<Polygon>> stringListEntry : mapOfPolygons.entrySet()) {
+        final List<Polygon> listOfPolygons = stringListEntry.getValue();
         final List<Area> listOfAreas = new ArrayList<>();
         for (final Polygon p : listOfPolygons) {
           listOfAreas.add(new Area(p));
         }
-        territoryAreas.put(territoryName, listOfAreas);
+        territoryAreas.put(stringListEntry.getKey(), listOfAreas);
       }
     } catch (final IOException e) {
       ToolLogger.error("Failed to load polygons: " + polyFile.getAbsolutePath(), e);


### PR DESCRIPTION
Static anlysis fix:  Reports iteration over the keySet() of a java.util.Map instance, where the iterated keys are used to retrieve the values from the map. Such iteration may be more efficiently replaced by iteration over the entrySet() of the map.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
