### PR TITLE
Add additional Interruptibles helpers

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -290,22 +290,18 @@ public class GameRunner {
   }
 
   private static void loadGame() {
-    try {
-      newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
-        gameSelectorModel.loadDefaultGameSameThread();
-        final String fileName = System.getProperty(TRIPLEA_GAME, "");
-        if (fileName.length() > 0) {
-          gameSelectorModel.load(new File(fileName), mainFrame);
-        }
+    Interruptibles.await(() -> newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
+      gameSelectorModel.loadDefaultGameSameThread();
+      final String fileName = System.getProperty(TRIPLEA_GAME, "");
+      if (fileName.length() > 0) {
+        gameSelectorModel.load(new File(fileName), mainFrame);
+      }
 
-        final String downloadableMap = System.getProperty(TRIPLEA_MAP_DOWNLOAD, "");
-        if (!downloadableMap.isEmpty()) {
-          SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(downloadableMap));
-        }
-      });
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+      final String downloadableMap = System.getProperty(TRIPLEA_MAP_DOWNLOAD, "");
+      if (!downloadableMap.isEmpty()) {
+        SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(downloadableMap));
+      }
+    }));
   }
 
   private static void checkLocalSystem() {

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -50,6 +50,7 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.util.Interruptibles;
 
 /**
  * Represents a running game.
@@ -255,13 +256,9 @@ public class ServerGame extends AbstractGame {
       while (!isGameOver) {
         if (delegateExecutionStopped) {
           // the delegate has told us to stop stepping through game steps
-          try {
-            // dont let this method return, as this method returning signals
-            // that the game is over.
-            delegateExecutionStoppedLatch.await();
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
+          // dont let this method return, as this method returning signals
+          // that the game is over.
+          Interruptibles.await(delegateExecutionStoppedLatch);
         } else {
           runStep(false);
         }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -37,6 +37,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 import games.strategy.ui.SwingComponents;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.OptionalUtils;
 import swinglib.JButtonBuilder;
 import swinglib.JPanelBuilder;
@@ -150,14 +151,14 @@ public class DownloadMapsWindow extends JFrame {
       assert state == State.UNINITIALIZED;
 
       state = State.INITIALIZING;
-      try {
-        final List<DownloadFileDescription> downloads = GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
-            "Downloading list of available maps...",
-            ClientContext::getMapDownloadList);
-        createAndShow(mapNames, downloads);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      Interruptibles.awaitResult(SingletonManager::getMapDownloadListInBackground).result
+          .ifPresent(downloads -> createAndShow(mapNames, downloads));
+    }
+
+    private static List<DownloadFileDescription> getMapDownloadListInBackground() throws InterruptedException {
+      return GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
+          "Downloading list of available maps...",
+          ClientContext::getMapDownloadList);
     }
 
     private void createAndShow(final Collection<String> mapNames, final List<DownloadFileDescription> downloads) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -37,6 +37,7 @@ import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 import swinglib.JButtonBuilder;
 
 /**
@@ -359,14 +360,11 @@ public class GameSelectorPanel extends JPanel implements Observer {
       if (file == null || !file.exists()) {
         return;
       }
-      try {
-        GameRunner.newBackgroundTaskRunner().runInBackground("Loading savegame...", () -> {
-          model.load(file, this);
-          setOriginalPropertiesMap(model.getGameData());
-        });
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+
+      Interruptibles.await(() -> GameRunner.newBackgroundTaskRunner().runInBackground("Loading savegame...", () -> {
+        model.load(file, this);
+        setOriginalPropertiesMap(model.getGameData());
+      }));
     } else {
       try {
         final GameChooserEntry entry =

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -28,6 +28,7 @@ import games.strategy.net.IMessageListener;
 import games.strategy.net.IMessenger;
 import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
+import games.strategy.util.Interruptibles;
 
 /**
  * A messenger general enough that both Channel and Remote messenger can be
@@ -121,11 +122,7 @@ public class UnifiedMessenger {
     final Invoke invoke = new HubInvoke(methodCallId, true, remoteCall);
     send(invoke, messenger.getServerNode());
 
-    try {
-      latch.await();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    Interruptibles.await(latch);
 
     synchronized (pendingLock) {
       final RemoteMethodCallResults methodCallResults = results.remove(methodCallId);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -33,6 +33,7 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.PredicateBuilder;
 
 public class AirBattle extends AbstractBattle {
@@ -733,9 +734,7 @@ public class AirBattle extends AbstractBattle {
     getRemote(hitPlayer, bridge).confirmOwnCasualties(battleId, "Press space to continue");
     try {
       bridge.leaveDelegateExecution();
-      t.join();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+      Interruptibles.join(t);
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -732,12 +732,9 @@ public class AirBattle extends AbstractBattle {
     }, "Click to continue waiter");
     t.start();
     getRemote(hitPlayer, bridge).confirmOwnCasualties(battleId, "Press space to continue");
-    try {
-      bridge.leaveDelegateExecution();
-      Interruptibles.join(t);
-    } finally {
-      bridge.enterDelegateExecution();
-    }
+    bridge.leaveDelegateExecution();
+    Interruptibles.join(t);
+    bridge.enterDelegateExecution();
   }
 
   private void removeFromDependents(final Collection<Unit> units, final IDelegateBridge bridge,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -186,12 +186,9 @@ public class Fire implements IExecutable {
     if (m_confirmOwnCasualties) {
       AbstractBattle.getRemote(m_hitPlayer, bridge).confirmOwnCasualties(m_battleID, "Press space to continue");
     }
-    try {
-      bridge.leaveDelegateExecution();
-      Interruptibles.join(t);
-    } finally {
-      bridge.enterDelegateExecution();
-    }
+    bridge.leaveDelegateExecution();
+    Interruptibles.join(t);
+    bridge.enterDelegateExecution();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -17,6 +17,7 @@ import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.util.CollectionUtils;
+import games.strategy.util.Interruptibles;
 
 public class Fire implements IExecutable {
 
@@ -187,9 +188,7 @@ public class Fire implements IExecutable {
     }
     try {
       bridge.leaveDelegateExecution();
-      t.join();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+      Interruptibles.join(t);
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2190,12 +2190,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
       }, "click to continue waiter");
       t.start();
-      try {
-        bridge.leaveDelegateExecution();
-        Interruptibles.join(t);
-      } finally {
-        bridge.enterDelegateExecution();
-      }
+      bridge.leaveDelegateExecution();
+      Interruptibles.join(t);
+      bridge.enterDelegateExecution();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -41,6 +41,7 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.PredicateBuilder;
 import games.strategy.util.Tuple;
 
@@ -2191,9 +2192,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       t.start();
       try {
         bridge.leaveDelegateExecution();
-        t.join();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
+        Interruptibles.join(t);
       } finally {
         bridge.enterDelegateExecution();
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -517,12 +517,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     t.start();
     final ITripleAPlayer attacker = (ITripleAPlayer) bridge.getRemotePlayer(m_attacker);
     attacker.confirmOwnCasualties(m_battleID, "Press space to continue");
-    try {
-      bridge.leaveDelegateExecution();
-      Interruptibles.join(t);
-    } finally {
-      bridge.enterDelegateExecution();
-    }
+    bridge.leaveDelegateExecution();
+    Interruptibles.join(t);
+    bridge.enterDelegateExecution();
   }
 
   private void removeAaHits(final IDelegateBridge bridge, final CasualtyDetails casualties,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -41,6 +41,7 @@ import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
+import games.strategy.util.Interruptibles;
 
 public class StrategicBombingRaidBattle extends AbstractBattle implements BattleStepStrings {
   private static final long serialVersionUID = 8490171037606078890L;
@@ -518,9 +519,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     attacker.confirmOwnCasualties(m_battleID, "Press space to continue");
     try {
       bridge.leaveDelegateExecution();
-      t.join();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+      Interruptibles.join(t);
     } finally {
       bridge.enterDelegateExecution();
     }

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -23,6 +23,7 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.framework.GameDataUtils;
 import games.strategy.util.CountUpAndDownLatch;
+import games.strategy.util.Interruptibles;
 
 /**
  * Concurrent wrapper class for the OddsCalculator. It spawns multiple worker threads and splits up the run count
@@ -166,11 +167,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
           }
           // the last one will use our already copied data from above, without copying it again
           workers.add(new OddsCalculator(newData, true));
-          try {
-            workerLatch.await();
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
+          Interruptibles.await(workerLatch);
         }
       } finally {
         newData.releaseReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -72,6 +72,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
 import games.strategy.util.CollectionUtils;
+import games.strategy.util.Interruptibles;
 import games.strategy.util.Tuple;
 
 /**
@@ -281,15 +282,12 @@ public class BattleDisplay extends JPanel {
 
     try {
       // wait for the button to be pressed.
-      continueLatch.await();
-    } catch (final InterruptedException ie) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(continueLatch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
   }
-
 
   void endBattle(final String message, final Window enclosingFrame) {
     steps.walkToLastStep();
@@ -340,9 +338,7 @@ public class BattleDisplay extends JPanel {
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     mapPanel.getUiContext().addShutdownLatch(latch);
     try {
-      latch.await();
-    } catch (final InterruptedException e1) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(latch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(latch);
     }
@@ -398,9 +394,7 @@ public class BattleDisplay extends JPanel {
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     mapPanel.getUiContext().addShutdownLatch(latch);
     try {
-      latch.await();
-    } catch (final InterruptedException e1) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(latch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(latch);
     }
@@ -525,9 +519,7 @@ public class BattleDisplay extends JPanel {
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
-      continueLatch.await();
-    } catch (final InterruptedException ex) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(continueLatch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -280,12 +280,9 @@ public class BattleDisplay extends JPanel {
       }, maxWaitTime);
     }
 
-    try {
-      // wait for the button to be pressed.
-      Interruptibles.await(continueLatch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
-    }
+    // wait for the button to be pressed.
+    Interruptibles.await(continueLatch);
+    mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
   }
 
@@ -337,11 +334,8 @@ public class BattleDisplay extends JPanel {
     SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     mapPanel.getUiContext().addShutdownLatch(latch);
-    try {
-      Interruptibles.await(latch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(latch);
-    }
+    Interruptibles.await(latch);
+    mapPanel.getUiContext().removeShutdownLatch(latch);
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
     return retreatTo[0];
   }
@@ -393,11 +387,8 @@ public class BattleDisplay extends JPanel {
     SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     mapPanel.getUiContext().addShutdownLatch(latch);
-    try {
-      Interruptibles.await(latch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(latch);
-    }
+    Interruptibles.await(latch);
+    mapPanel.getUiContext().removeShutdownLatch(latch);
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
     return retreatTo[0];
   }
@@ -518,11 +509,8 @@ public class BattleDisplay extends JPanel {
       });
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
-    try {
-      Interruptibles.await(continueLatch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
-    }
+    Interruptibles.await(continueLatch);
+    mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     return casualtyDetails.get();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1142,11 +1142,8 @@ public class TripleAFrame extends MainGameFrame {
       });
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
-    try {
-      Interruptibles.await(continueLatch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
-    }
+    Interruptibles.await(continueLatch);
+    mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     return selection;
   }
 
@@ -1229,11 +1226,8 @@ public class TripleAFrame extends MainGameFrame {
       });
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
-    try {
-      Interruptibles.await(continueLatch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
-    }
+    Interruptibles.await(continueLatch);
+    mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     return selection;
   }
 
@@ -1303,11 +1297,8 @@ public class TripleAFrame extends MainGameFrame {
       });
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
-    try {
-      Interruptibles.await(continueLatch);
-    } finally {
-      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
-    }
+    Interruptibles.await(continueLatch);
+    mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     return selection;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1047,11 +1047,7 @@ public class TripleAFrame extends MainGameFrame {
         tabsPanel.setSelectedIndex(0);
         latch1.countDown();
       });
-      try {
-        latch1.await();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      Interruptibles.await(latch1);
     }
     actionButtons.changeToPickTerritoryAndUnits(player);
     final Tuple<Territory, Set<Unit>> territoryAndUnits =
@@ -1066,11 +1062,7 @@ public class TripleAFrame extends MainGameFrame {
         }
         latch2.countDown();
       });
-      try {
-        latch2.await();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      Interruptibles.await(latch2);
     }
     if (actionButtons != null && actionButtons.getCurrent() != null) {
       actionButtons.getCurrent().setActive(false);
@@ -1151,9 +1143,7 @@ public class TripleAFrame extends MainGameFrame {
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
-      continueLatch.await();
-    } catch (final InterruptedException ex) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(continueLatch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
@@ -1240,9 +1230,7 @@ public class TripleAFrame extends MainGameFrame {
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
-      continueLatch.await();
-    } catch (final InterruptedException ex) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(continueLatch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
@@ -1316,9 +1304,7 @@ public class TripleAFrame extends MainGameFrame {
     });
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
-      continueLatch.await();
-    } catch (final InterruptedException ex) {
-      Thread.currentThread().interrupt();
+      Interruptibles.await(continueLatch);
     } finally {
       mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }

--- a/game-core/src/main/java/games/strategy/util/Interruptibles.java
+++ b/game-core/src/main/java/games/strategy/util/Interruptibles.java
@@ -55,7 +55,7 @@ public final class Interruptibles {
   public static boolean await(final CountDownLatch latch) {
     checkNotNull(latch);
 
-    return await(() -> latch.await());
+    return await(latch::await);
   }
 
   /**
@@ -79,6 +79,20 @@ public final class Interruptibles {
       Thread.currentThread().interrupt();
       return new Result<>(false, Optional.empty());
     }
+  }
+
+  /**
+   * Waits for the specified thread to die.
+   *
+   * @param thread The thread to await.
+   *
+   * @return {@code true} if the thread died; otherwise {@code false} if the current thread was interrupted before the
+   *         thread died.
+   */
+  public static boolean join(final Thread thread) {
+    checkNotNull(thread);
+
+    return await(thread::join);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/util/Interruptibles.java
+++ b/game-core/src/main/java/games/strategy/util/Interruptibles.java
@@ -3,6 +3,7 @@ package games.strategy.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -41,6 +42,20 @@ public final class Interruptibles {
       runnable.run();
       return null;
     }).completed;
+  }
+
+  /**
+   * Causes the current thread to wait for the specified latch to count down to zero or until the thread is interrupted.
+   *
+   * @param latch The latch to await.
+   *
+   * @return {@code true} if the latch counted down to zero; otherwise {@code false} if the current thread was
+   *         interrupted before the latch counted down to zero.
+   */
+  public static boolean await(final CountDownLatch latch) {
+    checkNotNull(latch);
+
+    return await(() -> latch.await());
   }
 
   /**

--- a/game-core/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/staging/panels/SelectGameWindow.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.util.Interruptibles;
 
 /**
  * Opens a dialog window where users can select from the available games they have installed.
@@ -22,23 +23,18 @@ public class SelectGameWindow {
    * the Runnable will open the select map window.
    */
   public static Runnable openSelectGameWindow(final LaunchScreen previousScreen, final StagingScreen stagingScreen) {
-    return () -> {
-      try {
-        final GameChooserEntry entry;
-        entry = GameChooser.chooseGame(
-            JOptionPane.getFrameForComponent(null),
-            ClientSetting.SELECTED_GAME_LOCATION.value());
-        if (entry != null) {
-          ClientSetting.SELECTED_GAME_LOCATION.save(entry.getLocation());
-          try {
-            LaunchScreenWindow.draw(previousScreen, stagingScreen, entry.fullyParseGameData());
-          } catch (final GameParseException e) {
-            throw new IllegalStateException(String.format("Could not parse: %s", entry.toString()), e);
-          }
+    return () -> Interruptibles.await(() -> {
+      final GameChooserEntry entry = GameChooser.chooseGame(
+          JOptionPane.getFrameForComponent(null),
+          ClientSetting.SELECTED_GAME_LOCATION.value());
+      if (entry != null) {
+        ClientSetting.SELECTED_GAME_LOCATION.save(entry.getLocation());
+        try {
+          LaunchScreenWindow.draw(previousScreen, stagingScreen, entry.fullyParseGameData());
+        } catch (final GameParseException e) {
+          throw new IllegalStateException(String.format("Could not parse: %s", entry.toString()), e);
         }
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
       }
-    };
+    });
   }
 }

--- a/game-core/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
+++ b/game-core/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
@@ -4,6 +4,8 @@ import java.awt.Image;
 import java.awt.image.ImageObserver;
 import java.util.concurrent.CountDownLatch;
 
+import games.strategy.util.Interruptibles;
+
 /**
  * Code originally contributed by "Thomas Carvin".
  */
@@ -14,11 +16,7 @@ public class ImageIoCompletionWatcher implements ImageObserver {
   public ImageIoCompletionWatcher() {}
 
   public void waitForCompletion() {
-    try {
-      countDownLatch.await();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    Interruptibles.await(countDownLatch);
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/engine/delegate/DelegateExecutionManagerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/delegate/DelegateExecutionManagerTest.java
@@ -7,6 +7,8 @@ import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.util.Interruptibles;
+
 public final class DelegateExecutionManagerTest {
   private final DelegateExecutionManager delegateExecutionManager = new DelegateExecutionManager();
 
@@ -39,11 +41,7 @@ public final class DelegateExecutionManagerTest {
     final Thread delegate1Thread = new Thread(() -> {
       delegateExecutionManager.enterDelegateExecution();
       delegate1RunningLatch.countDown();
-      try {
-        testCompleteLatch.await();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+      Interruptibles.await(testCompleteLatch);
     });
     delegate1Thread.start();
     delegate1RunningLatch.await();

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -269,12 +269,8 @@ public class RemoteMessengerTest {
       final IFoo foo = new IFoo() {
         @Override
         public void foo() {
-          try {
-            started.set(true);
-            latch.await();
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
+          started.set(true);
+          Interruptibles.await(latch);
         }
       };
       clientRemoteMessenger.registerRemote(foo, test);

--- a/game-core/src/test/java/games/strategy/thread/ThreadPoolTest.java
+++ b/game-core/src/test/java/games/strategy/thread/ThreadPoolTest.java
@@ -69,13 +69,7 @@ public class ThreadPoolTest {
       threads.add(t);
       t.start();
     }
-    for (final Thread thread : threads) {
-      try {
-        thread.join();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    threads.forEach(Interruptibles::join);
   }
 
   private static void threadTestBlock() {

--- a/game-core/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/game-core/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -3,7 +3,7 @@ package games.strategy.ui;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 
 import com.example.mockito.MockitoExtension;
+
+import games.strategy.util.Interruptibles;
 
 @ExtendWith(MockitoExtension.class)
 public class SwingActionTest {
@@ -65,12 +67,7 @@ public class SwingActionTest {
   public void testInvokeAndWaitWithRunnable_ShouldInvokeActionWhenCalledOnEdt(@Mock final Runnable action)
       throws Exception {
     SwingUtilities.invokeAndWait(() -> {
-      try {
-        SwingAction.invokeAndWait(action);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        fail("unexpected interruption");
-      }
+      assertTrue(Interruptibles.await(() -> SwingAction.invokeAndWait(action)), "should not be interrupted");
     });
 
     verify(action).run();
@@ -96,12 +93,9 @@ public class SwingActionTest {
   @Test
   public void testInvokeAndWaitWithSupplier_ShouldReturnActionResultWhenCalledOnEdt() throws Exception {
     SwingUtilities.invokeAndWait(() -> {
-      try {
-        assertEquals(VALUE, SwingAction.invokeAndWait(() -> VALUE));
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        fail("unexpected interruption");
-      }
+      assertTrue(
+          Interruptibles.await(() -> assertEquals(VALUE, SwingAction.invokeAndWait(() -> VALUE))),
+          "should not be interrupted");
     });
   }
 

--- a/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
+++ b/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
@@ -3,9 +3,12 @@ package games.strategy.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -88,6 +91,18 @@ public final class InterruptiblesTest {
       assertThrows(IllegalStateException.class, () -> Interruptibles.awaitResult(() -> {
         throw new IllegalStateException();
       }));
+    }
+  }
+
+  @Nested
+  public final class AwaitCountDownLatchTest {
+    @Test
+    public void shouldWaitUntilLatchCountIsZero() {
+      final CountDownLatch latch = new CountDownLatch(0);
+
+      assertTimeoutPreemptively(Duration.ofSeconds(5L), () -> {
+        assertThat(Interruptibles.await(latch), is(true));
+      });
     }
   }
 

--- a/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
+++ b/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
@@ -107,6 +107,20 @@ public final class InterruptiblesTest {
   }
 
   @Nested
+  public final class JoinTest {
+    @Test
+    public void shouldWaitUntilThreadIsDead() {
+      final Thread thread = new Thread(() -> {
+      });
+      thread.start();
+
+      assertTimeoutPreemptively(Duration.ofSeconds(5L), () -> {
+        assertThat(Interruptibles.join(thread), is(true));
+      });
+    }
+  }
+
+  @Nested
   public final class SleepTest {
     @Test
     public void shouldThrowExceptionWhenMillisIsNegative() {


### PR DESCRIPTION
This PR adds two additional helpers to the `Interruptibles` class:

* `await(CountDownLatch)`: Calls `CountDownLatch#await()` with a trivial `InterruptedException` handler.
* `join(Thread)`: Calls `Thread#join()` with a trivial `InterruptedException` handler.

The first commit also gets rid of a few trivial `InterruptedException` handlers by wrapping the interruptible code with `Interruptibles#await(InterruptibleRunnable)`.

The fourth commit removes some try-finally blocks that I believe are no longer necessary after introducing `Interruptibles` usage.  I verified no "expected" unchecked exceptions should be thrown from the code in the try blocks, but please scrutinize to ensure I didn't miss something.

The purpose of using these helpers is to hide the detail of re-interrupting the thread after catching `InterruptedException`.

#### Notes

It is recommended to ignore whitespace changes while reviewing this PR.