### PR TITLE
StringBuilder.toString in concatenation

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -257,7 +257,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
         }
         sb.append(c);
       }
-      extra = extra + " (" + sb.toString() + ")";
+      extra = extra + " (" + sb + ")";
     }
     if (extra.length() == 0) {
       return node.getName();

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -99,7 +99,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     for (int i = 1; i < allowedValues.length; ++i) {
       sb.append(" or ").append(allowedValues[i]);
     }
-    return new IllegalArgumentException(sb.toString() + " ([Not Allowed] Given: " + givenValue + ")");
+    return new IllegalArgumentException(sb + " ([Not Allowed] Given: " + givenValue + ")");
   }
 
   protected String thisErrorMsg() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -271,7 +271,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         text.append(" and ");
       }
     }
-    final String transcriptText = player.getName() + " discover " + text.toString();
+    final String transcriptText = player.getName() + " discover " + text;
     if (advances.size() > 0) {
       bridge.getHistoryWriter().startEvent(transcriptText);
       // play a sound

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -275,7 +275,7 @@ public class ProductionPanel extends JPanel {
       }
       final JLabel label =
           icon.isPresent() ? new JLabel(text, icon.get(), SwingConstants.LEFT) : new JLabel(text, SwingConstants.LEFT);
-      final String toolTipText = "<html>" + tooltip.toString() + "</html>";
+      final String toolTipText = "<html>" + tooltip + "</html>";
       info.setToolTipText(toolTipText);
       label.setToolTipText(toolTipText);
       final int space = 8;


### PR DESCRIPTION
IDE fix: Reports StringBuffer.toString() or StringBuilder.toString() calls in String concatenations. Such calls are unnecessary when concatenating and can be removed, saving a method call and an object allocation which may improve performance.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
