### PR TITLE
Fix unchecked warnings in MutableProperty usage

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.net.GUID;
@@ -151,16 +150,14 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("owner",
             MutableProperty.ofSimple(
-                TypeToken.of(PlayerID.class),
                 this::setOwner,
                 this::getOwner))
-        .put("uid", MutableProperty.ofReadOnlySimple(TypeToken.of(GUID.class), this::getId))
+        .put("uid", MutableProperty.ofReadOnlySimple(this::getId))
         .put("hits",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setHits,
                 this::getHits))
-        .put("type", MutableProperty.ofReadOnlySimple(TypeToken.of(UnitType.class), this::getType))
+        .put("type", MutableProperty.ofReadOnlySimple(this::getType))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.net.GUID;
@@ -150,15 +151,16 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("owner",
             MutableProperty.ofSimple(
-                PlayerID.class,
+                TypeToken.of(PlayerID.class),
                 this::setOwner,
                 this::getOwner))
-        .put("uid", MutableProperty.ofSimple(GUID.class, this::getId))
+        .put("uid", MutableProperty.ofReadOnlySimple(TypeToken.of(GUID.class), this::getId))
         .put("hits",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setHits,
                 this::getHits))
-        .put("type", MutableProperty.ofSimple(UnitType.class, this::getType))
+        .put("type", MutableProperty.ofReadOnlySimple(TypeToken.of(UnitType.class), this::getType))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -519,108 +518,87 @@ public class TripleAUnit extends Unit {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("transportedBy",
             MutableProperty.ofSimple(
-                TypeToken.of(TripleAUnit.class),
                 this::setTransportedBy,
                 this::getTransportedBy))
         .put("unloaded",
             MutableProperty.ofSimple(
-                new TypeToken<List<Unit>>() {},
                 this::setUnloaded,
                 this::getUnloaded))
         .put("wasLoadedThisTurn",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasLoadedThisTurn,
                 this::getWasLoadedThisTurn))
         .put("unloadedTo",
             MutableProperty.ofSimple(
-                TypeToken.of(Territory.class),
                 this::setUnloadedTo,
                 this::getUnloadedTo))
         .put("wasUnloadedInCombatPhase",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasUnloadedInCombatPhase,
                 this::getWasUnloadedInCombatPhase))
         .put("alreadyMoved",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setAlreadyMoved,
                 this::getAlreadyMoved))
         .put("bonusMovement",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setBonusMovement,
                 this::getBonusMovement))
         .put("unitDamage",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setUnitDamage,
                 this::getUnitDamage))
         .put("submerged",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setSubmerged,
                 this::getSubmerged))
         .put("originalOwner",
             MutableProperty.ofSimple(
-                TypeToken.of(PlayerID.class),
                 this::setOriginalOwner,
                 this::getOriginalOwner))
         .put("wasInCombat",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasInCombat,
                 this::getWasInCombat))
         .put("wasLoadedAfterCombat",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasLoadedAfterCombat,
                 this::getWasLoadedAfterCombat))
         .put("wasAmphibious",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasAmphibious,
                 this::getWasAmphibious))
         .put("originatedFrom",
             MutableProperty.ofSimple(
-                TypeToken.of(Territory.class),
                 this::setOriginatedFrom,
                 this::getOriginatedFrom))
         .put("wasScrambled",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasScrambled,
                 this::getWasScrambled))
         .put("maxScrambleCount",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount))
         .put("wasInAirBattle",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setWasInAirBattle,
                 this::getWasInAirBattle))
         .put("disabled",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setDisabled,
                 this::getDisabled))
         .put("launched",
             MutableProperty.ofSimple(
-                TypeToken.of(Integer.class),
                 this::setLaunched,
                 this::getLaunched))
         .put("airborne",
             MutableProperty.ofSimple(
-                TypeToken.of(Boolean.class),
                 this::setAirborne,
                 this::getAirborne))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -518,92 +519,108 @@ public class TripleAUnit extends Unit {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("transportedBy",
             MutableProperty.ofSimple(
-                TripleAUnit.class,
+                TypeToken.of(TripleAUnit.class),
                 this::setTransportedBy,
                 this::getTransportedBy))
         .put("unloaded",
             MutableProperty.ofSimple(
-                List.class,
+                new TypeToken<List<Unit>>() {},
                 this::setUnloaded,
                 this::getUnloaded))
         .put("wasLoadedThisTurn",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasLoadedThisTurn,
                 this::getWasLoadedThisTurn))
         .put("unloadedTo",
             MutableProperty.ofSimple(
-                Territory.class,
+                TypeToken.of(Territory.class),
                 this::setUnloadedTo,
                 this::getUnloadedTo))
         .put("wasUnloadedInCombatPhase",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasUnloadedInCombatPhase,
                 this::getWasUnloadedInCombatPhase))
         .put("alreadyMoved",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setAlreadyMoved,
                 this::getAlreadyMoved))
         .put("bonusMovement",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setBonusMovement,
                 this::getBonusMovement))
         .put("unitDamage",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setUnitDamage,
                 this::getUnitDamage))
         .put("submerged",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setSubmerged,
                 this::getSubmerged))
         .put("originalOwner",
             MutableProperty.ofSimple(
-                PlayerID.class,
+                TypeToken.of(PlayerID.class),
                 this::setOriginalOwner,
                 this::getOriginalOwner))
         .put("wasInCombat",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasInCombat,
                 this::getWasInCombat))
         .put("wasLoadedAfterCombat",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasLoadedAfterCombat,
                 this::getWasLoadedAfterCombat))
         .put("wasAmphibious",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasAmphibious,
                 this::getWasAmphibious))
         .put("originatedFrom",
             MutableProperty.ofSimple(
-                Territory.class,
+                TypeToken.of(Territory.class),
                 this::setOriginatedFrom,
                 this::getOriginatedFrom))
         .put("wasScrambled",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasScrambled,
                 this::getWasScrambled))
         .put("maxScrambleCount",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount))
         .put("wasInAirBattle",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setWasInAirBattle,
                 this::getWasInAirBattle))
         .put("disabled",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setDisabled,
                 this::getDisabled))
         .put("launched",
-            MutableProperty.ofSimpleInteger(
+            MutableProperty.ofSimple(
+                TypeToken.of(Integer.class),
                 this::setLaunched,
                 this::getLaunched))
         .put("airborne",
-            MutableProperty.ofSimpleBoolean(
+            MutableProperty.ofSimple(
+                TypeToken.of(Boolean.class),
                 this::setAirborne,
                 this::getAirborne))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -398,12 +397,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("conditions",
             MutableProperty.of(
-                new TypeToken<List<RulesAttachment>>() {},
                 this::setConditions,
                 this::setConditions,
                 this::getConditions,
@@ -415,7 +412,6 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::resetConditionType))
         .put("invert",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setInvert,
                 this::setInvert,
                 this::getInvert,
@@ -427,14 +423,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::resetChance))
         .put("chanceIncrementOnFailure",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setChanceIncrementOnFailure,
                 this::setChanceIncrementOnFailure,
                 this::getChanceIncrementOnFailure,
                 this::resetChanceIncrementOnFailure))
         .put("chanceDecrementOnSuccess",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setChanceDecrementOnSuccess,
                 this::setChanceDecrementOnSuccess,
                 this::getChanceDecrementOnSuccess,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -397,11 +398,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("conditions",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<RulesAttachment>>() {},
                 this::setConditions,
                 this::setConditions,
                 this::getConditions,
@@ -412,7 +414,8 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::getConditionType,
                 this::resetConditionType))
         .put("invert",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setInvert,
                 this::setInvert,
                 this::getInvert,
@@ -423,13 +426,15 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
                 this::getChance,
                 this::resetChance))
         .put("chanceIncrementOnFailure",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setChanceIncrementOnFailure,
                 this::setChanceIncrementOnFailure,
                 this::getChanceIncrementOnFailure,
                 this::resetChanceIncrementOnFailure))
         .put("chanceDecrementOnSuccess",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setChanceDecrementOnSuccess,
                 this::setChanceDecrementOnSuccess,
                 this::getChanceDecrementOnSuccess,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.attachments;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -335,6 +336,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
@@ -345,68 +347,77 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
                 this::resetMovementRestrictionType))
         .put("movementRestrictionTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setMovementRestrictionTerritories,
                 this::setMovementRestrictionTerritories,
                 this::getMovementRestrictionTerritories,
                 this::resetMovementRestrictionTerritories))
         .put("placementAnyTerritory",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setPlacementAnyTerritory,
                 this::setPlacementAnyTerritory,
                 this::getPlacementAnyTerritory,
                 this::resetPlacementAnyTerritory))
         .put("placementAnySeaZone",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setPlacementAnySeaZone,
                 this::setPlacementAnySeaZone,
                 this::getPlacementAnySeaZone,
                 this::resetPlacementAnySeaZone))
         .put("placementCapturedTerritory",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setPlacementCapturedTerritory,
                 this::setPlacementCapturedTerritory,
                 this::getPlacementCapturedTerritory,
                 this::resetPlacementCapturedTerritory))
         .put("unlimitedProduction",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setUnlimitedProduction,
                 this::setUnlimitedProduction,
                 this::getUnlimitedProduction,
                 this::resetUnlimitedProduction))
         .put("placementInCapitalRestricted",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setPlacementInCapitalRestricted,
                 this::setPlacementInCapitalRestricted,
                 this::getPlacementInCapitalRestricted,
                 this::resetPlacementInCapitalRestricted))
         .put("dominatingFirstRoundAttack",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setDominatingFirstRoundAttack,
                 this::setDominatingFirstRoundAttack,
                 this::getDominatingFirstRoundAttack,
                 this::resetDominatingFirstRoundAttack))
         .put("negateDominatingFirstRoundAttack",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setNegateDominatingFirstRoundAttack,
                 this::setNegateDominatingFirstRoundAttack,
                 this::getNegateDominatingFirstRoundAttack,
                 this::resetNegateDominatingFirstRoundAttack))
         .put("productionPerXTerritories",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setProductionPerXTerritories,
                 this::setProductionPerXTerritories,
                 this::getProductionPerXTerritories,
                 this::resetProductionPerXTerritories))
         .put("placementPerTerritory",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setPlacementPerTerritory,
                 this::setPlacementPerTerritory,
                 this::getPlacementPerTerritory,
                 this::resetPlacementPerTerritory))
         .put("maxPlacePerTerritory",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxPlacePerTerritory,
                 this::setMaxPlacePerTerritory,
                 this::getMaxPlacePerTerritory,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.attachments;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -336,7 +335,6 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
@@ -347,77 +345,66 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
                 this::resetMovementRestrictionType))
         .put("movementRestrictionTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setMovementRestrictionTerritories,
                 this::setMovementRestrictionTerritories,
                 this::getMovementRestrictionTerritories,
                 this::resetMovementRestrictionTerritories))
         .put("placementAnyTerritory",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setPlacementAnyTerritory,
                 this::setPlacementAnyTerritory,
                 this::getPlacementAnyTerritory,
                 this::resetPlacementAnyTerritory))
         .put("placementAnySeaZone",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setPlacementAnySeaZone,
                 this::setPlacementAnySeaZone,
                 this::getPlacementAnySeaZone,
                 this::resetPlacementAnySeaZone))
         .put("placementCapturedTerritory",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setPlacementCapturedTerritory,
                 this::setPlacementCapturedTerritory,
                 this::getPlacementCapturedTerritory,
                 this::resetPlacementCapturedTerritory))
         .put("unlimitedProduction",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setUnlimitedProduction,
                 this::setUnlimitedProduction,
                 this::getUnlimitedProduction,
                 this::resetUnlimitedProduction))
         .put("placementInCapitalRestricted",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setPlacementInCapitalRestricted,
                 this::setPlacementInCapitalRestricted,
                 this::getPlacementInCapitalRestricted,
                 this::resetPlacementInCapitalRestricted))
         .put("dominatingFirstRoundAttack",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setDominatingFirstRoundAttack,
                 this::setDominatingFirstRoundAttack,
                 this::getDominatingFirstRoundAttack,
                 this::resetDominatingFirstRoundAttack))
         .put("negateDominatingFirstRoundAttack",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setNegateDominatingFirstRoundAttack,
                 this::setNegateDominatingFirstRoundAttack,
                 this::getNegateDominatingFirstRoundAttack,
                 this::resetNegateDominatingFirstRoundAttack))
         .put("productionPerXTerritories",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setProductionPerXTerritories,
                 this::setProductionPerXTerritories,
                 this::getProductionPerXTerritories,
                 this::resetProductionPerXTerritories))
         .put("placementPerTerritory",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setPlacementPerTerritory,
                 this::setPlacementPerTerritory,
                 this::getPlacementPerTerritory,
                 this::resetPlacementPerTerritory))
         .put("maxPlacePerTerritory",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxPlacePerTerritory,
                 this::setMaxPlacePerTerritory,
                 this::getMaxPlacePerTerritory,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -435,39 +436,43 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
-        .put("countEach", MutableProperty.ofReadOnlyBoolean(this::getCountEach))
-        .put("eachMultiple", MutableProperty.ofReadOnlyInteger(this::getEachMultiple))
+        .put("countEach", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getCountEach))
+        .put("eachMultiple", MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getEachMultiple))
         .put("players",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("objectiveValue",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setObjectiveValue,
                 this::setObjectiveValue,
                 this::getObjectiveValue,
                 this::resetObjectiveValue))
         .put("uses",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("turns",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<Integer, Integer>>() {},
                 this::setTurns,
                 this::setTurns,
                 this::getTurns,
                 this::resetTurns))
         .put("switch",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setSwitch,
                 this::setSwitch,
                 this::getSwitch,
@@ -477,7 +482,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
                 this::setGameProperty,
                 this::getGameProperty,
                 this::resetGameProperty))
