### PR TITLE
Add missing attachment property definitions

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/AttachmentProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/AttachmentProperty.java
@@ -94,6 +94,17 @@ public interface AttachmentProperty<T> {
   }
 
   /**
+   * Convenience method to create an instance of this interface that only sets via the string value.
+   */
+  static <T> AttachmentProperty<T> ofWriteOnlyString(final GameParsingConsumer<String> stringSetter) {
+    return of(
+        t -> throwIllegalStateException("No Setter"),
+        stringSetter,
+        () -> throwIllegalStateException("No Getter"),
+        () -> throwIllegalStateException("No Resetter"));
+  }
+
+  /**
    * A Consumer capable of throwing a GameParseException.
    *
    * @param <T> The type of Object to consume.

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -1262,7 +1262,9 @@ public final class GameParser {
       final String count = current.getAttribute("count");
       final String itemValues = (count.length() > 0 ? count + ":" : "") + value;
       Optional.ofNullable(attachmentMap.get(name))
-          .orElseThrow(() -> new GameParseException("Missing property definition for option: " + name))
+          .orElseThrow(() -> new GameParseException(String.format(
+              "Missing property definition for option '%s' in attachment '%s'",
+              name, attachment.getName())))
           .setValue(itemValues);
 
       options.add(Tuple.of(name, itemValues));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -843,6 +843,9 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::setProduction,
                 this::getProduction,
                 this::resetProduction))
+        .put("productionOnly",
+            AttachmentProperty.ofWriteOnlyString(
+                this::setProductionOnly))
         .put("victoryCity",
             AttachmentProperty.of(
                 this::setVictoryCity,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3516,7 +3516,6 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
   public void setIsMechanized(final String s) {}
 
-
   private Map<String, AttachmentProperty<?>> createPropertyMap() {
     return ImmutableMap.<String, AttachmentProperty<?>>builder()
         .put("isAir",
@@ -3525,6 +3524,12 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsAir,
                 this::getIsAir,
                 this::resetIsAir))
+        .put("isMechanized",
+            AttachmentProperty.ofWriteOnlyString(
+                this::setIsMechanized))
+        .put("isParatroop",
+            AttachmentProperty.ofWriteOnlyString(
+                this::setIsParatroop))
         .put("isSea",
             AttachmentProperty.of(
                 this::setIsSea,


### PR DESCRIPTION
Fixes #3115 (only the errors that were reported; there may be similar errors lurking in unofficial maps that were not tested as part of #3042).