### PR TITLE
Remove outdated TODOs and associated unused code

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
@@ -32,10 +32,6 @@ public interface IPlayerBridge {
    */
   String getStepName();
 
-  /*
-   * Get the name of the current delegate being executed. TODO: add this in to next release
-   * public String getDelegateName();
-   */
   /**
    * Get the properties for the current step.
    */

--- a/game-core/src/main/java/games/strategy/engine/history/Step.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Step.java
@@ -26,10 +26,6 @@ public class Step extends IndexedHistoryNode {
     return new StepHistorySerializer(stepName, delegateName, player, super.getTitle());
   }
 
-  public String getDelegateName() {
-    return delegateName;
-  }
-
   public String getStepName() {
     return stepName;
   }

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -178,10 +178,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
     }
   }
 
-  public boolean isShutDown() {
-    return shutDown;
-  }
-
   @Override
   public void messageReceived(final MessageHeader msg, final SocketChannel channel) {
     if (msg.getFor() != null && !msg.getFor().equals(node)) {

--- a/game-core/src/main/java/games/strategy/net/IMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IMessenger.java
@@ -78,5 +78,4 @@ public interface IMessenger {
    * different than the actual port we use.
    */
   InetSocketAddress getRemoteServerSocketAddress();
-  // TODO: add this into next release: boolean isShutDown();
 }

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -127,10 +127,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
   }
 
-  public synchronized boolean isShutDown() {
-    return shutdown;
-  }
-
   @Override
   public boolean isConnected() {
     return !shutdown;


### PR DESCRIPTION
These TODOs were added in 06dc3f2 (2013).  They haven't been addressed in almost five years and are unlikely to be on anybody's radar.