### PR TITLE
When failing to log in to lobby (due to ban); show last few characters of hashed mac

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -60,7 +60,7 @@ public class LobbyLogin {
       panel.getLobbyLoginPreferences().save();
       return new LobbyClient(messenger, panel.isAnonymousLogin());
     } catch (final CouldNotLogInException e) {
-      showError("Login Failed", e.getMessage());
+      showError("Login Failed", e.getMessage() + "\n" + playerMacIdString());
       return loginToServer(); // NB: potential stack overflow due to recursive call
     } catch (final IOException e) {
       showError("Could Not Connect", "Could not connect to lobby: " + e.getMessage());
@@ -69,6 +69,11 @@ public class LobbyLogin {
       Thread.currentThread().interrupt();
       return null;
     }
+  }
+
+  private static String playerMacIdString() {
+    final String mac = MacFinder.getHashedMacAddress(new byte[6]);
+    return mac.substring(mac.length() - 10);
   }
 
   private IMessenger login(final String userName, final String password, final boolean anonymousLogin)

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -99,7 +99,7 @@ public class LobbyLogin {
   }
 
   private static String playerMacIdString() {
-    final String mac = MacFinder.getHashedMacAddress(new byte[6]);
+    final String mac = MacFinder.getHashedMacAddress();
     return mac.substring(mac.length() - 10);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -71,11 +71,6 @@ public class LobbyLogin {
     }
   }
 
-  private static String playerMacIdString() {
-    final String mac = MacFinder.getHashedMacAddress(new byte[6]);
-    return mac.substring(mac.length() - 10);
-  }
-
   private IMessenger login(final String userName, final String password, final boolean anonymousLogin)
       throws IOException {
     return new ClientMessenger(
@@ -101,6 +96,11 @@ public class LobbyLogin {
             return response;
           }
         });
+  }
+
+  private static String playerMacIdString() {
+    final String mac = MacFinder.getHashedMacAddress(new byte[6]);
+    return mac.substring(mac.length() - 10);
   }
 
   private void showError(final String title, final String message) {


### PR DESCRIPTION
These last 10 digits will let us know which ban row exists in DB that is blocked the ban. In case of ban mistake or bans which we want to make shorter, after the fact we have almost no way to know which user maps to which ban. By reporting the last 10 of the hashed mac, we'll be able to match up the ban in the DB.

Triggering this error message explicitly, it'll look something like:
![example_login_failure](https://user-images.githubusercontent.com/12397753/36638435-e35b91e6-19a9-11e8-8c40-2a6df34f8ea0.png)

------

This helps in case we ban accidently, or if we want to reverse a ban for whatever reason.


<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
