### PR TITLE
Error Prone: Fix default charset violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 
@@ -44,7 +45,7 @@ class LobbyPropertyFileParser {
   }
 
   private static JSONArray loadYaml(final File yamlFile) throws IOException {
-    final String yamlContent = new String(Files.readAllBytes(yamlFile.toPath()));
+    final String yamlContent = new String(Files.readAllBytes(yamlFile.toPath()), StandardCharsets.UTF_8);
     final Yaml yaml = new Yaml();
     return new JSONArray(yaml.loadAs(yamlContent, List.class));
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -74,7 +75,7 @@ public class ProcessRunnerUtil {
       // we need to read the input stream to prevent possible
       // deadlocks
       Util.createDaemonThread(() -> {
-        try (Scanner scanner = new Scanner(s)) {
+        try (Scanner scanner = new Scanner(s, Charset.defaultCharset().name())) {
           while (scanner.hasNextLine()) {
             System.out.println(scanner.nextLine());
           }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -161,7 +162,7 @@ public class EmailSenderEditor extends EditorPanel {
         final File dummy = new File(ClientFileSystemHelper.getUserRootFolder(), "dummySave.txt");
         dummy.deleteOnExit();
         try (OutputStream fout = new FileOutputStream(dummy)) {
-          fout.write("This file would normally be a save game".getBytes());
+          fout.write("This file would normally be a save game".getBytes(StandardCharsets.UTF_8));
         }
         ((IEmailSender) getBean()).sendEmail("TripleA Test", html, dummy, "dummy.txt");
         // email was sent, or an exception would have been thrown

--- a/game-core/src/main/java/games/strategy/triplea/help/HelpSupport.java
+++ b/game-core/src/main/java/games/strategy/triplea/help/HelpSupport.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A class for loading help files from the data folder (merged with src at runtime).
@@ -12,7 +13,7 @@ public class HelpSupport {
   public static String loadHelp(final String fileName) {
     try {
       final InputStream is = HelpSupport.class.getResourceAsStream(fileName);
-      final BufferedReader br = new BufferedReader(new InputStreamReader(is));
+      final BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
       String line;
       final StringBuilder sb = new StringBuilder();
       while ((line = br.readLine()) != null) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -1,8 +1,11 @@
 package games.strategy.triplea.printgenerator;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,7 +46,10 @@ class CountryChart {
       availableUnits = gameData.getUnitTypeList().iterator();
     }
     final File outFile = new File(printData.getOutDir(), player.getName() + ".csv");
-    try (FileWriter countryFileWriter = new FileWriter(outFile, true)) {
+    try (Writer countryFileWriter = Files.newBufferedWriter(
+        outFile.toPath(),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
       // Print Title
       final int numUnits = gameData.getUnitTypeList().size();
       for (int i = 0; i < numUnits / 2 - 1 + numUnits % 2; i++) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -1,9 +1,11 @@
 package games.strategy.triplea.printgenerator;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -47,7 +49,10 @@ class PlayerOrder {
     }
     printData.getOutDir().mkdir();
     final File outFile = new File(printData.getOutDir(), "General Information.csv");
-    try (Writer turnWriter = new FileWriter(outFile, true)) {
+    try (Writer turnWriter = Files.newBufferedWriter(
+        outFile.toPath(),
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
       turnWriter.write("Turn Order\r\n");
       int count = 1;
       for (final PlayerID currentPlayerId : removeDups(playerSet)) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
@@ -1,8 +1,11 @@
 package games.strategy.triplea.printgenerator;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -27,7 +30,10 @@ class PuInfo {
     }
     try {
       final File outFile = new File(printData.getOutDir(), "General Information.csv");
-      try (FileWriter resourceWriter = new FileWriter(outFile, true)) {
+      try (Writer resourceWriter = Files.newBufferedWriter(
+          outFile.toPath(),
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
         // Print Title
         final int numResources = gameData.getResourceList().size();
         for (int i = 0; i < numResources / 2 - 1 + numResources % 2; i++) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -1,8 +1,10 @@
 package games.strategy.triplea.printgenerator;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -29,7 +31,7 @@ class UnitInformation {
     data = printData.getData();
     printData.getOutDir().mkdir();
     final File outFile = new File(printData.getOutDir(), "General Information.csv");
-    try (FileWriter unitInformation = new FileWriter(outFile)) {
+    try (Writer unitInformation = Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8)) {
       for (int i = 0; i < 8; i++) {
         unitInformation.write(",");
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -106,7 +108,7 @@ final class ExportMenu extends JMenu {
     } finally {
       gameData.releaseReadLock();
     }
-    try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
+    try (Writer writer = Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8)) {
       writer.write(xmlFile);
     } catch (final IOException e1) {
       ClientLogger.logQuietly("Failed to write XML: " + chooser.getSelectedFile().getAbsolutePath(), e1);
@@ -369,7 +371,7 @@ final class ExportMenu extends JMenu {
     } finally {
       gameData.releaseReadLock();
     }
-    try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
+    try (Writer writer = Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8)) {
       writer.write(text.toString());
     } catch (final IOException e1) {
       ClientLogger.logQuietly("Failed to write stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
@@ -388,7 +390,7 @@ final class ExportMenu extends JMenu {
       if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
         return;
       }
-      try (Writer writer = new FileWriter(chooser.getSelectedFile())) {
+      try (Writer writer = Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8)) {
         writer.write(
             HelpMenu.getUnitStatsTable(gameData, uiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));

--- a/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -10,7 +10,9 @@ import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,7 +40,7 @@ public final class PointFileReaderWriter {
     checkNotNull(stream);
 
     final Map<String, Point> mapping = new HashMap<>();
-    try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
+    try (Reader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream), StandardCharsets.UTF_8);
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       @Nullable
       String current = reader.readLine();
@@ -126,7 +128,7 @@ public final class PointFileReaderWriter {
   }
 
   private static void write(final StringBuilder buf, final OutputStream sink) throws IOException {
-    try (Writer out = new OutputStreamWriter(new CloseShieldOutputStream(sink))) {
+    try (Writer out = new OutputStreamWriter(new CloseShieldOutputStream(sink), StandardCharsets.UTF_8)) {
       out.write(buf.toString());
     }
   }
@@ -172,7 +174,7 @@ public final class PointFileReaderWriter {
     checkNotNull(stream);
 
     final Map<String, List<Point>> mapping = new HashMap<>();
-    try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
+    try (Reader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream), StandardCharsets.UTF_8);
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       @Nullable
       String current = reader.readLine();
@@ -193,7 +195,7 @@ public final class PointFileReaderWriter {
     checkNotNull(stream);
 
     final Map<String, List<Polygon>> mapping = new HashMap<>();
-    try (InputStreamReader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream));
+    try (Reader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream), StandardCharsets.UTF_8);
         LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       @Nullable
       String current = reader.readLine();

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -97,7 +98,7 @@ public class AutoPlacementFinder {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          try (Scanner scanner = new Scanner(file)) {
+          try (Scanner scanner = new Scanner(file, StandardCharsets.UTF_8.name())) {
             while (scanner.hasNextLine()) {
               final String line = scanner.nextLine();
               if (line.contains(scaleProperty)) {

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -13,6 +13,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -188,9 +189,9 @@ public class ConnectionFinder {
       } else {
         try (OutputStream out = new FileOutputStream(fileName)) {
           if (territoryDefinitions != null) {
-            out.write(String.valueOf(territoryDefinitions).getBytes());
+            out.write(String.valueOf(territoryDefinitions).getBytes(StandardCharsets.UTF_8));
           }
-          out.write(String.valueOf(connectionsString).getBytes());
+          out.write(String.valueOf(connectionsString).getBytes(StandardCharsets.UTF_8));
         }
         ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
       }

--- a/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -328,7 +329,7 @@ public class MapPropertiesMaker extends JFrame {
       }
       final String stringToWrite = getOutPutString();
       try (OutputStream sink = new FileOutputStream(fileName);
-          Writer out = new OutputStreamWriter(sink)) {
+          Writer out = new OutputStreamWriter(sink, StandardCharsets.UTF_8)) {
         out.write(stringToWrite);
       }
       ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -21,6 +21,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -164,7 +165,7 @@ public class PlacementPicker extends JFrame {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          try (Scanner scanner = new Scanner(file)) {
+          try (Scanner scanner = new Scanner(file, StandardCharsets.UTF_8.name())) {
             while (scanner.hasNextLine()) {
               final String line = scanner.nextLine();
               if (line.contains(scaleProperty)) {


### PR DESCRIPTION
In almost all cases, I/O was against a file, and so I specified UTF-8 as the charset to use.  In one instance, I/O was with another process, and so I specified the default charset.