### PR TITLE
Minimize accessibility of DynamicallyModifiable methods

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -104,7 +104,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setTransportedBy(final TripleAUnit transportedBy) {
+  private void setTransportedBy(final TripleAUnit transportedBy) {
     m_transportedBy = transportedBy;
   }
 
@@ -135,7 +135,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setUnloaded(final List<Unit> unloaded) {
+  private void setUnloaded(final List<Unit> unloaded) {
     if (unloaded == null || unloaded.isEmpty()) {
       m_unloaded = Collections.emptyList();
     } else {
@@ -148,7 +148,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasLoadedThisTurn(final boolean value) {
+  private void setWasLoadedThisTurn(final boolean value) {
     m_wasLoadedThisTurn = value;
   }
 
@@ -157,7 +157,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setUnloadedTo(final Territory unloadedTo) {
+  private void setUnloadedTo(final Territory unloadedTo) {
     m_unloadedTo = unloadedTo;
   }
 
@@ -166,7 +166,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setOriginatedFrom(final Territory t) {
+  private void setOriginatedFrom(final Territory t) {
     m_originatedFrom = t;
   }
 
@@ -175,7 +175,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasUnloadedInCombatPhase(final boolean value) {
+  private void setWasUnloadedInCombatPhase(final boolean value) {
     m_wasUnloadedInCombatPhase = value;
   }
 
@@ -189,7 +189,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setBonusMovement(final int bonusMovement) {
+  private void setBonusMovement(final int bonusMovement) {
     m_bonusMovement = bonusMovement;
   }
 
@@ -249,7 +249,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setOriginalOwner(final PlayerID originalOwner) {
+  private void setOriginalOwner(final PlayerID originalOwner) {
     m_originalOwner = originalOwner;
   }
 
@@ -258,7 +258,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasInCombat(final boolean value) {
+  private void setWasInCombat(final boolean value) {
     m_wasInCombat = value;
   }
 
@@ -267,7 +267,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasScrambled(final boolean value) {
+  private void setWasScrambled(final boolean value) {
     m_wasScrambled = value;
   }
 
@@ -276,7 +276,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setMaxScrambleCount(final int value) {
+  private void setMaxScrambleCount(final int value) {
     m_maxScrambleCount = value;
   }
 
@@ -285,7 +285,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setLaunched(final int value) {
+  private void setLaunched(final int value) {
     m_launched = value;
   }
 
@@ -294,12 +294,12 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setAirborne(final boolean value) {
+  private void setAirborne(final boolean value) {
     m_airborne = value;
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasInAirBattle(final boolean value) {
+  private void setWasInAirBattle(final boolean value) {
     m_wasInAirBattle = value;
   }
 
@@ -312,7 +312,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasLoadedAfterCombat(final boolean value) {
+  private void setWasLoadedAfterCombat(final boolean value) {
     m_wasLoadedAfterCombat = value;
   }
 
@@ -325,7 +325,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setWasAmphibious(final boolean value) {
+  private void setWasAmphibious(final boolean value) {
     m_wasAmphibious = value;
   }
 
@@ -334,7 +334,7 @@ public class TripleAUnit extends Unit {
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setDisabled(final boolean value) {
+  private void setDisabled(final boolean value) {
     m_disabled = value;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -51,7 +51,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   // if chance succeeds, we should decrement the chance by x
   protected int m_chanceDecrementOnSuccess = 0;
 
-  public AbstractConditionsAttachment(final String name, final Attachable attachable, final GameData gameData) {
+  protected AbstractConditionsAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
@@ -81,7 +81,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConditions(final List<RulesAttachment> value) {
+  private void setConditions(final List<RulesAttachment> value) {
     m_conditions = value;
   }
 
@@ -107,7 +107,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setInvert(final boolean s) {
+  private void setInvert(final boolean s) {
     m_invert = s;
   }
 
@@ -285,7 +285,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChance(final String chance) throws GameParseException {
+  protected void setChance(final String chance) throws GameParseException {
     final String[] s = chance.split(":");
     try {
       final int i = getInt(s[0]);
@@ -305,11 +305,11 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   /**
    * @return The number you need to roll to get the action to succeed format "1:10" for 10% chance.
    */
-  public String getChance() {
+  private String getChance() {
     return m_chance;
   }
 
-  public void resetChance() {
+  private void resetChance() {
     m_chance = DEFAULT_CHANCE;
   }
 
@@ -322,12 +322,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChanceIncrementOnFailure(final String value) {
+  private void setChanceIncrementOnFailure(final String value) {
     setChanceIncrementOnFailure(getInt(value));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChanceIncrementOnFailure(final int value) {
+  private void setChanceIncrementOnFailure(final int value) {
     m_chanceIncrementOnFailure = value;
   }
 
@@ -335,17 +335,17 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_chanceIncrementOnFailure;
   }
 
-  public void resetChanceIncrementOnFailure() {
+  private void resetChanceIncrementOnFailure() {
     m_chanceIncrementOnFailure = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChanceDecrementOnSuccess(final String value) {
+  private void setChanceDecrementOnSuccess(final String value) {
     setChanceDecrementOnSuccess(getInt(value));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChanceDecrementOnSuccess(final int value) {
+  private void setChanceDecrementOnSuccess(final int value) {
     m_chanceDecrementOnSuccess = value;
   }
 
@@ -353,7 +353,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_chanceDecrementOnSuccess;
   }
 
-  public void resetChanceDecrementOnSuccess() {
+  private void resetChanceDecrementOnSuccess() {
     m_chanceDecrementOnSuccess = 0;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -57,7 +57,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   // It would wreck most map xmls to move the rulesAttachment's to another class, so don't move them out of here
   // please!
   // However, any new rules attachments that are not conditions, should be put into the "PlayerAttachment" class.
-  public AbstractPlayerRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
+  protected AbstractPlayerRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
@@ -80,7 +80,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementRestrictionTerritories(final String value) {
+  private void setMovementRestrictionTerritories(final String value) {
     if (value == null) {
       m_movementRestrictionTerritories = null;
       return;
@@ -90,7 +90,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementRestrictionTerritories(final String[] value) {
+  private void setMovementRestrictionTerritories(final String[] value) {
     m_movementRestrictionTerritories = value;
   }
 
@@ -98,12 +98,12 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_movementRestrictionTerritories;
   }
 
-  public void resetMovementRestrictionTerritories() {
+  private void resetMovementRestrictionTerritories() {
     m_movementRestrictionTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementRestrictionType(final String value) throws GameParseException {
+  private void setMovementRestrictionType(final String value) throws GameParseException {
     if (value == null) {
       m_movementRestrictionType = null;
       return;
@@ -118,7 +118,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_movementRestrictionType;
   }
 
-  public void resetMovementRestrictionType() {
+  private void resetMovementRestrictionType() {
     m_movementRestrictionType = null;
   }
 
@@ -126,7 +126,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setProductionPerXTerritories(final String value) throws GameParseException {
+  private void setProductionPerXTerritories(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
@@ -151,7 +151,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setProductionPerXTerritories(final IntegerMap<UnitType> value) {
+  private void setProductionPerXTerritories(final IntegerMap<UnitType> value) {
     m_productionPerXTerritories = value;
   }
 
@@ -163,17 +163,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     m_productionPerXTerritories.clear();
   }
 
-  public void resetProductionPerXTerritories() {
+  private void resetProductionPerXTerritories() {
     m_productionPerXTerritories = new IntegerMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementPerTerritory(final String value) {
+  private void setPlacementPerTerritory(final String value) {
     m_placementPerTerritory = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementPerTerritory(final Integer value) {
+  private void setPlacementPerTerritory(final Integer value) {
     m_placementPerTerritory = value;
   }
 
@@ -181,17 +181,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_placementPerTerritory;
   }
 
-  public void resetPlacementPerTerritory() {
+  private void resetPlacementPerTerritory() {
     m_placementPerTerritory = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxPlacePerTerritory(final String value) {
+  private void setMaxPlacePerTerritory(final String value) {
     m_maxPlacePerTerritory = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxPlacePerTerritory(final Integer value) {
+  private void setMaxPlacePerTerritory(final Integer value) {
     m_maxPlacePerTerritory = value;
   }
 
@@ -199,17 +199,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_maxPlacePerTerritory;
   }
 
-  public void resetMaxPlacePerTerritory() {
+  private void resetMaxPlacePerTerritory() {
     m_maxPlacePerTerritory = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementAnyTerritory(final String value) {
+  private void setPlacementAnyTerritory(final String value) {
     m_placementAnyTerritory = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementAnyTerritory(final Boolean value) {
+  private void setPlacementAnyTerritory(final Boolean value) {
     m_placementAnyTerritory = value;
   }
 
@@ -217,17 +217,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_placementAnyTerritory;
   }
 
-  public void resetPlacementAnyTerritory() {
+  private void resetPlacementAnyTerritory() {
     m_placementAnyTerritory = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementAnySeaZone(final String value) {
+  private void setPlacementAnySeaZone(final String value) {
     m_placementAnySeaZone = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementAnySeaZone(final Boolean value) {
+  private void setPlacementAnySeaZone(final Boolean value) {
     m_placementAnySeaZone = value;
   }
 
@@ -235,17 +235,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_placementAnySeaZone;
   }
 
-  public void resetPlacementAnySeaZone() {
+  private void resetPlacementAnySeaZone() {
     m_placementAnySeaZone = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementCapturedTerritory(final String value) {
+  private void setPlacementCapturedTerritory(final String value) {
     m_placementCapturedTerritory = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementCapturedTerritory(final Boolean value) {
+  private void setPlacementCapturedTerritory(final Boolean value) {
     m_placementCapturedTerritory = value;
   }
 
@@ -253,17 +253,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_placementCapturedTerritory;
   }
 
-  public void resetPlacementCapturedTerritory() {
+  private void resetPlacementCapturedTerritory() {
     m_placementCapturedTerritory = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementInCapitalRestricted(final String value) {
+  private void setPlacementInCapitalRestricted(final String value) {
     m_placementInCapitalRestricted = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementInCapitalRestricted(final Boolean value) {
+  private void setPlacementInCapitalRestricted(final Boolean value) {
     m_placementInCapitalRestricted = value;
   }
 
@@ -271,17 +271,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_placementInCapitalRestricted;
   }
 
-  public void resetPlacementInCapitalRestricted() {
+  private void resetPlacementInCapitalRestricted() {
     m_placementInCapitalRestricted = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnlimitedProduction(final String value) {
+  private void setUnlimitedProduction(final String value) {
     m_unlimitedProduction = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnlimitedProduction(final Boolean value) {
+  private void setUnlimitedProduction(final Boolean value) {
     m_unlimitedProduction = value;
   }
 
@@ -289,17 +289,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_unlimitedProduction;
   }
 
-  public void resetUnlimitedProduction() {
+  private void resetUnlimitedProduction() {
     m_unlimitedProduction = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDominatingFirstRoundAttack(final String value) {
+  private void setDominatingFirstRoundAttack(final String value) {
     m_dominatingFirstRoundAttack = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDominatingFirstRoundAttack(final Boolean value) {
+  private void setDominatingFirstRoundAttack(final Boolean value) {
     m_dominatingFirstRoundAttack = value;
   }
 
@@ -307,17 +307,17 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_dominatingFirstRoundAttack;
   }
 
-  public void resetDominatingFirstRoundAttack() {
+  private void resetDominatingFirstRoundAttack() {
     m_dominatingFirstRoundAttack = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNegateDominatingFirstRoundAttack(final String value) {
+  private void setNegateDominatingFirstRoundAttack(final String value) {
     m_negateDominatingFirstRoundAttack = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNegateDominatingFirstRoundAttack(final Boolean value) {
+  private void setNegateDominatingFirstRoundAttack(final Boolean value) {
     m_negateDominatingFirstRoundAttack = value;
   }
 
@@ -325,7 +325,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_negateDominatingFirstRoundAttack;
   }
 
-  public void resetNegateDominatingFirstRoundAttack() {
+  private void resetNegateDominatingFirstRoundAttack() {
     m_negateDominatingFirstRoundAttack = false;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -58,7 +58,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   // allows custom GameProperties
   protected String m_gameProperty = null;
 
-  public AbstractRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
+  protected AbstractRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
@@ -66,7 +66,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlayers(final String names) throws GameParseException {
+  private void setPlayers(final String names) throws GameParseException {
     final PlayerList pl = getData().getPlayerList();
     for (final String p : names.split(":")) {
       final PlayerID player = pl.getPlayerId(p);
@@ -78,11 +78,11 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayers(final List<PlayerID> value) {
+  private void setPlayers(final List<PlayerID> value) {
     m_players = value;
   }
 
-  public List<PlayerID> getPlayers() {
+  protected List<PlayerID> getPlayers() {
     return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
   }
 
@@ -90,25 +90,25 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     m_players.clear();
   }
 
-  public void resetPlayers() {
+  private void resetPlayers() {
     m_players = new ArrayList<>();
   }
 
   @Override
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChance(final String chance) throws GameParseException {
+  protected void setChance(final String chance) throws GameParseException {
     throw new GameParseException(
         "chance not allowed for use with RulesAttachments, instead use it with Triggers or PoliticalActions"
             + thisErrorMsg());
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setObjectiveValue(final String value) {
+  private void setObjectiveValue(final String value) {
     m_objectiveValue = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setObjectiveValue(final Integer value) {
+  private void setObjectiveValue(final Integer value) {
     m_objectiveValue = value;
   }
 
@@ -116,7 +116,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return m_objectiveValue;
   }
 
-  public void resetObjectiveValue() {
+  private void resetObjectiveValue() {
     m_objectiveValue = 0;
   }
 
@@ -158,12 +158,12 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUses(final String s) {
+  private void setUses(final String s) {
     m_uses = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUses(final Integer u) {
+  private void setUses(final Integer u) {
     m_uses = u;
   }
 
@@ -176,34 +176,34 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return m_uses;
   }
 
-  public void resetUses() {
+  private void resetUses() {
     m_uses = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSwitch(final String value) {
+  private void setSwitch(final String value) {
     m_switch = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSwitch(final Boolean value) {
+  private void setSwitch(final Boolean value) {
     m_switch = value;
   }
 
-  public boolean getSwitch() {
+  private boolean getSwitch() {
     return m_switch;
   }
 
-  public void resetSwitch() {
+  private void resetSwitch() {
     m_switch = true;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setGameProperty(final String value) {
+  private void setGameProperty(final String value) {
     m_gameProperty = value;
   }
 
-  public String getGameProperty() {
+  private String getGameProperty() {
     return m_gameProperty;
   }
 
@@ -214,12 +214,12 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return data.getProperties().get(m_gameProperty, false);
   }
 
-  public void resetGameProperty() {
+  private void resetGameProperty() {
     m_gameProperty = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setRounds(final String rounds) throws GameParseException {
+  private void setRounds(final String rounds) throws GameParseException {
     if (rounds == null) {
       m_turns = null;
       return;
@@ -252,20 +252,20 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTurns(final String turns) throws GameParseException {
+  private void setTurns(final String turns) throws GameParseException {
     setRounds(turns);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTurns(final Map<Integer, Integer> value) {
+  private void setTurns(final Map<Integer, Integer> value) {
     m_turns = value;
   }
 
-  public Map<Integer, Integer> getTurns() {
+  private Map<Integer, Integer> getTurns() {
     return m_turns;
   }
 
-  public void resetTurns() {
+  private void resetTurns() {
     m_turns = null;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -40,7 +40,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   private String m_notification = null;
   private List<Tuple<String, String>> m_when = new ArrayList<>();
 
-  public AbstractTriggerAttachment(final String name, final Attachable attachable, final GameData gameData) {
+  protected AbstractTriggerAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
@@ -66,7 +66,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = true)
-  public void setTrigger(final String conditions) throws GameParseException {
+  private void setTrigger(final String conditions) throws GameParseException {
     setConditions(conditions);
   }
 
@@ -74,7 +74,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */
   @Deprecated
-  public List<RulesAttachment> getTrigger() {
+  private List<RulesAttachment> getTrigger() {
     return getConditions();
   }
 
@@ -90,17 +90,17 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */
   @Deprecated
-  public void resetTrigger() {
+  private void resetTrigger() {
     resetConditions();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUses(final String s) {
+  private void setUses(final String s) {
     m_uses = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUses(final Integer u) {
+  private void setUses(final Integer u) {
     m_uses = u;
   }
 
@@ -110,7 +110,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setUsedThisRound(final String s) {
+  private void setUsedThisRound(final String s) {
     m_usedThisRound = getBool(s);
   }
 
@@ -120,15 +120,15 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setUsedThisRound(final Boolean usedThisRound) {
+  private void setUsedThisRound(final Boolean usedThisRound) {
     m_usedThisRound = usedThisRound;
   }
 
-  public boolean getUsedThisRound() {
+  protected boolean getUsedThisRound() {
     return m_usedThisRound;
   }
 
-  public void resetUsedThisRound() {
+  private void resetUsedThisRound() {
     m_usedThisRound = false;
   }
 
@@ -136,7 +136,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     return m_uses;
   }
 
-  public void resetUses() {
+  private void resetUses() {
     m_uses = -1;
   }
 
@@ -144,7 +144,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhen(final String when) throws GameParseException {
+  private void setWhen(final String when) throws GameParseException {
     final String[] s = when.split(":");
     if (s.length != 2) {
       throw new GameParseException("when must exist in 2 parts: \"before/after:stepName\"." + thisErrorMsg());
@@ -156,11 +156,11 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhen(final List<Tuple<String, String>> value) {
+  private void setWhen(final List<Tuple<String, String>> value) {
     m_when = value;
   }
 
-  public List<Tuple<String, String>> getWhen() {
+  protected List<Tuple<String, String>> getWhen() {
     return m_when;
   }
 
@@ -168,12 +168,12 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     m_when.clear();
   }
 
-  public void resetWhen() {
+  private void resetWhen() {
     m_when = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNotification(final String notification) {
+  private void setNotification(final String notification) {
     if (notification == null) {
       m_notification = null;
       return;
@@ -181,11 +181,11 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     m_notification = notification;
   }
 
-  public String getNotification() {
+  protected String getNotification() {
     return m_notification;
   }
 
-  public void resetNotification() {
+  private void resetNotification() {
     m_notification = null;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -24,11 +24,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   private static final long serialVersionUID = 3569461523853104614L;
   public static final String ATTEMPTS_LEFT_THIS_TURN = "attemptsLeftThisTurn";
 
-
-  public AbstractUserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
-    super(name, attachable, gameData);
-  }
-
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
   protected String m_text = "";
   // cost in PU to attempt this action
@@ -47,6 +42,10 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   // set "actionAccept" to "UK" so UK can accept this action to go through.
   protected List<PlayerID> m_actionAccept = new ArrayList<>();
 
+  protected AbstractUserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
+    super(name, attachable, gameData);
+  }
+
   /**
    * @return true if there is no condition to this action or if the condition is satisfied.
    */
@@ -59,7 +58,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    *        the Key that is used in politicstext.properties or other .properties for all the texts
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setText(final String text) {
+  private void setText(final String text) {
     m_text = text;
   }
 
@@ -70,7 +69,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return m_text;
   }
 
-  public void resetText() {
+  private void resetText() {
     m_text = "";
   }
 
@@ -79,7 +78,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    *        the amount you need to pay to perform the action.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCostPu(final String s) {
+  private void setCostPu(final String s) {
     m_costPU = getInt(s);
   }
 
@@ -95,7 +94,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return m_costPU;
   }
 
-  public void resetCostPu() {
+  private void resetCostPu() {
     m_costPU = 0;
   }
 
@@ -103,7 +102,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setActionAccept(final String value) throws GameParseException {
+  private void setActionAccept(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -116,7 +115,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setActionAccept(final List<PlayerID> value) {
+  private void setActionAccept(final List<PlayerID> value) {
     m_actionAccept = value;
   }
 
@@ -131,7 +130,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     m_actionAccept.clear();
   }
 
-  public void resetActionAccept() {
+  private void resetActionAccept() {
     m_actionAccept = new ArrayList<>();
   }
 
@@ -140,13 +139,13 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    *        the amount of times you can try this Action per Round.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttemptsPerTurn(final String s) {
+  private void setAttemptsPerTurn(final String s) {
     m_attemptsPerTurn = getInt(s);
     setAttemptsLeftThisTurn(m_attemptsPerTurn);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttemptsPerTurn(final Integer s) {
+  private void setAttemptsPerTurn(final Integer s) {
     m_attemptsPerTurn = s;
     setAttemptsLeftThisTurn(m_attemptsPerTurn);
   }
@@ -154,11 +153,11 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   /**
    * @return The amount of times you can try this Action per Round.
    */
-  public int getAttemptsPerTurn() {
+  private int getAttemptsPerTurn() {
     return m_attemptsPerTurn;
   }
 
-  public void resetAttemptsPerTurn() {
+  private void resetAttemptsPerTurn() {
     m_attemptsPerTurn = 1;
   }
 
@@ -167,23 +166,23 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    *        left this turn.
    */
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setAttemptsLeftThisTurn(final int attempts) {
+  private void setAttemptsLeftThisTurn(final int attempts) {
     m_attemptsLeftThisTurn = attempts;
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setAttemptsLeftThisTurn(final String attempts) {
+  private void setAttemptsLeftThisTurn(final String attempts) {
     setAttemptsLeftThisTurn(getInt(attempts));
   }
 
   /**
    * @return attempts that are left this turn.
    */
-  public int getAttemptsLeftThisTurn() {
+  private int getAttemptsLeftThisTurn() {
     return m_attemptsLeftThisTurn;
   }
 
-  public void resetAttemptsLeftThisTurn() {
+  private void resetAttemptsLeftThisTurn() {
     m_attemptsLeftThisTurn = 1;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -64,7 +64,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanalName(final String name) {
+  private void setCanalName(final String name) {
     if (name == null) {
       m_canalName = null;
       return;
@@ -76,12 +76,12 @@ public class CanalAttachment extends DefaultAttachment {
     return m_canalName;
   }
 
-  public void resetCanalName() {
+  private void resetCanalName() {
     m_canalName = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setLandTerritories(final String landTerritories) {
+  private void setLandTerritories(final String landTerritories) {
     if (landTerritories == null) {
       m_landTerritories = null;
       return;
@@ -98,7 +98,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setLandTerritories(final Set<Territory> value) {
+  private void setLandTerritories(final Set<Territory> value) {
     m_landTerritories = value;
   }
 
@@ -106,7 +106,7 @@ public class CanalAttachment extends DefaultAttachment {
     return m_landTerritories;
   }
 
-  public void resetLandTerritories() {
+  private void resetLandTerritories() {
     m_landTerritories = null;
   }
 
@@ -114,7 +114,7 @@ public class CanalAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setExcludedUnits(final String value) {
+  private void setExcludedUnits(final String value) {
     if (value == null) {
       m_excludedUnits = null;
       return;
@@ -139,7 +139,7 @@ public class CanalAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setExcludedUnits(final Set<UnitType> value) {
+  private void setExcludedUnits(final Set<UnitType> value) {
     m_excludedUnits = value;
   }
 
@@ -155,7 +155,7 @@ public class CanalAttachment extends DefaultAttachment {
     m_excludedUnits.clear();
   }
 
-  public void resetExcludedUnits() {
+  private void resetExcludedUnits() {
     m_excludedUnits = null;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -86,7 +86,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlacementLimit(final String value) throws GameParseException {
+  private void setPlacementLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
       throw new GameParseException("placementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
@@ -114,11 +114,11 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
+  private void setPlacementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
     m_placementLimit = value;
   }
 
-  public Set<Triple<Integer, String, Set<UnitType>>> getPlacementLimit() {
+  private Set<Triple<Integer, String, Set<UnitType>>> getPlacementLimit() {
     return m_placementLimit;
   }
 
@@ -126,7 +126,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_placementLimit.clear();
   }
 
-  public void resetPlacementLimit() {
+  private void resetPlacementLimit() {
     m_placementLimit = new HashSet<>();
   }
 
@@ -134,7 +134,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setMovementLimit(final String value) throws GameParseException {
+  private void setMovementLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
       throw new GameParseException("movementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
@@ -162,11 +162,11 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
+  private void setMovementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
     m_movementLimit = value;
   }
 
-  public Set<Triple<Integer, String, Set<UnitType>>> getMovementLimit() {
+  private Set<Triple<Integer, String, Set<UnitType>>> getMovementLimit() {
     return m_movementLimit;
   }
 
@@ -174,7 +174,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_movementLimit.clear();
   }
 
-  public void resetMovementLimit() {
+  private void resetMovementLimit() {
     m_movementLimit = new HashSet<>();
   }
 
@@ -182,7 +182,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAttackingLimit(final String value) throws GameParseException {
+  private void setAttackingLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
       throw new GameParseException("attackingLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
@@ -210,11 +210,11 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackingLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
+  private void setAttackingLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
     m_attackingLimit = value;
   }
 
-  public Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
+  private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
     return m_attackingLimit;
   }
 
@@ -222,7 +222,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_attackingLimit.clear();
   }
 
-  public void resetAttackingLimit() {
+  private void resetAttackingLimit() {
     m_attackingLimit = new HashSet<>();
   }
 
@@ -280,7 +280,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setSuicideAttackTargets(final String value) throws GameParseException {
+  private void setSuicideAttackTargets(final String value) throws GameParseException {
     if (value == null) {
       m_suicideAttackTargets = null;
       return;
@@ -299,7 +299,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSuicideAttackTargets(final Set<UnitType> value) {
+  private void setSuicideAttackTargets(final Set<UnitType> value) {
     m_suicideAttackTargets = value;
   }
 
@@ -311,7 +311,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_suicideAttackTargets.clear();
   }
 
-  public void resetSuicideAttackTargets() {
+  private void resetSuicideAttackTargets() {
     m_suicideAttackTargets = null;
   }
 
@@ -319,7 +319,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setSuicideAttackResources(final String value) throws GameParseException {
+  private void setSuicideAttackResources(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
       throw new GameParseException("suicideAttackResources must have exactly 2 fields" + thisErrorMsg());
@@ -336,7 +336,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSuicideAttackResources(final IntegerMap<Resource> value) {
+  private void setSuicideAttackResources(final IntegerMap<Resource> value) {
     m_suicideAttackResources = value;
   }
 
@@ -348,17 +348,17 @@ public class PlayerAttachment extends DefaultAttachment {
     m_suicideAttackResources.clear();
   }
 
-  public void resetSuicideAttackResources() {
+  private void resetSuicideAttackResources() {
     m_suicideAttackResources = new IntegerMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setVps(final String value) {
+  private void setVps(final String value) {
     m_vps = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setVps(final Integer value) {
+  private void setVps(final Integer value) {
     m_vps = value;
   }
 
@@ -366,17 +366,17 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_vps;
   }
 
-  public void resetVps() {
+  private void resetVps() {
     m_vps = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCaptureVps(final String value) {
+  private void setCaptureVps(final String value) {
     m_captureVps = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCaptureVps(final Integer value) {
+  private void setCaptureVps(final Integer value) {
     m_captureVps = value;
   }
 
@@ -384,17 +384,17 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_captureVps;
   }
 
-  public void resetCaptureVps() {
+  private void resetCaptureVps() {
     m_captureVps = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRetainCapitalNumber(final String value) {
+  private void setRetainCapitalNumber(final String value) {
     m_retainCapitalNumber = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRetainCapitalNumber(final Integer value) {
+  private void setRetainCapitalNumber(final Integer value) {
     m_retainCapitalNumber = value;
   }
 
@@ -402,25 +402,25 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_retainCapitalNumber;
   }
 
-  public void resetRetainCapitalNumber() {
+  private void resetRetainCapitalNumber() {
     m_retainCapitalNumber = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRetainCapitalProduceNumber(final String value) {
+  private void setRetainCapitalProduceNumber(final String value) {
     m_retainCapitalProduceNumber = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRetainCapitalProduceNumber(final Integer value) {
+  private void setRetainCapitalProduceNumber(final Integer value) {
     m_retainCapitalProduceNumber = value;
   }
 
-  public int getRetainCapitalProduceNumber() {
+  int getRetainCapitalProduceNumber() {
     return m_retainCapitalProduceNumber;
   }
 
-  public void resetRetainCapitalProduceNumber() {
+  private void resetRetainCapitalProduceNumber() {
     m_retainCapitalProduceNumber = 1;
   }
 
@@ -428,7 +428,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setGiveUnitControl(final String value) throws GameParseException {
+  private void setGiveUnitControl(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -441,7 +441,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setGiveUnitControl(final List<PlayerID> value) {
+  private void setGiveUnitControl(final List<PlayerID> value) {
     m_giveUnitControl = value;
   }
 
@@ -453,7 +453,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_giveUnitControl.clear();
   }
 
-  public void resetGiveUnitControl() {
+  private void resetGiveUnitControl() {
     m_giveUnitControl = new ArrayList<>();
   }
 
@@ -461,7 +461,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
+  private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -474,7 +474,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCaptureUnitOnEnteringBy(final List<PlayerID> value) {
+  private void setCaptureUnitOnEnteringBy(final List<PlayerID> value) {
     m_captureUnitOnEnteringBy = value;
   }
 
@@ -486,7 +486,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_captureUnitOnEnteringBy.clear();
   }
 
-  public void resetCaptureUnitOnEnteringBy() {
+  private void resetCaptureUnitOnEnteringBy() {
     m_captureUnitOnEnteringBy = new ArrayList<>();
   }
 
@@ -494,7 +494,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setShareTechnology(final String value) throws GameParseException {
+  private void setShareTechnology(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -507,7 +507,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setShareTechnology(final List<PlayerID> value) {
+  private void setShareTechnology(final List<PlayerID> value) {
     m_shareTechnology = value;
   }
 
@@ -519,7 +519,7 @@ public class PlayerAttachment extends DefaultAttachment {
     m_shareTechnology.clear();
   }
 
-  public void resetShareTechnology() {
+  private void resetShareTechnology() {
     m_shareTechnology = new ArrayList<>();
   }
 
@@ -527,7 +527,7 @@ public class PlayerAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setHelpPayTechCost(final String value) throws GameParseException {
+  private void setHelpPayTechCost(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -540,7 +540,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setHelpPayTechCost(final List<PlayerID> value) {
+  private void setHelpPayTechCost(final List<PlayerID> value) {
     m_helpPayTechCost = value;
   }
 
@@ -552,17 +552,17 @@ public class PlayerAttachment extends DefaultAttachment {
     m_helpPayTechCost.clear();
   }
 
-  public void resetHelpPayTechCost() {
+  private void resetHelpPayTechCost() {
     m_helpPayTechCost = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroysPUs(final String value) {
+  private void setDestroysPUs(final String value) {
     m_destroysPUs = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroysPUs(final Boolean value) {
+  private void setDestroysPUs(final Boolean value) {
     m_destroysPUs = value;
   }
 
@@ -570,17 +570,17 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_destroysPUs;
   }
 
-  public void resetDestroysPUs() {
+  private void resetDestroysPUs() {
     m_destroysPUs = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImmuneToBlockade(final String value) {
+  private void setImmuneToBlockade(final String value) {
     m_immuneToBlockade = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImmuneToBlockade(final Boolean value) {
+  private void setImmuneToBlockade(final Boolean value) {
     m_immuneToBlockade = value;
   }
 
@@ -588,7 +588,7 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_immuneToBlockade;
   }
 
-  public void resetImmuneToBlockade() {
+  private void resetImmuneToBlockade() {
     m_immuneToBlockade = false;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -78,7 +78,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationshipChange(final String relChange) throws GameParseException {
+  private void setRelationshipChange(final String relChange) throws GameParseException {
     final String[] s = relChange.split(":");
     if (s.length != 3) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
@@ -100,7 +100,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipChange(final List<String> value) {
+  private void setRelationshipChange(final List<String> value) {
     m_relationshipChange = value;
   }
 
@@ -112,7 +112,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     m_relationshipChange.clear();
   }
 
-  public void resetRelationshipChange() {
+  private void resetRelationshipChange() {
     m_relationshipChange = new ArrayList<>();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -101,7 +101,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_archeType;
   }
 
-  public void resetArcheType() {
+  private void resetArcheType() {
     m_archeType = ARCHETYPE_WAR;
   }
 
@@ -114,11 +114,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    *        should be "true", "false" or "default"
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanMoveAirUnitsOverOwnedLand(final String canFlyOver) {
+  private void setCanMoveAirUnitsOverOwnedLand(final String canFlyOver) {
     m_canMoveAirUnitsOverOwnedLand = canFlyOver;
   }
 
-  public String getCanMoveAirUnitsOverOwnedLand() {
+  private String getCanMoveAirUnitsOverOwnedLand() {
     return m_canMoveAirUnitsOverOwnedLand;
   }
 
@@ -136,16 +136,16 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canMoveAirUnitsOverOwnedLand.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanMoveAirUnitsOverOwnedLand() {
+  private void resetCanMoveAirUnitsOverOwnedLand() {
     m_canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanMoveLandUnitsOverOwnedLand(final String canFlyOver) {
+  private void setCanMoveLandUnitsOverOwnedLand(final String canFlyOver) {
     m_canMoveLandUnitsOverOwnedLand = canFlyOver;
   }
 
-  public String getCanMoveLandUnitsOverOwnedLand() {
+  private String getCanMoveLandUnitsOverOwnedLand() {
     return m_canMoveLandUnitsOverOwnedLand;
   }
 
@@ -156,16 +156,16 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canMoveLandUnitsOverOwnedLand.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanMoveLandUnitsOverOwnedLand() {
+  private void resetCanMoveLandUnitsOverOwnedLand() {
     m_canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanLandAirUnitsOnOwnedLand(final String canLandAir) {
+  private void setCanLandAirUnitsOnOwnedLand(final String canLandAir) {
     m_canLandAirUnitsOnOwnedLand = canLandAir;
   }
 
-  public String getCanLandAirUnitsOnOwnedLand() {
+  private String getCanLandAirUnitsOnOwnedLand() {
     return m_canLandAirUnitsOnOwnedLand;
   }
 
@@ -177,16 +177,16 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canLandAirUnitsOnOwnedLand.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanLandAirUnitsOnOwnedLand() {
+  private void resetCanLandAirUnitsOnOwnedLand() {
     m_canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanTakeOverOwnedTerritory(final String canTakeOver) {
+  private void setCanTakeOverOwnedTerritory(final String canTakeOver) {
     m_canTakeOverOwnedTerritory = canTakeOver;
   }
 
-  public String getCanTakeOverOwnedTerritory() {
+  private String getCanTakeOverOwnedTerritory() {
     return m_canTakeOverOwnedTerritory;
   }
 
@@ -198,12 +198,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canTakeOverOwnedTerritory.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanTakeOverOwnedTerritory() {
+  private void resetCanTakeOverOwnedTerritory() {
     m_canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUpkeepCost(final String integerCost) throws GameParseException {
+  private void setUpkeepCost(final String integerCost) throws GameParseException {
     if (integerCost.equals(PROPERTY_DEFAULT)) {
       m_upkeepCost = PROPERTY_DEFAULT;
     } else {
@@ -235,12 +235,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_upkeepCost;
   }
 
-  public void resetUpkeepCost() {
+  private void resetUpkeepCost() {
     m_upkeepCost = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliancesCanChainTogether(final String value) throws GameParseException {
+  private void setAlliancesCanChainTogether(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("alliancesCanChainTogether must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -248,7 +248,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_alliancesCanChainTogether = value;
   }
 
-  public String getAlliancesCanChainTogether() {
+  private String getAlliancesCanChainTogether() {
     return m_alliancesCanChainTogether;
   }
 
@@ -259,12 +259,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_alliancesCanChainTogether.equals(PROPERTY_TRUE);
   }
 
-  public void resetAlliancesCanChainTogether() {
+  private void resetAlliancesCanChainTogether() {
     m_alliancesCanChainTogether = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsDefaultWarPosition(final String value) throws GameParseException {
+  private void setIsDefaultWarPosition(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("isDefaultWarPosition must be either " + PROPERTY_DEFAULT + " or " + PROPERTY_FALSE
           + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -272,7 +272,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_isDefaultWarPosition = value;
   }
 
-  public String getIsDefaultWarPosition() {
+  private String getIsDefaultWarPosition() {
     return m_isDefaultWarPosition;
   }
 
@@ -283,12 +283,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_isDefaultWarPosition.equals(PROPERTY_TRUE);
   }
 
-  public void resetIsDefaultWarPosition() {
+  private void resetIsDefaultWarPosition() {
     m_isDefaultWarPosition = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setGivesBackOriginalTerritories(final String value) throws GameParseException {
+  private void setGivesBackOriginalTerritories(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("givesBackOriginalTerritories must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -296,7 +296,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_givesBackOriginalTerritories = value;
   }
 
-  public String getGivesBackOriginalTerritories() {
+  private String getGivesBackOriginalTerritories() {
     return m_givesBackOriginalTerritories;
   }
 
@@ -307,12 +307,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_givesBackOriginalTerritories.equals(PROPERTY_TRUE);
   }
 
-  public void resetGivesBackOriginalTerritories() {
+  private void resetGivesBackOriginalTerritories() {
     m_givesBackOriginalTerritories = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanMoveIntoDuringCombatMove(final String value) throws GameParseException {
+  private void setCanMoveIntoDuringCombatMove(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -320,7 +320,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveIntoDuringCombatMove = value;
   }
 
-  public String getCanMoveIntoDuringCombatMove() {
+  private String getCanMoveIntoDuringCombatMove() {
     return m_canMoveIntoDuringCombatMove;
   }
 
@@ -332,12 +332,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canMoveIntoDuringCombatMove.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanMoveIntoDuringCombatMove() {
+  private void resetCanMoveIntoDuringCombatMove() {
     m_canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanMoveThroughCanals(final String value) throws GameParseException {
+  private void setCanMoveThroughCanals(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -345,7 +345,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveThroughCanals = value;
   }
 
-  public String getCanMoveThroughCanals() {
+  private String getCanMoveThroughCanals() {
     return m_canMoveThroughCanals;
   }
 
@@ -357,12 +357,12 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_canMoveThroughCanals.equals(PROPERTY_TRUE);
   }
 
-  public void resetCanMoveThroughCanals() {
+  private void resetCanMoveThroughCanals() {
     m_canMoveThroughCanals = PROPERTY_DEFAULT;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketsCanFlyOver(final String value) throws GameParseException {
+  private void setRocketsCanFlyOver(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
@@ -370,7 +370,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_rocketsCanFlyOver = value;
   }
 
-  public String getRocketsCanFlyOver() {
+  private String getRocketsCanFlyOver() {
     return m_rocketsCanFlyOver;
   }
 
@@ -382,7 +382,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return m_rocketsCanFlyOver.equals(PROPERTY_TRUE);
   }
 
-  public void resetRocketsCanFlyOver() {
+  private void resetRocketsCanFlyOver() {
     m_rocketsCanFlyOver = PROPERTY_DEFAULT;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -152,7 +152,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroyedTuv(final String value) throws GameParseException {
+  private void setDestroyedTuv(final String value) throws GameParseException {
     if (value == null) {
       m_destroyedTUV = null;
       return;
@@ -173,11 +173,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_destroyedTUV = value;
   }
 
-  public String getDestroyedTuv() {
+  private String getDestroyedTuv() {
     return m_destroyedTUV;
   }
 
-  public void resetDestroyedTuv() {
+  private void resetDestroyedTuv() {
     m_destroyedTUV = null;
   }
 
@@ -185,7 +185,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setBattle(final String value) throws GameParseException {
+  private void setBattle(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 5) {
       throw new GameParseException(
@@ -224,11 +224,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBattle(final List<Tuple<String, List<Territory>>> value) {
+  private void setBattle(final List<Tuple<String, List<Territory>>> value) {
     m_battle = value;
   }
 
-  public List<Tuple<String, List<Territory>>> getBattle() {
+  private List<Tuple<String, List<Territory>>> getBattle() {
     return m_battle;
   }
 
@@ -236,7 +236,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_battle.clear();
   }
 
-  public void resetBattle() {
+  private void resetBattle() {
     m_battle = new ArrayList<>();
   }
 
@@ -247,7 +247,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    * @param value should be a string containing: "player:player:relationship"
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationship(final String value) throws GameParseException {
+  private void setRelationship(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3 || s.length > 4) {
       throw new GameParseException(
@@ -277,11 +277,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationship(final List<String> value) {
+  private void setRelationship(final List<String> value) {
     m_relationship = value;
   }
 
-  public List<String> getRelationship() {
+  private List<String> getRelationship() {
     return m_relationship;
   }
 
@@ -289,12 +289,12 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_relationship.clear();
   }
 
-  public void resetRelationship() {
+  private void resetRelationship() {
     m_relationship = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedOwnershipTerritories(final String value) {
+  private void setAlliedOwnershipTerritories(final String value) {
     if (value == null) {
       m_alliedOwnershipTerritories = null;
       return;
@@ -304,21 +304,21 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedOwnershipTerritories(final String[] value) {
+  private void setAlliedOwnershipTerritories(final String[] value) {
     m_alliedOwnershipTerritories = value;
   }
 
-  public String[] getAlliedOwnershipTerritories() {
+  private String[] getAlliedOwnershipTerritories() {
     return m_alliedOwnershipTerritories;
   }
 
-  public void resetAlliedOwnershipTerritories() {
+  private void resetAlliedOwnershipTerritories() {
     m_alliedOwnershipTerritories = null;
   }
 
   // exclusion types = controlled, controlledNoWater, original, all, or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedExclusionTerritories(final String value) {
+  private void setAlliedExclusionTerritories(final String value) {
     if (value == null) {
       m_alliedExclusionTerritories = null;
       return;
@@ -328,20 +328,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedExclusionTerritories(final String[] value) {
+  private void setAlliedExclusionTerritories(final String[] value) {
     m_alliedExclusionTerritories = value;
   }
 
-  public String[] getAlliedExclusionTerritories() {
+  private String[] getAlliedExclusionTerritories() {
     return m_alliedExclusionTerritories;
   }
 
-  public void resetAlliedExclusionTerritories() {
+  private void resetAlliedExclusionTerritories() {
     m_alliedExclusionTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectExclusionTerritories(final String value) {
+  private void setDirectExclusionTerritories(final String value) {
     if (value == null) {
       m_directExclusionTerritories = null;
       return;
@@ -351,21 +351,21 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectExclusionTerritories(final String[] value) {
+  private void setDirectExclusionTerritories(final String[] value) {
     m_directExclusionTerritories = value;
   }
 
-  public String[] getDirectExclusionTerritories() {
+  private String[] getDirectExclusionTerritories() {
     return m_directExclusionTerritories;
   }
 
-  public void resetDirectExclusionTerritories() {
+  private void resetDirectExclusionTerritories() {
     m_directExclusionTerritories = null;
   }
 
   // exclusion types = original or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyExclusionTerritories(final String value) {
+  private void setEnemyExclusionTerritories(final String value) {
     if (value == null) {
       m_enemyExclusionTerritories = null;
       return;
@@ -375,20 +375,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyExclusionTerritories(final String[] value) {
+  private void setEnemyExclusionTerritories(final String[] value) {
     m_enemyExclusionTerritories = value;
   }
 
-  public String[] getEnemyExclusionTerritories() {
+  private String[] getEnemyExclusionTerritories() {
     return m_enemyExclusionTerritories;
   }
 
-  public void resetEnemyExclusionTerritories() {
+  private void resetEnemyExclusionTerritories() {
     m_enemyExclusionTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectPresenceTerritories(final String value) {
+  private void setDirectPresenceTerritories(final String value) {
     if (value == null) {
       m_directPresenceTerritories = null;
       return;
@@ -398,20 +398,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectPresenceTerritories(final String[] value) {
+  private void setDirectPresenceTerritories(final String[] value) {
     m_directPresenceTerritories = value;
   }
 
-  public String[] getDirectPresenceTerritories() {
+  private String[] getDirectPresenceTerritories() {
     return m_directPresenceTerritories;
   }
 
-  public void resetDirectPresenceTerritories() {
+  private void resetDirectPresenceTerritories() {
     m_directPresenceTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedPresenceTerritories(final String value) {
+  private void setAlliedPresenceTerritories(final String value) {
     if (value == null) {
       m_alliedPresenceTerritories = null;
       return;
@@ -421,20 +421,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedPresenceTerritories(final String[] value) {
+  private void setAlliedPresenceTerritories(final String[] value) {
     m_alliedPresenceTerritories = value;
   }
 
-  public String[] getAlliedPresenceTerritories() {
+  private String[] getAlliedPresenceTerritories() {
     return m_alliedPresenceTerritories;
   }
 
-  public void resetAlliedPresenceTerritories() {
+  private void resetAlliedPresenceTerritories() {
     m_alliedPresenceTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyPresenceTerritories(final String value) {
+  private void setEnemyPresenceTerritories(final String value) {
     if (value == null) {
       m_enemyPresenceTerritories = null;
       return;
@@ -444,21 +444,21 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyPresenceTerritories(final String[] value) {
+  private void setEnemyPresenceTerritories(final String[] value) {
     m_enemyPresenceTerritories = value;
   }
 
-  public String[] getEnemyPresenceTerritories() {
+  private String[] getEnemyPresenceTerritories() {
     return m_enemyPresenceTerritories;
   }
 
-  public void resetEnemyPresenceTerritories() {
+  private void resetEnemyPresenceTerritories() {
     m_enemyPresenceTerritories = null;
   }
 
   // exclusion types = original or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemySurfaceExclusionTerritories(final String value) {
+  private void setEnemySurfaceExclusionTerritories(final String value) {
     if (value == null) {
       m_enemySurfaceExclusionTerritories = null;
       return;
@@ -468,20 +468,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemySurfaceExclusionTerritories(final String[] value) {
+  private void setEnemySurfaceExclusionTerritories(final String[] value) {
     m_enemySurfaceExclusionTerritories = value;
   }
 
-  public String[] getEnemySurfaceExclusionTerritories() {
+  private String[] getEnemySurfaceExclusionTerritories() {
     return m_enemySurfaceExclusionTerritories;
   }
 
-  public void resetEnemySurfaceExclusionTerritories() {
+  private void resetEnemySurfaceExclusionTerritories() {
     m_enemySurfaceExclusionTerritories = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectOwnershipTerritories(final String value) {
+  private void setDirectOwnershipTerritories(final String value) {
     if (value == null) {
       m_directOwnershipTerritories = null;
       return;
@@ -491,15 +491,15 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectOwnershipTerritories(final String[] value) {
+  private void setDirectOwnershipTerritories(final String[] value) {
     m_directOwnershipTerritories = value;
   }
 
-  public String[] getDirectOwnershipTerritories() {
+  private String[] getDirectOwnershipTerritories() {
     return m_directOwnershipTerritories;
   }
 
-  public void resetDirectOwnershipTerritories() {
+  private void resetDirectOwnershipTerritories() {
     m_directOwnershipTerritories = null;
   }
 
@@ -507,7 +507,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitPresence(String value) throws GameParseException {
+  private void setUnitPresence(String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 1) {
       throw new GameParseException("unitPresence must have at least 2 fields. Format value=unit1 count=number, or "
@@ -530,11 +530,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitPresence(final IntegerMap<String> value) {
+  private void setUnitPresence(final IntegerMap<String> value) {
     m_unitPresence = value;
   }
 
-  public IntegerMap<String> getUnitPresence() {
+  private IntegerMap<String> getUnitPresence() {
     return m_unitPresence;
   }
 
@@ -542,20 +542,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_unitPresence.clear();
   }
 
-  public void resetUnitPresence() {
+  private void resetUnitPresence() {
     m_unitPresence = new IntegerMap<>();
   }
 
-  public int getAtWarCount() {
+  private int getAtWarCount() {
     return m_atWarCount;
   }
 
-  public int getTechCount() {
+  private int getTechCount() {
     return m_techCount;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAtWarPlayers(final String players) throws GameParseException {
+  private void setAtWarPlayers(final String players) throws GameParseException {
     if (players == null) {
       m_atWarPlayers = null;
       return;
@@ -585,20 +585,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAtWarPlayers(final Set<PlayerID> value) {
+  private void setAtWarPlayers(final Set<PlayerID> value) {
     m_atWarPlayers = value;
   }
 
-  public Set<PlayerID> getAtWarPlayers() {
+  private Set<PlayerID> getAtWarPlayers() {
     return m_atWarPlayers;
   }
 
-  public void resetAtWarPlayers() {
+  private void resetAtWarPlayers() {
     m_atWarPlayers = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTechs(final String newTechs) throws GameParseException {
+  private void setTechs(final String newTechs) throws GameParseException {
     if (newTechs == null) {
       m_techs = null;
       return;
@@ -631,15 +631,15 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTechs(final List<TechAdvance> value) {
+  private void setTechs(final List<TechAdvance> value) {
     m_techs = value;
   }
 
-  public List<TechAdvance> getTechs() {
+  private List<TechAdvance> getTechs() {
     return m_techs;
   }
 
-  public void resetTechs() {
+  private void resetTechs() {
     m_techs = null;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -181,16 +181,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAttackBonus(final String value) throws GameParseException {
+  private void setAttackBonus(final String value) throws GameParseException {
     applyCheckedValue("attackBonus", value, m_attackBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackBonus(final IntegerMap<UnitType> value) {
+  private void setAttackBonus(final IntegerMap<UnitType> value) {
     m_attackBonus = value;
   }
 
-  public IntegerMap<UnitType> getAttackBonus() {
+  private IntegerMap<UnitType> getAttackBonus() {
     return m_attackBonus;
   }
 
@@ -202,7 +202,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_attackBonus.clear();
   }
 
-  public void resetAttackBonus() {
+  private void resetAttackBonus() {
     m_attackBonus = new IntegerMap<>();
   }
 
@@ -210,16 +210,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setDefenseBonus(final String value) throws GameParseException {
+  private void setDefenseBonus(final String value) throws GameParseException {
     applyCheckedValue("defenseBonus", value, m_defenseBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefenseBonus(final IntegerMap<UnitType> value) {
+  private void setDefenseBonus(final IntegerMap<UnitType> value) {
     m_defenseBonus = value;
   }
 
-  public IntegerMap<UnitType> getDefenseBonus() {
+  private IntegerMap<UnitType> getDefenseBonus() {
     return m_defenseBonus;
   }
 
@@ -231,7 +231,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_defenseBonus.clear();
   }
 
-  public void resetDefenseBonus() {
+  private void resetDefenseBonus() {
     m_defenseBonus = new IntegerMap<>();
   }
 
@@ -239,16 +239,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setMovementBonus(final String value) throws GameParseException {
+  private void setMovementBonus(final String value) throws GameParseException {
     applyCheckedValue("movementBonus", value, m_movementBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementBonus(final IntegerMap<UnitType> value) {
+  private void setMovementBonus(final IntegerMap<UnitType> value) {
     m_movementBonus = value;
   }
 
-  public IntegerMap<UnitType> getMovementBonus() {
+  private IntegerMap<UnitType> getMovementBonus() {
     return m_movementBonus;
   }
 
@@ -260,7 +260,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_movementBonus.clear();
   }
 
-  public void resetMovementBonus() {
+  private void resetMovementBonus() {
     m_movementBonus = new IntegerMap<>();
   }
 
@@ -268,16 +268,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRadarBonus(final String value) throws GameParseException {
+  private void setRadarBonus(final String value) throws GameParseException {
     applyCheckedValue("radarBonus", value, m_radarBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRadarBonus(final IntegerMap<UnitType> value) {
+  private void setRadarBonus(final IntegerMap<UnitType> value) {
     m_radarBonus = value;
   }
 
-  public IntegerMap<UnitType> getRadarBonus() {
+  private IntegerMap<UnitType> getRadarBonus() {
     return m_radarBonus;
   }
 
@@ -289,7 +289,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_radarBonus.clear();
   }
 
-  public void resetRadarBonus() {
+  private void resetRadarBonus() {
     m_radarBonus = new IntegerMap<>();
   }
 
@@ -297,16 +297,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirAttackBonus(final String value) throws GameParseException {
+  private void setAirAttackBonus(final String value) throws GameParseException {
     applyCheckedValue("airAttackBonus", value, m_airAttackBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirAttackBonus(final IntegerMap<UnitType> value) {
+  private void setAirAttackBonus(final IntegerMap<UnitType> value) {
     m_airAttackBonus = value;
   }
 
-  public IntegerMap<UnitType> getAirAttackBonus() {
+  private IntegerMap<UnitType> getAirAttackBonus() {
     return m_airAttackBonus;
   }
 
@@ -318,7 +318,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airAttackBonus.clear();
   }
 
-  public void resetAirAttackBonus() {
+  private void resetAirAttackBonus() {
     m_airAttackBonus = new IntegerMap<>();
   }
 
@@ -326,16 +326,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirDefenseBonus(final String value) throws GameParseException {
+  private void setAirDefenseBonus(final String value) throws GameParseException {
     applyCheckedValue("airDefenseBonus", value, m_airDefenseBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirDefenseBonus(final IntegerMap<UnitType> value) {
+  private void setAirDefenseBonus(final IntegerMap<UnitType> value) {
     m_airDefenseBonus = value;
   }
 
-  public IntegerMap<UnitType> getAirDefenseBonus() {
+  private IntegerMap<UnitType> getAirDefenseBonus() {
     return m_airDefenseBonus;
   }
 
@@ -347,7 +347,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airDefenseBonus.clear();
   }
 
-  public void resetAirDefenseBonus() {
+  private void resetAirDefenseBonus() {
     m_airDefenseBonus = new IntegerMap<>();
   }
 
@@ -355,16 +355,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setProductionBonus(final String value) throws GameParseException {
+  private void setProductionBonus(final String value) throws GameParseException {
     applyCheckedValue("productionBonus", value, m_productionBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setProductionBonus(final IntegerMap<UnitType> value) {
+  private void setProductionBonus(final IntegerMap<UnitType> value) {
     m_productionBonus = value;
   }
 
-  public IntegerMap<UnitType> getProductionBonus() {
+  private IntegerMap<UnitType> getProductionBonus() {
     return m_productionBonus;
   }
 
@@ -376,22 +376,22 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_productionBonus.clear();
   }
 
-  public void resetProductionBonus() {
+  private void resetProductionBonus() {
     m_productionBonus = new IntegerMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMinimumTerritoryValueForProductionBonus(final String value) throws GameParseException {
+  private void setMinimumTerritoryValueForProductionBonus(final String value) throws GameParseException {
     m_minimumTerritoryValueForProductionBonus =
         getIntInRange("minimumTerritoryValueForProductionBonus", value, 10000, true);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMinimumTerritoryValueForProductionBonus(final Integer value) {
+  private void setMinimumTerritoryValueForProductionBonus(final Integer value) {
     m_minimumTerritoryValueForProductionBonus = value;
   }
 
-  public int getMinimumTerritoryValueForProductionBonus() {
+  private int getMinimumTerritoryValueForProductionBonus() {
     return m_minimumTerritoryValueForProductionBonus;
   }
 
@@ -405,21 +405,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .orElse(-1));
   }
 
-  public void resetMinimumTerritoryValueForProductionBonus() {
+  private void resetMinimumTerritoryValueForProductionBonus() {
     m_minimumTerritoryValueForProductionBonus = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRepairDiscount(final String value) throws GameParseException {
+  private void setRepairDiscount(final String value) throws GameParseException {
     m_repairDiscount = getIntInRange("repairDiscount", value, 100, true);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRepairDiscount(final Integer value) {
+  private void setRepairDiscount(final Integer value) {
     m_repairDiscount = value;
   }
 
-  public int getRepairDiscount() {
+  private int getRepairDiscount() {
     return m_repairDiscount;
   }
 
@@ -433,21 +433,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .sum());
   }
 
-  public void resetRepairDiscount() {
+  private void resetRepairDiscount() {
     m_repairDiscount = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBondDiceSides(final String value) throws GameParseException {
+  private void setWarBondDiceSides(final String value) throws GameParseException {
     m_warBondDiceSides = getIntInRange("warBondDiceSides", value, 200, true);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBondDiceSides(final Integer value) {
+  private void setWarBondDiceSides(final Integer value) {
     m_warBondDiceSides = value;
   }
 
-  public int getWarBondDiceSides() {
+  private int getWarBondDiceSides() {
     return m_warBondDiceSides;
   }
 
@@ -455,21 +455,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumNumbers(TechAbilityAttachment::getWarBondDiceSides, player, data);
   }
 
-  public void resetWarBondDiceSides() {
+  private void resetWarBondDiceSides() {
     m_warBondDiceSides = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBondDiceNumber(final String value) throws GameParseException {
+  private void setWarBondDiceNumber(final String value) throws GameParseException {
     m_warBondDiceNumber = getIntInRange("warBondDiceNumber", value, 100, false);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBondDiceNumber(final Integer value) {
+  private void setWarBondDiceNumber(final Integer value) {
     m_warBondDiceNumber = value;
   }
 
-  public int getWarBondDiceNumber() {
+  private int getWarBondDiceNumber() {
     return m_warBondDiceNumber;
   }
 
@@ -477,7 +477,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumNumbers(TechAbilityAttachment::getWarBondDiceNumber, player, data);
   }
 
-  public void resetWarBondDiceNumber() {
+  private void resetWarBondDiceNumber() {
     m_warBondDiceNumber = 0;
   }
 
@@ -485,7 +485,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRocketDiceNumber(final String value) throws GameParseException {
+  private void setRocketDiceNumber(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
       throw new GameParseException("rocketDiceNumber must have two fields" + thisErrorMsg());
@@ -494,11 +494,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketDiceNumber(final IntegerMap<UnitType> value) {
+  private void setRocketDiceNumber(final IntegerMap<UnitType> value) {
     m_rocketDiceNumber = value;
   }
 
-  public IntegerMap<UnitType> getRocketDiceNumber() {
+  private IntegerMap<UnitType> getRocketDiceNumber() {
     return m_rocketDiceNumber;
   }
 
@@ -518,21 +518,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_rocketDiceNumber.clear();
   }
 
-  public void resetRocketDiceNumber() {
+  private void resetRocketDiceNumber() {
     m_rocketDiceNumber = new IntegerMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketDistance(final String value) throws GameParseException {
+  private void setRocketDistance(final String value) throws GameParseException {
     m_rocketDistance = getIntInRange("rocketDistance", value, 100, false);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketDistance(final Integer value) {
+  private void setRocketDistance(final Integer value) {
     m_rocketDistance = value;
   }
 
-  public int getRocketDistance() {
+  private int getRocketDistance() {
     return m_rocketDistance;
   }
 
@@ -540,21 +540,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumNumbers(TechAbilityAttachment::getRocketDistance, player, data);
   }
 
-  public void resetRocketDistance() {
+  private void resetRocketDistance() {
     m_rocketDistance = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketNumberPerTerritory(final String value) throws GameParseException {
+  private void setRocketNumberPerTerritory(final String value) throws GameParseException {
     m_rocketNumberPerTerritory = getIntInRange("rocketNumberPerTerritory", value, 200, false);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocketNumberPerTerritory(final Integer value) {
+  private void setRocketNumberPerTerritory(final Integer value) {
     m_rocketNumberPerTerritory = value;
   }
 
-  public int getRocketNumberPerTerritory() {
+  private int getRocketNumberPerTerritory() {
     return m_rocketNumberPerTerritory;
   }
 
@@ -562,7 +562,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumNumbers(TechAbilityAttachment::getRocketNumberPerTerritory, player, data);
   }
 
-  public void resetRocketNumberPerTerritory() {
+  private void resetRocketNumberPerTerritory() {
     m_rocketNumberPerTerritory = 0;
   }
 
@@ -570,7 +570,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitAbilitiesGained(final String value) throws GameParseException {
+  private void setUnitAbilitiesGained(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
       throw new GameParseException(
@@ -593,11 +593,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitAbilitiesGained(final Map<UnitType, Set<String>> value) {
+  private void setUnitAbilitiesGained(final Map<UnitType, Set<String>> value) {
     m_unitAbilitiesGained = value;
   }
 
-  public Map<UnitType, Set<String>> getUnitAbilitiesGained() {
+  private Map<UnitType, Set<String>> getUnitAbilitiesGained() {
     return m_unitAbilitiesGained;
   }
 
@@ -618,25 +618,25 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_unitAbilitiesGained.clear();
   }
 
-  public void resetUnitAbilitiesGained() {
+  private void resetUnitAbilitiesGained() {
     m_unitAbilitiesGained = new HashMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneForces(final String value) {
+  private void setAirborneForces(final String value) {
     m_airborneForces = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneForces(final Boolean value) {
+  private void setAirborneForces(final Boolean value) {
     m_airborneForces = value;
   }
 
-  public boolean getAirborneForces() {
+  private boolean getAirborneForces() {
     return m_airborneForces;
   }
 
-  public void resetAirborneForces() {
+  private void resetAirborneForces() {
     m_airborneForces = false;
   }
 
@@ -644,16 +644,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirborneCapacity(final String value) throws GameParseException {
+  private void setAirborneCapacity(final String value) throws GameParseException {
     applyCheckedValue("airborneCapacity", value, m_airborneCapacity::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneCapacity(final IntegerMap<UnitType> value) {
+  private void setAirborneCapacity(final IntegerMap<UnitType> value) {
     m_airborneCapacity = value;
   }
 
-  public IntegerMap<UnitType> getAirborneCapacity() {
+  private IntegerMap<UnitType> getAirborneCapacity() {
     return m_airborneCapacity;
   }
 
@@ -681,7 +681,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airborneCapacity.clear();
   }
 
-  public void resetAirborneCapacity() {
+  private void resetAirborneCapacity() {
     m_airborneCapacity = new IntegerMap<>();
   }
 
@@ -689,18 +689,18 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirborneTypes(final String value) throws GameParseException {
+  private void setAirborneTypes(final String value) throws GameParseException {
     for (final String unit : value.split(":")) {
       m_airborneTypes.add(getUnitType(unit));
     }
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneTypes(final Set<UnitType> value) {
+  private void setAirborneTypes(final Set<UnitType> value) {
     m_airborneTypes = value;
   }
 
-  public Set<UnitType> getAirborneTypes() {
+  private Set<UnitType> getAirborneTypes() {
     return m_airborneTypes;
   }
 
@@ -717,21 +717,21 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airborneTypes.clear();
   }
 
-  public void resetAirborneTypes() {
+  private void resetAirborneTypes() {
     m_airborneTypes = new HashSet<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneDistance(final String value) throws GameParseException {
+  private void setAirborneDistance(final String value) throws GameParseException {
     m_airborneDistance = getIntInRange("airborneDistance", value, 100, false);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneDistance(final Integer value) {
+  private void setAirborneDistance(final Integer value) {
     m_airborneDistance = value;
   }
 
-  public int getAirborneDistance() {
+  private int getAirborneDistance() {
     return m_airborneDistance;
   }
 
@@ -743,7 +743,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .sum());
   }
 
-  public void resetAirborneDistance() {
+  private void resetAirborneDistance() {
     m_airborneDistance = 0;
   }
 
@@ -751,18 +751,18 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirborneBases(final String value) throws GameParseException {
+  private void setAirborneBases(final String value) throws GameParseException {
     for (final String u : value.split(":")) {
       m_airborneBases.add(getUnitType(u));
     }
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneBases(final Set<UnitType> value) {
+  private void setAirborneBases(final Set<UnitType> value) {
     m_airborneBases = value;
   }
 
-  public Set<UnitType> getAirborneBases() {
+  private Set<UnitType> getAirborneBases() {
     return m_airborneBases;
   }
 
@@ -779,7 +779,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airborneBases.clear();
   }
 
-  public void resetAirborneBases() {
+  private void resetAirborneBases() {
     m_airborneBases = new HashSet<>();
   }
 
@@ -787,7 +787,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAirborneTargettedByAa(final String value) throws GameParseException {
+  private void setAirborneTargettedByAa(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
       throw new GameParseException("airborneTargettedByAA must have at least two fields" + thisErrorMsg());
@@ -800,11 +800,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneTargettedByAa(final Map<String, Set<UnitType>> value) {
+  private void setAirborneTargettedByAa(final Map<String, Set<UnitType>> value) {
     m_airborneTargettedByAA = value;
   }
 
-  public Map<String, Set<UnitType>> getAirborneTargettedByAa() {
+  private Map<String, Set<UnitType>> getAirborneTargettedByAa() {
     return m_airborneTargettedByAA;
   }
 
@@ -831,7 +831,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_airborneTargettedByAA.clear();
   }
 
-  public void resetAirborneTargettedByAa() {
+  private void resetAirborneTargettedByAa() {
     m_airborneTargettedByAA = new HashMap<>();
   }
 
@@ -839,16 +839,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAttackRollsBonus(final String value) throws GameParseException {
+  private void setAttackRollsBonus(final String value) throws GameParseException {
     applyCheckedValue("attackRollsBonus", value, m_attackRollsBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackRollsBonus(final IntegerMap<UnitType> value) {
+  private void setAttackRollsBonus(final IntegerMap<UnitType> value) {
     m_attackRollsBonus = value;
   }
 
-  public IntegerMap<UnitType> getAttackRollsBonus() {
+  private IntegerMap<UnitType> getAttackRollsBonus() {
     return m_attackRollsBonus;
   }
 
@@ -860,7 +860,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_attackRollsBonus.clear();
   }
 
-  public void resetAttackRollsBonus() {
+  private void resetAttackRollsBonus() {
     m_attackRollsBonus = new IntegerMap<>();
   }
 
@@ -868,16 +868,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setDefenseRollsBonus(final String value) throws GameParseException {
+  private void setDefenseRollsBonus(final String value) throws GameParseException {
     applyCheckedValue("defenseRollsBonus", value, m_defenseRollsBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefenseRollsBonus(final IntegerMap<UnitType> value) {
+  private void setDefenseRollsBonus(final IntegerMap<UnitType> value) {
     m_defenseRollsBonus = value;
   }
 
-  public IntegerMap<UnitType> getDefenseRollsBonus() {
+  private IntegerMap<UnitType> getDefenseRollsBonus() {
     return m_defenseRollsBonus;
   }
 
@@ -889,16 +889,16 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setBombingBonus(final String value) throws GameParseException {
+  private void setBombingBonus(final String value) throws GameParseException {
     applyCheckedValue("bombingBonus", value, m_bombingBonus::put);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingBonus(final IntegerMap<UnitType> value) {
+  private void setBombingBonus(final IntegerMap<UnitType> value) {
     m_bombingBonus = value;
   }
 
-  public IntegerMap<UnitType> getBombingBonus() {
+  private IntegerMap<UnitType> getBombingBonus() {
     return m_bombingBonus;
   }
 
@@ -910,7 +910,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_defenseRollsBonus.clear();
   }
 
-  public void resetDefenseRollsBonus() {
+  private void resetDefenseRollsBonus() {
     m_defenseRollsBonus = new IntegerMap<>();
   }
 
@@ -918,7 +918,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     m_bombingBonus.clear();
   }
 
-  public void resetBombingBonus() {
+  private void resetBombingBonus() {
     m_bombingBonus = new IntegerMap<>();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -96,123 +96,123 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTechCost(final Integer s) {
+  private void setTechCost(final Integer s) {
     techCost = s;
   }
 
-  public void resetTechCost() {
+  private void resetTechCost() {
     techCost = 5;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setHeavyBomber(final String s) {
+  private void setHeavyBomber(final String s) {
     heavyBomber = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setHeavyBomber(final Boolean s) {
+  private void setHeavyBomber(final Boolean s) {
     heavyBomber = s;
   }
 
-  public void resetHeavyBomber() {
+  private void resetHeavyBomber() {
     heavyBomber = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroyerBombard(final String s) {
+  private void setDestroyerBombard(final String s) {
     destroyerBombard = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroyerBombard(final Boolean s) {
+  private void setDestroyerBombard(final Boolean s) {
     destroyerBombard = s;
   }
 
-  public void resetDestroyerBombard() {
+  private void resetDestroyerBombard() {
     destroyerBombard = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setLongRangeAir(final String s) {
+  private void setLongRangeAir(final String s) {
     longRangeAir = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setLongRangeAir(final Boolean s) {
+  private void setLongRangeAir(final Boolean s) {
     longRangeAir = s;
   }
 
-  public void resetLongRangeAir() {
+  private void resetLongRangeAir() {
     longRangeAir = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setJetPower(final String s) {
+  private void setJetPower(final String s) {
     jetPower = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setJetPower(final Boolean s) {
+  private void setJetPower(final Boolean s) {
     jetPower = s;
   }
 
-  public void resetJetPower() {
+  private void resetJetPower() {
     jetPower = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocket(final String s) {
+  private void setRocket(final String s) {
     rocket = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRocket(final Boolean s) {
+  private void setRocket(final Boolean s) {
     rocket = s;
   }
 
-  public void resetRocket() {
+  private void resetRocket() {
     rocket = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIndustrialTechnology(final String s) {
+  private void setIndustrialTechnology(final String s) {
     industrialTechnology = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIndustrialTechnology(final Boolean s) {
+  private void setIndustrialTechnology(final Boolean s) {
     industrialTechnology = s;
   }
 
-  public void resetIndustrialTechnology() {
+  private void resetIndustrialTechnology() {
     industrialTechnology = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSuperSub(final String s) {
+  private void setSuperSub(final String s) {
     superSub = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSuperSub(final Boolean s) {
+  private void setSuperSub(final Boolean s) {
     superSub = s;
   }
 
-  public void resetSuperSub() {
+  private void resetSuperSub() {
     superSub = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImprovedArtillerySupport(final String s) {
+  private void setImprovedArtillerySupport(final String s) {
     improvedArtillerySupport = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImprovedArtillerySupport(final Boolean s) {
+  private void setImprovedArtillerySupport(final Boolean s) {
     improvedArtillerySupport = s;
   }
 
-  public void resetImprovedArtillerySupport() {
+  private void resetImprovedArtillerySupport() {
     improvedArtillerySupport = false;
   }
 
@@ -222,39 +222,39 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setParatroopers(final Boolean s) {
+  private void setParatroopers(final Boolean s) {
     paratroopers = s;
   }
 
-  public void resetParatroopers() {
+  private void resetParatroopers() {
     paratroopers = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIncreasedFactoryProduction(final String s) {
+  private void setIncreasedFactoryProduction(final String s) {
     increasedFactoryProduction = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIncreasedFactoryProduction(final Boolean s) {
+  private void setIncreasedFactoryProduction(final Boolean s) {
     increasedFactoryProduction = s;
   }
 
-  public void resetIncreasedFactoryProduction() {
+  private void resetIncreasedFactoryProduction() {
     increasedFactoryProduction = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBonds(final String s) {
+  private void setWarBonds(final String s) {
     warBonds = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWarBonds(final Boolean s) {
+  private void setWarBonds(final Boolean s) {
     warBonds = s;
   }
 
-  public void resetWarBonds() {
+  private void resetWarBonds() {
     warBonds = false;
   }
 
@@ -264,11 +264,11 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMechanizedInfantry(final Boolean s) {
+  private void setMechanizedInfantry(final Boolean s) {
     mechanizedInfantry = s;
   }
 
-  public void resetMechanizedInfantry() {
+  private void resetMechanizedInfantry() {
     mechanizedInfantry = false;
   }
 
@@ -278,25 +278,25 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAaRadar(final Boolean s) {
+  private void setAaRadar(final Boolean s) {
     aARadar = s;
   }
 
-  public void resetAaRadar() {
+  private void resetAaRadar() {
     aARadar = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setShipyards(final String s) {
+  private void setShipyards(final String s) {
     shipyards = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setShipyards(final Boolean s) {
+  private void setShipyards(final Boolean s) {
     shipyards = s;
   }
 
-  public void resetShipyards() {
+  private void resetShipyards() {
     shipyards = false;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -230,7 +230,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setResources(final String value) throws GameParseException {
+  private void setResources(final String value) throws GameParseException {
     if (value == null) {
       m_resources = null;
       return;
@@ -251,7 +251,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setResources(final ResourceCollection value) {
+  private void setResources(final ResourceCollection value) {
     m_resources = value;
   }
 
@@ -263,17 +263,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_resources = new ResourceCollection(getData());
   }
 
-  public void resetResources() {
+  private void resetResources() {
     m_resources = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsImpassable(final String value) {
+  private void setIsImpassable(final String value) {
     setIsImpassable(getBool(value));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsImpassable(final boolean value) {
+  private void setIsImpassable(final boolean value) {
     m_isImpassable = value;
   }
 
@@ -281,7 +281,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_isImpassable;
   }
 
-  public void resetIsImpassable() {
+  private void resetIsImpassable() {
     m_isImpassable = false;
   }
 
@@ -306,17 +306,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_capital;
   }
 
-  public void resetCapital() {
+  private void resetCapital() {
     m_capital = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setVictoryCity(final String value) {
+  private void setVictoryCity(final String value) {
     setVictoryCity(getInt(value));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setVictoryCity(final int value) {
+  private void setVictoryCity(final int value) {
     m_victoryCity = value;
   }
 
@@ -324,17 +324,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_victoryCity;
   }
 
-  public void resetVictoryCity() {
+  private void resetVictoryCity() {
     m_victoryCity = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOriginalFactory(final String value) {
+  private void setOriginalFactory(final String value) {
     setOriginalFactory(getBool(value));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOriginalFactory(final boolean value) {
+  private void setOriginalFactory(final boolean value) {
     m_originalFactory = value;
   }
 
@@ -342,7 +342,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_originalFactory;
   }
 
-  public void resetOriginalFactory() {
+  private void resetOriginalFactory() {
     m_originalFactory = false;
   }
 
@@ -352,7 +352,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * used when parsing game XML since it passes string values.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setProduction(final String value) {
+  private void setProduction(final String value) {
     m_production = getInt(value);
     // do NOT remove. unitProduction should always default to production
     m_unitProduction = m_production;
@@ -364,7 +364,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * used when working with game history since it passes Integer values.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setProduction(final Integer value) {
+  private void setProduction(final Integer value) {
     m_production = value;
     // do NOT remove. unitProduction should always default to production
     m_unitProduction = m_production;
@@ -373,7 +373,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   /**
    * Resets production and unitProduction (or just "production" in a map xml) of a territory to the default value.
    */
-  public void resetProduction() {
+  private void resetProduction() {
     m_production = 0;
     // do NOT remove. unitProduction should always default to production
     m_unitProduction = m_production;
@@ -383,22 +383,22 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Sets only m_production.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setProductionOnly(final String value) {
+  private void setProductionOnly(final String value) {
     m_production = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitProduction(final String value) {
+  private void setUnitProduction(final String value) {
     setUnitProduction(getInt(value));
   }
 
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitProduction(final int value) {
+  private void setUnitProduction(final int value) {
     m_unitProduction = value;
   }
 
-  public void resetUnitProduction() {
+  private void resetUnitProduction() {
     m_unitProduction = 0;
   }
 
@@ -412,7 +412,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOriginalOwner(final String player) throws GameParseException {
+  private void setOriginalOwner(final String player) throws GameParseException {
     if (player == null) {
       m_originalOwner = null;
     }
@@ -427,17 +427,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_originalOwner;
   }
 
-  public void resetOriginalOwner() {
+  private void resetOriginalOwner() {
     m_originalOwner = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConvoyRoute(final String value) {
+  private void setConvoyRoute(final String value) {
     m_convoyRoute = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConvoyRoute(final Boolean value) {
+  private void setConvoyRoute(final Boolean value) {
     m_convoyRoute = value;
   }
 
@@ -445,7 +445,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_convoyRoute;
   }
 
-  public void resetConvoyRoute() {
+  private void resetConvoyRoute() {
     m_convoyRoute = false;
   }
 
@@ -453,7 +453,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setChangeUnitOwners(final String value) throws GameParseException {
+  private void setChangeUnitOwners(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -468,7 +468,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChangeUnitOwners(final ArrayList<PlayerID> value) {
+  private void setChangeUnitOwners(final ArrayList<PlayerID> value) {
     m_changeUnitOwners = value;
   }
 
@@ -480,7 +480,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_changeUnitOwners.clear();
   }
 
-  public void resetChangeUnitOwners() {
+  private void resetChangeUnitOwners() {
     m_changeUnitOwners = new ArrayList<>();
   }
 
@@ -488,7 +488,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
+  private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -501,7 +501,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCaptureUnitOnEnteringBy(final ArrayList<PlayerID> value) {
+  private void setCaptureUnitOnEnteringBy(final ArrayList<PlayerID> value) {
     m_captureUnitOnEnteringBy = value;
   }
 
@@ -513,7 +513,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_captureUnitOnEnteringBy.clear();
   }
 
-  public void resetCaptureUnitOnEnteringBy() {
+  private void resetCaptureUnitOnEnteringBy() {
     m_captureUnitOnEnteringBy = new ArrayList<>();
   }
 
@@ -521,7 +521,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhenCapturedByGoesTo(final String value) throws GameParseException {
+  private void setWhenCapturedByGoesTo(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
       throw new GameParseException(
@@ -537,7 +537,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenCapturedByGoesTo(final ArrayList<String> value) {
+  private void setWhenCapturedByGoesTo(final ArrayList<String> value) {
     m_whenCapturedByGoesTo = value;
   }
 
@@ -549,7 +549,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_whenCapturedByGoesTo.clear();
   }
 
-  public void resetWhenCapturedByGoesTo() {
+  private void resetWhenCapturedByGoesTo() {
     m_whenCapturedByGoesTo = new ArrayList<>();
   }
 
@@ -557,7 +557,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryEffect(final String value) throws GameParseException {
+  private void setTerritoryEffect(final String value) throws GameParseException {
     final String[] s = value.split(":");
     for (final String name : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(name);
@@ -570,7 +570,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryEffect(final ArrayList<TerritoryEffect> value) {
+  private void setTerritoryEffect(final ArrayList<TerritoryEffect> value) {
     m_territoryEffect = value;
   }
 
@@ -582,7 +582,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_territoryEffect.clear();
   }
 
-  public void resetTerritoryEffect() {
+  private void resetTerritoryEffect() {
     m_territoryEffect = new ArrayList<>();
   }
 
@@ -590,7 +590,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setConvoyAttached(final String value) throws GameParseException {
+  private void setConvoyAttached(final String value) throws GameParseException {
     if (value.length() <= 0) {
       return;
     }
@@ -604,7 +604,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConvoyAttached(final HashSet<Territory> value) {
+  private void setConvoyAttached(final HashSet<Territory> value) {
     m_convoyAttached = value;
   }
 
@@ -616,17 +616,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_convoyAttached.clear();
   }
 
-  public void resetConvoyAttached() {
+  private void resetConvoyAttached() {
     m_convoyAttached = new HashSet<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNavalBase(final String value) {
+  private void setNavalBase(final String value) {
     m_navalBase = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNavalBase(final Boolean value) {
+  private void setNavalBase(final Boolean value) {
     m_navalBase = value;
   }
 
@@ -634,17 +634,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_navalBase;
   }
 
-  public void resetNavalBase() {
+  private void resetNavalBase() {
     m_navalBase = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirBase(final String value) {
+  private void setAirBase(final String value) {
     m_airBase = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirBase(final Boolean value) {
+  private void setAirBase(final Boolean value) {
     m_airBase = value;
   }
 
@@ -652,17 +652,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_airBase;
   }
 
-  public void resetAirBase() {
+  private void resetAirBase() {
     m_airBase = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setKamikazeZone(final String value) {
+  private void setKamikazeZone(final String value) {
     m_kamikazeZone = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setKamikazeZone(final Boolean value) {
+  private void setKamikazeZone(final Boolean value) {
     m_kamikazeZone = value;
   }
 
@@ -670,17 +670,17 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_kamikazeZone;
   }
 
-  public void resetKamikazeZone() {
+  private void resetKamikazeZone() {
     m_kamikazeZone = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBlockadeZone(final String value) {
+  private void setBlockadeZone(final String value) {
     m_blockadeZone = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBlockadeZone(final Boolean value) {
+  private void setBlockadeZone(final Boolean value) {
     m_blockadeZone = value;
   }
 
@@ -688,7 +688,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_blockadeZone;
   }
 
-  public void resetBlockadeZone() {
+  private void resetBlockadeZone() {
     m_blockadeZone = false;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -52,16 +52,16 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCombatDefenseEffect(final String combatDefenseEffect) throws GameParseException {
+  private void setCombatDefenseEffect(final String combatDefenseEffect) throws GameParseException {
     setCombatEffect(combatDefenseEffect, true);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCombatDefenseEffect(final IntegerMap<UnitType> value) {
+  private void setCombatDefenseEffect(final IntegerMap<UnitType> value) {
     m_combatDefenseEffect = value;
   }
 
-  public IntegerMap<UnitType> getCombatDefenseEffect() {
+  private IntegerMap<UnitType> getCombatDefenseEffect() {
     return new IntegerMap<>(m_combatDefenseEffect);
   }
 
@@ -69,7 +69,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     m_combatDefenseEffect.clear();
   }
 
-  public void resetCombatDefenseEffect() {
+  private void resetCombatDefenseEffect() {
     m_combatDefenseEffect = new IntegerMap<>();
   }
 
@@ -77,16 +77,16 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCombatOffenseEffect(final String combatOffenseEffect) throws GameParseException {
+  private void setCombatOffenseEffect(final String combatOffenseEffect) throws GameParseException {
     setCombatEffect(combatOffenseEffect, false);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCombatOffenseEffect(final IntegerMap<UnitType> value) {
+  private void setCombatOffenseEffect(final IntegerMap<UnitType> value) {
     m_combatOffenseEffect = value;
   }
 
-  public IntegerMap<UnitType> getCombatOffenseEffect() {
+  private IntegerMap<UnitType> getCombatOffenseEffect() {
     return new IntegerMap<>(m_combatOffenseEffect);
   }
 
@@ -94,7 +94,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     m_combatOffenseEffect.clear();
   }
 
-  public void resetCombatOffenseEffect() {
+  private void resetCombatOffenseEffect() {
     m_combatOffenseEffect = new IntegerMap<>();
   }
 
@@ -129,7 +129,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setNoBlitz(final String noBlitzUnitTypes) throws GameParseException {
+  private void setNoBlitz(final String noBlitzUnitTypes) throws GameParseException {
     final String[] s = noBlitzUnitTypes.split(":");
     if (s.length < 1) {
       throw new GameParseException("noBlitz must have at least one unitType" + thisErrorMsg());
@@ -144,7 +144,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNoBlitz(final List<UnitType> value) {
+  private void setNoBlitz(final List<UnitType> value) {
     m_noBlitz = value;
   }
 
@@ -156,7 +156,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     m_noBlitz.clear();
   }
 
-  public void resetNoBlitz() {
+  private void resetNoBlitz() {
     m_noBlitz = new ArrayList<>();
   }
 
@@ -164,7 +164,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitsNotAllowed(final String unitsNotAllowedUnitTypes) throws GameParseException {
+  private void setUnitsNotAllowed(final String unitsNotAllowedUnitTypes) throws GameParseException {
     final String[] s = unitsNotAllowedUnitTypes.split(":");
     if (s.length < 1) {
       throw new GameParseException("unitsNotAllowed must have at least one unitType" + thisErrorMsg());
@@ -179,7 +179,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitsNotAllowed(final List<UnitType> value) {
+  private void setUnitsNotAllowed(final List<UnitType> value) {
     m_unitsNotAllowed = value;
   }
 
@@ -191,7 +191,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     m_unitsNotAllowed.clear();
   }
 
-  public void resetUnitsNotAllowed() {
+  private void resetUnitsNotAllowed() {
     m_unitsNotAllowed = new ArrayList<>();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -284,7 +284,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setActivateTrigger(final String value) throws GameParseException {
+  private void setActivateTrigger(final String value) throws GameParseException {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
     final String[] s = value.split(":");
     if (s.length != 6) {
@@ -325,11 +325,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setActivateTrigger(final List<Tuple<String, String>> value) {
+  private void setActivateTrigger(final List<Tuple<String, String>> value) {
     m_activateTrigger = value;
   }
 
-  public List<Tuple<String, String>> getActivateTrigger() {
+  private List<Tuple<String, String>> getActivateTrigger() {
     return m_activateTrigger;
   }
 
@@ -337,12 +337,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_activateTrigger.clear();
   }
 
-  public void resetActivateTrigger() {
+  private void resetActivateTrigger() {
     m_activateTrigger = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setFrontier(final String s) throws GameParseException {
+  private void setFrontier(final String s) throws GameParseException {
     if (s == null) {
       m_frontier = null;
       return;
@@ -355,15 +355,15 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setFrontier(final ProductionFrontier value) {
+  private void setFrontier(final ProductionFrontier value) {
     m_frontier = value;
   }
 
-  public ProductionFrontier getFrontier() {
+  private ProductionFrontier getFrontier() {
     return m_frontier;
   }
 
-  public void resetFrontier() {
+  private void resetFrontier() {
     m_frontier = null;
   }
 
@@ -371,7 +371,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setProductionRule(final String prop) throws GameParseException {
+  private void setProductionRule(final String prop) throws GameParseException {
     if (prop == null) {
       m_productionRule = null;
       return;
@@ -397,11 +397,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setProductionRule(final List<String> value) {
+  private void setProductionRule(final List<String> value) {
     m_productionRule = value;
   }
 
-  public List<String> getProductionRule() {
+  List<String> getProductionRule() {
     return m_productionRule;
   }
 
@@ -409,30 +409,30 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_productionRule.clear();
   }
 
-  public void resetProductionRule() {
+  private void resetProductionRule() {
     m_productionRule = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setResourceCount(final String s) {
+  private void setResourceCount(final String s) {
     m_resourceCount = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setResourceCount(final Integer s) {
+  private void setResourceCount(final Integer s) {
     m_resourceCount = s;
   }
 
-  public int getResourceCount() {
+  private int getResourceCount() {
     return m_resourceCount;
   }
 
-  public void resetResourceCount() {
+  private void resetResourceCount() {
     m_resourceCount = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setVictory(final String s) {
+  private void setVictory(final String s) {
     if (s == null) {
       m_victory = null;
       return;
@@ -440,11 +440,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_victory = s;
   }
 
-  public String getVictory() {
+  private String getVictory() {
     return m_victory;
   }
 
-  public void resetVictory() {
+  private void resetVictory() {
     m_victory = null;
   }
 
@@ -452,7 +452,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTech(final String techs) throws GameParseException {
+  private void setTech(final String techs) throws GameParseException {
     for (final String subString : techs.split(":")) {
       TechAdvance ta = getData().getTechnologyFrontier().getAdvanceByProperty(subString);
       if (ta == null) {
@@ -466,11 +466,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTech(final List<TechAdvance> value) {
+  private void setTech(final List<TechAdvance> value) {
     m_tech = value;
   }
 
-  public List<TechAdvance> getTech() {
+  private List<TechAdvance> getTech() {
     return m_tech;
   }
 
@@ -478,7 +478,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_tech.clear();
   }
 
-  public void resetTech() {
+  private void resetTech() {
     m_tech = new ArrayList<>();
   }
 
@@ -486,7 +486,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setAvailableTech(final String techs) throws GameParseException {
+  private void setAvailableTech(final String techs) throws GameParseException {
     if (techs == null) {
       m_availableTech = null;
       return;
@@ -523,11 +523,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAvailableTech(final Map<String, Map<TechAdvance, Boolean>> value) {
+  private void setAvailableTech(final Map<String, Map<TechAdvance, Boolean>> value) {
     m_availableTech = value;
   }
 
-  public Map<String, Map<TechAdvance, Boolean>> getAvailableTech() {
+  private Map<String, Map<TechAdvance, Boolean>> getAvailableTech() {
     return m_availableTech;
   }
 
@@ -535,7 +535,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_availableTech.clear();
   }
 
-  public void resetAvailableTech() {
+  private void resetAvailableTech() {
     m_availableTech = null;
   }
 
@@ -543,7 +543,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setSupport(final String sup) throws GameParseException {
+  private void setSupport(final String sup) throws GameParseException {
     if (sup == null) {
       m_support = null;
       return;
@@ -573,11 +573,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSupport(final Map<String, Boolean> value) {
+  private void setSupport(final Map<String, Boolean> value) {
     m_support = value;
   }
 
-  public Map<String, Boolean> getSupport() {
+  private Map<String, Boolean> getSupport() {
     return m_support;
   }
 
@@ -585,12 +585,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_support.clear();
   }
 
-  public void resetSupport() {
+  private void resetSupport() {
     m_support = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setResource(final String s) throws GameParseException {
+  private void setResource(final String s) throws GameParseException {
     if (s == null) {
       m_resource = null;
       return;
@@ -602,11 +602,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_resource = s;
   }
 
-  public String getResource() {
+  private String getResource() {
     return m_resource;
   }
 
-  public void resetResource() {
+  private void resetResource() {
     m_resource = null;
   }
 
@@ -614,7 +614,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationshipChange(final String relChange) throws GameParseException {
+  private void setRelationshipChange(final String relChange) throws GameParseException {
     final String[] s = relChange.split(":");
     if (s.length != 4) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
@@ -643,11 +643,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipChange(final List<String> value) {
+  private void setRelationshipChange(final List<String> value) {
     m_relationshipChange = value;
   }
 
-  public List<String> getRelationshipChange() {
+  private List<String> getRelationshipChange() {
     return m_relationshipChange;
   }
 
@@ -655,7 +655,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_relationshipChange.clear();
   }
 
-  public void resetRelationshipChange() {
+  private void resetRelationshipChange() {
     m_relationshipChange = new ArrayList<>();
   }
 
@@ -663,7 +663,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitType(final String names) throws GameParseException {
+  private void setUnitType(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
@@ -675,11 +675,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitType(final List<UnitType> value) {
+  private void setUnitType(final List<UnitType> value) {
     m_unitType = value;
   }
 
-  public List<UnitType> getUnitType() {
+  private List<UnitType> getUnitType() {
     return m_unitType;
   }
 
@@ -687,12 +687,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_unitType.clear();
   }
 
-  public void resetUnitType() {
+  private void resetUnitType() {
     m_unitType = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitAttachmentName(final String name) throws GameParseException {
+  private void setUnitAttachmentName(final String name) throws GameParseException {
     if (name == null) {
       m_unitAttachmentName = null;
       return;
@@ -722,18 +722,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitAttachmentName(final Tuple<String, String> value) {
+  private void setUnitAttachmentName(final Tuple<String, String> value) {
     m_unitAttachmentName = value;
   }
 
-  public Tuple<String, String> getUnitAttachmentName() {
+  private Tuple<String, String> getUnitAttachmentName() {
     if (m_unitAttachmentName == null) {
       return Tuple.of("UnitAttachment", Constants.UNIT_ATTACHMENT_NAME);
     }
     return m_unitAttachmentName;
   }
 
-  public void resetUnitAttachmentName() {
+  private void resetUnitAttachmentName() {
     m_unitAttachmentName = null;
   }
 
@@ -741,7 +741,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitProperty(final String prop) {
+  private void setUnitProperty(final String prop) {
     if (prop == null) {
       m_unitProperty = null;
       return;
@@ -756,11 +756,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitProperty(final List<Tuple<String, String>> value) {
+  private void setUnitProperty(final List<Tuple<String, String>> value) {
     m_unitProperty = value;
   }
 
-  public List<Tuple<String, String>> getUnitProperty() {
+  private List<Tuple<String, String>> getUnitProperty() {
     return m_unitProperty;
   }
 
@@ -768,7 +768,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_unitProperty.clear();
   }
 
-  public void resetUnitProperty() {
+  private void resetUnitProperty() {
     m_unitProperty = null;
   }
 
@@ -776,7 +776,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritories(final String names) throws GameParseException {
+  private void setTerritories(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final Territory terr = getData().getMap().getTerritory(element);
@@ -788,11 +788,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritories(final List<Territory> value) {
+  private void setTerritories(final List<Territory> value) {
     m_territories = value;
   }
 
-  public List<Territory> getTerritories() {
+  private List<Territory> getTerritories() {
     return m_territories;
   }
 
@@ -800,12 +800,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_territories.clear();
   }
 
-  public void resetTerritories() {
+  private void resetTerritories() {
     m_territories = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryAttachmentName(final String name) throws GameParseException {
+  private void setTerritoryAttachmentName(final String name) throws GameParseException {
     if (name == null) {
       m_territoryAttachmentName = null;
       return;
@@ -835,18 +835,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryAttachmentName(final Tuple<String, String> value) {
+  private void setTerritoryAttachmentName(final Tuple<String, String> value) {
     m_territoryAttachmentName = value;
   }
 
-  public Tuple<String, String> getTerritoryAttachmentName() {
+  private Tuple<String, String> getTerritoryAttachmentName() {
     if (m_territoryAttachmentName == null) {
       return Tuple.of("TerritoryAttachment", Constants.TERRITORY_ATTACHMENT_NAME);
     }
     return m_territoryAttachmentName;
   }
 
-  public void resetTerritoryAttachmentName() {
+  private void resetTerritoryAttachmentName() {
     m_territoryAttachmentName = null;
   }
 
@@ -854,7 +854,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryProperty(final String prop) {
+  private void setTerritoryProperty(final String prop) {
     if (prop == null) {
       m_territoryProperty = null;
       return;
@@ -869,11 +869,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryProperty(final List<Tuple<String, String>> value) {
+  private void setTerritoryProperty(final List<Tuple<String, String>> value) {
     m_territoryProperty = value;
   }
 
-  public List<Tuple<String, String>> getTerritoryProperty() {
+  private List<Tuple<String, String>> getTerritoryProperty() {
     return m_territoryProperty;
   }
 
@@ -881,7 +881,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_territoryProperty.clear();
   }
 
-  public void resetTerritoryProperty() {
+  private void resetTerritoryProperty() {
     m_territoryProperty = null;
   }
 
@@ -889,7 +889,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlayers(final String names) throws GameParseException {
+  private void setPlayers(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerId(element);
@@ -901,11 +901,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayers(final List<PlayerID> value) {
+  private void setPlayers(final List<PlayerID> value) {
     m_players = value;
   }
 
-  public List<PlayerID> getPlayers() {
+  private List<PlayerID> getPlayers() {
     return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
   }
 
@@ -913,12 +913,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_players.clear();
   }
 
-  public void resetPlayers() {
+  private void resetPlayers() {
     m_players = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayerAttachmentName(final String name) throws GameParseException {
+  private void setPlayerAttachmentName(final String name) throws GameParseException {
     if (name == null) {
       m_playerAttachmentName = null;
       return;
@@ -964,18 +964,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayerAttachmentName(final Tuple<String, String> value) {
+  private void setPlayerAttachmentName(final Tuple<String, String> value) {
     m_playerAttachmentName = value;
   }
 
-  public Tuple<String, String> getPlayerAttachmentName() {
+  private Tuple<String, String> getPlayerAttachmentName() {
     if (m_playerAttachmentName == null) {
       return Tuple.of("PlayerAttachment", Constants.PLAYER_ATTACHMENT_NAME);
     }
     return m_playerAttachmentName;
   }
 
-  public void resetPlayerAttachmentName() {
+  private void resetPlayerAttachmentName() {
     m_playerAttachmentName = null;
   }
 
@@ -983,7 +983,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlayerProperty(final String prop) {
+  private void setPlayerProperty(final String prop) {
     if (prop == null) {
       m_playerProperty = null;
       return;
@@ -998,11 +998,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayerProperty(final List<Tuple<String, String>> value) {
+  private void setPlayerProperty(final List<Tuple<String, String>> value) {
     m_playerProperty = value;
   }
 
-  public List<Tuple<String, String>> getPlayerProperty() {
+  private List<Tuple<String, String>> getPlayerProperty() {
     return m_playerProperty;
   }
 
@@ -1010,7 +1010,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_playerProperty.clear();
   }
 
-  public void resetPlayerProperty() {
+  private void resetPlayerProperty() {
     m_playerProperty = null;
   }
 
@@ -1018,7 +1018,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationshipTypes(final String names) throws GameParseException {
+  private void setRelationshipTypes(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final RelationshipType relation = getData().getRelationshipTypeList().getRelationshipType(element);
@@ -1030,11 +1030,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipTypes(final List<RelationshipType> value) {
+  private void setRelationshipTypes(final List<RelationshipType> value) {
     m_relationshipTypes = value;
   }
 
-  public List<RelationshipType> getRelationshipTypes() {
+  private List<RelationshipType> getRelationshipTypes() {
     return m_relationshipTypes;
   }
 
@@ -1042,12 +1042,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_relationshipTypes.clear();
   }
 
-  public void resetRelationshipTypes() {
+  private void resetRelationshipTypes() {
     m_relationshipTypes = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipTypeAttachmentName(final String name) throws GameParseException {
+  private void setRelationshipTypeAttachmentName(final String name) throws GameParseException {
     if (name == null) {
       m_relationshipTypeAttachmentName = null;
       return;
@@ -1075,18 +1075,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipTypeAttachmentName(final Tuple<String, String> value) {
+  private void setRelationshipTypeAttachmentName(final Tuple<String, String> value) {
     m_relationshipTypeAttachmentName = value;
   }
 
-  public Tuple<String, String> getRelationshipTypeAttachmentName() {
+  private Tuple<String, String> getRelationshipTypeAttachmentName() {
     if (m_relationshipTypeAttachmentName == null) {
       return Tuple.of("RelationshipTypeAttachment", Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME);
     }
     return m_relationshipTypeAttachmentName;
   }
 
-  public void resetRelationshipTypeAttachmentName() {
+  private void resetRelationshipTypeAttachmentName() {
     m_relationshipTypeAttachmentName = null;
   }
 
@@ -1094,7 +1094,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationshipTypeProperty(final String prop) {
+  private void setRelationshipTypeProperty(final String prop) {
     if (prop == null) {
       m_relationshipTypeProperty = null;
       return;
@@ -1110,11 +1110,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRelationshipTypeProperty(final List<Tuple<String, String>> value) {
+  private void setRelationshipTypeProperty(final List<Tuple<String, String>> value) {
     m_relationshipTypeProperty = value;
   }
 
-  public List<Tuple<String, String>> getRelationshipTypeProperty() {
+  private List<Tuple<String, String>> getRelationshipTypeProperty() {
     return m_relationshipTypeProperty;
   }
 
@@ -1122,7 +1122,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_relationshipTypeProperty.clear();
   }
 
-  public void resetRelationshipTypeProperty() {
+  private void resetRelationshipTypeProperty() {
     m_relationshipTypeProperty = null;
   }
 
@@ -1130,7 +1130,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryEffects(final String names) throws GameParseException {
+  private void setTerritoryEffects(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(element);
@@ -1142,11 +1142,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryEffects(final List<TerritoryEffect> value) {
+  private void setTerritoryEffects(final List<TerritoryEffect> value) {
     m_territoryEffects = value;
   }
 
-  public List<TerritoryEffect> getTerritoryEffects() {
+  private List<TerritoryEffect> getTerritoryEffects() {
     return m_territoryEffects;
   }
 
@@ -1154,12 +1154,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_territoryEffects.clear();
   }
 
-  public void resetTerritoryEffects() {
+  private void resetTerritoryEffects() {
     m_territoryEffects = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryEffectAttachmentName(final String name) throws GameParseException {
+  private void setTerritoryEffectAttachmentName(final String name) throws GameParseException {
     if (name == null) {
       m_territoryEffectAttachmentName = null;
       return;
@@ -1187,18 +1187,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryEffectAttachmentName(final Tuple<String, String> value) {
+  private void setTerritoryEffectAttachmentName(final Tuple<String, String> value) {
     m_territoryEffectAttachmentName = value;
   }
 
-  public Tuple<String, String> getTerritoryEffectAttachmentName() {
+  private Tuple<String, String> getTerritoryEffectAttachmentName() {
     if (m_territoryEffectAttachmentName == null) {
       return Tuple.of("TerritoryEffectAttachment", Constants.TERRITORYEFFECT_ATTACHMENT_NAME);
     }
     return m_territoryEffectAttachmentName;
   }
 
-  public void resetTerritoryEffectAttachmentName() {
+  private void resetTerritoryEffectAttachmentName() {
     m_territoryEffectAttachmentName = null;
   }
 
@@ -1206,7 +1206,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryEffectProperty(final String prop) {
+  private void setTerritoryEffectProperty(final String prop) {
     if (prop == null) {
       m_territoryEffectProperty = null;
       return;
@@ -1222,11 +1222,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTerritoryEffectProperty(final List<Tuple<String, String>> value) {
+  private void setTerritoryEffectProperty(final List<Tuple<String, String>> value) {
     m_territoryEffectProperty = value;
   }
 
-  public List<Tuple<String, String>> getTerritoryEffectProperty() {
+  private List<Tuple<String, String>> getTerritoryEffectProperty() {
     return m_territoryEffectProperty;
   }
 
@@ -1234,7 +1234,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_territoryEffectProperty.clear();
   }
 
-  public void resetTerritoryEffectProperty() {
+  private void resetTerritoryEffectProperty() {
     m_territoryEffectProperty = null;
   }
 
@@ -1243,7 +1243,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlacement(final String place) throws GameParseException {
+  private void setPlacement(final String place) throws GameParseException {
     if (place == null) {
       m_placement = null;
       return;
@@ -1287,11 +1287,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacement(final Map<Territory, IntegerMap<UnitType>> value) {
+  private void setPlacement(final Map<Territory, IntegerMap<UnitType>> value) {
     m_placement = value;
   }
 
-  public Map<Territory, IntegerMap<UnitType>> getPlacement() {
+  private Map<Territory, IntegerMap<UnitType>> getPlacement() {
     return m_placement;
   }
 
@@ -1299,7 +1299,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_placement.clear();
   }
 
-  public void resetPlacement() {
+  private void resetPlacement() {
     m_placement = null;
   }
 
@@ -1307,7 +1307,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRemoveUnits(final String value) throws GameParseException {
+  private void setRemoveUnits(final String value) throws GameParseException {
     if (value == null) {
       m_removeUnits = null;
       return;
@@ -1368,11 +1368,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRemoveUnits(final Map<Territory, IntegerMap<UnitType>> value) {
+  private void setRemoveUnits(final Map<Territory, IntegerMap<UnitType>> value) {
     m_removeUnits = value;
   }
 
-  public Map<Territory, IntegerMap<UnitType>> getRemoveUnits() {
+  private Map<Territory, IntegerMap<UnitType>> getRemoveUnits() {
     return m_removeUnits;
   }
 
@@ -1380,7 +1380,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_removeUnits.clear();
   }
 
-  public void resetRemoveUnits() {
+  private void resetRemoveUnits() {
     m_removeUnits = null;
   }
 
@@ -1388,7 +1388,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPurchase(final String place) throws GameParseException {
+  private void setPurchase(final String place) throws GameParseException {
     if (place == null) {
       m_purchase = null;
       return;
@@ -1422,11 +1422,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPurchase(final IntegerMap<UnitType> value) {
+  private void setPurchase(final IntegerMap<UnitType> value) {
     m_purchase = value;
   }
 
-  public IntegerMap<UnitType> getPurchase() {
+  private IntegerMap<UnitType> getPurchase() {
     return m_purchase;
   }
 
@@ -1434,7 +1434,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_purchase.clear();
   }
 
-  public void resetPurchase() {
+  private void resetPurchase() {
     m_purchase = null;
   }
 
@@ -1442,7 +1442,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setChangeOwnership(final String value) throws GameParseException {
+  private void setChangeOwnership(final String value) throws GameParseException {
     // territory:oldOwner:newOwner:booleanConquered
     // can have "all" for territory and "any" for oldOwner
     final String[] s = value.split(":");
@@ -1471,11 +1471,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChangeOwnership(final List<String> value) {
+  private void setChangeOwnership(final List<String> value) {
     m_changeOwnership = value;
   }
 
-  public List<String> getChangeOwnership() {
+  private List<String> getChangeOwnership() {
     return m_changeOwnership;
   }
 
@@ -1483,7 +1483,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     m_changeOwnership.clear();
   }
 
-  public void resetChangeOwnership() {
+  private void resetChangeOwnership() {
     m_changeOwnership = new ArrayList<>();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -238,12 +238,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanIntercept(final String value) {
+  private void setCanIntercept(final String value) {
     m_canIntercept = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanIntercept(final Boolean value) {
+  private void setCanIntercept(final Boolean value) {
     m_canIntercept = value;
   }
 
@@ -251,17 +251,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canIntercept;
   }
 
-  public void resetCanIntercept() {
+  private void resetCanIntercept() {
     m_canIntercept = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanEscort(final String value) {
+  private void setCanEscort(final String value) {
     m_canEscort = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanEscort(final Boolean value) {
+  private void setCanEscort(final Boolean value) {
     m_canEscort = value;
   }
 
@@ -269,17 +269,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canEscort;
   }
 
-  public void resetCanEscort() {
+  private void resetCanEscort() {
     m_canEscort = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanAirBattle(final String value) {
+  private void setCanAirBattle(final String value) {
     m_canAirBattle = getBool(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanAirBattle(final Boolean value) {
+  private void setCanAirBattle(final Boolean value) {
     m_canAirBattle = value;
   }
 
@@ -287,21 +287,21 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canAirBattle;
   }
 
-  public void resetCanAirBattle() {
+  private void resetCanAirBattle() {
     m_canAirBattle = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirDefense(final String value) {
+  private void setAirDefense(final String value) {
     m_airDefense = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirDefense(final Integer value) {
+  private void setAirDefense(final Integer value) {
     m_airDefense = value;
   }
 
-  public int getAirDefense() {
+  private int getAirDefense() {
     return m_airDefense;
   }
 
@@ -310,21 +310,21 @@ public class UnitAttachment extends DefaultAttachment {
         m_airDefense + TechAbilityAttachment.getAirDefenseBonus((UnitType) this.getAttachedTo(), player, getData()))));
   }
 
-  public void resetAirDefense() {
+  private void resetAirDefense() {
     m_airDefense = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirAttack(final String value) {
+  private void setAirAttack(final String value) {
     m_airAttack = getInt(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirAttack(final Integer value) {
+  private void setAirAttack(final Integer value) {
     m_airAttack = value;
   }
 
-  public int getAirAttack() {
+  private int getAirAttack() {
     return m_airAttack;
   }
 
@@ -333,17 +333,17 @@ public class UnitAttachment extends DefaultAttachment {
         m_airAttack + TechAbilityAttachment.getAirAttackBonus((UnitType) this.getAttachedTo(), player, getData()))));
   }
 
-  public void resetAirAttack() {
+  private void resetAirAttack() {
     m_airAttack = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirTransport(final String s) {
+  private void setIsAirTransport(final String s) {
     m_isAirTransport = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirTransport(final Boolean s) {
+  private void setIsAirTransport(final Boolean s) {
     m_isAirTransport = s;
   }
 
@@ -351,17 +351,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAirTransport;
   }
 
-  public void resetIsAirTransport() {
+  private void resetIsAirTransport() {
     m_isAirTransport = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirTransportable(final String s) {
+  private void setIsAirTransportable(final String s) {
     m_isAirTransportable = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirTransportable(final Boolean s) {
+  private void setIsAirTransportable(final Boolean s) {
     m_isAirTransportable = s;
   }
 
@@ -369,7 +369,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAirTransportable;
   }
 
-  public void resetIsAirTransportable() {
+  private void resetIsAirTransportable() {
     m_isAirTransportable = false;
   }
 
@@ -377,7 +377,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCanBeGivenByTerritoryTo(final String value) throws GameParseException {
+  private void setCanBeGivenByTerritoryTo(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -392,7 +392,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBeGivenByTerritoryTo(final List<PlayerID> value) {
+  private void setCanBeGivenByTerritoryTo(final List<PlayerID> value) {
     m_canBeGivenByTerritoryTo = value;
   }
 
@@ -404,7 +404,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_canBeGivenByTerritoryTo.clear();
   }
 
-  public void resetCanBeGivenByTerritoryTo() {
+  private void resetCanBeGivenByTerritoryTo() {
     m_canBeGivenByTerritoryTo = new ArrayList<>();
   }
 
@@ -412,7 +412,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCanBeCapturedOnEnteringBy(final String value) throws GameParseException {
+  private void setCanBeCapturedOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = value.split(":");
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
@@ -425,7 +425,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBeCapturedOnEnteringBy(final List<PlayerID> value) {
+  private void setCanBeCapturedOnEnteringBy(final List<PlayerID> value) {
     m_canBeCapturedOnEnteringBy = value;
   }
 
@@ -437,7 +437,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_canBeCapturedOnEnteringBy.clear();
   }
 
-  public void resetCanBeCapturedOnEnteringBy() {
+  private void resetCanBeCapturedOnEnteringBy() {
     m_canBeCapturedOnEnteringBy = new ArrayList<>();
   }
 
@@ -445,7 +445,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhenHitPointsDamagedChangesInto(final String value) throws GameParseException {
+  private void setWhenHitPointsDamagedChangesInto(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 3) {
       throw new GameParseException(
@@ -459,7 +459,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenHitPointsDamagedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
+  private void setWhenHitPointsDamagedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
     m_whenHitPointsDamagedChangesInto = value;
   }
 
@@ -477,7 +477,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_whenHitPointsDamagedChangesInto.clear();
   }
 
-  public void resetWhenHitPointsDamagedChangesInto() {
+  private void resetWhenHitPointsDamagedChangesInto() {
     m_whenHitPointsDamagedChangesInto = new HashMap<>();
   }
 
@@ -485,7 +485,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhenHitPointsRepairedChangesInto(final String value) throws GameParseException {
+  private void setWhenHitPointsRepairedChangesInto(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 3) {
       throw new GameParseException(
@@ -499,7 +499,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenHitPointsRepairedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
+  private void setWhenHitPointsRepairedChangesInto(final Map<Integer, Tuple<Boolean, UnitType>> value) {
     m_whenHitPointsRepairedChangesInto = value;
   }
 
@@ -517,7 +517,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_whenHitPointsRepairedChangesInto.clear();
   }
 
-  public void resetWhenHitPointsRepairedChangesInto() {
+  private void resetWhenHitPointsRepairedChangesInto() {
     m_whenHitPointsRepairedChangesInto = new HashMap<>();
   }
 
@@ -525,7 +525,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhenCapturedChangesInto(final String value) throws GameParseException {
+  private void setWhenCapturedChangesInto(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 5 || (s.length - 1) % 2 != 0) {
       throw new GameParseException("whenCapturedChangesInto must have 5 or more values, "
@@ -555,7 +555,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenCapturedChangesInto(final Map<String, Tuple<String, IntegerMap<UnitType>>> value) {
+  private void setWhenCapturedChangesInto(final Map<String, Tuple<String, IntegerMap<UnitType>>> value) {
     m_whenCapturedChangesInto = value;
   }
 
@@ -567,17 +567,17 @@ public class UnitAttachment extends DefaultAttachment {
     m_whenCapturedChangesInto.clear();
   }
 
-  public void resetWhenCapturedChangesInto() {
+  private void resetWhenCapturedChangesInto() {
     m_whenCapturedChangesInto = new LinkedHashMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenCapturedSustainsDamage(final String s) {
+  private void setWhenCapturedSustainsDamage(final String s) {
     m_whenCapturedSustainsDamage = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenCapturedSustainsDamage(final Integer s) {
+  private void setWhenCapturedSustainsDamage(final Integer s) {
     m_whenCapturedSustainsDamage = s;
   }
 
@@ -585,7 +585,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_whenCapturedSustainsDamage;
   }
 
-  public void resetWhenCapturedSustainsDamage() {
+  private void resetWhenCapturedSustainsDamage() {
     m_whenCapturedSustainsDamage = 0;
   }
 
@@ -593,7 +593,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setDestroyedWhenCapturedBy(String value) throws GameParseException {
+  private void setDestroyedWhenCapturedBy(String value) throws GameParseException {
     // We can prefix this value with "BY" or "FROM" to change the setting. If no setting, default to "BY" since this
     // this is called by
     // destroyedWhenCapturedBy
@@ -617,12 +617,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDestroyedWhenCapturedBy(final List<Tuple<String, PlayerID>> value) {
+  private void setDestroyedWhenCapturedBy(final List<Tuple<String, PlayerID>> value) {
     m_destroyedWhenCapturedBy = value;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true, virtual = true)
-  public void setDestroyedWhenCapturedFrom(String value) throws GameParseException {
+  private void setDestroyedWhenCapturedFrom(String value) throws GameParseException {
     if (!(value.startsWith("BY:") || value.startsWith("FROM:"))) {
       value = "FROM:" + value;
     }
@@ -637,21 +637,21 @@ public class UnitAttachment extends DefaultAttachment {
     m_destroyedWhenCapturedBy.clear();
   }
 
-  public void resetDestroyedWhenCapturedBy() {
+  private void resetDestroyedWhenCapturedBy() {
     m_destroyedWhenCapturedBy = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBlitz(final String s) {
+  private void setCanBlitz(final String s) {
     m_canBlitz = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBlitz(final Boolean s) {
+  private void setCanBlitz(final Boolean s) {
     m_canBlitz = s;
   }
 
-  public boolean getCanBlitz() {
+  private boolean getCanBlitz() {
     return m_canBlitz;
   }
 
@@ -663,17 +663,17 @@ public class UnitAttachment extends DefaultAttachment {
         (UnitType) this.getAttachedTo(), player, getData());
   }
 
-  public void resetCanBlitz() {
+  private void resetCanBlitz() {
     m_canBlitz = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSub(final String s) {
+  private void setIsSub(final String s) {
     m_isSub = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSub(final Boolean s) {
+  private void setIsSub(final Boolean s) {
     m_isSub = s;
   }
 
@@ -681,17 +681,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isSub;
   }
 
-  public void resetIsSub() {
+  private void resetIsSub() {
     m_isSub = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsCombatTransport(final String s) {
+  private void setIsCombatTransport(final String s) {
     m_isCombatTransport = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsCombatTransport(final Boolean s) {
+  private void setIsCombatTransport(final Boolean s) {
     m_isCombatTransport = s;
   }
 
@@ -699,17 +699,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isCombatTransport;
   }
 
-  public void resetIsCombatTransport() {
+  private void resetIsCombatTransport() {
     m_isCombatTransport = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsStrategicBomber(final String s) {
+  private void setIsStrategicBomber(final String s) {
     m_isStrategicBomber = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsStrategicBomber(final Boolean s) {
+  private void setIsStrategicBomber(final Boolean s) {
     m_isStrategicBomber = s;
   }
 
@@ -717,17 +717,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isStrategicBomber;
   }
 
-  public void resetIsStrategicBomber() {
+  private void resetIsStrategicBomber() {
     m_isStrategicBomber = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsDestroyer(final String s) {
+  private void setIsDestroyer(final String s) {
     m_isDestroyer = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsDestroyer(final Boolean s) {
+  private void setIsDestroyer(final Boolean s) {
     m_isDestroyer = s;
   }
 
@@ -735,7 +735,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isDestroyer;
   }
 
-  public void resetIsDestroyer() {
+  private void resetIsDestroyer() {
     m_isDestroyer = false;
   }
 
@@ -745,11 +745,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBombard(final Boolean s) {
+  private void setCanBombard(final Boolean s) {
     m_canBombard = s;
   }
 
-  public boolean getCanBombard() {
+  private boolean getCanBombard() {
     return m_canBombard;
   }
 
@@ -761,17 +761,17 @@ public class UnitAttachment extends DefaultAttachment {
         (UnitType) this.getAttachedTo(), player, getData());
   }
 
-  public void resetCanBombard() {
+  private void resetCanBombard() {
     m_canBombard = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAir(final String s) {
+  private void setIsAir(final String s) {
     m_isAir = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAir(final Boolean s) {
+  private void setIsAir(final Boolean s) {
     m_isAir = s;
   }
 
@@ -779,17 +779,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAir;
   }
 
-  public void resetIsAir() {
+  private void resetIsAir() {
     m_isAir = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSea(final String s) {
+  private void setIsSea(final String s) {
     m_isSea = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSea(final Boolean s) {
+  private void setIsSea(final Boolean s) {
     m_isSea = s;
   }
 
@@ -797,18 +797,18 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isSea;
   }
 
-  public void resetIsSea() {
+  private void resetIsSea() {
     m_isSea = false;
   }
 
   // DO NOT REMOVE, this is an important convenience method for xmls
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsFactory(final String s) {
+  private void setIsFactory(final String s) {
     setIsFactory(getBool(s));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsFactory(final Boolean s) {
+  private void setIsFactory(final Boolean s) {
     setCanBeDamaged(s);
     setIsInfrastructure(s);
     setCanProduceUnits(s);
@@ -826,12 +826,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanProduceUnits(final String s) {
+  private void setCanProduceUnits(final String s) {
     m_canProduceUnits = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanProduceUnits(final Boolean s) {
+  private void setCanProduceUnits(final Boolean s) {
     m_canProduceUnits = s;
   }
 
@@ -839,17 +839,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canProduceUnits;
   }
 
-  public void resetCanProduceUnits() {
+  private void resetCanProduceUnits() {
     m_canProduceUnits = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanProduceXUnits(final String s) {
+  private void setCanProduceXUnits(final String s) {
     m_canProduceXUnits = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanProduceXUnits(final Integer s) {
+  private void setCanProduceXUnits(final Integer s) {
     m_canProduceXUnits = s;
   }
 
@@ -857,17 +857,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canProduceXUnits;
   }
 
-  public void resetCanProduceXUnits() {
+  private void resetCanProduceXUnits() {
     m_canProduceXUnits = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanOnlyBePlacedInTerritoryValuedAtX(final String s) {
+  private void setCanOnlyBePlacedInTerritoryValuedAtX(final String s) {
     m_canOnlyBePlacedInTerritoryValuedAtX = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanOnlyBePlacedInTerritoryValuedAtX(final Integer s) {
+  private void setCanOnlyBePlacedInTerritoryValuedAtX(final Integer s) {
     m_canOnlyBePlacedInTerritoryValuedAtX = s;
   }
 
@@ -875,12 +875,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canOnlyBePlacedInTerritoryValuedAtX;
   }
 
-  public void resetCanOnlyBePlacedInTerritoryValuedAtX() {
+  private void resetCanOnlyBePlacedInTerritoryValuedAtX() {
     m_canOnlyBePlacedInTerritoryValuedAtX = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitPlacementRestrictions(final String value) {
+  private void setUnitPlacementRestrictions(final String value) {
     if (value == null) {
       m_unitPlacementRestrictions = null;
       return;
@@ -889,7 +889,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitPlacementRestrictions(final String[] value) {
+  private void setUnitPlacementRestrictions(final String[] value) {
     m_unitPlacementRestrictions = value;
   }
 
@@ -897,14 +897,14 @@ public class UnitAttachment extends DefaultAttachment {
     return m_unitPlacementRestrictions;
   }
 
-  public void resetUnitPlacementRestrictions() {
+  private void resetUnitPlacementRestrictions() {
     m_unitPlacementRestrictions = null;
   }
 
   // no m_ variable for this, since it is the inverse of m_unitPlacementRestrictions
   // we might as well just use m_unitPlacementRestrictions
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
+  private void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
     final Collection<Territory> allowedTerritories = getListedTerritories(value.split(":"));
     final Collection<Territory> restrictedTerritories = new HashSet<>(getData().getMap().getTerritories());
     restrictedTerritories.removeAll(allowedTerritories);
@@ -914,7 +914,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRepairsUnits(final String value) throws GameParseException {
+  private void setRepairsUnits(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0) {
       throw new GameParseException("repairsUnits cannot be empty" + thisErrorMsg());
@@ -937,7 +937,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRepairsUnits(final IntegerMap<UnitType> value) {
+  private void setRepairsUnits(final IntegerMap<UnitType> value) {
     m_repairsUnits = value;
   }
 
@@ -949,7 +949,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_repairsUnits.clear();
   }
 
-  public void resetRepairsUnits() {
+  private void resetRepairsUnits() {
     m_repairsUnits = new IntegerMap<>();
   }
 
@@ -957,7 +957,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setSpecial(final String value) throws GameParseException {
+  private void setSpecial(final String value) throws GameParseException {
     final String[] s = value.split(":");
     for (final String option : s) {
       if (!(option.equals("none") || option.equals("canOnlyPlaceInOriginalTerritories"))) {
@@ -968,7 +968,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSpecial(final Set<String> value) {
+  private void setSpecial(final Set<String> value) {
     m_special = value;
   }
 
@@ -980,12 +980,12 @@ public class UnitAttachment extends DefaultAttachment {
     m_special.clear();
   }
 
-  public void resetSpecial() {
+  private void resetSpecial() {
     m_special = new HashSet<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanInvadeOnlyFrom(final String value) {
+  private void setCanInvadeOnlyFrom(final String value) {
     if (value == null) {
       m_canInvadeOnlyFrom = null;
       return;
@@ -1003,11 +1003,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanInvadeOnlyFrom(final String[] value) {
+  private void setCanInvadeOnlyFrom(final String[] value) {
     m_canInvadeOnlyFrom = value;
   }
 
-  public String[] getCanInvadeOnlyFrom() {
+  private String[] getCanInvadeOnlyFrom() {
     return m_canInvadeOnlyFrom;
   }
 
@@ -1019,7 +1019,7 @@ public class UnitAttachment extends DefaultAttachment {
     return Arrays.asList(m_canInvadeOnlyFrom).contains(transport.getType().getName());
   }
 
-  public void resetCanInvadeOnlyFrom() {
+  private void resetCanInvadeOnlyFrom() {
     m_canInvadeOnlyFrom = null;
   }
 
@@ -1027,12 +1027,12 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRequiresUnits(final String value) {
+  private void setRequiresUnits(final String value) {
     m_requiresUnits.add(value.split(":"));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRequiresUnits(final List<String[]> value) {
+  private void setRequiresUnits(final List<String[]> value) {
     m_requiresUnits = value;
   }
 
@@ -1044,7 +1044,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_requiresUnits.clear();
   }
 
-  public void resetRequiresUnits() {
+  private void resetRequiresUnits() {
     m_requiresUnits = new ArrayList<>();
   }
 
@@ -1052,7 +1052,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRequiresUnitsToMove(final String value) throws GameParseException {
+  private void setRequiresUnitsToMove(final String value) throws GameParseException {
     final String[] array = value.split(":");
     if (array.length == 0) {
       throw new GameParseException("requiresUnitsToMove must have at least 1 unit type" + thisErrorMsg());
@@ -1067,7 +1067,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRequiresUnitsToMove(final List<String[]> value) {
+  private void setRequiresUnitsToMove(final List<String[]> value) {
     m_requiresUnitsToMove = value;
   }
 
@@ -1079,7 +1079,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_requiresUnitsToMove.clear();
   }
 
-  public void resetRequiresUnitsToMove() {
+  private void resetRequiresUnitsToMove() {
     m_requiresUnitsToMove = new ArrayList<>();
   }
 
@@ -1087,7 +1087,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWhenCombatDamaged(final String value) throws GameParseException {
+  private void setWhenCombatDamaged(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (!(s.length == 3 || s.length == 4)) {
       throw new GameParseException(
@@ -1111,7 +1111,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWhenCombatDamaged(final List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>> value) {
+  private void setWhenCombatDamaged(final List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>> value) {
     m_whenCombatDamaged = value;
   }
 
@@ -1123,7 +1123,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_whenCombatDamaged.clear();
   }
 
-  public void resetWhenCombatDamaged() {
+  private void resetWhenCombatDamaged() {
     m_whenCombatDamaged = new ArrayList<>();
   }
 
@@ -1131,12 +1131,12 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setReceivesAbilityWhenWith(final String value) {
+  private void setReceivesAbilityWhenWith(final String value) {
     m_receivesAbilityWhenWith.add(value);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setReceivesAbilityWhenWith(final List<String> value) {
+  private void setReceivesAbilityWhenWith(final List<String> value) {
     m_receivesAbilityWhenWith = value;
   }
 
@@ -1148,7 +1148,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_receivesAbilityWhenWith.clear();
   }
 
-  public void resetReceivesAbilityWhenWith() {
+  private void resetReceivesAbilityWhenWith() {
     m_receivesAbilityWhenWith = new ArrayList<>();
   }
 
@@ -1190,12 +1190,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsConstruction(final String s) {
+  private void setIsConstruction(final String s) {
     m_isConstruction = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsConstruction(final Boolean s) {
+  private void setIsConstruction(final Boolean s) {
     m_isConstruction = s;
   }
 
@@ -1203,12 +1203,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isConstruction;
   }
 
-  public void resetIsConstruction() {
+  private void resetIsConstruction() {
     m_isConstruction = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConstructionType(final String s) {
+  private void setConstructionType(final String s) {
     m_constructionType = s;
   }
 
@@ -1216,17 +1216,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_constructionType;
   }
 
-  public void resetConstructionType() {
+  private void resetConstructionType() {
     m_constructionType = "none";
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConstructionsPerTerrPerTypePerTurn(final String s) {
+  private void setConstructionsPerTerrPerTypePerTurn(final String s) {
     m_constructionsPerTerrPerTypePerTurn = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConstructionsPerTerrPerTypePerTurn(final Integer s) {
+  private void setConstructionsPerTerrPerTypePerTurn(final Integer s) {
     m_constructionsPerTerrPerTypePerTurn = s;
   }
 
@@ -1234,17 +1234,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_constructionsPerTerrPerTypePerTurn;
   }
 
-  public void resetConstructionsPerTerrPerTypePerTurn() {
+  private void resetConstructionsPerTerrPerTypePerTurn() {
     m_constructionsPerTerrPerTypePerTurn = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxConstructionsPerTypePerTerr(final String s) {
+  private void setMaxConstructionsPerTypePerTerr(final String s) {
     m_maxConstructionsPerTypePerTerr = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxConstructionsPerTypePerTerr(final Integer s) {
+  private void setMaxConstructionsPerTypePerTerr(final Integer s) {
     m_maxConstructionsPerTypePerTerr = s;
   }
 
@@ -1252,12 +1252,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxConstructionsPerTypePerTerr;
   }
 
-  public void resetMaxConstructionsPerTypePerTerr() {
+  private void resetMaxConstructionsPerTypePerTerr() {
     m_maxConstructionsPerTypePerTerr = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsMarine(final String s) {
+  private void setIsMarine(final String s) {
     if (s.equalsIgnoreCase(Constants.PROPERTY_TRUE)) {
       m_isMarine = 1;
     } else if (s.equalsIgnoreCase(Constants.PROPERTY_FALSE)) {
@@ -1268,7 +1268,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsMarine(final Integer s) {
+  private void setIsMarine(final Integer s) {
     m_isMarine = s;
   }
 
@@ -1276,19 +1276,19 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isMarine;
   }
 
-  public void resetIsMarine() {
+  private void resetIsMarine() {
     m_isMarine = 0;
   }
 
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsInfantry(final String s) {
+  private void setIsInfantry(final String s) {
     m_isInfantry = getBool(s);
   }
 
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsInfantry(final Boolean s) {
+  private void setIsInfantry(final Boolean s) {
     m_isInfantry = s;
   }
 
@@ -1298,17 +1298,17 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @Deprecated
-  public void resetIsInfantry() {
+  private void resetIsInfantry() {
     m_isInfantry = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsLandTransportable(final String s) {
+  private void setIsLandTransportable(final String s) {
     m_isLandTransportable = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsLandTransportable(final Boolean s) {
+  private void setIsLandTransportable(final Boolean s) {
     m_isLandTransportable = s;
   }
 
@@ -1316,17 +1316,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isLandTransportable;
   }
 
-  public void resetIsLandTransportable() {
+  private void resetIsLandTransportable() {
     m_isLandTransportable = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsLandTransport(final String s) {
+  private void setIsLandTransport(final String s) {
     m_isLandTransport = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsLandTransport(final Boolean s) {
+  private void setIsLandTransport(final Boolean s) {
     m_isLandTransport = s;
   }
 
@@ -1338,17 +1338,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isLandTransport;
   }
 
-  public void resetIsLandTransport() {
+  private void resetIsLandTransport() {
     m_isLandTransport = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTransportCapacity(final String s) {
+  private void setTransportCapacity(final String s) {
     m_transportCapacity = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTransportCapacity(final Integer s) {
+  private void setTransportCapacity(final Integer s) {
     m_transportCapacity = s;
   }
 
@@ -1356,27 +1356,27 @@ public class UnitAttachment extends DefaultAttachment {
     return m_transportCapacity;
   }
 
-  public void resetTransportCapacity() {
+  private void resetTransportCapacity() {
     m_transportCapacity = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsTwoHit(final String s) {
+  private void setIsTwoHit(final String s) {
     setIsTwoHit(getBool(s));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsTwoHit(final boolean s) {
+  private void setIsTwoHit(final boolean s) {
     m_hitPoints = s ? 2 : 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setHitPoints(final String s) {
+  private void setHitPoints(final String s) {
     m_hitPoints = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setHitPoints(final Integer value) {
+  private void setHitPoints(final Integer value) {
     m_hitPoints = value;
   }
 
@@ -1384,17 +1384,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_hitPoints;
   }
 
-  public void resetHitPoints() {
+  private void resetHitPoints() {
     m_hitPoints = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTransportCost(final String s) {
+  private void setTransportCost(final String s) {
     m_transportCost = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTransportCost(final Integer s) {
+  private void setTransportCost(final Integer s) {
     m_transportCost = s;
   }
 
@@ -1402,17 +1402,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_transportCost;
   }
 
-  public void resetTransportCost() {
+  private void resetTransportCost() {
     m_transportCost = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxBuiltPerPlayer(final String s) {
+  private void setMaxBuiltPerPlayer(final String s) {
     m_maxBuiltPerPlayer = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxBuiltPerPlayer(final Integer s) {
+  private void setMaxBuiltPerPlayer(final Integer s) {
     m_maxBuiltPerPlayer = s;
   }
 
@@ -1420,17 +1420,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxBuiltPerPlayer;
   }
 
-  public void resetMaxBuiltPerPlayer() {
+  private void resetMaxBuiltPerPlayer() {
     m_maxBuiltPerPlayer = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCarrierCapacity(final String s) {
+  private void setCarrierCapacity(final String s) {
     m_carrierCapacity = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCarrierCapacity(final Integer s) {
+  private void setCarrierCapacity(final Integer s) {
     m_carrierCapacity = s;
   }
 
@@ -1438,17 +1438,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_carrierCapacity;
   }
 
-  public void resetCarrierCapacity() {
+  private void resetCarrierCapacity() {
     m_carrierCapacity = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCarrierCost(final String s) {
+  private void setCarrierCost(final String s) {
     m_carrierCost = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCarrierCost(final Integer s) {
+  private void setCarrierCost(final Integer s) {
     m_carrierCost = s;
   }
 
@@ -1456,12 +1456,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_carrierCost;
   }
 
-  public void resetCarrierCost() {
+  private void resetCarrierCost() {
     m_carrierCost = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setArtillery(final String s) throws GameParseException {
+  private void setArtillery(final String s) throws GameParseException {
     m_artillery = getBool(s);
     if (m_artillery) {
       UnitSupportAttachment.addRule((UnitType) getAttachedTo(), getData(), false);
@@ -1469,7 +1469,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setArtillery(final Boolean s) throws GameParseException {
+  private void setArtillery(final Boolean s) throws GameParseException {
     m_artillery = s;
     if (m_artillery) {
       UnitSupportAttachment.addRule((UnitType) getAttachedTo(), getData(), false);
@@ -1480,13 +1480,13 @@ public class UnitAttachment extends DefaultAttachment {
     return m_artillery;
   }
 
-  public void resetArtillery() {
+  private void resetArtillery() {
     throw new IllegalStateException(
         "Resetting Artillery (UnitAttachment) is not allowed, please use Support Attachments instead.");
   }
 
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setArtillerySupportable(final String s) throws GameParseException {
+  private void setArtillerySupportable(final String s) throws GameParseException {
     m_artillerySupportable = getBool(s);
     if (m_artillerySupportable) {
       UnitSupportAttachment.addTarget((UnitType) getAttachedTo(), getData());
@@ -1494,7 +1494,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setArtillerySupportable(final Boolean s) throws GameParseException {
+  private void setArtillerySupportable(final Boolean s) throws GameParseException {
     m_artillerySupportable = s;
     if (m_artillerySupportable) {
       UnitSupportAttachment.addTarget((UnitType) getAttachedTo(), getData());
@@ -1505,7 +1505,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_artillerySupportable;
   }
 
-  public void resetArtillerySupportable() {
+  private void resetArtillerySupportable() {
     throw new IllegalStateException(
         "Resetting Artillery Supportable (UnitAttachment) is not allowed, please use Support Attachments instead.");
   }
@@ -1517,16 +1517,16 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setUnitSupportCount(final Integer s) {
+  private void setUnitSupportCount(final Integer s) {
     m_unitSupportCount = s;
     UnitSupportAttachment.setOldSupportCount((UnitType) getAttachedTo(), getData(), s.toString());
   }
 
-  public int getUnitSupportCount() {
+  private int getUnitSupportCount() {
     return m_unitSupportCount > 0 ? m_unitSupportCount : 1;
   }
 
-  public void resetUnitSupportCount() {
+  private void resetUnitSupportCount() {
     throw new IllegalStateException(
         "Resetting Artillery Support Count (UnitAttachment) is not allowed, please use Support Attachments instead.");
   }
@@ -1537,7 +1537,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombard(final Integer s) {
+  private void setBombard(final Integer s) {
     m_bombard = s;
   }
 
@@ -1545,21 +1545,21 @@ public class UnitAttachment extends DefaultAttachment {
     return m_bombard > 0 ? m_bombard : m_attack;
   }
 
-  public void resetBombard() {
+  private void resetBombard() {
     m_bombard = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovement(final String s) {
+  private void setMovement(final String s) {
     m_movement = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovement(final Integer s) {
+  private void setMovement(final Integer s) {
     m_movement = s;
   }
 
-  public int getMovement() {
+  private int getMovement() {
     return m_movement;
   }
 
@@ -1568,21 +1568,21 @@ public class UnitAttachment extends DefaultAttachment {
         m_movement + TechAbilityAttachment.getMovementBonus((UnitType) this.getAttachedTo(), player, getData()));
   }
 
-  public void resetMovement() {
+  private void resetMovement() {
     m_movement = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttack(final String s) {
+  private void setAttack(final String s) {
     m_attack = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttack(final Integer s) {
+  private void setAttack(final Integer s) {
     m_attack = s;
   }
 
-  public int getAttack() {
+  int getAttack() {
     return m_attack;
   }
 
@@ -1592,21 +1592,21 @@ public class UnitAttachment extends DefaultAttachment {
     return Math.min(getData().getDiceSides(), Math.max(0, attackValue));
   }
 
-  public void resetAttack() {
+  private void resetAttack() {
     m_attack = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackRolls(final String s) {
+  private void setAttackRolls(final String s) {
     m_attackRolls = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackRolls(final Integer s) {
+  private void setAttackRolls(final Integer s) {
     m_attackRolls = s;
   }
 
-  public int getAttackRolls() {
+  private int getAttackRolls() {
     return m_attackRolls;
   }
 
@@ -1615,21 +1615,21 @@ public class UnitAttachment extends DefaultAttachment {
         m_attackRolls + TechAbilityAttachment.getAttackRollsBonus((UnitType) this.getAttachedTo(), player, getData()));
   }
 
-  public void resetAttackRolls() {
+  private void resetAttackRolls() {
     m_attackRolls = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefense(final String s) {
+  private void setDefense(final String s) {
     m_defense = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefense(final Integer s) {
+  private void setDefense(final Integer s) {
     m_defense = s;
   }
 
-  public int getDefense() {
+  private int getDefense() {
     return m_defense;
   }
 
@@ -1643,21 +1643,21 @@ public class UnitAttachment extends DefaultAttachment {
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
   }
 
-  public void resetDefense() {
+  private void resetDefense() {
     m_defense = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefenseRolls(final String s) {
+  private void setDefenseRolls(final String s) {
     m_defenseRolls = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDefenseRolls(final Integer s) {
+  private void setDefenseRolls(final Integer s) {
     m_defenseRolls = s;
   }
 
-  public int getDefenseRolls() {
+  private int getDefenseRolls() {
     return m_defenseRolls;
   }
 
@@ -1666,17 +1666,17 @@ public class UnitAttachment extends DefaultAttachment {
         + TechAbilityAttachment.getDefenseRollsBonus((UnitType) this.getAttachedTo(), player, getData()));
   }
 
-  public void resetDefenseRolls() {
+  private void resetDefenseRolls() {
     m_defenseRolls = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChooseBestRoll(final String s) {
+  private void setChooseBestRoll(final String s) {
     m_chooseBestRoll = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setChooseBestRoll(final Boolean s) {
+  private void setChooseBestRoll(final Boolean s) {
     m_chooseBestRoll = s;
   }
 
@@ -1684,17 +1684,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_chooseBestRoll;
   }
 
-  public void resetChooseBestRoll() {
+  private void resetChooseBestRoll() {
     m_chooseBestRoll = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanScramble(final String s) {
+  private void setCanScramble(final String s) {
     m_canScramble = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanScramble(final Boolean s) {
+  private void setCanScramble(final Boolean s) {
     m_canScramble = s;
   }
 
@@ -1702,17 +1702,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canScramble;
   }
 
-  public void resetCanScramble() {
+  private void resetCanScramble() {
     m_canScramble = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxScrambleCount(final String s) {
+  private void setMaxScrambleCount(final String s) {
     m_maxScrambleCount = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxScrambleCount(final Integer s) {
+  private void setMaxScrambleCount(final Integer s) {
     m_maxScrambleCount = s;
   }
 
@@ -1720,17 +1720,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxScrambleCount;
   }
 
-  public void resetMaxScrambleCount() {
+  private void resetMaxScrambleCount() {
     m_maxScrambleCount = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxScrambleDistance(final String s) {
+  private void setMaxScrambleDistance(final String s) {
     m_maxScrambleDistance = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxScrambleDistance(final Integer s) {
+  private void setMaxScrambleDistance(final Integer s) {
     m_maxScrambleDistance = s;
   }
 
@@ -1738,17 +1738,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxScrambleDistance;
   }
 
-  public void resetMaxScrambleDistance() {
+  private void resetMaxScrambleDistance() {
     m_maxScrambleDistance = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxOperationalDamage(final String s) {
+  private void setMaxOperationalDamage(final String s) {
     m_maxOperationalDamage = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxOperationalDamage(final Integer s) {
+  private void setMaxOperationalDamage(final Integer s) {
     m_maxOperationalDamage = s;
   }
 
@@ -1756,17 +1756,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxOperationalDamage;
   }
 
-  public void resetMaxOperationalDamage() {
+  private void resetMaxOperationalDamage() {
     m_maxOperationalDamage = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxDamage(final String s) {
+  private void setMaxDamage(final String s) {
     m_maxDamage = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxDamage(final Integer s) {
+  private void setMaxDamage(final Integer s) {
     m_maxDamage = s;
   }
 
@@ -1774,17 +1774,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxDamage;
   }
 
-  public void resetMaxDamage() {
+  private void resetMaxDamage() {
     m_maxDamage = 2;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirBase(final String s) {
+  private void setIsAirBase(final String s) {
     m_isAirBase = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAirBase(final Boolean s) {
+  private void setIsAirBase(final Boolean s) {
     m_isAirBase = s;
   }
 
@@ -1792,17 +1792,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAirBase;
   }
 
-  public void resetIsAirBase() {
+  private void resetIsAirBase() {
     m_isAirBase = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsInfrastructure(final String s) {
+  private void setIsInfrastructure(final String s) {
     m_isInfrastructure = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsInfrastructure(final Boolean s) {
+  private void setIsInfrastructure(final Boolean s) {
     m_isInfrastructure = s;
   }
 
@@ -1810,17 +1810,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isInfrastructure;
   }
 
-  public void resetIsInfrastructure() {
+  private void resetIsInfrastructure() {
     m_isInfrastructure = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBeDamaged(final String s) {
+  private void setCanBeDamaged(final String s) {
     m_canBeDamaged = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanBeDamaged(final Boolean s) {
+  private void setCanBeDamaged(final Boolean s) {
     m_canBeDamaged = s;
   }
 
@@ -1828,17 +1828,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canBeDamaged;
   }
 
-  public void resetCanBeDamaged() {
+  private void resetCanBeDamaged() {
     m_canBeDamaged = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanDieFromReachingMaxDamage(final String s) {
+  private void setCanDieFromReachingMaxDamage(final String s) {
     m_canDieFromReachingMaxDamage = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanDieFromReachingMaxDamage(final Boolean s) {
+  private void setCanDieFromReachingMaxDamage(final Boolean s) {
     m_canDieFromReachingMaxDamage = s;
   }
 
@@ -1846,17 +1846,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canDieFromReachingMaxDamage;
   }
 
-  public void resetCanDieFromReachingMaxDamage() {
+  private void resetCanDieFromReachingMaxDamage() {
     m_canDieFromReachingMaxDamage = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSuicide(final String s) {
+  private void setIsSuicide(final String s) {
     m_isSuicide = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSuicide(final Boolean s) {
+  private void setIsSuicide(final Boolean s) {
     m_isSuicide = s;
   }
 
@@ -1864,17 +1864,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isSuicide;
   }
 
-  public void resetIsSuicide() {
+  private void resetIsSuicide() {
     m_isSuicide = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSuicideOnHit(final String s) {
+  private void setIsSuicideOnHit(final String s) {
     m_isSuicideOnHit = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsSuicideOnHit(final Boolean s) {
+  private void setIsSuicideOnHit(final Boolean s) {
     m_isSuicideOnHit = s;
   }
 
@@ -1882,17 +1882,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isSuicideOnHit;
   }
 
-  public void resetIsSuicideOnHit() {
+  private void resetIsSuicideOnHit() {
     m_isSuicideOnHit = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsKamikaze(final String s) {
+  private void setIsKamikaze(final String s) {
     m_isKamikaze = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsKamikaze(final Boolean s) {
+  private void setIsKamikaze(final Boolean s) {
     m_isKamikaze = s;
   }
 
@@ -1900,17 +1900,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isKamikaze;
   }
 
-  public void resetIsKamikaze() {
+  private void resetIsKamikaze() {
     m_isKamikaze = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBlockade(final String s) {
+  private void setBlockade(final String s) {
     m_blockade = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBlockade(final Integer s) {
+  private void setBlockade(final Integer s) {
     m_blockade = s;
   }
 
@@ -1918,7 +1918,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_blockade;
   }
 
-  public void resetBlockade() {
+  private void resetBlockade() {
     m_blockade = 0;
   }
 
@@ -1926,7 +1926,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setGivesMovement(final String value) throws GameParseException {
+  private void setGivesMovement(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
@@ -1943,7 +1943,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setGivesMovement(final IntegerMap<UnitType> value) {
+  private void setGivesMovement(final IntegerMap<UnitType> value) {
     m_givesMovement = value;
   }
 
@@ -1955,7 +1955,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_givesMovement.clear();
   }
 
-  public void resetGivesMovement() {
+  private void resetGivesMovement() {
     m_givesMovement = new IntegerMap<>();
   }
 
@@ -1963,7 +1963,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setConsumesUnits(final String value) throws GameParseException {
+  private void setConsumesUnits(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
       throw new GameParseException("consumesUnits must have two fields" + thisErrorMsg());
@@ -1982,7 +1982,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConsumesUnits(final IntegerMap<UnitType> value) {
+  private void setConsumesUnits(final IntegerMap<UnitType> value) {
     m_consumesUnits = value;
   }
 
@@ -1994,7 +1994,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_consumesUnits.clear();
   }
 
-  public void resetConsumesUnits() {
+  private void resetConsumesUnits() {
     m_consumesUnits = new IntegerMap<>();
   }
 
@@ -2002,7 +2002,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCreatesUnitsList(final String value) throws GameParseException {
+  private void setCreatesUnitsList(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("createsUnitsList cannot be empty or have more than two fields" + thisErrorMsg());
@@ -2021,7 +2021,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCreatesUnitsList(final IntegerMap<UnitType> value) {
+  private void setCreatesUnitsList(final IntegerMap<UnitType> value) {
     m_createsUnitsList = value;
   }
 
@@ -2033,7 +2033,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_createsUnitsList.clear();
   }
 
-  public void resetCreatesUnitsList() {
+  private void resetCreatesUnitsList() {
     m_createsUnitsList = new IntegerMap<>();
   }
 
@@ -2041,7 +2041,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setCreatesResourcesList(final String value) throws GameParseException {
+  private void setCreatesResourcesList(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
@@ -2058,7 +2058,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCreatesResourcesList(final IntegerMap<Resource> value) {
+  private void setCreatesResourcesList(final IntegerMap<Resource> value) {
     m_createsResourcesList = value;
   }
 
@@ -2070,7 +2070,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_createsResourcesList.clear();
   }
 
-  public void resetCreatesResourcesList() {
+  private void resetCreatesResourcesList() {
     m_createsResourcesList = new IntegerMap<>();
   }
 
@@ -2078,7 +2078,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setFuelCost(final String value) throws GameParseException {
+  private void setFuelCost(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
       throw new GameParseException("fuelCost must have two fields" + thisErrorMsg());
@@ -2097,7 +2097,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setFuelCost(final IntegerMap<Resource> value) {
+  private void setFuelCost(final IntegerMap<Resource> value) {
     m_fuelCost = value;
   }
 
@@ -2109,17 +2109,17 @@ public class UnitAttachment extends DefaultAttachment {
     m_fuelCost.clear();
   }
 
-  public void resetFuelCost() {
+  private void resetFuelCost() {
     m_fuelCost = new IntegerMap<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingBonus(final String s) {
+  private void setBombingBonus(final String s) {
     m_bombingBonus = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingBonus(final Integer s) {
+  private void setBombingBonus(final Integer s) {
     m_bombingBonus = s;
   }
 
@@ -2127,17 +2127,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_bombingBonus;
   }
 
-  public void resetBombingBonus() {
+  private void resetBombingBonus() {
     m_bombingBonus = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingMaxDieSides(final String s) {
+  private void setBombingMaxDieSides(final String s) {
     m_bombingMaxDieSides = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingMaxDieSides(final Integer s) {
+  private void setBombingMaxDieSides(final Integer s) {
     m_bombingMaxDieSides = s;
   }
 
@@ -2145,7 +2145,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_bombingMaxDieSides;
   }
 
-  public void resetBombingMaxDieSides() {
+  private void resetBombingMaxDieSides() {
     m_bombingMaxDieSides = -1;
   }
 
@@ -2153,7 +2153,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setBombingTargets(final String value) throws GameParseException {
+  private void setBombingTargets(final String value) throws GameParseException {
     if (value == null) {
       m_bombingTargets = null;
       return;
@@ -2172,11 +2172,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombingTargets(final Set<UnitType> value) {
+  private void setBombingTargets(final Set<UnitType> value) {
     m_bombingTargets = value;
   }
 
-  public Set<UnitType> getBombingTargets() {
+  private Set<UnitType> getBombingTargets() {
     return m_bombingTargets;
   }
 
@@ -2191,7 +2191,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_bombingTargets.clear();
   }
 
-  public void resetBombingTargets() {
+  private void resetBombingTargets() {
     m_bombingTargets = null;
   }
 
@@ -2213,13 +2213,13 @@ public class UnitAttachment extends DefaultAttachment {
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAa(final String s) throws GameParseException {
+  private void setIsAa(final String s) throws GameParseException {
     setIsAa(getBool(s));
   }
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAa(final Boolean s) throws GameParseException {
+  private void setIsAa(final Boolean s) throws GameParseException {
     setIsAaForCombatOnly(s);
     setIsAaForBombingThisUnitOnly(s);
     setIsAaForFlyOverOnly(s);
@@ -2229,16 +2229,16 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAa(final String s) {
+  private void setAttackAa(final String s) {
     m_attackAA = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAa(final Integer s) {
+  private void setAttackAa(final Integer s) {
     m_attackAA = s;
   }
 
-  public int getAttackAa() {
+  private int getAttackAa() {
     return m_attackAA;
   }
 
@@ -2250,21 +2250,21 @@ public class UnitAttachment extends DefaultAttachment {
         m_attackAA + TechAbilityAttachment.getRadarBonus((UnitType) this.getAttachedTo(), player, getData())));
   }
 
-  public void resetAttackAa() {
+  private void resetAttackAa() {
     m_attackAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAa(final String s) {
+  private void setOffensiveAttackAa(final String s) {
     m_offensiveAttackAA = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAa(final Integer s) {
+  private void setOffensiveAttackAa(final Integer s) {
     m_offensiveAttackAA = s;
   }
 
-  public int getOffensiveAttackAa() {
+  private int getOffensiveAttackAa() {
     return m_offensiveAttackAA;
   }
 
@@ -2276,17 +2276,17 @@ public class UnitAttachment extends DefaultAttachment {
         m_offensiveAttackAA + TechAbilityAttachment.getRadarBonus((UnitType) this.getAttachedTo(), player, getData())));
   }
 
-  public void resetOffensiveAttackAa() {
+  private void resetOffensiveAttackAa() {
     m_offensiveAttackAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAaMaxDieSides(final String s) {
+  private void setAttackAaMaxDieSides(final String s) {
     m_attackAAmaxDieSides = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackAaMaxDieSides(final Integer s) {
+  private void setAttackAaMaxDieSides(final Integer s) {
     m_attackAAmaxDieSides = s;
   }
 
@@ -2297,17 +2297,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_attackAAmaxDieSides;
   }
 
-  public void resetAttackAaMaxDieSides() {
+  private void resetAttackAaMaxDieSides() {
     m_attackAAmaxDieSides = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAaMaxDieSides(final String s) {
+  private void setOffensiveAttackAaMaxDieSides(final String s) {
     m_offensiveAttackAAmaxDieSides = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setOffensiveAttackAaMaxDieSides(final Integer s) {
+  private void setOffensiveAttackAaMaxDieSides(final Integer s) {
     m_offensiveAttackAAmaxDieSides = s;
   }
 
@@ -2318,12 +2318,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_offensiveAttackAAmaxDieSides;
   }
 
-  public void resetOffensiveAttackAaMaxDieSides() {
+  private void resetOffensiveAttackAaMaxDieSides() {
     m_offensiveAttackAAmaxDieSides = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxAaAttacks(final String s) throws GameParseException {
+  private void setMaxAaAttacks(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
       throw new GameParseException("maxAAattacks must be positive (or -1 for attacking all) " + thisErrorMsg());
@@ -2332,7 +2332,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxAaAttacks(final Integer s) {
+  private void setMaxAaAttacks(final Integer s) {
     m_maxAAattacks = s;
   }
 
@@ -2340,12 +2340,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxAAattacks;
   }
 
-  public void resetMaxAaAttacks() {
+  private void resetMaxAaAttacks() {
     m_maxAAattacks = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxRoundsAa(final String s) throws GameParseException {
+  private void setMaxRoundsAa(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
       throw new GameParseException("maxRoundsAA must be positive (or -1 for infinite) " + thisErrorMsg());
@@ -2354,7 +2354,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMaxRoundsAa(final Integer s) {
+  private void setMaxRoundsAa(final Integer s) {
     m_maxRoundsAA = s;
   }
 
@@ -2362,17 +2362,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxRoundsAA;
   }
 
-  public void resetMaxRoundsAa() {
+  private void resetMaxRoundsAa() {
     m_maxRoundsAA = 1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMayOverStackAa(final String s) {
+  private void setMayOverStackAa(final String s) {
     m_mayOverStackAA = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMayOverStackAa(final Boolean s) {
+  private void setMayOverStackAa(final Boolean s) {
     m_mayOverStackAA = s;
   }
 
@@ -2380,17 +2380,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_mayOverStackAA;
   }
 
-  public void resetMayOverStackAa() {
+  private void resetMayOverStackAa() {
     m_mayOverStackAA = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDamageableAa(final String s) {
+  private void setDamageableAa(final String s) {
     m_damageableAA = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDamageableAa(final Boolean s) {
+  private void setDamageableAa(final Boolean s) {
     m_damageableAA = s;
   }
 
@@ -2398,17 +2398,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_damageableAA;
   }
 
-  public void resetDamageableAa() {
+  private void resetDamageableAa() {
     m_damageableAA = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForCombatOnly(final String s) {
+  private void setIsAaForCombatOnly(final String s) {
     m_isAAforCombatOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForCombatOnly(final Boolean s) {
+  private void setIsAaForCombatOnly(final Boolean s) {
     m_isAAforCombatOnly = s;
   }
 
@@ -2416,17 +2416,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAAforCombatOnly;
   }
 
-  public void resetIsAaForCombatOnly() {
+  private void resetIsAaForCombatOnly() {
     m_isAAforCombatOnly = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForBombingThisUnitOnly(final String s) {
+  private void setIsAaForBombingThisUnitOnly(final String s) {
     m_isAAforBombingThisUnitOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForBombingThisUnitOnly(final Boolean s) {
+  private void setIsAaForBombingThisUnitOnly(final Boolean s) {
     m_isAAforBombingThisUnitOnly = s;
   }
 
@@ -2434,17 +2434,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAAforBombingThisUnitOnly;
   }
 
-  public void resetIsAaForBombingThisUnitOnly() {
+  private void resetIsAaForBombingThisUnitOnly() {
     m_isAAforBombingThisUnitOnly = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForFlyOverOnly(final String s) {
+  private void setIsAaForFlyOverOnly(final String s) {
     m_isAAforFlyOverOnly = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsAaForFlyOverOnly(final Boolean s) {
+  private void setIsAaForFlyOverOnly(final Boolean s) {
     m_isAAforFlyOverOnly = s;
   }
 
@@ -2452,17 +2452,17 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isAAforFlyOverOnly;
   }
 
-  public void resetIsAaForFlyOverOnly() {
+  private void resetIsAaForFlyOverOnly() {
     m_isAAforFlyOverOnly = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsRocket(final String s) {
+  private void setIsRocket(final String s) {
     m_isRocket = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setIsRocket(final Boolean s) {
+  private void setIsRocket(final Boolean s) {
     m_isRocket = s;
   }
 
@@ -2470,12 +2470,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_isRocket;
   }
 
-  public void resetIsRocket() {
+  private void resetIsRocket() {
     m_isRocket = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTypeAa(final String s) {
+  private void setTypeAa(final String s) {
     m_typeAA = s;
   }
 
@@ -2483,7 +2483,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_typeAA;
   }
 
-  public void resetTypeAa() {
+  private void resetTypeAa() {
     m_typeAA = "AA";
   }
 
@@ -2501,7 +2501,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTargetsAa(final String value) throws GameParseException {
+  private void setTargetsAa(final String value) throws GameParseException {
     if (value == null) {
       m_targetsAA = null;
       return;
@@ -2520,11 +2520,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTargetsAa(final Set<UnitType> value) {
+  private void setTargetsAa(final Set<UnitType> value) {
     m_targetsAA = value;
   }
 
-  public Set<UnitType> getTargetsAa() {
+  private Set<UnitType> getTargetsAa() {
     return m_targetsAA;
   }
 
@@ -2541,7 +2541,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_targetsAA.clear();
   }
 
-  public void resetTargetsAa() {
+  private void resetTargetsAa() {
     m_targetsAA = null;
   }
 
@@ -2549,7 +2549,7 @@ public class UnitAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setWillNotFireIfPresent(final String value) throws GameParseException {
+  private void setWillNotFireIfPresent(final String value) throws GameParseException {
     final String[] s = value.split(":");
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
@@ -2561,7 +2561,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setWillNotFireIfPresent(final Set<UnitType> value) {
+  private void setWillNotFireIfPresent(final Set<UnitType> value) {
     m_willNotFireIfPresent = value;
   }
 
@@ -2573,17 +2573,17 @@ public class UnitAttachment extends DefaultAttachment {
     m_willNotFireIfPresent.clear();
   }
 
-  public void resetWillNotFireIfPresent() {
+  private void resetWillNotFireIfPresent() {
     m_willNotFireIfPresent = new HashSet<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAaMovement(final String s) throws GameParseException {
+  private void setIsAaMovement(final String s) throws GameParseException {
     setIsAaMovement(getBool(s));
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
-  public void setIsAaMovement(final boolean s) throws GameParseException {
+  private void setIsAaMovement(final boolean s) throws GameParseException {
     setCanNotMoveDuringCombatMove(s);
     if (s) {
       setMovementLimit(Integer.MAX_VALUE + ":allied");
@@ -2597,12 +2597,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanNotMoveDuringCombatMove(final String s) {
+  private void setCanNotMoveDuringCombatMove(final String s) {
     m_canNotMoveDuringCombatMove = getBool(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setCanNotMoveDuringCombatMove(final Boolean s) {
+  private void setCanNotMoveDuringCombatMove(final Boolean s) {
     m_canNotMoveDuringCombatMove = s;
   }
 
@@ -2610,12 +2610,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canNotMoveDuringCombatMove;
   }
 
-  public void resetCanNotMoveDuringCombatMove() {
+  private void resetCanNotMoveDuringCombatMove() {
     m_canNotMoveDuringCombatMove = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementLimit(final String value) throws GameParseException {
+  private void setMovementLimit(final String value) throws GameParseException {
     if (value == null) {
       m_movementLimit = null;
       return;
@@ -2639,7 +2639,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementLimit(final Tuple<Integer, String> value) {
+  private void setMovementLimit(final Tuple<Integer, String> value) {
     m_movementLimit = value;
   }
 
@@ -2647,12 +2647,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_movementLimit;
   }
 
-  public void resetMovementLimit() {
+  private void resetMovementLimit() {
     m_movementLimit = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackingLimit(final String value) throws GameParseException {
+  private void setAttackingLimit(final String value) throws GameParseException {
     if (value == null) {
       m_attackingLimit = null;
       return;
@@ -2676,7 +2676,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAttackingLimit(final Tuple<Integer, String> value) {
+  private void setAttackingLimit(final Tuple<Integer, String> value) {
     m_attackingLimit = value;
   }
 
@@ -2684,12 +2684,12 @@ public class UnitAttachment extends DefaultAttachment {
     return m_attackingLimit;
   }
 
-  public void resetAttackingLimit() {
+  private void resetAttackingLimit() {
     m_attackingLimit = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementLimit(final String value) throws GameParseException {
+  private void setPlacementLimit(final String value) throws GameParseException {
     if (value == null) {
       m_placementLimit = null;
       return;
@@ -2713,25 +2713,25 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlacementLimit(final Tuple<Integer, String> value) {
+  private void setPlacementLimit(final Tuple<Integer, String> value) {
     m_placementLimit = value;
   }
 
-  public Tuple<Integer, String> getPlacementLimit() {
+  private Tuple<Integer, String> getPlacementLimit() {
     return m_placementLimit;
   }
 
-  public void resetPlacementLimit() {
+  private void resetPlacementLimit() {
     m_placementLimit = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTuv(final String s) {
+  private void setTuv(final String s) {
     m_tuv = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setTuv(final Integer s) {
+  private void setTuv(final Integer s) {
     m_tuv = s;
   }
 
@@ -2739,7 +2739,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_tuv;
   }
 
-  public void resetTuv() {
+  private void resetTuv() {
     m_tuv = -1;
   }
 
@@ -3499,15 +3499,14 @@ public class UnitAttachment extends DefaultAttachment {
    */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setIsParatroop(final String s) {}
+  private void setIsParatroop(final String s) {}
 
   /**
    * @deprecated does nothing, used to keep compatibility with older xml files, do not remove.
    */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
-  public void setIsMechanized(final String s) {}
-
+  private void setIsMechanized(final String s) {}
 
   @Override
   public Map<String, MutableProperty<?>> getPropertyMap() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -83,7 +83,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitType(final String names) throws GameParseException {
+  private void setUnitType(final String names) throws GameParseException {
     if (names == null) {
       m_unitType = null;
       return;
@@ -100,16 +100,16 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setUnitType(final Set<UnitType> value) {
+  private void setUnitType(final Set<UnitType> value) {
     m_unitType = value;
   }
 
-  public void resetUnitType() {
+  private void resetUnitType() {
     m_unitType = null;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setFaction(final String faction) throws GameParseException {
+  private void setFaction(final String faction) throws GameParseException {
     m_faction = faction;
     if (faction == null) {
       resetFaction();
@@ -129,17 +129,17 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
   }
 
-  public String getFaction() {
+  private String getFaction() {
     return m_faction;
   }
 
-  public void resetFaction() {
+  private void resetFaction() {
     m_allied = false;
     m_enemy = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setSide(final String side) throws GameParseException {
+  private void setSide(final String side) throws GameParseException {
     if (side == null) {
       resetSide();
       return;
@@ -159,18 +159,18 @@ public class UnitSupportAttachment extends DefaultAttachment {
     m_side = side;
   }
 
-  public String getSide() {
+  private String getSide() {
     return m_side;
   }
 
-  public void resetSide() {
+  private void resetSide() {
     m_side = null;
     m_offence = false;
     m_defence = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDice(final String dice) throws GameParseException {
+  private void setDice(final String dice) throws GameParseException {
     if (dice == null) {
       resetDice();
       return;
@@ -190,46 +190,46 @@ public class UnitSupportAttachment extends DefaultAttachment {
     m_dice = dice;
   }
 
-  public String getDice() {
+  private String getDice() {
     return m_dice;
   }
 
-  public void resetDice() {
+  private void resetDice() {
     m_dice = null;
     m_roll = false;
     m_strength = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBonus(final String bonus) {
+  private void setBonus(final String bonus) {
     m_bonus = getInt(bonus);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBonus(final Integer bonus) {
+  private void setBonus(final Integer bonus) {
     m_bonus = bonus;
   }
 
-  public void resetBonus() {
+  private void resetBonus() {
     m_bonus = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNumber(final String number) {
+  private void setNumber(final String number) {
     m_number = getInt(number);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setNumber(final Integer number) {
+  private void setNumber(final Integer number) {
     m_number = number;
   }
 
-  public void resetNumber() {
+  private void resetNumber() {
     m_number = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBonusType(final String type) {
+  private void setBonusType(final String type) {
     if (type == null) {
       m_bonusType = null;
       return;
@@ -237,7 +237,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     m_bonusType = type;
   }
 
-  public void resetBonusType() {
+  private void resetBonusType() {
     m_bonusType = null;
   }
 
@@ -245,7 +245,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlayers(final String names) throws GameParseException {
+  private void setPlayers(final String names) throws GameParseException {
     final String[] s = names.split(":");
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerId(element);
@@ -257,7 +257,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setPlayers(final List<PlayerID> value) {
+  private void setPlayers(final List<PlayerID> value) {
     m_players = value;
   }
 
@@ -269,21 +269,21 @@ public class UnitSupportAttachment extends DefaultAttachment {
     m_players.clear();
   }
 
-  public void resetPlayers() {
+  private void resetPlayers() {
     m_players = new ArrayList<>();
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImpArtTech(final String tech) {
+  private void setImpArtTech(final String tech) {
     m_impArtTech = getBool(tech);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setImpArtTech(final Boolean tech) {
+  private void setImpArtTech(final Boolean tech) {
     m_impArtTech = tech;
   }
 
-  public void resetImpArtTech() {
+  private void resetImpArtTech() {
     m_impArtTech = false;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -57,7 +57,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
    * (same as one in TriggerAttachment)
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setActivateTrigger(final String value) throws GameParseException {
+  private void setActivateTrigger(final String value) throws GameParseException {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
     final String[] s = value.split(":");
     if (s.length != 6) {
@@ -95,11 +95,11 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setActivateTrigger(final List<Tuple<String, String>> value) {
+  private void setActivateTrigger(final List<Tuple<String, String>> value) {
     m_activateTrigger = value;
   }
 
-  public List<Tuple<String, String>> getActivateTrigger() {
+  private List<Tuple<String, String>> getActivateTrigger() {
     return m_activateTrigger;
   }
 
@@ -107,7 +107,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     m_activateTrigger.clear();
   }
 
-  public void resetActivateTrigger() {
+  private void resetActivateTrigger() {
     m_activateTrigger = new ArrayList<>();
   }
 


### PR DESCRIPTION
Many of the getter/setter/resetter methods in classes that implement `DynamicallyModifiable` (i.e. attachments and `Unit`) are only called via `MutableProperty` and do not require public accessibility.  This PR minimizes their accessibility where possible (almost always to private, but a few were only reduced to protected or package-private).

This is a large PR, but the only changes are to method accessibility modifiers.  No other changes (should) be present.  (**EXCEPTION:** The `AbstractUserActionAttachment` constructor was moved so it appears after the field declarations.)