### PR TITLE
Remove extra lobby.properties file

### DIFF
--- a/config/lobby/lobby.properties
+++ b/config/lobby/lobby.properties
@@ -1,4 +1,0 @@
-maintenance_mode = false
-port  = 3304
-postgres_user = postgres
-postgres_password = postgres


### PR DESCRIPTION
Looks like a copy of this file got left behind after the `game-core` subproject was added.  I ran the `release` task and verified the `server.zip` artifact still contains _config/lobby/lobby.properties_.