### PR TITLE
Increase min method length before a javadoc is required from more than 2 lines to more than 10

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -226,7 +226,7 @@
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
+            <property name="minLineCount" value="10"/>
             <property name="allowedAnnotations" value="Override, Test, BeforeAll, AfterAll, BeforeEach, AfterEach"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
             <property name="tokens" value="METHOD_DEF"/>


### PR DESCRIPTION
After reviewing the config, instead of outright removal, this seemed like a better first step. I first considered 20 lines, there was not much difference in violations compared to 10 lines. 10 lines and public method does seem like a good point where we would start to want a javadoc. 
<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
