### PR TITLE
Add New Unit Option "fuelFlatCost"

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -404,11 +404,14 @@ public class Route implements Serializable, Iterable<Territory> {
     final UnitAttachment ua = UnitAttachment.get(unit.getType());
     col.add(ua.getFuelCost());
     col.multiply(getMovementCost(unit));
+    if (Matches.unitHasNotMoved().test(unit)) {
+      col.add(ua.getFuelFlatCost());
+    }
     return col;
   }
 
   public static ResourceCollection getMovementFuelCostCharge(final Collection<Unit> unitsAll, final Route route,
-      final PlayerID currentPlayer, final GameData data /* , final boolean mustFight */) {
+      final PlayerID currentPlayer, final GameData data) {
     final Set<Unit> units = new HashSet<>(unitsAll);
 
     units.removeAll(CollectionUtils.getMatches(unitsAll,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3016,9 +3016,6 @@ public class UnitAttachment extends DefaultAttachment {
    */
   public String toStringShortAndOnlyImportantDifferences(final PlayerID player, final boolean useHtml,
       final boolean includeAttachedToName) {
-    // displays everything in a very short form, in English rather than as xml stuff
-    // shows all except for: m_constructionType, m_constructionsPerTerrPerTypePerTurn, m_maxConstructionsPerTypePerTerr,
-    // m_canBeGivenByTerritoryTo, m_destroyedWhenCapturedBy, m_canBeCapturedOnEnteringBy
     final StringBuilder stats = new StringBuilder();
     final UnitType unitType = (UnitType) this.getAttachedTo();
     if (includeAttachedToName && unitType != null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3009,6 +3009,11 @@ public class UnitAttachment extends DefaultAttachment {
         + "  tuv:" + m_tuv;
   }
 
+  /**
+   * Displays all unit options in a short description form that's user friendly rather than as XML.
+   * Shows all except for: m_constructionType, m_constructionsPerTerrPerTypePerTurn, m_maxConstructionsPerTypePerTerr,
+   * m_canBeGivenByTerritoryTo, m_destroyedWhenCapturedBy, m_canBeCapturedOnEnteringBy.
+   */
   public String toStringShortAndOnlyImportantDifferences(final PlayerID player, final boolean useHtml,
       final boolean includeAttachedToName) {
     // displays everything in a very short form, in English rather than as xml stuff

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -84,6 +84,7 @@ public class UnitAttachment extends DefaultAttachment {
   // and if empty it allows you to invade from all
   private String[] m_canInvadeOnlyFrom = null;
   private IntegerMap<Resource> m_fuelCost = new IntegerMap<>();
+  private IntegerMap<Resource> m_fuelFlatCost = new IntegerMap<>();
   private boolean m_canNotMoveDuringCombatMove = false;
   private Tuple<Integer, String> m_movementLimit = null;
   // combat related
@@ -2002,6 +2003,41 @@ public class UnitAttachment extends DefaultAttachment {
     m_fuelCost = new IntegerMap<>();
   }
 
+  /**
+   * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
+   */
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
+  private void setFuelFlatCost(final String value) throws GameParseException {
+    final String[] s = value.split(":");
+    if (s.length != 2) {
+      throw new GameParseException("fuelFlatCost must have two fields" + thisErrorMsg());
+    }
+    final String resourceToProduce = s[1];
+    // validate that this resource exists in the xml
+    final Resource r = getData().getResourceList().getResource(resourceToProduce);
+    if (r == null) {
+      throw new GameParseException("fuelFlatCost: No resource called:" + resourceToProduce + thisErrorMsg());
+    }
+    final int n = getInt(s[0]);
+    if (n < 0) {
+      throw new GameParseException("fuelFlatCost must have positive values" + thisErrorMsg());
+    }
+    m_fuelFlatCost.put(r, n);
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  private void setFuelFlatCost(final IntegerMap<Resource> value) {
+    m_fuelFlatCost = value;
+  }
+
+  public IntegerMap<Resource> getFuelFlatCost() {
+    return m_fuelFlatCost;
+  }
+
+  private void resetFuelFlatCost() {
+    m_fuelFlatCost = new IntegerMap<>();
+  }
+
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   private void setBombingBonus(final String s) {
     m_bombingBonus = getInt(s);
@@ -2895,6 +2931,8 @@ public class UnitAttachment extends DefaultAttachment {
             ? (m_createsResourcesList.size() == 0 ? "empty" : m_createsResourcesList.toString())
             : "null")
         + "  fuelCost:" + (m_fuelCost != null ? (m_fuelCost.size() == 0 ? "empty" : m_fuelCost.toString()) : "null")
+        + "  fuelFlatCost:"
+        + (m_fuelFlatCost != null ? (m_fuelFlatCost.size() == 0 ? "empty" : m_fuelFlatCost.toString()) : "null")
         + "  isInfrastructure:" + m_isInfrastructure + "  isConstruction:" + m_isConstruction + "  constructionType:"
         + m_constructionType + "  constructionsPerTerrPerTypePerTurn:" + m_constructionsPerTerrPerTypePerTurn
         + "  maxConstructionsPerTypePerTerr:" + m_maxConstructionsPerTypePerTerr + "  destroyedWhenCapturedBy:"
@@ -3038,6 +3076,17 @@ public class UnitAttachment extends DefaultAttachment {
           stats.append(entry.getValue()).append("x").append(entry.getKey().getName()).append(" ");
         }
         stats.append("Each movement point, ");
+      }
+    }
+    if (getFuelFlatCost() != null && getFuelFlatCost().size() > 0) {
+      if (getFuelFlatCost().size() > 4) {
+        stats.append("Uses ").append(m_fuelFlatCost.totalValues()).append(" Resources Each turn if moved, ");
+      } else {
+        stats.append("Uses ");
+        for (final Entry<Resource, Integer> entry : getFuelFlatCost().entrySet()) {
+          stats.append(entry.getValue()).append("x").append(entry.getKey().getName()).append(" ");
+        }
+        stats.append("Each turn if moved, ");
       }
     }
     if ((getIsAaForCombatOnly() || getIsAaForBombingThisUnitOnly() || getIsAaForFlyOverOnly())
@@ -3436,6 +3485,12 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setFuelCost,
                 this::getFuelCost,
                 this::resetFuelCost))
+        .put("fuelFlatCost",
+            MutableProperty.of(
+                this::setFuelFlatCost,
+                this::setFuelFlatCost,
+                this::getFuelFlatCost,
+                this::resetFuelFlatCost))
         .put("canNotMoveDuringCombatMove",
             MutableProperty.of(
                 this::setCanNotMoveDuringCombatMove,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -299,7 +299,7 @@ public class MovePerformer implements Serializable {
   private static Change markFuelCostResourceChange(final Collection<Unit> units, final Route route, final PlayerID id,
       final GameData data) {
     return ChangeFactory.removeResourceCollection(id,
-        Route.getMovementFuelCostCharge(units, route, id, data /* , mustFight */));
+        Route.getMovementFuelCostCharge(units, route, id, data));
   }
 
   private Change markMovementChange(final Collection<Unit> units, final Route route, final PlayerID id) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -159,23 +159,38 @@ public class VictoryTest {
   @Test
   public void testFuelUseMotorized() {
     gameData.performChange(ChangeFactory.changeOwner(kenya, italians));
+    gameData.performChange(ChangeFactory.changeOwner(britishCongo, italians));
+    gameData.performChange(ChangeFactory.changeOwner(frenchEastAfrica, italians));
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(1, italians)));
     testBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final int fuelAmount = italians.getResources().getQuantity("Fuel");
     final int puAmount = italians.getResources().getQuantity("PUs");
+    final int oreAmount = italians.getResources().getQuantity("Ore");
+
     moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
-    assertEquals(fuelAmount - 1, italians.getResources().getQuantity("Fuel"));
+    assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
+    assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
+
     gameData.performChange(ChangeFactory.addUnits(kenya, armour.create(1, italians)));
     moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
-    assertEquals(fuelAmount - 1, italians.getResources().getQuantity("Fuel"));
+    assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
+    assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
+
+    moveDelegate.move(britishCongo.getUnits().getUnits(), gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
+    assertEquals(fuelAmount - 3, italians.getResources().getQuantity("Fuel"));
+    assertEquals(puAmount - 2, italians.getResources().getQuantity("PUs"));
+    assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
+
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(5, italians)));
     moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
-    assertEquals(fuelAmount - 6, italians.getResources().getQuantity("Fuel"));
-    assertEquals(puAmount - 6, italians.getResources().getQuantity("PUs"));
+    assertEquals(fuelAmount - 13, italians.getResources().getQuantity("Fuel"));
+    assertEquals(puAmount - 7, italians.getResources().getQuantity("PUs"));
+    assertEquals(oreAmount - 12, italians.getResources().getQuantity("Ore"));
+
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(50, italians)));
     final String error =
         moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));

--- a/game-core/src/test/resources/victory_test.xml
+++ b/game-core/src/test/resources/victory_test.xml
@@ -1896,7 +1896,8 @@
                          <option name="defense" value="3"/>
                          <option name="fuelCost" value="Fuel" count="1"/>
                          <option name="fuelCost" value="PUs" count="1"/>
-
+                         <option name="fuelFlatCost" value="Fuel" count="1"/>
+                         <option name="fuelFlatCost" value="Ore" count="2"/>
                 </attachment>
 
                 <!-- Fighter -->


### PR DESCRIPTION
Addresses 4th item on: https://forums.triplea-game.org/topic/558/fuel-enhancements

**Functional Changes**
- New XML unit option "fuelFlatCost" which deducts cost once per turn if unit moves instead of per territory moved (especially useful for air units to simplify costs and simulate fuel tank)
- Updated logic to include new option and ensure it displays with the new route message

**Testing**
- Tested by editing new option into Civil War and testing
**XML**
```
    <attachment name="unitAttachment" attachTo="elite_cavalry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="consumesUnits" value="1:cavalry"/>
      <option name="movement" value="2"/>
      <option name="transportCost" value="3"/>
      <option name="canBlitz" value="true"/>
      <option name="requiresUnits" value="parade_ground"/>
      <option name="requiresUnits" value="general"/>
      <option name="createsResourcesList" value="-4:Supplies"/>
      <option name="fuelCost" value="Supplies" count="1"/>
      <option name="fuelFlatCost" value="Supplies" count="2"/>
      <option name="fuelFlatCost" value="Industry" count="1"/>
      <option name="canInvadeOnlyFrom" value="transport:train"/>
      <option name="createsResourcesList" value="-1:Manpower"/>
      <option name="attack" value="4"/>
      <option name="defense" value="3"/>
    </attachment>
```
**Before**
![image](https://user-images.githubusercontent.com/1427689/37071568-b4fec620-2182-11e8-98b4-1600deea440f.png)

**After**
![image](https://user-images.githubusercontent.com/1427689/37071487-5decb928-2182-11e8-92e5-d2e07a50b1ad.png)

