### PR TITLE
Anonymous type can be replaced by lambda

### DIFF
--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -65,12 +65,9 @@ public class ModeratorControllerIntegrationTest {
     connectionChangeListener = new ConnectionChangeListener();
     final INode booted = new Node("foo", InetAddress.getByAddress(new byte[] {1, 2, 3, 4}), 0);
 
-    doAnswer(new Answer<Void>() {
-      @Override
-      public Void answer(final InvocationOnMock invocation) {
-        connectionChangeListener.connectionRemoved(invocation.getArgument(0));
-        return null;
-      }
+    doAnswer((Answer<Void>) invocation -> {
+      connectionChangeListener.connectionRemoved(invocation.getArgument(0));
+      return null;
     }).when(serverMessenger).removeConnection(booted);
 
     final INode dummyNode = new Node("dummy", InetAddress.getLocalHost(), 0);

--- a/game-core/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -234,12 +234,7 @@ public class MessengerIntegrationTest {
   @Test
   public void testClose() {
     final AtomicBoolean closed = new AtomicBoolean(false);
-    client1Messenger.addErrorListener(new IMessengerErrorListener() {
-      @Override
-      public void messengerInvalid(final IMessenger messenger, final Exception reason) {
-        closed.set(true);
-      }
-    });
+    client1Messenger.addErrorListener((messenger, reason) -> closed.set(true));
     serverMessenger.removeConnection(client1Messenger.getLocalNode());
     int waitCount = 0;
     while (!closed.get() && waitCount < 10) {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -169,13 +169,10 @@ public class MapDownloadController {
   }
 
   private static UserMaps getUserMaps() {
-    return new UserMaps() {
-      @Override
-      public boolean isEmpty() {
-        final String[] entries = ClientFileSystemHelper.getUserMapsFolder().list();
-        final int entryCount = Optional.ofNullable(entries).map(it -> it.length).orElse(0);
-        return entryCount == 0;
-      }
+    return () -> {
+      final String[] entries = ClientFileSystemHelper.getUserMapsFolder().list();
+      final int entryCount = Optional.ofNullable(entries).map(it -> it.length).orElse(0);
+      return entryCount == 0;
     };
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -99,15 +99,12 @@ public class InGameLobbyWatcher {
     System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
     System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
     System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
-    final IConnectionLogin login = new IConnectionLogin() {
-      @Override
-      public Map<String, String> getProperties(final Map<String, String> challengeProperties) {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-        properties.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-        properties.put(LobbyLoginValidator.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
-        return properties;
-      }
+    final IConnectionLogin login = challengeProperties -> {
+      final Map<String, String> properties = new HashMap<>();
+      properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+      properties.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+      properties.put(LobbyLoginValidator.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
+      return properties;
     };
     try {
       System.out.println("host:" + host + " port:" + port);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -92,16 +92,13 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
 
   private void createComponents() {
     final JScrollPane scrollPane = new JScrollPane(localPlayerPanel);
-    localPlayerPanel.addHierarchyListener(new HierarchyListener() {
-      @Override
-      public void hierarchyChanged(final HierarchyEvent e) {
-        final Window window = SwingUtilities.getWindowAncestor(localPlayerPanel);
-        if (window instanceof Dialog) {
-          final Dialog dialog = (Dialog) window;
-          if (!dialog.isResizable()) {
-            dialog.setResizable(true);
-            dialog.setMinimumSize(new Dimension(700, 700));
-          }
+    localPlayerPanel.addHierarchyListener(e -> {
+      final Window window = SwingUtilities.getWindowAncestor(localPlayerPanel);
+      if (window instanceof Dialog) {
+        final Dialog dialog = (Dialog) window;
+        if (!dialog.isResizable()) {
+          dialog.setResizable(true);
+          dialog.setMinimumSize(new Dimension(700, 700));
         }
       }
     });

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -15,7 +15,6 @@ import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
-import games.strategy.net.IConnectionLogin;
 import games.strategy.net.IMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.triplea.UrlConstants;
@@ -78,23 +77,20 @@ public class LobbyLogin {
         lobbyServerProperties.port,
         userName,
         MacFinder.getHashedMacAddress(),
-        new IConnectionLogin() {
-          @Override
-          public Map<String, String> getProperties(final Map<String, String> challenge) {
-            final Map<String, String> response = new HashMap<>();
-            if (anonymousLogin) {
-              response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-            } else {
-              final String salt =
-                  challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, games.strategy.util.Md5Crypt.newSalt());
-              response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password, salt));
-              if (RsaAuthenticator.canProcessChallenge(challenge)) {
-                response.putAll(RsaAuthenticator.newResponse(challenge, password));
-              }
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          if (anonymousLogin) {
+            response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+          } else {
+            final String salt =
+                challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, games.strategy.util.Md5Crypt.newSalt());
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password, salt));
+            if (RsaAuthenticator.canProcessChallenge(challenge)) {
+              response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }
-            response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-            return response;
           }
+          response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+          return response;
         });
   }
 
@@ -157,21 +153,18 @@ public class LobbyLogin {
         lobbyServerProperties.port,
         userName,
         MacFinder.getHashedMacAddress(),
-        new IConnectionLogin() {
-          @Override
-          public Map<String, String> getProperties(final Map<String, String> challenge) {
-            final Map<String, String> response = new HashMap<>();
-            response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
-            response.put(LobbyLoginValidator.EMAIL_KEY, email);
-            // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
-            // backwards-compatibility
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password));
-            if (RsaAuthenticator.canProcessChallenge(challenge)) {
-              response.putAll(RsaAuthenticator.newResponse(challenge, password));
-            }
-            response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
-            return response;
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
+          response.put(LobbyLoginValidator.EMAIL_KEY, email);
+          // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
+          // backwards-compatibility
+          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password));
+          if (RsaAuthenticator.canProcessChallenge(challenge)) {
+            response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }
+          response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
+          return response;
         });
   }
 }

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -9,8 +9,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -325,20 +323,14 @@ public class DecorationPlacer extends JFrame {
     fileMenu.addSeparator();
     fileMenu.add(exitItem);
     final JCheckBoxMenuItem highlightAllModeItem = new JCheckBoxMenuItem("Highlight All", false);
-    highlightAllModeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        highlightAll = highlightAllModeItem.getState();
-        DecorationPlacer.this.repaint();
-      }
+    highlightAllModeItem.addActionListener(event -> {
+      highlightAll = highlightAllModeItem.getState();
+      DecorationPlacer.this.repaint();
     });
     final JCheckBoxMenuItem showNamesModeItem = new JCheckBoxMenuItem("Show Point Names", false);
-    showNamesModeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        showPointNames = showNamesModeItem.getState();
-        DecorationPlacer.this.repaint();
-      }
+    showNamesModeItem.addActionListener(event -> {
+      showPointNames = showNamesModeItem.getState();
+      DecorationPlacer.this.repaint();
     });
     final Action clearAction = SwingAction.of("Clear All Current Points.", e -> currentImagePoints.clear());
     clearAction.putValue(Action.SHORT_DESCRIPTION, "Delete all points.");

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -264,12 +264,9 @@ public class PolygonGrabber extends JFrame {
     final JMenuItem exitItem = new JMenuItem(exitAction);
     islandMode = false;
     modeItem = new JCheckBoxMenuItem("Island Mode", false);
-    modeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        islandMode = modeItem.getState();
-        repaint();
-      }
+    modeItem.addActionListener(event -> {
+      islandMode = modeItem.getState();
+      repaint();
     });
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -8,8 +8,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Toolkit;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -344,37 +342,28 @@ public class PlacementPicker extends JFrame {
     showIncompleteMode = false;
     incompleteNum = 1;
     showAllModeItem = new JCheckBoxMenuItem("Show All Placements Mode", false);
-    showAllModeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        showAllMode = showAllModeItem.getState();
-        repaint();
-      }
+    showAllModeItem.addActionListener(event -> {
+      showAllMode = showAllModeItem.getState();
+      repaint();
     });
     showOverflowModeItem = new JCheckBoxMenuItem("Show Overflow Mode", false);
-    showOverflowModeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        showOverflowMode = showOverflowModeItem.getState();
-        repaint();
-      }
+    showOverflowModeItem.addActionListener(event -> {
+      showOverflowMode = showOverflowModeItem.getState();
+      repaint();
     });
     showIncompleteModeItem = new JCheckBoxMenuItem("Show Incomplete Placements Mode", false);
-    showIncompleteModeItem.addActionListener(new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent event) {
-        if (showIncompleteModeItem.getState()) {
-          final String num = JOptionPane.showInputDialog(null,
-              "Enter the minimum number of placements each territory must have.\r\n(examples: 1, 4, etc.)");
-          try {
-            incompleteNum = Math.max(1, Math.min(50, Integer.parseInt(num)));
-          } catch (final Exception ex) {
-            incompleteNum = 1;
-          }
+    showIncompleteModeItem.addActionListener(event -> {
+      if (showIncompleteModeItem.getState()) {
+        final String num = JOptionPane.showInputDialog(null,
+            "Enter the minimum number of placements each territory must have.\r\n(examples: 1, 4, etc.)");
+        try {
+          incompleteNum = Math.max(1, Math.min(50, Integer.parseInt(num)));
+        } catch (final Exception ex) {
+          incompleteNum = 1;
         }
-        showIncompleteMode = showIncompleteModeItem.getState();
-        repaint();
       }
+      showIncompleteMode = showIncompleteModeItem.getState();
+      repaint();
     });
     final JMenu editMenu = new JMenu("Edit");
     editMenu.setMnemonic('E');


### PR DESCRIPTION
Collapses a few dozen anonymous inner classes to lambda. Probably best viewed with whitespace diff removed.

IDE assisted: This inspection reports all anonymous classes which can be replaced with lambda expressions
Lambda syntax is not supported under Java 1.7 or earlier JVMs.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
