### PR TITLE
Avoid ambiguity in SwingAction#invokeAndWait overloads

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -29,7 +29,7 @@ public class PropertiesSelector {
   public static Object getButton(final JComponent parent, final String title,
       final List<IEditableProperty> properties, final Object... buttonOptions) {
     final Supplier<Object> action = () -> showDialog(parent, title, properties, buttonOptions);
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .orElse(JOptionPane.UNINITIALIZED_VALUE);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -68,7 +68,7 @@ public class PbemDiceRoller implements IRandomSource {
       dialog.roll();
       return dialog.getDiceRoll();
     };
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .orElseGet(() -> new int[0]);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -282,7 +282,7 @@ public class BattlePanel extends ActionPanel {
       final Collection<Territory> territories, final boolean noneAvailable) {
     final Supplier<BombardComponent> action =
         () -> new BombardComponent(unit, unitTerritory, territories, noneAvailable);
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .map(comp -> {
           int option = JOptionPane.NO_OPTION;
           while (option != JOptionPane.OK_OPTION) {
@@ -403,7 +403,7 @@ public class BattlePanel extends ActionPanel {
           new CasualtyDetails(killed, chooser.getSelectedDamagedMultipleHitPointUnits(), false);
       return response;
     };
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .orElse(null);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -893,17 +893,18 @@ public class TripleAFrame extends MainGameFrame {
       return;
     }
     final Supplier<TechResultsDisplay> action = () -> new TechResultsDisplay(msg, uiContext, data);
-    messageAndDialogThreadPool.submit(() -> Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
-        .ifPresent(display -> EventThreadJOptionPane.showOptionDialog(
-            TripleAFrame.this,
-            display,
-            "Tech roll",
-            JOptionPane.OK_OPTION,
-            JOptionPane.PLAIN_MESSAGE,
-            null,
-            new String[] {"OK"},
-            "OK",
-            getUiContext().getCountDownLatchHandler())));
+    messageAndDialogThreadPool
+        .submit(() -> Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
+            .ifPresent(display -> EventThreadJOptionPane.showOptionDialog(
+                TripleAFrame.this,
+                display,
+                "Tech roll",
+                JOptionPane.OK_OPTION,
+                JOptionPane.PLAIN_MESSAGE,
+                null,
+                new String[] {"OK"},
+                "OK",
+                getUiContext().getCountDownLatchHandler())));
   }
 
   public boolean getStrategicBombingRaid(final Territory location) {
@@ -950,7 +951,7 @@ public class TripleAFrame extends MainGameFrame {
       panel.add(scroll, BorderLayout.CENTER);
       return Tuple.of(panel, list);
     };
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .map(comps -> {
           final JPanel panel = comps.getFirst();
           final JList<?> list = comps.getSecond();
@@ -1009,7 +1010,7 @@ public class TripleAFrame extends MainGameFrame {
     messageAndDialogThreadPool.waitForAll();
     final Supplier<DiceChooser> action =
         () -> new DiceChooser(getUiContext(), numDice, hitAt, hitOnlyIfEquals, diceSides);
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .map(chooser -> {
           do {
             EventThreadJOptionPane.showMessageDialog(null, chooser, title, JOptionPane.PLAIN_MESSAGE,
@@ -1047,7 +1048,7 @@ public class TripleAFrame extends MainGameFrame {
       panel.add(scroll, BorderLayout.CENTER);
       return Tuple.of(panel, list);
     };
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .map(comps -> {
           final JPanel panel = comps.getFirst();
           final JList<?> list = comps.getSecond();
@@ -1396,7 +1397,7 @@ public class TripleAFrame extends MainGameFrame {
           JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, null);
       return (selection == 0) ? list.getSelectedValue() : null;
     };
-    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWait(action)).result
+    return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .orElse(null);
   }
 

--- a/game-core/src/main/java/games/strategy/ui/SwingAction.java
+++ b/game-core/src/main/java/games/strategy/ui/SwingAction.java
@@ -82,7 +82,7 @@ public final class SwingAction {
   public static void invokeAndWait(final Runnable action) throws InterruptedException {
     checkNotNull(action);
 
-    invokeAndWait(() -> {
+    invokeAndWaitResult(() -> {
       action.run();
       return null;
     });
@@ -102,7 +102,7 @@ public final class SwingAction {
    * @throws RuntimeException If the action throws an unchecked exception.
    * @throws InterruptedException If the current thread is interrupted while waiting for the action to complete.
    */
-  public static <T> T invokeAndWait(final Supplier<T> action) throws InterruptedException {
+  public static <T> T invokeAndWaitResult(final Supplier<T> action) throws InterruptedException {
     checkNotNull(action);
 
     if (SwingUtilities.isEventDispatchThread()) {

--- a/game-core/src/test/java/games/strategy/ui/SwingActionTest.java
+++ b/game-core/src/test/java/games/strategy/ui/SwingActionTest.java
@@ -56,7 +56,7 @@ public class SwingActionTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithRunnable_ShouldInvokeActionWhenCalledOffEdt(@Mock final Runnable action)
+  public void testInvokeAndWait_ShouldInvokeActionWhenCalledOffEdt(@Mock final Runnable action)
       throws Exception {
     SwingAction.invokeAndWait(action);
 
@@ -64,7 +64,7 @@ public class SwingActionTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithRunnable_ShouldInvokeActionWhenCalledOnEdt(@Mock final Runnable action)
+  public void testInvokeAndWait_ShouldInvokeActionWhenCalledOnEdt(@Mock final Runnable action)
       throws Exception {
     SwingUtilities.invokeAndWait(() -> {
       assertTrue(Interruptibles.await(() -> SwingAction.invokeAndWait(action)), "should not be interrupted");
@@ -74,41 +74,41 @@ public class SwingActionTest {
   }
 
   @Test
-  public void testInvokeAndWaitWithRunnable_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
+  public void testInvokeAndWait_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
     assertThrows(IllegalStateException.class, () -> SwingAction.invokeAndWait(RUNNABLE_THROWING_EXCEPTION));
   }
 
   @Test
-  public void testInvokeAndWaitWithRunnable_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt() throws Exception {
+  public void testInvokeAndWait_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt() throws Exception {
     SwingUtilities.invokeAndWait(() -> assertThrows(
         IllegalStateException.class,
         () -> SwingAction.invokeAndWait(RUNNABLE_THROWING_EXCEPTION)));
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldReturnActionResultWhenCalledOffEdt() throws Exception {
-    assertEquals(VALUE, SwingAction.invokeAndWait(() -> VALUE));
+  public void testInvokeAndWaitResult_ShouldReturnActionResultWhenCalledOffEdt() throws Exception {
+    assertEquals(VALUE, SwingAction.invokeAndWaitResult(() -> VALUE));
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldReturnActionResultWhenCalledOnEdt() throws Exception {
+  public void testInvokeAndWaitResult_ShouldReturnActionResultWhenCalledOnEdt() throws Exception {
     SwingUtilities.invokeAndWait(() -> {
       assertTrue(
-          Interruptibles.await(() -> assertEquals(VALUE, SwingAction.invokeAndWait(() -> VALUE))),
+          Interruptibles.await(() -> assertEquals(VALUE, SwingAction.invokeAndWaitResult(() -> VALUE))),
           "should not be interrupted");
     });
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
-    assertThrows(IllegalStateException.class, () -> SwingAction.invokeAndWait(SUPPLIER_THROWING_EXCEPTION));
+  public void testInvokeAndWaitResult_ShouldRethrowActionUncheckedExceptionWhenCalledOffEdt() {
+    assertThrows(IllegalStateException.class, () -> SwingAction.invokeAndWaitResult(SUPPLIER_THROWING_EXCEPTION));
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt() throws Exception {
+  public void testInvokeAndWaitResult_ShouldRethrowActionUncheckedExceptionWhenCalledOnEdt() throws Exception {
     SwingUtilities.invokeAndWait(() -> assertThrows(
         IllegalStateException.class,
-        () -> SwingAction.invokeAndWait(SUPPLIER_THROWING_EXCEPTION)));
+        () -> SwingAction.invokeAndWaitResult(SUPPLIER_THROWING_EXCEPTION)));
   }
 
   @Test


### PR DESCRIPTION
Rename `invokeAndWait(Supplier)` to `invokeAndWaitResult(Supplier)` to avoid ambiguity with the `invokeAndWait(Runnable)` overload when the compiler can't distinguish between `Runnable` and `Supplier` when a lambda is used at the call site.  This can happen in a stubbed `Supplier` implementation that simply throws an exception (e.g. during testing).

Viewing with whitespace changes ignored will knock about 33% off the diff.