### PR TITLE
JavaFX Testing

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -121,6 +121,9 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
     testCompile 'org.mockito:mockito-core:2.13.0'
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
+    testCompile 'org.testfx:openjfx-monocle:8u76-b04'
+    testCompile 'org.testfx:testfx-core:4.0.12-alpha'
+    testCompile 'org.testfx:testfx-junit5:4.0.12-alpha'
 
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
 

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -121,9 +121,18 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
     testCompile 'org.mockito:mockito-core:2.13.0'
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
-    testCompile 'org.testfx:openjfx-monocle:8u76-b04'
-    testCompile 'org.testfx:testfx-core:4.0.12-alpha'
     testCompile 'org.testfx:testfx-junit5:4.0.12-alpha'
+
+    if (JavaVersion.current() == JavaVersion.VERSION_1_9) {
+        testCompile('org.testfx:testfx-core:4.0.12-alpha') {
+            exclude group: 'org.testfx', module: 'testfx-internal-java8'
+        }
+        testRuntime 'org.testfx:testfx-internal-java9:4.0.12-alpha'
+        testCompile 'org.testfx:openjfx-monocle:jdk-9+181'
+    } else {
+        testCompile 'org.testfx:testfx-core:4.0.12-alpha'
+        testCompile 'org.testfx:openjfx-monocle:8u76-b04'
+    }
 
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -173,6 +173,9 @@ public enum ClientSetting implements GameSetting {
     setPreferences(Preferences.userNodeForPackage(ClientSetting.class));
   }
 
+  /**
+   * A method exposing internals for testing purposes.
+   */
   @VisibleForTesting
   static void resetPreferences() {
     preferencesRef.set(null);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -213,7 +213,7 @@ public enum ClientSetting implements GameSetting {
   }
 
   @VisibleForTesting
-  static void setPreferences(final Preferences preferences) {
+  public static void setPreferences(final Preferences preferences) {
     preferencesRef.set(preferences);
   }
 

--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -1,0 +1,36 @@
+package org.triplea.client.ui.javafx;
+
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasChildren;
+import static org.testfx.matcher.base.NodeMatchers.isInvisible;
+import static org.testfx.matcher.base.NodeMatchers.isVisible;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit5.ApplicationExtension;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+@ExtendWith(ApplicationExtension.class)
+public class TripleAApplicationTest {
+
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    FxToolkit.registerPrimaryStage();
+    FxToolkit.setupApplication(TripleA.class);
+  }
+
+  @Test
+  public void testDisplay() {
+    verifyThat("#mainOptions", isVisible());
+    verifyThat("#gameOptions", isInvisible());
+    verifyThat("#aboutSection", isInvisible());
+    verifyThat("#mainOptions", hasChildren(5, ".button:visible"));
+  }
+}

--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -1,6 +1,5 @@
 package org.triplea.client.ui.javafx;
 
-
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.matcher.base.NodeMatchers.hasChildren;
 import static org.testfx.matcher.base.NodeMatchers.isInvisible;
@@ -24,7 +23,7 @@ public class TripleAApplicationTest {
     System.setProperty("testfx.headless", String.valueOf(true));
     System.setProperty("prism.order", "sw");
     System.setProperty("prism.text", "t2k");
-    System.setProperty("testfx.setup.timeout", String.valueOf(2500));
+    System.setProperty("testfx.setup.timeout", String.valueOf(10000));
   }
 
 

--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -18,6 +18,15 @@ import games.strategy.triplea.settings.ClientSetting;
 @ExtendWith(ApplicationExtension.class)
 public class TripleAApplicationTest {
 
+  static {
+    System.setProperty("java.awt.headless", String.valueOf(true));
+    System.setProperty("testfx.robot", "glass");
+    System.setProperty("testfx.headless", String.valueOf(true));
+    System.setProperty("prism.order", "sw");
+    System.setProperty("prism.text", "t2k");
+    System.setProperty("testfx.setup.timeout", String.valueOf(2500));
+  }
+
 
   @BeforeAll
   public static void setup() throws Exception {

--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -18,7 +18,6 @@ import games.strategy.triplea.settings.ClientSetting;
 public class TripleAApplicationTest {
 
   static {
-    System.setProperty("java.awt.headless", String.valueOf(true));
     System.setProperty("testfx.robot", "glass");
     System.setProperty("testfx.headless", String.valueOf(true));
     System.setProperty("prism.order", "sw");


### PR DESCRIPTION
This adds some basic tests for the JavaFX UI as a proof of concept.
The JDK9 Build should fail, because what TestFX basically does is replacing the internal JDK class files and making them work on headless environments as well and currently the only binaries file being used are the ones for JDK8.
See [the official README](https://github.com/TestFX/TestFX#java-9) for more information.
@ssoloff Any Ideas on how to make the dependency dependent on the JDK version currently being executed?