### PR TITLE
Attachment cleanup

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -3,6 +3,7 @@ package games.strategy.engine.data;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import games.strategy.engine.data.annotations.InternalDoNotExport;
 import games.strategy.triplea.Constants;
@@ -52,14 +53,10 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     checkNotNull(namedAttachable);
     checkNotNull(attachmentName);
     checkNotNull(attachmentType);
-
-    final T attachment = attachmentType.cast(namedAttachable.getAttachment(attachmentName));
-    if (attachment == null) {
-      throw new IllegalStateException(String.format("No attachment named '%s' of type '%s' for object named '%s'",
-          attachmentName, attachmentType, namedAttachable.getName()));
-    }
-
-    return attachment;
+    return Optional.ofNullable(attachmentType.cast(namedAttachable.getAttachment(attachmentName)))
+        .orElseThrow(
+            () -> new IllegalStateException(String.format("No attachment named '%s' of type '%s' for object named '%s'",
+                attachmentName, attachmentType, namedAttachable.getName())));
   }
 
   /**
@@ -81,25 +78,13 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
       return true;
     } else if (value.equalsIgnoreCase(Constants.PROPERTY_FALSE)) {
       return false;
-    } else {
-      throw new IllegalArgumentException("Attachments: " + value + " is not a valid boolean");
     }
-  }
+    throw new IllegalArgumentException("Attachments: " + value + " is not a valid boolean");
 
-  protected static IllegalArgumentException getSetterExceptionMessage(final DefaultAttachment failingObject,
-      final String propertyName, final String givenValue, final String... allowedValues) {
-    final StringBuilder sb = new StringBuilder();
-    sb.append(failingObject.getClass().getName()).append(": ").append(failingObject.getName()).append(": property ")
-        .append(propertyName).append(" must be either ");
-    sb.append(allowedValues[0]);
-    for (int i = 1; i < allowedValues.length; ++i) {
-      sb.append(" or ").append(allowedValues[i]);
-    }
-    return new IllegalArgumentException(sb + " ([Not Allowed] Given: " + givenValue + ")");
   }
 
   protected String thisErrorMsg() {
-    return "   for: " + this.toString();
+    return "   for: " + toString();
   }
 
   /**
@@ -153,10 +138,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
     final DefaultAttachment other = (DefaultAttachment) obj;
@@ -167,16 +149,6 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
     } else if (!m_attachedTo.toString().equals(other.m_attachedTo.toString())) {
       return false;
     }
-    // else if (!m_attachedTo.equals(other.m_attachedTo)) // m_attachedTo does not override equals, so we should not
-    // test it
-    // return false;
-    if (m_name == null) {
-      if (other.m_name != null) {
-        return false;
-      }
-    } else if (!m_name.equals(other.m_name)) {
-      return false;
-    }
-    return this.toString().equals(other.toString());
+    return Objects.equals(m_name, other.m_name) || this.toString().equals(other.toString());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -146,6 +146,13 @@ public final class MutableProperty<T> {
     return ofString(stringSetter, noGetter(), noResetter());
   }
 
+  /**
+   * A special convinience method trying to keep everything slightly more functional.
+   * Instead of specifying 2 setters, one getter and a resetter with this method
+   * only one setter, one getter, a function mapping a String to the setters type
+   * and a Supplier supplying the default value that's getting fed in again using the setter
+   * are required. This keeps stuff more readable and more testable.
+   */
   public static <T> MutableProperty<T> ofMapper(
       final ThrowingFunction<String, T, Exception> mapper,
       final ThrowingConsumer<T, Exception> setter,
@@ -154,6 +161,8 @@ public final class MutableProperty<T> {
     return new MutableProperty<>(setter, o -> setter.accept(mapper.apply(o)), getter, () -> {
       try {
         setter.accept(defaultValue.get());
+      } catch (final RuntimeException e) {
+        throw e;
       } catch (final Exception e) {
         throw new IllegalStateException("Unexpected Error while resetting value", e);
       }

--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.function.Supplier;
 
 import games.strategy.util.function.ThrowingConsumer;
+import games.strategy.util.function.ThrowingFunction;
 
 /**
  * A wrapper interface to Bundle setters, getters and resetters of the same field.
@@ -143,6 +144,20 @@ public final class MutableProperty<T> {
 
   public static MutableProperty<String> ofWriteOnlyString(final ThrowingConsumer<String, Exception> stringSetter) {
     return ofString(stringSetter, noGetter(), noResetter());
+  }
+
+  public static <T> MutableProperty<T> ofMapper(
+      final ThrowingFunction<String, T, Exception> mapper,
+      final ThrowingConsumer<T, Exception> setter,
+      final Supplier<T> getter,
+      final Supplier<T> defaultValue) {
+    return new MutableProperty<>(setter, o -> setter.accept(mapper.apply(o)), getter, () -> {
+      try {
+        setter.accept(defaultValue.get());
+      } catch (final Exception e) {
+        throw new IllegalStateException("Unexpected Error while resetting value", e);
+      }
+    });
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -71,11 +72,8 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
    * can be null.
    */
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
-  public void setOwner(PlayerID player) {
-    if (player == null) {
-      player = PlayerID.NULL_PLAYERID;
-    }
-    m_owner = player;
+  public void setOwner(final PlayerID player) {
+    m_owner = Optional.ofNullable(player).orElse(PlayerID.NULL_PLAYERID);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
@@ -98,8 +99,9 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_invert;
   }
 
+  @VisibleForTesting
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setConditionType(final String value) throws GameParseException {
+  void setConditionType(final String value) throws GameParseException {
     final String uppercaseValue = value.toUpperCase();
     if (uppercaseValue.matches("AND|X?OR|\\d+(?:-\\d+)?")) {
       final String[] split = uppercaseValue.split("-");

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -167,7 +167,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    * been tested.
    */
   @Override
-  public boolean isSatisfied(final HashMap<ICondition, Boolean> testedConditions) {
+  public boolean isSatisfied(final Map<ICondition, Boolean> testedConditions) {
     return isSatisfied(testedConditions, null);
   }
 
@@ -178,7 +178,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    */
   @Override
   public boolean isSatisfied(
-      final HashMap<ICondition, Boolean> testedConditions,
+      final Map<ICondition, Boolean> testedConditions,
       final IDelegateBridge delegateBridge) {
     if (testedConditions == null) {
       throw new IllegalStateException("testedCondititions cannot be null");
@@ -240,7 +240,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    * no testing of conditions done in this method.
    */
   public static boolean areConditionsMet(final List<ICondition> rulesToTest,
-      final HashMap<ICondition, Boolean> testedConditions, final String conditionType) {
+      final Map<ICondition, Boolean> testedConditions, final String conditionType) {
     boolean met = false;
     if (conditionType.equals("AND")) {
       for (final ICondition c : rulesToTest) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -60,7 +60,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setConditions(final String conditions) throws GameParseException {
+  protected void setConditions(final String conditions) throws GameParseException {
     if (m_conditions == null) {
       m_conditions = new ArrayList<>();
     }
@@ -99,7 +99,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setConditionType(final String value) throws GameParseException {
+  private void setConditionType(final String value) throws GameParseException {
     final String uppercaseValue = value.toUpperCase();
     if (uppercaseValue.matches("AND|X?OR|\\d+(?:-\\d+)?")) {
       final String[] split = uppercaseValue.split("-");
@@ -112,11 +112,11 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
         + "and Z are valid positive integers and Z is greater than Y" + thisErrorMsg());
   }
 
-  public String getConditionType() {
+  private String getConditionType() {
     return m_conditionType;
   }
 
-  public void resetConditionType() {
+  private void resetConditionType() {
     m_conditionType = AND;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -58,7 +58,6 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   /**
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
-  @Override
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setConditions(final String conditions) throws GameParseException {
     final Collection<PlayerID> playerIDs = getData().getPlayerList().getPlayers();
@@ -90,17 +89,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_conditions;
   }
 
-  @Override
-  public void clearConditions() {
-    m_conditions.clear();
-  }
-
-  @Override
-  public void resetConditions() {
+  protected void resetConditions() {
     m_conditions = new ArrayList<>();
   }
 
-  @Override
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setInvert(final String s) {
     setInvert(getBool(s));
@@ -111,17 +103,14 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     m_invert = s;
   }
 
-  @Override
   public boolean getInvert() {
     return m_invert;
   }
 
-  @Override
   public void resetInvert() {
     m_invert = false;
   }
 
-  @Override
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setConditionType(final String value) throws GameParseException {
     String s = value;
@@ -152,12 +141,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     m_conditionType = s;
   }
 
-  @Override
   public String getConditionType() {
     return m_conditionType;
   }
 
-  @Override
   public void resetConditionType() {
     m_conditionType = AND;
   }
@@ -186,8 +173,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     if (testedConditions.containsKey(this)) {
       return testedConditions.get(this);
     }
-    return areConditionsMet(new ArrayList<>(this.getConditions()), testedConditions,
-        this.getConditionType()) != this.getInvert();
+    return areConditionsMet(new ArrayList<>(getConditions()), testedConditions, getConditionType()) != getInvert();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -159,10 +159,6 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return m_productionPerXTerritories;
   }
 
-  public void clearProductionPerXTerritories() {
-    m_productionPerXTerritories.clear();
-  }
-
   private void resetProductionPerXTerritories() {
     m_productionPerXTerritories = new IntegerMap<>();
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -86,10 +86,6 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
   }
 
-  public void clearPlayers() {
-    m_players.clear();
-  }
-
   private void resetPlayers() {
     m_players = new ArrayList<>();
   }
@@ -108,7 +104,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setObjectiveValue(final Integer value) {
+  private void setObjectiveValue(final int value) {
     m_objectiveValue = value;
   }
 
@@ -163,7 +159,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setUses(final Integer u) {
+  private void setUses(final int u) {
     m_uses = u;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -82,14 +82,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */
   @Deprecated
-  public void clearTrigger() {
-    clearConditions();
-  }
-
-  /**
-   * @deprecated please use setConditions, getConditions, clearConditions, instead.
-   */
-  @Deprecated
   private void resetTrigger() {
     resetConditions();
   }
@@ -162,10 +154,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
 
   protected List<Tuple<String, String>> getWhen() {
     return m_when;
-  }
-
-  public void clearWhen() {
-    m_when.clear();
   }
 
   private void resetWhen() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.CompositeChange;
+import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.MutableProperty;
@@ -87,16 +88,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setUses(final String s) {
-    m_uses = getInt(s);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setUses(final Integer u) {
-    m_uses = u;
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setUses(final int u) {
     m_uses = u;
   }
@@ -126,10 +117,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
 
   public int getUses() {
     return m_uses;
-  }
-
-  private void resetUses() {
-    m_uses = -1;
   }
 
   /**
@@ -302,11 +289,11 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("uses",
-            MutableProperty.of(
-                this::setUses,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setUses,
                 this::getUses,
-                this::resetUses))
+                () -> -1))
         .put("usedThisRound",
             MutableProperty.of(
                 this::setUsedThisRound,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -126,10 +126,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return m_actionAccept;
   }
 
-  public void clearActionAccept() {
-    m_actionAccept.clear();
-  }
-
   private void resetActionAccept() {
     m_actionAccept = new ArrayList<>();
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -151,10 +151,6 @@ public class CanalAttachment extends DefaultAttachment {
     return m_excludedUnits;
   }
 
-  public void clearExcludedUnits() {
-    m_excludedUnits.clear();
-  }
-
   private void resetExcludedUnits() {
     m_excludedUnits = null;
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.attachments;
 import java.util.List;
 import java.util.Map;
 
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.delegate.IDelegateBridge;
 
@@ -15,41 +14,12 @@ import games.strategy.engine.delegate.IDelegateBridge;
  */
 public interface ICondition extends IAttachment {
   /**
-   * Only accepts RulesAttachments, and this is on purpose.
-   */
-  void setConditions(final String conditions) throws GameParseException;
-
-  /**
    * Returns attached RulesAttachments.
    * Yes, this should be RulesAttachment, not ICondition. The reason being that you can ONLY attach RulesAttachments to
    * a class that
    * implements ICondition.
    */
   List<RulesAttachment> getConditions();
-
-  void clearConditions();
-
-  void resetConditions();
-
-  void setConditionType(final String s) throws GameParseException;
-
-  void resetConditionType();
-
-  /**
-   * Modifies the attached conditions, with things like AND, OR, XOR, or requiring a specific number of attached
-   * conditions to be true (like
-   * exactly 3, or 4-6 only).
-   */
-  String getConditionType();
-
-  void setInvert(final String s);
-
-  void resetInvert();
-
-  /**
-   * Logical negation of the entire condition.
-   */
-  boolean getInvert();
 
   /**
    * Tests if the attachment, as a whole, is satisfied. This includes and takes account of all conditions that make up

--- a/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.attachments;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.IAttachment;
@@ -65,12 +65,12 @@ public interface ICondition extends IAttachment {
    * testing the
    * conditions the first time.
    */
-  boolean isSatisfied(HashMap<ICondition, Boolean> testedConditions, final IDelegateBridge bridge);
+  boolean isSatisfied(Map<ICondition, Boolean> testedConditions, final IDelegateBridge bridge);
 
   /**
    * HashMap&lt;ICondition, Boolean> testedConditions must be filled with completed tests of all conditions already, or
    * this will give you
    * errors.
    */
-  boolean isSatisfied(HashMap<ICondition, Boolean> testedConditions);
+  boolean isSatisfied(Map<ICondition, Boolean> testedConditions);
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -333,21 +333,12 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setVps(final String value) {
-    m_vps = getInt(value);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setVps(final Integer value) {
+  private void setVps(final int value) {
     m_vps = value;
   }
 
   public int getVps() {
     return m_vps;
-  }
-
-  private void resetVps() {
-    m_vps = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -563,11 +554,11 @@ public class PlayerAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put("vps",
-            MutableProperty.of(
-                this::setVps,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setVps,
                 this::getVps,
-                this::resetVps))
+                () -> 0))
         .put("captureVps",
             MutableProperty.of(
                 this::setCaptureVps,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -122,10 +122,6 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_placementLimit;
   }
 
-  public void clearPlacementLimit() {
-    m_placementLimit.clear();
-  }
-
   private void resetPlacementLimit() {
     m_placementLimit = new HashSet<>();
   }
@@ -170,10 +166,6 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_movementLimit;
   }
 
-  public void clearMovementLimit() {
-    m_movementLimit.clear();
-  }
-
   private void resetMovementLimit() {
     m_movementLimit = new HashSet<>();
   }
@@ -216,10 +208,6 @@ public class PlayerAttachment extends DefaultAttachment {
 
   private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
     return m_attackingLimit;
-  }
-
-  public void clearAttackingLimit() {
-    m_attackingLimit.clear();
   }
 
   private void resetAttackingLimit() {
@@ -307,10 +295,6 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_suicideAttackTargets;
   }
 
-  public void clearSuicideAttackTargets() {
-    m_suicideAttackTargets.clear();
-  }
-
   private void resetSuicideAttackTargets() {
     m_suicideAttackTargets = null;
   }
@@ -342,10 +326,6 @@ public class PlayerAttachment extends DefaultAttachment {
 
   public IntegerMap<Resource> getSuicideAttackResources() {
     return m_suicideAttackResources;
-  }
-
-  public void clearSuicideAttackResources() {
-    m_suicideAttackResources.clear();
   }
 
   private void resetSuicideAttackResources() {
@@ -449,10 +429,6 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_giveUnitControl;
   }
 
-  public void clearGiveUnitControl() {
-    m_giveUnitControl.clear();
-  }
-
   private void resetGiveUnitControl() {
     m_giveUnitControl = new ArrayList<>();
   }
@@ -480,10 +456,6 @@ public class PlayerAttachment extends DefaultAttachment {
 
   public List<PlayerID> getCaptureUnitOnEnteringBy() {
     return m_captureUnitOnEnteringBy;
-  }
-
-  public void clearCaptureUnitOnEnteringBy() {
-    m_captureUnitOnEnteringBy.clear();
   }
 
   private void resetCaptureUnitOnEnteringBy() {
@@ -515,10 +487,6 @@ public class PlayerAttachment extends DefaultAttachment {
     return m_shareTechnology;
   }
 
-  public void clearShareTechnology() {
-    m_shareTechnology.clear();
-  }
-
   private void resetShareTechnology() {
     m_shareTechnology = new ArrayList<>();
   }
@@ -546,10 +514,6 @@ public class PlayerAttachment extends DefaultAttachment {
 
   public List<PlayerID> getHelpPayTechCost() {
     return m_helpPayTechCost;
-  }
-
-  public void clearHelpPayTechCost() {
-    m_helpPayTechCost.clear();
   }
 
   private void resetHelpPayTechCost() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -108,10 +108,6 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     return m_relationshipChange;
   }
 
-  public void clearRelationshipChange() {
-    m_relationshipChange.clear();
-  }
-
   private void resetRelationshipChange() {
     m_relationshipChange = new ArrayList<>();
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -6,7 +6,6 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -232,10 +231,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return m_battle;
   }
 
-  public void clearBattle() {
-    m_battle.clear();
-  }
-
   private void resetBattle() {
     m_battle = new ArrayList<>();
   }
@@ -283,10 +278,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
 
   private List<String> getRelationship() {
     return m_relationship;
-  }
-
-  public void clearRelationship() {
-    m_relationship.clear();
   }
 
   private void resetRelationship() {
@@ -538,10 +529,6 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return m_unitPresence;
   }
 
-  public void clearUnitPresence() {
-    m_unitPresence.clear();
-  }
-
   private void resetUnitPresence() {
     m_unitPresence = new IntegerMap<>();
   }
@@ -644,7 +631,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  public boolean isSatisfied(final HashMap<ICondition, Boolean> testedConditions) {
+  public boolean isSatisfied(final Map<ICondition, Boolean> testedConditions) {
     checkNotNull(testedConditions);
     checkState(testedConditions.containsKey(this));
 
@@ -652,7 +639,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  public boolean isSatisfied(HashMap<ICondition, Boolean> testedConditions, final IDelegateBridge delegateBridge) {
+  public boolean isSatisfied(Map<ICondition, Boolean> testedConditions, final IDelegateBridge delegateBridge) {
     if (testedConditions != null) {
       if (testedConditions.containsKey(this)) {
         return testedConditions.get(this);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -198,10 +198,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumIntegerMap(TechAbilityAttachment::getAttackBonus, ut, player, data);
   }
 
-  public void clearAttackBonus() {
-    m_attackBonus.clear();
-  }
-
   private void resetAttackBonus() {
     m_attackBonus = new IntegerMap<>();
   }
@@ -225,10 +221,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   static int getDefenseBonus(final UnitType ut, final PlayerID player, final GameData data) {
     return sumIntegerMap(TechAbilityAttachment::getDefenseBonus, ut, player, data);
-  }
-
-  public void clearDefenseBonus() {
-    m_defenseBonus.clear();
   }
 
   private void resetDefenseBonus() {
@@ -256,10 +248,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumIntegerMap(TechAbilityAttachment::getMovementBonus, ut, player, data);
   }
 
-  public void clearMovementBonus() {
-    m_movementBonus.clear();
-  }
-
   private void resetMovementBonus() {
     m_movementBonus = new IntegerMap<>();
   }
@@ -283,10 +271,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   static int getRadarBonus(final UnitType ut, final PlayerID player, final GameData data) {
     return sumIntegerMap(TechAbilityAttachment::getRadarBonus, ut, player, data);
-  }
-
-  public void clearRadarBonus() {
-    m_radarBonus.clear();
   }
 
   private void resetRadarBonus() {
@@ -314,10 +298,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumIntegerMap(TechAbilityAttachment::getAirAttackBonus, ut, player, data);
   }
 
-  public void clearAirAttackBonus() {
-    m_airAttackBonus.clear();
-  }
-
   private void resetAirAttackBonus() {
     m_airAttackBonus = new IntegerMap<>();
   }
@@ -343,10 +323,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumIntegerMap(TechAbilityAttachment::getAirDefenseBonus, ut, player, data);
   }
 
-  public void clearAirDefenseBonus() {
-    m_airDefenseBonus.clear();
-  }
-
   private void resetAirDefenseBonus() {
     m_airDefenseBonus = new IntegerMap<>();
   }
@@ -370,10 +346,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   public static int getProductionBonus(final UnitType ut, final PlayerID player, final GameData data) {
     return sumIntegerMap(TechAbilityAttachment::getProductionBonus, ut, player, data);
-  }
-
-  public void clearProductionBonus() {
-    m_productionBonus.clear();
   }
 
   private void resetProductionBonus() {
@@ -514,10 +486,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rocketDiceNumber;
   }
 
-  public void clearRocketDiceNumber() {
-    m_rocketDiceNumber.clear();
-  }
-
   private void resetRocketDiceNumber() {
     m_rocketDiceNumber = new IntegerMap<>();
   }
@@ -614,10 +582,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .anyMatch(filterForAbility::equals);
   }
 
-  public void clearUnitAbilitiesGained() {
-    m_unitAbilitiesGained.clear();
-  }
-
   private void resetUnitAbilitiesGained() {
     m_unitAbilitiesGained = new HashMap<>();
   }
@@ -677,10 +641,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneCapacity;
   }
 
-  public void clearAirborneCapacity() {
-    m_airborneCapacity.clear();
-  }
-
   private void resetAirborneCapacity() {
     m_airborneCapacity = new IntegerMap<>();
   }
@@ -711,10 +671,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .map(TechAbilityAttachment::getAirborneTypes)
         .flatMap(Collection::stream)
         .collect(Collectors.toSet());
-  }
-
-  public void clearAirborneTypes() {
-    m_airborneTypes.clear();
   }
 
   private void resetAirborneTypes() {
@@ -775,10 +731,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
         .collect(Collectors.toSet());
   }
 
-  public void clearAirborneBases() {
-    m_airborneBases.clear();
-  }
-
   private void resetAirborneBases() {
     m_airborneBases = new HashSet<>();
   }
@@ -827,10 +779,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneTargettedByAa;
   }
 
-  public void clearAirborneTargettedByAa() {
-    m_airborneTargettedByAA.clear();
-  }
-
   private void resetAirborneTargettedByAa() {
     m_airborneTargettedByAA = new HashMap<>();
   }
@@ -854,10 +802,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   static int getAttackRollsBonus(final UnitType ut, final PlayerID player, final GameData data) {
     return sumIntegerMap(TechAbilityAttachment::getAttackRollsBonus, ut, player, data);
-  }
-
-  public void clearAttackRollsBonus() {
-    m_attackRollsBonus.clear();
   }
 
   private void resetAttackRollsBonus() {
@@ -906,16 +850,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return sumIntegerMap(TechAbilityAttachment::getBombingBonus, ut, player, data);
   }
 
-  public void clearDefenseRollsBonus() {
-    m_defenseRollsBonus.clear();
-  }
-
   private void resetDefenseRollsBonus() {
     m_defenseRollsBonus = new IntegerMap<>();
-  }
-
-  public void clearBombingBonus() {
-    m_bombingBonus.clear();
   }
 
   private void resetBombingBonus() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -398,27 +398,17 @@ public class TechAttachment extends DefaultAttachment {
     return genericTech;
   }
 
-  public void clearGenericTech() {
-    genericTech.clear();
-  }
-
   @Override
   public void validate(final GameData data) {}
 
   public static boolean isMechanizedInfantry(final PlayerID player) {
     final TechAttachment ta = (TechAttachment) player.getAttachment(Constants.TECH_ATTACHMENT_NAME);
-    if (ta == null) {
-      return false;
-    }
-    return ta.getMechanizedInfantry();
+    return ta != null && ta.getMechanizedInfantry();
   }
 
   public static boolean isAirTransportable(final PlayerID player) {
     final TechAttachment ta = (TechAttachment) player.getAttachment(Constants.TECH_ATTACHMENT_NAME);
-    if (ta == null) {
-      return false;
-    }
-    return ta.getParatroopers();
+    return ta != null && ta.getParatroopers();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -307,21 +307,12 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setVictoryCity(final String value) {
-    setVictoryCity(getInt(value));
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   private void setVictoryCity(final int value) {
     m_victoryCity = value;
   }
 
   public int getVictoryCity() {
     return m_victoryCity;
-  }
-
-  private void resetVictoryCity() {
-    m_victoryCity = 0;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -384,18 +375,8 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setUnitProduction(final String value) {
-    setUnitProduction(getInt(value));
-  }
-
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   private void setUnitProduction(final int value) {
     m_unitProduction = value;
-  }
-
-  private void resetUnitProduction() {
-    m_unitProduction = 0;
   }
 
   /**
@@ -822,11 +803,11 @@ public class TerritoryAttachment extends DefaultAttachment {
             MutableProperty.ofWriteOnlyString(
                 this::setProductionOnly))
         .put("victoryCity",
-            MutableProperty.of(
-                this::setVictoryCity,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setVictoryCity,
                 this::getVictoryCity,
-                this::resetVictoryCity))
+                () -> 0))
         .put("isImpassable",
             MutableProperty.of(
                 this::setIsImpassable,
@@ -882,11 +863,11 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getKamikazeZone,
                 this::resetKamikazeZone))
         .put("unitProduction",
-            MutableProperty.of(
-                this::setUnitProduction,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setUnitProduction,
                 this::getUnitProduction,
-                this::resetUnitProduction))
+                () -> 0))
         .put("blockadeZone",
             MutableProperty.of(
                 this::setBlockadeZone,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -259,10 +259,6 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_resources;
   }
 
-  public void clearResources() {
-    m_resources = new ResourceCollection(getData());
-  }
-
   private void resetResources() {
     m_resources = null;
   }
@@ -476,10 +472,6 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_changeUnitOwners;
   }
 
-  public void clearChangeUnitOwners() {
-    m_changeUnitOwners.clear();
-  }
-
   private void resetChangeUnitOwners() {
     m_changeUnitOwners = new ArrayList<>();
   }
@@ -507,10 +499,6 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   public ArrayList<PlayerID> getCaptureUnitOnEnteringBy() {
     return m_captureUnitOnEnteringBy;
-  }
-
-  public void clearCaptureUnitOnEnteringBy() {
-    m_captureUnitOnEnteringBy.clear();
   }
 
   private void resetCaptureUnitOnEnteringBy() {
@@ -545,10 +533,6 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_whenCapturedByGoesTo;
   }
 
-  public void clearWhenCapturedByGoesTo() {
-    m_whenCapturedByGoesTo.clear();
-  }
-
   private void resetWhenCapturedByGoesTo() {
     m_whenCapturedByGoesTo = new ArrayList<>();
   }
@@ -576,10 +560,6 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   public ArrayList<TerritoryEffect> getTerritoryEffect() {
     return m_territoryEffect;
-  }
-
-  public void clearTerritoryEffect() {
-    m_territoryEffect.clear();
   }
 
   private void resetTerritoryEffect() {
@@ -610,10 +590,6 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   public HashSet<Territory> getConvoyAttached() {
     return m_convoyAttached;
-  }
-
-  public void clearConvoyAttached() {
-    m_convoyAttached.clear();
   }
 
   private void resetConvoyAttached() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -65,10 +65,6 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     return new IntegerMap<>(m_combatDefenseEffect);
   }
 
-  public void clearCombatDefenseEffect() {
-    m_combatDefenseEffect.clear();
-  }
-
   private void resetCombatDefenseEffect() {
     m_combatDefenseEffect = new IntegerMap<>();
   }
@@ -88,10 +84,6 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
 
   private IntegerMap<UnitType> getCombatOffenseEffect() {
     return new IntegerMap<>(m_combatOffenseEffect);
-  }
-
-  public void clearCombatOffenseEffect() {
-    m_combatOffenseEffect.clear();
   }
 
   private void resetCombatOffenseEffect() {
@@ -152,10 +144,6 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     return new ArrayList<>(m_noBlitz);
   }
 
-  public void clearNoBlitz() {
-    m_noBlitz.clear();
-  }
-
   private void resetNoBlitz() {
     m_noBlitz = new ArrayList<>();
   }
@@ -185,10 +173,6 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
 
   public List<UnitType> getUnitsNotAllowed() {
     return new ArrayList<>(m_unitsNotAllowed);
-  }
-
-  public void clearUnitsNotAllowed() {
-    m_unitsNotAllowed.clear();
   }
 
   private void resetUnitsNotAllowed() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -333,10 +333,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_activateTrigger;
   }
 
-  public void clearActivateTrigger() {
-    m_activateTrigger.clear();
-  }
-
   private void resetActivateTrigger() {
     m_activateTrigger = new ArrayList<>();
   }
@@ -405,10 +401,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_productionRule;
   }
 
-  public void clearProductionRule() {
-    m_productionRule.clear();
-  }
-
   private void resetProductionRule() {
     m_productionRule = null;
   }
@@ -474,10 +466,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_tech;
   }
 
-  public void clearTech() {
-    m_tech.clear();
-  }
-
   private void resetTech() {
     m_tech = new ArrayList<>();
   }
@@ -531,10 +519,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_availableTech;
   }
 
-  public void clearAvailableTech() {
-    m_availableTech.clear();
-  }
-
   private void resetAvailableTech() {
     m_availableTech = null;
   }
@@ -579,10 +563,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private Map<String, Boolean> getSupport() {
     return m_support;
-  }
-
-  public void clearSupport() {
-    m_support.clear();
   }
 
   private void resetSupport() {
@@ -651,10 +631,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_relationshipChange;
   }
 
-  public void clearRelationshipChange() {
-    m_relationshipChange.clear();
-  }
-
   private void resetRelationshipChange() {
     m_relationshipChange = new ArrayList<>();
   }
@@ -681,10 +657,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<UnitType> getUnitType() {
     return m_unitType;
-  }
-
-  public void clearUnitType() {
-    m_unitType.clear();
   }
 
   private void resetUnitType() {
@@ -764,10 +736,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_unitProperty;
   }
 
-  public void clearUnitProperty() {
-    m_unitProperty.clear();
-  }
-
   private void resetUnitProperty() {
     m_unitProperty = null;
   }
@@ -794,10 +762,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<Territory> getTerritories() {
     return m_territories;
-  }
-
-  public void clearTerritories() {
-    m_territories.clear();
   }
 
   private void resetTerritories() {
@@ -877,10 +841,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_territoryProperty;
   }
 
-  public void clearTerritoryProperty() {
-    m_territoryProperty.clear();
-  }
-
   private void resetTerritoryProperty() {
     m_territoryProperty = null;
   }
@@ -907,10 +867,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<PlayerID> getPlayers() {
     return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
-  }
-
-  public void clearPlayers() {
-    m_players.clear();
   }
 
   private void resetPlayers() {
@@ -1006,10 +962,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_playerProperty;
   }
 
-  public void clearPlayerProperty() {
-    m_playerProperty.clear();
-  }
-
   private void resetPlayerProperty() {
     m_playerProperty = null;
   }
@@ -1036,10 +988,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<RelationshipType> getRelationshipTypes() {
     return m_relationshipTypes;
-  }
-
-  public void clearRelationshipTypes() {
-    m_relationshipTypes.clear();
   }
 
   private void resetRelationshipTypes() {
@@ -1118,10 +1066,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_relationshipTypeProperty;
   }
 
-  public void clearRelationshipTypeProperty() {
-    m_relationshipTypeProperty.clear();
-  }
-
   private void resetRelationshipTypeProperty() {
     m_relationshipTypeProperty = null;
   }
@@ -1148,10 +1092,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<TerritoryEffect> getTerritoryEffects() {
     return m_territoryEffects;
-  }
-
-  public void clearTerritoryEffects() {
-    m_territoryEffects.clear();
   }
 
   private void resetTerritoryEffects() {
@@ -1230,10 +1170,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_territoryEffectProperty;
   }
 
-  public void clearTerritoryEffectProperty() {
-    m_territoryEffectProperty.clear();
-  }
-
   private void resetTerritoryEffectProperty() {
     m_territoryEffectProperty = null;
   }
@@ -1293,10 +1229,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private Map<Territory, IntegerMap<UnitType>> getPlacement() {
     return m_placement;
-  }
-
-  public void clearPlacement() {
-    m_placement.clear();
   }
 
   private void resetPlacement() {
@@ -1376,10 +1308,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_removeUnits;
   }
 
-  public void clearRemoveUnits() {
-    m_removeUnits.clear();
-  }
-
   private void resetRemoveUnits() {
     m_removeUnits = null;
   }
@@ -1430,10 +1358,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return m_purchase;
   }
 
-  public void clearPurchase() {
-    m_purchase.clear();
-  }
-
   private void resetPurchase() {
     m_purchase = null;
   }
@@ -1477,10 +1401,6 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private List<String> getChangeOwnership() {
     return m_changeOwnership;
-  }
-
-  public void clearChangeOwnership() {
-    m_changeOwnership.clear();
   }
 
   private void resetChangeOwnership() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -15,6 +15,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
@@ -552,21 +553,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setWhenCapturedSustainsDamage(final String s) {
-    m_whenCapturedSustainsDamage = getInt(s);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setWhenCapturedSustainsDamage(final Integer s) {
+  private void setWhenCapturedSustainsDamage(final int s) {
     m_whenCapturedSustainsDamage = s;
   }
 
   public int getWhenCapturedSustainsDamage() {
     return m_whenCapturedSustainsDamage;
-  }
-
-  private void resetWhenCapturedSustainsDamage() {
-    m_whenCapturedSustainsDamage = 0;
   }
 
   /**
@@ -1295,21 +1287,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setTransportCapacity(final String s) {
-    m_transportCapacity = getInt(s);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setTransportCapacity(final Integer s) {
+  private void setTransportCapacity(final int s) {
     m_transportCapacity = s;
   }
 
   public int getTransportCapacity() {
     return m_transportCapacity;
-  }
-
-  private void resetTransportCapacity() {
-    m_transportCapacity = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
@@ -1323,26 +1306,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setHitPoints(final String s) {
-    m_hitPoints = getInt(s);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setHitPoints(final Integer value) {
+  private void setHitPoints(final int value) {
     m_hitPoints = value;
   }
 
   public int getHitPoints() {
     return m_hitPoints;
-  }
-
-  private void resetHitPoints() {
-    m_hitPoints = 1;
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setTransportCost(final String s) {
-    m_transportCost = getInt(s);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -1352,10 +1321,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getTransportCost() {
     return m_transportCost;
-  }
-
-  private void resetTransportCost() {
-    m_transportCost = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -1483,22 +1448,14 @@ public class UnitAttachment extends DefaultAttachment {
         "Resetting Artillery Support Count (UnitAttachment) is not allowed, please use Support Attachments instead.");
   }
 
+  @VisibleForTesting
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setBombard(final String s) {
-    m_bombard = getInt(s);
-  }
-
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setBombard(final Integer s) {
+  public void setBombard(final int s) {
     m_bombard = s;
   }
 
   public int getBombard() {
     return m_bombard > 0 ? m_bombard : m_attack;
-  }
-
-  private void resetBombard() {
-    m_bombard = -1;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -3516,11 +3473,11 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getCanBombard,
                 this::resetCanBombard))
         .put("bombard",
-            MutableProperty.of(
-                this::setBombard,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setBombard,
                 this::getBombard,
-                this::resetBombard))
+                () -> -1))
         .put("isSub",
             MutableProperty.of(
                 this::setIsSub,
@@ -3600,17 +3557,17 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getIsCombatTransport,
                 this::resetIsCombatTransport))
         .put("transportCapacity",
-            MutableProperty.of(
-                this::setTransportCapacity,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setTransportCapacity,
                 this::getTransportCapacity,
-                this::resetTransportCapacity))
+                () -> -1))
         .put("transportCost",
-            MutableProperty.of(
-                this::setTransportCost,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setTransportCost,
                 this::getTransportCost,
-                this::resetTransportCost))
+                () -> -1))
         .put("carrierCapacity",
             MutableProperty.of(
                 this::setCarrierCapacity,
@@ -3821,11 +3778,11 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getCreatesResourcesList,
                 this::resetCreatesResourcesList))
         .put("hitPoints",
-            MutableProperty.of(
-                this::setHitPoints,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setHitPoints,
                 this::getHitPoints,
-                this::resetHitPoints))
+                () -> 1))
         .put("canBeDamaged",
             MutableProperty.of(
                 this::setCanBeDamaged,
@@ -3982,11 +3939,11 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getWhenCapturedChangesInto,
                 this::resetWhenCapturedChangesInto))
         .put("whenCapturedSustainsDamage",
-            MutableProperty.of(
-                this::setWhenCapturedSustainsDamage,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getInt,
                 this::setWhenCapturedSustainsDamage,
                 this::getWhenCapturedSustainsDamage,
-                this::resetWhenCapturedSustainsDamage))
+                () -> 0))
         .put("canBeCapturedOnEnteringBy",
             MutableProperty.of(
                 this::setCanBeCapturedOnEnteringBy,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -400,10 +400,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_canBeGivenByTerritoryTo;
   }
 
-  public void clearCanBeGivenByTerritoryTo() {
-    m_canBeGivenByTerritoryTo.clear();
-  }
-
   private void resetCanBeGivenByTerritoryTo() {
     m_canBeGivenByTerritoryTo = new ArrayList<>();
   }
@@ -431,10 +427,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public List<PlayerID> getCanBeCapturedOnEnteringBy() {
     return m_canBeCapturedOnEnteringBy;
-  }
-
-  public void clearCanBeCapturedOnEnteringBy() {
-    m_canBeCapturedOnEnteringBy.clear();
   }
 
   private void resetCanBeCapturedOnEnteringBy() {
@@ -473,10 +465,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_whenHitPointsDamagedChangesInto;
   }
 
-  public void clearWhenHitPointsDamagedChangesInto() {
-    m_whenHitPointsDamagedChangesInto.clear();
-  }
-
   private void resetWhenHitPointsDamagedChangesInto() {
     m_whenHitPointsDamagedChangesInto = new HashMap<>();
   }
@@ -511,10 +499,6 @@ public class UnitAttachment extends DefaultAttachment {
       resetWhenHitPointsRepairedChangesInto(); // TODO: Can remove for incompatible release
     }
     return m_whenHitPointsRepairedChangesInto;
-  }
-
-  public void clearWhenHitPointsRepairedChangesInto() {
-    m_whenHitPointsRepairedChangesInto.clear();
   }
 
   private void resetWhenHitPointsRepairedChangesInto() {
@@ -561,10 +545,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public Map<String, Tuple<String, IntegerMap<UnitType>>> getWhenCapturedChangesInto() {
     return m_whenCapturedChangesInto;
-  }
-
-  public void clearWhenCapturedChangesInto() {
-    m_whenCapturedChangesInto.clear();
   }
 
   private void resetWhenCapturedChangesInto() {
@@ -631,10 +611,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public List<Tuple<String, PlayerID>> getDestroyedWhenCapturedBy() {
     return m_destroyedWhenCapturedBy;
-  }
-
-  public void clearDestroyedWhenCapturedBy() {
-    m_destroyedWhenCapturedBy.clear();
   }
 
   private void resetDestroyedWhenCapturedBy() {
@@ -945,10 +921,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_repairsUnits;
   }
 
-  public void clearRepairsUnits() {
-    m_repairsUnits.clear();
-  }
-
   private void resetRepairsUnits() {
     m_repairsUnits = new IntegerMap<>();
   }
@@ -974,10 +946,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public Set<String> getSpecial() {
     return m_special;
-  }
-
-  public void clearSpecial() {
-    m_special.clear();
   }
 
   private void resetSpecial() {
@@ -1040,10 +1008,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_requiresUnits;
   }
 
-  public void clearRequiresUnits() {
-    m_requiresUnits.clear();
-  }
-
   private void resetRequiresUnits() {
     m_requiresUnits = new ArrayList<>();
   }
@@ -1073,10 +1037,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public List<String[]> getRequiresUnitsToMove() {
     return m_requiresUnitsToMove;
-  }
-
-  public void clearRequiresUnitsToMove() {
-    m_requiresUnitsToMove.clear();
   }
 
   private void resetRequiresUnitsToMove() {
@@ -1119,10 +1079,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_whenCombatDamaged;
   }
 
-  public void clearWhenCombatDamaged() {
-    m_whenCombatDamaged.clear();
-  }
-
   private void resetWhenCombatDamaged() {
     m_whenCombatDamaged = new ArrayList<>();
   }
@@ -1142,10 +1098,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public List<String> getReceivesAbilityWhenWith() {
     return m_receivesAbilityWhenWith;
-  }
-
-  public void clearReceivesAbilityWhenWith() {
-    m_receivesAbilityWhenWith.clear();
   }
 
   private void resetReceivesAbilityWhenWith() {
@@ -1951,10 +1903,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_givesMovement;
   }
 
-  public void clearGivesMovement() {
-    m_givesMovement.clear();
-  }
-
   private void resetGivesMovement() {
     m_givesMovement = new IntegerMap<>();
   }
@@ -1988,10 +1936,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public IntegerMap<UnitType> getConsumesUnits() {
     return m_consumesUnits;
-  }
-
-  public void clearConsumesUnits() {
-    m_consumesUnits.clear();
   }
 
   private void resetConsumesUnits() {
@@ -2029,10 +1973,6 @@ public class UnitAttachment extends DefaultAttachment {
     return m_createsUnitsList;
   }
 
-  public void clearCreatesUnitsList() {
-    m_createsUnitsList.clear();
-  }
-
   private void resetCreatesUnitsList() {
     m_createsUnitsList = new IntegerMap<>();
   }
@@ -2064,10 +2004,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public IntegerMap<Resource> getCreatesResourcesList() {
     return m_createsResourcesList;
-  }
-
-  public void clearCreatesResourcesList() {
-    m_createsResourcesList.clear();
   }
 
   private void resetCreatesResourcesList() {
@@ -2103,10 +2039,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public IntegerMap<Resource> getFuelCost() {
     return m_fuelCost;
-  }
-
-  public void clearFuelCost() {
-    m_fuelCost.clear();
   }
 
   private void resetFuelCost() {
@@ -2185,10 +2117,6 @@ public class UnitAttachment extends DefaultAttachment {
       return m_bombingTargets;
     }
     return new HashSet<>(data.getUnitTypeList().getAllUnitTypes());
-  }
-
-  public void clearBombingTargets() {
-    m_bombingTargets.clear();
   }
 
   private void resetBombingTargets() {
@@ -2537,10 +2465,6 @@ public class UnitAttachment extends DefaultAttachment {
         .collect(Collectors.toSet());
   }
 
-  public void clearTargetsAa() {
-    m_targetsAA.clear();
-  }
-
   private void resetTargetsAa() {
     m_targetsAA = null;
   }
@@ -2567,10 +2491,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public Set<UnitType> getWillNotFireIfPresent() {
     return m_willNotFireIfPresent;
-  }
-
-  public void clearWillNotFireIfPresent() {
-    m_willNotFireIfPresent.clear();
   }
 
   private void resetWillNotFireIfPresent() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -89,8 +89,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
       return;
     }
     m_unitType = new HashSet<>();
-    final String[] s = names.split(":");
-    for (final String element : s) {
+    for (final String element : names.split(":")) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
         throw new GameParseException("Could not find unitType. name:" + element + thisErrorMsg());
@@ -117,8 +116,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_allied = false;
     m_enemy = false;
-    final String[] s = faction.split(":");
-    for (final String element : s) {
+    for (final String element : faction.split(":")) {
       if (element.equalsIgnoreCase("allied")) {
         m_allied = true;
       } else if (element.equalsIgnoreCase("enemy")) {
@@ -146,8 +144,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_defence = false;
     m_offence = false;
-    final String[] s = side.split(":");
-    for (final String element : s) {
+    for (final String element : side.split(":")) {
       if (element.equalsIgnoreCase("defence")) {
         m_defence = true;
       } else if (element.equalsIgnoreCase("offence")) {
@@ -177,8 +174,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_roll = false;
     m_strength = false;
-    final String[] s = dice.split(":");
-    for (final String element : s) {
+    for (final String element : dice.split(":")) {
       if (element.equalsIgnoreCase("roll")) {
         m_roll = true;
       } else if (element.equalsIgnoreCase("strength")) {
@@ -206,7 +202,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setBonus(final Integer bonus) {
+  private void setBonus(final int bonus) {
     m_bonus = bonus;
   }
 
@@ -220,7 +216,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setNumber(final Integer number) {
+  private void setNumber(final int number) {
     m_number = number;
   }
 
@@ -230,10 +226,6 @@ public class UnitSupportAttachment extends DefaultAttachment {
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   private void setBonusType(final String type) {
-    if (type == null) {
-      m_bonusType = null;
-      return;
-    }
     m_bonusType = type;
   }
 
@@ -279,7 +271,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  private void setImpArtTech(final Boolean tech) {
+  private void setImpArtTech(final boolean tech) {
     m_impArtTech = tech;
   }
 
@@ -341,22 +333,14 @@ public class UnitSupportAttachment extends DefaultAttachment {
     final String attachmentName =
         (first ? Constants.SUPPORT_RULE_NAME_OLD_TEMP_FIRST : Constants.SUPPORT_RULE_NAME_OLD) + type.getName();
     final UnitSupportAttachment rule = new UnitSupportAttachment(attachmentName, type, data);
-    rule.setBonus("1");
+    rule.setBonus(1);
     rule.setBonusType(Constants.OLD_ART_RULE_NAME);
     rule.setDice("strength");
     rule.setFaction("allied");
-    rule.setImpArtTech("true");
-    if (first) {
-      rule.setNumber("0");
-    } else {
-      rule.setNumber("1");
-    }
+    rule.setImpArtTech(String.valueOf(true));
+    rule.setNumber(first ? 0 : 1);
     rule.setSide("offence");
-    if (first) {
-      rule.addUnitTypes(Collections.singleton(type));
-    } else {
-      rule.addUnitTypes(getTargets(data));
-    }
+    rule.addUnitTypes(first ? Collections.singleton(type) : getTargets(data));
     if (!first) {
       rule.setPlayers(new ArrayList<>(data.getPlayerList().getPlayers()));
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -30,10 +30,8 @@ public class UnitSupportAttachment extends DefaultAttachment {
 
   private Set<UnitType> m_unitType = null;
   @InternalDoNotExport
-  // Do Not Export
   private boolean m_offence = false;
   @InternalDoNotExport
-  // Do Not Export
   private boolean m_defence = false;
   @InternalDoNotExport
   private boolean m_roll = false;
@@ -337,7 +335,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     rule.setBonusType(Constants.OLD_ART_RULE_NAME);
     rule.setDice("strength");
     rule.setFaction("allied");
-    rule.setImpArtTech(String.valueOf(true));
+    rule.setImpArtTech(true);
     rule.setNumber(first ? 0 : 1);
     rule.setSide("offence");
     rule.addUnitTypes(first ? Collections.singleton(type) : getTargets(data));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -103,10 +103,6 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     return m_activateTrigger;
   }
 
-  public void clearActivateTrigger() {
-    m_activateTrigger.clear();
-  }
-
   private void resetActivateTrigger() {
     m_activateTrigger = new ArrayList<>();
   }

--- a/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -22,9 +22,7 @@ public final class FakeAttachment implements IAttachment {
   private final String name;
 
   public FakeAttachment(final String name) {
-    checkNotNull(name);
-
-    this.name = name;
+    this.name = checkNotNull(name);
   }
 
   @Override
@@ -34,9 +32,7 @@ public final class FakeAttachment implements IAttachment {
     } else if (!(obj instanceof FakeAttachment)) {
       return false;
     }
-
-    final FakeAttachment other = (FakeAttachment) obj;
-    return Objects.equals(name, other.name);
+    return Objects.equals(name, ((FakeAttachment) obj).name);
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
@@ -1,0 +1,71 @@
+package games.strategy.triplea.attachments;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.Attachable;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameParseException;
+
+public class AbstractConditionsAttachmentTest {
+
+  private final GameData mockData = mock(GameData.class);
+  private final Attachable mockAttachable = mock(Attachable.class);
+  private final AbstractConditionsAttachment instance =
+      new AbstractConditionsAttachment("", mockAttachable, mockData) {
+        private static final long serialVersionUID = -40443726954483090L;
+
+        @Override
+        public void validate(GameData data) {}
+      };
+
+  @Test
+  public void testSetConditionType_validValues() throws Exception {
+    instance.setConditionType("OR");
+    assertEquals("OR", instance.m_conditionType);
+    instance.setConditionType("AND");
+    assertEquals("AND", instance.m_conditionType);
+    instance.setConditionType("XOR");
+    assertEquals("XOR", instance.m_conditionType);
+    instance.setConditionType("00000012345656");
+    assertEquals("00000012345656", instance.m_conditionType);
+    instance.setConditionType("0-9");
+    assertEquals("0-9", instance.m_conditionType);
+    instance.setConditionType("0987654321-1234567890");
+    assertEquals("0987654321-1234567890", instance.m_conditionType);
+  }
+
+  @Test
+  public void testSetConditionType_validLowercase() throws Exception {
+    instance.setConditionType("or");
+    assertEquals("OR", instance.m_conditionType);
+    instance.setConditionType("and");
+    assertEquals("AND", instance.m_conditionType);
+    instance.setConditionType("xor");
+    assertEquals("XOR", instance.m_conditionType);
+    instance.setConditionType("123");
+    assertEquals("123", instance.m_conditionType);
+    instance.setConditionType("123-456");
+    assertEquals("123-456", instance.m_conditionType);
+  }
+
+  @Test
+  public void testSetConditionType_invalidValues() {
+    assertThrows(GameParseException.class, () -> instance.setConditionType("XNOR"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("NAND"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("NOR"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("NOT"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("5e10"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("9-"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("0-"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("-9"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("-0"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("0-0"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("1234567890-0987654321"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("-1-0"));
+    assertThrows(GameParseException.class, () -> instance.setConditionType("1--0"));
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1050,7 +1050,7 @@ public class WW2V3Year41Test {
     while (ddIter.hasNext()) {
       final Unit unit = ddIter.next();
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      ua.setBombard("3");
+      ua.setBombard(3);
     }
     // start the battle phase, this will ask the user to bombard
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);


### PR DESCRIPTION
This PR consists of roughly 2 parts.
1. A Cleanup part where all of the unused clear Methods have been removed and
2. A "migration" part, where I try to reduce overloads in favour of mapper functions

@ssoloff IMO The GameProperty and InternalDoNotExport annotations can be removed once all non-adder-setters have adopted this (or a better, similar) scheme.