### PR TITLE
Checkstyle: Fix abbreviation violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -645,7 +645,7 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
               .test(action)) {
             continue;
           }
-          if (action.getCostPU() > 0 && action.getCostPU() > id.getResources().getQuantity(Constants.PUS)) {
+          if (action.getCostPu() > 0 && action.getCostPu() > id.getResources().getQuantity(Constants.PUS)) {
             continue;
           }
           i++;

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -115,7 +115,7 @@ public class AiPoliticalUtils {
   }
 
   private static boolean isFree(final PoliticalActionAttachment nextAction) {
-    return nextAction.getCostPU() <= 0;
+    return nextAction.getCostPu() <= 0;
   }
 
   private static boolean isAcceptableCost(final PoliticalActionAttachment nextAction, final PlayerID player,
@@ -123,6 +123,6 @@ public class AiPoliticalUtils {
     // if we have 21 or more PUs and the cost of the action is l0% or less of our total money, then it is an acceptable
     // price.
     final float production = AbstractEndTurnDelegate.getProduction(data.getMap().getTerritoriesOwnedBy(player), data);
-    return production >= 21 && (nextAction.getCostPU()) <= ((production / 10));
+    return production >= 21 && (nextAction.getCostPu()) <= ((production / 10));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -152,7 +152,7 @@ class ProPoliticsAi {
               .test(action)) {
             continue;
           }
-          if (action.getCostPU() > 0 && action.getCostPU() > player.getResources().getQuantity(Constants.PUS)) {
+          if (action.getCostPu() > 0 && action.getCostPu() > player.getResources().getQuantity(Constants.PUS)) {
             continue;
           }
           i++;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -79,23 +79,23 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    *        the amount you need to pay to perform the action.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCostPU(final String s) {
+  public void setCostPu(final String s) {
     m_costPU = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCostPU(final Integer s) {
+  public void setCostPu(final Integer s) {
     m_costPU = s;
   }
 
   /**
    * @return The amount you need to pay to perform the action.
    */
-  public int getCostPU() {
+  public int getCostPu() {
     return m_costPU;
   }
 
-  public void resetCostPU() {
+  public void resetCostPu() {
     m_costPU = 0;
   }
 
@@ -220,10 +220,10 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
                 this::resetText))
         .put("costPU",
             MutableProperty.of(
-                this::setCostPU,
-                this::setCostPU,
-                this::getCostPU,
-                this::resetCostPU))
+                this::setCostPu,
+                this::setCostPu,
+                this::getCostPu,
+                this::resetCostPu))
         .put("attemptsPerTurn",
             MutableProperty.of(
                 this::setAttemptsPerTurn,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -152,7 +152,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroyedTUV(final String value) throws GameParseException {
+  public void setDestroyedTuv(final String value) throws GameParseException {
     if (value == null) {
       m_destroyedTUV = null;
       return;
@@ -173,11 +173,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_destroyedTUV = value;
   }
 
-  public String getDestroyedTUV() {
+  public String getDestroyedTuv() {
     return m_destroyedTUV;
   }
 
-  public void resetDestroyedTUV() {
+  public void resetDestroyedTuv() {
     m_destroyedTUV = null;
   }
 
@@ -1192,9 +1192,9 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             MutableProperty.ofReadOnly(this::getAtWarCount))
         .put("destroyedTUV",
             MutableProperty.ofString(
-                this::setDestroyedTUV,
-                this::getDestroyedTUV,
-                this::resetDestroyedTUV))
+                this::setDestroyedTuv,
+                this::getDestroyedTuv,
+                this::resetDestroyedTuv))
         .put("battle",
             MutableProperty.of(
                 this::setBattle,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -787,7 +787,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirborneTargettedByAA(final String value) throws GameParseException {
+  public void setAirborneTargettedByAa(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
       throw new GameParseException("airborneTargettedByAA must have at least two fields" + thisErrorMsg());
@@ -800,21 +800,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneTargettedByAA(final Map<String, Set<UnitType>> value) {
+  public void setAirborneTargettedByAa(final Map<String, Set<UnitType>> value) {
     m_airborneTargettedByAA = value;
   }
 
-  public Map<String, Set<UnitType>> getAirborneTargettedByAA() {
+  public Map<String, Set<UnitType>> getAirborneTargettedByAa() {
     return m_airborneTargettedByAA;
   }
 
-  public static HashMap<String, HashSet<UnitType>> getAirborneTargettedByAA(final PlayerID player,
+  public static HashMap<String, HashSet<UnitType>> getAirborneTargettedByAa(final PlayerID player,
       final GameData data) {
     final HashMap<String, HashSet<UnitType>> airborneTargettedByAa = new HashMap<>();
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
       if (taa != null) {
-        final Map<String, Set<UnitType>> mapAa = taa.getAirborneTargettedByAA();
+        final Map<String, Set<UnitType>> mapAa = taa.getAirborneTargettedByAa();
         if (mapAa != null && !mapAa.isEmpty()) {
           for (final Entry<String, Set<UnitType>> entry : mapAa.entrySet()) {
             final HashSet<UnitType> current = airborneTargettedByAa.getOrDefault(entry.getKey(), new HashSet<>());
@@ -827,11 +827,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneTargettedByAa;
   }
 
-  public void clearAirborneTargettedByAA() {
+  public void clearAirborneTargettedByAa() {
     m_airborneTargettedByAA.clear();
   }
 
-  public void resetAirborneTargettedByAA() {
+  public void resetAirborneTargettedByAa() {
     m_airborneTargettedByAA = new HashMap<>();
   }
 
@@ -1209,10 +1209,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::resetAirborneBases))
         .put("airborneTargettedByAA",
             MutableProperty.of(
-                this::setAirborneTargettedByAA,
-                this::setAirborneTargettedByAA,
-                this::getAirborneTargettedByAA,
-                this::resetAirborneTargettedByAA))
+                this::setAirborneTargettedByAa,
+                this::setAirborneTargettedByAa,
+                this::getAirborneTargettedByAa,
+                this::resetAirborneTargettedByAa))
         .put("attackRollsBonus",
             MutableProperty.of(
                 this::setAttackRollsBonus,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -273,16 +273,16 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAARadar(final String s) {
+  public void setAaRadar(final String s) {
     aARadar = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAARadar(final Boolean s) {
+  public void setAaRadar(final Boolean s) {
     aARadar = s;
   }
 
-  public void resetAARadar() {
+  public void resetAaRadar() {
     aARadar = false;
   }
 
@@ -353,7 +353,7 @@ public class TechAttachment extends DefaultAttachment {
     return mechanizedInfantry;
   }
 
-  public boolean getAARadar() {
+  public boolean getAaRadar() {
     return aARadar;
   }
 
@@ -504,10 +504,10 @@ public class TechAttachment extends DefaultAttachment {
                 this::resetMechanizedInfantry))
         .put("aARadar",
             MutableProperty.of(
-                this::setAARadar,
-                this::setAARadar,
-                this::getAARadar,
-                this::resetAARadar))
+                this::setAaRadar,
+                this::setAaRadar,
+                this::getAaRadar,
+                this::resetAaRadar))
         .put("shipyards",
             MutableProperty.of(
                 this::setShipyards,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2213,117 +2213,117 @@ public class UnitAttachment extends DefaultAttachment {
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAA(final String s) throws GameParseException {
-    setIsAA(getBool(s));
+  public void setIsAa(final String s) throws GameParseException {
+    setIsAa(getBool(s));
   }
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAA(final Boolean s) throws GameParseException {
-    setIsAAforCombatOnly(s);
-    setIsAAforBombingThisUnitOnly(s);
-    setIsAAforFlyOverOnly(s);
-    setIsAAmovement(s);
+  public void setIsAa(final Boolean s) throws GameParseException {
+    setIsAaForCombatOnly(s);
+    setIsAaForBombingThisUnitOnly(s);
+    setIsAaForFlyOverOnly(s);
+    setIsAaMovement(s);
     setIsRocket(s);
     setIsInfrastructure(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAA(final String s) {
+  public void setAttackAa(final String s) {
     m_attackAA = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAA(final Integer s) {
+  public void setAttackAa(final Integer s) {
     m_attackAA = s;
   }
 
-  public int getAttackAA() {
+  public int getAttackAa() {
     return m_attackAA;
   }
 
-  public int getAttackAA(final PlayerID player) {
+  public int getAttackAa(final PlayerID player) {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something other than 6, or it
     // does not divide
     // perfectly into attackAAmaxDieSides
-    return Math.max(0, Math.min(getAttackAAmaxDieSides(),
+    return Math.max(0, Math.min(getAttackAaMaxDieSides(),
         m_attackAA + TechAbilityAttachment.getRadarBonus((UnitType) this.getAttachedTo(), player, getData())));
   }
 
-  public void resetAttackAA() {
+  public void resetAttackAa() {
     m_attackAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAA(final String s) {
+  public void setOffensiveAttackAa(final String s) {
     m_offensiveAttackAA = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAA(final Integer s) {
+  public void setOffensiveAttackAa(final Integer s) {
     m_offensiveAttackAA = s;
   }
 
-  public int getOffensiveAttackAA() {
+  public int getOffensiveAttackAa() {
     return m_offensiveAttackAA;
   }
 
-  public int getOffensiveAttackAA(final PlayerID player) {
+  public int getOffensiveAttackAa(final PlayerID player) {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something other than 6, or it
     // does not divide
     // perfectly into attackAAmaxDieSides
-    return Math.max(0, Math.min(getOffensiveAttackAAmaxDieSides(),
+    return Math.max(0, Math.min(getOffensiveAttackAaMaxDieSides(),
         m_offensiveAttackAA + TechAbilityAttachment.getRadarBonus((UnitType) this.getAttachedTo(), player, getData())));
   }
 
-  public void resetOffensiveAttackAA() {
+  public void resetOffensiveAttackAa() {
     m_offensiveAttackAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAAmaxDieSides(final String s) {
+  public void setAttackAaMaxDieSides(final String s) {
     m_attackAAmaxDieSides = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAAmaxDieSides(final Integer s) {
+  public void setAttackAaMaxDieSides(final Integer s) {
     m_attackAAmaxDieSides = s;
   }
 
-  public int getAttackAAmaxDieSides() {
+  public int getAttackAaMaxDieSides() {
     if (m_attackAAmaxDieSides < 0) {
       return getData().getDiceSides();
     }
     return m_attackAAmaxDieSides;
   }
 
-  public void resetAttackAAmaxDieSides() {
+  public void resetAttackAaMaxDieSides() {
     m_attackAAmaxDieSides = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAAmaxDieSides(final String s) {
+  public void setOffensiveAttackAaMaxDieSides(final String s) {
     m_offensiveAttackAAmaxDieSides = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAAmaxDieSides(final Integer s) {
+  public void setOffensiveAttackAaMaxDieSides(final Integer s) {
     m_offensiveAttackAAmaxDieSides = s;
   }
 
-  public int getOffensiveAttackAAmaxDieSides() {
+  public int getOffensiveAttackAaMaxDieSides() {
     if (m_offensiveAttackAAmaxDieSides < 0) {
       return getData().getDiceSides();
     }
     return m_offensiveAttackAAmaxDieSides;
   }
 
-  public void resetOffensiveAttackAAmaxDieSides() {
+  public void resetOffensiveAttackAaMaxDieSides() {
     m_offensiveAttackAAmaxDieSides = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxAAattacks(final String s) throws GameParseException {
+  public void setMaxAaAttacks(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
       throw new GameParseException("maxAAattacks must be positive (or -1 for attacking all) " + thisErrorMsg());
@@ -2332,20 +2332,20 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxAAattacks(final Integer s) {
+  public void setMaxAaAttacks(final Integer s) {
     m_maxAAattacks = s;
   }
 
-  public int getMaxAAattacks() {
+  public int getMaxAaAttacks() {
     return m_maxAAattacks;
   }
 
-  public void resetMaxAAattacks() {
+  public void resetMaxAaAttacks() {
     m_maxAAattacks = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxRoundsAA(final String s) throws GameParseException {
+  public void setMaxRoundsAa(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
       throw new GameParseException("maxRoundsAA must be positive (or -1 for infinite) " + thisErrorMsg());
@@ -2354,105 +2354,105 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxRoundsAA(final Integer s) {
+  public void setMaxRoundsAa(final Integer s) {
     m_maxRoundsAA = s;
   }
 
-  public int getMaxRoundsAA() {
+  public int getMaxRoundsAa() {
     return m_maxRoundsAA;
   }
 
-  public void resetMaxRoundsAA() {
+  public void resetMaxRoundsAa() {
     m_maxRoundsAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMayOverStackAA(final String s) {
+  public void setMayOverStackAa(final String s) {
     m_mayOverStackAA = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMayOverStackAA(final Boolean s) {
+  public void setMayOverStackAa(final Boolean s) {
     m_mayOverStackAA = s;
   }
 
-  public boolean getMayOverStackAA() {
+  public boolean getMayOverStackAa() {
     return m_mayOverStackAA;
   }
 
-  public void resetMayOverStackAA() {
+  public void resetMayOverStackAa() {
     m_mayOverStackAA = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDamageableAA(final String s) {
+  public void setDamageableAa(final String s) {
     m_damageableAA = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDamageableAA(final Boolean s) {
+  public void setDamageableAa(final Boolean s) {
     m_damageableAA = s;
   }
 
-  public boolean getDamageableAA() {
+  public boolean getDamageableAa() {
     return m_damageableAA;
   }
 
-  public void resetDamageableAA() {
+  public void resetDamageableAa() {
     m_damageableAA = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforCombatOnly(final String s) {
+  public void setIsAaForCombatOnly(final String s) {
     m_isAAforCombatOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforCombatOnly(final Boolean s) {
+  public void setIsAaForCombatOnly(final Boolean s) {
     m_isAAforCombatOnly = s;
   }
 
-  public boolean getIsAAforCombatOnly() {
+  public boolean getIsAaForCombatOnly() {
     return m_isAAforCombatOnly;
   }
 
-  public void resetIsAAforCombatOnly() {
+  public void resetIsAaForCombatOnly() {
     m_isAAforCombatOnly = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforBombingThisUnitOnly(final String s) {
+  public void setIsAaForBombingThisUnitOnly(final String s) {
     m_isAAforBombingThisUnitOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforBombingThisUnitOnly(final Boolean s) {
+  public void setIsAaForBombingThisUnitOnly(final Boolean s) {
     m_isAAforBombingThisUnitOnly = s;
   }
 
-  public boolean getIsAAforBombingThisUnitOnly() {
+  public boolean getIsAaForBombingThisUnitOnly() {
     return m_isAAforBombingThisUnitOnly;
   }
 
-  public void resetIsAAforBombingThisUnitOnly() {
+  public void resetIsAaForBombingThisUnitOnly() {
     m_isAAforBombingThisUnitOnly = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforFlyOverOnly(final String s) {
+  public void setIsAaForFlyOverOnly(final String s) {
     m_isAAforFlyOverOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAAforFlyOverOnly(final Boolean s) {
+  public void setIsAaForFlyOverOnly(final Boolean s) {
     m_isAAforFlyOverOnly = s;
   }
 
-  public boolean getIsAAforFlyOverOnly() {
+  public boolean getIsAaForFlyOverOnly() {
     return m_isAAforFlyOverOnly;
   }
 
-  public void resetIsAAforFlyOverOnly() {
+  public void resetIsAaForFlyOverOnly() {
     m_isAAforFlyOverOnly = false;
   }
 
@@ -2475,22 +2475,22 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTypeAA(final String s) {
+  public void setTypeAa(final String s) {
     m_typeAA = s;
   }
 
-  public String getTypeAA() {
+  public String getTypeAa() {
     return m_typeAA;
   }
 
-  public void resetTypeAA() {
+  public void resetTypeAa() {
     m_typeAA = "AA";
   }
 
-  public static List<String> getAllOfTypeAAs(final Collection<Unit> aaUnitsAlreadyVerified) {
+  public static List<String> getAllOfTypeAas(final Collection<Unit> aaUnitsAlreadyVerified) {
     final Set<String> aaSet = new HashSet<>();
     for (final Unit u : aaUnitsAlreadyVerified) {
-      aaSet.add(UnitAttachment.get(u.getType()).getTypeAA());
+      aaSet.add(UnitAttachment.get(u.getType()).getTypeAa());
     }
     final List<String> aaTypes = new ArrayList<>(aaSet);
     Collections.sort(aaTypes);
@@ -2501,7 +2501,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTargetsAA(final String value) throws GameParseException {
+  public void setTargetsAa(final String value) throws GameParseException {
     if (value == null) {
       m_targetsAA = null;
       return;
@@ -2520,15 +2520,15 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTargetsAA(final Set<UnitType> value) {
+  public void setTargetsAa(final Set<UnitType> value) {
     m_targetsAA = value;
   }
 
-  public Set<UnitType> getTargetsAA() {
+  public Set<UnitType> getTargetsAa() {
     return m_targetsAA;
   }
 
-  public Set<UnitType> getTargetsAA(final GameData data) {
+  public Set<UnitType> getTargetsAa(final GameData data) {
     if (m_targetsAA != null) {
       return m_targetsAA;
     }
@@ -2537,11 +2537,11 @@ public class UnitAttachment extends DefaultAttachment {
         .collect(Collectors.toSet());
   }
 
-  public void clearTargetsAA() {
+  public void clearTargetsAa() {
     m_targetsAA.clear();
   }
 
-  public void resetTargetsAA() {
+  public void resetTargetsAa() {
     m_targetsAA = null;
   }
 
@@ -2578,12 +2578,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAAmovement(final String s) throws GameParseException {
-    setIsAAmovement(getBool(s));
+  public void setIsAaMovement(final String s) throws GameParseException {
+    setIsAaMovement(getBool(s));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAAmovement(final boolean s) throws GameParseException {
+  public void setIsAaMovement(final boolean s) throws GameParseException {
     setCanNotMoveDuringCombatMove(s);
     if (s) {
       setMovementLimit(Integer.MAX_VALUE + ":allied");
@@ -2761,7 +2761,7 @@ public class UnitAttachment extends DefaultAttachment {
       return Integer.MAX_VALUE;
     }
     int max = stackingLimit.getFirst();
-    if (max == Integer.MAX_VALUE && (ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly())) {
+    if (max == Integer.MAX_VALUE && (ua.getIsAaForBombingThisUnitOnly() || ua.getIsAaForCombatOnly())) {
       // under certain rules (classic rules) there can only be 1 aa gun in a territory.
       if (!(Properties.getWW2V2(data) || Properties.getWW2V3(data)
           || Properties.getMultipleAaPerTerritory(data))) {
@@ -3163,35 +3163,35 @@ public class UnitAttachment extends DefaultAttachment {
         stats.append("Each movement point, ");
       }
     }
-    if ((getIsAAforCombatOnly() || getIsAAforBombingThisUnitOnly() || getIsAAforFlyOverOnly())
-        && (getAttackAA(player) > 0 || getOffensiveAttackAA(player) > 0)) {
-      if (getOffensiveAttackAA(player) > 0) {
-        stats.append(getOffensiveAttackAA(player)).append("/").append(
-            getOffensiveAttackAAmaxDieSides() != -1 ? getOffensiveAttackAAmaxDieSides() : getData().getDiceSides())
+    if ((getIsAaForCombatOnly() || getIsAaForBombingThisUnitOnly() || getIsAaForFlyOverOnly())
+        && (getAttackAa(player) > 0 || getOffensiveAttackAa(player) > 0)) {
+      if (getOffensiveAttackAa(player) > 0) {
+        stats.append(getOffensiveAttackAa(player)).append("/").append(
+            getOffensiveAttackAaMaxDieSides() != -1 ? getOffensiveAttackAaMaxDieSides() : getData().getDiceSides())
             .append(" att ");
       }
-      if (getAttackAA(player) > 0) {
-        stats.append(getAttackAA(player)).append("/")
-            .append(getAttackAAmaxDieSides() != -1 ? getAttackAAmaxDieSides() : getData().getDiceSides())
+      if (getAttackAa(player) > 0) {
+        stats.append(getAttackAa(player)).append("/")
+            .append(getAttackAaMaxDieSides() != -1 ? getAttackAaMaxDieSides() : getData().getDiceSides())
             .append(" def ");
       }
-      if (getIsAAforCombatOnly() && getIsAAforBombingThisUnitOnly() && getIsAAforFlyOverOnly()) {
-        stats.append(getTypeAA()).append(", ");
-      } else if (getIsAAforCombatOnly() && getIsAAforFlyOverOnly()
+      if (getIsAaForCombatOnly() && getIsAaForBombingThisUnitOnly() && getIsAaForFlyOverOnly()) {
+        stats.append(getTypeAa()).append(", ");
+      } else if (getIsAaForCombatOnly() && getIsAaForFlyOverOnly()
           && !Properties.getAaTerritoryRestricted(getData())) {
-        stats.append(getTypeAA()).append(" for Combat & Move Through, ");
-      } else if (getIsAAforBombingThisUnitOnly() && getIsAAforFlyOverOnly()
+        stats.append(getTypeAa()).append(" for Combat & Move Through, ");
+      } else if (getIsAaForBombingThisUnitOnly() && getIsAaForFlyOverOnly()
           && !Properties.getAaTerritoryRestricted(getData())) {
-        stats.append(getTypeAA()).append(" for Raids & Move Through, ");
-      } else if (getIsAAforCombatOnly()) {
-        stats.append(getTypeAA()).append(" for Combat, ");
-      } else if (getIsAAforBombingThisUnitOnly()) {
-        stats.append(getTypeAA()).append(" for Raids, ");
-      } else if (getIsAAforFlyOverOnly()) {
-        stats.append(getTypeAA()).append(" for Move Through, ");
+        stats.append(getTypeAa()).append(" for Raids & Move Through, ");
+      } else if (getIsAaForCombatOnly()) {
+        stats.append(getTypeAa()).append(" for Combat, ");
+      } else if (getIsAaForBombingThisUnitOnly()) {
+        stats.append(getTypeAa()).append(" for Raids, ");
+      } else if (getIsAaForFlyOverOnly()) {
+        stats.append(getTypeAa()).append(" for Move Through, ");
       }
-      if (getMaxAAattacks() > -1) {
-        stats.append(getMaxAAattacks()).append(" ").append(getTypeAA()).append(" Attacks, ");
+      if (getMaxAaAttacks() > -1) {
+        stats.append(getMaxAaAttacks()).append(" ").append(getTypeAa()).append(" Attacks, ");
       }
     }
     if (getIsRocket() && playerHasRockets(player)) {
@@ -3448,7 +3448,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (getMovementLimit() != null) {
       if (getMovementLimit().getFirst() == Integer.MAX_VALUE
-          && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
+          && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
               || Properties.getMultipleAaPerTerritory(getData()))) {
@@ -3460,7 +3460,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (getAttackingLimit() != null) {
       if (getAttackingLimit().getFirst() == Integer.MAX_VALUE
-          && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
+          && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
               || Properties.getMultipleAaPerTerritory(getData()))) {
@@ -3472,7 +3472,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (getPlacementLimit() != null) {
       if (getPlacementLimit().getFirst() == Integer.MAX_VALUE
-          && (getIsAAforBombingThisUnitOnly() || getIsAAforCombatOnly())
+          && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
           && !(Properties.getWW2V2(getData())
               || Properties.getWW2V3(getData())
               || Properties.getMultipleAaPerTerritory(getData()))) {
@@ -3736,22 +3736,22 @@ public class UnitAttachment extends DefaultAttachment {
                 this::resetIsLandTransportable))
         .put("isAAforCombatOnly",
             MutableProperty.of(
-                this::setIsAAforCombatOnly,
-                this::setIsAAforCombatOnly,
-                this::getIsAAforCombatOnly,
-                this::resetIsAAforCombatOnly))
+                this::setIsAaForCombatOnly,
+                this::setIsAaForCombatOnly,
+                this::getIsAaForCombatOnly,
+                this::resetIsAaForCombatOnly))
         .put("isAAforBombingThisUnitOnly",
             MutableProperty.of(
-                this::setIsAAforBombingThisUnitOnly,
-                this::setIsAAforBombingThisUnitOnly,
-                this::getIsAAforBombingThisUnitOnly,
-                this::resetIsAAforBombingThisUnitOnly))
+                this::setIsAaForBombingThisUnitOnly,
+                this::setIsAaForBombingThisUnitOnly,
+                this::getIsAaForBombingThisUnitOnly,
+                this::resetIsAaForBombingThisUnitOnly))
         .put("isAAforFlyOverOnly",
             MutableProperty.of(
-                this::setIsAAforFlyOverOnly,
-                this::setIsAAforFlyOverOnly,
-                this::getIsAAforFlyOverOnly,
-                this::resetIsAAforFlyOverOnly))
+                this::setIsAaForFlyOverOnly,
+                this::setIsAaForFlyOverOnly,
+                this::getIsAaForFlyOverOnly,
+                this::resetIsAaForFlyOverOnly))
         .put("isRocket",
             MutableProperty.of(
                 this::setIsRocket,
@@ -3760,63 +3760,63 @@ public class UnitAttachment extends DefaultAttachment {
                 this::resetIsRocket))
         .put("attackAA",
             MutableProperty.of(
-                this::setAttackAA,
-                this::setAttackAA,
-                this::getAttackAA,
-                this::resetAttackAA))
+                this::setAttackAa,
+                this::setAttackAa,
+                this::getAttackAa,
+                this::resetAttackAa))
         .put("offensiveAttackAA",
             MutableProperty.of(
-                this::setOffensiveAttackAA,
-                this::setOffensiveAttackAA,
-                this::getOffensiveAttackAA,
-                this::resetOffensiveAttackAA))
+                this::setOffensiveAttackAa,
+                this::setOffensiveAttackAa,
+                this::getOffensiveAttackAa,
+                this::resetOffensiveAttackAa))
         .put("attackAAmaxDieSides",
             MutableProperty.of(
-                this::setAttackAAmaxDieSides,
-                this::setAttackAAmaxDieSides,
-                this::getAttackAAmaxDieSides,
-                this::resetAttackAAmaxDieSides))
+                this::setAttackAaMaxDieSides,
+                this::setAttackAaMaxDieSides,
+                this::getAttackAaMaxDieSides,
+                this::resetAttackAaMaxDieSides))
         .put("offensiveAttackAAmaxDieSides",
             MutableProperty.of(
-                this::setOffensiveAttackAAmaxDieSides,
-                this::setOffensiveAttackAAmaxDieSides,
-                this::getOffensiveAttackAAmaxDieSides,
-                this::resetOffensiveAttackAAmaxDieSides))
+                this::setOffensiveAttackAaMaxDieSides,
+                this::setOffensiveAttackAaMaxDieSides,
+                this::getOffensiveAttackAaMaxDieSides,
+                this::resetOffensiveAttackAaMaxDieSides))
         .put("maxAAattacks",
             MutableProperty.of(
-                this::setMaxAAattacks,
-                this::setMaxAAattacks,
-                this::getMaxAAattacks,
-                this::resetMaxAAattacks))
+                this::setMaxAaAttacks,
+                this::setMaxAaAttacks,
+                this::getMaxAaAttacks,
+                this::resetMaxAaAttacks))
         .put("maxRoundsAA",
             MutableProperty.of(
-                this::setMaxRoundsAA,
-                this::setMaxRoundsAA,
-                this::getMaxRoundsAA,
-                this::resetMaxRoundsAA))
+                this::setMaxRoundsAa,
+                this::setMaxRoundsAa,
+                this::getMaxRoundsAa,
+                this::resetMaxRoundsAa))
         .put("typeAA",
             MutableProperty.ofString(
-                this::setTypeAA,
-                this::getTypeAA,
-                this::resetTypeAA))
+                this::setTypeAa,
+                this::getTypeAa,
+                this::resetTypeAa))
         .put("targetsAA",
             MutableProperty.of(
-                this::setTargetsAA,
-                this::setTargetsAA,
-                this::getTargetsAA,
-                this::resetTargetsAA))
+                this::setTargetsAa,
+                this::setTargetsAa,
+                this::getTargetsAa,
+                this::resetTargetsAa))
         .put("mayOverStackAA",
             MutableProperty.of(
-                this::setMayOverStackAA,
-                this::setMayOverStackAA,
-                this::getMayOverStackAA,
-                this::resetMayOverStackAA))
+                this::setMayOverStackAa,
+                this::setMayOverStackAa,
+                this::getMayOverStackAa,
+                this::resetMayOverStackAa))
         .put("damageableAA",
             MutableProperty.of(
-                this::setDamageableAA,
-                this::setDamageableAA,
-                this::getDamageableAA,
-                this::resetDamageableAA))
+                this::setDamageableAa,
+                this::setDamageableAa,
+                this::getDamageableAa,
+                this::resetDamageableAa))
         .put("willNotFireIfPresent",
             MutableProperty.of(
                 this::setWillNotFireIfPresent,
@@ -4110,8 +4110,8 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsFactory))
         .put("isAA",
             MutableProperty.<Boolean>ofWriteOnly(
-                this::setIsAA,
-                this::setIsAA))
+                this::setIsAa,
+                this::setIsAa))
         .put("destroyedWhenCapturedFrom",
             MutableProperty.ofWriteOnlyString(
                 this::setDestroyedWhenCapturedFrom))
@@ -4120,8 +4120,8 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setUnitPlacementOnlyAllowedIn))
         .put("isAAmovement",
             MutableProperty.<Boolean>ofWriteOnly(
-                this::setIsAAmovement,
-                this::setIsAAmovement))
+                this::setIsAaMovement,
+                this::setIsAaMovement))
         .put("isTwoHit",
             MutableProperty.<Boolean>ofWriteOnly(
                 this::setIsTwoHit,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -87,18 +87,18 @@ class AAInMoveUtil implements Serializable {
     }
     final PlayerID movingPlayer = movingPlayer(units);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAA(movingPlayer, getData());
+        TechAbilityAttachment.getAirborneTargettedByAa(movingPlayer, getData());
     final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.unitIsAaThatCanFire(units,
         airborneTechTargetsAllowed, movingPlayer, Matches.unitIsAaForFlyOverOnly(), 1, true, getData()));
     // comes ordered alphabetically already
-    final List<String> aaTypes = UnitAttachment.getAllOfTypeAAs(defendingAa);
+    final List<String> aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
     // stacks are backwards
     Collections.reverse(aaTypes);
     for (final String currentTypeAa : aaTypes) {
       final Collection<Unit> currentPossibleAa =
           CollectionUtils.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
       final Set<UnitType> targetUnitTypesForThisTypeAa =
-          UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(getData());
+          UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAa(getData());
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =
           CollectionUtils.getMatches(units, Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa)
@@ -195,7 +195,7 @@ class AAInMoveUtil implements Serializable {
     // look at the units being moved to determine allies and enemies
     final PlayerID movingPlayer = movingPlayer(units);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAA(movingPlayer, data);
+        TechAbilityAttachment.getAirborneTargettedByAa(movingPlayer, data);
     // don't iterate over the end
     // that will be a battle
     // and handled else where in this tangled mess

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AARadarAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AARadarAdvance.java
@@ -25,6 +25,6 @@ final class AARadarAdvance extends TechAdvance {
 
   @Override
   public boolean hasTech(final TechAttachment ta) {
-    return ta.getAARadar();
+    return ta.getAaRadar();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -69,11 +69,11 @@ public class DiceRoll implements Externalizable {
     int chosenDiceSize = diceSize;
     for (final Unit u : defendingEnemyAa) {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
-      int uaDiceSides = defending ? ua.getAttackAAmaxDieSides() : ua.getOffensiveAttackAAmaxDieSides();
+      int uaDiceSides = defending ? ua.getAttackAaMaxDieSides() : ua.getOffensiveAttackAaMaxDieSides();
       if (uaDiceSides < 1) {
         uaDiceSides = diceSize;
       }
-      int attack = defending ? ua.getAttackAA(u.getOwner()) : ua.getOffensiveAttackAA(u.getOwner());
+      int attack = defending ? ua.getAttackAa(u.getOwner()) : ua.getOffensiveAttackAa(u.getOwner());
       if (attack > uaDiceSides) {
         attack = uaDiceSides;
       }
@@ -99,13 +99,13 @@ public class DiceRoll implements Externalizable {
     int totalAAattacksSurplus = 0;
     for (final Unit aa : defendingEnemyAa) {
       final UnitAttachment ua = UnitAttachment.get(aa.getType());
-      if (ua.getMaxAAattacks() == -1) {
+      if (ua.getMaxAaAttacks() == -1) {
         totalAAattacksNormal = validAttackingUnitsForThisRoll.size();
       } else {
-        if (ua.getMayOverStackAA()) {
-          totalAAattacksSurplus += ua.getMaxAAattacks();
+        if (ua.getMayOverStackAa()) {
+          totalAAattacksSurplus += ua.getMaxAaAttacks();
         } else {
-          totalAAattacksNormal += ua.getMaxAAattacks();
+          totalAAattacksNormal += ua.getMaxAaAttacks();
         }
       }
     }
@@ -146,7 +146,7 @@ public class DiceRoll implements Externalizable {
     final int chosenDiceSizeForAll = attackThenDiceSidesForAll.getSecond();
     int hits = 0;
     final List<Die> sortedDice = new ArrayList<>();
-    final String typeAa = UnitAttachment.get(defendingAa.get(0).getType()).getTypeAA();
+    final String typeAa = UnitAttachment.get(defendingAa.get(0).getType()).getTypeAa();
     // LOW LUCK
     final Triple<Integer, Integer, Boolean> triple = getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
         null, null, defending, defendingAa, validAttackingUnitsForThisRoll, data, false);
@@ -257,7 +257,7 @@ public class DiceRoll implements Externalizable {
     while (i < runningMaximum && normalAAiter.hasNext()) {
       final Unit aaGun = normalAAiter.next();
       // should be > 0 at this point
-      int numAttacks = UnitAttachment.get(aaGun.getType()).getMaxAAattacks();
+      int numAttacks = UnitAttachment.get(aaGun.getType()).getMaxAaAttacks();
       final int hitAt = getAAattackAndMaxDiceSides(Collections.singleton(aaGun), data, defending).getFirst();
       if (hitAt < hitAtForInfinite) {
         continue;
@@ -299,7 +299,7 @@ public class DiceRoll implements Externalizable {
     while (i < runningMaximum && overstackAAiter.hasNext()) {
       final Unit aaGun = overstackAAiter.next();
       // should be > 0 at this point
-      int numAttacks = UnitAttachment.get(aaGun.getType()).getMaxAAattacks();
+      int numAttacks = UnitAttachment.get(aaGun.getType()).getMaxAaAttacks();
       // zero based, so subtract 1
       final int hitAt = getAAattackAndMaxDiceSides(Collections.singleton(aaGun), data, defending).getFirst();
       while (i < runningMaximum && numAttacks > 0) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -595,23 +595,23 @@ public final class Matches {
         return false;
       }
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
-      final Set<UnitType> targetsAa = ua.getTargetsAA(obj.getData());
+      final Set<UnitType> targetsAa = ua.getTargetsAa(obj.getData());
       for (final Unit u : targets) {
         if (targetsAa.contains(u.getType())) {
           return true;
         }
       }
       return targets.stream()
-          .anyMatch(unitIsAirborne().and(unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAA()))));
+          .anyMatch(unitIsAirborne().and(unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAa()))));
     };
   }
 
   static Predicate<Unit> unitIsAaOfTypeAa(final String typeAa) {
-    return obj -> UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAa);
+    return obj -> UnitAttachment.get(obj.getType()).getTypeAa().matches(typeAa);
   }
 
   static Predicate<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {
-    return obj -> UnitAttachment.get(obj.getType()).getDamageableAA();
+    return obj -> UnitAttachment.get(obj.getType()).getDamageableAa();
   }
 
   private static Predicate<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
@@ -628,7 +628,7 @@ public final class Matches {
 
   private static Predicate<UnitType> unitTypeIsAaThatCanFireOnRound(final int battleRoundNumber) {
     return obj -> {
-      final int maxRoundsAa = UnitAttachment.get(obj).getMaxRoundsAA();
+      final int maxRoundsAa = UnitAttachment.get(obj).getMaxRoundsAa();
       return maxRoundsAa < 0 || maxRoundsAa >= battleRoundNumber;
     };
   }
@@ -651,7 +651,7 @@ public final class Matches {
   }
 
   private static Predicate<UnitType> unitTypeIsAaForCombatOnly() {
-    return obj -> UnitAttachment.get(obj).getIsAAforCombatOnly();
+    return obj -> UnitAttachment.get(obj).getIsAaForCombatOnly();
   }
 
   static Predicate<Unit> unitIsAaForCombatOnly() {
@@ -659,7 +659,7 @@ public final class Matches {
   }
 
   public static Predicate<UnitType> unitTypeIsAaForBombingThisUnitOnly() {
-    return obj -> UnitAttachment.get(obj).getIsAAforBombingThisUnitOnly();
+    return obj -> UnitAttachment.get(obj).getIsAaForBombingThisUnitOnly();
   }
 
   public static Predicate<Unit> unitIsAaForBombingThisUnitOnly() {
@@ -667,7 +667,7 @@ public final class Matches {
   }
 
   private static Predicate<UnitType> unitTypeIsAaForFlyOverOnly() {
-    return obj -> UnitAttachment.get(obj).getIsAAforFlyOverOnly();
+    return obj -> UnitAttachment.get(obj).getIsAaForFlyOverOnly();
   }
 
   static Predicate<Unit> unitIsAaForFlyOverOnly() {
@@ -677,7 +677,7 @@ public final class Matches {
   public static Predicate<UnitType> unitTypeIsAaForAnything() {
     return obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj);
-      return ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly() || ua.getIsAAforFlyOverOnly();
+      return ua.getIsAaForBombingThisUnitOnly() || ua.getIsAaForCombatOnly() || ua.getIsAaForFlyOverOnly();
     };
   }
 
@@ -690,7 +690,7 @@ public final class Matches {
   }
 
   private static Predicate<UnitType> unitTypeMaxAaAttacksIsInfinite() {
-    return obj -> UnitAttachment.get(obj).getMaxAAattacks() == -1;
+    return obj -> UnitAttachment.get(obj).getMaxAaAttacks() == -1;
   }
 
   static Predicate<Unit> unitMaxAaAttacksIsInfinite() {
@@ -698,7 +698,7 @@ public final class Matches {
   }
 
   private static Predicate<UnitType> unitTypeMayOverStackAa() {
-    return obj -> UnitAttachment.get(obj).getMayOverStackAA();
+    return obj -> UnitAttachment.get(obj).getMayOverStackAa();
   }
 
   static Predicate<Unit> unitMayOverStackAa() {
@@ -708,14 +708,14 @@ public final class Matches {
   static Predicate<Unit> unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
-      return ua.getAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
+      return ua.getAttackAa(obj.getOwner()) > 0 && ua.getMaxAaAttacks() != 0;
     };
   }
 
   static Predicate<Unit> unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
     return obj -> {
       final UnitAttachment ua = UnitAttachment.get(obj.getType());
-      return ua.getOffensiveAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
+      return ua.getOffensiveAttackAa(obj.getOwner()) > 0 && ua.getMaxAaAttacks() != 0;
     };
   }
 
@@ -2064,7 +2064,7 @@ public final class Matches {
 
   public static Predicate<PoliticalActionAttachment> politicalActionHasCostBetween(final int greaterThanEqualTo,
       final int lessThanEqualTo) {
-    return paa -> paa.getCostPU() >= greaterThanEqualTo && paa.getCostPU() <= lessThanEqualTo;
+    return paa -> paa.getCostPu() >= greaterThanEqualTo && paa.getCostPu() <= lessThanEqualTo;
   }
 
   static Predicate<Unit> unitCanOnlyPlaceInOriginalTerritories() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -253,11 +253,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     canFire.addAll(m_defendingUnits);
     canFire.addAll(m_defendingWaitingToDie);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
+        TechAbilityAttachment.getAirborneTargettedByAa(m_attacker, m_data);
     m_defendingAA = CollectionUtils.getMatches(canFire, Matches.unitIsAaThatCanFire(m_attackingUnits,
         airborneTechTargetsAllowed, m_attacker, Matches.unitIsAaForCombatOnly(), m_round, true, m_data));
     // comes ordered alphabetically
-    m_defendingAAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
+    m_defendingAAtypes = UnitAttachment.getAllOfTypeAas(m_defendingAA);
     // stacks are backwards
     Collections.reverse(m_defendingAAtypes);
   }
@@ -270,7 +270,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_offensiveAA = CollectionUtils.getMatches(canFire, Matches.unitIsAaThatCanFire(m_defendingUnits,
         new HashMap<>(), m_defender, Matches.unitIsAaForCombatOnly(), m_round, false, m_data));
     // comes ordered alphabetically
-    m_offensiveAAtypes = UnitAttachment.getAllOfTypeAAs(m_offensiveAA);
+    m_offensiveAAtypes = UnitAttachment.getAllOfTypeAas(m_offensiveAA);
     // stacks are backwards
     Collections.reverse(m_offensiveAAtypes);
   }
@@ -444,14 +444,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   List<String> determineStepStrings(final boolean showFirstRun) {
     final List<String> steps = new ArrayList<>();
     if (canFireOffensiveAa()) {
-      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
+      for (final String typeAa : UnitAttachment.getAllOfTypeAas(m_offensiveAA)) {
         steps.add(m_attacker.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
         steps.add(m_defender.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
         steps.add(m_defender.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
       }
     }
     if (canFireDefendingAa()) {
-      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+      for (final String typeAa : UnitAttachment.getAllOfTypeAas(m_defendingAA)) {
         steps.add(m_defender.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
         steps.add(m_attacker.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
         steps.add(m_attacker.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
@@ -2077,9 +2077,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         final List<Collection<Unit>> firingGroups = createFiringUnitGroups(currentAaUnits);
         for (final Collection<Unit> currentPossibleAa : firingGroups) {
           final Set<UnitType> targetUnitTypesForThisTypeAa =
-              UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
+              UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAa(m_data);
           final Set<UnitType> airborneTypesTargettedToo =
-              m_defending ? TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAa)
+              m_defending ? TechAbilityAttachment.getAirborneTargettedByAa(m_attacker, m_data).get(currentTypeAa)
                   : new HashSet<>();
           final Collection<Unit> validAttackingUnitsForThisRoll = CollectionUtils.getMatches(
               (m_defending ? m_attackingUnits : m_defendingUnits), Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -244,9 +244,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    */
   private void notifyMoney(final PoliticalActionAttachment paa, final boolean enough) {
     if (enough) {
-      sendNotification("Charging " + paa.getCostPU() + " PU's to perform this action");
+      sendNotification("Charging " + paa.getCostPu() + " PU's to perform this action");
     } else {
-      sendNotification("You don't have ennough money, you need " + paa.getCostPU() + " PU's to perform this action");
+      sendNotification("You don't have ennough money, you need " + paa.getCostPu() + " PU's to perform this action");
     }
   }
 
@@ -258,7 +258,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    */
   private void chargeForAction(final PoliticalActionAttachment paa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
-    final int cost = paa.getCostPU();
+    final int cost = paa.getCostPu();
     if (cost > 0) {
       // don't notify user of spending money anymore
       // notifyMoney(paa, true);
@@ -282,7 +282,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    */
   private boolean checkEnoughMoney(final PoliticalActionAttachment paa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
-    final int cost = paa.getCostPU();
+    final int cost = paa.getCostPu();
     final int has = bridge.getPlayerId().getResources().getQuantity(pus);
     return has >= cost;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -90,7 +90,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   protected void updateDefendingUnits() {
     // fill in defenders
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
+        TechAbilityAttachment.getAirborneTargettedByAa(m_attacker, m_data);
     final Predicate<Unit> defenders = Matches.enemyUnit(m_attacker, m_data)
         .and(Matches.unitCanBeDamaged()
             .or(Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
@@ -179,16 +179,16 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     BattleCalculator.sortPreBattle(m_attackingUnits);
     // TODO: determine if the target has the property, not just any unit with the property isAAforBombingThisUnitOnly
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
+        TechAbilityAttachment.getAirborneTargettedByAa(m_attacker, m_data);
     m_defendingAA = m_battleSite.getUnits().getMatches(Matches.unitIsAaThatCanFire(m_attackingUnits,
         airborneTechTargetsAllowed, m_attacker, Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data));
-    m_AAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
+    m_AAtypes = UnitAttachment.getAllOfTypeAas(m_defendingAA);
     // reverse since stacks are in reverse order
     Collections.reverse(m_AAtypes);
     final boolean hasAa = m_defendingAA.size() > 0;
     m_steps = new ArrayList<>();
     if (hasAa) {
-      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+      for (final String typeAa : UnitAttachment.getAllOfTypeAas(m_defendingAA)) {
         m_steps.add(typeAa + AA_GUNS_FIRE_SUFFIX);
         m_steps.add(SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
         m_steps.add(REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
@@ -200,7 +200,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     if (hasAa) {
       // global1940 rules - each target type fires an AA shot against the planes bombing it
       steps.addAll(m_targets.entrySet().stream()
-          .filter(entry -> entry.getKey().getUnitAttachment().getIsAAforBombingThisUnitOnly())
+          .filter(entry -> entry.getKey().getUnitAttachment().getIsAaForBombingThisUnitOnly())
           .map(Entry::getValue)
           .map(FireAA::new)
           .collect(Collectors.toList()));
@@ -352,9 +352,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Collection<Unit> currentPossibleAa =
             CollectionUtils.getMatches(m_defendingAA, Matches.unitIsAaOfTypeAa(currentTypeAa));
         final Set<UnitType> targetUnitTypesForThisTypeAa =
-            UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
+            UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAa(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
-            TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAa);
+            TechAbilityAttachment.getAirborneTargettedByAa(m_attacker, m_data).get(currentTypeAa);
         if (determineAttackers) {
           validAttackingUnitsForThisRoll = CollectionUtils.getMatches(m_attackingUnits,
               Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -126,6 +126,6 @@ public final class TechTracker {
   }
 
   public static boolean hasAaRadar(final PlayerID player) {
-    return TechAttachment.get(player).getAARadar();
+    return TechAttachment.get(player).getAaRadar();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -110,7 +110,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    */
   private boolean checkEnoughMoney(final UserActionAttachment uaa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
-    final int cost = uaa.getCostPU();
+    final int cost = uaa.getCostPu();
     final int has = bridge.getPlayerId().getResources().getQuantity(pus);
     return has >= cost;
   }
@@ -123,7 +123,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    */
   private void chargeForAction(final UserActionAttachment uaa) {
     final Resource pus = getData().getResourceList().getResource(Constants.PUS);
-    final int cost = uaa.getCostPU();
+    final int cost = uaa.getCostPu();
     if (cost > 0) {
       // don't notify user of spending money anymore
       // notifyMoney(uaa, true);
@@ -260,7 +260,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    *
    */
   private void notifyMoney(final UserActionAttachment uaa) {
-    sendNotification("You don't have enough money, you need " + uaa.getCostPU() + " PU's to perform this action");
+    sendNotification("You don't have enough money, you need " + uaa.getCostPu() + " PU's to perform this action");
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -133,7 +133,7 @@ public class ExtendedStats extends StatPanel {
       if (ta.getMechanizedInfantry()) {
         count++;
       }
-      if (ta.getAARadar()) {
+      if (ta.getAaRadar()) {
         count++;
       }
       if (ta.getShipyards()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -224,7 +224,7 @@ public class PoliticsPanel extends ActionPanel {
   }
 
   private static String getActionButtonText(final PoliticalActionAttachment paa) {
-    final String costString = paa.getCostPU() == 0 ? "" : "[" + paa.getCostPU() + " PU] ";
+    final String costString = paa.getCostPu() == 0 ? "" : "[" + paa.getCostPu() + " PU] ";
     return costString + PoliticsText.getInstance().getButtonText(paa.getText());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -152,7 +152,7 @@ public class UserActionPanel extends ActionPanel {
 
   @VisibleForTesting
   static boolean canSpendResourcesOnUserActions(final Collection<UserActionAttachment> userActions) {
-    return userActions.stream().anyMatch(userAction -> userAction.getCostPU() > 0);
+    return userActions.stream().anyMatch(userAction -> userAction.getCostPu() > 0);
   }
 
   private JPanel getUserActionButtonPanel(final JDialog parent) {
@@ -197,7 +197,7 @@ public class UserActionPanel extends ActionPanel {
 
   @VisibleForTesting
   static boolean canPlayerAffordUserAction(final PlayerID player, final UserActionAttachment userAction) {
-    return userAction.getCostPU() <= player.getResources().getQuantity(Constants.PUS);
+    return userAction.getCostPu() <= player.getResources().getQuantity(Constants.PUS);
   }
 
   private static Dimension getUserActionScrollPanePreferredSize(final JScrollPane scrollPane) {
@@ -243,7 +243,7 @@ public class UserActionPanel extends ActionPanel {
   }
 
   private static String getActionButtonText(final UserActionAttachment paa) {
-    final String costString = paa.getCostPU() == 0 ? "" : "[" + paa.getCostPU() + " PU] ";
+    final String costString = paa.getCostPu() == 0 ? "" : "[" + paa.getCostPu() + " PU] ";
     return costString + UserActionText.getInstance().getButtonText(paa.getText());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -96,7 +96,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
@@ -124,7 +124,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -167,7 +167,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
@@ -206,7 +206,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
@@ -236,7 +236,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
@@ -270,7 +270,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
@@ -301,7 +301,7 @@ public class BattleCalculatorTest {
             .rollAa(
                 CollectionUtils.getMatches(planes,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(data))),
+                        .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
                 defendingAa, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -259,7 +259,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
     // aa missses at 1 (0 based)
@@ -270,7 +270,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
@@ -282,7 +282,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertThat(hitNoRoll.getHits(), is(1));
   }
@@ -308,7 +308,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
   }
@@ -325,7 +325,7 @@ public class DiceRollTest {
     GameDataTestUtil.addTo(finnland, aaGunList);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     List<Unit> fighterList = fighterType.create(1, russians);
-    TechAttachment.get(germans).setAARadar("true");
+    TechAttachment.get(germans).setAaRadar("true");
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
     // aa radar hits at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
@@ -334,7 +334,7 @@ public class DiceRollTest {
             .rollAa(
                 CollectionUtils.getMatches(fighterList,
                     Matches.unitIsOfTypes(
-                        UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, finnland, true);
     assertThat(hit.getHits(), is(1));
     // aa missses at 2 (0 based)
@@ -345,7 +345,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, finnland, true);
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
@@ -357,7 +357,7 @@ public class DiceRollTest {
                 CollectionUtils.getMatches(fighterList,
                     Matches
                         .unitIsOfTypes(
-                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
                 aaGunList, bridge, finnland, true);
     assertThat(hitNoRoll.getHits(), is(2));
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -444,7 +444,7 @@ public class GameDataTestUtil {
   }
 
   static void givePlayerRadar(final PlayerID player) {
-    TechAttachment.get(player).setAARadar(Boolean.TRUE.toString());
+    TechAttachment.get(player).setAaRadar(Boolean.TRUE.toString());
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -146,7 +146,7 @@ public class WW2V3Year41Test {
         DiceRoll.rollAa(
             CollectionUtils.getMatches(planes,
                 Matches
-                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
+                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
             defendingAa, bridge, territory("Germany", gameData), true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
@@ -177,7 +177,7 @@ public class WW2V3Year41Test {
         DiceRoll.rollAa(
             CollectionUtils.getMatches(planes,
                 Matches
-                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
+                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
             defendingAa, bridge, territory("Germany", gameData), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
@@ -211,7 +211,7 @@ public class WW2V3Year41Test {
         DiceRoll.rollAa(
             CollectionUtils.getMatches(planes,
                 Matches
-                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAA(gameData))),
+                    .unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
             defendingAa, bridge, territory("Germany", gameData), true);
     assertEquals(roll.getHits(), 2);
     // make sure we rolled once

--- a/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -61,7 +61,7 @@ public final class UserActionPanelTest {
 
   private UserActionAttachment createUserActionWithCost(final int costInPUs) {
     final UserActionAttachment userAction = new UserActionAttachment("userAction", mock(Attachable.class), data);
-    userAction.setCostPU(costInPUs);
+    userAction.setCostPu(costInPUs);
     return userAction;
   }
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in the attachment classes.  Now that the attachment methods are no longer invoked via reflection, it should be safe to rename them.

This PR consists solely of method renames.