### PR TITLE
Add additional lobby database properties

### DIFF
--- a/game-core/config/lobby/lobby.properties
+++ b/game-core/config/lobby/lobby.properties
@@ -1,4 +1,24 @@
-maintenance_mode = false
-port  = 3304
-postgres_user = postgres
+## Lobby server
+##
+## Available properties:
+##
+## Name              Type     Default  Description
+## maintenance_mode  Boolean  false    "true" to enable lobby maintenance mode or "false" to disable it.
+## port              Integer  <none>   The port on which the lobby will listen for connections.  This property is
+##                                     required for the lobby server to start.
+##
+port = 3304
+
+## Lobby database connection
+##
+## Available properties:
+##
+## Name               Type     Default    Description
+## postgres_database  String   ta_users   The name of the lobby database.
+## postgres_host      String   localhost  The host running the lobby database.
+## postgres_password  String   <empty>    The password of the lobby database user.
+## postgres_port      Integer  5432       The port on which the lobby database is listening for connections.
+## postgres_user      String   <empty>    The name of the lobby database user.
+##
 postgres_password = postgres
+postgres_user = postgres

--- a/game-core/config/lobby/lobby.properties
+++ b/game-core/config/lobby/lobby.properties
@@ -4,10 +4,8 @@
 ##
 ## Name              Type     Default  Description
 ## maintenance_mode  Boolean  false    "true" to enable lobby maintenance mode or "false" to disable it.
-## port              Integer  <none>   The port on which the lobby will listen for connections.  This property is
-##                                     required for the lobby server to start.
+## port              Integer  3304     The port on which the lobby will listen for connections.
 ##
-port = 3304
 
 ## Lobby database connection
 ##

--- a/game-core/src/main/java/games/strategy/engine/config/PropertyReader.java
+++ b/game-core/src/main/java/games/strategy/engine/config/PropertyReader.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.config;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Reads properties from a source.
  */