-        .put("rounds", MutableProperty.of(String.class, this::setRounds, this::setRounds))
+        .put("rounds", MutableProperty.ofWriteOnlyString(this::setRounds))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -436,43 +435,37 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
-        .put("countEach", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getCountEach))
-        .put("eachMultiple", MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getEachMultiple))
+        .put("countEach", MutableProperty.ofReadOnly(this::getCountEach))
+        .put("eachMultiple", MutableProperty.ofReadOnly(this::getEachMultiple))
         .put("players",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("objectiveValue",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setObjectiveValue,
                 this::setObjectiveValue,
                 this::getObjectiveValue,
                 this::resetObjectiveValue))
         .put("uses",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("turns",
             MutableProperty.of(
-                new TypeToken<Map<Integer, Integer>>() {},
                 this::setTurns,
                 this::setTurns,
                 this::getTurns,
                 this::resetTurns))
         .put("switch",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setSwitch,
                 this::setSwitch,
                 this::getSwitch,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.CompositeChange;
@@ -311,20 +310,17 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("uses",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("usedThisRound",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setUsedThisRound,
                 this::setUsedThisRound,
                 this::getUsedThisRound,
@@ -336,14 +332,12 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
                 this::resetNotification))
         .put("when",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setWhen,
                 this::setWhen,
                 this::getWhen,
                 this::resetWhen))
         .put("trigger",
             MutableProperty.of(
-                new TypeToken<List<RulesAttachment>>() {},
                 l -> {
                   throw new IllegalStateException("Can't set trigger directly");
                 },

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.CompositeChange;
@@ -310,17 +311,20 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("uses",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setUses,
                 this::setUses,
                 this::getUses,
                 this::resetUses))
         .put("usedThisRound",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setUsedThisRound,
                 this::setUsedThisRound,
                 this::getUsedThisRound,
@@ -332,14 +336,14 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
                 this::resetNotification))
         .put("when",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setWhen,
                 this::setWhen,
                 this::getWhen,
                 this::resetWhen))
         .put("trigger",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<RulesAttachment>>() {},
                 l -> {
                   throw new IllegalStateException("Can't set trigger directly");
                 },

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -211,7 +210,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
@@ -222,28 +220,24 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
                 this::resetText))
         .put("costPU",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCostPU,
                 this::setCostPU,
                 this::getCostPU,
                 this::resetCostPU))
         .put("attemptsPerTurn",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttemptsPerTurn,
                 this::setAttemptsPerTurn,
                 this::getAttemptsPerTurn,
                 this::resetAttemptsPerTurn))
         .put("attemptsLeftThisTurn",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttemptsLeftThisTurn,
                 this::setAttemptsLeftThisTurn,
                 this::getAttemptsLeftThisTurn,
                 this::resetAttemptsLeftThisTurn))
         .put("actionAccept",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setActionAccept,
                 this::setActionAccept,
                 this::getActionAccept,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -210,6 +211,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
@@ -219,26 +221,29 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
                 this::getText,
                 this::resetText))
         .put("costPU",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCostPU,
                 this::setCostPU,
                 this::getCostPU,
                 this::resetCostPU))
         .put("attemptsPerTurn",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttemptsPerTurn,
                 this::setAttemptsPerTurn,
                 this::getAttemptsPerTurn,
                 this::resetAttemptsPerTurn))
         .put("attemptsLeftThisTurn",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttemptsLeftThisTurn,
                 this::setAttemptsLeftThisTurn,
                 this::getAttemptsLeftThisTurn,
                 this::resetAttemptsLeftThisTurn))
         .put("actionAccept",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setActionAccept,
                 this::setActionAccept,
                 this::getActionAccept,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -171,20 +170,17 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("canalName", MutableProperty.ofString(this::setCanalName, this::getCanalName, this::resetCanalName))
         .put("landTerritories",
             MutableProperty.of(
-                new TypeToken<Set<Territory>>() {},
                 this::setLandTerritories,
                 this::setLandTerritories,
                 this::getLandTerritories,
                 this::resetLandTerritories))
         .put("excludedUnits",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setExcludedUnits,
                 this::setExcludedUnits,
                 this::getExcludedUnits,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -170,19 +171,20 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("canalName", MutableProperty.ofString(this::setCanalName, this::getCanalName, this::resetCanalName))
         .put("landTerritories",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<Territory>>() {},
                 this::setLandTerritories,
                 this::setLandTerritories,
                 this::getLandTerritories,
                 this::resetLandTerritories))
         .put("excludedUnits",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setExcludedUnits,
                 this::setExcludedUnits,
                 this::getExcludedUnits,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -597,110 +596,94 @@ public class PlayerAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("vps",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setVps,
                 this::setVps,
                 this::getVps,
                 this::resetVps))
         .put("captureVps",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCaptureVps,
                 this::setCaptureVps,
                 this::getCaptureVps,
                 this::resetCaptureVps))
         .put("retainCapitalNumber",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setRetainCapitalNumber,
                 this::setRetainCapitalNumber,
                 this::getRetainCapitalNumber,
                 this::resetRetainCapitalNumber))
         .put("retainCapitalProduceNumber",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setRetainCapitalProduceNumber,
                 this::setRetainCapitalProduceNumber,
                 this::getRetainCapitalProduceNumber,
                 this::resetRetainCapitalProduceNumber))
         .put("giveUnitControl",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setGiveUnitControl,
                 this::setGiveUnitControl,
                 this::getGiveUnitControl,
                 this::resetGiveUnitControl))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("shareTechnology",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setShareTechnology,
                 this::setShareTechnology,
                 this::getShareTechnology,
                 this::resetShareTechnology))
         .put("helpPayTechCost",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setHelpPayTechCost,
                 this::setHelpPayTechCost,
                 this::getHelpPayTechCost,
                 this::resetHelpPayTechCost))
         .put("destroysPUs",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setDestroysPUs,
                 this::setDestroysPUs,
                 this::getDestroysPUs,
                 this::resetDestroysPUs))
         .put("immuneToBlockade",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setImmuneToBlockade,
                 this::setImmuneToBlockade,
                 this::getImmuneToBlockade,
                 this::resetImmuneToBlockade))
         .put("suicideAttackResources",
             MutableProperty.of(
-                new TypeToken<IntegerMap<Resource>>() {},
                 this::setSuicideAttackResources,
                 this::setSuicideAttackResources,
                 this::getSuicideAttackResources,
                 this::resetSuicideAttackResources))
         .put("suicideAttackTargets",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setSuicideAttackTargets,
                 this::setSuicideAttackTargets,
                 this::getSuicideAttackTargets,
                 this::resetSuicideAttackTargets))
         .put("placementLimit",
             MutableProperty.of(
-                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("movementLimit",
             MutableProperty.of(
-                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attackingLimit",
             MutableProperty.of(
-                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -596,103 +597,110 @@ public class PlayerAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("vps",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setVps,
                 this::setVps,
                 this::getVps,
                 this::resetVps))
         .put("captureVps",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCaptureVps,
                 this::setCaptureVps,
                 this::getCaptureVps,
                 this::resetCaptureVps))
         .put("retainCapitalNumber",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setRetainCapitalNumber,
                 this::setRetainCapitalNumber,
                 this::getRetainCapitalNumber,
                 this::resetRetainCapitalNumber))
         .put("retainCapitalProduceNumber",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setRetainCapitalProduceNumber,
                 this::setRetainCapitalProduceNumber,
                 this::getRetainCapitalProduceNumber,
                 this::resetRetainCapitalProduceNumber))
         .put("giveUnitControl",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setGiveUnitControl,
                 this::setGiveUnitControl,
                 this::getGiveUnitControl,
                 this::resetGiveUnitControl))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("shareTechnology",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setShareTechnology,
                 this::setShareTechnology,
                 this::getShareTechnology,
                 this::resetShareTechnology))
         .put("helpPayTechCost",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setHelpPayTechCost,
                 this::setHelpPayTechCost,
                 this::getHelpPayTechCost,
                 this::resetHelpPayTechCost))
         .put("destroysPUs",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setDestroysPUs,
                 this::setDestroysPUs,
                 this::getDestroysPUs,
                 this::resetDestroysPUs))
         .put("immuneToBlockade",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setImmuneToBlockade,
                 this::setImmuneToBlockade,
                 this::getImmuneToBlockade,
                 this::resetImmuneToBlockade))
         .put("suicideAttackResources",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<Resource>>() {},
                 this::setSuicideAttackResources,
                 this::setSuicideAttackResources,
                 this::getSuicideAttackResources,
                 this::resetSuicideAttackResources))
         .put("suicideAttackTargets",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setSuicideAttackTargets,
                 this::setSuicideAttackTargets,
                 this::getSuicideAttackTargets,
                 this::resetSuicideAttackTargets))
         .put("placementLimit",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("movementLimit",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attackingLimit",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<Triple<Integer, String, Set<UnitType>>>>() {},
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -153,13 +152,11 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("relationshipChange",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
@@ -152,12 +153,13 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("relationshipChange",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.BattleRecordsList;
@@ -1165,34 +1166,35 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("techs",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<TechAdvance>>() {},
                 this::setTechs,
                 this::setTechs,
                 this::getTechs,
                 this::resetTechs))
         .put("techCount",
-            MutableProperty.ofReadOnlyInteger(this::getTechCount))
+            MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getTechCount))
         .put("relationship",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setRelationship,
                 this::setRelationship,
                 this::getRelationship,
                 this::resetRelationship))
         .put("atWarPlayers",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<PlayerID>>() {},
                 this::setAtWarPlayers,
                 this::setAtWarPlayers,
                 this::getAtWarPlayers,
                 this::resetAtWarPlayers))
         .put("atWarCount",
-            MutableProperty.ofReadOnlyInteger(this::getAtWarCount))
+            MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getAtWarCount))
         .put("destroyedTUV",
             MutableProperty.ofString(
                 this::setDestroyedTUV,
@@ -1200,77 +1202,77 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
                 this::resetDestroyedTUV))
         .put("battle",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, List<Territory>>>>() {},
                 this::setBattle,
                 this::setBattle,
                 this::getBattle,
                 this::resetBattle))
         .put("alliedOwnershipTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setAlliedOwnershipTerritories,
                 this::setAlliedOwnershipTerritories,
                 this::getAlliedOwnershipTerritories,
                 this::resetAlliedOwnershipTerritories))
         .put("directOwnershipTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setDirectOwnershipTerritories,
                 this::setDirectOwnershipTerritories,
                 this::getDirectOwnershipTerritories,
                 this::resetDirectOwnershipTerritories))
         .put("alliedExclusionTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setAlliedExclusionTerritories,
                 this::setAlliedExclusionTerritories,
                 this::getAlliedExclusionTerritories,
                 this::resetAlliedExclusionTerritories))
         .put("directExclusionTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setDirectExclusionTerritories,
                 this::setDirectExclusionTerritories,
                 this::getDirectExclusionTerritories,
                 this::resetDirectExclusionTerritories))
         .put("enemyExclusionTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setEnemyExclusionTerritories,
                 this::setEnemyExclusionTerritories,
                 this::getEnemyExclusionTerritories,
                 this::resetEnemyExclusionTerritories))
         .put("enemySurfaceExclusionTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setEnemySurfaceExclusionTerritories,
                 this::setEnemySurfaceExclusionTerritories,
                 this::getEnemySurfaceExclusionTerritories,
                 this::resetEnemySurfaceExclusionTerritories))
         .put("directPresenceTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setDirectPresenceTerritories,
                 this::setDirectPresenceTerritories,
                 this::getDirectPresenceTerritories,
                 this::resetDirectPresenceTerritories))
         .put("alliedPresenceTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setAlliedPresenceTerritories,
                 this::setAlliedPresenceTerritories,
                 this::getAlliedPresenceTerritories,
                 this::resetAlliedPresenceTerritories))
         .put("enemyPresenceTerritories",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setEnemyPresenceTerritories,
                 this::setEnemyPresenceTerritories,
                 this::getEnemyPresenceTerritories,
                 this::resetEnemyPresenceTerritories))
         .put("unitPresence",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<String>>() {},
                 this::setUnitPresence,
                 this::setUnitPresence,
                 this::getUnitPresence,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.BattleRecordsList;
@@ -1166,35 +1165,31 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("techs",
             MutableProperty.of(
-                new TypeToken<List<TechAdvance>>() {},
                 this::setTechs,
                 this::setTechs,
                 this::getTechs,
                 this::resetTechs))
         .put("techCount",
-            MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getTechCount))
+            MutableProperty.ofReadOnly(this::getTechCount))
         .put("relationship",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setRelationship,
                 this::setRelationship,
                 this::getRelationship,
                 this::resetRelationship))
         .put("atWarPlayers",
             MutableProperty.of(
-                new TypeToken<Set<PlayerID>>() {},
                 this::setAtWarPlayers,
                 this::setAtWarPlayers,
                 this::getAtWarPlayers,
                 this::resetAtWarPlayers))
         .put("atWarCount",
-            MutableProperty.ofReadOnly(TypeToken.of(Integer.class), this::getAtWarCount))
+            MutableProperty.ofReadOnly(this::getAtWarCount))
         .put("destroyedTUV",
             MutableProperty.ofString(
                 this::setDestroyedTUV,
@@ -1202,77 +1197,66 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
                 this::resetDestroyedTUV))
         .put("battle",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, List<Territory>>>>() {},
                 this::setBattle,
                 this::setBattle,
                 this::getBattle,
                 this::resetBattle))
         .put("alliedOwnershipTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setAlliedOwnershipTerritories,
                 this::setAlliedOwnershipTerritories,
                 this::getAlliedOwnershipTerritories,
                 this::resetAlliedOwnershipTerritories))
         .put("directOwnershipTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setDirectOwnershipTerritories,
                 this::setDirectOwnershipTerritories,
                 this::getDirectOwnershipTerritories,
                 this::resetDirectOwnershipTerritories))
         .put("alliedExclusionTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setAlliedExclusionTerritories,
                 this::setAlliedExclusionTerritories,
                 this::getAlliedExclusionTerritories,
                 this::resetAlliedExclusionTerritories))
         .put("directExclusionTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setDirectExclusionTerritories,
                 this::setDirectExclusionTerritories,
                 this::getDirectExclusionTerritories,
                 this::resetDirectExclusionTerritories))
         .put("enemyExclusionTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setEnemyExclusionTerritories,
                 this::setEnemyExclusionTerritories,
                 this::getEnemyExclusionTerritories,
                 this::resetEnemyExclusionTerritories))
         .put("enemySurfaceExclusionTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setEnemySurfaceExclusionTerritories,
                 this::setEnemySurfaceExclusionTerritories,
                 this::getEnemySurfaceExclusionTerritories,
                 this::resetEnemySurfaceExclusionTerritories))
         .put("directPresenceTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setDirectPresenceTerritories,
                 this::setDirectPresenceTerritories,
                 this::getDirectPresenceTerritories,
                 this::resetDirectPresenceTerritories))
         .put("alliedPresenceTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setAlliedPresenceTerritories,
                 this::setAlliedPresenceTerritories,
                 this::getAlliedPresenceTerritories,
                 this::resetAlliedPresenceTerritories))
         .put("enemyPresenceTerritories",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setEnemyPresenceTerritories,
                 this::setEnemyPresenceTerritories,
                 this::getEnemyPresenceTerritories,
                 this::resetEnemyPresenceTerritories))
         .put("unitPresence",
             MutableProperty.of(
-                new TypeToken<IntegerMap<String>>() {},
                 this::setUnitPresence,
                 this::setUnitPresence,
                 this::getUnitPresence,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -1085,164 +1086,173 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("attackBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAttackBonus,
                 this::setAttackBonus,
                 this::getAttackBonus,
                 this::resetAttackBonus))
         .put("defenseBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setDefenseBonus,
                 this::setDefenseBonus,
                 this::getDefenseBonus,
                 this::resetDefenseBonus))
         .put("movementBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setMovementBonus,
                 this::setMovementBonus,
                 this::getMovementBonus,
                 this::resetMovementBonus))
         .put("radarBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRadarBonus,
                 this::setRadarBonus,
                 this::getRadarBonus,
                 this::resetRadarBonus))
         .put("airAttackBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirAttackBonus,
                 this::setAirAttackBonus,
                 this::getAirAttackBonus,
                 this::resetAirAttackBonus))
         .put("airDefenseBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirDefenseBonus,
                 this::setAirDefenseBonus,
                 this::getAirDefenseBonus,
                 this::resetAirDefenseBonus))
         .put("productionBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setProductionBonus,
                 this::setProductionBonus,
                 this::getProductionBonus,
                 this::resetProductionBonus))
         .put("minimumTerritoryValueForProductionBonus",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::getMinimumTerritoryValueForProductionBonus,
                 this::resetMinimumTerritoryValueForProductionBonus))
         .put("repairDiscount",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setRepairDiscount,
                 this::setRepairDiscount,
                 this::getRepairDiscount,
                 this::resetRepairDiscount))
         .put("warBondDiceSides",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setWarBondDiceSides,
                 this::setWarBondDiceSides,
                 this::getWarBondDiceSides,
                 this::resetWarBondDiceSides))
         .put("warBondDiceNumber",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setWarBondDiceNumber,
                 this::setWarBondDiceNumber,
                 this::getWarBondDiceNumber,
                 this::resetWarBondDiceNumber))
         .put("rocketDiceNumber",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRocketDiceNumber,
                 this::setRocketDiceNumber,
                 this::getRocketDiceNumber,
                 this::resetRocketDiceNumber))
         .put("rocketDistance",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setRocketDistance,
                 this::setRocketDistance,
                 this::getRocketDistance,
                 this::resetRocketDistance))
         .put("rocketNumberPerTerritory",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setRocketNumberPerTerritory,
                 this::setRocketNumberPerTerritory,
                 this::getRocketNumberPerTerritory,
                 this::resetRocketNumberPerTerritory))
         .put("unitAbilitiesGained",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<UnitType, Set<String>>>() {},
                 this::setUnitAbilitiesGained,
                 this::setUnitAbilitiesGained,
                 this::getUnitAbilitiesGained,
                 this::resetUnitAbilitiesGained))
         .put("airborneForces",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setAirborneForces,
                 this::setAirborneForces,
                 this::getAirborneForces,
                 this::resetAirborneForces))
         .put("airborneCapacity",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirborneCapacity,
                 this::setAirborneCapacity,
                 this::getAirborneCapacity,
                 this::resetAirborneCapacity))
         .put("airborneTypes",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setAirborneTypes,
                 this::setAirborneTypes,
                 this::getAirborneTypes,
                 this::resetAirborneTypes))
         .put("airborneDistance",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAirborneDistance,
                 this::setAirborneDistance,
                 this::getAirborneDistance,
                 this::resetAirborneDistance))
         .put("airborneBases",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setAirborneBases,
                 this::setAirborneBases,
                 this::getAirborneBases,
                 this::resetAirborneBases))
         .put("airborneTargettedByAA",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<String, Set<UnitType>>>() {},
                 this::setAirborneTargettedByAA,
                 this::setAirborneTargettedByAA,
                 this::getAirborneTargettedByAA,
                 this::resetAirborneTargettedByAA))
         .put("attackRollsBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAttackRollsBonus,
                 this::setAttackRollsBonus,
                 this::getAttackRollsBonus,
                 this::resetAttackRollsBonus))
         .put("defenseRollsBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setDefenseRollsBonus,
                 this::setDefenseRollsBonus,
                 this::getDefenseRollsBonus,
                 this::resetDefenseRollsBonus))
         .put("bombingBonus",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -1086,173 +1085,148 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("attackBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAttackBonus,
                 this::setAttackBonus,
                 this::getAttackBonus,
                 this::resetAttackBonus))
         .put("defenseBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setDefenseBonus,
                 this::setDefenseBonus,
                 this::getDefenseBonus,
                 this::resetDefenseBonus))
         .put("movementBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setMovementBonus,
                 this::setMovementBonus,
                 this::getMovementBonus,
                 this::resetMovementBonus))
         .put("radarBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRadarBonus,
                 this::setRadarBonus,
                 this::getRadarBonus,
                 this::resetRadarBonus))
         .put("airAttackBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirAttackBonus,
                 this::setAirAttackBonus,
                 this::getAirAttackBonus,
                 this::resetAirAttackBonus))
         .put("airDefenseBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirDefenseBonus,
                 this::setAirDefenseBonus,
                 this::getAirDefenseBonus,
                 this::resetAirDefenseBonus))
         .put("productionBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setProductionBonus,
                 this::setProductionBonus,
                 this::getProductionBonus,
                 this::resetProductionBonus))
         .put("minimumTerritoryValueForProductionBonus",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::setMinimumTerritoryValueForProductionBonus,
                 this::getMinimumTerritoryValueForProductionBonus,
                 this::resetMinimumTerritoryValueForProductionBonus))
         .put("repairDiscount",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setRepairDiscount,
                 this::setRepairDiscount,
                 this::getRepairDiscount,
                 this::resetRepairDiscount))
         .put("warBondDiceSides",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setWarBondDiceSides,
                 this::setWarBondDiceSides,
                 this::getWarBondDiceSides,
                 this::resetWarBondDiceSides))
         .put("warBondDiceNumber",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setWarBondDiceNumber,
                 this::setWarBondDiceNumber,
                 this::getWarBondDiceNumber,
                 this::resetWarBondDiceNumber))
         .put("rocketDiceNumber",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRocketDiceNumber,
                 this::setRocketDiceNumber,
                 this::getRocketDiceNumber,
                 this::resetRocketDiceNumber))
         .put("rocketDistance",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setRocketDistance,
                 this::setRocketDistance,
                 this::getRocketDistance,
                 this::resetRocketDistance))
         .put("rocketNumberPerTerritory",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setRocketNumberPerTerritory,
                 this::setRocketNumberPerTerritory,
                 this::getRocketNumberPerTerritory,
                 this::resetRocketNumberPerTerritory))
         .put("unitAbilitiesGained",
             MutableProperty.of(
-                new TypeToken<Map<UnitType, Set<String>>>() {},
                 this::setUnitAbilitiesGained,
                 this::setUnitAbilitiesGained,
                 this::getUnitAbilitiesGained,
                 this::resetUnitAbilitiesGained))
         .put("airborneForces",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setAirborneForces,
                 this::setAirborneForces,
                 this::getAirborneForces,
                 this::resetAirborneForces))
         .put("airborneCapacity",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAirborneCapacity,
                 this::setAirborneCapacity,
                 this::getAirborneCapacity,
                 this::resetAirborneCapacity))
         .put("airborneTypes",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setAirborneTypes,
                 this::setAirborneTypes,
                 this::getAirborneTypes,
                 this::resetAirborneTypes))
         .put("airborneDistance",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAirborneDistance,
                 this::setAirborneDistance,
                 this::getAirborneDistance,
                 this::resetAirborneDistance))
         .put("airborneBases",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setAirborneBases,
                 this::setAirborneBases,
                 this::getAirborneBases,
                 this::resetAirborneBases))
         .put("airborneTargettedByAA",
             MutableProperty.of(
-                new TypeToken<Map<String, Set<UnitType>>>() {},
                 this::setAirborneTargettedByAA,
                 this::setAirborneTargettedByAA,
                 this::getAirborneTargettedByAA,
                 this::resetAirborneTargettedByAA))
         .put("attackRollsBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setAttackRollsBonus,
                 this::setAttackRollsBonus,
                 this::getAttackRollsBonus,
                 this::resetAttackRollsBonus))
         .put("defenseRollsBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setDefenseRollsBonus,
                 this::setDefenseRollsBonus,
                 this::getDefenseRollsBonus,
                 this::resetDefenseRollsBonus))
         .put("bombingBonus",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -425,91 +426,106 @@ public class TechAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("techCost",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setTechCost,
                 this::setTechCost,
                 this::getTechCost,
                 this::resetTechCost))
         .put("heavyBomber",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setHeavyBomber,
                 this::setHeavyBomber,
                 this::getHeavyBomber,
                 this::resetHeavyBomber))
         .put("longRangeAir",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setLongRangeAir,
                 this::setLongRangeAir,
                 this::getLongRangeAir,
                 this::resetLongRangeAir))
         .put("jetPower",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setJetPower,
                 this::setJetPower,
                 this::getJetPower,
                 this::resetJetPower))
         .put("rocket",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setRocket,
                 this::setRocket,
                 this::getRocket,
                 this::resetRocket))
         .put("industrialTechnology",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIndustrialTechnology,
                 this::setIndustrialTechnology,
                 this::getIndustrialTechnology,
                 this::resetIndustrialTechnology))
         .put("superSub",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setSuperSub,
                 this::setSuperSub,
                 this::getSuperSub,
                 this::resetSuperSub))
         .put("destroyerBombard",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setDestroyerBombard,
                 this::setDestroyerBombard,
                 this::getDestroyerBombard,
                 this::resetDestroyerBombard))
         .put("improvedArtillerySupport",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setImprovedArtillerySupport,
                 this::setImprovedArtillerySupport,
                 this::getImprovedArtillerySupport,
                 this::resetImprovedArtillerySupport))
         .put("paratroopers",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setParatroopers,
                 this::setParatroopers,
                 this::getParatroopers,
                 this::resetParatroopers))
         .put("increasedFactoryProduction",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIncreasedFactoryProduction,
                 this::setIncreasedFactoryProduction,
                 this::getIncreasedFactoryProduction,
                 this::resetIncreasedFactoryProduction))
         .put("warBonds",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setWarBonds,
                 this::setWarBonds,
                 this::getWarBonds,
                 this::resetWarBonds))
         .put("mechanizedInfantry",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setMechanizedInfantry,
                 this::setMechanizedInfantry,
                 this::getMechanizedInfantry,
                 this::resetMechanizedInfantry))
         .put("aARadar",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setAARadar,
                 this::setAARadar,
                 this::getAARadar,
                 this::resetAARadar))
         .put("shipyards",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setShipyards,
                 this::setShipyards,
                 this::getShipyards,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -427,105 +426,90 @@ public class TechAttachment extends DefaultAttachment {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("techCost",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setTechCost,
                 this::setTechCost,
                 this::getTechCost,
                 this::resetTechCost))
         .put("heavyBomber",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setHeavyBomber,
                 this::setHeavyBomber,
                 this::getHeavyBomber,
                 this::resetHeavyBomber))
         .put("longRangeAir",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setLongRangeAir,
                 this::setLongRangeAir,
                 this::getLongRangeAir,
                 this::resetLongRangeAir))
         .put("jetPower",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setJetPower,
                 this::setJetPower,
                 this::getJetPower,
                 this::resetJetPower))
         .put("rocket",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setRocket,
                 this::setRocket,
                 this::getRocket,
                 this::resetRocket))
         .put("industrialTechnology",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIndustrialTechnology,
                 this::setIndustrialTechnology,
                 this::getIndustrialTechnology,
                 this::resetIndustrialTechnology))
         .put("superSub",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setSuperSub,
                 this::setSuperSub,
                 this::getSuperSub,
                 this::resetSuperSub))
         .put("destroyerBombard",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setDestroyerBombard,
                 this::setDestroyerBombard,
                 this::getDestroyerBombard,
                 this::resetDestroyerBombard))
         .put("improvedArtillerySupport",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setImprovedArtillerySupport,
                 this::setImprovedArtillerySupport,
                 this::getImprovedArtillerySupport,
                 this::resetImprovedArtillerySupport))
         .put("paratroopers",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setParatroopers,
                 this::setParatroopers,
                 this::getParatroopers,
                 this::resetParatroopers))
         .put("increasedFactoryProduction",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIncreasedFactoryProduction,
                 this::setIncreasedFactoryProduction,
                 this::getIncreasedFactoryProduction,
                 this::resetIncreasedFactoryProduction))
         .put("warBonds",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setWarBonds,
                 this::setWarBonds,
                 this::getWarBonds,
                 this::resetWarBonds))
         .put("mechanizedInfantry",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setMechanizedInfantry,
                 this::setMechanizedInfantry,
                 this::getMechanizedInfantry,
                 this::resetMechanizedInfantry))
         .put("aARadar",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setAARadar,
                 this::setAARadar,
                 this::getAARadar,
                 this::resetAARadar))
         .put("shipyards",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setShipyards,
                 this::setShipyards,
                 this::getShipyards,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -823,6 +824,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("capital",
@@ -831,13 +833,15 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getCapital,
                 this::resetCapital))
         .put("originalFactory",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setOriginalFactory,
                 this::setOriginalFactory,
                 this::getOriginalFactory,
                 this::resetOriginalFactory))
         .put("production",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setProduction,
                 this::setProduction,
                 this::getProduction,
@@ -846,98 +850,106 @@ public class TerritoryAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setProductionOnly))
         .put("victoryCity",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setVictoryCity,
                 this::setVictoryCity,
                 this::getVictoryCity,
                 this::resetVictoryCity))
         .put("isImpassable",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsImpassable,
                 this::setIsImpassable,
                 this::getIsImpassable,
                 this::resetIsImpassable))
         .put("originalOwner",
             MutableProperty.of(
-                PlayerID.class,
+                TypeToken.of(PlayerID.class),
                 this::setOriginalOwner,
                 this::setOriginalOwner,
                 this::getOriginalOwner,
                 this::resetOriginalOwner))
         .put("convoyRoute",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setConvoyRoute,
                 this::setConvoyRoute,
                 this::getConvoyRoute,
                 this::resetConvoyRoute))
         .put("convoyAttached",
             MutableProperty.of(
-                HashSet.class,
+                new TypeToken<HashSet<Territory>>() {},
                 this::setConvoyAttached,
                 this::setConvoyAttached,
                 this::getConvoyAttached,
                 this::resetConvoyAttached))
         .put("changeUnitOwners",
             MutableProperty.of(
-                ArrayList.class,
+                new TypeToken<ArrayList<PlayerID>>() {},
                 this::setChangeUnitOwners,
                 this::setChangeUnitOwners,
                 this::getChangeUnitOwners,
                 this::resetChangeUnitOwners))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
