### PR TITLE
Add readme files for future sub-projects.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,9 @@
+# Client
+*Future* sub-project for the java thick client for TripleA
+
+
+## TODO
+- Move/create a main method here that would launch TripleA from GameRunner
+- Move most of the build contents from game-core/build.gradle to a build 
+file here
+- Update travis.yml to refer to the right artifact location

--- a/docs/dev/project_structure.md
+++ b/docs/dev/project_structure.md
@@ -1,0 +1,14 @@
+
+See README.md in sub-projects for details on the individual projects.
+
+
+![project_dependency](https://user-images.githubusercontent.com/12397753/36956914-da96d2ea-1fe5-11e8-92d9-9efd74bb1585.png)
+
+
+## design goals
+
+- Avoid direct dependency between game-core, client and the lobby
+- lobby client interface provided by client-lobby will remain relatively stable
+- integration test is done between lobby-client and lobby. From there on the
+ game engine client can use a mock of lobby-client and avoid direct integration testing
+ with lobby.

--- a/lobby-client-common/README.md
+++ b/lobby-client-common/README.md
@@ -1,0 +1,6 @@
+## lobby-client-common
+
+Common data dependency between `lobby` and `lobby-client`. 
+
+Data dependency here should ideally be kept to a minimum and care
+taken to minimize coupling between `lobby` and `lobby-client`.

--- a/lobby-client/README.md
+++ b/lobby-client/README.md
@@ -1,0 +1,11 @@
+## lobby-client
+
+Java client code for using the triplea lobby. 
+
+
+
+### TODO
+
+- Find classes used by the java client that are 'closest' to the lobby communication, move them
+here. Then try to fix up the API so any breaking changes are contained in this project.
+


### PR DESCRIPTION
The structure create here would have the lobby to client interaction be captured in a single library 'lobby-client'. Future plan is to have 'GameRunner' move to 'client', which would then in turn depend on 'lobby-client'. 'lobby-client' would start small, eventually it'll be the classes we use to talk to the lobby. With luck we'll be able to contain compatibility requirements to that library.

Last, there will be some common data model elements between client and lobby, those data models are hopefully kept to something of a minimum and would live in 'lobby-client-commonb', which both 'lobby' and 'lobby-client' would depend on.

#### For review

- the approach is reasonable, we're okay with having 'lobby-client' and 'lobby' be the points of communication, that it would be a project (jar lib) dependency between game-core and lobby-client.
- naming. I think biggest consideration is when a new client or lobby would start dropping in. We may start to see a web component integration come along in the next few years. I'm already working on a second server websocket based tech that will be easier to integrate new features. 
The convention implicitly implied here is that 'client' and 'lobby' will refer to the original/long-running java thick client and server. Meaning new clients or server projects would need a unique name

![project_dependency](https://user-images.githubusercontent.com/12397753/36956914-da96d2ea-1fe5-11e8-92d9-9efd74bb1585.png)



<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
