### PR TITLE
Change lobby port in headless bot launch configuration

### DIFF
--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -8,7 +8,7 @@
 <listEntry value="1"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game= -Ptriplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3300&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game= -Ptriplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-core"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>


### PR DESCRIPTION
The lobby server launch configuration sets the lobby port to 3304, so it seems logical for the headless bot launch configuration to assume that's where the lobby is listening, by default.