### PR TITLE
Change test to mock mapper Function instead of IntegerMap

### DIFF
--- a/game-core/src/main/java/games/strategy/util/IntegerMap.java
+++ b/game-core/src/main/java/games/strategy/util/IntegerMap.java
@@ -13,7 +13,7 @@ import java.util.Set;
  *
  * @param <T> The type of the map key.
  */
-public class IntegerMap<T> implements Cloneable, Serializable {
+public final class IntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
   private final Map<T, Integer> mapValues;
 
@@ -265,7 +265,7 @@ public class IntegerMap<T> implements Cloneable, Serializable {
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return Objects.hashCode(mapValues);
   }
 
@@ -275,7 +275,7 @@ public class IntegerMap<T> implements Cloneable, Serializable {
    * then a and b are not equal.
    */
   @Override
-  public final boolean equals(final Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     } else if (!(o instanceof IntegerMap)) {

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -13,6 +14,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -156,15 +158,16 @@ public class TechAbilityAttachmentTest {
 
   @Test
   public void testSumIntegerMap() {
-    final IntegerMap<UnitType> map = spy(new IntegerMap<>());
-    when(map.getInt(dummyUnitType)).thenReturn(-1, 20, 300);
-    final int result = TechAbilityAttachment.sumIntegerMap(a -> {
-      assertEquals(attachment, a);
-      return map;
-    }, dummyUnitType, mock(PlayerID.class), data);
+    @SuppressWarnings("unchecked")
+    final Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper = mock(Function.class);
+    doReturn(
+        new IntegerMap<>(dummyUnitType, -1),
+        new IntegerMap<>(dummyUnitType, 20),
+        new IntegerMap<>(dummyUnitType, 300))
+            .when(mapper).apply(attachment);
+    final int result = TechAbilityAttachment.sumIntegerMap(mapper, dummyUnitType, mock(PlayerID.class), data);
     assertEquals(319, result);
   }
-
 
   @Test
   public void testSumNumbers() {


### PR DESCRIPTION
Avoids the need to alter the definition of `IntegerMap` simply to test a complicated scenario.  Having the same `IntegerMap` instance return three different values in response to a lookup for the same key is a bit of a smell.  The alternative approach employed in this change is to return three different `IntegerMap` instances, each with a different value for the same key.