### PR TITLE
Replace StringBuffer by String

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -98,7 +98,7 @@ class EngineVersionProperties {
   }
 
   private String getOutOfDateMessage() {
-    final String text = "<html>" + "<h2>A new version of TripleA is out.  Please Update TripleA!</h2>"
+    return "<html>" + "<h2>A new version of TripleA is out.  Please Update TripleA!</h2>"
         + "<br />Your current version: " + ClientContext.engineVersion().getExactVersion()
         + "<br />Latest version available for download: " + getLatestVersionOut()
         + "<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
@@ -111,15 +111,12 @@ class EngineVersionProperties {
         + "shortcuts to the new TripleA."
         + "<br /><br />What is new:<br />"
         + "</html>";
-    return text;
   }
 
   private String getOutOfDateReleaseUpdates() {
-    final String text =
-        "<html><body>" + "Link to full Change Log:<br /><a class=\"external\" href=\"" + getChangeLogLink() + "\">"
+    return "<html><body>" + "Link to full Change Log:<br /><a class=\"external\" href=\"" + getChangeLogLink() + "\">"
             + getChangeLogLink() + "</a><br />"
             + "</body></html>";
-    return text;
   }
 
   Component getOutOfDateComponent() {

--- a/game-core/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -98,29 +98,28 @@ class EngineVersionProperties {
   }
 
   private String getOutOfDateMessage() {
-    final StringBuilder text = new StringBuilder("<html>");
-    text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: ").append(ClientContext.engineVersion().getExactVersion());
-    text.append("<br />Latest version available for download: ").append(getLatestVersionOut());
-    text.append("<br /><br />Click to download: <a class=\"external\" href=\"").append(getLinkToDownloadLatestVersion())
-        .append("\">").append(getLinkToDownloadLatestVersion()).append("</a>");
-    text.append("<br />Backup Mirror: <a class=\"external\" href=\"").append(getLinkAltToDownloadLatestVersion())
-        .append("\">").append(getLinkAltToDownloadLatestVersion()).append("</a>");
-    text.append("<br /><br />Please note that installing a new version of TripleA will not remove any old copies of ")
-        .append("TripleA.");
-    text.append("<br />So be sure to either manually uninstall all older versions of TripleA, or change your ")
-        .append("shortcuts to the new TripleA.");
-    text.append("<br /><br />What is new:<br />");
-    text.append("</html>");
-    return text.toString();
+    final String text = "<html>" + "<h2>A new version of TripleA is out.  Please Update TripleA!</h2>"
+        + "<br />Your current version: " + ClientContext.engineVersion().getExactVersion()
+        + "<br />Latest version available for download: " + getLatestVersionOut()
+        + "<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
+        + "\">" + getLinkToDownloadLatestVersion() + "</a>"
+        + "<br />Backup Mirror: <a class=\"external\" href=\"" + getLinkAltToDownloadLatestVersion()
+        + "\">" + getLinkAltToDownloadLatestVersion() + "</a>"
+        + "<br /><br />Please note that installing a new version of TripleA will not remove any old copies of "
+        + "TripleA."
+        + "<br />So be sure to either manually uninstall all older versions of TripleA, or change your "
+        + "shortcuts to the new TripleA."
+        + "<br /><br />What is new:<br />"
+        + "</html>";
+    return text;
   }
 
   private String getOutOfDateReleaseUpdates() {
-    final StringBuilder text = new StringBuilder("<html><body>");
-    text.append("Link to full Change Log:<br /><a class=\"external\" href=\"").append(getChangeLogLink()).append("\">")
-        .append(getChangeLogLink()).append("</a><br />");
-    text.append("</body></html>");
-    return text.toString();
+    final String text =
+        "<html><body>" + "Link to full Change Log:<br /><a class=\"external\" href=\"" + getChangeLogLink() + "\">"
+            + getChangeLogLink() + "</a><br />"
+            + "</body></html>";
+    return text;
   }
 
   Component getOutOfDateComponent() {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -515,7 +515,7 @@ public class HeadlessGameServer {
   }
 
   public void printThreadDumpsAndStatus() {
-    final String sb = "Dump to Log:"
+    System.out.println("Dump to Log:"
         + "\n\nStatus:\n"
         + getStatus()
         + "\n\nServer:\n"
@@ -524,8 +524,7 @@ public class HeadlessGameServer {
         + DebugUtils.getThreadDumps()
         + "\n\n"
         + DebugUtils.getMemory()
-        + "\n\nDump finished.\n";
-    System.out.println(sb);
+        + "\n\nDump finished.\n");
   }
 
   synchronized void shutdown() {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -515,18 +515,17 @@ public class HeadlessGameServer {
   }
 
   public void printThreadDumpsAndStatus() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("Dump to Log:");
-    sb.append("\n\nStatus:\n");
-    sb.append(getStatus());
-    sb.append("\n\nServer:\n");
-    sb.append(getServerModel());
-    sb.append("\n\n");
-    sb.append(DebugUtils.getThreadDumps());
-    sb.append("\n\n");
-    sb.append(DebugUtils.getMemory());
-    sb.append("\n\nDump finished.\n");
-    System.out.println(sb.toString());
+    final String sb = "Dump to Log:"
+        + "\n\nStatus:\n"
+        + getStatus()
+        + "\n\nServer:\n"
+        + getServerModel()
+        + "\n\n"
+        + DebugUtils.getThreadDumps()
+        + "\n\n"
+        + DebugUtils.getMemory()
+        + "\n\nDump finished.\n";
+    System.out.println(sb);
   }
 
   synchronized void shutdown() {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -99,10 +99,9 @@ class FileSystemAccessStrategy {
 
   private static void showDialog(final String message, final List<DownloadFileDescription> mapList,
       final Function<DownloadFileDescription, String> outputFunction) {
-    final StringBuilder sb = new StringBuilder("<html>" + message + "<br /> " + formatMapList(mapList, outputFunction));
-    sb.append("</html>");
 
-    SwingComponents.newMessageDialog(sb.toString());
+    SwingComponents.newMessageDialog(
+        "<html>" + message + "<br /> " + formatMapList(mapList, outputFunction) + "</html>");
   }
 
   private static String createDialogMessage(final String message, final List<DownloadFileDescription> mapList) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -471,16 +471,15 @@ public class ClientModel implements IMessengerErrorListener {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("ClientModel GameData:").append(gameDataOnStartup == null ? "null" : gameDataOnStartup.getGameName())
-        .append("\n");
-    sb.append("Connected:").append(messenger == null ? "null" : messenger.isConnected()).append("\n");
-    sb.append(messenger);
-    sb.append("\n");
-    sb.append(remoteMessenger);
-    sb.append("\n");
-    sb.append(channelMessenger);
-    return sb.toString();
+    final String sb = "ClientModel GameData:" + (gameDataOnStartup == null ? "null" : gameDataOnStartup.getGameName())
+        + "\n"
+        + "Connected:" + (messenger == null ? "null" : messenger.isConnected()) + "\n"
+        + messenger
+        + "\n"
+        + remoteMessenger
+        + "\n"
+        + channelMessenger;
+    return sb;
   }
 
   static class ClientProps {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -471,7 +471,7 @@ public class ClientModel implements IMessengerErrorListener {
 
   @Override
   public String toString() {
-    final String sb = "ClientModel GameData:" + (gameDataOnStartup == null ? "null" : gameDataOnStartup.getGameName())
+    return "ClientModel GameData:" + (gameDataOnStartup == null ? "null" : gameDataOnStartup.getGameName())
         + "\n"
         + "Connected:" + (messenger == null ? "null" : messenger.isConnected()) + "\n"
         + messenger
@@ -479,7 +479,6 @@ public class ClientModel implements IMessengerErrorListener {
         + remoteMessenger
         + "\n"
         + channelMessenger;
-    return sb;
   }
 
   static class ClientProps {

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -108,11 +108,10 @@ public class UnitCategory implements Comparable<UnitCategory> {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("Entry type:").append(type.getName()).append(" owner:").append(owner.getName()).append(" damaged:")
-        .append(damaged).append(" bombingUnitDamage:").append(bombingDamage).append(" disabled:").append(disabled)
-        .append(" dependents:").append(dependents).append(" movement:").append(movement);
-    return sb.toString();
+    final String sb = "Entry type:" + type.getName() + " owner:" + owner.getName() + " damaged:"
+        + damaged + " bombingUnitDamage:" + bombingDamage + " disabled:" + disabled
+        + " dependents:" + dependents + " movement:" + movement;
+    return sb;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -108,10 +108,9 @@ public class UnitCategory implements Comparable<UnitCategory> {
 
   @Override
   public String toString() {
-    final String sb = "Entry type:" + type.getName() + " owner:" + owner.getName() + " damaged:"
+    return "Entry type:" + type.getName() + " owner:" + owner.getName() + " damaged:"
         + damaged + " bombingUnitDamage:" + bombingDamage + " disabled:" + disabled
         + " dependents:" + dependents + " movement:" + movement;
-    return sb;
   }
 
   /**


### PR DESCRIPTION
IDE fix: Reports any usages of java.lang.StringBuffer and java.lang.StringBuilder which can be replaced with a single java.lang.String concatenation. Using a String concatenation makes the code shorter and simpler. This inspection only reports when the resulting concatenation is at least as efficient or more efficient than the original StringBuffer or StringBuilder code.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
