### PR TITLE
Clean up TechTracker

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -13,11 +12,9 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.TechAttachment;
 
 /**
- * Tracks which players have which technology advances.
+ * A collection of methods for tracking which players have which technology advances.
  */
-public class TechTracker implements Serializable {
-  private static final long serialVersionUID = 4705039229340373735L;
-
+public final class TechTracker {
   private TechTracker() {}
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -56,8 +56,7 @@ public final class TechTracker {
     return technologyFrontiers;
   }
 
-  public static synchronized void addAdvance(final PlayerID player, final IDelegateBridge bridge,
-      final TechAdvance advance) {
+  public static void addAdvance(final PlayerID player, final IDelegateBridge bridge, final TechAdvance advance) {
     final Change attachmentChange;
     if (advance instanceof GenericTechAdvance && ((GenericTechAdvance) advance).getAdvance() == null) {
       attachmentChange = ChangeFactory.genericTechChange(TechAttachment.get(player), true, advance.getProperty());
@@ -69,8 +68,7 @@ public final class TechTracker {
     advance.perform(player, bridge);
   }
 
-  static synchronized void removeAdvance(final PlayerID player, final IDelegateBridge bridge,
-      final TechAdvance advance) {
+  static void removeAdvance(final PlayerID player, final IDelegateBridge bridge, final TechAdvance advance) {
     final Change attachmentChange;
     if (advance instanceof GenericTechAdvance) {
       if (((GenericTechAdvance) advance).getAdvance() == null) {


### PR DESCRIPTION
A few clean-ups based on the observation that `TechTracker` is now simply a collection of static methods.

It was first introduced as a type that held instance state back in 317bfa337 (and thus required synchronization and later serialization), but, at some point, the instance state was removed and it was left with only static utility methods.