### PR TITLE
Narrow scope of Md5Crypt deprecation

### DIFF
--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import java.util.Random;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.stubbing.Answer;
 
 import games.strategy.engine.lobby.server.db.HashedPassword;
@@ -52,7 +53,7 @@ public class ModeratorControllerIntegrationTest {
     final DBUser dbUser = new DBUser(new DBUser.UserName(adminName), new DBUser.UserEmail("n@n.n"), DBUser.Role.ADMIN);
 
     final UserController userController = new UserController();
-    userController.createUser(dbUser, new HashedPassword(encryptPassword(adminName)));
+    userController.createUser(dbUser, new HashedPassword(BCrypt.hashpw(adminName, BCrypt.gensalt())));
     userController.makeAdmin(dbUser);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -35,7 +35,7 @@ public class ModeratorControllerIntegrationTest {
   private INode adminNode;
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
   }
 
   private static String newHashedMacAddress() {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 public class ModeratorControllerIntegrationTest {
@@ -34,7 +35,7 @@ public class ModeratorControllerIntegrationTest {
   private INode adminNode;
 
   private static String md5Crypt(final String value) {
-    return games.strategy.util.Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value);
   }
 
   private static String newHashedMacAddress() {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -34,8 +34,8 @@ public class ModeratorControllerIntegrationTest {
   private ConnectionChangeListener connectionChangeListener;
   private INode adminNode;
 
-  private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
+  private static String encryptPassword(final String value) {
+    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
   }
 
   private static String newHashedMacAddress() {
@@ -52,7 +52,7 @@ public class ModeratorControllerIntegrationTest {
     final DBUser dbUser = new DBUser(new DBUser.UserName(adminName), new DBUser.UserEmail("n@n.n"), DBUser.Role.ADMIN);
 
     final UserController userController = new UserController();
-    userController.createUser(dbUser, new HashedPassword(md5Crypt(adminName)));
+    userController.createUser(dbUser, new HashedPassword(encryptPassword(adminName)));
     userController.makeAdmin(dbUser);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
@@ -79,14 +79,14 @@ public class ModeratorControllerIntegrationTest {
   @Test
   public void testCantResetAdminPassword() {
     MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = md5Crypt("" + System.currentTimeMillis());
+    final String newPassword = encryptPassword("" + System.currentTimeMillis());
     assertNotNull(moderatorController.setPassword(adminNode, newPassword));
   }
 
   @Test
   public void testResetUserPasswordUnknownUser() throws UnknownHostException {
     MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = md5Crypt("" + System.currentTimeMillis());
+    final String newPassword = encryptPassword("" + System.currentTimeMillis());
     final INode node = new Node(Util.createUniqueTimeStamp(), InetAddress.getLocalHost(), 0);
     assertNotNull(moderatorController.setPassword(node, newPassword));
   }

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.lobby.server;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -26,7 +25,6 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
-import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 public class ModeratorControllerIntegrationTest {
@@ -34,10 +32,6 @@ public class ModeratorControllerIntegrationTest {
   private ModeratorController moderatorController;
   private ConnectionChangeListener connectionChangeListener;
   private INode adminNode;
-
-  private static String encryptPassword(final String value) {
-    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
-  }
 
   private static String newHashedMacAddress() {
     final byte[] bytes = new byte[6];
@@ -75,21 +69,6 @@ public class ModeratorControllerIntegrationTest {
     when(serverMessenger.getServerNode()).thenReturn(dummyNode);
     moderatorController.boot(booted);
     assertTrue(connectionChangeListener.getRemoved().contains(booted));
-  }
-
-  @Test
-  public void testCantResetAdminPassword() {
-    MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = encryptPassword("" + System.currentTimeMillis());
-    assertNotNull(moderatorController.setPassword(adminNode, newPassword));
-  }
-
-  @Test
-  public void testResetUserPasswordUnknownUser() throws UnknownHostException {
-    MessageContext.setSenderNodeForThread(adminNode);
-    final String newPassword = encryptPassword("" + System.currentTimeMillis());
-    final INode node = new Node(Util.createUniqueTimeStamp(), InetAddress.getLocalHost(), 0);
-    assertNotNull(moderatorController.setPassword(node, newPassword));
   }
 
   @Test

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -9,10 +9,10 @@ import java.sql.SQLException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
 
 import com.google.common.base.Strings;
 
-import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 /**
@@ -46,10 +46,10 @@ public class EmailLimitIntegrationTest {
 
   private static void createAccountWithEmail(final String email) throws SQLException {
     try (PreparedStatement ps =
-        connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
+        connection.prepareStatement("insert into ta_users (username, email, bcrypt_password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
-      ps.setString(3, Md5Crypt.cryptSensitive("password", Md5Crypt.newSalt()));
+      ps.setString(3, BCrypt.hashpw("password", BCrypt.gensalt()));
       ps.execute();
     }
   }

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -49,7 +49,7 @@ public class EmailLimitIntegrationTest {
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
-      ps.setString(3, Md5Crypt.crypt("password", Md5Crypt.newSalt()));
+      ps.setString(3, Md5Crypt.cryptSensitive("password", Md5Crypt.newSalt()));
       ps.execute();
     }
   }

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -49,7 +49,7 @@ public class EmailLimitIntegrationTest {
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
-      ps.setString(3, Md5Crypt.crypt("password"));
+      ps.setString(3, Md5Crypt.crypt("password", Md5Crypt.newSalt()));
       ps.execute();
     }
   }

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Strings;
 
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 /**
@@ -48,7 +49,7 @@ public class EmailLimitIntegrationTest {
         connection.prepareStatement("insert into ta_users (username, email, password) values (?, ?, ?)")) {
       ps.setString(1, Util.createUniqueTimeStamp());
       ps.setString(2, email);
-      ps.setString(3, games.strategy.util.Md5Crypt.crypt("password"));
+      ps.setString(3, Md5Crypt.crypt("password"));
       ps.execute();
     }
   }

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -119,7 +119,7 @@ public class UserControllerIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
+    return Md5Crypt.hashPassword(value, Md5Crypt.newSalt());
   }
 
   private static String obfuscate(final String string) {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.mindrot.jbcrypt.BCrypt;
 
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.engine.lobby.server.userDB.DBUser;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 public class UserControllerIntegrationTest {
@@ -118,7 +119,7 @@ public class UserControllerIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return games.strategy.util.Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value);
   }
 
   private static String obfuscate(final String string) {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -119,7 +119,7 @@ public class UserControllerIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
+    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
   }
 
   private static String obfuscate(final String string) {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -119,7 +119,7 @@ public class UserControllerIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
   }
 
   private static String obfuscate(final String string) {

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -70,7 +70,7 @@ public class LobbyLoginValidatorIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
+    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
   }
 
   @Test

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -28,6 +28,7 @@ import games.strategy.engine.lobby.server.db.UserController;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MacFinder;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 
 public class LobbyLoginValidatorIntegrationTest {
@@ -69,7 +70,7 @@ public class LobbyLoginValidatorIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return games.strategy.util.Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value);
   }
 
   @Test

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -70,7 +70,7 @@ public class LobbyLoginValidatorIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.crypt(value);
+    return Md5Crypt.crypt(value, Md5Crypt.newSalt());
   }
 
   @Test

--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -70,7 +70,7 @@ public class LobbyLoginValidatorIntegrationTest {
   }
 
   private static String md5Crypt(final String value) {
-    return Md5Crypt.cryptSensitive(value, Md5Crypt.newSalt());
+    return Md5Crypt.hashPassword(value, Md5Crypt.newSalt());
   }
 
   @Test

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -235,8 +235,8 @@ public class HeadlessGameServer {
     return Md5Crypt.newSalt();
   }
 
-  private static String encryptPassword(final String password, final String salt) {
-    return Md5Crypt.cryptSensitive(password, salt);
+  private static String hashPassword(final String password, final String salt) {
+    return Md5Crypt.hashPassword(password, salt);
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {
@@ -245,8 +245,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       new Thread(() -> {
         System.out.println("Remote Shutdown Initiated.");
         System.exit(0);
@@ -263,8 +262,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       final ServerGame serverGame = game;
       if (serverGame != null) {
         new Thread(() -> {
@@ -291,8 +289,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       final IChatPanel chat = getServerModel().getChatPanel();
       if (chat == null || chat.getAllText() == null) {
         return "Empty or null chat";
@@ -310,10 +307,9 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
     // (48 hours max)
     final Instant expire = Instant.now().plus(Duration.ofMinutes(Math.min(60 * 24 * 2, minutes)));
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
           return;
@@ -355,8 +351,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
           return;
@@ -394,10 +389,9 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = encryptPassword(localPassword, salt);
     // milliseconds (30 days max)
     final Instant expire = Instant.now().plus(Duration.ofHours(Math.min(24 * 30, hours)));
-    if (encryptedPassword.equals(hashedPassword)) {
+    if (hashPassword(localPassword, salt).equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
           return;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -50,6 +50,7 @@ import games.strategy.sound.ClipPlayer;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.util.Interruptibles;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.TimeManager;
 import games.strategy.util.Util;
 
@@ -231,16 +232,12 @@ public class HeadlessGameServer {
   }
 
   public String getSalt() {
-    final String encryptedPassword = md5Crypt(System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, ""));
-    return games.strategy.util.Md5Crypt.getSalt(encryptedPassword);
-  }
-
-  private static String md5Crypt(final String value) {
-    return games.strategy.util.Md5Crypt.crypt(value);
+    final String encryptedPassword = Md5Crypt.crypt(System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, ""));
+    return Md5Crypt.getSalt(encryptedPassword);
   }
 
   private static String md5Crypt(final String value, final String salt) {
-    return games.strategy.util.Md5Crypt.crypt(value, salt);
+    return Md5Crypt.crypt(value, salt);
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -235,8 +235,8 @@ public class HeadlessGameServer {
     return Md5Crypt.newSalt();
   }
 
-  private static String md5Crypt(final String value, final String salt) {
-    return Md5Crypt.crypt(value, salt);
+  private static String encryptPassword(final String password, final String salt) {
+    return Md5Crypt.cryptSensitive(password, salt);
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {
@@ -245,7 +245,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
         System.out.println("Remote Shutdown Initiated.");
@@ -263,7 +263,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final ServerGame serverGame = game;
       if (serverGame != null) {
@@ -291,7 +291,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       final IChatPanel chat = getServerModel().getChatPanel();
       if (chat == null || chat.getAllText() == null) {
@@ -310,7 +310,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     // (48 hours max)
     final Instant expire = Instant.now().plus(Duration.ofMinutes(Math.min(60 * 24 * 2, minutes)));
     if (encryptedPassword.equals(hashedPassword)) {
@@ -355,7 +355,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
@@ -394,7 +394,7 @@ public class HeadlessGameServer {
       return "Host not accepting remote requests!";
     }
     final String localPassword = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
-    final String encryptedPassword = md5Crypt(localPassword, salt);
+    final String encryptedPassword = encryptPassword(localPassword, salt);
     // milliseconds (30 days max)
     final Instant expire = Instant.now().plus(Duration.ofHours(Math.min(24 * 30, hours)));
     if (encryptedPassword.equals(hashedPassword)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -232,8 +232,7 @@ public class HeadlessGameServer {
   }
 
   public String getSalt() {
-    final String encryptedPassword = Md5Crypt.crypt(System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, ""));
-    return Md5Crypt.getSalt(encryptedPassword);
+    return Md5Crypt.newSalt();
   }
 
   private static String md5Crypt(final String value, final String salt) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
@@ -95,7 +95,7 @@ final class Md5CryptAuthenticator {
   }
 
   private static String digest(final String password, final String salt) {
-    return Md5Crypt.crypt(password, salt);
+    return Md5Crypt.cryptSensitive(password, salt);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
@@ -95,7 +95,7 @@ final class Md5CryptAuthenticator {
   }
 
   private static String digest(final String password, final String salt) {
-    return Md5Crypt.cryptSensitive(password, salt);
+    return Md5Crypt.hashPassword(password, salt);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticator.java
@@ -6,6 +6,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+import games.strategy.util.Md5Crypt;
+
 /**
  * Implements the MD5-crypt authentication protocol for peer-to-peer network games.
  *
@@ -39,7 +41,7 @@ final class Md5CryptAuthenticator {
    */
   static Map<String, String> newChallenge() {
     return Maps.newHashMap(ImmutableMap.of(
-        ChallengePropertyNames.SALT, games.strategy.util.Md5Crypt.newSalt()));
+        ChallengePropertyNames.SALT, Md5Crypt.newSalt()));
   }
 
   /**
@@ -93,7 +95,7 @@ final class Md5CryptAuthenticator {
   }
 
   private static String digest(final String password, final String salt) {
-    return games.strategy.util.Md5Crypt.crypt(password, salt);
+    return Md5Crypt.crypt(password, salt);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -84,7 +84,7 @@ public class LobbyLogin {
             response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
           } else {
             final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, Md5Crypt.newSalt());
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password, salt));
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, encryptPassword(password, salt));
             if (RsaAuthenticator.canProcessChallenge(challenge)) {
               response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }
@@ -92,6 +92,10 @@ public class LobbyLogin {
           response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyServer.LOBBY_VERSION.toString());
           return response;
         });
+  }
+
+  private static String encryptPassword(final String password, final String salt) {
+    return Md5Crypt.cryptSensitive(password, salt);
   }
 
   private static String playerMacIdString() {
@@ -164,7 +168,7 @@ public class LobbyLogin {
           response.put(LobbyLoginValidator.EMAIL_KEY, email);
           // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
           // backwards-compatibility
-          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password, Md5Crypt.newSalt()));
+          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, encryptPassword(password, Md5Crypt.newSalt()));
           if (RsaAuthenticator.canProcessChallenge(challenge)) {
             response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -84,7 +84,7 @@ public class LobbyLogin {
             response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
           } else {
             final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, Md5Crypt.newSalt());
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, encryptPassword(password, salt));
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, hashPassword(password, salt));
             if (RsaAuthenticator.canProcessChallenge(challenge)) {
               response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }
@@ -94,8 +94,8 @@ public class LobbyLogin {
         });
   }
 
-  private static String encryptPassword(final String password, final String salt) {
-    return Md5Crypt.cryptSensitive(password, salt);
+  private static String hashPassword(final String password, final String salt) {
+    return Md5Crypt.hashPassword(password, salt);
   }
 
   private static String playerMacIdString() {
@@ -168,7 +168,7 @@ public class LobbyLogin {
           response.put(LobbyLoginValidator.EMAIL_KEY, email);
           // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
           // backwards-compatibility
-          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, encryptPassword(password, Md5Crypt.newSalt()));
+          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, hashPassword(password, Md5Crypt.newSalt()));
           if (RsaAuthenticator.canProcessChallenge(challenge)) {
             response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -18,6 +18,7 @@ import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.IMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.util.Md5Crypt;
 
 public class LobbyLogin {
   private final Window parentWindow;
@@ -82,9 +83,8 @@ public class LobbyLogin {
           if (anonymousLogin) {
             response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
           } else {
-            final String salt =
-                challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, games.strategy.util.Md5Crypt.newSalt());
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password, salt));
+            final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, Md5Crypt.newSalt());
+            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password, salt));
             if (RsaAuthenticator.canProcessChallenge(challenge)) {
               response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }
@@ -164,7 +164,7 @@ public class LobbyLogin {
           response.put(LobbyLoginValidator.EMAIL_KEY, email);
           // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
           // backwards-compatibility
-          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, games.strategy.util.Md5Crypt.crypt(password));
+          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password));
           if (RsaAuthenticator.canProcessChallenge(challenge)) {
             response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -164,7 +164,7 @@ public class LobbyLogin {
           response.put(LobbyLoginValidator.EMAIL_KEY, email);
           // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
           // backwards-compatibility
-          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password));
+          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, Md5Crypt.crypt(password, Md5Crypt.newSalt()));
           if (RsaAuthenticator.canProcessChallenge(challenge)) {
             response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -32,6 +32,7 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.Node;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Md5Crypt;
 
 class LobbyGamePanel extends JPanel {
   private static final long serialVersionUID = -2576314388949606337L;
@@ -322,7 +323,7 @@ class LobbyGamePanel extends JPanel {
   }
 
   private static String md5Crypt(final String value, final String salt) {
-    return games.strategy.util.Md5Crypt.crypt(value, salt);
+    return Md5Crypt.crypt(value, salt);
   }
 
   private INode getLobbyWatcherNodeForTableRow(final int selectedIndex) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -307,7 +307,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response = controller.getChatLogHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     final JTextPane textPane = new JTextPane();
     textPane.setEditable(false);
@@ -322,8 +322,8 @@ class LobbyGamePanel extends JPanel {
     JOptionPane.showMessageDialog(null, scroll, "Bot Chat Log", JOptionPane.INFORMATION_MESSAGE);
   }
 
-  private static String md5Crypt(final String value, final String salt) {
-    return Md5Crypt.crypt(value, salt);
+  private static String encryptPassword(final String password, final String salt) {
+    return Md5Crypt.cryptSensitive(password, salt);
   }
 
   private INode getLobbyWatcherNodeForTableRow(final int selectedIndex) {
@@ -380,7 +380,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response =
         controller.mutePlayerHeadlessHostBot(lobbyWatcherNode, playerToBeMuted, min, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -420,7 +420,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response =
         controller.bootPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBooted, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -472,7 +472,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response =
         controller.banPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBanned, hrs, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -507,7 +507,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response = controller.stopGameHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted stop of current game on host" : "Failed: " + response));
@@ -540,7 +540,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = md5Crypt(password, salt);
+    final String hashedPassword = encryptPassword(password, salt);
     final String response = controller.shutDownHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted to shut down host" : "Failed: " + response));

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -307,7 +307,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response = controller.getChatLogHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     final JTextPane textPane = new JTextPane();
     textPane.setEditable(false);
@@ -322,8 +322,8 @@ class LobbyGamePanel extends JPanel {
     JOptionPane.showMessageDialog(null, scroll, "Bot Chat Log", JOptionPane.INFORMATION_MESSAGE);
   }
 
-  private static String encryptPassword(final String password, final String salt) {
-    return Md5Crypt.cryptSensitive(password, salt);
+  private static String hashPassword(final String password, final String salt) {
+    return Md5Crypt.hashPassword(password, salt);
   }
 
   private INode getLobbyWatcherNodeForTableRow(final int selectedIndex) {
@@ -380,7 +380,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response =
         controller.mutePlayerHeadlessHostBot(lobbyWatcherNode, playerToBeMuted, min, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -420,7 +420,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response =
         controller.bootPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBooted, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -472,7 +472,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response =
         controller.banPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBanned, hrs, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
@@ -507,7 +507,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response = controller.stopGameHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted stop of current game on host" : "Failed: " + response));
@@ -540,7 +540,7 @@ class LobbyGamePanel extends JPanel {
     }
     final String password = new String(passwordField.getPassword());
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
-    final String hashedPassword = encryptPassword(password, salt);
+    final String hashedPassword = hashPassword(password, salt);
     final String response = controller.shutDownHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
         (response == null ? "Successfully attempted to shut down host" : "Failed: " + response));

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 
+import games.strategy.util.Md5Crypt;
+
 /**
  * A Wrapper class for salted password hashes.
  * If the given String is not matching the format
@@ -29,7 +31,7 @@ public final class HashedPassword {
   }
 
   public boolean isMd5Crypted() {
-    return games.strategy.util.Md5Crypt.isLegalEncryptedPassword(value);
+    return Md5Crypt.isLegalEncryptedPassword(value);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/db/HashedPassword.java
@@ -31,7 +31,7 @@ public final class HashedPassword {
   }
 
   public boolean isMd5Crypted() {
-    return Md5Crypt.isLegalEncryptedPassword(value);
+    return Md5Crypt.isLegalHashedValue(value);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -32,6 +32,7 @@ import games.strategy.engine.lobby.server.db.UserDao;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MacFinder;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
@@ -116,11 +117,11 @@ public final class LobbyLoginValidator implements ILoginValidator {
   private Map<String, String> newMd5CryptAuthenticatorChallenge(final String userName) {
     final Map<String, String> challenge = new HashMap<>();
     if (lobbyPropertyReader.isMaintenanceMode()) {
-      challenge.put(SALT_KEY, games.strategy.util.Md5Crypt.newSalt());
+      challenge.put(SALT_KEY, Md5Crypt.newSalt());
     } else {
       final HashedPassword password = userDao.getLegacyPassword(userName);
       if (password != null && Strings.emptyToNull(password.value) != null) {
-        challenge.put(SALT_KEY, games.strategy.util.Md5Crypt.getSalt(password.value));
+        challenge.put(SALT_KEY, Md5Crypt.getSalt(password.value));
       }
     }
     return challenge;

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -60,7 +60,7 @@ public final class MacFinder {
   }
 
   private static String getHashedMacAddress(final String macAddress) {
-    return Md5Crypt.cryptInsensitive(macAddress, HASHED_MAC_ADDRESS_SALT);
+    return Md5Crypt.hash(macAddress, HASHED_MAC_ADDRESS_SALT);
   }
 
   private static String getMacAddress() {

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -60,7 +60,7 @@ public final class MacFinder {
   }
 
   private static String getHashedMacAddress(final String macAddress) {
-    return Md5Crypt.crypt(macAddress, HASHED_MAC_ADDRESS_SALT);
+    return Md5Crypt.cryptInsensitive(macAddress, HASHED_MAC_ADDRESS_SALT);
   }
 
   private static String getMacAddress() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -39,6 +39,7 @@ import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
+import games.strategy.util.Md5Crypt;
 
 /**
  * The lobby client menu bar.
@@ -310,7 +311,7 @@ public final class LobbyMenu extends JMenuBar {
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),
-            games.strategy.util.Md5Crypt.crypt(panel.getPassword())))
+            Md5Crypt.crypt(panel.getPassword())))
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -311,7 +311,7 @@ public final class LobbyMenu extends JMenuBar {
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),
-            Md5Crypt.crypt(panel.getPassword(), Md5Crypt.newSalt())))
+            Md5Crypt.cryptSensitive(panel.getPassword(), Md5Crypt.newSalt())))
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -311,7 +311,7 @@ public final class LobbyMenu extends JMenuBar {
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),
-            Md5Crypt.cryptSensitive(panel.getPassword(), Md5Crypt.newSalt())))
+            Md5Crypt.hashPassword(panel.getPassword(), Md5Crypt.newSalt())))
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -311,7 +311,7 @@ public final class LobbyMenu extends JMenuBar {
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),
-            Md5Crypt.crypt(panel.getPassword())))
+            Md5Crypt.crypt(panel.getPassword(), Md5Crypt.newSalt())))
         + Strings.nullToEmpty(manager.updateUser(
             panel.getUserName(),
             panel.getEmail(),

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -9,54 +9,54 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * A collection of methods for using the FreeBSD MD5-crypt password encryption algorithm.
+ * A collection of methods for using the FreeBSD MD5-crypt hash algorithm.
  *
  * @see https://www.usenix.org/legacyurl/md5-crypt
  * @see https://www.systutorials.com/docs/linux/man/n-md5crypt/
  */
 public final class Md5Crypt {
   private static final String MAGIC = "$1$";
-  private static final Pattern ENCRYPTED_PASSWORD_PATTERN =
+  private static final Pattern HASHED_VALUE_PATTERN =
       Pattern.compile("^" + MAGIC.replace("$", "\\$") + "([\\.\\/a-zA-Z0-9]{1,8})\\$([\\.\\/a-zA-Z0-9]{22})$");
   private static final byte[] EMPTY_KEY_BYTES = new byte[0];
 
   private Md5Crypt() {}
 
   /**
-   * Encrypts the specified password using the specified salt.
+   * Hashes the specified password using the specified salt.
    *
-   * @param password The password to be encrypted.
+   * @param password The password to be hashed.
    * @param salt The salt. May begin with {@code $1$} and end with {@code $} followed by any number of characters.
    *        No more than eight characters will be used. If empty, a new random salt will be used.
    *
-   * @return The encrypted password.
+   * @return The hashed password.
    *
-   * @deprecated MD5-crypt is not secure for encrypting sensitive information. Use a different encryption algorithm,
-   *             such as bcrypt.
+   * @deprecated MD5-crypt is not secure for hashing sensitive information, such as passwords. Use a different hashing
+   *             algorithm, such as bcrypt.
    */
   @Deprecated
-  public static String cryptSensitive(final String password, final String salt) {
-    return cryptInsensitive(password, salt);
+  public static String hashPassword(final String password, final String salt) {
+    return hash(password, salt);
   }
 
   /**
-   * Encrypts the specified password using the specified salt.
+   * Hashes the specified value using the specified salt.
    *
    * <p>
-   * <b>WARNING:</b> This method should only be used to encrypt insensitive information.
+   * <b>WARNING:</b> This method should not be used to hash sensitive information.
    * </p>
    *
-   * @param password The password to be encrypted.
+   * @param value The value to be hashed.
    * @param salt The salt. May begin with {@code $1$} and end with {@code $} followed by any number of characters.
    *        No more than eight characters will be used. If empty, a new random salt will be used.
    *
-   * @return The encrypted password.
+   * @return The hashed value.
    */
-  public static String cryptInsensitive(final String password, final String salt) {
-    checkNotNull(password);
+  public static String hash(final String value, final String salt) {
+    checkNotNull(value);
     checkNotNull(salt);
 
-    return md5Crypt(password.getBytes(StandardCharsets.UTF_8), MAGIC + normalizeSalt(salt));
+    return md5Crypt(value.getBytes(StandardCharsets.UTF_8), MAGIC + normalizeSalt(salt));
   }
 
   private static String normalizeSalt(final String salt) {
@@ -71,7 +71,7 @@ public final class Md5Crypt {
   }
 
   /**
-   * Creates a new random salt that can be passed to {@link #crypt(String, String)}.
+   * Creates a new random salt that can be passed to {@link #hash(String, String)}.
    *
    * @return A new random salt.
    */
@@ -80,51 +80,51 @@ public final class Md5Crypt {
   }
 
   /**
-   * Gets the hash for the specified encrypted password.
+   * Gets the hash for the specified hashed value.
    *
-   * @param encryptedPassword The encrypted password from a previous call to {@link #crypt(String, String)} whose hash
-   *        is to be returned.
+   * @param hashedValue The hashed value from a previous call to {@link #hash(String, String)} whose hash is to be
+   *        returned.
    *
-   * @return The hash for the specified encrypted password.
+   * @return The hash for the specified hashed value.
    *
-   * @throws IllegalArgumentException If {@code encryptedPassword} is not an MD5-crypted password.
+   * @throws IllegalArgumentException If {@code hashedValue} is not an MD5-crypt hashed value.
    */
-  public static String getHash(final String encryptedPassword) {
-    checkNotNull(encryptedPassword);
+  public static String getHash(final String hashedValue) {
+    checkNotNull(hashedValue);
 
-    final Matcher matcher = ENCRYPTED_PASSWORD_PATTERN.matcher(encryptedPassword);
-    checkArgument(matcher.matches(), "'" + encryptedPassword + "' is not an MD5-crypted password");
+    final Matcher matcher = HASHED_VALUE_PATTERN.matcher(hashedValue);
+    checkArgument(matcher.matches(), "'" + hashedValue + "' is not an MD5-crypt hashed value");
     return matcher.group(2);
   }
 
   /**
-   * Gets the salt for the specified encrypted password.
+   * Gets the salt for the specified hashed value.
    *
-   * @param encryptedPassword The encrypted password from a previous call to {@link #crypt(String, String)} whose salt
-   *        is to be returned.
+   * @param hashedValue The hashed value from a previous call to {@link #hash(String, String)} whose salt is to be
+   *        returned.
    *
-   * @return The salt for the specified encrypted password.
+   * @return The salt for the specified hashed value.
    *
-   * @throws IllegalArgumentException If {@code encryptedPassword} is not an MD5-crypted password.
+   * @throws IllegalArgumentException If {@code hashedValue} is not an MD5-crypt hashed value.
    */
-  public static String getSalt(final String encryptedPassword) {
-    checkNotNull(encryptedPassword);
+  public static String getSalt(final String hashedValue) {
+    checkNotNull(hashedValue);
 
-    final Matcher matcher = ENCRYPTED_PASSWORD_PATTERN.matcher(encryptedPassword);
-    checkArgument(matcher.matches(), "'" + encryptedPassword + "' is not an MD5-crypted password");
+    final Matcher matcher = HASHED_VALUE_PATTERN.matcher(hashedValue);
+    checkArgument(matcher.matches(), "'" + hashedValue + "' is not an MD5-crypt hashed value");
     return matcher.group(1);
   }
 
   /**
-   * Indicates the specified value is a legal MD5-crypted password.
+   * Indicates the specified value is a legal MD5-crypt hashed value.
    *
    * @param value The value to test.
    *
-   * @return {@code true} if the specified value is a legal MD5-crypted password; otherwise {@code false}.
+   * @return {@code true} if the specified value is a legal MD5-crypt hashed value; otherwise {@code false}.
    */
-  public static boolean isLegalEncryptedPassword(final String value) {
+  public static boolean isLegalHashedValue(final String value) {
     checkNotNull(value);
 
-    return ENCRYPTED_PASSWORD_PATTERN.matcher(value).matches();
+    return HASHED_VALUE_PATTERN.matcher(value).matches();
   }
 }

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -23,22 +23,6 @@ public final class Md5Crypt {
   private Md5Crypt() {}
 
   /**
-   * Encrypts the specified password using a new random salt.
-   *
-   * @param password The password to be encrypted.
-   *
-   * @return The encrypted password.
-   *
-   * @deprecated Do not use this method for protecting sensitive information.
-   */
-  @Deprecated
-  public static String crypt(final String password) {
-    checkNotNull(password);
-
-    return crypt(password, newSalt());
-  }
-
-  /**
    * Encrypts the specified password using the specified salt.
    *
    * @param password The password to be encrypted.

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -31,10 +31,28 @@ public final class Md5Crypt {
    *
    * @return The encrypted password.
    *
-   * @deprecated Do not use this method for protecting sensitive information.
+   * @deprecated MD5-crypt is not secure for encrypting sensitive information. Use a different encryption algorithm,
+   *             such as bcrypt.
    */
   @Deprecated
-  public static String crypt(final String password, final String salt) {
+  public static String cryptSensitive(final String password, final String salt) {
+    return cryptInsensitive(password, salt);
+  }
+
+  /**
+   * Encrypts the specified password using the specified salt.
+   *
+   * <p>
+   * <b>WARNING:</b> This method should only be used to encrypt insensitive information.
+   * </p>
+   *
+   * @param password The password to be encrypted.
+   * @param salt The salt. May begin with {@code $1$} and end with {@code $} followed by any number of characters.
+   *        No more than eight characters will be used. If empty, a new random salt will be used.
+   *
+   * @return The encrypted password.
+   */
+  public static String cryptInsensitive(final String password, final String salt) {
     checkNotNull(password);
     checkNotNull(salt);
 

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -13,11 +13,7 @@ import java.util.regex.Pattern;
  *
  * @see https://www.usenix.org/legacyurl/md5-crypt
  * @see https://www.systutorials.com/docs/linux/man/n-md5crypt/
- *
- * @deprecated Use SHA512(fast) or BCrypt(secure) in the future instead
- *             (kept for backwards compatibility)
  */
-@Deprecated
 public final class Md5Crypt {
   private static final String MAGIC = "$1$";
   private static final Pattern ENCRYPTED_PASSWORD_PATTERN =
@@ -32,7 +28,10 @@ public final class Md5Crypt {
    * @param password The password to be encrypted.
    *
    * @return The encrypted password.
+   *
+   * @deprecated Do not use this method for protecting sensitive information.
    */
+  @Deprecated
   public static String crypt(final String password) {
     checkNotNull(password);
 
@@ -47,7 +46,10 @@ public final class Md5Crypt {
    *        No more than eight characters will be used. If empty, a new random salt will be used.
    *
    * @return The encrypted password.
+   *
+   * @deprecated Do not use this method for protecting sensitive information.
    */
+  @Deprecated
   public static String crypt(final String password, final String salt) {
     checkNotNull(password);
     checkNotNull(salt);

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 
 import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.ChallengePropertyNames;
 import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.ResponsePropertyNames;
+import games.strategy.util.Md5Crypt;
 
 public final class Md5CryptAuthenticatorTest {
   private static final String PASSWORD = "←PASSWORD↑WITH→UNICODE↓CHARS";
@@ -83,7 +84,7 @@ public final class Md5CryptAuthenticatorTest {
   @Test
   public void newResponse_ShouldIncludeResponseWhenChallengeContainsSalt() throws Exception {
     final Map<String, String> challenge = ImmutableMap.of(
-        ChallengePropertyNames.SALT, games.strategy.util.Md5Crypt.newSalt());
+        ChallengePropertyNames.SALT, Md5Crypt.newSalt());
 
     final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -41,6 +41,7 @@ import games.strategy.engine.lobby.server.db.HashedPassword;
 import games.strategy.engine.lobby.server.db.UserDao;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.security.TestSecurityUtils;
+import games.strategy.util.Md5Crypt;
 import games.strategy.util.Tuple;
 
 public final class LobbyLoginValidatorTest {
@@ -80,7 +81,7 @@ public final class LobbyLoginValidatorTest {
 
     private final DBUser dbUser = new DBUser(new DBUser.UserName(user.getUsername()), new DBUser.UserEmail(EMAIL));
 
-    private final String md5CryptSalt = games.strategy.util.Md5Crypt.newSalt();
+    private final String md5CryptSalt = Md5Crypt.newSalt();
 
     @BeforeEach
     public void setUp() throws IOException, GeneralSecurityException {
@@ -107,7 +108,7 @@ public final class LobbyLoginValidatorTest {
     }
 
     final String md5Crypt(final String password) {
-      return games.strategy.util.Md5Crypt.crypt(password, md5CryptSalt);
+      return Md5Crypt.crypt(password, md5CryptSalt);
     }
 
     final void givenAnonymousAuthenticationWillFail() {

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -108,7 +108,7 @@ public final class LobbyLoginValidatorTest {
     }
 
     final String md5Crypt(final String password) {
-      return Md5Crypt.crypt(password, md5CryptSalt);
+      return Md5Crypt.cryptSensitive(password, md5CryptSalt);
     }
 
     final void givenAnonymousAuthenticationWillFail() {

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -108,7 +108,7 @@ public final class LobbyLoginValidatorTest {
     }
 
     final String md5Crypt(final String password) {
-      return Md5Crypt.cryptSensitive(password, md5CryptSalt);
+      return Md5Crypt.hashPassword(password, md5CryptSalt);
     }
 
     final void givenAnonymousAuthenticationWillFail() {

--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -1,10 +1,10 @@
 package games.strategy.util;
 
-import static games.strategy.util.Md5Crypt.cryptInsensitive;
-import static games.strategy.util.Md5Crypt.cryptSensitive;
 import static games.strategy.util.Md5Crypt.getHash;
 import static games.strategy.util.Md5Crypt.getSalt;
-import static games.strategy.util.Md5Crypt.isLegalEncryptedPassword;
+import static games.strategy.util.Md5Crypt.hash;
+import static games.strategy.util.Md5Crypt.hashPassword;
+import static games.strategy.util.Md5Crypt.isLegalHashedValue;
 import static games.strategy.util.Md5Crypt.newSalt;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -13,133 +13,149 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public final class Md5CryptTest {
-  @Test
-  public void cryptSensitive_ShouldReturnEncryptedPassword() {
-    final String password = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F";
-    final String salt = "wwmV2glD";
-    assertThat(cryptSensitive(password, salt), is("$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11"));
+  @Nested
+  public final class HashPasswordTest {
+    @Test
+    public void shouldReturnHashedPassword() {
+      final String password = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+          + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F";
+      final String salt = "wwmV2glD";
+      assertThat(hashPassword(password, salt), is("$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11"));
+    }
   }
 
-  @Test
-  public void cryptInsensitive_ShouldReturnEncryptedPassword() {
-    Arrays.asList(
-        Triple.of("", "ll5ESPtE", "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"),
-        Triple.of("password", "Eim8FgMk", "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1"),
-        Triple.of("the quick brown fox", "XlnQ6h98", "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv."),
-        Triple.of("ABYZabyz0189", "3lvJqBhy", "$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq."),
-        Triple.of(" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F", "wwmV2glD", "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11"))
-        .forEach(t -> {
-          final String password = t.getFirst();
-          final String salt = t.getSecond();
-          final String encryptedPassword = t.getThird();
-          assertThat(
-              String.format("wrong encrypted password for '%s'", password),
-              cryptInsensitive(password, salt),
-              is(encryptedPassword));
-        });
+  @Nested
+  public final class HashTest {
+    @Test
+    public void shouldReturnHashedValue() {
+      Arrays.asList(
+          Triple.of("", "ll5ESPtE", "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"),
+          Triple.of("value", "Eim8FgMk", "$1$Eim8FgMk$TYixIMiLc1BA6XHJBw66y0"),
+          Triple.of("the quick brown fox", "XlnQ6h98", "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv."),
+          Triple.of("ABYZabyz0189", "3lvJqBhy", "$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq."),
+          Triple.of(" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+              + "[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F", "wwmV2glD", "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11"))
+          .forEach(t -> {
+            final String value = t.getFirst();
+            final String salt = t.getSecond();
+            final String hashedValue = t.getThird();
+            assertThat(String.format("wrong hashed value for '%s'", value), hash(value, salt), is(hashedValue));
+          });
+    }
+
+    @Test
+    public void shouldUseNewRandomSaltWhenSaltIsEmpty() {
+      assertThat(getSalt(hash("value", "")).length(), is(8));
+    }
+
+    @Test
+    public void shouldIgnoreLeadingMagicInSalt() {
+      assertThat(hash("value", "$1$Eim8FgMk"), is(hash("value", "Eim8FgMk")));
+    }
+
+    @Test
+    public void shouldIgnoreTrailingHashInSalt() {
+      assertThat(hash("value", "Z$IGNOREME"), is(hash("value", "Z")));
+    }
+
+    @Test
+    public void shouldUseNoMoreThanEightCharactersFromSalt() {
+      assertThat(hash("value", "123456789"), is(hash("value", "12345678")));
+    }
+
+    @Test
+    public void shouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
+      assertThat(hash("value", "ABC!@DEF"), is(hash("value", "ABC..DEF")));
+    }
   }
 
-  @Test
-  public void cryptInsensitive_ShouldUseNewRandomSaltWhenSaltIsEmpty() {
-    assertThat(getSalt(cryptInsensitive("password", "")).length(), is(8));
+  @Nested
+  public final class GetHashTest {
+    @Test
+    public void shouldReturnHashWhenHashedValueIsLegal() {
+      assertThat(getHash("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"), is("KsXRew.PuhVQTNMKSXQZx0"));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHashedValueIsIllegal() {
+      assertThrows(IllegalArgumentException.class, () -> getHash("1$A$KnCRC85Rudn6P3cpfe3LR/"));
+    }
   }
 
-  @Test
-  public void cryptInsensitive_ShouldIgnoreLeadingMagicInSalt() {
-    assertThat(cryptInsensitive("password", "$1$Eim8FgMk"), is(cryptInsensitive("password", "Eim8FgMk")));
+  @Nested
+  public final class GetSaltTest {
+    @Test
+    public void shouldReturnSaltWhenHashedValueIsLegal() {
+      assertThat(getSalt("$1$A$KnCRC85Rudn6P3cpfe3LR/"), is("A"));
+      assertThat(getSalt("$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1"), is("ABCDEFGH"));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHashedValueIsIllegal() {
+      assertThrows(IllegalArgumentException.class, () -> getSalt("1$A$KnCRC85Rudn6P3cpfe3LR/"));
+    }
   }
 
-  @Test
-  public void cryptInsensitive_ShouldIgnoreTrailingHashInSalt() {
-    assertThat(cryptInsensitive("password", "Z$IGNOREME"), is(cryptInsensitive("password", "Z")));
+  @Nested
+  public final class IsLegalHashedValueTest {
+    @Test
+    public void shouldReturnTrueWhenHashedValueIsLegal() {
+      Arrays.asList(
+          "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0",
+          "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1",
+          "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv.",
+          "$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq.",
+          "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11",
+          "$1$A$KnCRC85Rudn6P3cpfe3LR/",
+          "$1$AB$4jo772pXjQ9qCwNdBde3d1",
+          "$1$ABC$3tP1DHUbEbG4bd67/3fFu/",
+          "$1$ABCD$dQqZjlWf5HeY7rWTLu23s.",
+          "$1$ABCDE$ACfvKmv8y/KjlzX1R.tBw.",
+          "$1$ABCDEF$f.URqvCLElutKgCndKcMI1",
+          "$1$ABCDEFG$mN7iGIbBXdAAjJtrJG2ia1",
+          "$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1")
+          .forEach(value -> {
+            assertThat(
+                String.format("expected legal hashed value '%s'", value),
+                isLegalHashedValue(value),
+                is(true));
+          });
+    }
+
+    @Test
+    public void shouldReturnFalseWhenHashedValueIsIlegal() {
+      Arrays.asList(
+          "1$A$KnCRC85Rudn6P3cpfe3LR/",
+          "$$AB$4jo772pXjQ9qCwNdBde3d1",
+          "$1ABC$3tP1DHUbEbG4bd67/3fFu/",
+          "$1$$dQqZjlWf5HeY7rWTLu23s.",
+          "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.",
+          "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw_",
+          "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw",
+          "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw..")
+          .forEach(value -> {
+            assertThat(
+                String.format("expected illegal hashed value '%s'", value),
+                isLegalHashedValue(value),
+                is(false));
+          });
+    }
   }
 
-  @Test
-  public void cryptInsensitive_ShouldUseNoMoreThanEightCharactersFromSalt() {
-    assertThat(cryptInsensitive("password", "123456789"), is(cryptInsensitive("password", "12345678")));
-  }
+  @Nested
+  public final class NewSaltTest {
+    @Test
+    public void shouldReturnSaltOfLengthEight() {
+      assertThat(newSalt().length(), is(8));
+    }
 
-  @Test
-  public void cryptInsensitive_ShouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
-    assertThat(cryptInsensitive("password", "ABC!@DEF"), is(cryptInsensitive("password", "ABC..DEF")));
-  }
-
-  @Test
-  public void getHash_ShouldReturnHashWhenEncryptedPasswordIsLegal() {
-    assertThat(getHash("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"), is("KsXRew.PuhVQTNMKSXQZx0"));
-  }
-
-  @Test
-  public void getHash_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
-    assertThrows(IllegalArgumentException.class, () -> getHash("1$A$KnCRC85Rudn6P3cpfe3LR/"));
-  }
-
-  @Test
-  public void getSalt_ShouldReturnSaltWhenEncryptedPasswordIsLegal() {
-    assertThat(getSalt("$1$A$KnCRC85Rudn6P3cpfe3LR/"), is("A"));
-    assertThat(getSalt("$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1"), is("ABCDEFGH"));
-  }
-
-  @Test
-  public void getSalt_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
-    assertThrows(IllegalArgumentException.class, () -> getSalt("1$A$KnCRC85Rudn6P3cpfe3LR/"));
-  }
-
-  @Test
-  public void isLegalEncryptedPassword_ShouldReturnTrueWhenEncryptedPasswordIsLegal() {
-    Arrays.asList(
-        "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0",
-        "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1",
-        "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv.",
-        "$1$3lvJqBhy$ZjNcN3vfMfRdNcDyzQbQq.",
-        "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11",
-        "$1$A$KnCRC85Rudn6P3cpfe3LR/",
-        "$1$AB$4jo772pXjQ9qCwNdBde3d1",
-        "$1$ABC$3tP1DHUbEbG4bd67/3fFu/",
-        "$1$ABCD$dQqZjlWf5HeY7rWTLu23s.",
-        "$1$ABCDE$ACfvKmv8y/KjlzX1R.tBw.",
-        "$1$ABCDEF$f.URqvCLElutKgCndKcMI1",
-        "$1$ABCDEFG$mN7iGIbBXdAAjJtrJG2ia1",
-        "$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1")
-        .forEach(value -> {
-          assertThat(
-              String.format("expected legal encrypted password '%s'", value),
-              isLegalEncryptedPassword(value),
-              is(true));
-        });
-  }
-
-  @Test
-  public void isLegalEncryptedPassword_ShouldReturnFalseWhenEncryptedPasswordIsIlegal() {
-    Arrays.asList(
-        "1$A$KnCRC85Rudn6P3cpfe3LR/",
-        "$$AB$4jo772pXjQ9qCwNdBde3d1",
-        "$1ABC$3tP1DHUbEbG4bd67/3fFu/",
-        "$1$$dQqZjlWf5HeY7rWTLu23s.",
-        "$1$ABCDEFGHI$ACfvKmv8y/KjlzX1R.tBw.",
-        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw_",
-        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw",
-        "$1$ABCDEFGH$ACfvKmv8y/KjlzX1R.tBw..")
-        .forEach(value -> {
-          assertThat(
-              String.format("expected illegal encrypted password '%s'", value),
-              isLegalEncryptedPassword(value),
-              is(false));
-        });
-  }
-
-  @Test
-  public void newSalt_ShouldReturnSaltOfLengthEight() {
-    assertThat(newSalt().length(), is(8));
-  }
-
-  @Test
-  public void newSalt_ShouldReturnDifferentSuccessiveSalts() {
-    assertThat(newSalt(), is(not(newSalt())));
+    @Test
+    public void shouldReturnDifferentSuccessiveSalts() {
+      assertThat(newSalt(), is(not(newSalt())));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -11,25 +11,7 @@ import org.junit.jupiter.api.Test;
 
 public final class Md5CryptTest {
   @Test
-  public void cryptWithoutSalt_ShouldReturnEncryptedPassword() {
-    Arrays.asList(
-        "",
-        "password",
-        "the quick brown fox",
-        "ABYZabyz0189",
-        " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F")
-        .forEach(password -> {
-          final String encryptedPassword = Md5Crypt.crypt(password);
-          final String salt = Md5Crypt.getSalt(encryptedPassword);
-          assertThat(
-              String.format("wrong encrypted password for '%s'", password),
-              Md5Crypt.crypt(password, salt),
-              is(encryptedPassword));
-        });
-  }
-
-  @Test
-  public void cryptWithSalt_ShouldReturnEncryptedPassword() {
+  public void crypt_ShouldReturnEncryptedPassword() {
     Arrays.asList(
         Triple.of("", "ll5ESPtE", "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"),
         Triple.of("password", "Eim8FgMk", "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1"),
@@ -49,27 +31,27 @@ public final class Md5CryptTest {
   }
 
   @Test
-  public void cryptWithSalt_ShouldUseNewRandomSaltWhenSaltIsEmpty() {
+  public void crypt_ShouldUseNewRandomSaltWhenSaltIsEmpty() {
     assertThat(Md5Crypt.getSalt(Md5Crypt.crypt("password", "")).length(), is(8));
   }
 
   @Test
-  public void cryptWithSalt_ShouldIgnoreLeadingMagicInSalt() {
+  public void crypt_ShouldIgnoreLeadingMagicInSalt() {
     assertThat(Md5Crypt.crypt("password", "$1$Eim8FgMk"), is(Md5Crypt.crypt("password", "Eim8FgMk")));
   }
 
   @Test
-  public void cryptWithSalt_ShouldIgnoreTrailingHashInSalt() {
+  public void crypt_ShouldIgnoreTrailingHashInSalt() {
     assertThat(Md5Crypt.crypt("password", "Z$IGNOREME"), is(Md5Crypt.crypt("password", "Z")));
   }
 
   @Test
-  public void cryptWithSalt_ShouldUseNoMoreThanEightCharactersFromSalt() {
+  public void crypt_ShouldUseNoMoreThanEightCharactersFromSalt() {
     assertThat(Md5Crypt.crypt("password", "123456789"), is(Md5Crypt.crypt("password", "12345678")));
   }
 
   @Test
-  public void cryptWithSalt_ShouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
+  public void crypt_ShouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
     assertThat(Md5Crypt.crypt("password", "ABC!@DEF"), is(Md5Crypt.crypt("password", "ABC..DEF")));
   }
 

--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -10,30 +10,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public final class Md5CryptTest {
-  private static String crypt(final String password) {
-    return Md5Crypt.crypt(password);
-  }
-
-  private static String crypt(final String password, final String salt) {
-    return Md5Crypt.crypt(password, salt);
-  }
-
-  private static String getHash(final String encryptedPassword) {
-    return Md5Crypt.getHash(encryptedPassword);
-  }
-
-  private static String getSalt(final String encryptedPassword) {
-    return Md5Crypt.getSalt(encryptedPassword);
-  }
-
-  private static boolean isLegalEncryptedPassword(final String encryptedPassword) {
-    return Md5Crypt.isLegalEncryptedPassword(encryptedPassword);
-  }
-
-  private static String newSalt() {
-    return Md5Crypt.newSalt();
-  }
-
   @Test
   public void cryptWithoutSalt_ShouldReturnEncryptedPassword() {
     Arrays.asList(
@@ -43,11 +19,11 @@ public final class Md5CryptTest {
         "ABYZabyz0189",
         " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007F")
         .forEach(password -> {
-          final String encryptedPassword = crypt(password);
-          final String salt = getSalt(encryptedPassword);
+          final String encryptedPassword = Md5Crypt.crypt(password);
+          final String salt = Md5Crypt.getSalt(encryptedPassword);
           assertThat(
               String.format("wrong encrypted password for '%s'", password),
-              crypt(password, salt),
+              Md5Crypt.crypt(password, salt),
               is(encryptedPassword));
         });
   }
@@ -67,55 +43,55 @@ public final class Md5CryptTest {
           final String encryptedPassword = t.getThird();
           assertThat(
               String.format("wrong encrypted password for '%s'", password),
-              crypt(password, salt),
+              Md5Crypt.crypt(password, salt),
               is(encryptedPassword));
         });
   }
 
   @Test
   public void cryptWithSalt_ShouldUseNewRandomSaltWhenSaltIsEmpty() {
-    assertThat(getSalt(crypt("password", "")).length(), is(8));
+    assertThat(Md5Crypt.getSalt(Md5Crypt.crypt("password", "")).length(), is(8));
   }
 
   @Test
   public void cryptWithSalt_ShouldIgnoreLeadingMagicInSalt() {
-    assertThat(crypt("password", "$1$Eim8FgMk"), is(crypt("password", "Eim8FgMk")));
+    assertThat(Md5Crypt.crypt("password", "$1$Eim8FgMk"), is(Md5Crypt.crypt("password", "Eim8FgMk")));
   }
 
   @Test
   public void cryptWithSalt_ShouldIgnoreTrailingHashInSalt() {
-    assertThat(crypt("password", "Z$IGNOREME"), is(crypt("password", "Z")));
+    assertThat(Md5Crypt.crypt("password", "Z$IGNOREME"), is(Md5Crypt.crypt("password", "Z")));
   }
 
   @Test
   public void cryptWithSalt_ShouldUseNoMoreThanEightCharactersFromSalt() {
-    assertThat(crypt("password", "123456789"), is(crypt("password", "12345678")));
+    assertThat(Md5Crypt.crypt("password", "123456789"), is(Md5Crypt.crypt("password", "12345678")));
   }
 
   @Test
   public void cryptWithSalt_ShouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
-    assertThat(crypt("password", "ABC!@DEF"), is(crypt("password", "ABC..DEF")));
+    assertThat(Md5Crypt.crypt("password", "ABC!@DEF"), is(Md5Crypt.crypt("password", "ABC..DEF")));
   }
 
   @Test
   public void getHash_ShouldReturnHashWhenEncryptedPasswordIsLegal() {
-    assertThat(getHash("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"), is("KsXRew.PuhVQTNMKSXQZx0"));
+    assertThat(Md5Crypt.getHash("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"), is("KsXRew.PuhVQTNMKSXQZx0"));
   }
 
   @Test
   public void getHash_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
-    assertThrows(IllegalArgumentException.class, () -> getHash("1$A$KnCRC85Rudn6P3cpfe3LR/"));
+    assertThrows(IllegalArgumentException.class, () -> Md5Crypt.getHash("1$A$KnCRC85Rudn6P3cpfe3LR/"));
   }
 
   @Test
   public void getSalt_ShouldReturnSaltWhenEncryptedPasswordIsLegal() {
-    assertThat(getSalt("$1$A$KnCRC85Rudn6P3cpfe3LR/"), is("A"));
-    assertThat(getSalt("$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1"), is("ABCDEFGH"));
+    assertThat(Md5Crypt.getSalt("$1$A$KnCRC85Rudn6P3cpfe3LR/"), is("A"));
+    assertThat(Md5Crypt.getSalt("$1$ABCDEFGH$hGGndps75hhROKqu/zh9q1"), is("ABCDEFGH"));
   }
 
   @Test
   public void getSalt_ShouldThrowExceptionWhenEncryptedPasswordIsIllegal() {
-    assertThrows(IllegalArgumentException.class, () -> getSalt("1$A$KnCRC85Rudn6P3cpfe3LR/"));
+    assertThrows(IllegalArgumentException.class, () -> Md5Crypt.getSalt("1$A$KnCRC85Rudn6P3cpfe3LR/"));
   }
 
   @Test
@@ -137,7 +113,7 @@ public final class Md5CryptTest {
         .forEach(value -> {
           assertThat(
               String.format("expected legal encrypted password '%s'", value),
-              isLegalEncryptedPassword(value),
+              Md5Crypt.isLegalEncryptedPassword(value),
               is(true));
         });
   }
@@ -156,18 +132,18 @@ public final class Md5CryptTest {
         .forEach(value -> {
           assertThat(
               String.format("expected illegal encrypted password '%s'", value),
-              isLegalEncryptedPassword(value),
+              Md5Crypt.isLegalEncryptedPassword(value),
               is(false));
         });
   }
 
   @Test
   public void newSalt_ShouldReturnSaltOfLengthEight() {
-    assertThat(newSalt().length(), is(8));
+    assertThat(Md5Crypt.newSalt().length(), is(8));
   }
 
   @Test
   public void newSalt_ShouldReturnDifferentSuccessiveSalts() {
-    assertThat(newSalt(), is(not(newSalt())));
+    assertThat(Md5Crypt.newSalt(), is(not(Md5Crypt.newSalt())));
   }
 }


### PR DESCRIPTION
Per a discussion in https://github.com/triplea-game/triplea/pull/3150#discussion_r170442773.

#### Functional changes

None.

#### Refactoring changes

* Replaced fully-qualified `Md5Crypt` type names with imports.
* Changed the use of the adjective "encrypted" to "hashed" (e.g. "encrypted password" -> "hashed password").  This was done mostly for consistency of terminology with the `BCrypt` code we use in parallel with `Md5Crypt`.
* Undeprecated the `Md5Crypt` type.
* Split the `crypt()` method into two:
    * `hash()`: not deprecated; used for hashing data that is not sensitive (e.g. hashed MACs).
    * `hashPassword()`: deprecated; used in places where we are hashing sensitive data (e.g. passwords).  It is anticipated that we will remove code that uses MD5-crypt to hash passwords in the next incompatible release, and this method will ultimately be removed.
* A few other minor changes (please see the commit list).

#### Notes

Recommended to view with whitespace changes ignored.