@@ -15,4 +17,63 @@ public interface PropertyReader {
    * @throws IllegalStateException If an error occurs reading the property source.
    */
   String readProperty(String key);
+
+  /**
+   * Reads the specified property or uses the specified default value if the property does not exist.
+   *
+   * @param key The property key.
+   * @param defaultValue The default property value.
+   *
+   * @return The property value or {@code defaultValue} if the key is not present.
+   *
+   * @throws IllegalArgumentException If {@code key} is empty or contains only whitespace.
+   * @throws IllegalStateException If an error occurs reading the property source.
+   */
+  default String readPropertyOrDefault(final String key, final String defaultValue) {
+    checkNotNull(defaultValue);
+
+    final String value = readProperty(key);
+    return !value.isEmpty() ? value : defaultValue;
+  }
+
+  /**
+   * Reads the specified boolean property or uses the specified default value if the property does not exist.
+   *
+   * @param key The property key.
+   * @param defaultValue The default property value.
+   *
+   * @return The boolean property value or {@code defaultValue} if the key is not present.
+   *
+   * @throws IllegalArgumentException If {@code key} is empty or contains only whitespace.
+   * @throws IllegalStateException If an error occurs reading the property source.
+   */
+  default boolean readBooleanPropertyOrDefault(final String key, final boolean defaultValue) {
+    final String value = readProperty(key);
+    return !value.isEmpty() ? Boolean.parseBoolean(value) : defaultValue;
+  }
+
+  /**
+   * Reads the specified integer property or uses the specified default value if the property does not exist.
+   *
+   * @param key The property key.
+   * @param defaultValue The default property value.
+   *
+   * @return The integer property value or {@code defaultValue} if the key is not present or if the property value
+   *         cannot be parsed as an integer.
+   *
+   * @throws IllegalArgumentException If {@code key} is empty or contains only whitespace.
+   * @throws IllegalStateException If an error occurs reading the property source.
+   */
+  default int readIntegerPropertyOrDefault(final String key, final int defaultValue) {
+    final String value = readProperty(key);
+    if (!value.isEmpty()) {
+      try {
+        return Integer.parseInt(value);
+      } catch (final NumberFormatException e) {
+        // malformed value will return default value below
+      }
+    }
+
+    return defaultValue;
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/config/PropertyReader.java
+++ b/game-core/src/main/java/games/strategy/engine/config/PropertyReader.java
@@ -2,6 +2,9 @@ package games.strategy.engine.config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Reads properties from a source.
  */
@@ -70,7 +73,12 @@ public interface PropertyReader {
       try {
         return Integer.parseInt(value);
       } catch (final NumberFormatException e) {
-        // malformed value will return default value below
+        Logger.getLogger(PropertyReader.class.getName()).log(
+            Level.WARNING,
+            String.format(
+                "property '%s' has a value ('%s') that is not an integer; using default value (%d) instead",
+                key, value, defaultValue),
+            e);
       }
     }
 

--- a/game-core/src/main/java/games/strategy/engine/config/lobby/LobbyPropertyReader.java
+++ b/game-core/src/main/java/games/strategy/engine/config/lobby/LobbyPropertyReader.java
@@ -27,17 +27,15 @@ public final class LobbyPropertyReader {
   }
 
   public int getPort() {
-    return Integer.parseInt(propertyReader.readProperty(PropertyKeys.PORT));
+    return propertyReader.readIntegerPropertyOrDefault(PropertyKeys.PORT, DefaultValues.PORT);
   }
 
   public String getPostgresDatabase() {
-    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_DATABASE);
-    return !value.isEmpty() ? value : DefaultValues.POSTGRES_DATABASE;
+    return propertyReader.readPropertyOrDefault(PropertyKeys.POSTGRES_DATABASE, DefaultValues.POSTGRES_DATABASE);
   }
 
   public String getPostgresHost() {
-    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_HOST);
-    return !value.isEmpty() ? value : DefaultValues.POSTGRES_HOST;
+    return propertyReader.readPropertyOrDefault(PropertyKeys.POSTGRES_HOST, DefaultValues.POSTGRES_HOST);
   }
 
   public String getPostgresPassword() {
@@ -45,8 +43,7 @@ public final class LobbyPropertyReader {
   }
 
   public int getPostgresPort() {
-    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_PORT);
-    return !value.isEmpty() ? Integer.parseInt(value) : DefaultValues.POSTGRES_PORT;
+    return propertyReader.readIntegerPropertyOrDefault(PropertyKeys.POSTGRES_PORT, DefaultValues.POSTGRES_PORT);
   }
 
   public String getPostgresUser() {
@@ -54,7 +51,7 @@ public final class LobbyPropertyReader {
   }
 
   public boolean isMaintenanceMode() {
-    return Boolean.parseBoolean(propertyReader.readProperty(PropertyKeys.MAINTENANCE_MODE));
+    return propertyReader.readBooleanPropertyOrDefault(PropertyKeys.MAINTENANCE_MODE, DefaultValues.MAINTENANCE_MODE);
   }
 
   /**
@@ -73,6 +70,8 @@ public final class LobbyPropertyReader {
 
   @VisibleForTesting
   interface DefaultValues {
+    boolean MAINTENANCE_MODE = false;
+    int PORT = 3304;
     String POSTGRES_DATABASE = "ta_users";
     String POSTGRES_HOST = "localhost";
     int POSTGRES_PORT = 5432;

--- a/game-core/src/main/java/games/strategy/engine/config/lobby/LobbyPropertyReader.java
+++ b/game-core/src/main/java/games/strategy/engine/config/lobby/LobbyPropertyReader.java
@@ -30,12 +30,27 @@ public final class LobbyPropertyReader {
     return Integer.parseInt(propertyReader.readProperty(PropertyKeys.PORT));
   }
 
-  public String getPostgresUser() {
-    return propertyReader.readProperty(PropertyKeys.POSTGRES_USER);
+  public String getPostgresDatabase() {
+    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_DATABASE);
+    return !value.isEmpty() ? value : DefaultValues.POSTGRES_DATABASE;
+  }
+
+  public String getPostgresHost() {
+    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_HOST);
+    return !value.isEmpty() ? value : DefaultValues.POSTGRES_HOST;
   }
 
   public String getPostgresPassword() {
     return propertyReader.readProperty(PropertyKeys.POSTGRES_PASSWORD);
+  }
+
+  public int getPostgresPort() {
+    final String value = propertyReader.readProperty(PropertyKeys.POSTGRES_PORT);
+    return !value.isEmpty() ? Integer.parseInt(value) : DefaultValues.POSTGRES_PORT;
+  }
+
+  public String getPostgresUser() {
+    return propertyReader.readProperty(PropertyKeys.POSTGRES_USER);
   }
 
   public boolean isMaintenanceMode() {
@@ -49,7 +64,17 @@ public final class LobbyPropertyReader {
   public interface PropertyKeys {
     String MAINTENANCE_MODE = "maintenance_mode";
     String PORT = "port";
-    String POSTGRES_USER = "postgres_user";
+    String POSTGRES_DATABASE = "postgres_database";
+    String POSTGRES_HOST = "postgres_host";
     String POSTGRES_PASSWORD = "postgres_password";
+    String POSTGRES_PORT = "postgres_port";
+    String POSTGRES_USER = "postgres_user";
+  }
+
+  @VisibleForTesting
+  interface DefaultValues {
+    String POSTGRES_DATABASE = "ta_users";
+    String POSTGRES_HOST = "localhost";
+    int POSTGRES_PORT = 5432;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -5,15 +5,18 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.engine.lobby.server.LobbyContext;
 
 /**
  * Utility to get connections to the database.
  */
-public class Database {
-  private static final Properties connectionProperties = getPostgresDbProps();
+public final class Database {
+  private static final Properties connectionProperties = getConnectionProperties();
 
-  private static Properties getPostgresDbProps() {
+  private Database() {}
+
+  private static Properties getConnectionProperties() {
     final Properties props = new Properties();
     props.put("user", LobbyContext.lobbyPropertyReader().getPostgresUser());
     props.put("password", LobbyContext.lobbyPropertyReader().getPostgresPassword());
@@ -25,8 +28,7 @@ public class Database {
    */
   public static Connection getPostgresConnection() {
     try {
-      final Connection connection =
-          DriverManager.getConnection("jdbc:postgresql://localhost/ta_users", connectionProperties);
+      final Connection connection = DriverManager.getConnection(getConnectionUrl(), connectionProperties);
       connection.setAutoCommit(false);
       return connection;
     } catch (final SQLException e) {
@@ -34,4 +36,12 @@ public class Database {
     }
   }
 
+  private static String getConnectionUrl() {
+    final LobbyPropertyReader lobbyPropertyReader = LobbyContext.lobbyPropertyReader();
+    return String.format(
+        "jdbc:postgresql://%s:%d/%s",
+        lobbyPropertyReader.getPostgresHost(),
+        lobbyPropertyReader.getPostgresPort(),
+        lobbyPropertyReader.getPostgresDatabase());
+  }
 }

--- a/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -1,60 +1,175 @@
 package games.strategy.engine.config.lobby;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.config.MemoryPropertyReader;
+import games.strategy.engine.config.lobby.LobbyPropertyReader.DefaultValues;
 import games.strategy.engine.config.lobby.LobbyPropertyReader.PropertyKeys;
 
-public class LobbyPropertyReaderTest {
+public final class LobbyPropertyReaderTest {
   private static LobbyPropertyReader newLobbyPropertyReader(final String key, final String value) {
     return new LobbyPropertyReader(new MemoryPropertyReader(Collections.singletonMap(key, value)));
   }
 
-  @Test
-  public void getPort() {
-    final int value = 100;
-    final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, String.valueOf(value));
+  @Nested
+  public final class GetPortTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final int value = 100;
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, String.valueOf(value));
 
-    assertThat(lobbyPropertyReader.getPort(), is(value));
+      assertThat(lobbyPropertyReader.getPort(), is(value));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, "");
+
+      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPort());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMalformed() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, "other");
+
+      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPort());
+    }
   }
 
-  @Test
-  public void postgresUser() {
-    final String value = "funnyName";
-    final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, value);
+  @Nested
+  public final class GetPostgresDatabaseTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final String value = "database";
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_DATABASE, value);
 
