### PR TITLE
Equals() call on enum -> '=='

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -483,7 +483,7 @@ public class GameRunner {
 
   public static void joinGame(final GameDescription description, final Messengers messengers, final Container parent) {
     final GameDescription.GameStatus status = description.getStatus();
-    if (GameDescription.GameStatus.LAUNCHING.equals(status)) {
+    if (GameDescription.GameStatus.LAUNCHING == status) {
       return;
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -216,7 +216,7 @@ public class DownloadMapsWindow extends JFrame {
     }
 
     pendingDownloads.addAll(ClientContext.downloadCoordinator().getDownloads().stream()
-        .filter(download -> !download.getDownloadState().equals(DownloadState.CANCELLED))
+        .filter(download -> download.getDownloadState() != DownloadState.CANCELLED)
         .map(DownloadFile::getDownload)
         .collect(Collectors.toList()));
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
@@ -87,7 +87,7 @@ public final class TimespanDialog extends JDialog {
   }
 
   private void updateComponents() {
-    durationSpinner.setEnabled(!TimeUnit.FOREVER.equals(timeUnitComboBox.getSelectedItem()));
+    durationSpinner.setEnabled(TimeUnit.FOREVER != timeUnitComboBox.getSelectedItem());
   }
 
   Optional<Timespan> open() {
@@ -106,7 +106,7 @@ public final class TimespanDialog extends JDialog {
   }
 
   private enum Result {
-    OK, CANCEL;
+    OK, CANCEL
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -230,7 +230,7 @@ abstract class AbstractBattle implements IBattle {
     }
     final IBattle other = (IBattle) o;
     return other.getTerritory().equals(this.m_battleSite) && other.isBombingRun() == this.isBombingRun()
-        && other.getBattleType().equals(this.getBattleType());
+        && other.getBattleType() == this.getBattleType();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -934,7 +934,7 @@ public class BattleTracker implements Serializable {
   public IBattle getPendingBattle(final Territory t, final boolean bombing, final BattleType type) {
     for (final IBattle battle : m_pendingBattles) {
       if (battle.getTerritory().equals(t) && battle.isBombingRun() == bombing) {
-        if (type == null || type.equals(battle.getBattleType())) {
+        if (type == null || type == battle.getBattleType()) {
           return battle;
         }
       }
@@ -957,7 +957,7 @@ public class BattleTracker implements Serializable {
   Collection<IBattle> getPendingBattles(final Territory t, final BattleType type) {
     final Collection<IBattle> battles = new HashSet<>();
     for (final IBattle battle : m_pendingBattles) {
-      if (battle.getTerritory().equals(t) && (type == null || type.equals(battle.getBattleType()))) {
+      if (battle.getTerritory().equals(t) && (type == null || type == battle.getBattleType())) {
         battles.add(battle);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
@@ -193,7 +193,7 @@ public class BattleRecord implements Serializable {
       return false;
     }
     final BattleRecord other = (BattleRecord) o;
-    return other.battleSite.equals(this.battleSite) && other.battleType.equals(this.battleType)
+    return other.battleSite.equals(this.battleSite) && other.battleType == this.battleType
         && other.attacker.equals(this.attacker);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -488,7 +488,7 @@ final class ViewMenu extends JMenu {
     return createRadioButtonItem(text, group, e -> {
       UnitsDrawer.setUnitFlagDrawMode(drawMode, prefs);
       frame.getMapPanel().resetMap();
-    }, setting.equals(drawMode));
+    }, setting == drawMode);
   }
 
   private static JRadioButtonMenuItem createRadioButtonItem(final String text, final ButtonGroup group,


### PR DESCRIPTION
IDE fix: Reports calls to equals() on Enum constants. Such calls can be replaced by an identity comparison (==) because two Enum constants are equal only when they have the same identity.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
