### PR TITLE
Clean up ProLogSettings

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
@@ -17,10 +17,10 @@ import games.strategy.triplea.ai.pro.ProAi;
  */
 public class ProLogSettings implements Serializable {
   private static final long serialVersionUID = 2696071717784800413L;
-  public boolean LimitLogHistory = true;
-  public int LimitLogHistoryTo = 5;
-  public boolean EnableAILogging = true;
-  public Level AILoggingDepth = Level.FINEST;
+  public boolean limitLogHistory = true;
+  public int limitLogHistoryTo = 5;
+  public boolean enableAiLogging = true;
+  public Level aiLoggingDepth = Level.FINEST;
   private static ProLogSettings lastSettings = null;
   private static final String PROGRAM_SETTINGS = "Program Settings";
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
@@ -11,18 +11,24 @@ import java.util.prefs.Preferences;
 import games.strategy.debug.ClientLogger;
 import games.strategy.io.IoUtils;
 import games.strategy.triplea.ai.pro.ProAi;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Class to manage log settings.
  */
-public class ProLogSettings implements Serializable {
-  private static final long serialVersionUID = 2696071717784800413L;
-  public boolean limitLogHistory = true;
-  public int limitLogHistoryTo = 5;
-  public boolean enableAiLogging = true;
-  public Level aiLoggingDepth = Level.FINEST;
-  private static ProLogSettings lastSettings = null;
+@Getter
+@Setter
+public final class ProLogSettings implements Serializable {
+  private static final long serialVersionUID = -984294698285587329L;
   private static final String PROGRAM_SETTINGS = "Program Settings";
+
+  private static ProLogSettings lastSettings = null;
+
+  private boolean logHistoryLimited = true;
+  private int logHistoryLimit = 5;
+  private boolean loggingEnabled = true;
+  private Level loggingLevel = Level.FINEST;
 
   static ProLogSettings loadSettings() {
     if (lastSettings == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
@@ -23,42 +23,31 @@ public final class ProLogSettings implements Serializable {
   private static final long serialVersionUID = -984294698285587329L;
   private static final String PROGRAM_SETTINGS = "Program Settings";
 
-  private static ProLogSettings lastSettings = null;
-
   private boolean logHistoryLimited = true;
   private int logHistoryLimit = 5;
   private boolean loggingEnabled = true;
   private Level loggingLevel = Level.FINEST;
 
   static ProLogSettings loadSettings() {
-    if (lastSettings == null) {
-      ProLogSettings result = new ProLogSettings();
-      try {
-        final byte[] pool = Preferences.userNodeForPackage(ProAi.class).getByteArray(PROGRAM_SETTINGS, null);
-        if (pool != null) {
-          result = IoUtils.readFromMemory(pool, is -> {
-            try (ObjectInputStream ois = new ObjectInputStream(is)) {
-              return (ProLogSettings) ois.readObject();
-            } catch (final ClassNotFoundException e) {
-              throw new IOException(e);
-            }
-          });
-        }
-      } catch (final Exception ex) {
-        ClientLogger.logQuietly("Failed to load pro AI log settings", ex);
+    try {
+      final byte[] pool = Preferences.userNodeForPackage(ProAi.class).getByteArray(PROGRAM_SETTINGS, null);
+      if (pool != null) {
+        return IoUtils.readFromMemory(pool, is -> {
+          try (ObjectInputStream ois = new ObjectInputStream(is)) {
+            return (ProLogSettings) ois.readObject();
+          } catch (final ClassNotFoundException e) {
+            throw new IOException(e);
+          }
+        });
       }
-      if (result == null) {
-        result = new ProLogSettings();
-      }
-      lastSettings = result;
-      return result;
+    } catch (final Exception ex) {
+      ClientLogger.logQuietly("Failed to load pro AI log settings", ex);
     }
 
-    return lastSettings;
+    return new ProLogSettings();
   }
 
   static void saveSettings(final ProLogSettings settings) {
-    lastSettings = settings;
     try {
       final byte[] bytes = IoUtils.writeToMemory(os -> {
         try (ObjectOutputStream outputStream = new ObjectOutputStream(os)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogSettings.java
@@ -20,13 +20,13 @@ import lombok.Setter;
 @Getter
 @Setter
 public final class ProLogSettings implements Serializable {
-  private static final long serialVersionUID = -984294698285587329L;
+  private static final long serialVersionUID = 5532153908942939829L;
   private static final String PROGRAM_SETTINGS = "Program Settings";
 
   private boolean logHistoryLimited = true;
   private int logHistoryLimit = 5;
-  private boolean loggingEnabled = true;
-  private Level loggingLevel = Level.FINEST;
+  private boolean logEnabled = true;
+  private Level logLevel = Level.FINEST;
 
   static ProLogSettings loadSettings() {
     try {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -263,30 +263,30 @@ class ProLogWindow extends JDialog {
    * Loads the settings provided and displays it in this settings window.
    */
   private void loadSettings(final ProLogSettings settings) {
-    enableAiLogging.setSelected(settings.EnableAILogging);
-    if (settings.AILoggingDepth.equals(Level.FINE)) {
+    enableAiLogging.setSelected(settings.enableAiLogging);
+    if (settings.aiLoggingDepth.equals(Level.FINE)) {
       logDepth.setSelectedIndex(0);
-    } else if (settings.AILoggingDepth.equals(Level.FINER)) {
+    } else if (settings.aiLoggingDepth.equals(Level.FINER)) {
       logDepth.setSelectedIndex(1);
-    } else if (settings.AILoggingDepth.equals(Level.FINEST)) {
+    } else if (settings.aiLoggingDepth.equals(Level.FINEST)) {
       logDepth.setSelectedIndex(2);
     }
-    limitLogHistoryCheckBox.setSelected(settings.LimitLogHistory);
-    limitLogHistoryToSpinner.setValue(settings.LimitLogHistoryTo);
+    limitLogHistoryCheckBox.setSelected(settings.limitLogHistory);
+    limitLogHistoryToSpinner.setValue(settings.limitLogHistoryTo);
   }
 
   ProLogSettings createSettings() {
     final ProLogSettings settings = new ProLogSettings();
-    settings.EnableAILogging = enableAiLogging.isSelected();
+    settings.enableAiLogging = enableAiLogging.isSelected();
     if (logDepth.getSelectedIndex() == 0) {
-      settings.AILoggingDepth = Level.FINE;
+      settings.aiLoggingDepth = Level.FINE;
     } else if (logDepth.getSelectedIndex() == 1) {
-      settings.AILoggingDepth = Level.FINER;
+      settings.aiLoggingDepth = Level.FINER;
     } else if (logDepth.getSelectedIndex() == 2) {
-      settings.AILoggingDepth = Level.FINEST;
+      settings.aiLoggingDepth = Level.FINEST;
     }
-    settings.LimitLogHistory = limitLogHistoryCheckBox.isSelected();
-    settings.LimitLogHistoryTo = Integer.parseInt(limitLogHistoryToSpinner.getValue().toString());
+    settings.limitLogHistory = limitLogHistoryCheckBox.isSelected();
+    settings.limitLogHistoryTo = Integer.parseInt(limitLogHistoryToSpinner.getValue().toString());
     return settings;
   }
 
@@ -413,10 +413,10 @@ class ProLogWindow extends JDialog {
 
   private void trimLogRoundPanels() {
     // If we're logging and we have trimming enabled, or if we have logging turned off
-    if (!ProLogSettings.loadSettings().EnableAILogging || ProLogSettings.loadSettings().LimitLogHistory) {
+    if (!ProLogSettings.loadSettings().enableAiLogging || ProLogSettings.loadSettings().limitLogHistory) {
       final int maxHistoryRounds;
-      if (ProLogSettings.loadSettings().EnableAILogging) {
-        maxHistoryRounds = ProLogSettings.loadSettings().LimitLogHistoryTo;
+      if (ProLogSettings.loadSettings().enableAiLogging) {
+        maxHistoryRounds = ProLogSettings.loadSettings().limitLogHistoryTo;
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -412,12 +412,12 @@ class ProLogWindow extends JDialog {
   }
 
   private void trimLogRoundPanels() {
-    final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
+    final ProLogSettings settings = ProLogSettings.loadSettings();
     // If we're logging and we have trimming enabled, or if we have logging turned off
-    if (!proLogSettings.isLogEnabled() || proLogSettings.isLogHistoryLimited()) {
+    if (!settings.isLogEnabled() || settings.isLogHistoryLimited()) {
       final int maxHistoryRounds;
-      if (proLogSettings.isLogEnabled()) {
-        maxHistoryRounds = proLogSettings.getLogHistoryLimit();
+      if (settings.isLogEnabled()) {
+        maxHistoryRounds = settings.getLogHistoryLimit();
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -263,12 +263,12 @@ class ProLogWindow extends JDialog {
    * Loads the settings provided and displays it in this settings window.
    */
   private void loadSettings(final ProLogSettings settings) {
-    enableAiLogging.setSelected(settings.isLoggingEnabled());
-    if (settings.getLoggingLevel().equals(Level.FINE)) {
+    enableAiLogging.setSelected(settings.isLogEnabled());
+    if (settings.getLogLevel().equals(Level.FINE)) {
       logDepth.setSelectedIndex(0);
-    } else if (settings.getLoggingLevel().equals(Level.FINER)) {
+    } else if (settings.getLogLevel().equals(Level.FINER)) {
       logDepth.setSelectedIndex(1);
-    } else if (settings.getLoggingLevel().equals(Level.FINEST)) {
+    } else if (settings.getLogLevel().equals(Level.FINEST)) {
       logDepth.setSelectedIndex(2);
     }
     limitLogHistoryCheckBox.setSelected(settings.isLogHistoryLimited());
@@ -277,13 +277,13 @@ class ProLogWindow extends JDialog {
 
   ProLogSettings createSettings() {
     final ProLogSettings settings = new ProLogSettings();
-    settings.setLoggingEnabled(enableAiLogging.isSelected());
+    settings.setLogEnabled(enableAiLogging.isSelected());
     if (logDepth.getSelectedIndex() == 0) {
-      settings.setLoggingLevel(Level.FINE);
+      settings.setLogLevel(Level.FINE);
     } else if (logDepth.getSelectedIndex() == 1) {
-      settings.setLoggingLevel(Level.FINER);
+      settings.setLogLevel(Level.FINER);
     } else if (logDepth.getSelectedIndex() == 2) {
-      settings.setLoggingLevel(Level.FINEST);
+      settings.setLogLevel(Level.FINEST);
     }
     settings.setLogHistoryLimited(limitLogHistoryCheckBox.isSelected());
     settings.setLogHistoryLimit(Integer.parseInt(limitLogHistoryToSpinner.getValue().toString()));
@@ -414,9 +414,9 @@ class ProLogWindow extends JDialog {
   private void trimLogRoundPanels() {
     final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
     // If we're logging and we have trimming enabled, or if we have logging turned off
-    if (!proLogSettings.isLoggingEnabled() || proLogSettings.isLogHistoryLimited()) {
+    if (!proLogSettings.isLogEnabled() || proLogSettings.isLogHistoryLimited()) {
       final int maxHistoryRounds;
-      if (proLogSettings.isLoggingEnabled()) {
+      if (proLogSettings.isLogEnabled()) {
         maxHistoryRounds = proLogSettings.getLogHistoryLimit();
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -263,30 +263,30 @@ class ProLogWindow extends JDialog {
    * Loads the settings provided and displays it in this settings window.
    */
   private void loadSettings(final ProLogSettings settings) {
-    enableAiLogging.setSelected(settings.enableAiLogging);
-    if (settings.aiLoggingDepth.equals(Level.FINE)) {
+    enableAiLogging.setSelected(settings.isLoggingEnabled());
+    if (settings.getLoggingLevel().equals(Level.FINE)) {
       logDepth.setSelectedIndex(0);
-    } else if (settings.aiLoggingDepth.equals(Level.FINER)) {
+    } else if (settings.getLoggingLevel().equals(Level.FINER)) {
       logDepth.setSelectedIndex(1);
-    } else if (settings.aiLoggingDepth.equals(Level.FINEST)) {
+    } else if (settings.getLoggingLevel().equals(Level.FINEST)) {
       logDepth.setSelectedIndex(2);
     }
-    limitLogHistoryCheckBox.setSelected(settings.limitLogHistory);
-    limitLogHistoryToSpinner.setValue(settings.limitLogHistoryTo);
+    limitLogHistoryCheckBox.setSelected(settings.isLogHistoryLimited());
+    limitLogHistoryToSpinner.setValue(settings.getLogHistoryLimit());
   }
 
   ProLogSettings createSettings() {
     final ProLogSettings settings = new ProLogSettings();
-    settings.enableAiLogging = enableAiLogging.isSelected();
+    settings.setLoggingEnabled(enableAiLogging.isSelected());
     if (logDepth.getSelectedIndex() == 0) {
-      settings.aiLoggingDepth = Level.FINE;
+      settings.setLoggingLevel(Level.FINE);
     } else if (logDepth.getSelectedIndex() == 1) {
-      settings.aiLoggingDepth = Level.FINER;
+      settings.setLoggingLevel(Level.FINER);
     } else if (logDepth.getSelectedIndex() == 2) {
-      settings.aiLoggingDepth = Level.FINEST;
+      settings.setLoggingLevel(Level.FINEST);
     }
-    settings.limitLogHistory = limitLogHistoryCheckBox.isSelected();
-    settings.limitLogHistoryTo = Integer.parseInt(limitLogHistoryToSpinner.getValue().toString());
+    settings.setLogHistoryLimited(limitLogHistoryCheckBox.isSelected());
+    settings.setLogHistoryLimit(Integer.parseInt(limitLogHistoryToSpinner.getValue().toString()));
     return settings;
   }
 
@@ -413,10 +413,10 @@ class ProLogWindow extends JDialog {
 
   private void trimLogRoundPanels() {
     // If we're logging and we have trimming enabled, or if we have logging turned off
-    if (!ProLogSettings.loadSettings().enableAiLogging || ProLogSettings.loadSettings().limitLogHistory) {
+    if (!ProLogSettings.loadSettings().isLoggingEnabled() || ProLogSettings.loadSettings().isLogHistoryLimited()) {
       final int maxHistoryRounds;
-      if (ProLogSettings.loadSettings().enableAiLogging) {
-        maxHistoryRounds = ProLogSettings.loadSettings().limitLogHistoryTo;
+      if (ProLogSettings.loadSettings().isLoggingEnabled()) {
+        maxHistoryRounds = ProLogSettings.loadSettings().getLogHistoryLimit();
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -412,11 +412,12 @@ class ProLogWindow extends JDialog {
   }
 
   private void trimLogRoundPanels() {
+    final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
     // If we're logging and we have trimming enabled, or if we have logging turned off
-    if (!ProLogSettings.loadSettings().isLoggingEnabled() || ProLogSettings.loadSettings().isLogHistoryLimited()) {
+    if (!proLogSettings.isLoggingEnabled() || proLogSettings.isLogHistoryLimited()) {
       final int maxHistoryRounds;
-      if (ProLogSettings.loadSettings().isLoggingEnabled()) {
-        maxHistoryRounds = ProLogSettings.loadSettings().getLogHistoryLimit();
+      if (proLogSettings.isLoggingEnabled()) {
+        maxHistoryRounds = proLogSettings.getLogHistoryLimit();
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -50,10 +50,11 @@ public class ProLogger {
    * Just keep these things in mind while adding new logging code.
    */
   public static void log(final Level level, final String message, final @Nullable Throwable t) {
-    if (!ProLogSettings.loadSettings().isLoggingEnabled()) {
+    final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
+    if (!proLogSettings.isLoggingEnabled()) {
       return; // Skip displaying to settings window if settings window option is turned off
     }
-    final Level logDepth = ProLogSettings.loadSettings().getLoggingLevel();
+    final Level logDepth = proLogSettings.getLoggingLevel();
     if (logDepth.equals(Level.FINE) && (level.equals(Level.FINER) || level.equals(Level.FINEST))) {
       return; // If the settings window log depth is a higher level than this messages, skip
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -51,11 +51,11 @@ public final class ProLogger {
    * Just keep these things in mind while adding new logging code.
    */
   public static void log(final Level level, final String message, final @Nullable Throwable t) {
-    final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
-    if (!proLogSettings.isLogEnabled()) {
+    final ProLogSettings settings = ProLogSettings.loadSettings();
+    if (!settings.isLogEnabled()) {
       return; // Skip displaying to settings window if settings window option is turned off
     }
-    final Level logDepth = proLogSettings.getLogLevel();
+    final Level logDepth = settings.getLogLevel();
     if (logDepth.equals(Level.FINE) && (level.equals(Level.FINER) || level.equals(Level.FINEST))) {
       return; // If the settings window log depth is a higher level than this messages, skip
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -50,10 +50,10 @@ public class ProLogger {
    * Just keep these things in mind while adding new logging code.
    */
   public static void log(final Level level, final String message, final @Nullable Throwable t) {
-    if (!ProLogSettings.loadSettings().EnableAILogging) {
+    if (!ProLogSettings.loadSettings().enableAiLogging) {
       return; // Skip displaying to settings window if settings window option is turned off
     }
-    final Level logDepth = ProLogSettings.loadSettings().AILoggingDepth;
+    final Level logDepth = ProLogSettings.loadSettings().aiLoggingDepth;
     if (logDepth.equals(Level.FINE) && (level.equals(Level.FINER) || level.equals(Level.FINEST))) {
       return; // If the settings window log depth is a higher level than this messages, skip
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -7,7 +7,8 @@ import javax.annotation.Nullable;
 /**
  * Class to log messages to log window and console.
  */
-public class ProLogger {
+public final class ProLogger {
+  private ProLogger() {}
 
   public static void warn(final String message) {
     log(Level.WARNING, message);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -50,10 +50,10 @@ public class ProLogger {
    * Just keep these things in mind while adding new logging code.
    */
   public static void log(final Level level, final String message, final @Nullable Throwable t) {
-    if (!ProLogSettings.loadSettings().enableAiLogging) {
+    if (!ProLogSettings.loadSettings().isLoggingEnabled()) {
       return; // Skip displaying to settings window if settings window option is turned off
     }
-    final Level logDepth = ProLogSettings.loadSettings().aiLoggingDepth;
+    final Level logDepth = ProLogSettings.loadSettings().getLoggingLevel();
     if (logDepth.equals(Level.FINE) && (level.equals(Level.FINER) || level.equals(Level.FINEST))) {
       return; // If the settings window log depth is a higher level than this messages, skip
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogger.java
@@ -51,10 +51,10 @@ public class ProLogger {
    */
   public static void log(final Level level, final String message, final @Nullable Throwable t) {
     final ProLogSettings proLogSettings = ProLogSettings.loadSettings();
-    if (!proLogSettings.isLoggingEnabled()) {
+    if (!proLogSettings.isLogEnabled()) {
       return; // Skip displaying to settings window if settings window option is turned off
     }
-    final Level logDepth = proLogSettings.getLoggingLevel();
+    final Level logDepth = proLogSettings.getLogLevel();
     if (logDepth.equals(Level.FINE) && (level.equals(Level.FINER) || level.equals(Level.FINEST))) {
       return; // If the settings window log depth is a higher level than this messages, skip
     }


### PR DESCRIPTION
The primary change in this PR is to fix the Checkstyle member name violations in `ProLogSettings`.  This should have been part of #3184 where we chose to break compatibility with respect to this class.  If any user has happened to save their Hard AI log settings since #3184 was merged three days ago, this change will once again silently (minus a quiet log message) reset their settings to the defaults.

I also did some additional refactoring:

* Encapsulated `ProLogSettings` state behind getters and setters.  (I renamed the fields here so the Lombok-generated methods would have names that read well)
* Removed the internal `ProLogSettings` caching and improved instance caching at the call sites.
    * The internal caching seemed a bit of overkill for this type.
    * Changed call sites to store the settings in a local rather than making repeated calls to `loadSettings()`.
* Added a private constructor to `ProLogger` since it only consists of static methods.

Recommended to view with whitespace changes ignored.