-    assertThat(lobbyPropertyReader.getPostgresUser(), is(value));
+      assertThat(lobbyPropertyReader.getPostgresDatabase(), is(value));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_DATABASE, "");
+
+      assertThat(lobbyPropertyReader.getPostgresDatabase(), is(DefaultValues.POSTGRES_DATABASE));
+    }
   }
 
-  @Test
-  public void postgresPassword() {
-    final String value = "funnyPasssword";
-    final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, value);
+  @Nested
+  public final class GetPostgresHostTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final String value = "myhost.mydomain";
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_HOST, value);
 
-    assertThat(lobbyPropertyReader.getPostgresPassword(), is(value));
+      assertThat(lobbyPropertyReader.getPostgresHost(), is(value));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_HOST, "");
+
+      assertThat(lobbyPropertyReader.getPostgresHost(), is(DefaultValues.POSTGRES_HOST));
+    }
   }
 
-  @Test
-  public void isMaintenanceMode_ShouldReturnTrueWhenMaintenanceModeEnabled() {
-    Arrays.asList("true", "TRUE")
-        .forEach(value -> {
-          final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
-          assertThat(lobbyPropertyReader.isMaintenanceMode(), is(true));
-        });
+  @Nested
+  public final class GetPostgresPasswordTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final String value = "funnyPasssword";
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, value);
+
+      assertThat(lobbyPropertyReader.getPostgresPassword(), is(value));
+    }
+
+    @Test
+    public void shouldReturnEmptyStringWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, "");
+
+      assertThat(lobbyPropertyReader.getPostgresPassword(), is(emptyString()));
+    }
   }
 
