### PR TITLE
Preference Save actions - open console and set L&F

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -1,5 +1,6 @@
 package games.strategy.debug;
 
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.ErrorHandler;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
@@ -10,6 +11,15 @@ import games.strategy.util.Interruptibles;
 public final class ErrorConsole extends GenericConsole {
   private static final long serialVersionUID = -3489030525309243438L;
   private static ErrorConsole console;
+
+
+  static {
+    ClientSetting.SHOW_CONSOLE_ALWAYS.addSaveListener(newValue -> {
+      if (newValue.equals(String.valueOf(true))) {
+        ErrorConsole.showConsole();
+      }
+    });
+  }
 
   private ErrorConsole() {
     super("TripleA Console");

--- a/game-core/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/game-core/src/main/java/games/strategy/debug/GenericConsole.java
@@ -14,6 +14,7 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
+import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 
@@ -29,6 +30,7 @@ public abstract class GenericConsole extends JFrame {
 
   protected GenericConsole(final String title) {
     super(title);
+    LookAndFeelSwingFrameListener.register(this);
     setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     getContentPane().setLayout(new BorderLayout());
     textArea.setLineWrap(true);

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -59,6 +59,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
+import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.download.MapDownloadController;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -157,6 +158,7 @@ public class GameRunner {
 
   private static JFrame newMainFrame() {
     final JFrame frame = new JFrame("TripleA");
+    LookAndFeelSwingFrameListener.register(frame);
 
     frame.add(new MainPanel(setupPanelModel));
     frame.pack();

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -54,7 +54,8 @@ public final class LookAndFeel {
       SettingsWindow.updateLookAndFeel();
       JOptionPane.showMessageDialog(
           null,
-          "WARNING: look and feel changes can cause instability. Please restart all running TripleA instances",
+          "Look and feel changes can cause instability.\n"
+              + "Please restart all running TripleA instances.",
           "Close TripleA and Restart",
           JOptionPane.WARNING_MESSAGE);
     });

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -77,13 +77,14 @@ public final class LookAndFeel {
   /**
    * Sets the user's preferred Look-And-Feel. If not available, the system Look-And-Feel will be used.
    *
+   * @param lookAndFeelName Value that is sent to UIManager for new look and feel setting.
    * @throws IllegalStateException If this method is not called from the EDT.
    */
-  public static void setupLookAndFeel() {
+  public static void setupLookAndFeel(final String lookAndFeelName) {
     checkState(SwingUtilities.isEventDispatchThread());
 
     try {
-      UIManager.setLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
+      UIManager.setLookAndFeel(lookAndFeelName);
     } catch (final Throwable t) {
       if (!SystemProperties.isMac()) {
         try {
@@ -93,5 +94,9 @@ public final class LookAndFeel {
         }
       }
     }
+  }
+
+  public static void setupLookAndFeel() {
+    setupLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
@@ -41,11 +42,24 @@ import org.pushingpixels.substance.api.skin.SubstanceTwilightLookAndFeel;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.SettingsWindow;
 
 /**
  * Provides methods for working with the Swing Look-And-Feel.
  */
 public final class LookAndFeel {
+  static {
+    ClientSetting.LOOK_AND_FEEL_PREF.addSaveListener(newValue -> {
+      setupLookAndFeel(newValue);
+      SettingsWindow.updateLookAndFeel();
+      JOptionPane.showMessageDialog(
+          null,
+          "WARNING: look and feel changes can cause instability. Please restart all running TripleA instances",
+          "Close TripleA and Restart",
+          JOptionPane.WARNING_MESSAGE);
+    });
+  }
+
   private LookAndFeel() {}
 
   /**
@@ -80,9 +94,11 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void setupLookAndFeel() {
-    checkState(SwingUtilities.isEventDispatchThread());
+    setupLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
+  }
 
-    final String lookAndFeelName = ClientSetting.LOOK_AND_FEEL_PREF.value();
+  private static void setupLookAndFeel(final String lookAndFeelName) {
+    checkState(SwingUtilities.isEventDispatchThread());
     try {
       UIManager.setLookAndFeel(lookAndFeelName);
     } catch (final Throwable t) {

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -77,12 +77,12 @@ public final class LookAndFeel {
   /**
    * Sets the user's preferred Look-And-Feel. If not available, the system Look-And-Feel will be used.
    *
-   * @param lookAndFeelName Value that is sent to UIManager for new look and feel setting.
    * @throws IllegalStateException If this method is not called from the EDT.
    */
-  public static void setupLookAndFeel(final String lookAndFeelName) {
+  public static void setupLookAndFeel() {
     checkState(SwingUtilities.isEventDispatchThread());
 
+    final String lookAndFeelName = ClientSetting.LOOK_AND_FEEL_PREF.value();
     try {
       UIManager.setLookAndFeel(lookAndFeelName);
     } catch (final Throwable t) {
@@ -94,9 +94,5 @@ public final class LookAndFeel {
         }
       }
     }
-  }
-
-  public static void setupLookAndFeel() {
-    setupLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
@@ -1,0 +1,42 @@
+package games.strategy.engine.framework.lookandfeel;
+
+import java.util.function.Consumer;
+
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.ui.SwingComponents;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * Look and feel listener specific for a JFrame.
+ * JFrame will be updated when the L&F is updated, listener is automatically removed on teh frame close event.
+ *
+ * <pre>
+ * <code>
+ *   LookAndFeelSwingFrameListener.register(yourSwingFrame);
+ * </code>
+ * </pre>
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LookAndFeelSwingFrameListener implements Consumer<String> {
+  private final JFrame component;
+
+  /**
+   * Creates a look and feel update listener that will update the passed in JFrame
+   * component. Listener removal is also handled and is attached to the window close event.
+   */
+  public static void register(final JFrame component) {
+    final Consumer<String> listener = new LookAndFeelSwingFrameListener(component);
+    ClientSetting.LOOK_AND_FEEL_PREF.addSaveListener(listener);
+    SwingComponents.addWindowClosingListener(component,
+        () -> ClientSetting.LOOK_AND_FEEL_PREF.removeSaveListener(listener));
+  }
+
+  @Override
+  public void accept(final String s) {
+    SwingUtilities.updateComponentTreeUI(component);
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -35,6 +35,7 @@ import javax.swing.event.ListSelectionListener;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.Interruptibles;
@@ -168,6 +169,7 @@ public class DownloadMapsWindow extends JFrame {
 
       window = new DownloadMapsWindow(mapNames, downloads);
       SwingComponents.addWindowClosedListener(window, this::uninitialize);
+      LookAndFeelSwingFrameListener.register(window);
       state = State.INITIALIZED;
 
       show();

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -14,6 +14,7 @@ import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.IRemote;
@@ -82,7 +83,9 @@ public class TripleA implements IGameLoader {
     }
 
     if (display != null) {
-      game.removeDisplay(display);
+      if (game != null) {
+        game.removeDisplay(display);
+      }
       display.shutDown();
       display = null;
     }
@@ -116,6 +119,7 @@ public class TripleA implements IGameLoader {
     } else {
       SwingAction.invokeAndWait(() -> {
         final TripleAFrame frame = new TripleAFrame(game, localPlayers);
+        LookAndFeelSwingFrameListener.register(frame);
         display = new TripleADisplay(frame);
         game.addDisplay(display);
         soundChannel = new DefaultSoundChannel(localPlayers);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -225,7 +225,12 @@ public enum ClientSetting implements GameSetting {
   @Override
   public void save(final String newValue) {
     onSaveActions.forEach(saveAction -> saveAction.accept(Strings.nullToEmpty(newValue)));
-    getPreferences().put(name(), newValue);
+
+    if (newValue == null) {
+      getPreferences().remove(name());
+    } else {
+      getPreferences().put(name(), newValue);
+    }
   }
 
   public static void save(final String key, final String value) {

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -224,7 +224,7 @@ public enum ClientSetting implements GameSetting {
 
   @Override
   public void save(final String newValue) {
-    onSaveActions.forEach(saveAction -> saveAction.accept(newValue));
+    onSaveActions.forEach(saveAction -> saveAction.accept(Strings.nullToEmpty(newValue)));
     getPreferences().put(name(), newValue);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -10,6 +10,9 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 import javax.annotation.Nonnull;
+import javax.swing.UIManager;
+
+import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -66,7 +69,10 @@ public enum ClientSetting implements GameSetting {
 
   LOBBY_LAST_USED_PORT,
 
-  LOOK_AND_FEEL_PREF,
+  LOOK_AND_FEEL_PREF(
+      SystemProperties.isMac()
+          ? UIManager.getSystemLookAndFeelClassName()
+          : SubstanceGraphiteLookAndFeel.class.getName()),
 
   MAP_EDGE_SCROLL_SPEED(30),
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -68,8 +68,7 @@ public enum ClientSetting implements GameSetting {
 
   LOBBY_LAST_USED_PORT,
 
-  LOOK_AND_FEEL_PREF(getDefaultLookAndFeelClassName(),
-      games.strategy.engine.framework.lookandfeel.LookAndFeel::setupLookAndFeel),
+  LOOK_AND_FEEL_PREF,
 
   MAP_EDGE_SCROLL_SPEED(30),
 
@@ -206,13 +205,6 @@ public enum ClientSetting implements GameSetting {
           + "or ClientSetting#setPreferences() in test code?");
     }
     return preferences;
-  }
-
-  private static String getDefaultLookAndFeelClassName() {
-    // stay consistent with mac look and feel if we are on a mac
-    return SystemProperties.isMac()
-        ? UIManager.getSystemLookAndFeelClassName()
-        : SubstanceGraphiteLookAndFeel.class.getName();
   }
 
   public static void showSettingsWindow() {

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -68,7 +68,8 @@ public enum ClientSetting implements GameSetting {
 
   LOBBY_LAST_USED_PORT,
 
-  LOOK_AND_FEEL_PREF(getDefaultLookAndFeelClassName()),
+  LOOK_AND_FEEL_PREF(getDefaultLookAndFeelClassName(),
+      games.strategy.engine.framework.lookandfeel.LookAndFeel::setupLookAndFeel),
 
   MAP_EDGE_SCROLL_SPEED(30),
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -170,8 +170,7 @@ public enum ClientSetting implements GameSetting {
    * </p>
    */
   public static void initialize() {
-    setPreferences(
-        Preconditions.checkNotNull(Preferences.userNodeForPackage(ClientSetting.class)));
+    setPreferences(Preferences.userNodeForPackage(ClientSetting.class));
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -180,6 +180,7 @@ public enum ClientSetting implements GameSetting {
 
   @Override
   public void addSaveListener(final Consumer<String> saveListener) {
+    Preconditions.checkNotNull(saveListener);
     onSaveActions.add(saveListener);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -76,8 +76,8 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           LookAndFeel.getLookAndFeelAvailableList(),
           s -> s.replaceFirst(".*\\.", "").replaceFirst("LookAndFeel$", "")),
       "Select a new value and save to see a preview of the new theme\n"
-          + "Please restart TripleA if you change this value for it to take effect properly."),
-
+          + "Please restart TripleA for new UI theme to take full effect"),
+  
   MAP_EDGE_SCROLL_SPEED_BINDING(
       "Map Scroll Speed",
       SettingType.MAP_SCROLLING,

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -74,10 +74,11 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       SelectionComponentFactory.selectionBox(
           ClientSetting.LOOK_AND_FEEL_PREF,
           LookAndFeel.getLookAndFeelAvailableList(),
+          ClientSetting.LOOK_AND_FEEL_PREF.value(),
           s -> s.replaceFirst(".*\\.", "").replaceFirst("LookAndFeel$", "")),
-      "Select a new value and save to see a preview of the new theme\n"
-          + "Please restart TripleA for new UI theme to take full effect"),
-  
+      "Updates UI theme for TripleA.\n"
+          + "WARNING: restart all running TripleA instances after changing this setting to avoid system instability."),
+
   MAP_EDGE_SCROLL_SPEED_BINDING(
       "Map Scroll Speed",
       SettingType.MAP_SCROLLING,

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -75,7 +75,8 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           ClientSetting.LOOK_AND_FEEL_PREF,
           LookAndFeel.getLookAndFeelAvailableList(),
           s -> s.replaceFirst(".*\\.", "").replaceFirst("LookAndFeel$", "")),
-      "Adjust the UI theme for the game, requires a restart to take effect"),
+      "Select a new value and save to see a preview of the new theme\n"
+          + "Please restart TripleA if you change this value for it to take effect properly."),
 
   MAP_EDGE_SCROLL_SPEED_BINDING(
       "Map Scroll Speed",

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -42,4 +42,6 @@ public interface GameSetting {
   void resetAndFlush();
 
   void addSaveListener(Consumer<String> listener);
+
+  void removeSaveListener(Consumer<String> listener);
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.settings;
 
+import java.util.function.Consumer;
+
 /**
  * Basic save/read API for a 'game setting'. Generally these will be values the user can modify over the
  * course of the game, either directly or indirectly. For example, default window size may saved here,
@@ -38,4 +40,6 @@ public interface GameSetting {
   }
 
   void resetAndFlush();
+
+  void addSaveListener(Consumer<String> listener);
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -338,6 +338,7 @@ final class SelectionComponentFactory {
   static <T> Supplier<SelectionComponent<JComponent>> selectionBox(
       final ClientSetting clientSetting,
       final List<T> availableOptions,
+      final T selectedOption,
       final Function<T, ?> renderFunction) {
     return () -> new AlwaysValidInputSelectionComponent() {
       final JComboBox<T> comboBox = getCombobox();
@@ -345,6 +346,7 @@ final class SelectionComponentFactory {
       private JComboBox<T> getCombobox() {
         final JComboBox<T> comboBox = new JComboBox<>();
         availableOptions.forEach(comboBox::addItem);
+        comboBox.setSelectedItem(selectedOption);
         comboBox.setRenderer(new DefaultListCellRenderer() {
           private static final long serialVersionUID = -3094995494539073655L;
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -37,13 +37,22 @@ import swinglib.JTextAreaBuilder;
  * one tab per non-hidden {@code SettingType}.
  * All data needed to render the settings UI is pulled from the {@code ClientSetting} enum.
  */
-enum SettingsWindow {
+public enum SettingsWindow {
   INSTANCE;
 
   private @Nullable JDialog dialog;
   private @Nullable JTabbedPane tabbedPane;
   private final List<SettingType> settingTypes = Collections.unmodifiableList(Arrays.asList(SettingType.values()));
 
+
+  public static void updateLookAndFeel() {
+    Optional.ofNullable(INSTANCE.dialog).ifPresent(SwingUtilities::updateComponentTreeUI);
+    Optional.ofNullable(INSTANCE.tabbedPane).ifPresent(SwingUtilities::updateComponentTreeUI);
+  }
+
+  /**
+   * Disposes window and nulls out references.
+   */
   public void close() {
     if (dialog != null) {
       dialog.dispose();
@@ -53,6 +62,9 @@ enum SettingsWindow {
     }
   }
 
+  /**
+   * Opens the settings Swing window.
+   */
   public void open() {
     Preconditions.checkState(SwingUtilities.isEventDispatchThread());
     if (dialog == null) {

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -1,0 +1,27 @@
+package games.strategy.triplea.settings;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import com.example.mockito.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ClientSettingTest extends AbstractClientSettingTestCase {
+  @Mock
+  private Consumer<String> mockSaveListener;
+
+  @Test
+  public void saveActionListenerIsCalled() {
+    ClientSetting.TEST_SETTING.addSaveListener(mockSaveListener);
+
+    final String value = "value";
+    ClientSetting.TEST_SETTING.save(value);
+
+    Mockito.verify(mockSaveListener, Mockito.times(1))
+        .accept(value);
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -4,6 +4,7 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -11,6 +12,9 @@ import com.example.mockito.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class ClientSettingTest extends AbstractClientSettingTestCase {
+
+  private static final String TEST_VALUE = "value";
+
   @Mock
   private Consumer<String> mockSaveListener;
 
@@ -18,10 +22,20 @@ public class ClientSettingTest extends AbstractClientSettingTestCase {
   public void saveActionListenerIsCalled() {
     ClientSetting.TEST_SETTING.addSaveListener(mockSaveListener);
 
-    final String value = "value";
-    ClientSetting.TEST_SETTING.save(value);
+    ClientSetting.TEST_SETTING.save(TEST_VALUE);
 
     Mockito.verify(mockSaveListener, Mockito.times(1))
-        .accept(value);
+        .accept(TEST_VALUE);
+  }
+
+  @Test
+  public void verifyRemovedSavedListenersAreNotCalled() {
+    ClientSetting.TEST_SETTING.addSaveListener(mockSaveListener);
+    ClientSetting.TEST_SETTING.removeSaveListener(mockSaveListener);
+
+    ClientSetting.TEST_SETTING.save(TEST_VALUE);
+
+    Mockito.verify(mockSaveListener, Mockito.never())
+        .accept(TEST_VALUE);
   }
 }


### PR DESCRIPTION
### Code Update Overview
- Added a save action callback that can be used to perform an action when settings are changed
- Updated enum configuration to provide a callback and update L&F or open the console window when 'console is always open' is set to true.

### Functional changes

#### Console Window:

Now opens when 'always show console window is toggled from false->true and save button is clicked.
![show_console](https://user-images.githubusercontent.com/12397753/36636109-66798b90-1974-11e8-9524-dab85184de6b.png)

#### Look and Feel (L&F) Setting:

L&F  is now applied to the UI immediately on save instead of application start. The settings text is updated to request a game re-start after saving. In this way the new L&F can be previewed as early as the save confirmation window.

![on_save](https://user-images.githubusercontent.com/12397753/36636123-a73ea64c-1974-11e8-85f9-e9dcbb76534c.png)

An easier preview of L&F was requested in: https://forums.triplea-game.org/topic/537/preview-for-look-and-feel-setting