-                ArrayList.class,
+                new TypeToken<ArrayList<PlayerID>>() {},
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("navalBase",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setNavalBase,
                 this::setNavalBase,
                 this::getNavalBase,
                 this::resetNavalBase))
         .put("airBase",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setAirBase,
                 this::setAirBase,
                 this::getAirBase,
                 this::resetAirBase))
         .put("kamikazeZone",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setKamikazeZone,
                 this::setKamikazeZone,
                 this::getKamikazeZone,
                 this::resetKamikazeZone))
         .put("unitProduction",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setUnitProduction,
                 this::setUnitProduction,
                 this::getUnitProduction,
                 this::resetUnitProduction))
         .put("blockadeZone",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setBlockadeZone,
                 this::setBlockadeZone,
                 this::getBlockadeZone,
                 this::resetBlockadeZone))
         .put("territoryEffect",
             MutableProperty.of(
-                ArrayList.class,
+                new TypeToken<ArrayList<TerritoryEffect>>() {},
                 this::setTerritoryEffect,
                 this::setTerritoryEffect,
                 this::getTerritoryEffect,
                 this::resetTerritoryEffect))
         .put("whenCapturedByGoesTo",
             MutableProperty.of(
-                ArrayList.class,
+                new TypeToken<ArrayList<String>>() {},
                 this::setWhenCapturedByGoesTo,
                 this::setWhenCapturedByGoesTo,
                 this::getWhenCapturedByGoesTo,
                 this::resetWhenCapturedByGoesTo))
         .put("resources",
             MutableProperty.of(
-                ResourceCollection.class,
+                TypeToken.of(ResourceCollection.class),
                 this::setResources,
                 this::setResources,
                 this::getResources,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -824,7 +823,6 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("capital",
@@ -834,14 +832,12 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::resetCapital))
         .put("originalFactory",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setOriginalFactory,
                 this::setOriginalFactory,
                 this::getOriginalFactory,
                 this::resetOriginalFactory))
         .put("production",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setProduction,
                 this::setProduction,
                 this::getProduction,
@@ -851,105 +847,90 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::setProductionOnly))
         .put("victoryCity",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setVictoryCity,
                 this::setVictoryCity,
                 this::getVictoryCity,
                 this::resetVictoryCity))
         .put("isImpassable",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsImpassable,
                 this::setIsImpassable,
                 this::getIsImpassable,
                 this::resetIsImpassable))
         .put("originalOwner",
             MutableProperty.of(
-                TypeToken.of(PlayerID.class),
                 this::setOriginalOwner,
                 this::setOriginalOwner,
                 this::getOriginalOwner,
                 this::resetOriginalOwner))
         .put("convoyRoute",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setConvoyRoute,
                 this::setConvoyRoute,
                 this::getConvoyRoute,
                 this::resetConvoyRoute))
         .put("convoyAttached",
             MutableProperty.of(
-                new TypeToken<HashSet<Territory>>() {},
                 this::setConvoyAttached,
                 this::setConvoyAttached,
                 this::getConvoyAttached,
                 this::resetConvoyAttached))
         .put("changeUnitOwners",
             MutableProperty.of(
-                new TypeToken<ArrayList<PlayerID>>() {},
                 this::setChangeUnitOwners,
                 this::setChangeUnitOwners,
                 this::getChangeUnitOwners,
                 this::resetChangeUnitOwners))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
