### PR TITLE
Make MemoryPropertyReader mutable

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/config/MemoryPropertyReader.java
+++ b/game-core/src/test/java/games/strategy/engine/config/MemoryPropertyReader.java
@@ -1,28 +1,52 @@
 package games.strategy.engine.config;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Implementation of {@link PropertyReader} that uses a memory store as the property source.
  */
-@Immutable
+@ThreadSafe
 public final class MemoryPropertyReader extends AbstractPropertyReader {
   private final Map<String, String> properties;
 
+  public MemoryPropertyReader() {
+    this(Collections.emptyMap());
+  }
+
+  /**
+   * @throws IllegalArgumentException If {@code properties} contains a {@code null} key or value.
+   */
   public MemoryPropertyReader(final Map<String, String> properties) {
     checkNotNull(properties);
+    checkArgument(!properties.containsKey(null), "properties must not contain a null key");
+    checkArgument(!properties.containsValue(null), "properties must not contain a null value");
 
-    this.properties = new HashMap<>(properties);
+    this.properties = new ConcurrentHashMap<>(properties);
   }
 
   @Override
   protected @Nullable String readPropertyInternal(final String key) {
     return properties.get(key);
+  }
+
+  /**
+   * Sets the value of the property with the specified key.
+   *
+   * @param key The property key.
+   * @param value The property value.
+   */
+  public void setProperty(final String key, final String value) {
+    checkNotNull(key);
+    checkNotNull(value);
+
+    properties.put(key, value);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
@@ -3,23 +3,19 @@ package games.strategy.engine.config.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.config.MemoryPropertyReader;
 import games.strategy.engine.config.client.GameEnginePropertyReader.PropertyKeys;
 import games.strategy.util.Version;
 
-public class GameEnginePropertyReaderTest {
-  private static GameEnginePropertyReader newGameEnginePropertyReader(final String key, final String value) {
-    return new GameEnginePropertyReader(new MemoryPropertyReader(Collections.singletonMap(key, value)));
-  }
+public final class GameEnginePropertyReaderTest {
+  private final MemoryPropertyReader memoryPropertyReader = new MemoryPropertyReader();
+  private final GameEnginePropertyReader gameEnginePropertyReader = new GameEnginePropertyReader(memoryPropertyReader);
 
   @Test
   public void engineVersion() {
-    final GameEnginePropertyReader gameEnginePropertyReader =
-        newGameEnginePropertyReader(PropertyKeys.ENGINE_VERSION, "1.0.1.3");
+    memoryPropertyReader.setProperty(PropertyKeys.ENGINE_VERSION, "1.0.1.3");
 
     assertThat(gameEnginePropertyReader.getEngineVersion(), is(new Version(1, 0, 1, 3)));
   }

--- a/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/lobby/LobbyPropertyReaderTest.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Collections;
-
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -14,23 +12,22 @@ import games.strategy.engine.config.lobby.LobbyPropertyReader.DefaultValues;
 import games.strategy.engine.config.lobby.LobbyPropertyReader.PropertyKeys;
 
 public final class LobbyPropertyReaderTest {
-  private static LobbyPropertyReader newLobbyPropertyReader(final String key, final String value) {
-    return new LobbyPropertyReader(new MemoryPropertyReader(Collections.singletonMap(key, value)));
-  }
+  private final MemoryPropertyReader memoryPropertyReader = new MemoryPropertyReader();
+  private final LobbyPropertyReader lobbyPropertyReader = new LobbyPropertyReader(memoryPropertyReader);
 
   @Nested
   public final class GetPortTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final int value = 100;
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, String.valueOf(value));
+      memoryPropertyReader.setProperty(PropertyKeys.PORT, String.valueOf(value));
 
       assertThat(lobbyPropertyReader.getPort(), is(value));
     }
 
     @Test
     public void shouldReturnDefaultValueWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.PORT, "");
+      memoryPropertyReader.setProperty(PropertyKeys.PORT, "");
 
       assertThat(lobbyPropertyReader.getPort(), is(DefaultValues.PORT));
     }
@@ -41,14 +38,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final String value = "database";
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_DATABASE, value);
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_DATABASE, value);
 
       assertThat(lobbyPropertyReader.getPostgresDatabase(), is(value));
     }
 
     @Test
     public void shouldReturnDefaultValueWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_DATABASE, "");
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_DATABASE, "");
 
       assertThat(lobbyPropertyReader.getPostgresDatabase(), is(DefaultValues.POSTGRES_DATABASE));
     }
@@ -59,14 +56,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final String value = "myhost.mydomain";
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_HOST, value);
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_HOST, value);
 
       assertThat(lobbyPropertyReader.getPostgresHost(), is(value));
     }
 
     @Test
     public void shouldReturnDefaultValueWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_HOST, "");
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_HOST, "");
 
       assertThat(lobbyPropertyReader.getPostgresHost(), is(DefaultValues.POSTGRES_HOST));
     }
@@ -77,14 +74,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final String value = "funnyPasssword";
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, value);
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_PASSWORD, value);
 
       assertThat(lobbyPropertyReader.getPostgresPassword(), is(value));
     }
 
     @Test
     public void shouldReturnEmptyStringWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PASSWORD, "");
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_PASSWORD, "");
 
       assertThat(lobbyPropertyReader.getPostgresPassword(), is(emptyString()));
     }
@@ -95,15 +92,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final int value = 1234;
-      final LobbyPropertyReader lobbyPropertyReader =
-          newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, String.valueOf(value));
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_PORT, String.valueOf(value));
 
       assertThat(lobbyPropertyReader.getPostgresPort(), is(value));
     }
 
     @Test
     public void shouldReturnDefaultValueWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_PORT, "");
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_PORT, "");
 
       assertThat(lobbyPropertyReader.getPostgresPort(), is(DefaultValues.POSTGRES_PORT));
     }
@@ -114,14 +110,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final String value = "funnyName";
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, value);
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_USER, value);
 
       assertThat(lobbyPropertyReader.getPostgresUser(), is(value));
     }
 
     @Test
     public void shouldReturnEmptyStringWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.POSTGRES_USER, "");
+      memoryPropertyReader.setProperty(PropertyKeys.POSTGRES_USER, "");
 
       assertThat(lobbyPropertyReader.getPostgresUser(), is(emptyString()));
     }
@@ -132,15 +128,14 @@ public final class LobbyPropertyReaderTest {
     @Test
     public void shouldReturnValueWhenPresent() {
       final boolean value = !DefaultValues.MAINTENANCE_MODE;
-      final LobbyPropertyReader lobbyPropertyReader =
-          newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, String.valueOf(value));
+      memoryPropertyReader.setProperty(PropertyKeys.MAINTENANCE_MODE, String.valueOf(value));
 
       assertThat(lobbyPropertyReader.isMaintenanceMode(), is(value));
     }
 
     @Test
     public void shouldReturnDefaultValueWhenAbsent() {
-      final LobbyPropertyReader lobbyPropertyReader = newLobbyPropertyReader(PropertyKeys.MAINTENANCE_MODE, "");
+      memoryPropertyReader.setProperty(PropertyKeys.MAINTENANCE_MODE, "");
 
       assertThat(lobbyPropertyReader.isMaintenanceMode(), is(DefaultValues.MAINTENANCE_MODE));
     }


### PR DESCRIPTION
The immutability of `MemoryPropertyReader` was making it awkward to use in some test cases because it is typically a transitive dependency of what's actually being tested.  Thus, changes to the property source required creating an entirely new object under test, which added a lot of noise.

Note that `MemoryPropertyReader` is test-only code, and does not affect anything in production.