-  @Test
-  public void isMaintenanceMode_ShouldReturnFalseWhenMaintenanceModeDisabled() {
-    Arrays.asList("", "false", "FALSE", "other")
-        .forEach(value -> {
-          final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
-          assertThat(lobbyPropertyReader.isMaintenanceMode(), is(false));
-        });
+  @Nested
+  public final class GetPostgresPortTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final int value = 1234;
+      final LobbyPropertyReader lobbyPropertyReader =
+          newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, String.valueOf(value));
+
+      assertThat(lobbyPropertyReader.getPostgresPort(), is(value));
+    }
+
+    @Test
+    public void shouldReturnDefaultValueWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, "");
+
+      assertThat(lobbyPropertyReader.getPostgresPort(), is(DefaultValues.POSTGRES_PORT));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenMalformed() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, "other");
+
+      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPostgresPort());
+    }
+  }
+
+  @Nested
+  public final class GetPostgresUserTest {
+    @Test
+    public void shouldReturnValueFromDelegateWhenPresent() {
+      final String value = "funnyName";
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, value);
+
+      assertThat(lobbyPropertyReader.getPostgresUser(), is(value));
+    }
+
+    @Test
+    public void shouldReturnEmptyStringWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, "");
+
+      assertThat(lobbyPropertyReader.getPostgresUser(), is(emptyString()));
+    }
+  }
+
+  @Nested
+  public final class IsMaintenanceModeTest {
+    @Test
+    public void shouldReturnTrueWhenPresentAndEnabled() {
+      Arrays.asList("true", "TRUE")
+          .forEach(value -> {
+            final LobbyPropertyReader lobbyPropertyReader =
+                newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
+            assertThat(lobbyPropertyReader.isMaintenanceMode(), is(true));
+          });
+    }
+
+    @Test
+    public void shouldReturnFalseWhenPresentAndDisabled() {
+      Arrays.asList("false", "FALSE", "other")
+          .forEach(value -> {
+            final LobbyPropertyReader lobbyPropertyReader =
+                newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
+            assertThat(lobbyPropertyReader.isMaintenanceMode(), is(false));
+          });
+    }
+
+    @Test
+    public void shouldReturnFalseWhenAbsent() {
+      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, "");
+
+      assertThat(lobbyPropertyReader.isMaintenanceMode(), is(false));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -3,9 +3,7 @@ package games.strategy.engine.config.lobby;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Nested;
@@ -23,7 +21,7 @@ public final class LobbyPropertyReaderTest {
   @Nested
   public final class GetPortTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final int value = 100;
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, String.valueOf(value));
 
@@ -31,24 +29,17 @@ public final class LobbyPropertyReaderTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenAbsent() {
+    public void shouldReturnDefaultValueWhenAbsent() {
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, "");
 
-      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPort());
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenMalformed() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, "other");
-
-      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPort());
+      assertThat(lobbyPropertyReader.getPort(), is(DefaultValues.PORT));
     }
   }
 
   @Nested
   public final class GetPostgresDatabaseTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final String value = "database";
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_DATABASE, value);
 
@@ -66,7 +57,7 @@ public final class LobbyPropertyReaderTest {
   @Nested
   public final class GetPostgresHostTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final String value = "myhost.mydomain";
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_HOST, value);
 
@@ -84,7 +75,7 @@ public final class LobbyPropertyReaderTest {
   @Nested
   public final class GetPostgresPasswordTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final String value = "funnyPasssword";
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, value);
 
@@ -102,7 +93,7 @@ public final class LobbyPropertyReaderTest {
   @Nested
   public final class GetPostgresPortTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final int value = 1234;
       final LobbyPropertyReader lobbyPropertyReader =
           newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, String.valueOf(value));
