### PR TITLE
Initialize client setting framework in all support tools

### DIFF
--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -29,6 +29,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 public class AutoPlacementFinder {
@@ -51,7 +52,12 @@ public class AutoPlacementFinder {
     return new String[] {TRIPLEA_MAP_FOLDER, TRIPLEA_UNIT_ZOOM, TRIPLEA_UNIT_WIDTH, TRIPLEA_UNIT_HEIGHT};
   }
 
+  /**
+   * Entry point for the Automatic Placement Finder tool.
+   */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the AutoPlacementFinder, it will create a place.txt file for you. "

--- a/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-core/src/main/java/tools/image/CenterPicker.java
@@ -40,6 +40,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 public class CenterPicker extends JFrame {
@@ -55,7 +56,6 @@ public class CenterPicker extends JFrame {
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
-   * main(java.lang.String[])
    * Main program begins here.
    * Asks the user to select the map then runs the
    * the actual picker.
@@ -63,6 +63,8 @@ public class CenterPicker extends JFrame {
    * @param args The command line arguments.
    */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -55,6 +55,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import games.strategy.util.Triple;
 import games.strategy.util.Tuple;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -118,7 +119,12 @@ public class DecorationPlacer extends JFrame {
   private static boolean cheapMutex = false;
   private static boolean showPointNames = false;
 
+  /**
+   * Entry point for the Decoration Placer tool.
+   */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -45,6 +45,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -79,6 +80,8 @@ public class PolygonGrabber extends JFrame {
    * @param args The command line arguments.
    */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     ToolLogger.info("Select the map");
     final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");

--- a/game-core/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/game-core/src/main/java/tools/image/ReliefImageBreaker.java
@@ -24,6 +24,7 @@ import javax.swing.JOptionPane;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 import tools.map.making.ImageIoCompletionWatcher;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -46,6 +47,8 @@ public class ReliefImageBreaker {
    * Creates a new instance of ReliefImageBreaker and calls createMaps() method to start the computations.
    */
   public static void main(final String[] args) throws Exception {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the ReliefImageBreaker, it is no longer used. "

--- a/game-core/src/main/java/tools/image/TileImageBreaker.java
+++ b/game-core/src/main/java/tools/image/TileImageBreaker.java
@@ -18,6 +18,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import games.strategy.triplea.ui.screen.TileManager;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -37,15 +38,14 @@ public class TileImageBreaker {
       "TileImageBreaker Log\r\n\r\n", "", "TileImageBreaker Log", null, 500, 300, true, 1, null);
 
   /**
-   * main(java.lang.String[] args)
    * Main program begins here. Creates a new instance of ReliefImageBreaker
    * and calls createMaps() method to start the computations.
    *
    * @param args The command line parameters.
-   * @exception java.lang.Exception
-   *            throws
    */
   public static void main(final String[] args) throws Exception {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the TileImageBreaker, it will create the map image tiles file for you. "

--- a/game-core/src/main/java/tools/image/TileImageReconstructor.java
+++ b/game-core/src/main/java/tools/image/TileImageReconstructor.java
@@ -28,6 +28,7 @@ import javax.swing.filechooser.FileFilter;
 import games.strategy.triplea.ui.screen.TileManager;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -44,7 +45,12 @@ public class TileImageReconstructor {
   private static int sizeY = -1;
   private static Map<String, List<Polygon>> polygons = new HashMap<>();
 
+  /**
+   * Entry point for the Tile Image Reconstructor tool.
+   */
   public static void main(final String[] args) throws Exception {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>"

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -33,6 +33,7 @@ import games.strategy.util.AlphanumComparator;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -57,7 +58,12 @@ public class ConnectionFinder {
   // default 32, or if LINE_THICKNESS is given 16 x linethickness
   private static double minOverlap = 32.0;
 
+  /**
+   * Entry point for the Connection Finder tool.
+   */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the ConnectionFinder. "

--- a/game-core/src/main/java/tools/map/making/ImageShrinker.java
+++ b/game-core/src/main/java/tools/map/making/ImageShrinker.java
@@ -17,6 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
 import tools.image.FileOpen;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -26,7 +27,12 @@ public class ImageShrinker {
   private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder"; // TODO: find other duplications of this value.
 
+  /**
+   * Entry point for the Image Shrinker tool.
+   */
   public static void main(final String[] args) throws Exception {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the ImageShrinker, it will create a smallMap.jpeg file for you. "

--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -29,7 +29,6 @@ import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
-import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 import tools.image.AutoPlacementFinder;
 import tools.image.CenterPicker;
@@ -39,6 +38,7 @@ import tools.image.PolygonGrabber;
 import tools.image.ReliefImageBreaker;
 import tools.image.TileImageBreaker;
 import tools.image.TileImageReconstructor;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -75,7 +75,7 @@ public class MapCreator extends JFrame {
    * Entry point for the map-making utilities application.
    */
   public static void main(final String[] args) throws InterruptedException {
-    ClientSetting.initialize();
+    ToolApplication.initialize();
 
     SwingAction.invokeAndWait(() -> {
       LookAndFeel.setupLookAndFeel();

--- a/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -54,6 +54,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.util.Tuple;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 /**
@@ -83,6 +84,8 @@ public class MapPropertiesMaker extends JFrame {
    * Entry point for the Map Properties Maker tool.
    */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     // JOptionPane.showMessageDialog(null, new JLabel("<html>" + "This is the MapPropertiesMaker, it will create a
     // map.properties file for

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -50,6 +50,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
 import tools.image.FileOpen;
 import tools.image.FileSave;
+import tools.util.ToolApplication;
 import tools.util.ToolLogger;
 
 public class PlacementPicker extends JFrame {
@@ -85,7 +86,6 @@ public class PlacementPicker extends JFrame {
   }
 
   /**
-   * main(java.lang.String[])
    * Main program begins here.
    * Asks the user to select the map then runs the
    * the actual placement picker program.
@@ -93,6 +93,8 @@ public class PlacementPicker extends JFrame {
    * @param args the command line arguments
    */
   public static void main(final String[] args) {
+    ToolApplication.initialize();
+
     handleCommandLineArgs(args);
     JOptionPane.showMessageDialog(null,
         new JLabel("<html>" + "This is the PlacementPicker, it will create a place.txt file for you. "

--- a/game-core/src/main/java/tools/util/ToolApplication.java
+++ b/game-core/src/main/java/tools/util/ToolApplication.java
@@ -1,0 +1,17 @@
+package tools.util;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+/**
+ * Provides methods for support tools when run as standalone applications.
+ */
+public final class ToolApplication {
+  private ToolApplication() {}
+
+  /**
+   * Performs initialization required by all map making tool applications.
+   */
+  public static void initialize() {
+    ClientSetting.initialize();
+  }
+}


### PR DESCRIPTION
Fixes https://forums.triplea-game.org/topic/648/automatic-placement-finder-doesn-t-work

#### Functional changes

Ensure `ClientSetting#initialize()` is called for all support tools that can be started from the Map Making Utilities application.  I extracted a new `ToolApplication#initialize()` method that will ideally hold all the common initialization required by the support tools.

Note that I didn't modify the `main()` methods in `XmlUpdater` nor `MapPropertyWrapper`.  The former seems to be a standalone utility not reachable from the Map Making Utilities application, while the latter looks like it was just used for testing.

#### Testing

I verified I could run the Automatic Placement Finder tool without error.  By induction, the other tools should run without a `ClientSetting` initialization error since they all call the same `ToolApplication#initialize()` method.