### PR TITLE
Document MutableProperty#setValue() allows null values

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MutableProperty.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
+
 import games.strategy.util.function.ThrowingConsumer;
 import games.strategy.util.function.ThrowingFunction;
 
@@ -81,9 +83,7 @@ public final class MutableProperty<T> {
    *
    * @throws InvalidValueException If the new property value is invalid.
    */
-  public void setValue(final Object value) throws InvalidValueException {
-    // TODO: do we need to allow null values? if so, document it; if not, add precondition check
-
+  public void setValue(final @Nullable Object value) throws InvalidValueException {
     if (value instanceof String) {
       setStringValue((String) value);
     } else {


### PR DESCRIPTION
Following up on a TODO left in this method.

I confirmed that some `MutableProperty` setters allow `null` values (usually used to reset the associated field), and that there are `Change` instances created during the game that will attempt to set a `null` value.  Therefore, this PR simply documents that possibility.