### PR TITLE
Add fuel to scrambling

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -163,11 +163,10 @@ public class MovePerformer implements Serializable {
         final Collection<Unit> presentFromStartTilEnd = new ArrayList<>(arrived);
         presentFromStartTilEnd.removeAll(dependentOnSomethingTilTheEndOfRoute);
         final CompositeChange change = new CompositeChange();
-        if (Properties.getUseFuelCost(data)) {
-          // markFuelCostResourceChange must be done
-          // before we load/unload units
-          change.add(Route.getFuelChanges(units, route, id, data));
-        }
+
+        // markFuelCostResourceChange must be done before we load/unload units
+        change.add(Route.getFuelChanges(units, route, id, data));
+
         markTransportsMovement(arrived, transporting, route);
         if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
           boolean bombing = false;

--- a/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -1,8 +1,18 @@
 package games.strategy.triplea.image;
 
-import javax.swing.JLabel;
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.ResourceCollection;
 import games.strategy.util.IntegerMap;
 
 /**
@@ -37,6 +47,39 @@ public class ResourceImageFactory extends AbstractImageFactory {
       label.setText(resource.getName() + " " + text);
     }
     return label;
+  }
+
+  public JPanel getResourcesPanel(final ResourceCollection resources, final GameData data) {
+    return getResourcesPanel(resources, false, null, data);
+  }
+
+  public JPanel getResourcesPanel(final ResourceCollection resources, final PlayerID player, final GameData data) {
+    return getResourcesPanel(resources, true, player, data);
+  }
+
+  private JPanel getResourcesPanel(final ResourceCollection resources, final boolean showEmpty, final PlayerID player,
+      final GameData data) {
+    final JPanel resourcePanel = new JPanel();
+    List<Resource> resourcesInOrder = new ArrayList<>();
+    data.acquireReadLock();
+    try {
+      resourcesInOrder = data.getResourceList().getResources();
+    } finally {
+      data.releaseReadLock();
+    }
+    int count = 0;
+    for (final Resource resource : resourcesInOrder) {
+      if ((player != null && !resource.isDisplayedFor(player))
+          || (!showEmpty && resources.getQuantity(resource) == 0)) {
+        continue;
+      }
+      final JLabel resourceLabel = getLabel(resource, resources.getResourcesCopy());
+      resourceLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
+      resourcePanel.add(resourceLabel,
+          new GridBagConstraints(count++, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+              new Insets(0, 0, 0, 0), 0, 0));
+    }
+    return resourcePanel;
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -174,26 +174,7 @@ public class ProductionPanel extends JPanel {
     remainingResources.removeAll();
     left.setText(String.format("%d total units purchased. Remaining resources: ", totalUnits));
     if (resourceCollection != null) {
-      final IntegerMap<Resource> resources = resourceCollection.getResourcesCopy();
-      int count = 0;
-      List<Resource> resourcesInOrder = new ArrayList<>();
-      data.acquireReadLock();
-      try {
-        resourcesInOrder = data.getResourceList().getResources();
-      } finally {
-        data.releaseReadLock();
-      }
-      for (final Resource resource : resourcesInOrder) {
-        if (!resource.isDisplayedFor(id)) {
-          continue;
-        }
-        final JLabel resourceLabel =
-            uiContext.getResourceImageFactory().getLabel(resource, resources);
-        resourceLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
-        remainingResources.add(resourceLabel,
-            new GridBagConstraints(count++, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-                new Insets(0, 0, 0, 0), 0, 0));
-      }
+      remainingResources.add(uiContext.getResourceImageFactory().getResourcesPanel(resourceCollection, id, data));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1204,12 +1204,11 @@ public class TripleAFrame extends MainGameFrame {
       panel.setLayout(new BorderLayout());
       final String optionScramble = "Scramble";
       final String optionNone = "None";
-      final JButton scramble = new JButton(optionScramble);
-      scramble.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(scramble));
-      final JButton none = new JButton(optionNone);
-      none.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(none));
-      // final Object[] options = {optionScramble, optionNone};
-      final Object[] options = {scramble, none};
+      final JButton scrambleButton = new JButton(optionScramble);
+      scrambleButton.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(scrambleButton));
+      final JButton noneButton = new JButton(optionNone);
+      noneButton.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(noneButton));
+      final Object[] options = {scrambleButton, noneButton};
       final JOptionPane optionPane = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE,
           JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[1]);
       final JLabel whereTo = new JLabel("Scramble To: " + scrambleTo.getName());
@@ -1265,7 +1264,7 @@ public class TripleAFrame extends MainGameFrame {
               label.setForeground(Color.RED);
             }
           }
-          scramble.setEnabled(hasEnoughFuel);
+          scrambleButton.setEnabled(hasEnoughFuel);
           dialog.pack();
         });
         choosers.add(Tuple.of(from, chooser));

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1310,13 +1310,9 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   private JOptionPane getOptionPane(final JComponent parent) {
-    JOptionPane pane = null;
-    if (!(parent instanceof JOptionPane)) {
-      pane = getOptionPane((JComponent) parent.getParent());
-    } else {
-      pane = (JOptionPane) parent;
-    }
-    return pane;
+    return !(parent instanceof JOptionPane)
+        ? getOptionPane((JComponent) parent.getParent())
+        : (JOptionPane) parent;
   }
 
   public Collection<Unit> selectUnitsQuery(final Territory current, final Collection<Unit> possible,

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1199,7 +1199,7 @@ public class TripleAFrame extends MainGameFrame {
     final Collection<Tuple<Territory, UnitChooser>> choosers = new ArrayList<>();
     SwingUtilities.invokeLater(() -> {
       mapPanel.centerOn(scrambleTo);
-      final JDialog dialog = new JDialog((Frame) getParent(), "Select units to scramble to " + scrambleTo.getName());
+      final JDialog dialog = new JDialog(this, "Select units to scramble to " + scrambleTo.getName());
       final JPanel panel = new JPanel();
       panel.setLayout(new BorderLayout());
       final String optionScramble = "Scramble";

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1205,7 +1205,9 @@ public class TripleAFrame extends MainGameFrame {
       final String optionScramble = "Scramble";
       final String optionNone = "None";
       final JButton scramble = new JButton(optionScramble);
+      scramble.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(scramble));
       final JButton none = new JButton(optionNone);
+      none.addActionListener(e -> getOptionPane((JComponent) e.getSource()).setValue(none));
       // final Object[] options = {optionScramble, optionNone};
       final Object[] options = {scramble, none};
       final JOptionPane optionPane = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE,
@@ -1283,7 +1285,7 @@ public class TripleAFrame extends MainGameFrame {
         if (!dialog.isVisible()) {
           return;
         }
-        final String option = ((String) optionPane.getValue());
+        final String option = ((JButton) optionPane.getValue()).getText();
         if (option.equals(optionNone)) {
           choosers.clear();
           selection.clear();
@@ -1306,6 +1308,16 @@ public class TripleAFrame extends MainGameFrame {
     Interruptibles.await(continueLatch);
     mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     return selection;
+  }
+
+  private JOptionPane getOptionPane(final JComponent parent) {
+    JOptionPane pane = null;
+    if (!(parent instanceof JOptionPane)) {
+      pane = getOptionPane((JComponent) parent.getParent());
+    } else {
+      pane = (JOptionPane) parent;
+    }
+    return pane;
   }
 
   public Collection<Unit> selectUnitsQuery(final Territory current, final Collection<Unit> possible,

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -302,6 +302,10 @@ final class UnitChooser extends JPanel {
     });
   }
 
+  public void addChangeListener(final ScrollableTextFieldListener listener) {
+    entries.stream().forEach(entry -> entry.addChangeListener(listener));
+  }
+
   private final ScrollableTextFieldListener textFieldListener = new ScrollableTextFieldListener() {
     @Override
     public void changedValue(final ScrollableTextField field) {
@@ -448,6 +452,10 @@ final class UnitChooser extends JPanel {
 
     boolean hasMultipleHitPoints() {
       return hasMultipleHits;
+    }
+
+    void addChangeListener(final ScrollableTextFieldListener listener) {
+      hitTexts.stream().forEach(field -> field.addChangeListener(listener));
     }
 
     private class UnitChooserEntryIcon extends JComponent {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -303,7 +303,7 @@ final class UnitChooser extends JPanel {
   }
 
   public void addChangeListener(final ScrollableTextFieldListener listener) {
-    entries.stream().forEach(entry -> entry.addChangeListener(listener));
+    entries.forEach(entry -> entry.addChangeListener(listener));
   }
 
   private final ScrollableTextFieldListener textFieldListener = new ScrollableTextFieldListener() {
@@ -455,7 +455,7 @@ final class UnitChooser extends JPanel {
     }
 
     void addChangeListener(final ScrollableTextFieldListener listener) {
-      hitTexts.stream().forEach(field -> field.addChangeListener(listener));
+      hitTexts.forEach(field -> field.addChangeListener(listener));
     }
 
     private class UnitChooserEntryIcon extends JComponent {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -29,8 +29,6 @@ import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
-import games.strategy.engine.data.ResourceCollection;
-import games.strategy.engine.data.util.ResourceCollectionUtils;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Constants;
@@ -130,18 +128,6 @@ public class UserActionPanel extends ActionPanel {
       choiceScroll.setPreferredSize(getUserActionScrollPanePreferredSize(choiceScroll));
       userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 2, 1, 0.0, 0.0, GridBagConstraints.CENTER,
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-
-      if (canSpendResourcesOnUserActions(validUserActions)) {
-        final JLabel resourcesLabel = new JLabel("Remaining resources: ");
-        final ResourceCollection resources =
-            ResourceCollectionUtils.getProductionResources(getCurrentPlayer().getResources());
-        final JPanel resourcesPanel = getMap().getUiContext().getResourceImageFactory().getResourcesPanel(resources,
-            getCurrentPlayer(), getData());
-        userChoicePanel.add(resourcesLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-            GridBagConstraints.NONE, new Insets(8, 0, 0, 0), 0, 0));
-        userChoicePanel.add(resourcesPanel, new GridBagConstraints(1, row++, 1, 1, 0, 0, GridBagConstraints.WEST,
-            GridBagConstraints.NONE, new Insets(8, 0, 0, 0), 0, 0));
-      }
 
       final JButton noActionButton = new JButton(SwingAction.of("No Actions", e -> userChoiceDialog.setVisible(false)));
       SwingUtilities.invokeLater(() -> noActionButton.requestFocusInWindow());

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -29,6 +29,7 @@ import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.util.ResourceCollectionUtils;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
@@ -127,19 +128,24 @@ public class UserActionPanel extends ActionPanel {
       final JScrollPane choiceScroll = new JScrollPane(getUserActionButtonPanel(userChoiceDialog));
       choiceScroll.setBorder(BorderFactory.createEtchedBorder());
       choiceScroll.setPreferredSize(getUserActionScrollPanePreferredSize(choiceScroll));
-      userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER,
+      userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 2, 1, 0.0, 0.0, GridBagConstraints.CENTER,
           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 
       if (canSpendResourcesOnUserActions(validUserActions)) {
-        final JLabel resourcesLabel = new JLabel(String.format("You have %s left",
-            ResourceCollectionUtils.getProductionResources(getCurrentPlayer().getResources())));
-        userChoicePanel.add(resourcesLabel, new GridBagConstraints(0, row++, 1, 1, 0.0, 0.0, GridBagConstraints.WEST,
-            GridBagConstraints.HORIZONTAL, new Insets(8, 0, 0, 0), 0, 0));
+        final JLabel resourcesLabel = new JLabel("Remaining resources: ");
+        final ResourceCollection resources =
+            ResourceCollectionUtils.getProductionResources(getCurrentPlayer().getResources());
+        final JPanel resourcesPanel = getMap().getUiContext().getResourceImageFactory().getResourcesPanel(resources,
+            getCurrentPlayer(), getData());
+        userChoicePanel.add(resourcesLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+            GridBagConstraints.NONE, new Insets(8, 0, 0, 0), 0, 0));
+        userChoicePanel.add(resourcesPanel, new GridBagConstraints(1, row++, 1, 1, 0, 0, GridBagConstraints.WEST,
+            GridBagConstraints.NONE, new Insets(8, 0, 0, 0), 0, 0));
       }
 
       final JButton noActionButton = new JButton(SwingAction.of("No Actions", e -> userChoiceDialog.setVisible(false)));
       SwingUtilities.invokeLater(() -> noActionButton.requestFocusInWindow());
-      userChoicePanel.add(noActionButton, new GridBagConstraints(0, row, 1, 1, 0.0, 0.0, GridBagConstraints.EAST,
+      userChoicePanel.add(noActionButton, new GridBagConstraints(0, row, 2, 1, 0.0, 0.0, GridBagConstraints.EAST,
           GridBagConstraints.NONE, new Insets(12, 0, 0, 0), 0, 0));
 
       userChoiceDialog.add(userChoicePanel);


### PR DESCRIPTION
Address point 6 on https://forums.triplea-game.org/topic/558/fuel-enhancements

**Functional Changes**
- Scramble dialog now shows estimated fuel costs for any units selected to move there and back
- Fuel costs are treated just like movement during a player's turn so 'fuelFlatCost' is charged once if unit is scrambled, 'fuelCost' is charged for each move
- Fuel validation and game data changes for selected scramble units added
- Fixed scramble window to have proper icon and close if game is exited to main menu
- Updated Actions and Operations window to remove remaining resources since its duplicate information of the bottom bar:
![image](https://user-images.githubusercontent.com/1427689/37558685-adc457a6-29e5-11e8-8f00-cb66d2648ea2.png)

**Testing**
Manually edited Global 40 2nd to add this to fighters:
```
	  <option name="fuelFlatCost" value="PUs" count="4"/>
	  <option name="fuelCost" value="PUs" count="1"/>
```
And this property:
```
    <property name="Use Fuel Cost" value="true" editable="false">
      <boolean/>
    </property>
```
Result:
![image](https://user-images.githubusercontent.com/1427689/37551441-85c96fe8-296d-11e8-8a91-ee0d18778bf5.png)

More examples: https://forums.triplea-game.org/topic/558/fuel-enhancements/227

