### PR TITLE
Remove always false boolean condition

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -50,7 +50,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     if (result != null) {
       return result;
     }
-    if (units == null || units.isEmpty()) {
+    if (units.isEmpty()) {
       return null;
     }
     final Collection<PlayerID> owners = new HashSet<>();


### PR DESCRIPTION
If units were null we would get a NPE first in an earlier method, line 49: ` EditValidator.validateRemoveUnits(getData(), territory, units);`

So condition is always false and can be removed.
<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
