### PR TITLE
Use jcenter instead of mavenCentral

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }
 

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.2'


### PR DESCRIPTION
> 8 Get rid of mavenCentral
 jcenter has faster response time and now acts as a superset of mavenCental content.


https://proandroiddev.com/make-your-build-gradle-great-again-c84cc172a654


<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
