### PR TITLE
Restore AbstractRulesAttachment#setTurns(String) method

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -248,6 +248,11 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setTurns(final String turns) throws GameParseException {
+    setRounds(turns);
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setTurns(final HashMap<Integer, Integer> value) {
     m_turns = value;
   }


### PR DESCRIPTION
Fixes #2973 and fixes #3100.

#### Functional changes

The root cause of the reported issues was due to the engine attempting to set the `AbstractRulesAttachment#m_turns` property with a `String` value.  The `setTurns(String)` overload was renamed to `setRounds(String)` in 0cd3154a5.  Thus, only the `setTurns(HashMap<Integer, Integer>)` overload is left, which, when called, results in an exception due to an argument type mismatch.

The fix is to simply restore the `setTurns(String)` overload and have it delegate to `setRounds(String)`.

#### Functional issues for review

This may be only one solution.  My first attempt to fix this problem was to change the value of the `playerProperty` option in the following attachment from `turns` to `rounds` to match all the other usage of this property:

```xml
    <!-- French Triggers -->
    <attachment name="triggerAttachment_Germans_Conquer_France" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
      <option name="trigger" value="conditionAttachment_French_1_Lose_France"/>
      <option name="uses" value="1"/>
      <option name="when" value="after:germansBattle"/>
      <option name="players" value="French"/>
      <option name="playerAttachmentName" value="RulesAttachment" count="conditionAttachment_French_1_Liberation"/>
      <option name="playerProperty" value="turns" count="1-+"/>
    </attachment>
```

However, that resulted in a different error due to the fact that `rounds` is not a true property (it doesn't have a backing field; it is simply an alias for the `turns` property):

```
Error: No such Property Field named: m_rounds, or: rounds, for Subject: RulesAttachment attached to:PlayerID named:French with name:conditionAttachment_French_1_Liberation
java.lang.IllegalStateException: No such Property Field named: m_rounds, or: rounds, for Subject: RulesAttachment attached to:PlayerID named:French with name:conditionAttachment_French_1_Liberation
	at games.strategy.util.PropertyUtil.getPropertyFieldObject(PropertyUtil.java:78)
	at games.strategy.engine.data.DefaultAttachment.getRawPropertyString(DefaultAttachment.java:113)
	at games.strategy.triplea.attachments.TriggerAttachment.triggerPlayerPropertyChange(TriggerAttachment.java:1629)
	at games.strategy.triplea.attachments.TriggerAttachment.fireTriggers(TriggerAttachment.java:222)
	at games.strategy.triplea.attachments.TriggerAttachment.collectAndFireTriggers(TriggerAttachment.java:168)
	at games.strategy.triplea.delegate.BaseTripleADelegate.triggerWhenTriggerAttachments(BaseTripleADelegate.java:90)
	at games.strategy.triplea.delegate.BaseTripleADelegate.end(BaseTripleADelegate.java:59)
	at games.strategy.triplea.delegate.BattleDelegate.end(BattleDelegate.java:119)
	at games.strategy.engine.framework.ServerGame.endStep(ServerGame.java:454)
	at games.strategy.engine.framework.ServerGame.runStep(ServerGame.java:418)
	at games.strategy.engine.framework.ServerGame.startGame(ServerGame.java:266)
	at games.strategy.engine.framework.startup.launcher.LocalLauncher.launchInNewThread(LocalLauncher.java:58)
	at games.strategy.engine.framework.startup.launcher.AbstractLauncher.lambda$0(AbstractLauncher.java:51)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: No such Property Field: rounds
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:60)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:65)
	at games.strategy.util.PropertyUtil.getFieldIncludingFromSuperClasses(PropertyUtil.java:55)
	at games.strategy.util.PropertyUtil.getPropertyField(PropertyUtil.java:103)
	at games.strategy.util.PropertyUtil.getPropertyField(PropertyUtil.java:83)
	at games.strategy.util.PropertyUtil.getPropertyFieldObject(PropertyUtil.java:71)
	... 13 more
```

I'm sure we could probably modify `DefaultAttachment#getRawPropertyString()` to work with virtual properties.  However, in light of the fact that we're trying to stop using reflection with all attachments (#3042), I punted on this possibility and chose the simplest thing that would work.

#### Testing

I used the following repro:

1. Start a local WW2 Europe 1940 Original game.
1. Have Germany attack _France_ with enough units to ensure a win (I sent everything from _Holland Belgium_ and _Western Germany_).
1. Complete battle (bug will only occur when Germany is the winner because it is dependent on `triggerAttachment_Germans_Conquer_France` being fired).

Without this PR, the console will pop up with the stack trace described in the associated issues.  With this PR, no error occurs.