-                new TypeToken<ArrayList<PlayerID>>() {},
                 this::setCaptureUnitOnEnteringBy,
                 this::setCaptureUnitOnEnteringBy,
                 this::getCaptureUnitOnEnteringBy,
                 this::resetCaptureUnitOnEnteringBy))
         .put("navalBase",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setNavalBase,
                 this::setNavalBase,
                 this::getNavalBase,
                 this::resetNavalBase))
         .put("airBase",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setAirBase,
                 this::setAirBase,
                 this::getAirBase,
                 this::resetAirBase))
         .put("kamikazeZone",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setKamikazeZone,
                 this::setKamikazeZone,
                 this::getKamikazeZone,
                 this::resetKamikazeZone))
         .put("unitProduction",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setUnitProduction,
                 this::setUnitProduction,
                 this::getUnitProduction,
                 this::resetUnitProduction))
         .put("blockadeZone",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setBlockadeZone,
                 this::setBlockadeZone,
                 this::getBlockadeZone,
                 this::resetBlockadeZone))
         .put("territoryEffect",
             MutableProperty.of(
-                new TypeToken<ArrayList<TerritoryEffect>>() {},
                 this::setTerritoryEffect,
                 this::setTerritoryEffect,
                 this::getTerritoryEffect,
                 this::resetTerritoryEffect))
         .put("whenCapturedByGoesTo",
             MutableProperty.of(
-                new TypeToken<ArrayList<String>>() {},
                 this::setWhenCapturedByGoesTo,
                 this::setWhenCapturedByGoesTo,
                 this::getWhenCapturedByGoesTo,
                 this::resetWhenCapturedByGoesTo))
         .put("resources",
             MutableProperty.of(
-                TypeToken.of(ResourceCollection.class),
                 this::setResources,
                 this::setResources,
                 this::getResources,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -199,32 +200,33 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("combatDefenseEffect",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCombatDefenseEffect,
                 this::setCombatDefenseEffect,
                 this::getCombatDefenseEffect,
                 this::resetCombatDefenseEffect))
         .put("combatOffenseEffect",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCombatOffenseEffect,
                 this::setCombatOffenseEffect,
                 this::getCombatOffenseEffect,
                 this::resetCombatOffenseEffect))
         .put("noBlitz",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<UnitType>>() {},
                 this::setNoBlitz,
                 this::setNoBlitz,
                 this::getNoBlitz,
                 this::resetNoBlitz))
         .put("unitsNotAllowed",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<UnitType>>() {},
                 this::setUnitsNotAllowed,
                 this::setUnitsNotAllowed,
                 this::getUnitsNotAllowed,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -200,33 +199,28 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("combatDefenseEffect",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCombatDefenseEffect,
                 this::setCombatDefenseEffect,
                 this::getCombatDefenseEffect,
                 this::resetCombatDefenseEffect))
         .put("combatOffenseEffect",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCombatOffenseEffect,
                 this::setCombatOffenseEffect,
                 this::getCombatOffenseEffect,
                 this::resetCombatOffenseEffect))
         .put("noBlitz",
             MutableProperty.of(
-                new TypeToken<List<UnitType>>() {},
                 this::setNoBlitz,
                 this::setNoBlitz,
                 this::getNoBlitz,
                 this::resetNoBlitz))
         .put("unitsNotAllowed",
             MutableProperty.of(
-                new TypeToken<List<UnitType>>() {},
                 this::setUnitsNotAllowed,
                 this::setUnitsNotAllowed,
                 this::getUnitsNotAllowed,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.Attachable;
@@ -2606,55 +2605,47 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("frontier",
             MutableProperty.of(
-                TypeToken.of(ProductionFrontier.class),
                 this::setFrontier,
                 this::setFrontier,
                 this::getFrontier,
                 this::resetFrontier))
         .put("productionRule",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setProductionRule,
                 this::setProductionRule,
                 this::getProductionRule,
                 this::resetProductionRule))
         .put("tech",
             MutableProperty.of(
-                new TypeToken<List<TechAdvance>>() {},
                 this::setTech,
                 this::setTech,
                 this::getTech,
                 this::resetTech))
         .put("availableTech",
             MutableProperty.of(
-                new TypeToken<Map<String, Map<TechAdvance, Boolean>>>() {},
                 this::setAvailableTech,
                 this::setAvailableTech,
                 this::getAvailableTech,
                 this::resetAvailableTech))
         .put("placement",
             MutableProperty.of(
-                new TypeToken<Map<Territory, IntegerMap<UnitType>>>() {},
                 this::setPlacement,
                 this::setPlacement,
                 this::getPlacement,
                 this::resetPlacement))
         .put("removeUnits",
             MutableProperty.of(
-                new TypeToken<Map<Territory, IntegerMap<UnitType>>>() {},
                 this::setRemoveUnits,
                 this::setRemoveUnits,
                 this::getRemoveUnits,
                 this::resetRemoveUnits))
         .put("purchase",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setPurchase,
                 this::setPurchase,
                 this::getPurchase,
@@ -2666,21 +2657,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::resetResource))
         .put("resourceCount",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setResourceCount,
                 this::setResourceCount,
                 this::getResourceCount,
                 this::resetResourceCount))
         .put("support",
             MutableProperty.of(
-                new TypeToken<Map<String, Boolean>>() {},
                 this::setSupport,
                 this::setSupport,
                 this::getSupport,
                 this::resetSupport))
         .put("relationshipChange",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,
@@ -2692,119 +2680,102 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::resetVictory))
         .put("activateTrigger",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,
                 this::resetActivateTrigger))
         .put("changeOwnership",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setChangeOwnership,
                 this::setChangeOwnership,
                 this::getChangeOwnership,
                 this::resetChangeOwnership))
         .put("unitType",
             MutableProperty.of(
-                new TypeToken<List<UnitType>>() {},
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
         .put("unitAttachmentName",
             MutableProperty.of(
-                new TypeToken<Tuple<String, String>>() {},
                 this::setUnitAttachmentName,
                 this::setUnitAttachmentName,
                 this::getUnitAttachmentName,
                 this::resetUnitAttachmentName))
         .put("unitProperty",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setUnitProperty,
                 this::setUnitProperty,
                 this::getUnitProperty,
                 this::resetUnitProperty))
         .put("territories",
             MutableProperty.of(
-                new TypeToken<List<Territory>>() {},
                 this::setTerritories,
                 this::setTerritories,
                 this::getTerritories,
                 this::resetTerritories))
         .put("territoryAttachmentName",
             MutableProperty.of(
-                new TypeToken<Tuple<String, String>>() {},
                 this::setTerritoryAttachmentName,
                 this::setTerritoryAttachmentName,
                 this::getTerritoryAttachmentName,
                 this::resetTerritoryAttachmentName))
         .put("territoryProperty",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setTerritoryProperty,
                 this::setTerritoryProperty,
                 this::getTerritoryProperty,
                 this::resetTerritoryProperty))
         .put("players",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("playerAttachmentName",
             MutableProperty.of(
-                new TypeToken<Tuple<String, String>>() {},
                 this::setPlayerAttachmentName,
                 this::setPlayerAttachmentName,
                 this::getPlayerAttachmentName,
                 this::resetPlayerAttachmentName))
         .put("playerProperty",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setPlayerProperty,
                 this::setPlayerProperty,
                 this::getPlayerProperty,
                 this::resetPlayerProperty))
         .put("relationshipTypes",
             MutableProperty.of(
-                new TypeToken<List<RelationshipType>>() {},
                 this::setRelationshipTypes,
                 this::setRelationshipTypes,
                 this::getRelationshipTypes,
                 this::resetRelationshipTypes))
         .put("relationshipTypeAttachmentName",
             MutableProperty.of(
-                new TypeToken<Tuple<String, String>>() {},
                 this::setRelationshipTypeAttachmentName,
                 this::setRelationshipTypeAttachmentName,
                 this::getRelationshipTypeAttachmentName,
                 this::resetRelationshipTypeAttachmentName))
         .put("relationshipTypeProperty",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setRelationshipTypeProperty,
                 this::setRelationshipTypeProperty,
                 this::getRelationshipTypeProperty,
                 this::resetRelationshipTypeProperty))
         .put("territoryEffects",
             MutableProperty.of(
-                new TypeToken<List<TerritoryEffect>>() {},
                 this::setTerritoryEffects,
                 this::setTerritoryEffects,
                 this::getTerritoryEffects,
                 this::resetTerritoryEffects))
         .put("territoryEffectAttachmentName",
             MutableProperty.of(
-                new TypeToken<Tuple<String, String>>() {},
                 this::setTerritoryEffectAttachmentName,
                 this::setTerritoryEffectAttachmentName,
                 this::getTerritoryEffectAttachmentName,
                 this::resetTerritoryEffectAttachmentName))
         .put("territoryEffectProperty",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setTerritoryEffectProperty,
                 this::setTerritoryEffectProperty,
                 this::getTerritoryEffectProperty,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.Attachable;
@@ -2605,54 +2606,55 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("frontier",
             MutableProperty.of(
-                ProductionFrontier.class,
+                TypeToken.of(ProductionFrontier.class),
                 this::setFrontier,
                 this::setFrontier,
                 this::getFrontier,
                 this::resetFrontier))
         .put("productionRule",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setProductionRule,
                 this::setProductionRule,
                 this::getProductionRule,
                 this::resetProductionRule))
         .put("tech",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<TechAdvance>>() {},
                 this::setTech,
                 this::setTech,
                 this::getTech,
                 this::resetTech))
         .put("availableTech",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<String, Map<TechAdvance, Boolean>>>() {},
                 this::setAvailableTech,
                 this::setAvailableTech,
                 this::getAvailableTech,
                 this::resetAvailableTech))
         .put("placement",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<Territory, IntegerMap<UnitType>>>() {},
                 this::setPlacement,
                 this::setPlacement,
                 this::getPlacement,
                 this::resetPlacement))
         .put("removeUnits",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<Territory, IntegerMap<UnitType>>>() {},
                 this::setRemoveUnits,
                 this::setRemoveUnits,
                 this::getRemoveUnits,
                 this::resetRemoveUnits))
         .put("purchase",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setPurchase,
                 this::setPurchase,
                 this::getPurchase,
@@ -2663,21 +2665,22 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::getResource,
                 this::resetResource))
         .put("resourceCount",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setResourceCount,
                 this::setResourceCount,
                 this::getResourceCount,
                 this::resetResourceCount))
         .put("support",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<String, Boolean>>() {},
                 this::setSupport,
                 this::setSupport,
                 this::getSupport,
                 this::resetSupport))
         .put("relationshipChange",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setRelationshipChange,
                 this::setRelationshipChange,
                 this::getRelationshipChange,
@@ -2689,119 +2692,119 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
                 this::resetVictory))
         .put("activateTrigger",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,
                 this::resetActivateTrigger))
         .put("changeOwnership",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setChangeOwnership,
                 this::setChangeOwnership,
                 this::getChangeOwnership,
                 this::resetChangeOwnership))
         .put("unitType",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<UnitType>>() {},
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
         .put("unitAttachmentName",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<String, String>>() {},
                 this::setUnitAttachmentName,
                 this::setUnitAttachmentName,
                 this::getUnitAttachmentName,
                 this::resetUnitAttachmentName))
         .put("unitProperty",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setUnitProperty,
                 this::setUnitProperty,
                 this::getUnitProperty,
                 this::resetUnitProperty))
         .put("territories",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Territory>>() {},
                 this::setTerritories,
                 this::setTerritories,
                 this::getTerritories,
                 this::resetTerritories))
         .put("territoryAttachmentName",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<String, String>>() {},
                 this::setTerritoryAttachmentName,
                 this::setTerritoryAttachmentName,
                 this::getTerritoryAttachmentName,
                 this::resetTerritoryAttachmentName))
         .put("territoryProperty",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setTerritoryProperty,
                 this::setTerritoryProperty,
                 this::getTerritoryProperty,
                 this::resetTerritoryProperty))
         .put("players",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("playerAttachmentName",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<String, String>>() {},
                 this::setPlayerAttachmentName,
                 this::setPlayerAttachmentName,
                 this::getPlayerAttachmentName,
                 this::resetPlayerAttachmentName))
         .put("playerProperty",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setPlayerProperty,
                 this::setPlayerProperty,
                 this::getPlayerProperty,
                 this::resetPlayerProperty))
         .put("relationshipTypes",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<RelationshipType>>() {},
                 this::setRelationshipTypes,
                 this::setRelationshipTypes,
                 this::getRelationshipTypes,
                 this::resetRelationshipTypes))
         .put("relationshipTypeAttachmentName",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<String, String>>() {},
                 this::setRelationshipTypeAttachmentName,
                 this::setRelationshipTypeAttachmentName,
                 this::getRelationshipTypeAttachmentName,
                 this::resetRelationshipTypeAttachmentName))
         .put("relationshipTypeProperty",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setRelationshipTypeProperty,
                 this::setRelationshipTypeProperty,
                 this::getRelationshipTypeProperty,
                 this::resetRelationshipTypeProperty))
         .put("territoryEffects",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<TerritoryEffect>>() {},
                 this::setTerritoryEffects,
                 this::setTerritoryEffects,
                 this::getTerritoryEffects,
                 this::resetTerritoryEffects))
         .put("territoryEffectAttachmentName",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<String, String>>() {},
                 this::setTerritoryEffectAttachmentName,
                 this::setTerritoryEffectAttachmentName,
                 this::getTerritoryEffectAttachmentName,
                 this::resetTerritoryEffectAttachmentName))
         .put("territoryEffectProperty",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setTerritoryEffectProperty,
                 this::setTerritoryEffectProperty,
                 this::getTerritoryEffectProperty,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -3510,10 +3511,12 @@ public class UnitAttachment extends DefaultAttachment {
 
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("isAir",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAir,
                 this::setIsAir,
                 this::getIsAir,
@@ -3525,275 +3528,316 @@ public class UnitAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setIsParatroop))
         .put("isSea",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsSea,
                 this::setIsSea,
                 this::getIsSea,
                 this::resetIsSea))
         .put("movement",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMovement,
                 this::setMovement,
                 this::getMovement,
                 this::resetMovement))
         .put("canBlitz",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanBlitz,
                 this::setCanBlitz,
                 this::getCanBlitz,
                 this::resetCanBlitz))
         .put("isKamikaze",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsKamikaze,
                 this::setIsKamikaze,
                 this::getIsKamikaze,
                 this::resetIsKamikaze))
         .put("canInvadeOnlyFrom",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setCanInvadeOnlyFrom,
                 this::setCanInvadeOnlyFrom,
                 this::getCanInvadeOnlyFrom,
                 this::resetCanInvadeOnlyFrom))
         .put("fuelCost",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<Resource>>() {},
                 this::setFuelCost,
                 this::setFuelCost,
                 this::getFuelCost,
                 this::resetFuelCost))
         .put("canNotMoveDuringCombatMove",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanNotMoveDuringCombatMove,
                 this::setCanNotMoveDuringCombatMove,
                 this::getCanNotMoveDuringCombatMove,
                 this::resetCanNotMoveDuringCombatMove))
         .put("movementLimit",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<Integer, String>>() {},
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attack",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttack,
                 this::setAttack,
                 this::getAttack,
                 this::resetAttack))
         .put("defense",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setDefense,
                 this::setDefense,
                 this::getDefense,
                 this::resetDefense))
         .put("isInfrastructure",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsInfrastructure,
                 this::setIsInfrastructure,
                 this::getIsInfrastructure,
                 this::resetIsInfrastructure))
         .put("canBombard",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanBombard,
                 this::setCanBombard,
                 this::getCanBombard,
                 this::resetCanBombard))
         .put("bombard",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setBombard,
                 this::setBombard,
                 this::getBombard,
                 this::resetBombard))
         .put("isSub",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsSub,
                 this::setIsSub,
                 this::getIsSub,
                 this::resetIsSub))
         .put("isDestroyer",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsDestroyer,
                 this::setIsDestroyer,
                 this::getIsDestroyer,
                 this::resetIsDestroyer))
         .put("artillery",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setArtillery,
                 this::setArtillery,
                 this::getArtillery,
                 this::resetArtillery))
         .put("artillerySupportable",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setArtillerySupportable,
                 this::setArtillerySupportable,
                 this::getArtillerySupportable,
                 this::resetArtillerySupportable))
         .put("unitSupportCount",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setUnitSupportCount,
                 this::setUnitSupportCount,
                 this::getUnitSupportCount,
                 this::resetUnitSupportCount))
         .put("isMarine",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setIsMarine,
                 this::setIsMarine,
                 this::getIsMarine,
                 this::resetIsMarine))
         .put("isSuicide",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsSuicide,
                 this::setIsSuicide,
                 this::getIsSuicide,
                 this::resetIsSuicide))
         .put("isSuicideOnHit",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsSuicideOnHit,
                 this::setIsSuicideOnHit,
                 this::getIsSuicideOnHit,
                 this::resetIsSuicideOnHit))
         .put("attackingLimit",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<Integer, String>>() {},
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,
                 this::resetAttackingLimit))
         .put("attackRolls",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttackRolls,
                 this::setAttackRolls,
                 this::getAttackRolls,
                 this::resetAttackRolls))
         .put("defenseRolls",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setDefenseRolls,
                 this::setDefenseRolls,
                 this::getDefenseRolls,
                 this::resetDefenseRolls))
         .put("chooseBestRoll",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setChooseBestRoll,
                 this::setChooseBestRoll,
                 this::getChooseBestRoll,
                 this::resetChooseBestRoll))
         .put("isCombatTransport",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsCombatTransport,
                 this::setIsCombatTransport,
                 this::getIsCombatTransport,
                 this::resetIsCombatTransport))
         .put("transportCapacity",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setTransportCapacity,
                 this::setTransportCapacity,
                 this::getTransportCapacity,
                 this::resetTransportCapacity))
         .put("transportCost",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setTransportCost,
                 this::setTransportCost,
                 this::getTransportCost,
                 this::resetTransportCost))
         .put("carrierCapacity",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCarrierCapacity,
                 this::setCarrierCapacity,
                 this::getCarrierCapacity,
                 this::resetCarrierCapacity))
         .put("carrierCost",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCarrierCost,
                 this::setCarrierCost,
                 this::getCarrierCost,
                 this::resetCarrierCost))
         .put("isAirTransport",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAirTransport,
                 this::setIsAirTransport,
                 this::getIsAirTransport,
                 this::resetIsAirTransport))
         .put("isAirTransportable",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAirTransportable,
                 this::setIsAirTransportable,
                 this::getIsAirTransportable,
                 this::resetIsAirTransportable))
         .put("isInfantry",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsInfantry,
                 this::setIsInfantry,
                 this::getIsInfantry,
                 this::resetIsInfantry))
         .put("isLandTransport",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsLandTransport,
                 this::setIsLandTransport,
                 this::getIsLandTransport,
                 this::resetIsLandTransport))
         .put("isLandTransportable",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsLandTransportable,
                 this::setIsLandTransportable,
                 this::getIsLandTransportable,
                 this::resetIsLandTransportable))
         .put("isAAforCombatOnly",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAAforCombatOnly,
                 this::setIsAAforCombatOnly,
                 this::getIsAAforCombatOnly,
                 this::resetIsAAforCombatOnly))
         .put("isAAforBombingThisUnitOnly",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAAforBombingThisUnitOnly,
                 this::setIsAAforBombingThisUnitOnly,
                 this::getIsAAforBombingThisUnitOnly,
                 this::resetIsAAforBombingThisUnitOnly))
         .put("isAAforFlyOverOnly",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAAforFlyOverOnly,
                 this::setIsAAforFlyOverOnly,
                 this::getIsAAforFlyOverOnly,
                 this::resetIsAAforFlyOverOnly))
         .put("isRocket",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsRocket,
                 this::setIsRocket,
                 this::getIsRocket,
                 this::resetIsRocket))
         .put("attackAA",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttackAA,
                 this::setAttackAA,
                 this::getAttackAA,
                 this::resetAttackAA))
         .put("offensiveAttackAA",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setOffensiveAttackAA,
                 this::setOffensiveAttackAA,
                 this::getOffensiveAttackAA,
                 this::resetOffensiveAttackAA))
         .put("attackAAmaxDieSides",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAttackAAmaxDieSides,
                 this::setAttackAAmaxDieSides,
                 this::getAttackAAmaxDieSides,
                 this::resetAttackAAmaxDieSides))
         .put("offensiveAttackAAmaxDieSides",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setOffensiveAttackAAmaxDieSides,
                 this::setOffensiveAttackAAmaxDieSides,
                 this::getOffensiveAttackAAmaxDieSides,
                 this::resetOffensiveAttackAAmaxDieSides))
         .put("maxAAattacks",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxAAattacks,
                 this::setMaxAAattacks,
                 this::getMaxAAattacks,
                 this::resetMaxAAattacks))
         .put("maxRoundsAA",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxRoundsAA,
                 this::setMaxRoundsAA,
                 this::getMaxRoundsAA,
@@ -3805,143 +3849,161 @@ public class UnitAttachment extends DefaultAttachment {
                 this::resetTypeAA))
         .put("targetsAA",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setTargetsAA,
                 this::setTargetsAA,
                 this::getTargetsAA,
                 this::resetTargetsAA))
         .put("mayOverStackAA",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setMayOverStackAA,
                 this::setMayOverStackAA,
                 this::getMayOverStackAA,
                 this::resetMayOverStackAA))
         .put("damageableAA",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setDamageableAA,
                 this::setDamageableAA,
                 this::getDamageableAA,
                 this::resetDamageableAA))
         .put("willNotFireIfPresent",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setWillNotFireIfPresent,
                 this::setWillNotFireIfPresent,
                 this::getWillNotFireIfPresent,
                 this::resetWillNotFireIfPresent))
         .put("isStrategicBomber",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsStrategicBomber,
                 this::setIsStrategicBomber,
                 this::getIsStrategicBomber,
                 this::resetIsStrategicBomber))
         .put("bombingMaxDieSides",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setBombingMaxDieSides,
                 this::setBombingMaxDieSides,
                 this::getBombingMaxDieSides,
                 this::resetBombingMaxDieSides))
         .put("bombingBonus",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,
                 this::resetBombingBonus))
         .put("canIntercept",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanIntercept,
                 this::setCanIntercept,
                 this::getCanIntercept,
                 this::resetCanIntercept))
         .put("canEscort",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanEscort,
                 this::setCanEscort,
                 this::getCanEscort,
                 this::resetCanEscort))
         .put("canAirBattle",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanAirBattle,
                 this::setCanAirBattle,
                 this::getCanAirBattle,
                 this::resetCanAirBattle))
         .put("airDefense",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAirDefense,
                 this::setAirDefense,
                 this::getAirDefense,
                 this::resetAirDefense))
         .put("airAttack",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setAirAttack,
                 this::setAirAttack,
                 this::getAirAttack,
                 this::resetAirAttack))
         .put("bombingTargets",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setBombingTargets,
                 this::setBombingTargets,
                 this::getBombingTargets,
                 this::resetBombingTargets))
         .put("canProduceUnits",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanProduceUnits,
                 this::setCanProduceUnits,
                 this::getCanProduceUnits,
                 this::resetCanProduceUnits))
         .put("canProduceXUnits",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCanProduceXUnits,
                 this::setCanProduceXUnits,
                 this::getCanProduceXUnits,
                 this::resetCanProduceXUnits))
         .put("createsUnitsList",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCreatesUnitsList,
                 this::setCreatesUnitsList,
                 this::getCreatesUnitsList,
                 this::resetCreatesUnitsList))
         .put("createsResourcesList",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<Resource>>() {},
                 this::setCreatesResourcesList,
                 this::setCreatesResourcesList,
                 this::getCreatesResourcesList,
                 this::resetCreatesResourcesList))
         .put("hitPoints",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setHitPoints,
                 this::setHitPoints,
                 this::getHitPoints,
                 this::resetHitPoints))
         .put("canBeDamaged",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanBeDamaged,
                 this::setCanBeDamaged,
                 this::getCanBeDamaged,
                 this::resetCanBeDamaged))
         .put("maxDamage",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxDamage,
                 this::setMaxDamage,
                 this::getMaxDamage,
                 this::resetMaxDamage))
         .put("maxOperationalDamage",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxOperationalDamage,
                 this::setMaxOperationalDamage,
                 this::getMaxOperationalDamage,
                 this::resetMaxOperationalDamage))
         .put("canDieFromReachingMaxDamage",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanDieFromReachingMaxDamage,
                 this::setCanDieFromReachingMaxDamage,
                 this::getCanDieFromReachingMaxDamage,
                 this::resetCanDieFromReachingMaxDamage))
         .put("isConstruction",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsConstruction,
                 this::setIsConstruction,
                 this::getIsConstruction,
@@ -3952,207 +4014,218 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getConstructionType,
                 this::resetConstructionType))
         .put("constructionsPerTerrPerTypePerTurn",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::getConstructionsPerTerrPerTypePerTurn,
                 this::resetConstructionsPerTerrPerTypePerTurn))
         .put("maxConstructionsPerTypePerTerr",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxConstructionsPerTypePerTerr,
                 this::setMaxConstructionsPerTypePerTerr,
                 this::getMaxConstructionsPerTypePerTerr,
                 this::resetMaxConstructionsPerTypePerTerr))
         .put("canOnlyBePlacedInTerritoryValuedAtX",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::getCanOnlyBePlacedInTerritoryValuedAtX,
                 this::resetCanOnlyBePlacedInTerritoryValuedAtX))
         .put("requiresUnits",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String[]>>() {},
                 this::setRequiresUnits,
                 this::setRequiresUnits,
                 this::getRequiresUnits,
                 this::resetRequiresUnits))
         .put("consumesUnits",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setConsumesUnits,
                 this::setConsumesUnits,
                 this::getConsumesUnits,
                 this::resetConsumesUnits))
         .put("requiresUnitsToMove",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String[]>>() {},
                 this::setRequiresUnitsToMove,
                 this::setRequiresUnitsToMove,
                 this::getRequiresUnitsToMove,
                 this::resetRequiresUnitsToMove))
         .put("unitPlacementRestrictions",
             MutableProperty.of(
-                String[].class,
+                TypeToken.of(String[].class),
                 this::setUnitPlacementRestrictions,
                 this::setUnitPlacementRestrictions,
                 this::getUnitPlacementRestrictions,
                 this::resetUnitPlacementRestrictions))
         .put("maxBuiltPerPlayer",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxBuiltPerPlayer,
                 this::setMaxBuiltPerPlayer,
                 this::getMaxBuiltPerPlayer,
                 this::resetMaxBuiltPerPlayer))
         .put("placementLimit",
             MutableProperty.of(
-                Tuple.class,
+                new TypeToken<Tuple<Integer, String>>() {},
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("canScramble",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setCanScramble,
                 this::setCanScramble,
                 this::getCanScramble,
                 this::resetCanScramble))
         .put("isAirBase",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setIsAirBase,
                 this::setIsAirBase,
                 this::getIsAirBase,
                 this::resetIsAirBase))
         .put("maxScrambleDistance",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxScrambleDistance,
                 this::setMaxScrambleDistance,
                 this::getMaxScrambleDistance,
                 this::resetMaxScrambleDistance))
         .put("maxScrambleCount",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setMaxScrambleCount,
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount,
                 this::resetMaxScrambleCount))
         .put("blockade",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setBlockade,
                 this::setBlockade,
                 this::getBlockade,
                 this::resetBlockade))
         .put("repairsUnits",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRepairsUnits,
                 this::setRepairsUnits,
                 this::getRepairsUnits,
                 this::resetRepairsUnits))
         .put("givesMovement",
             MutableProperty.of(
-                IntegerMap.class,
+                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setGivesMovement,
                 this::setGivesMovement,
                 this::getGivesMovement,
                 this::resetGivesMovement))
         .put("destroyedWhenCapturedBy",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, PlayerID>>>() {},
                 this::setDestroyedWhenCapturedBy,
                 this::setDestroyedWhenCapturedBy,
                 this::getDestroyedWhenCapturedBy,
                 this::resetDestroyedWhenCapturedBy))
         .put("whenHitPointsDamagedChangesInto",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<Integer, Tuple<Boolean, UnitType>>>() {},
                 this::setWhenHitPointsDamagedChangesInto,
                 this::setWhenHitPointsDamagedChangesInto,
                 this::getWhenHitPointsDamagedChangesInto,
                 this::resetWhenHitPointsDamagedChangesInto))
         .put("whenHitPointsRepairedChangesInto",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<Integer, Tuple<Boolean, UnitType>>>() {},
                 this::setWhenHitPointsRepairedChangesInto,
                 this::setWhenHitPointsRepairedChangesInto,
                 this::getWhenHitPointsRepairedChangesInto,
                 this::resetWhenHitPointsRepairedChangesInto))
         .put("whenCapturedChangesInto",
             MutableProperty.of(
-                Map.class,
+                new TypeToken<Map<String, Tuple<String, IntegerMap<UnitType>>>>() {},
                 this::setWhenCapturedChangesInto,
                 this::setWhenCapturedChangesInto,
                 this::getWhenCapturedChangesInto,
                 this::resetWhenCapturedChangesInto))
         .put("whenCapturedSustainsDamage",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setWhenCapturedSustainsDamage,
                 this::setWhenCapturedSustainsDamage,
                 this::getWhenCapturedSustainsDamage,
                 this::resetWhenCapturedSustainsDamage))
         .put("canBeCapturedOnEnteringBy",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setCanBeCapturedOnEnteringBy,
                 this::setCanBeCapturedOnEnteringBy,
                 this::getCanBeCapturedOnEnteringBy,
                 this::resetCanBeCapturedOnEnteringBy))
         .put("canBeGivenByTerritoryTo",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setCanBeGivenByTerritoryTo,
                 this::setCanBeGivenByTerritoryTo,
                 this::getCanBeGivenByTerritoryTo,
                 this::resetCanBeGivenByTerritoryTo))
         .put("whenCombatDamaged",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>>>() {},
                 this::setWhenCombatDamaged,
                 this::setWhenCombatDamaged,
                 this::getWhenCombatDamaged,
                 this::resetWhenCombatDamaged))
         .put("receivesAbilityWhenWith",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<String>>() {},
                 this::setReceivesAbilityWhenWith,
                 this::setReceivesAbilityWhenWith,
                 this::getReceivesAbilityWhenWith,
                 this::resetReceivesAbilityWhenWith))
         .put("special",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<String>>() {},
                 this::setSpecial,
                 this::setSpecial,
                 this::getSpecial,
                 this::resetSpecial))
         .put("tuv",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setTuv,
                 this::setTuv,
                 this::getTuv,
                 this::resetTuv))
         .put("isFactory",
-            MutableProperty.ofWriteOnlyBoolean(
+            MutableProperty.ofWriteOnly(
+                TypeToken.of(Boolean.class),
                 this::setIsFactory,
                 this::setIsFactory))
         .put("isAA",
-            MutableProperty.ofWriteOnlyBoolean(
+            MutableProperty.ofWriteOnly(
+                TypeToken.of(Boolean.class),
                 this::setIsAA,
                 this::setIsAA))
         .put("destroyedWhenCapturedFrom",
-            MutableProperty.of(
-                String.class,
-                this::setDestroyedWhenCapturedFrom,
+            MutableProperty.ofWriteOnlyString(
                 this::setDestroyedWhenCapturedFrom))
         .put("unitPlacementOnlyAllowedIn",
-            MutableProperty.of(
-                String.class,
-                this::setUnitPlacementOnlyAllowedIn,
+            MutableProperty.ofWriteOnlyString(
                 this::setUnitPlacementOnlyAllowedIn))
         .put("isAAmovement",
-            MutableProperty.ofWriteOnlyBoolean(
+            MutableProperty.ofWriteOnly(
+                TypeToken.of(Boolean.class),
                 this::setIsAAmovement,
                 this::setIsAAmovement))
         .put("isTwoHit",
-            MutableProperty.ofWriteOnlyBoolean(
+            MutableProperty.ofWriteOnly(
+                TypeToken.of(Boolean.class),
                 this::setIsTwoHit,
                 this::setIsTwoHit))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -3511,12 +3510,10 @@ public class UnitAttachment extends DefaultAttachment {
 
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("isAir",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAir,
                 this::setIsAir,
                 this::getIsAir,
@@ -3529,315 +3526,270 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsParatroop))
         .put("isSea",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsSea,
                 this::setIsSea,
                 this::getIsSea,
                 this::resetIsSea))
         .put("movement",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMovement,
                 this::setMovement,
                 this::getMovement,
                 this::resetMovement))
         .put("canBlitz",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanBlitz,
                 this::setCanBlitz,
                 this::getCanBlitz,
                 this::resetCanBlitz))
         .put("isKamikaze",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsKamikaze,
                 this::setIsKamikaze,
                 this::getIsKamikaze,
                 this::resetIsKamikaze))
         .put("canInvadeOnlyFrom",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setCanInvadeOnlyFrom,
                 this::setCanInvadeOnlyFrom,
                 this::getCanInvadeOnlyFrom,
                 this::resetCanInvadeOnlyFrom))
         .put("fuelCost",
             MutableProperty.of(
-                new TypeToken<IntegerMap<Resource>>() {},
                 this::setFuelCost,
                 this::setFuelCost,
                 this::getFuelCost,
                 this::resetFuelCost))
         .put("canNotMoveDuringCombatMove",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanNotMoveDuringCombatMove,
                 this::setCanNotMoveDuringCombatMove,
                 this::getCanNotMoveDuringCombatMove,
                 this::resetCanNotMoveDuringCombatMove))
         .put("movementLimit",
             MutableProperty.of(
-                new TypeToken<Tuple<Integer, String>>() {},
                 this::setMovementLimit,
                 this::setMovementLimit,
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put("attack",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttack,
                 this::setAttack,
                 this::getAttack,
                 this::resetAttack))
         .put("defense",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setDefense,
                 this::setDefense,
                 this::getDefense,
                 this::resetDefense))
         .put("isInfrastructure",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsInfrastructure,
                 this::setIsInfrastructure,
                 this::getIsInfrastructure,
                 this::resetIsInfrastructure))
         .put("canBombard",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanBombard,
                 this::setCanBombard,
                 this::getCanBombard,
                 this::resetCanBombard))
         .put("bombard",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setBombard,
                 this::setBombard,
                 this::getBombard,
                 this::resetBombard))
         .put("isSub",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsSub,
                 this::setIsSub,
                 this::getIsSub,
                 this::resetIsSub))
         .put("isDestroyer",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsDestroyer,
                 this::setIsDestroyer,
                 this::getIsDestroyer,
                 this::resetIsDestroyer))
         .put("artillery",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setArtillery,
                 this::setArtillery,
                 this::getArtillery,
                 this::resetArtillery))
         .put("artillerySupportable",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setArtillerySupportable,
                 this::setArtillerySupportable,
                 this::getArtillerySupportable,
                 this::resetArtillerySupportable))
         .put("unitSupportCount",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setUnitSupportCount,
                 this::setUnitSupportCount,
                 this::getUnitSupportCount,
                 this::resetUnitSupportCount))
         .put("isMarine",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setIsMarine,
                 this::setIsMarine,
                 this::getIsMarine,
                 this::resetIsMarine))
         .put("isSuicide",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsSuicide,
                 this::setIsSuicide,
                 this::getIsSuicide,
                 this::resetIsSuicide))
         .put("isSuicideOnHit",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsSuicideOnHit,
                 this::setIsSuicideOnHit,
                 this::getIsSuicideOnHit,
                 this::resetIsSuicideOnHit))
         .put("attackingLimit",
             MutableProperty.of(
-                new TypeToken<Tuple<Integer, String>>() {},
                 this::setAttackingLimit,
                 this::setAttackingLimit,
                 this::getAttackingLimit,
                 this::resetAttackingLimit))
         .put("attackRolls",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttackRolls,
                 this::setAttackRolls,
                 this::getAttackRolls,
                 this::resetAttackRolls))
         .put("defenseRolls",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setDefenseRolls,
                 this::setDefenseRolls,
                 this::getDefenseRolls,
                 this::resetDefenseRolls))
         .put("chooseBestRoll",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setChooseBestRoll,
                 this::setChooseBestRoll,
                 this::getChooseBestRoll,
                 this::resetChooseBestRoll))
         .put("isCombatTransport",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsCombatTransport,
                 this::setIsCombatTransport,
                 this::getIsCombatTransport,
                 this::resetIsCombatTransport))
         .put("transportCapacity",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setTransportCapacity,
                 this::setTransportCapacity,
                 this::getTransportCapacity,
                 this::resetTransportCapacity))
         .put("transportCost",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setTransportCost,
                 this::setTransportCost,
                 this::getTransportCost,
                 this::resetTransportCost))
         .put("carrierCapacity",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCarrierCapacity,
                 this::setCarrierCapacity,
                 this::getCarrierCapacity,
                 this::resetCarrierCapacity))
         .put("carrierCost",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCarrierCost,
                 this::setCarrierCost,
                 this::getCarrierCost,
                 this::resetCarrierCost))
         .put("isAirTransport",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAirTransport,
                 this::setIsAirTransport,
                 this::getIsAirTransport,
                 this::resetIsAirTransport))
         .put("isAirTransportable",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAirTransportable,
                 this::setIsAirTransportable,
                 this::getIsAirTransportable,
                 this::resetIsAirTransportable))
         .put("isInfantry",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsInfantry,
                 this::setIsInfantry,
                 this::getIsInfantry,
                 this::resetIsInfantry))
         .put("isLandTransport",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsLandTransport,
                 this::setIsLandTransport,
                 this::getIsLandTransport,
                 this::resetIsLandTransport))
         .put("isLandTransportable",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsLandTransportable,
                 this::setIsLandTransportable,
                 this::getIsLandTransportable,
                 this::resetIsLandTransportable))
         .put("isAAforCombatOnly",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAAforCombatOnly,
                 this::setIsAAforCombatOnly,
                 this::getIsAAforCombatOnly,
                 this::resetIsAAforCombatOnly))
         .put("isAAforBombingThisUnitOnly",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAAforBombingThisUnitOnly,
                 this::setIsAAforBombingThisUnitOnly,
                 this::getIsAAforBombingThisUnitOnly,
                 this::resetIsAAforBombingThisUnitOnly))
         .put("isAAforFlyOverOnly",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAAforFlyOverOnly,
                 this::setIsAAforFlyOverOnly,
                 this::getIsAAforFlyOverOnly,
                 this::resetIsAAforFlyOverOnly))
         .put("isRocket",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsRocket,
                 this::setIsRocket,
                 this::getIsRocket,
                 this::resetIsRocket))
         .put("attackAA",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttackAA,
                 this::setAttackAA,
                 this::getAttackAA,
                 this::resetAttackAA))
         .put("offensiveAttackAA",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setOffensiveAttackAA,
                 this::setOffensiveAttackAA,
                 this::getOffensiveAttackAA,
                 this::resetOffensiveAttackAA))
         .put("attackAAmaxDieSides",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAttackAAmaxDieSides,
                 this::setAttackAAmaxDieSides,
                 this::getAttackAAmaxDieSides,
                 this::resetAttackAAmaxDieSides))
         .put("offensiveAttackAAmaxDieSides",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setOffensiveAttackAAmaxDieSides,
                 this::setOffensiveAttackAAmaxDieSides,
                 this::getOffensiveAttackAAmaxDieSides,
                 this::resetOffensiveAttackAAmaxDieSides))
         .put("maxAAattacks",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxAAattacks,
                 this::setMaxAAattacks,
                 this::getMaxAAattacks,
                 this::resetMaxAAattacks))
         .put("maxRoundsAA",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxRoundsAA,
                 this::setMaxRoundsAA,
                 this::getMaxRoundsAA,
@@ -3849,161 +3801,138 @@ public class UnitAttachment extends DefaultAttachment {
                 this::resetTypeAA))
         .put("targetsAA",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setTargetsAA,
                 this::setTargetsAA,
                 this::getTargetsAA,
                 this::resetTargetsAA))
         .put("mayOverStackAA",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setMayOverStackAA,
                 this::setMayOverStackAA,
                 this::getMayOverStackAA,
                 this::resetMayOverStackAA))
         .put("damageableAA",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setDamageableAA,
                 this::setDamageableAA,
                 this::getDamageableAA,
                 this::resetDamageableAA))
         .put("willNotFireIfPresent",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setWillNotFireIfPresent,
                 this::setWillNotFireIfPresent,
                 this::getWillNotFireIfPresent,
                 this::resetWillNotFireIfPresent))
         .put("isStrategicBomber",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsStrategicBomber,
                 this::setIsStrategicBomber,
                 this::getIsStrategicBomber,
                 this::resetIsStrategicBomber))
         .put("bombingMaxDieSides",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setBombingMaxDieSides,
                 this::setBombingMaxDieSides,
                 this::getBombingMaxDieSides,
                 this::resetBombingMaxDieSides))
         .put("bombingBonus",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setBombingBonus,
                 this::setBombingBonus,
                 this::getBombingBonus,
                 this::resetBombingBonus))
         .put("canIntercept",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanIntercept,
                 this::setCanIntercept,
                 this::getCanIntercept,
                 this::resetCanIntercept))
         .put("canEscort",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanEscort,
                 this::setCanEscort,
                 this::getCanEscort,
                 this::resetCanEscort))
         .put("canAirBattle",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanAirBattle,
                 this::setCanAirBattle,
                 this::getCanAirBattle,
                 this::resetCanAirBattle))
         .put("airDefense",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAirDefense,
                 this::setAirDefense,
                 this::getAirDefense,
                 this::resetAirDefense))
         .put("airAttack",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setAirAttack,
                 this::setAirAttack,
                 this::getAirAttack,
                 this::resetAirAttack))
         .put("bombingTargets",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setBombingTargets,
                 this::setBombingTargets,
                 this::getBombingTargets,
                 this::resetBombingTargets))
         .put("canProduceUnits",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanProduceUnits,
                 this::setCanProduceUnits,
                 this::getCanProduceUnits,
                 this::resetCanProduceUnits))
         .put("canProduceXUnits",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCanProduceXUnits,
                 this::setCanProduceXUnits,
                 this::getCanProduceXUnits,
                 this::resetCanProduceXUnits))
         .put("createsUnitsList",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setCreatesUnitsList,
                 this::setCreatesUnitsList,
                 this::getCreatesUnitsList,
                 this::resetCreatesUnitsList))
         .put("createsResourcesList",
             MutableProperty.of(
-                new TypeToken<IntegerMap<Resource>>() {},
                 this::setCreatesResourcesList,
                 this::setCreatesResourcesList,
                 this::getCreatesResourcesList,
                 this::resetCreatesResourcesList))
         .put("hitPoints",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setHitPoints,
                 this::setHitPoints,
                 this::getHitPoints,
                 this::resetHitPoints))
         .put("canBeDamaged",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanBeDamaged,
                 this::setCanBeDamaged,
                 this::getCanBeDamaged,
                 this::resetCanBeDamaged))
         .put("maxDamage",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxDamage,
                 this::setMaxDamage,
                 this::getMaxDamage,
                 this::resetMaxDamage))
         .put("maxOperationalDamage",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxOperationalDamage,
                 this::setMaxOperationalDamage,
                 this::getMaxOperationalDamage,
                 this::resetMaxOperationalDamage))
         .put("canDieFromReachingMaxDamage",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanDieFromReachingMaxDamage,
                 this::setCanDieFromReachingMaxDamage,
                 this::getCanDieFromReachingMaxDamage,
                 this::resetCanDieFromReachingMaxDamage))
         .put("isConstruction",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsConstruction,
                 this::setIsConstruction,
                 this::getIsConstruction,
@@ -4015,201 +3944,172 @@ public class UnitAttachment extends DefaultAttachment {
                 this::resetConstructionType))
         .put("constructionsPerTerrPerTypePerTurn",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::setConstructionsPerTerrPerTypePerTurn,
                 this::getConstructionsPerTerrPerTypePerTurn,
                 this::resetConstructionsPerTerrPerTypePerTurn))
         .put("maxConstructionsPerTypePerTerr",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxConstructionsPerTypePerTerr,
                 this::setMaxConstructionsPerTypePerTerr,
                 this::getMaxConstructionsPerTypePerTerr,
                 this::resetMaxConstructionsPerTypePerTerr))
         .put("canOnlyBePlacedInTerritoryValuedAtX",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::setCanOnlyBePlacedInTerritoryValuedAtX,
                 this::getCanOnlyBePlacedInTerritoryValuedAtX,
                 this::resetCanOnlyBePlacedInTerritoryValuedAtX))
         .put("requiresUnits",
             MutableProperty.of(
-                new TypeToken<List<String[]>>() {},
                 this::setRequiresUnits,
                 this::setRequiresUnits,
                 this::getRequiresUnits,
                 this::resetRequiresUnits))
         .put("consumesUnits",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setConsumesUnits,
                 this::setConsumesUnits,
                 this::getConsumesUnits,
                 this::resetConsumesUnits))
         .put("requiresUnitsToMove",
             MutableProperty.of(
-                new TypeToken<List<String[]>>() {},
                 this::setRequiresUnitsToMove,
                 this::setRequiresUnitsToMove,
                 this::getRequiresUnitsToMove,
                 this::resetRequiresUnitsToMove))
         .put("unitPlacementRestrictions",
             MutableProperty.of(
-                TypeToken.of(String[].class),
                 this::setUnitPlacementRestrictions,
                 this::setUnitPlacementRestrictions,
                 this::getUnitPlacementRestrictions,
                 this::resetUnitPlacementRestrictions))
         .put("maxBuiltPerPlayer",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxBuiltPerPlayer,
                 this::setMaxBuiltPerPlayer,
                 this::getMaxBuiltPerPlayer,
                 this::resetMaxBuiltPerPlayer))
         .put("placementLimit",
             MutableProperty.of(
-                new TypeToken<Tuple<Integer, String>>() {},
                 this::setPlacementLimit,
                 this::setPlacementLimit,
                 this::getPlacementLimit,
                 this::resetPlacementLimit))
         .put("canScramble",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setCanScramble,
                 this::setCanScramble,
                 this::getCanScramble,
                 this::resetCanScramble))
         .put("isAirBase",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setIsAirBase,
                 this::setIsAirBase,
                 this::getIsAirBase,
                 this::resetIsAirBase))
         .put("maxScrambleDistance",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxScrambleDistance,
                 this::setMaxScrambleDistance,
                 this::getMaxScrambleDistance,
                 this::resetMaxScrambleDistance))
         .put("maxScrambleCount",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setMaxScrambleCount,
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount,
                 this::resetMaxScrambleCount))
         .put("blockade",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setBlockade,
                 this::setBlockade,
                 this::getBlockade,
                 this::resetBlockade))
         .put("repairsUnits",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setRepairsUnits,
                 this::setRepairsUnits,
                 this::getRepairsUnits,
                 this::resetRepairsUnits))
         .put("givesMovement",
             MutableProperty.of(
-                new TypeToken<IntegerMap<UnitType>>() {},
                 this::setGivesMovement,
                 this::setGivesMovement,
                 this::getGivesMovement,
                 this::resetGivesMovement))
         .put("destroyedWhenCapturedBy",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, PlayerID>>>() {},
                 this::setDestroyedWhenCapturedBy,
                 this::setDestroyedWhenCapturedBy,
                 this::getDestroyedWhenCapturedBy,
                 this::resetDestroyedWhenCapturedBy))
         .put("whenHitPointsDamagedChangesInto",
             MutableProperty.of(
-                new TypeToken<Map<Integer, Tuple<Boolean, UnitType>>>() {},
                 this::setWhenHitPointsDamagedChangesInto,
                 this::setWhenHitPointsDamagedChangesInto,
                 this::getWhenHitPointsDamagedChangesInto,
                 this::resetWhenHitPointsDamagedChangesInto))
         .put("whenHitPointsRepairedChangesInto",
             MutableProperty.of(
-                new TypeToken<Map<Integer, Tuple<Boolean, UnitType>>>() {},
                 this::setWhenHitPointsRepairedChangesInto,
                 this::setWhenHitPointsRepairedChangesInto,
                 this::getWhenHitPointsRepairedChangesInto,
                 this::resetWhenHitPointsRepairedChangesInto))
         .put("whenCapturedChangesInto",
             MutableProperty.of(
-                new TypeToken<Map<String, Tuple<String, IntegerMap<UnitType>>>>() {},
                 this::setWhenCapturedChangesInto,
                 this::setWhenCapturedChangesInto,
                 this::getWhenCapturedChangesInto,
                 this::resetWhenCapturedChangesInto))
         .put("whenCapturedSustainsDamage",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setWhenCapturedSustainsDamage,
                 this::setWhenCapturedSustainsDamage,
                 this::getWhenCapturedSustainsDamage,
                 this::resetWhenCapturedSustainsDamage))
         .put("canBeCapturedOnEnteringBy",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setCanBeCapturedOnEnteringBy,
                 this::setCanBeCapturedOnEnteringBy,
                 this::getCanBeCapturedOnEnteringBy,
                 this::resetCanBeCapturedOnEnteringBy))
         .put("canBeGivenByTerritoryTo",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setCanBeGivenByTerritoryTo,
                 this::setCanBeGivenByTerritoryTo,
                 this::getCanBeGivenByTerritoryTo,
                 this::resetCanBeGivenByTerritoryTo))
         .put("whenCombatDamaged",
             MutableProperty.of(
-                new TypeToken<List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>>>() {},
                 this::setWhenCombatDamaged,
                 this::setWhenCombatDamaged,
                 this::getWhenCombatDamaged,
                 this::resetWhenCombatDamaged))
         .put("receivesAbilityWhenWith",
             MutableProperty.of(
-                new TypeToken<List<String>>() {},
                 this::setReceivesAbilityWhenWith,
                 this::setReceivesAbilityWhenWith,
                 this::getReceivesAbilityWhenWith,
                 this::resetReceivesAbilityWhenWith))
         .put("special",
             MutableProperty.of(
-                new TypeToken<Set<String>>() {},
                 this::setSpecial,
                 this::setSpecial,
                 this::getSpecial,
                 this::resetSpecial))
         .put("tuv",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setTuv,
                 this::setTuv,
                 this::getTuv,
                 this::resetTuv))
         .put("isFactory",
-            MutableProperty.ofWriteOnly(
-                TypeToken.of(Boolean.class),
+            MutableProperty.<Boolean>ofWriteOnly(
                 this::setIsFactory,
                 this::setIsFactory))
         .put("isAA",
-            MutableProperty.ofWriteOnly(
-                TypeToken.of(Boolean.class),
+            MutableProperty.<Boolean>ofWriteOnly(
                 this::setIsAA,
                 this::setIsAA))
         .put("destroyedWhenCapturedFrom",
@@ -4219,13 +4119,11 @@ public class UnitAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setUnitPlacementOnlyAllowedIn))
         .put("isAAmovement",
-            MutableProperty.ofWriteOnly(
-                TypeToken.of(Boolean.class),
+            MutableProperty.<Boolean>ofWriteOnly(
                 this::setIsAAmovement,
                 this::setIsAAmovement))
         .put("isTwoHit",
-            MutableProperty.ofWriteOnly(
-                TypeToken.of(Boolean.class),
+            MutableProperty.<Boolean>ofWriteOnly(
                 this::setIsTwoHit,
                 this::setIsTwoHit))
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -421,33 +422,36 @@ public class UnitSupportAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("unitType",
             MutableProperty.of(
-                Set.class,
+                new TypeToken<Set<UnitType>>() {},
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
-        .put("offence", MutableProperty.ofReadOnlyBoolean(this::getOffence))
-        .put("defence", MutableProperty.ofReadOnlyBoolean(this::getDefence))
-        .put("roll", MutableProperty.ofReadOnlyBoolean(this::getRoll))
-        .put("strength", MutableProperty.ofReadOnlyBoolean(this::getStrength))
+        .put("offence", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getOffence))
+        .put("defence", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getDefence))
+        .put("roll", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getRoll))
+        .put("strength", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getStrength))
         .put("bonus",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setBonus,
                 this::setBonus,
                 this::getBonus,
                 this::resetBonus))
         .put("number",
-            MutableProperty.ofInteger(
+            MutableProperty.of(
+                TypeToken.of(Integer.class),
                 this::setNumber,
                 this::setNumber,
                 this::getNumber,
                 this::resetNumber))
-        .put("allied", MutableProperty.ofReadOnlyBoolean(this::getAllied))
-        .put("enemy", MutableProperty.ofReadOnlyBoolean(this::getEnemy))
+        .put("allied", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getAllied))
+        .put("enemy", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getEnemy))
         .put("bonusType",
             MutableProperty.ofString(
                 this::setBonusType,
@@ -455,13 +459,14 @@ public class UnitSupportAttachment extends DefaultAttachment {
                 this::resetBonusType))
         .put("players",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("impArtTech",
-            MutableProperty.ofBoolean(
+            MutableProperty.of(
+                TypeToken.of(Boolean.class),
                 this::setImpArtTech,
                 this::setImpArtTech,
                 this::getImpArtTech,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -422,36 +421,32 @@ public class UnitSupportAttachment extends DefaultAttachment {
   public void validate(final GameData data) {}
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("unitType",
             MutableProperty.of(
-                new TypeToken<Set<UnitType>>() {},
                 this::setUnitType,
                 this::setUnitType,
                 this::getUnitType,
                 this::resetUnitType))
-        .put("offence", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getOffence))
-        .put("defence", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getDefence))
-        .put("roll", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getRoll))
-        .put("strength", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getStrength))
+        .put("offence", MutableProperty.ofReadOnly(this::getOffence))
+        .put("defence", MutableProperty.ofReadOnly(this::getDefence))
+        .put("roll", MutableProperty.ofReadOnly(this::getRoll))
+        .put("strength", MutableProperty.ofReadOnly(this::getStrength))
         .put("bonus",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setBonus,
                 this::setBonus,
                 this::getBonus,
                 this::resetBonus))
         .put("number",
             MutableProperty.of(
-                TypeToken.of(Integer.class),
                 this::setNumber,
                 this::setNumber,
                 this::getNumber,
                 this::resetNumber))
-        .put("allied", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getAllied))
-        .put("enemy", MutableProperty.ofReadOnly(TypeToken.of(Boolean.class), this::getEnemy))
+        .put("allied", MutableProperty.ofReadOnly(this::getAllied))
+        .put("enemy", MutableProperty.ofReadOnly(this::getEnemy))
         .put("bonusType",
             MutableProperty.ofString(
                 this::setBonusType,
@@ -459,14 +454,12 @@ public class UnitSupportAttachment extends DefaultAttachment {
                 this::resetBonusType))
         .put("players",
             MutableProperty.of(
-                new TypeToken<List<PlayerID>>() {},
                 this::setPlayers,
                 this::setPlayers,
                 this::getPlayers,
                 this::resetPlayers))
         .put("impArtTech",
             MutableProperty.of(
-                TypeToken.of(Boolean.class),
                 this::setImpArtTech,
                 this::setImpArtTech,
                 this::getImpArtTech,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -10,14 +10,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.PlayerID;
-import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
@@ -174,13 +172,11 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
-  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("activateTrigger",
             MutableProperty.of(
-                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -10,12 +10,14 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
@@ -172,12 +174,13 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   @Override
+  @SuppressWarnings("serial")
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("activateTrigger",
             MutableProperty.of(
-                List.class,
+                new TypeToken<List<Tuple<String, String>>>() {},
                 this::setActivateTrigger,
                 this::setActivateTrigger,
                 this::getActivateTrigger,

--- a/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
@@ -7,14 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.reflect.TypeToken;
-
 import games.strategy.engine.data.MutableProperty.InvalidValueException;
 
 public final class MutablePropertyTest {
   @Test
   public void setValue_ShouldThrowExceptionWhenValueHasWrongType() {
-    final MutableProperty<Integer> mutableProperty = MutableProperty.ofReadOnly(TypeToken.of(Integer.class), () -> 42);
+    final MutableProperty<Integer> mutableProperty = MutableProperty.ofSimple(value -> {
+    }, () -> 42);
 
     final Exception e = assertThrows(InvalidValueException.class, () -> mutableProperty.setValue(new Object()));
     assertThat(e.getCause(), is(instanceOf(ClassCastException.class)));

--- a/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
@@ -7,13 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.reflect.TypeToken;
+
 import games.strategy.engine.data.MutableProperty.InvalidValueException;
 
 public final class MutablePropertyTest {
   @Test
   public void setValue_ShouldThrowExceptionWhenValueHasWrongType() {
-    final MutableProperty<Integer> mutableProperty = MutableProperty.ofSimple(Integer.class, value -> {
-    }, () -> 42);
+    final MutableProperty<Integer> mutableProperty = MutableProperty.ofReadOnly(TypeToken.of(Integer.class), () -> 42);
 
     final Exception e = assertThrows(InvalidValueException.class, () -> mutableProperty.setValue(new Object()));
     assertThat(e.getCause(), is(instanceOf(ClassCastException.class)));


### PR DESCRIPTION
This PR fixes the unchecked warnings introduced when I added the `type` field to `MutableProperty` in #3107.

The root cause of the unchecked warnings is due to the compiler's inability to infer the correct generic type `T` in the various `MutableProperty` factory methods when specifying a `Class` literal for a generic type (e.g. `List.class`) because the `Class` literal loses the generic type parameters of the base type.  This forces the compiler to change the generic type of the various callbacks passed to the factory method to the base type (e.g. `ThrowingConsumer<List<String>>` is changed to `ThrowingConsumer<List>`).

The solution employed in this PR is to rely on the fact that Java [retains generic type information for superclasses](http://gafter.blogspot.com/2006/12/super-type-tokens.html).  Guava provides a super type token implementation via `TypeToken`.  I simply replaced the `Class<T>` field of `MutableProperty` with one of `TypeToken<T>` and all unchecked warnings are corrected.

##### Benefits of `TypeToken`

###### Complete type information at runtime

We have access to the complete type at runtime.  For example, assume a property has type `List<Tuple<Integer, String>>`.  If the wrong type is passed to `setValue(Object)` for this property, the error message will indicate the expected type is `List<Tuple<Integer, String>>` rather than just `List`.

##### Drawbacks of `TypeToken`

###### `TypeToken` subclassses

To capture the generic type information of generic types, a (typically anonymous) subclass of `TypeToken` must be created.  One can't simply create a generic helper method to do this (see the `TypeToken` [Javadocs](http://google.github.io/guava/releases/23.0/api/docs/com/google/common/reflect/TypeToken.html) for more information).  Thus, expect to see instances of `MutableProperty` created like this:

```
MutableProperty.of(
    new TypeToken<List<String>>() {},
    this::setReceivesAbilityWhenWith,
    this::setReceivesAbilityWhenWith,
    this::getReceivesAbilityWhenWith,
    this::resetReceivesAbilityWhenWith)
```

That may lead to a proliferation of anonymous types in classes that use `MutableProperty`.

This does not affect non-generic types, as `TypeToken` provides a factory method that uses a single anonymous class (e.g. `TypeToken.of(Boolean.class)`).

The number of `TypeToken` subclasses can be reduced by extracting static instances to one or more utility classes (e.g. `TypeTokens`) for use by the various `DynamicallyModifiable` types.  However, naming will be a challenge as we have some pretty nasty types in the attachments, such as `List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>>`.  The name `LIST_OF_TUPLE_OF_TUPLE_OF_INTEGER_AND_INTEGER_AND_TUPLE_OF_STRING_AND_STRING` doesn't seem very useful. :smile:  (Note that naming the types after what they logically represent (e.g. "WhenCombatDamaged") wouldn't help reduce the number of `TypeToken` subclasses because, while the actual types may be shared among multiple properties, it's unlikely that the same logical property appears in multiple `DynamicallyModifiable` instances.)

###### Serializability

`TypeToken` implements `Serializable`, and thus all its subclasses should have a `serialVersionUID` field.  This is particularly ugly when creating an anonymous subclass inline with the `MutableProperty` factory method.

In this PR, I'm simply suppressing `serial` warnings on all `getPropertyMap()` methods because we're not going to be serializing the `MutableProperty` instances that hold the `TypeToken`s.  I figured suppressing the warning at this scope is fairly safe as we're unlikely to define anonymous subclasses for types we really do want to serialize in these methods.

Again, if we were to extract the `TypeToken` subclasses to a utility class, it wouldn't be a big deal to add a `serialVersionUID` field because the formatting issues go away.

##### Other changes

I removed the `Boolean` and `Integer` factory method helpers in `MutableProperty` for now.  I think there needs to be some further stabilization of this type before we start making decisions on what constitutes a useful helper method.  I did leave the `String` factory methods simply because `String` is "special" in the context of `MutableProperty`.  As a result, the public API of `MutableProperty` is almost identical to what it was before I added the `type` field.