@@ -116,19 +107,12 @@ public final class LobbyPropertyReaderTest {
 
       assertThat(lobbyPropertyReader.getPostgresPort(), is(DefaultValues.POSTGRES_PORT));
     }
-
-    @Test
-    public void shouldThrowExceptionWhenMalformed() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, "other");
-
-      assertThrows(NumberFormatException.class, () -> lobbyPropertyReader.getPostgresPort());
-    }
   }
 
   @Nested
   public final class GetPostgresUserTest {
     @Test
-    public void shouldReturnValueFromDelegateWhenPresent() {
+    public void shouldReturnValueWhenPresent() {
       final String value = "funnyName";
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, value);
 
@@ -146,30 +130,19 @@ public final class LobbyPropertyReaderTest {
   @Nested
   public final class IsMaintenanceModeTest {
     @Test
-    public void shouldReturnTrueWhenPresentAndEnabled() {
-      Arrays.asList("true", "TRUE")
-          .forEach(value -> {
-            final LobbyPropertyReader lobbyPropertyReader =
-                newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
-            assertThat(lobbyPropertyReader.isMaintenanceMode(), is(true));
-          });
+    public void shouldReturnValueWhenPresent() {
+      final boolean value = !DefaultValues.MAINTENANCE_MODE;
+      final LobbyPropertyReader lobbyPropertyReader =
+          newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, String.valueOf(value));
+
+      assertThat(lobbyPropertyReader.isMaintenanceMode(), is(value));
     }
 
     @Test
-    public void shouldReturnFalseWhenPresentAndDisabled() {
-      Arrays.asList("false", "FALSE", "other")
-          .forEach(value -> {
-            final LobbyPropertyReader lobbyPropertyReader =
-                newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, value);
-            assertThat(lobbyPropertyReader.isMaintenanceMode(), is(false));
-          });
-    }
-
-    @Test
-    public void shouldReturnFalseWhenAbsent() {
+    public void shouldReturnDefaultValueWhenAbsent() {
       final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, "");
 
-      assertThat(lobbyPropertyReader.isMaintenanceMode(), is(false));
+      assertThat(lobbyPropertyReader.isMaintenanceMode(), is(DefaultValues.MAINTENANCE_MODE));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -136,8 +137,10 @@ public final class LobbyLoginValidatorTest {
     }
 
     final void givenMaintenanceModeIsEnabled() {
-      when(propertyReader.readProperty(LobbyPropertyReader.PropertyKeys.MAINTENANCE_MODE))
-          .thenReturn(Boolean.TRUE.toString());
+      when(propertyReader.readBooleanPropertyOrDefault(
+          eq(LobbyPropertyReader.PropertyKeys.MAINTENANCE_MODE),
+          anyBoolean()))
+              .thenReturn(true);
     }
 
     private void givenNoMacIsBanned() {


### PR DESCRIPTION
This PR allows the lobby database connection string to be customized.  This will provide some flexibility for creating a staging lobby and possibly Dockerizing the lobby in the future.

#### Functional changes

* Allow the following properties to be specified in _lobby.properties_:
    * `postgres_host`: The name or IP address of the Postgres database host (defaults to `localhost`).
    * `postgres_port`: The port on which the Postgres database is listening for connections (defaults to `5432`).
    * `postgres_database`: The name of the Postgres database to which the lobby will connect (defaults to `ta_users`).
* Add a default value (3304) for the existing `port` property, and remove the explicit value from the properties file.
* Previously, if an invalid value was provided for `port`, an exception would be raised and the lobby would terminate.  During the refactoring of `PropertyReader` (see below), I implemented the same behavior as `java.util.prefs.Preferences#getInt()`, which returns the default value if the specified value cannot be parsed.  Therefore, if an invalid value is now provided for this property, the default value (3304) will be used, a warning about the malformed property will be logged, and the lobby will continue to run.
* Removed the explicit value for `maintenance_mode` from the properties file since it already had an implicit default value of `false`.  (The implicit default value was made explicit in this PR as part of the refactoring below.)

#### Refactoring changes

The second commit is pretty much all refactoring.  I extracted helpers to the `PropertyReader` interface for reading properties and using a default value if the property does not exist.  The `LobbyPropertyReader` class makes use of these helpers extensively.

#### Notes

Most of the changes in this PR are due to new tests and test refactoring.