### PR TITLE
IDE fix: narrow scope of variables

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -112,10 +112,10 @@ public class Chat {
   }
 
   private static LinkedHashSet<String> getTagText(final Tag tag) {
-    final LinkedHashSet<String> tagText = new LinkedHashSet<>();
     if (tag == Tag.NONE) {
       return null;
     }
+    final LinkedHashSet<String> tagText = new LinkedHashSet<>();
     if (tag == Tag.MODERATOR) {
       tagText.add(TAG_MODERATOR);
     }

--- a/game-core/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -80,7 +80,6 @@ public class BattleRecordsList extends GameDataComponent {
   // Interpretation stuff below
   public static int getTuvDamageCausedByPlayer(final PlayerID attacker, final BattleRecordsList brl,
       final int beginningRound, final int endRound, final boolean currentRoundOnly, final boolean includeNullPlayer) {
-    int damageCausedByAttacker = 0;
     final Collection<BattleRecords> brs = new ArrayList<>();
     if (currentRoundOnly) {
       if (brl != null) {
@@ -102,6 +101,7 @@ public class BattleRecordsList extends GameDataComponent {
         }
       }
     }
+    int damageCausedByAttacker = 0;
     for (final BattleRecords br : brs) {
       damageCausedByAttacker += BattleRecords
           .getLostTuvForBattleRecords(BattleRecords.getRecordsForPlayerId(attacker, br), false, includeNullPlayer);

--- a/game-core/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -40,7 +40,6 @@ public class CompositeRouteFinder {
         CollectionUtils.getMatches(map.getTerritories(), t -> matches.keySet().stream().anyMatch(p -> p.test(t))));
     final Map<Territory, Integer> terScoreMap = createScoreMap();
     final Map<Territory, Integer> routeScoreMap = new HashMap<>();
-    int bestRouteToEndScore = Integer.MAX_VALUE;
     final Map<Territory, Territory> previous = new HashMap<>();
     List<Territory> routeLeadersToProcess = new ArrayList<>();
     for (final Territory ter : map.getNeighbors(start, Matches.territoryIsInList(allMatchingTers))) {
@@ -49,6 +48,7 @@ public class CompositeRouteFinder {
       routeLeadersToProcess.add(ter);
       previous.put(ter, start);
     }
+    int bestRouteToEndScore = Integer.MAX_VALUE;
     while (routeLeadersToProcess.size() > 0) {
       final List<Territory> newLeaders = new ArrayList<>();
       for (final Territory oldLeader : routeLeadersToProcess) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -590,12 +590,7 @@ public final class GameParser {
     } else {
       throw newGameParseException("diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
-    final int sizeY;
-    if (ys != null) {
-      sizeY = Integer.valueOf(ys);
-    } else {
-      sizeY = 0;
-    }
+    final int sizeY = (ys != null) ? Integer.valueOf(ys) : 0;
     final int sizeX = Integer.valueOf(xs);
     map.setGridDimensions(sizeX, sizeY);
     if (gridType.equals("square")) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -298,7 +298,6 @@ public final class GameParser {
         throw new RuntimeException(String.format("Map: %s, Could not find in classpath %s", mapName, dtdFile));
       }
       final String dtdSystem = url.toExternalForm();
-      final String system = dtdSystem.substring(0, dtdSystem.length() - 8);
       final DocumentBuilder builder = factory.newDocumentBuilder();
       builder.setErrorHandler(new ErrorHandler() {
         @Override
@@ -316,6 +315,7 @@ public final class GameParser {
           errorsSax.add(exception);
         }
       });
+      final String system = dtdSystem.substring(0, dtdSystem.length() - 8);
       return builder.parse(input, system);
     } catch (final IOException | ParserConfigurationException e) {
       throw new IllegalStateException("Error parsing: " + mapName, e);
@@ -590,20 +590,19 @@ public final class GameParser {
     } else {
       throw newGameParseException("diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
-    final int sizeX = Integer.valueOf(xs);
     final int sizeY;
     if (ys != null) {
       sizeY = Integer.valueOf(ys);
     } else {
       sizeY = 0;
     }
+    final int sizeX = Integer.valueOf(xs);
     map.setGridDimensions(sizeX, sizeY);
     if (gridType.equals("square")) {
       // Add territories
       for (int y = 0; y < sizeY; y++) {
         for (int x = 0; x < sizeX; x++) {
-          final boolean isWater;
-          isWater = water.contains(x + "-" + y);
+          final boolean isWater = water.contains(x + "-" + y);
           map.addTerritory(new Territory(name + "_" + x + "_" + y, isWater, data, x, y));
         }
       }
@@ -644,8 +643,8 @@ public final class GameParser {
       // Add territories
       for (int y = 0; y < sizeY; y++) {
         for (int x = 0; x < sizeX; x++) {
-          final boolean isWater = false;
           if (!water.contains(x + "-" + y)) {
+            final boolean isWater = false;
             map.addTerritory(new Territory(name + "_" + x + "_" + y, isWater, data, x, y));
           }
         }

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -297,7 +297,6 @@ public final class GameParser {
       if (url == null) {
         throw new RuntimeException(String.format("Map: %s, Could not find in classpath %s", mapName, dtdFile));
       }
-      final String dtdSystem = url.toExternalForm();
       final DocumentBuilder builder = factory.newDocumentBuilder();
       builder.setErrorHandler(new ErrorHandler() {
         @Override
@@ -315,6 +314,7 @@ public final class GameParser {
           errorsSax.add(exception);
         }
       });
+      final String dtdSystem = url.toExternalForm();
       final String system = dtdSystem.substring(0, dtdSystem.length() - 8);
       return builder.parse(input, system);
     } catch (final IOException | ParserConfigurationException e) {

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -52,8 +52,8 @@ public class ProductionRule extends DefaultNamed {
 
   public String toStringCosts() {
     final StringBuilder sb = new StringBuilder();
-    final Resource pus;
     getData().acquireReadLock();
+    final Resource pus;
     try {
       pus = getData().getResourceList().getResource(Constants.PUS);
     } finally {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -40,8 +40,6 @@ class FileSystemAccessStrategy {
   private static Runnable createRemoveMapAction(final List<DownloadFileDescription> maps,
       final DefaultListModel<String> listModel) {
     return () -> {
-      final List<DownloadFileDescription> fails = new ArrayList<>();
-      final List<DownloadFileDescription> deletes = new ArrayList<>();
 
       // delete the map files
       for (final DownloadFileDescription map : maps) {
@@ -57,6 +55,8 @@ class FileSystemAccessStrategy {
       Interruptibles.sleep(10);
 
       // check our work, see if we actuall deleted stuff
+      final List<DownloadFileDescription> deletes = new ArrayList<>();
+      final List<DownloadFileDescription> fails = new ArrayList<>();
       for (final DownloadFileDescription map : maps) {
         if (map.getInstallLocation().exists()) {
           fails.add(map);

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadListSort.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadListSort.java
@@ -20,8 +20,6 @@ public final class MapDownloadListSort {
   public static List<DownloadFileDescription> sortByMapName(final List<DownloadFileDescription> downloads) {
     checkNotNull(downloads);
 
-    final List<DownloadFileDescription> returnList = new ArrayList<>();
-
     // Until we see a header, save each map to this List.
     // When we see a header, we'll sort this list, add it
     // to the return values, and then clear it.
@@ -29,6 +27,7 @@ public final class MapDownloadListSort {
     maps.addAll(downloads);
 
     // in case the file does not end with a header, sort and add any remaining maps
+    final List<DownloadFileDescription> returnList = new ArrayList<>();
     if (!maps.isEmpty()) {
       returnList.addAll(sort(maps));
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -97,9 +97,8 @@ public class InGameLobbyWatcher {
     // add them as temporary properties (in case we load an old savegame and need them again)
     System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
     System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
-
-    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION,
-        System.getProperty(LOBBY_GAME_HOSTED_BY));
+    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
+    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override
       public Map<String, String> getProperties(final Map<String, String> challengeProperties) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -97,8 +97,9 @@ public class InGameLobbyWatcher {
     // add them as temporary properties (in case we load an old savegame and need them again)
     System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
     System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
-    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
-    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
+
+    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION,
+        System.getProperty(LOBBY_GAME_HOSTED_BY));
     final IConnectionLogin login = new IConnectionLogin() {
       @Override
       public Map<String, String> getProperties(final Map<String, String> challengeProperties) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -87,7 +87,6 @@ public class InGameLobbyWatcher {
       final InGameLobbyWatcher oldWatcher) {
     final String host = System.getProperty(LOBBY_HOST);
     final String port = System.getProperty(LOBBY_PORT);
-    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
     if (host == null || port == null) {
       return null;
     }
@@ -98,6 +97,7 @@ public class InGameLobbyWatcher {
     // add them as temporary properties (in case we load an old savegame and need them again)
     System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
     System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
+    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
     System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -157,12 +157,12 @@ public class EmailSenderEditor extends EditorPanel {
       String message = "An unknown occurred, report this as a bug on the TripleA dev forum";
       int messageType = JOptionPane.ERROR_MESSAGE;
       try {
-        final String html = "<html><body><h1>Success</h1><p>This was a test email sent by TripleA<p></body></html>";
         final File dummy = new File(ClientFileSystemHelper.getUserRootFolder(), "dummySave.txt");
         dummy.deleteOnExit();
         try (OutputStream fout = new FileOutputStream(dummy)) {
           fout.write("This file would normally be a save game".getBytes());
         }
+        final String html = "<html><body><h1>Success</h1><p>This was a test email sent by TripleA<p></body></html>";
         ((IEmailSender) getBean()).sendEmail("TripleA Test", html, dummy, "dummy.txt");
         // email was sent, or an exception would have been thrown
         message = "Email sent, it should arrive shortly, otherwise check your spam folder";

--- a/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -129,10 +129,10 @@ public class History extends DefaultTreeModel {
       while (changes.size() > lastChange) {
         changes.remove(lastChange);
       }
-      final List<HistoryNode> nodesToRemove = new ArrayList<>();
       final Enumeration<?> enumeration = ((DefaultMutableTreeNode) this.getRoot()).preorderEnumeration();
       enumeration.nextElement();
       boolean startRemoving = false;
+      final List<HistoryNode> nodesToRemove = new ArrayList<>();
       while (enumeration.hasMoreElements()) {
         final HistoryNode node = (HistoryNode) enumeration.nextElement();
         if (node instanceof IndexedHistoryNode) {

--- a/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
@@ -21,9 +21,9 @@ class SerializedHistory implements Serializable {
 
   public SerializedHistory(final History history, final GameData data, final List<Change> changes) {
     m_data = data;
-    int changeIndex = 0;
     final Enumeration<?> enumeration = ((DefaultMutableTreeNode) history.getRoot()).preorderEnumeration();
     enumeration.nextElement();
+    int changeIndex = 0;
     while (enumeration.hasMoreElements()) {
       final HistoryNode node = (HistoryNode) enumeration.nextElement();
       // write the changes to the start of the node

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -188,9 +188,8 @@ public class UnifiedMessenger {
   }
 
   public void removeImplementor(final String name, final Object implementor) {
-    final EndPoint endPoint;
     synchronized (endPointMutex) {
-      endPoint = localEndPoints.get(name);
+      final EndPoint endPoint = localEndPoints.get(name);
       if (endPoint == null) {
         throw new IllegalStateException("No end point for:" + name);
       }

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -56,7 +56,6 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
    * @return the collection of available dice rollers
    */
   public static Collection<PropertiesDiceRoller> loadFromFile() {
-    final List<PropertiesDiceRoller> rollers = new ArrayList<>();
     final File f = new File(ClientFileSystemHelper.getRootFolder(), "dice_servers");
     if (!f.exists()) {
       throw new IllegalStateException("No dice server folder:" + f);
@@ -65,8 +64,8 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
     for (final File file : FileUtils.listFiles(f)) {
       if (!file.isDirectory() && file.getName().endsWith(".properties")) {
         try {
-          final Properties props = new Properties();
           try (InputStream fin = new FileInputStream(file)) {
+            final Properties props = new Properties();
             props.load(fin);
             propFiles.add(props);
           }
@@ -80,6 +79,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       final int n2 = Integer.parseInt(o2.getProperty("order"));
       return n1 - n2;
     });
+    final List<PropertiesDiceRoller> rollers = new ArrayList<>();
     for (final Properties prop : propFiles) {
       rollers.add(new PropertiesDiceRoller(prop));
     }

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -90,9 +90,8 @@ public class Vault {
   }
 
   private byte[] secretKeyToBytes(final SecretKey key) {
-    final DESKeySpec ks;
     try {
-      ks = (DESKeySpec) secretKeyFactory.getKeySpec(key, DESKeySpec.class);
+      final DESKeySpec ks = (DESKeySpec) secretKeyFactory.getKeySpec(key, DESKeySpec.class);
       return ks.getKey();
     } catch (final GeneralSecurityException e) {
       throw new IllegalStateException(e.getMessage());

--- a/game-core/src/main/java/games/strategy/net/IpFinder.java
+++ b/game-core/src/main/java/games/strategy/net/IpFinder.java
@@ -83,21 +83,21 @@ public class IpFinder {
 
   private static boolean isPublicNetworkAddress(final InetAddress address) {
     // stupid java signed byte type
-    final byte octet192 = (byte) 0xC0;
-    final byte octet172 = (byte) 0xAC;
-    final byte octet168 = (byte) 0xA8;
-    final byte octet169 = (byte) 0xA9;
-    final byte octet252 = (byte) 0xFC;
     final byte octet254 = (byte) 0xFE;
     final byte[] bytes = address.getAddress();
     // ip 4
     if (bytes.length == 4) {
       // http://en.wikipedia.org/wiki/Private_network
+      final byte octet169 = (byte) 0xA9;
+      final byte octet168 = (byte) 0xA8;
+      final byte octet172 = (byte) 0xAC;
+      final byte octet192 = (byte) 0xC0;
       return (bytes[0] != 10) && (bytes[0] != octet172 || bytes[1] < 16 || bytes[1] > 31)
           && (bytes[0] != octet192 || bytes[1] != octet168) && (bytes[0] != octet169 || bytes[1] != octet254);
     }
     // ip 6
     // http://en.wikipedia.org/wiki/IPv6#Addressing
+    final byte octet252 = (byte) 0xFC;
     return (bytes[0] != octet252 || bytes[1] != 0) && bytes[0] != octet254;
 
   }

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -328,8 +328,8 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   private void bareBonesSendChatMessage(final String message, final INode to) {
     final List<Object> args = new ArrayList<>();
-    final Class<? extends Object>[] argTypes = new Class<?>[1];
     args.add(message);
+    final Class<? extends Object>[] argTypes = new Class<?>[1];
     argTypes[0] = args.get(0).getClass();
     final RemoteName rn;
     if (isLobby()) {

--- a/game-core/src/main/java/games/strategy/net/nio/NioReader.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioReader.java
@@ -107,12 +107,12 @@ class NioReader {
               if (done) {
                 totalBytes += packet.size();
                 if (logger.isLoggable(Level.FINE)) {
-                  String remote = "null";
                   final Socket s = channel.socket();
                   SocketAddress sa = null;
                   if (s != null) {
                     sa = s.getRemoteSocketAddress();
                   }
+                  String remote = "null";
                   if (sa != null) {
                     remote = sa.toString();
                   }

--- a/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
@@ -110,12 +110,12 @@ class NioWriter {
                 if (done) {
                   totalBytes += packet.size();
                   if (logger.isLoggable(Level.FINE)) {
-                    String remote = "null";
                     final Socket s = channel.socket();
                     SocketAddress sa = null;
                     if (s != null) {
                       sa = s.getRemoteSocketAddress();
                     }
+                    String remote = "null";
                     if (sa != null) {
                       remote = sa.toString();
                     }

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -135,11 +135,11 @@ public class ResourceLoader implements Closeable {
     try (URLClassLoader url = new URLClassLoader(new URL[] {match.get().toURI().toURL()})) {
       final URL dependencesUrl = url.getResource("dependencies.txt");
       if (dependencesUrl != null) {
-        final java.util.Properties dependenciesFile = new java.util.Properties();
 
         final Optional<InputStream> inputStream = UrlStreams.openStream(dependencesUrl);
         if (inputStream.isPresent()) {
           try (InputStream stream = inputStream.get()) {
+            final java.util.Properties dependenciesFile = new java.util.Properties();
             dependenciesFile.load(stream);
             final String dependencies = dependenciesFile.getProperty("dependencies");
             final StringTokenizer tokens = new StringTokenizer(dependencies, ",", false);

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -115,8 +115,7 @@ public class TripleA implements IGameLoader {
       connectPlayers(players, null);
     } else {
       SwingAction.invokeAndWait(() -> {
-        final TripleAFrame frame;
-        frame = new TripleAFrame(game, localPlayers);
+        final TripleAFrame frame = new TripleAFrame(game, localPlayers);
         display = new TripleADisplay(frame);
         game.addDisplay(display);
         soundChannel = new DefaultSoundChannel(localPlayers);

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -111,8 +111,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     // We should never touch the game data directly. All changes to game data are done through the remote,
     // which then changes the game using the DelegateBridge -> change factory
     ui.requiredTurnSeries(getPlayerId());
-    boolean badStep = false;
     enableEditModeMenu();
+    boolean badStep = false;
     if (name.endsWith("Tech")) {
       tech();
     } else if (name.endsWith("TechActivation")) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -423,7 +423,6 @@ public class TripleAUnit extends Unit {
     if (!Matches.unitCanProduceUnits().test(u)) {
       return 0;
     }
-    int productionCapacity;
     final UnitAttachment ua = UnitAttachment.get(u.getType());
     final TripleAUnit taUnit = (TripleAUnit) u;
     final TerritoryAttachment ta = TerritoryAttachment.get(producer);
@@ -433,6 +432,7 @@ public class TripleAUnit extends Unit {
       territoryProduction = ta.getProduction();
       territoryUnitProduction = ta.getUnitProduction();
     }
+    int productionCapacity;
     if (accountForDamage) {
       if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
         if (ua.getCanProduceXUnits() < 0) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -133,10 +133,10 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
     if (defaultCasualties.getKilled().size() <= 0) {
       return new CasualtyDetails(defaultCasualties, false);
     }
-    final int numberOfPlanesThatDoNotNeedToLandOnCarriers = 0;
     final CasualtyDetails myCasualties = new CasualtyDetails(false);
     myCasualties.addToDamaged(defaultCasualties.getDamaged());
     final List<Unit> selectFromSorted = new ArrayList<>(selectFrom);
+    final int numberOfPlanesThatDoNotNeedToLandOnCarriers = 0;
     final List<Unit> interleavedTargetList = new ArrayList<>(
         AiUtils.interleaveCarriersAndPlanes(selectFromSorted, numberOfPlanesThatDoNotNeedToLandOnCarriers));
     for (int i = 0; i < defaultCasualties.getKilled().size(); ++i) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -36,10 +36,10 @@ public class AiPoliticalUtils {
   public static List<PoliticalActionAttachment> getPoliticalActionsOther(final PlayerID id,
       final HashMap<ICondition, Boolean> testedConditions, final GameData data) {
     final List<PoliticalActionAttachment> warActions = getPoliticalActionsTowardsWar(id, testedConditions, data);
-    final List<PoliticalActionAttachment> acceptableActions = new ArrayList<>();
     final Collection<PoliticalActionAttachment> validActions =
         PoliticalActionAttachment.getValidActions(id, testedConditions, data);
     validActions.removeAll(warActions);
+    final List<PoliticalActionAttachment> acceptableActions = new ArrayList<>();
     for (final PoliticalActionAttachment nextAction : validActions) {
       if (warActions.contains(nextAction)) {
         continue;

--- a/game-core/src/main/java/games/strategy/triplea/ai/fastAI/FastOddsEstimator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fastAI/FastOddsEstimator.java
@@ -38,7 +38,6 @@ public class FastOddsEstimator implements IOddsCalculator {
   public AggregateResults calculate() {
     final double winPercentage = ProBattleUtils.estimateStrengthDifference(location, new ArrayList<>(attackingUnits),
         new ArrayList<>(defendingUnits));
-    final int battleRoundsFought = 3;
     List<Unit> remainingAttackingUnits = new ArrayList<>();
     List<Unit> remainingDefendingUnits = new ArrayList<>();
     if (winPercentage > 50) {
@@ -52,6 +51,7 @@ public class FastOddsEstimator implements IOddsCalculator {
       final int numRemainingUnits = (int) Math.ceil(defendingUnits.size() * (50 - Math.max(0, winPercentage)) / 50);
       remainingDefendingUnits = remainingDefendingUnits.subList(0, numRemainingUnits);
     }
+    final int battleRoundsFought = 3;
     return new AggregateEstimate(battleRoundsFought, winPercentage / 100, remainingAttackingUnits,
         remainingDefendingUnits);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAi.java
@@ -42,7 +42,6 @@ class ProPoliticsAi {
     final double round = data.getSequence().getRound();
     final ProTerritoryManager territoryManager = new ProTerritoryManager(calc);
     final PoliticsDelegate politicsDelegate = DelegateFinder.politicsDelegate(data);
-    final List<PoliticalActionAttachment> results = new ArrayList<>();
     ProLogger.info("Politics for " + player.getName());
 
     // Find valid war actions
@@ -84,6 +83,7 @@ class ProPoliticsAi {
     }
     ProLogger.debug("Neutral options: " + neutralMap);
     ProLogger.debug("Enemy options: " + enemyMap);
+    final List<PoliticalActionAttachment> results = new ArrayList<>();
     if (!enemyMap.isEmpty()) {
 
       // Find all attack options

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAi.java
@@ -1141,11 +1141,11 @@ class ProPurchaseAi {
       }
       int unusedCarrierCapacity = Math.min(0, ProTransportUtils.getUnusedCarrierCapacity(player, t, new ArrayList<>()));
       int unusedLocalCarrierCapacity = ProTransportUtils.getUnusedLocalCarrierCapacity(player, t, new ArrayList<>());
-      boolean needDestroyer = false;
       ProLogger.trace(t + ", unusedCarrierCapacity=" + unusedCarrierCapacity + ", unusedLocalCarrierCapacity="
           + unusedLocalCarrierCapacity);
 
       // If any enemy attackers then purchase sea defenders until it can be held
+      boolean needDestroyer = false;
       if (enemyAttackOptions.getMax(t) != null) {
 
         // Determine if need destroyer
@@ -1155,7 +1155,6 @@ class ProPurchaseAi {
         }
         ProLogger.trace(t + ", needDestroyer=" + needDestroyer + ", checking defense since has enemy attackers: "
             + enemyAttackOptions.getMax(t).getMaxUnits());
-        final List<Unit> unitsToPlace = new ArrayList<>();
         final List<Unit> initialDefendingUnits = new ArrayList<>(placeTerritory.getDefendingUnits());
         initialDefendingUnits.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
         ProBattleResult result = calc.calculateBattleResults(t, enemyAttackOptions.getMax(t).getMaxUnits(),
@@ -1164,6 +1163,7 @@ class ProPurchaseAi {
             Properties.getSubRetreatBeforeBattle(data)
                 && !initialDefendingUnits.isEmpty() && initialDefendingUnits.stream().allMatch(Matches.unitIsSub())
                 && enemyAttackOptions.getMax(t).getMaxUnits().stream().noneMatch(Matches.unitIsDestroyer());
+        final List<Unit> unitsToPlace = new ArrayList<>();
         for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
 
           // Check remaining production
@@ -1256,7 +1256,6 @@ class ProPurchaseAi {
         landDistance = 10;
       }
       final int enemyDistance = Math.max(3, (landDistance + 1));
-      final int alliedDistance = (enemyDistance + 1) / 2;
       final Set<Territory> nearbyTerritories =
           data.getMap().getNeighbors(t, enemyDistance, ProMatches.territoryCanMoveAirUnits(player, data, false));
       final List<Territory> nearbyLandTerritories =
@@ -1264,16 +1263,16 @@ class ProPurchaseAi {
       final Set<Territory> nearbyEnemySeaTerritories =
           data.getMap().getNeighbors(t, enemyDistance, Matches.territoryIsWater());
       nearbyEnemySeaTerritories.add(t);
+      final int alliedDistance = (enemyDistance + 1) / 2;
       final Set<Territory> nearbyAlliedSeaTerritories =
           data.getMap().getNeighbors(t, alliedDistance, Matches.territoryIsWater());
       nearbyAlliedSeaTerritories.add(t);
-      final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
       final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
-      final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
       for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
         enemyUnitsInLandTerritories
             .addAll(nearbyLandTerritory.getUnits().getMatches(ProMatches.unitIsEnemyAir(player, data)));
       }
+      final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
       for (final Territory nearbySeaTerritory : nearbyEnemySeaTerritories) {
         final List<Unit> enemySeaUnits =
             nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
@@ -1292,6 +1291,7 @@ class ProPurchaseAi {
           enemyUnitsInSeaTerritories.addAll(enemySeaUnits);
         }
       }
+      final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
       for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
         myUnitsInSeaTerritories
             .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -58,9 +58,9 @@ public class ProOtherMoveOptions {
       for (final Territory t : moveMap.keySet()) {
 
         // Get current player
-        final PlayerID movePlayer;
         final Set<Unit> currentUnits = new HashSet<>(moveMap.get(t).getMaxUnits());
         currentUnits.addAll(moveMap.get(t).getMaxAmphibUnits());
+        final PlayerID movePlayer;
         if (!currentUnits.isEmpty()) {
           movePlayer = currentUnits.iterator().next().getOwner();
         } else {

--- a/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -197,24 +197,22 @@ public class ProBattleUtils {
       landDistance = 10;
     }
     final int enemyDistance = Math.max(3, (landDistance + 1));
-    final int alliedDistance = (enemyDistance + 1) / 2;
     final Set<Territory> nearbyTerritories = data.getMap().getNeighbors(t, enemyDistance);
     final List<Territory> nearbyLandTerritories =
         CollectionUtils.getMatches(nearbyTerritories, Matches.territoryIsLand());
     final Set<Territory> nearbyEnemySeaTerritories =
         data.getMap().getNeighbors(t, enemyDistance, Matches.territoryIsWater());
     nearbyEnemySeaTerritories.add(t);
+    final int alliedDistance = (enemyDistance + 1) / 2;
     final Set<Territory> nearbyAlliedSeaTerritories =
         data.getMap().getNeighbors(t, alliedDistance, Matches.territoryIsWater());
     nearbyAlliedSeaTerritories.add(t);
-    final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
     final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
-    final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
-    final List<Unit> alliedUnitsInSeaTerritories = new ArrayList<>();
     for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
       enemyUnitsInLandTerritories
           .addAll(nearbyLandTerritory.getUnits().getMatches(ProMatches.unitIsEnemyAir(player, data)));
     }
+    final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
     for (final Territory nearbySeaTerritory : nearbyEnemySeaTerritories) {
       final List<Unit> enemySeaUnits =
           nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
@@ -233,6 +231,8 @@ public class ProBattleUtils {
         enemyUnitsInSeaTerritories.addAll(enemySeaUnits);
       }
     }
+    final List<Unit> alliedUnitsInSeaTerritories = new ArrayList<>();
+    final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
     for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
       myUnitsInSeaTerritories.addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));
       myUnitsInSeaTerritories.addAll(ProPurchaseUtils.getPlaceUnits(nearbySeaTerritory, purchaseTerritories));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -323,11 +323,11 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       setTerritoryCount(String.valueOf(allTerrs.size()));
       return allTerrs;
     } else { // The list just contained 1 territory
-      final Set<Territory> terr = new HashSet<>();
       final Territory t = data.getMap().getTerritory(name);
       if (t == null) {
         throw new IllegalStateException("No territory called:" + name + thisErrorMsg());
       }
+      final Set<Territory> terr = new HashSet<>();
       terr.add(t);
       setTerritoryCount(String.valueOf(1));
       return terr;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -557,10 +557,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       return;
     }
     final String[] s = players.split(":");
-    int count = -1;
     if (s.length < 1) {
       throw new GameParseException("Empty enemy list" + thisErrorMsg());
     }
+    int count = -1;
     try {
       count = getInt(s[0]);
       m_atWarCount = count;
@@ -600,10 +600,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       return;
     }
     final String[] s = newTechs.split(":");
-    int count = -1;
     if (s.length < 1) {
       throw new GameParseException("Empty tech list" + thisErrorMsg());
     }
+    int count = -1;
     try {
       count = getInt(s[0]);
       m_techCount = count;
@@ -926,12 +926,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    */
   private boolean checkUnitPresence(final Collection<Territory> territories, final String exclType,
       final int numberNeeded, final List<PlayerID> players, final GameData data) {
-    int numberMet = 0;
-    boolean satisfied = false;
     boolean useSpecific = false;
     if (getUnitPresence() != null && !getUnitPresence().keySet().isEmpty()) {
       useSpecific = true;
     }
+    boolean satisfied = false;
+    int numberMet = 0;
     for (final Territory terr : territories) {
       final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());
       if (exclType.equals("direct")) {
@@ -994,13 +994,13 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    */
   private boolean checkUnitExclusions(final Collection<Territory> territories, final String exclType,
       final int numberNeeded, final List<PlayerID> players, final GameData data) {
-    int numberMet = 0;
-    boolean satisfied = false;
     boolean useSpecific = false;
     if (getUnitPresence() != null && !getUnitPresence().keySet().isEmpty()) {
       useSpecific = true;
     }
     // Go through the owned territories and see if there are any units owned by allied/enemy based on exclType
+    boolean satisfied = false;
+    int numberMet = 0;
     for (final Territory terr : territories) {
       // get all the units in the territory
       final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -109,8 +109,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("attackBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -158,8 +157,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("defenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -207,8 +205,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("movementBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -256,8 +253,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("radarBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -305,8 +301,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("airAttackBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -354,8 +349,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("airDefenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -403,8 +397,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("productionBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -600,8 +593,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length != 2) {
       throw new GameParseException("rocketDiceNumber must have two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -730,8 +722,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
       throw new GameParseException(
           "unitAbilitiesGained must list the unit type, then all abilities gained" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[0];
+    final String unitType = s[0];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -817,8 +808,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("airborneCapacity cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -1054,8 +1044,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("attackRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -1103,8 +1092,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("defenseRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
@@ -1144,8 +1132,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("bombingBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitType;
-    unitType = s[1];
+    final String unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -667,11 +667,11 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   public static Set<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(final Territory t, final GameData data) {
-    final Set<Territory> territories = new HashSet<>();
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta == null || !ta.getConvoyRoute()) {
       return null;
     }
+    final Set<Territory> territories = new HashSet<>();
     for (final Territory current : data.getMap().getTerritories()) {
       final TerritoryAttachment cta = TerritoryAttachment.get(current);
       if (cta == null || !cta.getConvoyRoute()) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1245,11 +1245,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       return;
     }
     final String[] s = place.split(":");
-    int i = 0;
     if (s.length < 1) {
       throw new GameParseException("Empty placement list" + thisErrorMsg());
     }
     int count;
+    int i = 0;
     try {
       count = getInt(s[0]);
       i++;
@@ -1312,11 +1312,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_removeUnits = new HashMap<>();
     }
     final String[] s = value.split(":");
-    int i = 0;
     if (s.length < 1) {
       throw new GameParseException("Empty removeUnits list" + thisErrorMsg());
     }
     int count;
+    int i = 0;
     try {
       count = getInt(s[0]);
       i++;
@@ -1390,11 +1390,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       return;
     }
     final String[] s = place.split(":");
-    int i = 0;
     if (s.length < 1) {
       throw new GameParseException("Empty purchase list" + thisErrorMsg());
     }
     int count;
+    int i = 0;
     try {
       count = getInt(s[0]);
       i++;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1924,8 +1924,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitTypeToProduce;
-    unitTypeToProduce = s[1];
+    final String unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
@@ -1962,8 +1961,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (s.length != 2) {
       throw new GameParseException("consumesUnits must have two fields" + thisErrorMsg());
     }
-    final String unitTypeToProduce;
-    unitTypeToProduce = s[1];
+    final String unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
@@ -2002,8 +2000,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("createsUnitsList cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String unitTypeToProduce;
-    unitTypeToProduce = s[1];
+    final String unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
@@ -2043,8 +2040,7 @@ public class UnitAttachment extends DefaultAttachment {
       throw new GameParseException(
           "createsResourcesList cannot be empty or have more than two fields" + thisErrorMsg());
     }
-    final String resourceToProduce;
-    resourceToProduce = s[1];
+    final String resourceToProduce = s[1];
     // validate that this resource exists in the xml
     final Resource r = getData().getResourceList().getResource(resourceToProduce);
     if (r == null) {
@@ -2080,8 +2076,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (s.length != 2) {
       throw new GameParseException("fuelCost must have two fields" + thisErrorMsg());
     }
-    final String resourceToProduce;
-    resourceToProduce = s[1];
+    final String resourceToProduce = s[1];
     // validate that this resource exists in the xml
     final Resource r = getData().getResourceList().getResource(resourceToProduce);
     if (r == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -156,10 +156,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       // now we do upkeep costs, including upkeep cost as a percentage of our entire income for this turn (including
       // NOs)
       final int currentPUs = player.getResources().getQuantity(pus);
-      final float gainedPus = Math.max(0, currentPUs - leftOverPUs);
       int relationshipUpkeepCostFlat = 0;
       int relationshipUpkeepCostPercentage = 0;
-      int relationshipUpkeepTotalCost = 0;
       for (final Relationship r : data.getRelationshipTracker().getRelationships(player)) {
         final String[] upkeep = r.getRelationshipType().getRelationshipTypeAttachment().getUpkeepCost().split(":");
         if (upkeep.length == 1 || upkeep[1].equals(RelationshipTypeAttachment.UPKEEP_FLAT)) {
@@ -169,7 +167,9 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
         }
       }
       relationshipUpkeepCostPercentage = Math.min(100, relationshipUpkeepCostPercentage);
+      int relationshipUpkeepTotalCost = 0;
       if (relationshipUpkeepCostPercentage != 0) {
+        final float gainedPus = Math.max(0, currentPUs - leftOverPUs);
         relationshipUpkeepTotalCost += Math.round(gainedPus * (relationshipUpkeepCostPercentage) / 100f);
       }
       if (relationshipUpkeepCostFlat != 0) {
@@ -248,8 +248,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       return 0;
     }
     final String annotation = player.getName() + " rolling to resolve War Bonds: ";
-    final DiceRoll dice;
-    dice = DiceRoll.rollNDice(delegateBridge, count, sides, player, DiceType.NONCOMBAT, annotation);
+    final DiceRoll dice = DiceRoll.rollNDice(delegateBridge, count, sides, player, DiceType.NONCOMBAT, annotation);
     int total = 0;
     for (int i = 0; i < dice.size(); i++) {
       total += dice.getDie(i).getValue() + 1;
@@ -408,11 +407,11 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       if (maxLoss <= 0) {
         continue;
       }
-      int loss = 0;
       final Collection<Unit> enemies = CollectionUtils.getMatches(b.getUnits().getUnits(), enemyUnits);
       if (enemies.isEmpty()) {
         continue;
       }
+      int loss = 0;
       if (rollDiceForBlockadeDamage) {
         int numberOfDice = 0;
         for (final Unit u : enemies) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -350,7 +350,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   protected void freePlacementCapacity(final Territory producer, final int freeSize,
       final Collection<Unit> unitsLeftToPlace, final Territory at, final PlayerID player) {
-    int foundSpaceTotal = 0;
     // placements of the producer that could be redone by other territories
     final List<UndoablePlacement> redoPlacements = new ArrayList<>();
     // territories the producer produced for (but not itself) and the amount of units it produced
@@ -379,6 +378,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // remember placement move and new territory if a placement has to be split up
     final Collection<Tuple<UndoablePlacement, Territory>> splitPlacements =
         new ArrayList<>();
+    int foundSpaceTotal = 0;
     for (final Entry<Territory, Integer> entry : redoPlacementsCount.entrySet()) {
       final Territory placeTerritory = entry.getKey();
       final int maxProductionThatCanBeTakenOverFromThisPlacement = entry.getValue();
@@ -432,9 +432,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     // we had a bug where we tried to split the same undoable placement twice (it can only be undone once!)
     boolean unusedSplitPlacments = false;
-    final Collection<UndoablePlacement> usedUnoablePlacements = new ArrayList<>();
     if (foundSpaceTotal < freeSize) {
       // we need to split some placement moves
+      final Collection<UndoablePlacement> usedUnoablePlacements = new ArrayList<>();
       for (final Tuple<UndoablePlacement, Territory> tuple : splitPlacements) {
         final UndoablePlacement placement = tuple.getFirst();
         if (usedUnoablePlacements.contains(placement)) {
@@ -1163,13 +1163,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
             productionCanNotBeMoved += unitsPlacedByCurrentPlacementMove.size();
           } else {
             final int maxProductionThatCanBeTakenOverFromThisPlacement = unitsPlacedByCurrentPlacementMove.size();
-            int productionThatCanBeTakenOverFromThisPlacement = 0;
             // find other producers for this placement move to the same water territory
             final List<Territory> newPotentialOtherProducers =
                 getAllProducers(placeTerritory, player, unitsCanBePlacedByThisProducer);
             newPotentialOtherProducers.removeAll(notUsableAsOtherProducers);
             Collections.sort(newPotentialOtherProducers,
                 getBestProducerComparator(placeTerritory, unitsCanBePlacedByThisProducer, player));
+            int productionThatCanBeTakenOverFromThisPlacement = 0;
             for (final Territory potentialOtherProducer : newPotentialOtherProducers) {
               Integer potential = currentAvailablePlacementForOtherProducers.get(potentialOtherProducer);
               if (potential == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -85,9 +85,9 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
   // Otherwise, we'll log a new event.
   void logEvent(final String message, final Object renderingObject) {
     // find last event node
-    boolean foundChild = false;
     final GameData gameData = getData();
     gameData.acquireReadLock();
+    boolean foundChild = false;
     try {
       HistoryNode curNode = gameData.getHistory().getLastNode();
       while (!(curNode instanceof Step) && !(curNode instanceof Event)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -571,9 +571,7 @@ public class BattleCalculator {
   }
 
   private static List<Unit> killAmphibiousFirst(final List<Unit> killed, final Collection<Unit> targets) {
-    final Collection<Unit> allAmphibUnits = new ArrayList<>();
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
-    final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
     final Predicate<Unit> match = Matches.unitIsLand().and(Matches.unitWasNotAmphibious());
     killedNonAmphibUnits.addAll(CollectionUtils.getMatches(killed, match));
@@ -582,9 +580,11 @@ public class BattleCalculator {
       return killed;
     }
     // Get a list of all units that are amphibious and remove those that are killed
+    final Collection<Unit> allAmphibUnits = new ArrayList<>();
     allAmphibUnits.addAll(CollectionUtils.getMatches(targets, Matches.unitWasAmphibious()));
     allAmphibUnits.removeAll(CollectionUtils.getMatches(killed, Matches.unitWasAmphibious()));
     // Get a collection of the unit types of the amphib units
+    final Collection<UnitType> amphibTypes = new ArrayList<>();
     for (final Unit unit : allAmphibUnits) {
       final UnitType ut = unit.getType();
       if (!amphibTypes.contains(ut)) {
@@ -719,7 +719,6 @@ public class BattleCalculator {
     Collections.reverse(sortedUnitsList);
     final UnitBattleComparator unitComparatorWithoutPrimaryPower =
         new UnitBattleComparator(defending, costs, territoryEffects, data, bonus, true);
-    final List<Unit> sortedWellEnoughUnitsList = new ArrayList<>();
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<>();
     final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<>();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(
@@ -727,6 +726,7 @@ public class BattleCalculator {
         territoryEffects, amphibious, amphibiousLandAttackers, unitSupportPowerMap, unitSupportRollsMap);
     // Sort units starting with weakest for finding the worst units
     Collections.reverse(sortedUnitsList);
+    final List<Unit> sortedWellEnoughUnitsList = new ArrayList<>();
     for (int i = 0; i < sortedUnitsList.size(); ++i) {
       // Loop through all target units to find the best unit to take as casualty
       Unit worstUnit = null;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -632,7 +632,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         .andIf(fromIslandOnly, Matches.territoryIsIsland())
         .build();
 
-    final Map<Territory, Set<Territory>> scrambleTerrs = new HashMap<>();
     final Set<Territory> territoriesWithBattles =
         battleTracker.getPendingBattleSites().getNormalBattlesIncludingAirBattles();
     if (toSbr) {
@@ -640,9 +639,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           .addAll(battleTracker.getPendingBattleSites().getStrategicBombingRaidsIncludingAirBattles());
     }
     final Set<Territory> territoriesWithBattlesWater = new HashSet<>();
-    final Set<Territory> territoriesWithBattlesLand = new HashSet<>();
     territoriesWithBattlesWater.addAll(CollectionUtils.getMatches(territoriesWithBattles, Matches.territoryIsWater()));
+    final Set<Territory> territoriesWithBattlesLand = new HashSet<>();
     territoriesWithBattlesLand.addAll(CollectionUtils.getMatches(territoriesWithBattles, Matches.territoryIsLand()));
+    final Map<Territory, Set<Territory>> scrambleTerrs = new HashMap<>();
     for (final Territory battleTerr : territoriesWithBattlesWater) {
       final Set<Territory> canScrambleFrom = new HashSet<>(
           CollectionUtils.getMatches(data.getMap().getNeighbors(battleTerr, maxScrambleDistance), canScramble));
@@ -685,12 +685,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Tuple<Territory, PlayerID>, Collection<Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>>>> scramblersByTerritoryPlayer =
         new HashMap<>();
     for (final Territory to : scrambleTerrs.keySet()) {
-      final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers = new HashMap<>();
       // find who we should ask
       PlayerID defender = null;
       if (battleTracker.hasPendingBattle(to, false)) {
         defender = AbstractBattle.findDefender(to, player, data);
       }
+      final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers = new HashMap<>();
       for (final Territory from : scrambleTerrs.get(to)) {
         if (defender == null) {
           defender = AbstractBattle.findDefender(from, player, data);
@@ -770,8 +770,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             // TODO: maybe sort from biggest to smallest first?
             for (final Unit airbase : airbases) {
               final int allowedScramble = ((TripleAUnit) airbase).getMaxScrambleCount();
-              final int newAllowed;
               if (allowedScramble > 0) {
+                final int newAllowed;
                 if (allowedScramble >= numberScrambled) {
                   newAllowed = allowedScramble - numberScrambled;
                   numberScrambled = 0;
@@ -836,7 +836,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               bridge.addChange(change1);
             }
             // after that is applied, we have to make a map of all dependencies
-            final Map<Territory, Map<Unit, Collection<Unit>>> dependencies = new HashMap<>();
             final Map<Unit, Collection<Unit>> dependenciesForMfb =
                 TransportTracker.transporting(attackingUnits, attackingUnits);
             for (final Unit transport : CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport())) {
@@ -847,6 +846,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                 dependenciesForMfb.put(transport, new ArrayList<>());
               }
             }
+            final Map<Territory, Map<Unit, Collection<Unit>>> dependencies = new HashMap<>();
             dependencies.put(to, dependenciesForMfb);
             for (final Territory t : neighborsLand) {
               // All other maps, must hold only the transported units that in their territory
@@ -1417,7 +1417,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final PlayerID alliedPlayer, final GameData data, final BattleTracker battleTracker,
       final int carrierCostForCurrentTerr, final int allowedMovement,
       final boolean useMaxScrambleDistance) {
-    final HashSet<Territory> whereCanLand = new HashSet<>();
     int maxDistance = allowedMovement;
     if ((maxDistance > 1) || useMaxScrambleDistance) {
       UnitType ut = null;
@@ -1459,6 +1458,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     availableLand.addAll(CollectionUtils.getMatches(possibleTerrs,
         Matches.isTerritoryAllied(alliedPlayer, data).and(Matches.territoryIsLand())));
     availableLand.removeAll(canNotLand);
+    final HashSet<Territory> whereCanLand = new HashSet<>();
     whereCanLand.addAll(availableLand);
     // now for carrier-air-landing validation
     if (!strandedAir.isEmpty() && strandedAir.stream().allMatch(Matches.unitCanLandOnCarrier())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -26,20 +26,6 @@ import games.strategy.util.Triple;
  */
 class EditValidator {
   private static String validateTerritoryBasic(final GameData data, final Territory territory) {
-    final String result = null;
-    /*
-     * // territory cannot contain enemy units
-     * if (!Matches.territoryIsEmptyOfCombatUnits(data, player).test(territory))
-     * return "Territory contains enemy units";
-     */
-    /*
-     * // territory cannot be in a pending battle
-     * BattleTracker battleTracker = DelegateFinder.battleDelegate(data).getBattleTracker();
-     * if (battleTracker.getPendingBattle(territory, true) != null)
-     * return "Territory contains a pending SBR battle";
-     * if (battleTracker.getPendingBattle(territory, false) != null)
-     * return "Territory contains a pending battle";
-     */
     // territory cannot be in an UndoableMove route
     final List<UndoableMove> moves = DelegateFinder.moveDelegate(data).getMovesMade();
     for (final UndoableMove move : moves) {
@@ -47,7 +33,7 @@ class EditValidator {
         return "Territory is start or end of a pending move";
       }
     }
-    return result;
+    return null;
   }
 
   static String validateChangeTerritoryOwner(final GameData data, final Territory territory) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -206,8 +206,8 @@ public class GameStepPropertiesHelper {
    *         empty. never null.
    */
   public static Set<PlayerID> getCombinedTurns(final GameData data, final PlayerID player) {
-    final Set<PlayerID> allowedIDs = new HashSet<>();
     data.acquireReadLock();
+    final Set<PlayerID> allowedIDs = new HashSet<>();
     try {
       final String allowedPlayers =
           data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.COMBINED_TURNS);
@@ -279,8 +279,8 @@ public class GameStepPropertiesHelper {
    *         empty. never null.
    */
   public static Set<PlayerID> getRepairPlayers(final GameData data, final PlayerID player) {
-    final Set<PlayerID> allowedIDs = new HashSet<>();
     data.acquireReadLock();
+    final Set<PlayerID> allowedIDs = new HashSet<>();
     try {
       final String allowedPlayers =
           data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.REPAIR_PLAYERS);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -779,7 +779,6 @@ public class MoveValidator {
             .or(Matches.unitIsSub()).or(Matches.enemyUnit(player, data).negate());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
-    boolean validMove = false;
     final List<Territory> steps;
     if (ignoreRouteEnd) {
       steps = route.getMiddleSteps();
@@ -791,6 +790,7 @@ public class MoveValidator {
     if (steps.isEmpty() && route.numberOfStepsIncludingStart() == 1 && !ignoreRouteEnd) {
       steps.add(route.getStart());
     }
+    boolean validMove = false;
     for (final Territory current : steps) {
       if (current.isWater()) {
         if (getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(transportOrSubOnly)) {
@@ -1469,7 +1469,6 @@ public class MoveValidator {
             Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, player, data, true)
                 .negate()));
     boolean mustGoLand = false;
-    boolean mustGoSea = false;
     // If start and end are land, try a land route. Don't force a land route, since planes may be moving
     if (!start.isWater() && !end.isWater()) {
       final Route landRoute;
@@ -1489,6 +1488,7 @@ public class MoveValidator {
       }
     }
     // If the start and end are water, try and get a water route don't force a water route, since planes may be moving
+    boolean mustGoSea = false;
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
           data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsWater().and(noImpassable));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -359,7 +359,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Set<PlayerID> playerSet = m_battleSite.getUnits().getPlayersWithUnits();
     // find all attacking players (unsorted)
     final Collection<PlayerID> attackers = new ArrayList<>();
-    final Collection<Unit> allAttackingUnits = new ArrayList<>();
     for (final PlayerID current : playerSet) {
       if (m_data.getRelationshipTracker().isAllied(m_attacker, current) || current.equals(m_attacker)) {
         attackers.add(current);
@@ -367,6 +366,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     final StringBuilder transcriptText = new StringBuilder();
     // find all attacking units (unsorted)
+    final Collection<Unit> allAttackingUnits = new ArrayList<>();
     for (final Iterator<PlayerID> attackersIter = attackers.iterator(); attackersIter.hasNext();) {
       final PlayerID current = attackersIter.next();
       final String delim;
@@ -401,7 +401,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // find all defending players (unsorted)
     final Collection<PlayerID> defenders = new ArrayList<>();
-    final Collection<Unit> allDefendingUnits = new ArrayList<>();
     for (final PlayerID current : playerSet) {
       if (m_data.getRelationshipTracker().isAllied(m_defender, current) || current.equals(m_defender)) {
         defenders.add(current);
@@ -409,16 +408,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     final StringBuilder transcriptBuilder = new StringBuilder();
     // find all defending units (unsorted)
+    final Collection<Unit> allDefendingUnits = new ArrayList<>();
     for (final Iterator<PlayerID> defendersIter = defenders.iterator(); defendersIter.hasNext();) {
       final PlayerID current = defendersIter.next();
-      final Collection<Unit> defendingUnits;
       final String delim;
       if (defendersIter.hasNext()) {
         delim = "; ";
       } else {
         delim = "";
       }
-      defendingUnits = CollectionUtils.getMatches(m_defendingUnits, Matches.unitIsOwnedBy(current));
+      final Collection<Unit> defendingUnits =
+          CollectionUtils.getMatches(m_defendingUnits, Matches.unitIsOwnedBy(current));
       transcriptBuilder
           .append(current.getName())
           .append(" defend with ")
@@ -1255,16 +1255,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private void queryRetreat(final boolean defender, final RetreatType retreatType, final IDelegateBridge bridge,
       Collection<Territory> availableTerritories) {
-    final boolean subs;
-    final boolean planes;
-    final boolean partialAmphib;
-    planes = retreatType == RetreatType.PLANES;
-    subs = retreatType == RetreatType.SUBS;
+    final boolean planes = retreatType == RetreatType.PLANES;
+    final boolean subs = retreatType == RetreatType.SUBS;
     final boolean canSubsSubmerge = canSubsSubmerge();
-    final boolean submerge = subs && canSubsSubmerge;
     final boolean canDefendingSubsSubmergeOrRetreat =
         subs && defender && Properties.getSubmarinesDefendingMaySubmergeOrRetreat(m_data);
-    partialAmphib = retreatType == RetreatType.PARTIAL_AMPHIB;
+    final boolean partialAmphib = retreatType == RetreatType.PARTIAL_AMPHIB;
+    final boolean submerge = subs && canSubsSubmerge;
     if (availableTerritories.isEmpty() && !(submerge || canDefendingSubsSubmergeOrRetreat)) {
       return;
     }
@@ -1428,9 +1425,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     units = CollectionUtils.getMatches(units, Matches.unitIsTransport());
     final Collection<Unit> retreated = getTransportDependents(units);
     if (!retreated.isEmpty()) {
-      Territory retreatedFrom;
       for (final Unit unit : units) {
-        retreatedFrom = TransportTracker.getTerritoryTransportHasUnloadedTo(unit);
+        final Territory retreatedFrom = TransportTracker.getTerritoryTransportHasUnloadedTo(unit);
         if (retreatedFrom != null) {
           reLoadTransports(units, change);
           change.add(ChangeFactory.moveUnits(retreatedFrom, retreatTo, retreated));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -63,11 +63,11 @@ public class NoPUPurchaseDelegate extends PurchaseDelegate {
     final Collection<UnitType> unitTypes = new ArrayList<>(productionPerXTerritories.keySet());
     for (final UnitType ut : unitTypes) {
       int unitCount = 0;
-      int terrCount = 0;
       final int prodPerXTerrs = productionPerXTerritories.getInt(ut);
       if (isPacific) {
         unitCount += getBurmaRoad(player);
       }
+      int terrCount = 0;
       for (final Territory current : territories) {
         if (!isProductionPerValuedTerritoryRestricted()) {
           terrCount++;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -112,8 +112,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   @Override
   public Collection<PoliticalActionAttachment> getValidActions() {
     final GameData data = bridge.getData();
-    final HashMap<ICondition, Boolean> testedConditions;
     data.acquireReadLock();
+    final HashMap<ICondition, Boolean> testedConditions;
     try {
       testedConditions = getTestedConditions();
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -185,7 +185,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     final Collection<Unit> totalUnits = new ArrayList<>();
     final Collection<UnitType> totalUnitTypes = new ArrayList<>();
     final Collection<Resource> totalResources = new ArrayList<>();
-    final Collection<NamedAttachable> totalAll = new ArrayList<>();
     final CompositeChange changes = new CompositeChange();
     // add changes for added resources
     // and find all added units
@@ -208,6 +207,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
         }
       }
     }
+    final Collection<NamedAttachable> totalAll = new ArrayList<>();
     totalAll.addAll(totalUnitTypes);
     totalAll.addAll(totalResources);
     // add changes for added units

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -122,10 +122,9 @@ public class RandomStartDelegate extends BaseTripleADelegate {
             + picked.getName() + " with units " + MyFormatter.unitsToTextNoOwner(unitsToPlace), picked);
         bridge.addChange(change);
       } else {
-        Tuple<Territory, Set<Unit>> pick;
         Set<Unit> unitsToPlace;
         while (true) {
-          pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
+          final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
               new ArrayList<>(allPickableTerritories),
               new ArrayList<>(currentPickingPlayer.getUnits().getUnits()), UNITS_PER_PICK);
           picked = pick.getFirst();
@@ -169,11 +168,10 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         currentPickingPlayer = playersCanPick.get(0);
       }
       final List<Territory> territoriesToPickFrom = data.getMap().getTerritoriesOwnedBy(currentPickingPlayer);
-      Tuple<Territory, Set<Unit>> pick;
       Territory picked;
       Set<Unit> unitsToPlace;
       while (true) {
-        pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
+        final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
             new ArrayList<>(territoriesToPickFrom),
             new ArrayList<>(currentPickingPlayer.getUnits().getUnits()), UNITS_PER_PICK);
         picked = pick.getFirst();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -198,7 +198,6 @@ public class RocketsFireHelper {
         Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
     final Collection<Unit> enemyTargetsTotal =
         CollectionUtils.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).negate());
-    final Collection<Unit> targets = new ArrayList<>();
     final Collection<Unit> rockets;
     // attackFrom could be null if WW2V1
     if (attackFrom == null) {
@@ -212,7 +211,7 @@ public class RocketsFireHelper {
     if (numberOfAttacks <= 0) {
       return;
     }
-    final String transcript;
+    final Collection<Unit> targets = new ArrayList<>();
     if (damageFromBombingDoneToUnits) {
       // TODO: rockets needs to be completely redone to allow for multiple rockets to fire at different targets, etc
       // etc.
@@ -248,6 +247,7 @@ public class RocketsFireHelper {
     final boolean doNotUseBombingBonus =
         !Properties.getUseBombingMaxDiceSidesAndBonus(data) || rockets == null;
     int cost = 0;
+    final String transcript;
     if (!Properties.getLowLuckDamageOnly(data)) {
       if (doNotUseBombingBonus || rockets == null) {
         // no low luck, and no bonus, so just roll based on the map's dice sides

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -234,10 +234,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         // TODO remove the reference to the constant.japanese- replace with a rule
         if (isPacificTheater() || isSbrVictoryPoints()) {
           if (m_defender.getName().equals(Constants.PLAYER_NAME_JAPANESE)) {
-            final Change changeVp;
             final PlayerAttachment pa = PlayerAttachment.get(m_defender);
             if (pa != null) {
-              changeVp =
+              final Change changeVp =
                   ChangeFactory.attachmentPropertyChange(pa, ((-(m_bombingRaidTotal / 10)) + pa.getVps()), "vps");
               bridge.addChange(changeVp);
               bridge.getHistoryWriter().addChildToEvent("Bombing raid costs " + (m_bombingRaidTotal / 10) + " "
@@ -709,8 +708,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       // limit to maxDamage
       for (final Unit attacker : m_attackingUnits) {
         final UnitAttachment ua = UnitAttachment.get(attacker.getType());
-        final int rolls;
-        rolls = BattleCalculator.getRolls(attacker, m_attacker, false, true, m_territoryEffects);
+        final int rolls = BattleCalculator.getRolls(attacker, m_attacker, false, true, m_territoryEffects);
         int costThisUnit = 0;
         if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
           // LHTR means we select the best Dice roll for the unit

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -164,9 +164,8 @@ public abstract class TechAdvance extends NamedAttachable {
       throw new IllegalArgumentException(s + " is not a valid technology");
     }
     final TechAdvance ta;
-    final Constructor<? extends TechAdvance> constructor;
     try {
-      constructor = clazz.getConstructor(preDefinedTechConstructorParameter);
+      final Constructor<? extends TechAdvance> constructor = clazz.getConstructor(preDefinedTechConstructorParameter);
       ta = constructor.newInstance(data);
     } catch (final Exception e) {
       throw new IllegalStateException(s + " is not a valid technology or could not be instantiated", e);
@@ -190,8 +189,8 @@ public abstract class TechAdvance extends NamedAttachable {
    * @return first is air&naval, second is land&production.
    */
   private static Tuple<List<TechAdvance>, List<TechAdvance>> getWW2v3CategoriesWithTheirAdvances(final GameData data) {
-    List<TechAdvance> allAdvances;
     data.acquireReadLock();
+    List<TechAdvance> allAdvances;
     try {
       allAdvances = new ArrayList<>(data.getTechnologyFrontier().getTechs());
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -66,8 +66,8 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   @Override
   public Collection<UserActionAttachment> getValidActions() {
     final GameData data = bridge.getData();
-    final HashMap<ICondition, Boolean> testedConditions;
     data.acquireReadLock();
+    final HashMap<ICondition, Boolean> testedConditions;
     try {
       testedConditions = getTestedConditions();
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -31,9 +31,9 @@ public class DiceImageFactory {
   private final Map<Integer, Image> imagesIgnored = new HashMap<>();
 
   public DiceImageFactory(final ResourceLoader loader, final int diceSides) {
-    final int pipSize = 6;
     this.diceSides = Math.max(6, diceSides);
     resourceLoader = loader;
+    final int pipSize = 6;
     generateDice(pipSize, Color.black, images);
     generateDice(pipSize, Color.red, imagesHit);
     generateDice(pipSize, IGNORED, imagesIgnored);

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -320,7 +320,6 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     if (ool == null || ool.trim().length() == 0) {
       return null;
     }
-    final List<Tuple<Integer, UnitType>> map = new ArrayList<>();
     final String[] sections;
     if (ool.contains(OOL_SEPARATOR)) {
       sections = ool.trim().split(OOL_SEPARATOR_REGEX);
@@ -328,6 +327,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
       sections = new String[1];
       sections[0] = ool.trim();
     }
+    final List<Tuple<Integer, UnitType>> map = new ArrayList<>();
     for (final String section : sections) {
       if (section.length() == 0) {
         continue;

--- a/game-core/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/game-core/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -130,8 +130,6 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
         String body = EntityUtils.toString(response.getEntity());
         if (status == 200) {
           final String numReplies;
-          final String seqNum;
-          final String sc;
           Matcher m = NUM_REPLIES_PATTERN.matcher(body);
           if (m.matches()) {
             numReplies = m.group(1);
@@ -139,12 +137,14 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
             throw new Exception("Hidden field 'num_replies' not found on page");
           }
           m = SEQ_NUM_PATTERN.matcher(body);
+          final String seqNum;
           if (m.matches()) {
             seqNum = m.group(1);
           } else {
             throw new Exception("Hidden field 'seqnum' not found on page");
           }
           m = SC_PATTERN.matcher(body);
+          final String sc;
           if (m.matches()) {
             sc = m.group(1);
           } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -199,8 +199,8 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final Resource pus;
         getData().acquireReadLock();
+        final Resource pus;
         try {
           pus = getData().getResourceList().getResource(Constants.PUS);
         } finally {
@@ -211,7 +211,6 @@ class EditPanel extends ActionPanel {
           return;
         }
         final int oldTotal = player.getResources().getQuantity(pus);
-        int newTotal = oldTotal;
         final JTextField pusField = new JTextField(String.valueOf(oldTotal), 4);
         pusField.setMaximumSize(pusField.getPreferredSize());
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), new JScrollPane(pusField),
@@ -220,6 +219,7 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
+        int newTotal = oldTotal;
         try {
           newTotal = Integer.parseInt(pusField.getText());
         } catch (final Exception e) {
@@ -249,8 +249,8 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final Collection<TechAdvance> techs;
         getData().acquireReadLock();
+        final Collection<TechAdvance> techs;
         try {
           techs = TechnologyDelegate.getAvailableTechs(player, data);
         } finally {
@@ -296,8 +296,8 @@ class EditPanel extends ActionPanel {
           cancelEditAction.actionPerformed(null);
           return;
         }
-        final Collection<TechAdvance> techs;
         getData().acquireReadLock();
+        final Collection<TechAdvance> techs;
         try {
           techs = TechTracker.getCurrentTechAdvances(player, data);
           // there is no way to "undo" these two techs, so do not allow them to be removed

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -139,7 +139,6 @@ public class ObjectivePanel extends AbstractStatPanel {
           FileNameUtils.replaceIllegalCharacters(gameData.getGameName(), '_').replaceAll(" ", "_").concat(".");
       final Map<String, List<String>> sectionsUnsorted = new HashMap<>();
       final List<String> sectionsSorters = new ArrayList<>();
-      final Map<String, Map<ICondition, String>> statsObjectiveUnsorted = new HashMap<>();
       // do sections first
       for (final Entry<Object, Object> entry : op.entrySet()) {
         final String fileKey = (String) entry.getKey();
@@ -166,6 +165,7 @@ public class ObjectivePanel extends AbstractStatPanel {
         sectionsUnsorted.put(key[1], Arrays.asList(value.split(";")));
       }
       Collections.sort(sectionsSorters);
+      final Map<String, Map<ICondition, String>> statsObjectiveUnsorted = new HashMap<>();
       for (final String section : sectionsSorters) {
         final String key = section.split(";")[1];
         sections.put(key, sectionsUnsorted.get(key));

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -146,8 +146,8 @@ public class PoliticalStateOverview extends JPanel {
         }
 
         // see if there is actually a change
-        final RelationshipType actualRelationship;
         data.acquireReadLock();
+        final RelationshipType actualRelationship;
         try {
           actualRelationship = data.getRelationshipTracker().getRelationshipType(player1, player2);
         } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -145,10 +145,10 @@ public class ProductionPanel extends JPanel {
     final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
     final int availHeight = screenResolution.height - 80;
     final int availWidth = screenResolution.width - 30;
-    final int availHeightRules = availHeight - 116;
-    final int availWidthRules = availWidth - 16;
     final JScrollPane scroll = new JScrollPane(panel);
     scroll.setBorder(BorderFactory.createEmptyBorder());
+    final int availWidthRules = availWidth - 16;
+    final int availHeightRules = availHeight - 116;
     scroll
         .setPreferredSize(
             new Dimension(

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -142,11 +142,11 @@ public class ProductionPanel extends JPanel {
       panel.add(rules.get(x).getPanelComponent(), new GridBagConstraints(x / rows, (x % rows), 1, 1, 10, 10,
           GridBagConstraints.EAST, GridBagConstraints.BOTH, nullInsets, 0, 0));
     }
+    final JScrollPane scroll = new JScrollPane(panel);
+    scroll.setBorder(BorderFactory.createEmptyBorder());
     final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
     final int availHeight = screenResolution.height - 80;
     final int availWidth = screenResolution.width - 30;
-    final JScrollPane scroll = new JScrollPane(panel);
-    scroll.setBorder(BorderFactory.createEmptyBorder());
     final int availWidthRules = availWidth - 16;
     final int availHeightRules = availHeight - 116;
     scroll

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -155,8 +155,8 @@ public class PurchasePanel extends ActionPanel {
     // give a warning if the
     // player tries to produce too much
     if (isWW2V2() || isRestrictedPurchase()) {
-      int totalProd = 0;
       getData().acquireReadLock();
+      int totalProd = 0;
       try {
         for (final Territory t : CollectionUtils.getMatches(getData().getMap().getTerritories(),
             Matches.territoryHasOwnedIsFactoryOrCanProduceUnits(getCurrentPlayer()))) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -179,7 +179,6 @@ public class TechPanel extends ActionPanel {
     final TechnologyFrontier category = list.getSelectedValue();
 
     final int pus = currentPlayer.getResources().getQuantity(Constants.PUS);
-    final String message = "Purchase Tech Tokens";
     // see if anyone will help us to pay
     Collection<PlayerID> helpPay;
     final PlayerAttachment pa = PlayerAttachment.get(currentPlayer);
@@ -189,6 +188,7 @@ public class TechPanel extends ActionPanel {
       helpPay = null;
     }
     final TechTokenPanel techTokenPanel = new TechTokenPanel(pus, currTokens, currentPlayer, helpPay);
+    final String message = "Purchase Tech Tokens";
     final int choice = JOptionPane.showConfirmDialog(getTopLevelAncestor(), techTokenPanel, message,
         JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
     if (choice != JOptionPane.OK_OPTION) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -84,8 +84,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br></html>";
     }
     add(new JLabel(labelText));
-    Collection<Unit> unitsInTerritory;
     gameData.acquireReadLock();
+    Collection<Unit> unitsInTerritory;
     try {
       unitsInTerritory = territory.getUnits().getUnits();
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -380,8 +380,8 @@ public class TripleAFrame extends MainGameFrame {
         notesPanel.removeNotes();
       }
       if (pane.getComponentAt(sel).equals(editPanel)) {
-        final PlayerID player1;
         data.acquireReadLock();
+        final PlayerID player1;
         try {
           player1 = data.getSequence().getStep().getPlayerId();
         } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -121,11 +121,11 @@ public class UserActionPanel extends ActionPanel {
       final JPanel userChoicePanel = new JPanel();
       userChoicePanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
       userChoicePanel.setLayout(new GridBagLayout());
-      int row = 0;
 
       final JScrollPane choiceScroll = new JScrollPane(getUserActionButtonPanel(userChoiceDialog));
       choiceScroll.setBorder(BorderFactory.createEtchedBorder());
       choiceScroll.setPreferredSize(getUserActionScrollPanePreferredSize(choiceScroll));
+      int row = 0;
       userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER,
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -122,10 +122,10 @@ public class UserActionPanel extends ActionPanel {
       userChoicePanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
       userChoicePanel.setLayout(new GridBagLayout());
 
+      int row = 0;
       final JScrollPane choiceScroll = new JScrollPane(getUserActionButtonPanel(userChoiceDialog));
       choiceScroll.setBorder(BorderFactory.createEtchedBorder());
       choiceScroll.setPreferredSize(getUserActionScrollPanePreferredSize(choiceScroll));
-      int row = 0;
       userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER,
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -81,14 +81,12 @@ public class HistoryLog extends JFrame {
 
   public void printFullTurn(final GameData data, final boolean verbose, final Collection<PlayerID> playersAllowed) {
     HistoryNode curNode = data.getHistory().getLastNode();
-    Step stepNode = null;
-    Step turnStartNode = null;
-    final PlayerID curPlayer;
     final Collection<PlayerID> players = new HashSet<>();
     if (playersAllowed != null) {
       players.addAll(playersAllowed);
     }
     // find Step node, if exists in this path
+    Step stepNode = null;
     while (curNode != null) {
       if (curNode instanceof Step) {
         stepNode = (Step) curNode;
@@ -97,11 +95,12 @@ public class HistoryLog extends JFrame {
       curNode = (HistoryNode) curNode.getPreviousNode();
     }
     if (stepNode != null) {
-      curPlayer = stepNode.getPlayerId();
+      final PlayerID curPlayer = stepNode.getPlayerId();
       if (players.isEmpty()) {
         players.add(curPlayer);
       }
       // get first step for this turn
+      Step turnStartNode = null;
       while (true) {
         turnStartNode = stepNode;
         stepNode = (Step) stepNode.getPreviousSibling();

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -238,11 +238,10 @@ public class MapData implements Closeable {
   }
 
   private Optional<Image> loadTerritoryNameImage(final String imageName) {
-    Optional<Image> img;
     try {
       // try first file names that have underscores instead of spaces
       final String normalizedName = imageName.replace(' ', '_');
-      img = loadImage(constructTerritoryNameImagePath(normalizedName));
+      Optional<Image> img = loadImage(constructTerritoryNameImagePath(normalizedName));
       if (!img.isPresent()) {
         img = loadImage(constructTerritoryNameImagePath(imageName));
       }
@@ -414,10 +413,10 @@ public class MapData implements Closeable {
   private void initializeContains() {
     contains = new HashMap<>();
     for (final String seaTerritory : getTerritories()) {
-      final List<String> contained = new ArrayList<>();
       if (!Util.isTerritoryNameIndicatingWater(seaTerritory)) {
         continue;
       }
+      final List<String> contained = new ArrayList<>();
       for (final String landTerritory : getTerritories()) {
         if (Util.isTerritoryNameIndicatingWater(landTerritory)) {
           continue;
@@ -439,9 +438,8 @@ public class MapData implements Closeable {
   }
 
   public Color getColorProperty(final String propertiesKey) throws IllegalStateException {
-    final String colorString;
     if (mapProperties.getProperty(propertiesKey) != null) {
-      colorString = mapProperties.getProperty(propertiesKey);
+      final String colorString = mapProperties.getProperty(propertiesKey);
       if (colorString.length() != 6) {
         throw new IllegalStateException("Colors must be a 6 digit hex number, eg FF0011, not:" + colorString);
       }
@@ -460,9 +458,9 @@ public class MapData implements Closeable {
       return playerColors.get(playerName);
     }
     // look in map.properties
-    final String propertiesKey = PROPERTY_COLOR_PREFIX + playerName;
     Color color;
     try {
+      final String propertiesKey = PROPERTY_COLOR_PREFIX + playerName;
       color = getColorProperty(propertiesKey);
     } catch (final Exception e) {
       throw new IllegalStateException("Player colors must be a 6 digit hex number, eg FF0011");

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -154,10 +154,9 @@ final class ExportMenu extends JMenu {
       return;
     }
     final StringBuilder text = new StringBuilder(1000);
-    final GameData clone;
     try {
       gameData.acquireReadLock();
-      clone = GameDataUtils.cloneGameData(gameData);
+      final GameData clone = GameDataUtils.cloneGameData(gameData);
       final IStat[] stats = statPanel.getStats();
       // extended stats covers stuff that doesn't show up in the game stats menu bar, like custom resources or tech
       // tokens or # techs, etc.

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -70,6 +70,9 @@ public final class HelpMenu extends JMenu {
     final String moveSelectionHelpTitle = "Movement/Selection Help";
     add(SwingAction.of(moveSelectionHelpTitle, e -> {
       // html formatted string
+      final JEditorPane editorPane = new JEditorPane();
+      editorPane.setEditable(false);
+      editorPane.setContentType("text/html");
       final String hints = "<b> Selecting Units</b><br>" + "Left click on a unit stack to select 1 unit.<br>"
           + "ALT-Left click on a unit stack to select 10 units of that type in the stack.<br>"
           + "CTRL-Left click on a unit stack to select all units of that type in the stack.<br>"
@@ -108,9 +111,6 @@ public final class HelpMenu extends JMenu {
           + "Press 'u' while mousing over a unit to undo all moves that unit has made (beta).<br>"
           + "To list specific units from a territory in the Territory panel, drag and drop from the territory on the "
           + "map to the territory panel.<br>";
-      final JEditorPane editorPane = new JEditorPane();
-      editorPane.setEditable(false);
-      editorPane.setContentType("text/html");
       editorPane.setText(hints);
       final JScrollPane scroll = new JScrollPane(editorPane);
       JOptionPane.showMessageDialog(null, scroll, moveSelectionHelpTitle, JOptionPane.PLAIN_MESSAGE);
@@ -119,10 +119,6 @@ public final class HelpMenu extends JMenu {
 
   static String getUnitStatsTable(final GameData gameData, final UiContext uiContext) {
     // html formatted string
-    int i = 0;
-    final String color1 = "ABABAB";
-    final String color2 = "BDBDBD";
-    final String color3 = "FEECE2";
     final StringBuilder hints = new StringBuilder();
     hints.append("<html>");
     hints.append("<head><style>th, tr{color:black}</style></head>");
@@ -132,6 +128,10 @@ public final class HelpMenu extends JMenu {
           TuvUtils.getResourceCostsForTuv(gameData, true);
       final Map<PlayerID, List<UnitType>> playerUnitTypes =
           UnitType.getAllPlayerUnitsWithImages(gameData, uiContext, true);
+      final String color3 = "FEECE2";
+      final String color2 = "BDBDBD";
+      final String color1 = "ABABAB";
+      int i = 0;
       for (final Map.Entry<PlayerID, List<UnitType>> entry : playerUnitTypes.entrySet()) {
         final PlayerID player = entry.getKey();
         hints.append("<p><table border=\"1\" bgcolor=\"" + color1 + "\">");

--- a/game-core/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
@@ -23,8 +23,8 @@ public class PlayerOrderComparator implements Comparator<PlayerID> {
     if (p1.equals(p2)) {
       return 0;
     }
-    final GameSequence sequence;
     gameData.acquireReadLock();
+    final GameSequence sequence;
     try {
       sequence = gameData.getSequence();
     } finally {
@@ -34,8 +34,8 @@ public class PlayerOrderComparator implements Comparator<PlayerID> {
       if (s.getPlayerId() == null) {
         continue;
       }
-      final IDelegate delegate;
       gameData.acquireReadLock();
+      final IDelegate delegate;
       try {
         delegate = s.getDelegate();
       } finally {

--- a/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -46,8 +46,8 @@ public class TuvUtils {
    * @return a map of unit types to PU cost
    */
   public static IntegerMap<UnitType> getCostsForTuv(final PlayerID player, final GameData data) {
-    final Resource pus;
     data.acquireReadLock();
+    final Resource pus;
     try {
       pus = data.getResourceList().getResource(Constants.PUS);
     } finally {
@@ -97,8 +97,8 @@ public class TuvUtils {
    * Therefore, this map should NOT be used for Purchasing information!
    */
   private static IntegerMap<UnitType> getCostsForTuvForAllPlayersMergedAndAveraged(final GameData data) {
-    final Resource pus;
     data.acquireReadLock();
+    final Resource pus;
     try {
       pus = data.getResourceList().getResource(Constants.PUS);
     } finally {

--- a/game-core/src/main/java/games/strategy/ui/IntTextField.java
+++ b/game-core/src/main/java/games/strategy/ui/IntTextField.java
@@ -133,9 +133,9 @@ public class IntTextField extends JTextField {
       final String currentText = this.getText(0, getLength());
       final String beforeOffset = currentText.substring(0, offs);
       final String afterOffset = currentText.substring(offs, currentText.length());
-      final String proposedResult = beforeOffset + str + afterOffset;
       // allow start of negative
       try {
+        final String proposedResult = beforeOffset + str + afterOffset;
         Integer.parseInt(proposedResult);
         super.insertString(offs, str, a);
         checkValue();

--- a/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-core/src/main/java/games/strategy/ui/Util.java
@@ -76,8 +76,6 @@ public final class Util {
   public static Image getBanner(final String text) {
     final int w = 400;
     final int h = 60;
-    final float loginStringX = w * .05f;
-    final float loginStringY = h * .75f;
     final BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
     final Graphics2D g2 = img.createGraphics();
     final Font font = new Font("Arial Bold", Font.PLAIN, 36);
@@ -104,6 +102,8 @@ public final class Util {
     g2.fill(curveShape);
     // g2.setPaint(Color.white);
     originalGraphics.setColor(Color.WHITE);
+    final float loginStringY = h * .75f;
+    final float loginStringX = w * .05f;
     originalGraphics.drawString(text, loginStringX, loginStringY);
     return img;
   }

--- a/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -221,11 +221,11 @@ public final class PointFileReaderWriter {
         char current = line.charAt(index);
         if (current == '<') {
           int x = 0;
-          int y;
           int base = 0;
           // inside a poly
           while (true) {
             current = line.charAt(++index);
+            final int y;
             switch (current) {
               case '0':
               case '1':

--- a/game-core/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
@@ -24,8 +24,7 @@ public class SelectGameWindow {
   public static Runnable openSelectGameWindow(final LaunchScreen previousScreen, final StagingScreen stagingScreen) {
     return () -> {
       try {
-        final GameChooserEntry entry;
-        entry = GameChooser.chooseGame(
+        final GameChooserEntry entry = GameChooser.chooseGame(
             JOptionPane.getFrameForComponent(null),
             ClientSetting.SELECTED_GAME_LOCATION.value());
         if (entry != null) {

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -75,7 +75,6 @@ public class AutoPlacementFinder {
    * Will calculate the placements on the map automatically.
    */
   static void calculate() {
-    final Map<String, List<Point>> placements = new HashMap<>();
     // ask user where the map is
     final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
@@ -94,10 +93,10 @@ public class AutoPlacementFinder {
           int width = unitWidth;
           int height = unitHeight;
           boolean found = false;
-          final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
-          final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
-          final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
           try (Scanner scanner = new Scanner(file)) {
+            final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
+            final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
+            final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
             while (scanner.hasNextLine()) {
               final String line = scanner.nextLine();
               if (line.contains(scaleProperty)) {
@@ -197,6 +196,7 @@ public class AutoPlacementFinder {
     textOptionPane.show();
     textOptionPane.appendNewLine("Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
+    final Map<String, List<Point>> placements = new HashMap<>();
     for (final String name : mapData.getTerritories()) {
       final List<Point> points;
       if (mapData.hasContainedTerritory(name)) {

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -500,8 +500,8 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void topLeftOrBottomLeft() {
-    final Object[] options = {"Point is Top Left", "Point is Bottom Left"};
     ToolLogger.info("Select Show images from top left or bottom left point?");
+    final Object[] options = {"Point is Top Left", "Point is Bottom Left"};
     showFromTopLeft = JOptionPane.showOptionDialog(this,
         "Are the images shown from the top left, or from the bottom left point? \r\n"
             + "All images are shown from the top left, except for 'name_place.txt', 'pu_place.txt', and "
@@ -520,10 +520,8 @@ public class DecorationPlacer extends JFrame {
     currentImagePoints = new HashMap<>();
     currentSelectedImage = null;
     selectImagePointType();
-    final Object[] miscOrNamesOptions = {"Folder Full of Images", "Text File Full of Points"};
-    final Object[] pointsAreNamesOptions = {"Points end in .png", "Points do NOT end in .png"};
-    final Object[] fillAllOptions = {"Fill In All Territories", "Let Me Select Territories"};
     ToolLogger.info("Select Folder full of images OR Text file full of points?");
+    final Object[] miscOrNamesOptions = {"Folder Full of Images", "Text File Full of Points"};
     if (JOptionPane.showOptionDialog(this,
         "Are you doing a folder full of different images (decorations.txt [misc] and name_place.txt [territoryNames]) "
             + "\r\n"
@@ -546,6 +544,7 @@ public class DecorationPlacer extends JFrame {
       // image based on some
       // in game property in the game data.
       ToolLogger.info("Points end in .png OR they do not?");
+      final Object[] pointsAreNamesOptions = {"Points end in .png", "Points do NOT end in .png"};
       fillCurrentImagePointsBasedOnImageFolder(JOptionPane.showOptionDialog(this,
           "Does the text file use the exact image file name, including the .png extension (decorations.txt) \r\n"
               + "Or does the text file not use the full file name with no extension, just a territory name "
@@ -562,6 +561,7 @@ public class DecorationPlacer extends JFrame {
       // blockade.txt and
       // kamikaze_place.txt and capitols.txt will only have a small number of territories
       ToolLogger.info("Select Fill in all territories OR let you select them?");
+      final Object[] fillAllOptions = {"Fill In All Territories", "Let Me Select Territories"};
       fillCurrentImagePointsBasedOnTextFile(JOptionPane.showOptionDialog(this,
           "Are you going to do a point for every single territory (pu_place.txt) \r\n"
               + "Or are you going to do just a few territories (capitols.txt, convoy.txt, vc.txt, etc, most others) ? "

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -678,9 +678,8 @@ public class PolygonGrabber extends JFrame {
                 + "and removing any anti-aliasing.");
         return null;
       }
-      int tempDirection;
       for (int i = 2; i >= -3; i--) { // was -4
-        tempDirection = (currentDirection + i) % 8;
+        int tempDirection = (currentDirection + i) % 8;
         if (tempDirection < 0) {
           tempDirection += 8;
         }

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -424,9 +424,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * doneCurrentGroup()
-   * Does something with respect to check if the name
-   * of a territory is valid or not.
+   * Does something with respect to check if the name of a territory is valid or not.
    */
   private void doneCurrentGroup() {
     final JTextField text = new JTextField();
@@ -452,7 +450,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * Guess the country name based on the location of the previous centers
+   * Guess the country name based on the location of the previous centers.
    */
   private void guessCountryName(final JTextField text, final Iterable<Entry<String, Point>> centersiter) {
     final List<String> options = new ArrayList<>();
@@ -506,7 +504,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * Checks if the given x/y coordinate point is inbounds or not
+   * Checks if the given x/y coordinate point is inbounds or not.
    */
   private boolean inBounds(final int x, final int y) {
     return x >= 0 && x < bufferedImage.getWidth(null) && y >= 0 && y < bufferedImage.getHeight(null);
@@ -517,7 +515,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * Moves to a specified direction
+   * Moves to a specified direction.
    * Directions
    * 0 - North
    * 1 - North east

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -50,14 +50,14 @@ import games.strategy.util.PointFileReaderWriter;
 import tools.util.ToolLogger;
 
 /**
- * old comments
  * Utility to break a map into polygons.
- * Not pretty, meant only for one time use.
  * Inputs - a map with 1 pixel wide borders
  * - a list of centers - this is used to guess the territory name and to verify the
  * - territory name entered
  * Outputs - a list of polygons for each country
+ * @deprecated Not pretty, meant only for one time use.
  */
+@Deprecated
 public class PolygonGrabber extends JFrame {
   private static final long serialVersionUID = 6381498094805120687L;
   private static boolean islandMode;
@@ -76,7 +76,6 @@ public class PolygonGrabber extends JFrame {
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
-   * main(java.lang.String[])
    * Main program begins here.
    * Asks the user to select the map then runs the
    * the actual polygon grabber program.
@@ -117,7 +116,7 @@ public class PolygonGrabber extends JFrame {
       ToolLogger.info("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
-  } // end main
+  }
 
   /**
    * Constructor PolygonGrabber(java.lang.String)
@@ -293,7 +292,6 @@ public class PolygonGrabber extends JFrame {
   } // end constructor
 
   /**
-   * createImage(java.lang.String)
    * We create the image of the map here and
    * assure that it is loaded properly.
    *
@@ -310,7 +308,6 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * javax.swing.JPanel createMainPanel()
    * Creates a JPanel to be used. Dictates how the map is
    * painted. Current problem is that islands inside sea
    * zones are not recognized when filling in the sea zone
@@ -356,7 +353,6 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * savePolygons()
    * Saves the polygons to disk.
    */
   private void savePolygons() {
@@ -374,7 +370,6 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * loadPolygons()
    * Loads a pre-defined file with map polygon points.
    */
   private void loadPolygons() {
@@ -392,16 +387,6 @@ public class PolygonGrabber extends JFrame {
     repaint();
   }
 
-  /**
-   * mouseEvent(java.awt.Point, java.lang.boolean, java.lang.boolean)
-   *
-   * @param java
-   *        .awt.Point point a point clicked by mouse
-   * @param java
-   *        .lang.boolean ctrlDown true if ctrl key was hit
-   * @param java
-   *        .lang.boolean rightMouse true if the right mouse button was hit
-   */
   private void mouseEvent(final Point point, final boolean ctrlDown, final boolean rightMouse) {
     final Polygon p = findPolygon(point.x, point.y);
     if (p == null) {
@@ -425,13 +410,8 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * java.lang.boolean pointInCurrentPolygon(java.awt.Point)
    * returns false if there is no points in a current polygon.
    * returns true if there is.
-   *
-   * @param java
-   *        .awt.Point p the point to check for
-   * @return java.lang.boolean
    */
   private boolean pointInCurrentPolygon(final Point p) {
     if (current == null) {
@@ -474,13 +454,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * guessCountryName(javax.swing.JTextField, java.tools.Iterator)
    * Guess the country name based on the location of the previous centers
-   *
-   * @param javax
-   *        .swing.JTextField text text dialog
-   * @param java
-   *        .tools.Iterator centersiter center iterator
    */
   private void guessCountryName(final JTextField text, final Iterable<Entry<String, Point>> centersiter) {
     final List<String> options = new ArrayList<>();
@@ -499,27 +473,15 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * java.lang.boolean isBlack(java.awt.Point)
    * Checks to see if the given point is of color black.
-   *
-   * @param java
-   *        .awt.Point p the point to check
-   * @return java.lang.boolean
    */
   private boolean isBlack(final Point p) {
     return isBlack(p.x, p.y);
   }
 
   /**
-   * java.lang.boolean isBlack(java.lang.int, java.lang.int)
    * Checks to see if the x/y coordinates from a given point
    * are inbounds and if so is it black.
-   *
-   * @param java
-   *        .lang.int x the x coordinate
-   * @param java
-   *        .lang.int y the y coordinate
-   * @return java.lang.boolean
    */
   private boolean isBlack(final int x, final int y) {
     if (!inBounds(x, y)) {
@@ -546,14 +508,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * java.lang.boolean inBounds(java.lang.int, java.lang.int)
    * Checks if the given x/y coordinate point is inbounds or not
-   *
-   * @param java
-   *        .lang.int x the x coordinate
-   * @param java
-   *        .lang.int y the y coordinate
-   * @return java.lang.boolean
    */
   private boolean inBounds(final int x, final int y) {
     return x >= 0 && x < bufferedImage.getWidth(null) && y >= 0 && y < bufferedImage.getHeight(null);
@@ -564,7 +519,6 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * move(java.awt.Point, java.lang.int)
    * Moves to a specified direction
    * Directions
    * 0 - North
@@ -575,11 +529,6 @@ public class PolygonGrabber extends JFrame {
    * 5 - South west
    * 6 - West
    * 7 - North west
-   *
-   * @param java
-   *        .awt.Point p the given point
-   * @param java
-   *        .lang.int direction the specified direction to move
    */
   private static void move(final Point p, final int direction) {
     if (direction < 0 || direction > 7) {
@@ -601,15 +550,7 @@ public class PolygonGrabber extends JFrame {
   private final Point testPoint = new Point();
 
   /**
-   * java.lang.boolean isOnEdge(java.lang.int, java.awt.Point)
    * Checks to see if the direction we're going is on the edge.
-   * At least thats what I can understand from this.
-   *
-   * @param java
-   *        .lang.int direction the given direction
-   * @param java
-   *        .awt.Point currentPoint the current point
-   * @return java.lang.boolean
    */
   private boolean isOnEdge(final int direction, final Point currentPoint) {
     testPoint.setLocation(currentPoint);
@@ -648,15 +589,8 @@ public class PolygonGrabber extends JFrame {
   }
 
   /**
-   * java.awt.Polygon findPolygon(java.lang.int, java.lang.int)
    * Algorithm to find a polygon given a x/y coordinates and
    * returns the found polygon.
-   *
-   * @param java
-   *        .lang.int x the x coordinate
-   * @param java
-   *        .lang.int y the y coordinate
-   * @return java.awt.Polygon
    */
   private Polygon findPolygon(final int x, final int y) {
     // walk up, find the first black point
@@ -678,11 +612,8 @@ public class PolygonGrabber extends JFrame {
                 + "and removing any anti-aliasing.");
         return null;
       }
-      for (int i = 2; i >= -3; i--) { // was -4
-        int tempDirection = (currentDirection + i) % 8;
-        if (tempDirection < 0) {
-          tempDirection += 8;
-        }
+      for (int i = 2; i >= -3; i--) {
+        final int tempDirection = Math.floorMod(currentDirection + i, 8);
         if (isOnEdge(tempDirection, currentPoint)) {
           // if we need to change our course
           if (i != 0) {

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -55,9 +55,7 @@ import tools.util.ToolLogger;
  * - a list of centers - this is used to guess the territory name and to verify the
  * - territory name entered
  * Outputs - a list of polygons for each country
- * @deprecated Not pretty, meant only for one time use.
  */
-@Deprecated
 public class PolygonGrabber extends JFrame {
   private static final long serialVersionUID = 6381498094805120687L;
   private static boolean islandMode;

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -134,7 +134,6 @@ public class ConnectionFinder {
         // ignore malformed input
       }
     }
-    final Map<String, Collection<String>> connections = new HashMap<>();
     ToolLogger.info("Now Scanning for Connections");
     // sort so that they are in alphabetic order (makes xml's prettier and easier to update in future)
     final List<String> allTerritories =
@@ -142,6 +141,7 @@ public class ConnectionFinder {
     Collections.sort(allTerritories, new AlphanumComparator());
     final List<String> allAreas = new ArrayList<>(territoryAreas.keySet());
     Collections.sort(allAreas, new AlphanumComparator());
+    final Map<String, Collection<String>> connections = new HashMap<>();
     for (final String territory : allTerritories) {
       final Set<String> thisTerritoryConnections = new LinkedHashSet<>();
       final List<Polygon> currentPolygons = mapOfPolygons.get(territory);
@@ -268,11 +268,9 @@ public class ConnectionFinder {
    */
   private static double calcSignedPolygonArea(final Point2D[] pointArray) {
     final int length = pointArray.length;
-    int i;
-    int j;
     double area = 0;
-    for (i = 0; i < length; i++) {
-      j = (i + 1) % length;
+    for (int i = 0; i < length; i++) {
+      final int j = (i + 1) % length;
       area += pointArray[i].getX() * pointArray[j].getY();
       area -= pointArray[i].getY() * pointArray[j].getX();
     }
@@ -293,10 +291,8 @@ public class ConnectionFinder {
     double cy = 0;
     double area = calcSignedPolygonArea(pointArray);
     final Point2D centroid = new Point2D.Double();
-    int i;
-    int j;
-    for (i = 0; i < length; i++) {
-      j = (i + 1) % length;
+    for (int i = 0; i < length; i++) {
+      final int j = (i + 1) % length;
       final double factor = (pointArray[i].getX() * pointArray[j].getY() - pointArray[j].getX() * pointArray[i].getY());
       cx += (pointArray[i].getX() + pointArray[j].getX()) * factor;
       cy += (pointArray[i].getY() + pointArray[j].getY()) * factor;

--- a/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -295,7 +295,6 @@ public class MapPropertiesMaker extends JFrame {
   }
 
   private void loadProperties() {
-    final Properties properties = new Properties();
     ToolLogger.info("Load a properties file");
     final String centerName =
         new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
@@ -303,6 +302,7 @@ public class MapPropertiesMaker extends JFrame {
       return;
     }
     try (InputStream in = new FileInputStream(centerName)) {
+      final Properties properties = new Properties();
       properties.load(in);
     } catch (final IOException e) {
       ToolLogger.error("Failed to load map properties: " + centerName, e);


### PR DESCRIPTION
Reports any variable declarations which can be moved to a smaller scope. Especially useful for Pascal style declarations at the start of a method, but variables with too broad a scope are also often left over after refactorings.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
