### PR TITLE
Add logic to ensure data read lock is acquired

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -176,7 +176,14 @@ public class ProductionPanel extends JPanel {
     if (resourceCollection != null) {
       final IntegerMap<Resource> resources = resourceCollection.getResourcesCopy();
       int count = 0;
-      for (final Resource resource : data.getResourceList().getResources()) {
+      List<Resource> resourcesInOrder = new ArrayList<>();
+      data.acquireReadLock();
+      try {
+        resourcesInOrder = data.getResourceList().getResources();
+      } finally {
+        data.releaseReadLock();
+      }
+      for (final Resource resource : resourcesInOrder) {
         if (!resource.isDisplayedFor(id)) {
           continue;
         }


### PR DESCRIPTION
Addresses: #3135

`data.getResourceList()` calls `ensureLockHeld()` so any calls to it must ensure data read lock is acquired first.