### PR TITLE
Use HTTPS for dice server connections

### DIFF
--- a/game-core/dice_servers/tripleawarclub-staging.properties
+++ b/game-core/dice_servers/tripleawarclub-staging.properties
@@ -4,6 +4,7 @@ order=11
 name=dice-staging.tripleawarclub.org (experimental BETA)
 # dice server host
 host=dice-staging.tripleawarclub.org
+scheme=https
 # path in dice server post to post too
 path=/MARTI.php
 roll.single.start=your dice are: 

--- a/game-core/dice_servers/tripleawarclub.properties
+++ b/game-core/dice_servers/tripleawarclub.properties
@@ -4,6 +4,7 @@ order=10
 name=dice.tripleawarclub.org
 #dice server host
 host=dice.tripleawarclub.org
+scheme=https
 #path in dice server post to post too
 path=/MARTI.php
 roll.single.start=your dice are: 

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -143,7 +143,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       // rather than sending out email for each roll
       httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = m_props.getProperty("host");
-      final int port = Integer.parseInt(m_props.getProperty("port", "80"));
+      final int port = Integer.parseInt(m_props.getProperty("port", "-1"));
       final String scheme = m_props.getProperty("scheme", "http");
       final HttpHost hostConfig = new HttpHost(host, port, scheme);
       HttpProxy.addProxy(httpPost);


### PR DESCRIPTION
Per triplea-game/dice-server#19.

Connections from the TripleA client to MARTI (production and staging) are now made over HTTPS.

#### Testing

I verified the Test Server command on the PBEM/PBF menu works for both MARTI production and staging.  I confirmed that the links in the emails sent by MARTI are now HTTPS and are all reachable.