### PR TITLE
Enforce integer version in YAML map definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,13 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'application'
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
 
+ext {
+    schemasDir = file('config/triplea/schemas')
+}
 
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {
     doLast {
@@ -23,3 +25,6 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
     }
 }
 
+check {
+    dependsOn 'validateYamls'
+}

--- a/config/triplea/schemas/triplea_maps.json
+++ b/config/triplea/schemas/triplea_maps.json
@@ -28,7 +28,7 @@
       },
       "version": {
         "description": "The map download version",
-        "type": "number",
+        "type": "integer",
         "minimum": 1
       },
       "img": {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'de.undercouch.download' version '3.3.0'
 }
 
-apply from: '../gradle/scripts/yaml.gradle'
 apply plugin: 'org.junit.platform.gradle.plugin'
 
 group = 'triplea'
@@ -30,7 +29,6 @@ ext {
     releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")
-    schemasDir = file('config/triplea/schemas')
 
     gameEnginePropertiesFile = file('game_engine.properties')
     gameEnginePropertiesArtifactFile = file("$rootFilesDir/${gameEnginePropertiesFile.name}")
@@ -162,17 +160,6 @@ task jacocoRootReport(type: JacocoReport) {
             destination = file("${project.jacoco.reportsDir}/root/jacocoRootReport.xml")
             enabled = true
         }
-    }
-}
-
-task validateYamls(group: 'verification', description: 'Validates YAML files.') {
-    doLast {
-        def lobbyServerYamlFile = file('lobby_server.yaml')
-        validateYaml(lobbyServerYamlFile, file("$schemasDir/lobby_server.json"))
-
-        def mapsYamlFile = file('triplea_maps.yaml')
-        validateYaml(mapsYamlFile, file("$schemasDir/triplea_maps.json"))
-        validateMapsYamlUris(mapsYamlFile)
     }
 }
 


### PR DESCRIPTION
The engine only supports integer map versions in the YAML, so this PR updates the `validateYamls` task to enforce that constraint.

Also had to re-enable the `validateYamls` task, which appears to have been unintentionally disabled during the introduction of subprojects.