### PR TITLE
Improve Battle Calculator result formatting

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -14,7 +14,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.WindowEvent;
 import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -430,12 +429,12 @@ class OddsCalculatorPanel extends JPanel {
           CollectionUtils.getMatches(defenders.get(), Matches.unitCanBeInBattle(false, isLand, 1, false, true, true));
       final int attackersTotal = mainCombatAttackers.size();
       final int defendersTotal = mainCombatDefenders.size();
-      defenderLeft.setText(formatValue(results.get().getAverageDefendingUnitsLeft()) + " /" + defendersTotal);
-      attackerLeft.setText(formatValue(results.get().getAverageAttackingUnitsLeft()) + " /" + attackersTotal);
+      defenderLeft.setText(formatValue(results.get().getAverageDefendingUnitsLeft()) + " / " + defendersTotal);
+      attackerLeft.setText(formatValue(results.get().getAverageAttackingUnitsLeft()) + " / " + attackersTotal);
       defenderLeftWhenDefenderWon
-          .setText(formatValue(results.get().getAverageDefendingUnitsLeftWhenDefenderWon()) + " /" + defendersTotal);
+          .setText(formatValue(results.get().getAverageDefendingUnitsLeftWhenDefenderWon()) + " / " + defendersTotal);
       attackerLeftWhenAttackerWon
-          .setText(formatValue(results.get().getAverageAttackingUnitsLeftWhenAttackerWon()) + " /" + attackersTotal);
+          .setText(formatValue(results.get().getAverageAttackingUnitsLeftWhenAttackerWon()) + " / " + attackersTotal);
       roundsAverage.setText("" + formatValue(results.get().getAverageBattleRoundsFought()));
       try {
         data.acquireReadLock();
@@ -445,18 +444,16 @@ class OddsCalculatorPanel extends JPanel {
         data.releaseReadLock();
       }
       count.setText(results.get().getRollCount() + "");
-      time.setText(formatValue(results.get().getTime() / 1000.0) + "s");
+      time.setText(formatValue(results.get().getTime() / 1000.0) + " s");
     }
   }
 
-  String formatPercentage(final double percentage) {
-    final NumberFormat format = new DecimalFormat("%");
-    return format.format(percentage);
+  private static String formatPercentage(final double percentage) {
+    return new DecimalFormat("#%").format(percentage);
   }
 
-  String formatValue(final double value) {
-    final NumberFormat format = new DecimalFormat("#0.##");
-    return format.format(value);
+  private static String formatValue(final double value) {
+    return new DecimalFormat("#0.##").format(value);
   }
 
   private void updateDefender(List<Unit> units) {


### PR DESCRIPTION
This PR hijacks some of the UI improvements @RoiEXLab made in #2950, which was never merged, and adds a few others:

* Format percentages with the percent sign to the right (`82%` instead of `%82`).
* Use balanced spacing between the `/` separating average values and totals (`2.46 / 6` instead of `2.46 /6`).
* Add a space between time magnitude and unit (`1.35 s` instead of `1.35s`).

##### Before

![battle-calc-before](https://user-images.githubusercontent.com/4826349/36930669-0da5f440-1e74-11e8-93b7-5c20e2c1cfa5.png)

##### After

![battle-calc-after](https://user-images.githubusercontent.com/4826349/36930670-13d4d002-1e74-11e8-9ce9-f7af14b62749.png)