### PR TITLE
Extract throwing variants of common functional interfaces

### DIFF
--- a/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/game-core/src/integ_test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 
 import games.strategy.engine.lobby.server.TestUserUtils;
 import games.strategy.engine.lobby.server.User;
+import games.strategy.util.function.ThrowingConsumer;
 
 /**
  * Superclass for fixtures that test a moderator service controller.
@@ -43,11 +44,11 @@ public abstract class AbstractModeratorServiceControllerTestCase {
   protected static void assertUserEquals(
       final User expected,
       final String userQuerySql,
-      final PreparedStatementInitializer preparedStatementInitializer,
+      final ThrowingConsumer<PreparedStatement, SQLException> preparedStatementInitializer,
       final String unknownUserMessage) {
     try (Connection conn = Database.getPostgresConnection();
         PreparedStatement ps = conn.prepareStatement(userQuerySql)) {
-      preparedStatementInitializer.initialize(ps);
+      preparedStatementInitializer.accept(ps);
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
           assertEquals(expected.getUsername(), rs.getString(1));
@@ -62,20 +63,5 @@ public abstract class AbstractModeratorServiceControllerTestCase {
     } catch (final SQLException e) {
       fail("user query failed", e);
     }
-  }
-
-  /**
-   * Initializes the parameters of a {@link PreparedStatement}.
-   */
-  @FunctionalInterface
-  protected interface PreparedStatementInitializer {
-    /**
-     * Initializes the parameters of the specified prepared statement.
-     *
-     * @param ps The prepared statement to initialize.
-     *
-     * @throws SQLException If an error occurs while initializing the prepared statement.
-     */
-    void initialize(PreparedStatement ps) throws SQLException;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.function.Supplier;
 
+import games.strategy.util.function.ThrowingConsumer;
+
 /**
  * A wrapper interface to Bundle setters, getters and resetters of the same field.
  *
@@ -141,17 +143,6 @@ public final class MutableProperty<T> {
 
   public static MutableProperty<String> ofWriteOnlyString(final ThrowingConsumer<String, Exception> stringSetter) {
     return ofString(stringSetter, noGetter(), noResetter());
-  }
-
-  /**
-   * A Consumer capable of throwing an exception.
-   *
-   * @param <T> The type of Object to consume.
-   * @param <E> The type of Throwable to throw.
-   */
-  @FunctionalInterface
-  public interface ThrowingConsumer<T, E extends Throwable> {
-    void accept(T object) throws E;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -14,6 +14,8 @@ import javax.swing.SwingWorker;
 
 import com.google.common.base.Throwables;
 
+import games.strategy.util.function.ThrowingSupplier;
+
 /**
  * Provides methods for running tasks in the background to avoid blocking the UI.
  */
@@ -146,23 +148,5 @@ public final class BackgroundTaskRunner {
     }
 
     return resultRef.get();
-  }
-
-  /**
-   * A supplier of results that may throw an exception.
-   *
-   * @param <T> The type of the supplied result.
-   * @param <E> The type of exception that may be thrown by the supplier.
-   */
-  @FunctionalInterface
-  public interface ThrowingSupplier<T, E extends Exception> {
-    /**
-     * Gets the result.
-     *
-     * @return The result.
-     *
-     * @throws E If an error occurs while getting the result.
-     */
-    T get() throws E;
   }
 }

--- a/game-core/src/main/java/games/strategy/io/IoUtils.java
+++ b/game-core/src/main/java/games/strategy/io/IoUtils.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import games.strategy.util.function.ThrowingConsumer;
+import games.strategy.util.function.ThrowingFunction;
+
 /**
  * A collection of useful methods related to I/O.
  */
