### PR TITLE
Air moving with carriers ignore fuel costs

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -434,12 +434,10 @@ public class Route implements Serializable, Iterable<Territory> {
               .and(Matches.isUnitAllied(player, data))
               .and(Matches.unitCanLandOnCarrier()));
       canLandOnCarrierUnits.addAll(CollectionUtils.getMatches(units,
-          Matches.unitIsOwnedBy(player)
-              .and(Matches.unitCanLandOnCarrier())));
+          Matches.unitIsOwnedBy(player).and(Matches.unitCanLandOnCarrier())));
       unitsToChargeFuelCosts.removeAll(AirMovementValidator.whatAirCanLandOnTheseCarriers(
           CollectionUtils.getMatches(units, Matches.unitIsCarrier()),
-          canLandOnCarrierUnits,
-          route.getStart()));
+          canLandOnCarrierUnits, route.getStart()));
     }
 
     // Remove dependent units

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -11,10 +11,14 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.AirMovementValidator;
+import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
+import games.strategy.util.Tuple;
 
 /**
  * A route between two territories.
@@ -396,31 +400,80 @@ public class Route implements Serializable, Iterable<Territory> {
     return movementLeft;
   }
 
-  private ResourceCollection getMovementFuelCostCharge(final Unit unit, final GameData data) {
-    final ResourceCollection col = new ResourceCollection(data);
-    if (Matches.unitIsBeingTransported().test(unit)) {
-      return col;
+  public static Change getFuelChanges(final Collection<Unit> units, final Route route, final PlayerID player,
+      final GameData data) {
+    final CompositeChange changes = new CompositeChange();
+    final Tuple<ResourceCollection, Set<Unit>> tuple =
+        Route.getFuelCostsAndUnitsChargedFlatFuelCost(units, route, player, data);
+    changes.add(ChangeFactory.removeResourceCollection(player, tuple.getFirst()));
+    for (final Unit unit : tuple.getSecond()) {
+      changes.add(ChangeFactory.unitPropertyChange(unit, Boolean.TRUE, TripleAUnit.CHARGED_FLAT_FUEL_COST));
     }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    col.add(ua.getFuelCost());
-    col.multiply(getMovementCost(unit));
-    if (Matches.unitHasNotMoved().test(unit)) {
-      col.add(ua.getFuelFlatCost());
-    }
-    return col;
+    return changes;
   }
 
-  public static ResourceCollection getMovementFuelCostCharge(final Collection<Unit> unitsAll, final Route route,
-      final PlayerID currentPlayer, final GameData data) {
-    final Set<Unit> units = new HashSet<>(unitsAll);
+  public static ResourceCollection getMovementFuelCostCharge(final Collection<Unit> units, final Route route,
+      final PlayerID player, final GameData data) {
+    return Route.getFuelCostsAndUnitsChargedFlatFuelCost(units, route, player, data).getFirst();
+  }
 
-    units.removeAll(CollectionUtils.getMatches(unitsAll,
-        Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(unitsAll, currentPlayer, data, true)));
-    final ResourceCollection movementCharge = new ResourceCollection(data);
-    for (final Unit unit : units) {
-      movementCharge.add(route.getMovementFuelCostCharge(unit, data));
+  /**
+   * Find fuel costs and which units are to be charged flat fuel costs. Ignores dependent units
+   * and if non-combat then ignores air units moving with carrier.
+   */
+  private static Tuple<ResourceCollection, Set<Unit>> getFuelCostsAndUnitsChargedFlatFuelCost(
+      final Collection<Unit> units, final Route route, final PlayerID player, final GameData data) {
+    final Set<Unit> unitsToChargeFuelCosts = new HashSet<>(units);
+
+    // If non-combat then remove air units moving with a carrier
+    if (GameStepPropertiesHelper.isNonCombatMove(data, true)) {
+
+      // Add allied air first so that the carriers take them into account before owned air
+      final List<Unit> canLandOnCarrierUnits = CollectionUtils.getMatches(units,
+          Matches.unitIsOwnedBy(player).negate()
+              .and(Matches.isUnitAllied(player, data))
+              .and(Matches.unitCanLandOnCarrier()));
+      canLandOnCarrierUnits.addAll(CollectionUtils.getMatches(units,
+          Matches.unitIsOwnedBy(player)
+              .and(Matches.unitCanLandOnCarrier())));
+      unitsToChargeFuelCosts.removeAll(AirMovementValidator.whatAirCanLandOnTheseCarriers(
+          CollectionUtils.getMatches(units, Matches.unitIsCarrier()),
+          canLandOnCarrierUnits,
+          route.getStart()));
     }
-    return movementCharge;
+
+    // Remove dependent units
+    unitsToChargeFuelCosts.removeAll(CollectionUtils.getMatches(units,
+        Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, player, data, true)));
+
+    // Find fuel cost and whether to charge flat fuel cost
+    final ResourceCollection movementCharge = new ResourceCollection(data);
+    final Set<Unit> unitsChargedFlatFuelCost = new HashSet<>();
+    for (final Unit unit : unitsToChargeFuelCosts) {
+      final Tuple<ResourceCollection, Boolean> tuple = route.getFuelCostsAndIfChargedFlatFuelCost(unit, data);
+      movementCharge.add(tuple.getFirst());
+      if (tuple.getSecond()) {
+        unitsChargedFlatFuelCost.add(unit);
+      }
+    }
+    return Tuple.of(movementCharge, unitsChargedFlatFuelCost);
+  }
+
+  private Tuple<ResourceCollection, Boolean> getFuelCostsAndIfChargedFlatFuelCost(final Unit unit,
+      final GameData data) {
+    final ResourceCollection resources = new ResourceCollection(data);
+    boolean chargedFlatFuelCost = false;
+    if (Matches.unitIsBeingTransported().test(unit)) {
+      return Tuple.of(resources, chargedFlatFuelCost);
+    }
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    resources.add(ua.getFuelCost());
+    resources.multiply(getMovementCost(unit));
+    if (Matches.unitHasNotBeenChargedFlatFuelCost().test(unit)) {
+      resources.add(ua.getFuelFlatCost());
+      chargedFlatFuelCost = true;
+    }
+    return Tuple.of(resources, chargedFlatFuelCost);
   }
 
   public static Route create(final List<Route> routes) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -56,6 +56,7 @@ public class TripleAUnit extends Unit {
   public static final String WAS_IN_AIR_BATTLE = "wasInAirBattle";
   public static final String LAUNCHED = "launched";
   public static final String AIRBORNE = "airborne";
+  public static final String CHARGED_FLAT_FUEL_COST = "chargedFlatFuelCost";
   // the transport that is currently transporting us
   private TripleAUnit m_transportedBy = null;
   // the units we have unloaded this turn
@@ -90,6 +91,8 @@ public class TripleAUnit extends Unit {
   private int m_launched = 0;
   // was this unit airborne and launched this turn
   private boolean m_airborne = false;
+  // was charged flat fuel cost already this turn
+  private boolean m_chargedFlatFuelCost = false;
 
   public static TripleAUnit get(final Unit u) {
     return (TripleAUnit) u;
@@ -296,6 +299,15 @@ public class TripleAUnit extends Unit {
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
   private void setAirborne(final boolean value) {
     m_airborne = value;
+  }
+
+  public boolean getChargedFlatFuelCost() {
+    return m_chargedFlatFuelCost;
+  }
+
+  @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
+  private void setChargedFlatFuelCost(final boolean value) {
+    m_chargedFlatFuelCost = value;
   }
 
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
@@ -601,6 +613,10 @@ public class TripleAUnit extends Unit {
             MutableProperty.ofSimple(
                 this::setAirborne,
                 this::getAirborne))
+        .put("chargedFlatFuelCost",
+            MutableProperty.ofSimple(
+                this::setChargedFlatFuelCost,
+                this::getChargedFlatFuelCost))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -497,7 +497,12 @@ public class AirMovementValidator {
     return max;
   }
 
-  private static Collection<Unit> whatAirCanLandOnTheseCarriers(final Collection<Unit> carriers,
+  /**
+   * Does not, and is not supposed to, account for any units already on this carrier (like allied/cargo fighters).
+   * Instead this method only adds up the total capacity of each unit, and accounts for damaged carriers with special
+   * properties and restrictions. So should pass allied/cargo fighters in and have them first in the list.
+   */
+  public static Collection<Unit> whatAirCanLandOnTheseCarriers(final Collection<Unit> carriers,
       final Collection<Unit> airUnits, final Territory territoryUnitsAreIn) {
     final Collection<Unit> airThatCanLandOnThem = new ArrayList<>();
     for (final Unit carrier : carriers) {
@@ -654,8 +659,7 @@ public class AirMovementValidator {
   /**
    * Does not, and is not supposed to, account for any units already on this carrier (like allied/cargo fighters).
    * Instead this method only adds up the total capacity of each unit, and accounts for damaged carriers with special
-   * properties and
-   * restrictions.
+   * properties and restrictions.
    */
   public static int carrierCapacity(final Collection<Unit> units, final Territory territoryUnitsAreCurrentlyIn) {
     int sum = 0;
@@ -668,8 +672,7 @@ public class AirMovementValidator {
   /**
    * Does not, and is not supposed to, account for any units already on this carrier (like allied/cargo fighters).
    * Instead this method only adds up the total capacity of each unit, and accounts for damaged carriers with special
-   * properties and
-   * restrictions.
+   * properties and restrictions.
    */
   public static int carrierCapacity(final Unit unit, final Territory territoryUnitsAreCurrentlyIn) {
     if (Matches.unitIsCarrier().test(unit)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -202,6 +202,10 @@ public final class Matches {
     return unitHasMoved().negate();
   }
 
+  public static Predicate<Unit> unitHasNotBeenChargedFlatFuelCost() {
+    return unit -> !TripleAUnit.get(unit).getChargedFlatFuelCost();
+  }
+
   static Predicate<Unit> unitCanAttack(final PlayerID id) {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -307,6 +307,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (taUnit.getWasAmphibious()) {
         change.add(ChangeFactory.unitPropertyChange(u, Boolean.FALSE, TripleAUnit.UNLOADED_AMPHIBIOUS));
       }
+      if (taUnit.getChargedFlatFuelCost()) {
+        change.add(ChangeFactory.unitPropertyChange(u, Boolean.FALSE, TripleAUnit.CHARGED_FLAT_FUEL_COST));
+      }
     }
     return change;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -163,7 +163,7 @@ public class MovePerformer implements Serializable {
         if (Properties.getUseFuelCost(data)) {
           // markFuelCostResourceChange must be done
           // before we load/unload units
-          change.add(markFuelCostResourceChange(units, route, id, data));
+          change.add(Route.getFuelChanges(units, route, id, data));
         }
         markTransportsMovement(arrived, transporting, route);
         if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
@@ -294,12 +294,6 @@ public class MovePerformer implements Serializable {
     return Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)
         .or(Matches.territoryHasNonSubmergedEnemyUnits(id, data))
         .or(Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id));
-  }
-
-  private static Change markFuelCostResourceChange(final Collection<Unit> units, final Route route, final PlayerID id,
-      final GameData data) {
-    return ChangeFactory.removeResourceCollection(id,
-        Route.getMovementFuelCostCharge(units, route, id, data));
   }
 
   private Change markMovementChange(final Collection<Unit> units, final Route route, final PlayerID id) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -33,6 +33,9 @@ import games.strategy.triplea.util.TransportUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.PredicateBuilder;
 
+/**
+ * Used to move units and make changes to game state.
+ */
 public class MovePerformer implements Serializable {
   private static final long serialVersionUID = 3752242292777658310L;
   private transient AbstractMoveDelegate moveDelegate;

--- a/game-core/src/test/resources/victory_test.xml
+++ b/game-core/src/test/resources/victory_test.xml
@@ -1914,6 +1914,8 @@
                          <option name="canEscort" value="true"/>
                          <option name="airDefense" value="2"/>
                          <option name="airAttack" value="2"/>
+                         <option name="fuelCost" value="Fuel" count="1"/>
+                         <option name="fuelFlatCost" value="Fuel" count="2"/>
                 </attachment>
 
                 <attachment name="unitAttachment" attachTo="jp_fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
@@ -2037,6 +2039,7 @@
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
                          <option name="blockade" value="1"/>
+                         <option name="fuelCost" value="Fuel" count="1"/>                        
                 </attachment>
 
                 <!-- Super_Carrier -->
@@ -4444,7 +4447,7 @@
                         <resourceGiven player="Italians" resource="PUs" quantity="16"/>
                         <resourceGiven player="Chinese" resource="PUs" quantity="0"/>
 
-                        <resourceGiven player="Italians" resource="Fuel" quantity="20"/>
+                        <resourceGiven player="Italians" resource="Fuel" quantity="50"/>
                         <resourceGiven player="Italians" resource="Ore" quantity="20"/>
 
                 </resourceInitialize>


### PR DESCRIPTION
Address 5th point here: https://forums.triplea-game.org/topic/558/fuel-enhancements

**Functional Changes**
- During non-combat move, air units that are moved with their carrier no longer cost fuel. During combat move, they do cost fuel for all moves as its consider that they launch from their initial territory to head towards battle.
- Since air can now potentially move with carriers for no fuel charge, a new unit property needs added since checking 'unitNotMoved' is no longer sufficient for fuelFlatCost.

**Testing**
- Tested on WaW Fuel Variant that it works as expected and lines up with the unit tests that were added