### PR TITLE
Read system property before clearing it

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -87,6 +87,7 @@ public class InGameLobbyWatcher {
       final InGameLobbyWatcher oldWatcher) {
     final String host = System.getProperty(LOBBY_HOST);
     final String port = System.getProperty(LOBBY_PORT);
+    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
     if (host == null || port == null) {
       return null;
     }
@@ -97,7 +98,6 @@ public class InGameLobbyWatcher {
     // add them as temporary properties (in case we load an old savegame and need them again)
     System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
     System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
-    final String hostedBy = System.getProperty(LOBBY_GAME_HOSTED_BY);
     System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = new IConnectionLogin() {
       @Override


### PR DESCRIPTION
Fixes #3120.

Regression caused by automated IDE refactoring in #3096.  This wasn't caught during review because the gap in the diff hid the call to `System#clearProperty()` that was in-between the old and new locations of the `System#getProperty()` call.

#### Testing

I verified starting a bot no longer results in the NPE reported in #3120.