@@ -22,7 +25,10 @@ public final class IoUtils {
    *
    * @throws IOException If {@code consumer} encounters an error while reading from the input stream.
    */
-  public static void consumeFromMemory(final byte[] bytes, final InputStreamConsumer consumer) throws IOException {
+  public static void consumeFromMemory(
+      final byte[] bytes,
+      final ThrowingConsumer<InputStream, IOException> consumer)
+      throws IOException {
     checkNotNull(bytes);
     checkNotNull(consumer);
 
@@ -43,7 +49,10 @@ public final class IoUtils {
    *
    * @throws IOException If {@code function} encounters an error while reading from the input stream.
    */
-  public static <T> T readFromMemory(final byte[] bytes, final InputStreamFunction<T> function) throws IOException {
+  public static <T> T readFromMemory(
+      final byte[] bytes,
+      final ThrowingFunction<InputStream, T, IOException> function)
+      throws IOException {
     checkNotNull(bytes);
     checkNotNull(function);
 
@@ -60,61 +69,12 @@ public final class IoUtils {
    *
    * @throws IOException If {@code consumer} encounters an error while writing to the output stream.
    */
-  public static byte[] writeToMemory(final OutputStreamConsumer consumer) throws IOException {
+  public static byte[] writeToMemory(final ThrowingConsumer<OutputStream, IOException> consumer) throws IOException {
     checkNotNull(consumer);
 
     // NB: ByteArrayOutputStream does not need to be closed
     final ByteArrayOutputStream os = new ByteArrayOutputStream();
     consumer.accept(os);
     return os.toByteArray();
-  }
-
-  /**
-   * An operation that accepts an {@link InputStream} and returns no result.
-   */
-  @FunctionalInterface
-  public interface InputStreamConsumer {
-    /**
-     * Performs the operation using the specified input stream.
-     *
-     * @param is The input stream from which the consumer will read.
-     *
-     * @throws IOException If an I/O error occurs while reading from the input stream.
-     */
-    void accept(InputStream is) throws IOException;
-  }
-
-  /**
-   * A function that accepts an {@link InputStream} and produces a result.
-   *
-   * @param <R> The type of the function result.
-   */
-  @FunctionalInterface
-  public interface InputStreamFunction<R> {
-    /**
-     * Applies this function to the specified input stream.
-     *
-     * @param is The input stream from which the function will read.
-     *
-     * @return The function result.
-     *
-     * @throws IOException If an I/O error occurs while reading from the input stream.
-     */
-    R apply(InputStream is) throws IOException;
-  }
-
-  /**
-   * An operation that accepts an {@link OutputStream} and returns no result.
-   */
-  @FunctionalInterface
-  public interface OutputStreamConsumer {
-    /**
-     * Performs the operation using the specified output stream.
-     *
-     * @param os The output stream to which the consumer will write.
-     *
-     * @throws IOException If an I/O error occurs while writing to the output stream.
-     */
-    void accept(OutputStream os) throws IOException;
   }
 }

--- a/game-core/src/main/java/games/strategy/util/Interruptibles.java
+++ b/game-core/src/main/java/games/strategy/util/Interruptibles.java
@@ -5,8 +5,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+
+import games.strategy.util.function.ThrowingRunnable;
+import games.strategy.util.function.ThrowingSupplier;
 
 /**
  * A collection of methods that assist working with operations that may be interrupted but it is typically awkward to
@@ -35,7 +37,7 @@ public final class Interruptibles {
    * @return {@code true} if the operation completed without interruption; otherwise {@code false} if the current thread
    *         was interrupted while waiting for the operation to complete.
    */
-  public static boolean await(final InterruptibleRunnable runnable) {
+  public static boolean await(final ThrowingRunnable<InterruptedException> runnable) {
     checkNotNull(runnable);
 
     return awaitResult(() -> {
@@ -70,7 +72,7 @@ public final class Interruptibles {
    *         will contain the operation's result (a {@code null} result is modeled as an empty result); if the operation
    *         was interrupted, {@code completed} will be {@code false} and {@code result} will be empty.
    */
-  public static <T> Result<T> awaitResult(final InterruptibleSupplier<T> supplier) {
+  public static <T> Result<T> awaitResult(final ThrowingSupplier</* @Nullable */ T, InterruptedException> supplier) {
     checkNotNull(supplier);
 
     try {
@@ -123,37 +125,6 @@ public final class Interruptibles {
    */
   public static boolean sleep(final long millis, final int nanos) {
     return await(() -> Thread.sleep(millis, nanos));
-  }
-
-  /**
-   * An interruptible action that does not supply a result.
-   */
-  @FunctionalInterface
-  public interface InterruptibleRunnable {
-    /**
-     * Invokes the action.
-     *
-     * @throws InterruptedException If the current thread is interrupted while waiting for the action to complete.
-     */
-    void run() throws InterruptedException;
-  }
-
-  /**
-   * An interruptible supplier of results.
-   *
-   * @param <T> The type of the result.
-   */
-  @FunctionalInterface
-  public interface InterruptibleSupplier<T> {
-    /**
-     * Gets the result.
-     *
-     * @return The result.
-     *
-     * @throws InterruptedException If the current thread is interrupted while waiting for the supplier to complete.
-     */
-    @Nullable
-    T get() throws InterruptedException;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/util/function/ThrowingConsumer.java
+++ b/game-core/src/main/java/games/strategy/util/function/ThrowingConsumer.java
@@ -1,0 +1,19 @@
+package games.strategy.util.function;
+
+/**
+ * An operation that accepts a single input argument, returns no result, and may throw a checked exception.
+ *
+ * @param <T> The type of the consumed value.
+ * @param <E> The type of exception that may be thrown by the consumer.
+ */
+@FunctionalInterface
+public interface ThrowingConsumer<T, E extends Throwable> {
+  /**
+   * Performs the operation on the given argument.
+   *
+   * @param value The input argument.
+   *
+   * @throws E If an error occurs while performing the operation.
+   */
+  void accept(T value) throws E;
+}

--- a/game-core/src/main/java/games/strategy/util/function/ThrowingFunction.java
+++ b/game-core/src/main/java/games/strategy/util/function/ThrowingFunction.java
@@ -1,0 +1,22 @@
+package games.strategy.util.function;
+
+/**
+ * A function that accepts one argument, produces a result, and may throw a checked exception.
+ *
+ * @param <T> The type of the input to the function.
+ * @param <R> The type of the result of the function.
+ * @param <E> The type of exception that may be thrown by the function.
+ */
+@FunctionalInterface
+public interface ThrowingFunction<T, R, E extends Throwable> {
+  /**
+   * Applies the function to the given argument.
+   *
+   * @param value The function argument.
+   *
+   * @return The function result.
+   *
+   * @throws E If an error occurs while applying the function.
+   */
+  R apply(T value) throws E;
+}

--- a/game-core/src/main/java/games/strategy/util/function/ThrowingRunnable.java
+++ b/game-core/src/main/java/games/strategy/util/function/ThrowingRunnable.java
@@ -1,0 +1,16 @@
+package games.strategy.util.function;
+
+/**
+ * Executes an operation that accepts no input, produces no result, and may throw a checked exception.
+ *
+ * @param <E> The type of exception that may be thrown during the operation.
+ */
+@FunctionalInterface
+public interface ThrowingRunnable<E extends Throwable> {
+  /**
+   * Executes the operation.
+   *
+   * @throws E If an error occurs while performing the operation.
+   */
+  void run() throws E;
+}

--- a/game-core/src/main/java/games/strategy/util/function/ThrowingSupplier.java
+++ b/game-core/src/main/java/games/strategy/util/function/ThrowingSupplier.java
@@ -1,0 +1,19 @@
+package games.strategy.util.function;
+
+/**
+ * A supplier of results that may throw a checked exception.
+ *
+ * @param <T> The type of the supplied result.
+ * @param <E> The type of exception that may be thrown by the supplier.
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Throwable> {
+  /**
+   * Gets the result.
+   *
+   * @return The result.
+   *
+   * @throws E If an error occurs while getting the result.
+   */
+  T get() throws E;
+}

--- a/game-core/src/test/java/games/strategy/io/IoUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/io/IoUtilsTest.java
@@ -2,17 +2,22 @@ package games.strategy.io;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 
-import games.strategy.io.IoUtils.InputStreamConsumer;
-import games.strategy.io.IoUtils.InputStreamFunction;
+import com.example.mockito.MockitoExtension;
 
+import games.strategy.util.function.ThrowingConsumer;
+import games.strategy.util.function.ThrowingFunction;
+
+@ExtendWith(MockitoExtension.class)
 public final class IoUtilsTest {
   private final byte[] bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
@@ -24,9 +29,9 @@ public final class IoUtilsTest {
   }
 
   @Test
-  public void consumeFromMemory_ShouldPassBytesToConsumer() throws Exception {
-    final InputStreamConsumer consumer = mock(InputStreamConsumer.class);
-
+  public void consumeFromMemory_ShouldPassBytesToConsumer(
+      @Mock final ThrowingConsumer<InputStream, IOException> consumer)
+      throws Exception {
     IoUtils.consumeFromMemory(bytes, consumer);
 
     final ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
@@ -35,9 +40,9 @@ public final class IoUtilsTest {
   }
 
   @Test
-  public void readFromMemory_ShouldPassBytesToFunction() throws Exception {
-    final InputStreamFunction<?> function = mock(InputStreamFunction.class);
-
+  public void readFromMemory_ShouldPassBytesToFunction(
+      @Mock final ThrowingFunction<InputStream, ?, IOException> function)
+      throws Exception {
     IoUtils.readFromMemory(bytes, function);
 
     final ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);

--- a/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
+++ b/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mock;
 
 import com.example.mockito.MockitoExtension;
 
-import games.strategy.util.Interruptibles.InterruptibleRunnable;
+import games.strategy.util.function.ThrowingRunnable;
 
 @ExtendWith(MockitoExtension.class)
 public final class InterruptiblesTest {
@@ -30,7 +30,8 @@ public final class InterruptiblesTest {
   @Nested
   public final class AwaitTest {
     @Test
-    public void shouldReturnTrueWhenCompleted(@Mock final InterruptibleRunnable runnable) throws Exception {
+    public void shouldReturnTrueWhenCompleted(@Mock final ThrowingRunnable<InterruptedException> runnable)
+        throws Exception {
       final boolean completed = Interruptibles.await(runnable);
 
       verify(runnable).run();

--- a/game-core/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/game-core/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -12,6 +12,7 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -29,14 +30,18 @@ import com.google.common.collect.Streams;
 import com.google.common.primitives.Ints;
 
 import games.strategy.io.IoUtils;
+import games.strategy.util.function.ThrowingConsumer;
+import games.strategy.util.function.ThrowingFunction;
 
 public final class PointFileReaderWriterTest {
-  private static <R> R readFromString(final IoUtils.InputStreamFunction<R> function, final String content)
+  private static <R> R readFromString(
+      final ThrowingFunction<InputStream, R, IOException> function,
+      final String content)
       throws Exception {
     return IoUtils.readFromMemory(content.getBytes(StandardCharsets.UTF_8), function);
   }
 
-  private static String writeToString(final IoUtils.OutputStreamConsumer consumer) throws Exception {
+  private static String writeToString(final ThrowingConsumer<OutputStream, IOException> consumer) throws Exception {
     return new String(IoUtils.writeToMemory(consumer), StandardCharsets.UTF_8);
   }
 


### PR DESCRIPTION
We have several custom functional interfaces that are basically throwing variants of the following JDK functional interfaces:

* `Runnable`
* `Consumer<T>`
* `Supplier<T>`
* `Function<T, R>`

This PR extracts one generic `Throwing*` interface for each of the above JDK interfaces, and then replaces all custom interfaces with an appropriate parameterization of the new generic interfaces.