### PR TITLE
Replace Guava functional primitives with Java

### DIFF
--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -75,9 +75,12 @@ public final class MacFinder {
       final NetworkInterface localHostNetworkInterface = NetworkInterface.getByInetAddress(address);
       if (localHostNetworkInterface != null) {
         final byte[] rawMac = localHostNetworkInterface.getHardwareAddress();
-        final String mac = convertMacBytesToString(rawMac);
-        if (isMacValid(mac)) {
-          return mac;
+        
+        if (rawMac != null) {
+          final String mac = convertMacBytesToString(rawMac);
+          if (isMacValid(mac)) {
+            return mac;
+          }
         }
       }
     } catch (final SocketException | UnknownHostException e) {
@@ -88,9 +91,11 @@ public final class MacFinder {
     try {
       for (final NetworkInterface ni : Collections.list(NetworkInterface.getNetworkInterfaces())) {
         final byte[] rawMac = ni.getHardwareAddress();
-        final String mac = convertMacBytesToString(rawMac);
-        if (isMacValid(mac)) {
-          return mac;
+        if (rawMac != null) {
+          final String mac = convertMacBytesToString(rawMac);
+          if (isMacValid(mac)) {
+            return mac;
+          }
         }
       }
     } catch (final SocketException e) {
@@ -222,9 +227,6 @@ public final class MacFinder {
   }
 
   private static String convertMacBytesToString(final byte[] mac) {
-    if (mac == null) {
-      return null;
-    }
     return Joiner.on('.').join(Bytes.asList(mac).stream()
         .map(macbyte -> String.format("%02X", macbyte))
         .collect(Collectors.toList()));

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -12,14 +12,15 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
 import com.google.common.primitives.Bytes;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.util.Md5Crypt;
 
 /**
  * Provides access to the MAC address of the local node.
@@ -59,7 +60,7 @@ public final class MacFinder {
   }
 
   private static String getHashedMacAddress(final String macAddress) {
-    return games.strategy.util.Md5Crypt.crypt(macAddress, HASHED_MAC_ADDRESS_SALT);
+    return Md5Crypt.crypt(macAddress, HASHED_MAC_ADDRESS_SALT);
   }
 
   private static String getMacAddress() {
@@ -216,7 +217,7 @@ public final class MacFinder {
       return null;
     }
     return Joiner.on('.')
-        .join(FluentIterable.from(Bytes.asList(mac)).transform(macbyte -> String.format("%02X", macbyte)));
+        .join(Bytes.asList(mac).stream().map(macbyte -> String.format("%02X", macbyte)).collect(Collectors.toList()));
   }
 
   private static boolean isMacValid(final String mac) {
@@ -286,7 +287,7 @@ public final class MacFinder {
     checkNotNull(value);
 
     try {
-      return HASHED_MAC_ADDRESS_SALT.equals(games.strategy.util.Md5Crypt.getSalt(value));
+      return HASHED_MAC_ADDRESS_SALT.equals(Md5Crypt.getSalt(value));
     } catch (final IllegalArgumentException e) {
       return false;
     }
@@ -304,6 +305,6 @@ public final class MacFinder {
   public static String trimHashedMacAddressPrefix(final String hashedMacAddress) {
     checkNotNull(hashedMacAddress);
 
-    return games.strategy.util.Md5Crypt.getHash(hashedMacAddress);
+    return Md5Crypt.getHash(hashedMacAddress);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -82,6 +82,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.PlayerChatRenderer;
 import games.strategy.engine.data.Change;
+import games.strategy.engine.data.DefaultNamed;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.ProductionRule;
@@ -846,14 +847,17 @@ public class TripleAFrame extends MainGameFrame {
     }
     messageAndDialogThreadPool.waitForAll();
     final StringBuilder buf = new StringBuilder("Units in the following territories will die: ");
-    Joiner.on(' ').appendTo(buf, unitsCantFight.stream().map(unit -> unit.getName()).collect(Collectors.toList()));
+    Joiner.on(' ').appendTo(buf, unitsCantFight.stream()
+        .map(DefaultNamed::getName)
+        .collect(Collectors.toList()));
     final String ok = movePhase ? "Done Moving" : "Kill Units";
     final String cancel = movePhase ? "Keep Moving" : "Change Placement";
     final String[] options = {cancel, ok};
     this.mapPanel.centerOn(unitsCantFight.iterator().next());
-    final int choice =
-        EventThreadJOptionPane.showOptionDialog(this, buf.toString(), "Units cannot fight", JOptionPane.YES_NO_OPTION,
-            JOptionPane.WARNING_MESSAGE, null, options, cancel, getUiContext().getCountDownLatchHandler());
+    final int choice = EventThreadJOptionPane.showOptionDialog(this, buf.toString(),
+            "Units cannot fight", JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE, null, options, cancel,
+            getUiContext().getCountDownLatchHandler());
     return choice == 1;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
@@ -75,7 +76,6 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
 import games.strategy.debug.ClientLogger;
@@ -846,7 +846,7 @@ public class TripleAFrame extends MainGameFrame {
     }
     messageAndDialogThreadPool.waitForAll();
     final StringBuilder buf = new StringBuilder("Units in the following territories will die: ");
-    Joiner.on(' ').appendTo(buf, FluentIterable.from(unitsCantFight).transform(unit -> unit.getName()));
+    Joiner.on(' ').appendTo(buf, unitsCantFight.stream().map(unit -> unit.getName()).collect(Collectors.toList()));
     final String ok = movePhase ? "Done Moving" : "Kill Units";
     final String cancel = movePhase ? "Keep Moving" : "Change Placement";
     final String[] options = {cancel, ok};


### PR DESCRIPTION
IDE assisted: Inspection detects usages of Guava's functional primitives like FluentIterable, Optional, Function, Predicate and Supplier. May change semantic: some of lazy-evaluated guava's iterables could be transformed to eager-evaluated iterable.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
