### PR TITLE
Update triplea_maps.yaml

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -728,7 +728,7 @@
 - mapName: Iron War
   mapCategory: GOOD
   url: https://github.com/triplea-maps/iron_war/archive/master.zip
-  version: 13
+  version: 14
   img: https://raw.githubusercontent.com/triplea-maps/iron_war/master/description/MapThumbnail.png
   description: |
     <br><b><em>by Frostion</em></b>


### PR DESCRIPTION
New v0.2.2 of Iron War.
Playable of course with the current stable TripleA release.
(This version includes uploaded resource Icons to prepare for next stable release and potential use of these icons)