### PR TITLE
Allow unit overflow to left and improve unit placement sorting

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.data;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +12,7 @@ import java.util.Set;
  */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
-  private final Map<String, UnitType> m_unitTypes = new HashMap<>();
+  private final Map<String, UnitType> m_unitTypes = new LinkedHashMap<>();
 
   /**
    * Creates new UnitTypeCollection.

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -40,6 +40,7 @@ import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import games.strategy.util.Tuple;
 import games.strategy.util.function.ThrowingFunction;
 import games.strategy.util.function.ThrowingSupplier;
 
@@ -96,7 +97,7 @@ public class MapData implements Closeable {
 
   private final DefaultColors defaultColors = new DefaultColors();
   private final Map<String, Color> playerColors = new HashMap<>();
-  private Map<String, List<Point>> place;
+  private Map<String, Tuple<List<Point>, Boolean>> place;
   private Map<String, List<Polygon>> polys;
   private Map<String, Point> centers;
   private Map<String, Point> vcPlace;
@@ -139,7 +140,7 @@ public class MapData implements Closeable {
   public MapData(final ResourceLoader loader) {
     resourceLoader = loader;
     try {
-      place = readPointsOneToMany(optionalResource(PLACEMENT_FILE));
+      place = readPlacementsOneToMany(optionalResource(PLACEMENT_FILE));
       territoryEffects = readPointsOneToMany(optionalResource(TERRITORY_EFFECT_FILE));
 
       if (loader.getResource(POLYGON_FILE) == null) {
@@ -196,6 +197,12 @@ public class MapData implements Closeable {
       final ThrowingSupplier<InputStream, IOException> inputStreamFactory)
       throws IOException {
     return runWithInputStream(inputStreamFactory, PointFileReaderWriter::readOneToMany);
+  }
+
+  private static Map<String, Tuple<List<Point>, Boolean>> readPlacementsOneToMany(
+      final ThrowingSupplier<InputStream, IOException> inputStreamFactory)
+      throws IOException {
+    return runWithInputStream(inputStreamFactory, PointFileReaderWriter::readOneToManyPlacements);
   }
 
   private static Map<String, List<Polygon>> readPolygonsOneToMany(
@@ -534,7 +541,11 @@ public class MapData implements Closeable {
   }
 
   public List<Point> getPlacementPoints(final Territory terr) {
-    return place.get(terr.getName());
+    return place.get(terr.getName()).getFirst();
+  }
+
+  public boolean getPlacementOverflowToLeft(final Territory terr) {
+    return place.get(terr.getName()).getSecond();
   }
 
   public List<Polygon> getPolygons(final String terr) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -352,8 +352,12 @@ public class TileManager {
         overflow = false;
       } else {
         lastPlace = new Point(lastPlace);
-        lastPlace.x += uiContext.getUnitImageFactory().getUnitImageWidth();
         overflow = true;
+        if (mapData.getPlacementOverflowToLeft(territory)) {
+          lastPlace.x -= uiContext.getUnitImageFactory().getUnitImageWidth();
+        } else {
+          lastPlace.x += uiContext.getUnitImageFactory().getUnitImageWidth();
+        }
       }
       final UnitsDrawer drawable = new UnitsDrawer(category.getUnits().size(), category.getType().getName(),
           category.getOwner().getName(), lastPlace, category.getDamaged(), category.getBombingDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -346,8 +346,7 @@ public class TileManager {
     }
 
     Point lastPlace = null;
-    final List<UnitCategory> categories = getSortedUnitCategories(territory, data);
-    for (final UnitCategory category : categories) {
+    for (final UnitCategory category : getSortedUnitCategories(territory, data)) {
       final boolean overflow;
       if (placementPoints.hasNext()) {
         lastPlace = new Point(placementPoints.next());

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -24,6 +24,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -376,7 +378,8 @@ public class TileManager {
     }
   }
 
-  private static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
+  @VisibleForTesting
+  public static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
     final List<UnitCategory> categories = new ArrayList<>(UnitSeperator.categorize(t.getUnits().getUnits()));
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -379,7 +379,7 @@ public class TileManager {
   }
 
   @VisibleForTesting
-  public static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
+  static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
     final List<UnitCategory> categories = new ArrayList<>(UnitSeperator.categorize(t.getUnits().getUnits()));
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -378,18 +378,18 @@ public class TileManager {
 
   private static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
     final List<UnitCategory> categories = new ArrayList<>(UnitSeperator.categorize(t.getUnits().getUnits()));
-    final List<PlayerID> players = data.getPlayerList().getPlayers();
-    if (players.contains(t.getOwner())) {
-      players.remove(t.getOwner());
-      players.add(0, t.getOwner());
-    }
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator
-        .comparing(UnitCategory::getOwner, Comparator.comparing(players::indexOf))
-        .thenComparing(UnitCategory::getType, Comparator.comparing(ut -> !UnitAttachment.get(ut).getIsInfrastructure()))
-        .thenComparing(UnitCategory::getType, Comparator.comparing(ut -> !Matches.unitTypeIsLand().test(ut)))
-        .thenComparing(UnitCategory::getType, Comparator.comparing(ut -> !UnitAttachment.get(ut).getIsSea()))
-        .thenComparing(UnitCategory::getType, Comparator.comparing(xmlUnitTypes::indexOf)));
+        .comparing(UnitCategory::getOwner, Comparator
+            .comparing((final PlayerID p) -> !p.equals(t.getOwner()))
+            .thenComparing(p -> !Matches.isAllied(p, data).test(t.getOwner()))
+            .thenComparing(data.getPlayerList().getPlayers()::indexOf))
+        .thenComparing(Comparator.comparing(uc -> Matches.unitTypeCanMove(uc.getOwner()).test(uc.getType())))
+        .thenComparing(UnitCategory::getType, Comparator
+            .comparing((final UnitType ut) -> !Matches.unitTypeCanNotMoveDuringCombatMove().test(ut))
+            .thenComparing(ut -> !Matches.unitTypeIsLand().test(ut))
+            .thenComparing(ut -> !UnitAttachment.get(ut).getIsSea())
+            .thenComparing(xmlUnitTypes::indexOf)));
     return categories;
   }
 

--- a/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -189,6 +189,69 @@ public final class PointFileReaderWriter {
   }
 
   /**
+   * Writes the specified one-to-many mapping between names and points to the specified stream.
+   *
+   * @param sink The stream to which the name-to-points mappings will be written.
+   * @param mapping The name-to-points mapping to be written.
+   *
+   * @throws IOException If an I/O error occurs while writing to the stream.
+   */
+  public static void writeOneToManyPlacements(final OutputStream sink,
+      final Map<String, Tuple<List<Point>, Boolean>> mapping)
+      throws IOException {
+    checkNotNull(sink);
+    checkNotNull(mapping);
+
+    final StringBuilder out = new StringBuilder();
+    final Iterator<String> keyIter = mapping.keySet().iterator();
+    while (keyIter.hasNext()) {
+      final String name = keyIter.next();
+      out.append(name).append(" ");
+      final Collection<Point> points = mapping.get(name).getFirst();
+      final boolean overflowToLeft = mapping.get(name).getSecond();
+      final Iterator<Point> pointIter = points.iterator();
+      while (pointIter.hasNext()) {
+        final Point point = pointIter.next();
+        out.append(" (").append(point.x).append(",").append(point.y).append(")");
+        if (pointIter.hasNext()) {
+          out.append(" ");
+        }
+      }
+      out.append(" | overflowToLeft=" + overflowToLeft);
+      if (keyIter.hasNext()) {
+        out.append("\r\n");
+      }
+    }
+    write(out, sink);
+  }
+
+  /**
+   * Returns a map of the form String -> Collection of points.
+   */
+  public static Map<String, Tuple<List<Point>, Boolean>> readOneToManyPlacements(final InputStream stream)
+      throws IOException {
+    checkNotNull(stream);
+
+    final Map<String, List<Point>> mapping = new HashMap<>();
+    final Map<String, Tuple<List<Point>, Boolean>> result = new HashMap<>();
+    try (Reader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream), StandardCharsets.UTF_8);
+        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
+      @Nullable
+      String current = reader.readLine();
+      while (current != null) {
+        if (current.trim().length() != 0) {
+          final String[] s = current.split(" \\| ");
+          final Tuple<String, List<Point>> tuple = readMultiple(s[0], mapping);
+          final boolean overflowToLeft = s.length == 2 ? Boolean.parseBoolean(s[1].split("=")[1]) : false;
+          result.put(tuple.getFirst(), Tuple.of(tuple.getSecond(), overflowToLeft));
+        }
+        current = reader.readLine();
+      }
+    }
+    return result;
+  }
+
+  /**
    * Returns a map of the form String -> Collection of polygons.
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
@@ -285,7 +348,8 @@ public final class PointFileReaderWriter {
     polygons.add(new Polygon(pointsX, pointsY, pointsX.length));
   }
 
-  private static void readMultiple(final String line, final Map<String, List<Point>> mapping) throws IOException {
+  private static Tuple<String, List<Point>> readMultiple(final String line, final Map<String, List<Point>> mapping)
+      throws IOException {
     final StringTokenizer tokens = new StringTokenizer(line, "");
     final String name = tokens.nextToken("(").trim();
     if (mapping.containsKey(name)) {
@@ -303,5 +367,6 @@ public final class PointFileReaderWriter {
       points.add(new Point(x, y));
     }
     mapping.put(name, points);
+    return Tuple.of(name, points);
   }
 }

--- a/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -189,7 +189,7 @@ public final class PointFileReaderWriter {
   }
 
   /**
-   * Writes the specified one-to-many mapping between names and points to the specified stream.
+   * Writes the specified one-to-many mapping between names and (points, overflowToLeft) to the specified stream.
    *
    * @param sink The stream to which the name-to-points mappings will be written.
    * @param mapping The name-to-points mapping to be written.
@@ -226,7 +226,7 @@ public final class PointFileReaderWriter {
   }
 
   /**
-   * Returns a map of the form String -> Collection of points.
+   * Returns a map of the form String -> (points, overflowToLeft).
    */
   public static Map<String, Tuple<List<Point>, Boolean>> readOneToManyPlacements(final InputStream stream)
       throws IOException {

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -12,6 +12,7 @@ import java.awt.Polygon;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
@@ -50,6 +51,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import games.strategy.util.Tuple;
 import tools.image.FileOpen;
 import tools.image.FileSave;
 import tools.util.ToolArguments;
@@ -99,14 +101,16 @@ public final class PlacementPicker {
             + "<br><br>Holding CTRL/SHIFT + LEFT CLICK = Create a new placement for that territory. "
             + "<br><br>RIGHT CLICK = Remove last placement for that territory. "
             + "<br><br>Holding CTRL/SHIFT + RIGHT CLICK = Save all placements for that territory. "
+            + "<br><br>Pressing the 'O' key = Toggle the direction for placement overflow for that territory. "
             + "<br><br>It is a very good idea to check each territory using the PlacementPicker after running the "
             + "AutoPlacementFinder "
             + "<br>to make sure there are enough placements for each territory. If not, you can always add more then "
             + "save it. "
-            + "<br><br>IF there are not enough placements, the units will Overflow to the RIGHT of the very LAST "
-            + "placement made, "
+            + "<br><br>IF there are not enough placements, by default the units will Overflow to the RIGHT of the "
+            + "very LAST placement made, "
             + "<br>so be sure that the last placement is on the right side of the territory "
-            + "<br>or that it does not overflow directly on top of other placements. "
+            + "<br>or that it doesn't overflow directly on top of other placements. Can instead toggle the overflow "
+            + "direction."
             + "<br><br>To show all placements, or see the overflow direction, or see which territories you have not "
             + "yet completed enough, "
             + "<br>placements for, turn on the mode options in the 'edit' menu. " + "</html>"));
@@ -140,8 +144,9 @@ public final class PlacementPicker {
     private Image image;
     private final JLabel locationLabel = new JLabel();
     private Map<String, List<Polygon>> polygons = new HashMap<>();
-    private Map<String, List<Point>> placements;
+    private Map<String, Tuple<List<Point>, Boolean>> placements;
     private List<Point> currentPlacements;
+    private boolean currentOverflowToLeft = false;
     private String currentCountry;
 
     /**
@@ -316,6 +321,23 @@ public final class PlacementPicker {
           mouseEvent(e.getPoint(), e.isControlDown() || e.isShiftDown(), SwingUtilities.isRightMouseButton(e));
         }
       });
+
+      this.addKeyListener(new KeyListener() {
+        @Override
+        public void keyPressed(final KeyEvent e) {
+          if (showOverflowMode && currentCountry != null && (e.getKeyCode() == KeyEvent.VK_O)) {
+            currentOverflowToLeft = !currentOverflowToLeft;
+            repaint();
+          }
+        }
+
+        @Override
+        public void keyTyped(final KeyEvent e) {}
+
+        @Override
+        public void keyReleased(final KeyEvent e) {}
+      });
+
       // set up the image panel size dimensions ...etc
       imagePanel.setMinimumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
       imagePanel.setPreferredSize(new Dimension(image.getWidth(this), image.getHeight(this)));
@@ -413,18 +435,22 @@ public final class PlacementPicker {
           g.drawImage(image, 0, 0, this);
           if (showAllMode) {
             g.setColor(Color.yellow);
-            for (final Entry<String, List<Point>> entry : placements.entrySet()) {
+            for (final Entry<String, Tuple<List<Point>, Boolean>> entry : placements.entrySet()) {
               if (entry.getKey().equals(currentCountry) && currentPlacements != null
                   && !currentPlacements.isEmpty()) {
                 continue;
               }
-              final Iterator<Point> pointIter = entry.getValue().iterator();
+              final Iterator<Point> pointIter = entry.getValue().getFirst().iterator();
               while (pointIter.hasNext()) {
                 final Point item = pointIter.next();
                 g.fillRect(item.x, item.y, placeWidth, placeHeight);
                 if (showOverflowMode && !pointIter.hasNext()) {
                   g.setColor(Color.gray);
-                  g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+                  if (entry.getValue().getSecond()) {
+                    g.fillRect(item.x - placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+                  } else {
+                    g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+                  }
                   g.setColor(Color.yellow);
                 }
               }
@@ -436,7 +462,7 @@ public final class PlacementPicker {
             final Iterator<String> terrIter = territories.iterator();
             while (terrIter.hasNext()) {
               final String terr = terrIter.next();
-              final List<Point> points = placements.get(terr);
+              final List<Point> points = placements.get(terr).getFirst();
               if (points != null && points.size() >= incompleteNum) {
                 terrIter.remove();
               }
@@ -464,7 +490,11 @@ public final class PlacementPicker {
             g.fillRect(item.x, item.y, placeWidth, placeHeight);
             if (showOverflowMode && !pointIter.hasNext()) {
               g.setColor(Color.gray);
-              g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+              if (currentOverflowToLeft) {
+                g.fillRect(item.x - placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+              } else {
+                g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
+              }
               g.setColor(Color.red);
             }
           }
@@ -483,7 +513,7 @@ public final class PlacementPicker {
         return;
       }
       try (OutputStream out = new FileOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToMany(out, placements);
+        PointFileReaderWriter.writeOneToManyPlacements(out, placements);
         ToolLogger.info("Data written to :" + new File(fileName).getCanonicalPath());
       } catch (final IOException e) {
         ToolLogger.error("Failed to write placements: " + fileName, e);
@@ -500,7 +530,8 @@ public final class PlacementPicker {
         return;
       }
       try (InputStream in = new FileInputStream(placeName)) {
-        placements = PointFileReaderWriter.readOneToMany(in);
+        placements = PointFileReaderWriter.readOneToManyPlacements(in);
+        System.out.println(placements);
       } catch (final IOException e) {
         ToolLogger.error("Failed to load placements: " + placeName, e);
       }
@@ -521,8 +552,10 @@ public final class PlacementPicker {
         // If there isn't an existing array, create one
         if (placements == null || placements.get(currentCountry) == null) {
           currentPlacements = new ArrayList<>();
+          currentOverflowToLeft = false;
         } else {
-          currentPlacements = new ArrayList<>(placements.get(currentCountry));
+          currentPlacements = new ArrayList<>(placements.get(currentCountry).getFirst());
+          currentOverflowToLeft = placements.get(currentCountry).getSecond();
         }
         JOptionPane.showMessageDialog(this, currentCountry);
       } else if (!rightMouse && ctrlDown) {
@@ -535,7 +568,7 @@ public final class PlacementPicker {
           if (placements == null) {
             placements = new HashMap<>();
           }
-          placements.put(currentCountry, currentPlacements);
+          placements.put(currentCountry, Tuple.of(currentPlacements, currentOverflowToLeft));
           currentPlacements = new ArrayList<>();
           ToolLogger.info("done:" + currentCountry);
         }

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -531,7 +531,6 @@ public final class PlacementPicker {
       }
       try (InputStream in = new FileInputStream(placeName)) {
         placements = PointFileReaderWriter.readOneToManyPlacements(in);
-        System.out.println(placements);
       } catch (final IOException e) {
         ToolLogger.error("Failed to load placements: " + placeName, e);
       }

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -11,8 +11,8 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Toolkit;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
@@ -322,7 +322,7 @@ public final class PlacementPicker {
         }
       });
 
-      this.addKeyListener(new KeyListener() {
+      this.addKeyListener(new KeyAdapter() {
         @Override
         public void keyPressed(final KeyEvent e) {
           if (showOverflowMode && currentCountry != null && (e.getKeyCode() == KeyEvent.VK_O)) {
@@ -330,12 +330,6 @@ public final class PlacementPicker {
             repaint();
           }
         }
-
-        @Override
-        public void keyTyped(final KeyEvent e) {}
-
-        @Override
-        public void keyReleased(final KeyEvent e) {}
       });
 
       // set up the image panel size dimensions ...etc

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -58,6 +58,10 @@ public class GameDataTestUtil {
     return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_ITALIANS);
   }
 
+  public static PlayerID italy(final GameData data) {
+    return data.getPlayerList().getPlayerId("Italy");
+  }
+
   /**
    * Get the russian PlayerID for the given GameData object.
    *
@@ -92,6 +96,10 @@ public class GameDataTestUtil {
    */
   public static PlayerID british(final GameData data) {
     return data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_BRITISH);
+  }
+
+  public static PlayerID britain(final GameData data) {
+    return data.getPlayerList().getPlayerId("Britain");
   }
 
   /**
@@ -218,6 +226,14 @@ public class GameDataTestUtil {
     return unitType("germanInfantry", data);
   }
 
+  public static UnitType italianInfantry(final GameData data) {
+    return unitType("italianInfantry", data);
+  }
+
+  public static UnitType britishInfantry(final GameData data) {
+    return unitType("britishInfantry", data);
+  }
+
   /**
    * Returns a bomber UnitType object for the specified GameData object.
    */
@@ -237,6 +253,14 @@ public class GameDataTestUtil {
    */
   public static UnitType germanFactory(final GameData data) {
     return unitType("germanFactory", data);
+  }
+
+  public static UnitType italianFactory(final GameData data) {
+    return unitType("italianFactory", data);
+  }
+
+  public static UnitType britishFactory(final GameData data) {
+    return unitType("britishFactory", data);
   }
 
   /**
@@ -312,7 +336,7 @@ public class GameDataTestUtil {
   /**
    * Adds all units from the given Collection to the given Territory.
    */
-  static void addTo(final Territory t, final Collection<Unit> units) {
+  public static void addTo(final Territory t, final Collection<Unit> units) {
     t.getData().performChange(ChangeFactory.addUnits(t, units));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/ui/screen/TileManagerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/screen/TileManagerTest.java
@@ -1,0 +1,59 @@
+package games.strategy.triplea.ui.screen;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.util.UnitCategory;
+import games.strategy.triplea.xml.TestMapGameData;
+
+public class TileManagerTest {
+
+  @Test
+  public void testGetSortedUnitCategories() throws Exception {
+    final GameData data = TestMapGameData.TWW.getGameData();
+    final Territory northernGermany = territory("Northern Germany", data);
+    northernGermany.getUnits().clear();
+    final List<Unit> units = new ArrayList<>();
+    final PlayerID italians = GameDataTestUtil.italy(data);
+    units.addAll(GameDataTestUtil.italianInfantry(data).create(1, italians));
+    units.addAll(GameDataTestUtil.italianFactory(data).create(1, italians));
+    units.addAll(GameDataTestUtil.truck(data).create(1, italians));
+    final PlayerID british = GameDataTestUtil.britain(data);
+    units.addAll(GameDataTestUtil.britishInfantry(data).create(1, british));
+    units.addAll(GameDataTestUtil.britishFactory(data).create(1, british));
+    units.addAll(GameDataTestUtil.truck(data).create(1, british));
+    final PlayerID germans = GameDataTestUtil.germany(data);
+    units.addAll(GameDataTestUtil.germanInfantry(data).create(1, germans));
+    units.addAll(GameDataTestUtil.germanFactory(data).create(1, germans));
+    units.addAll(GameDataTestUtil.truck(data).create(1, germans));
+    GameDataTestUtil.addTo(northernGermany, units);
+    final List<UnitCategory> categories = TileManager.getSortedUnitCategories(northernGermany, data);
+    final List<UnitCategory> expected = new ArrayList<>();
+    expected.add(createUnitCategory("germanFactory", germans, data));
+    expected.add(createUnitCategory("Truck", germans, data));
+    expected.add(createUnitCategory("germanInfantry", germans, data));
+    expected.add(createUnitCategory("italianFactory", italians, data));
+    expected.add(createUnitCategory("Truck", italians, data));
+    expected.add(createUnitCategory("italianInfantry", italians, data));
+    expected.add(createUnitCategory("britishFactory", british, data));
+    expected.add(createUnitCategory("Truck", british, data));
+    expected.add(createUnitCategory("britishInfantry", british, data));
+    assertEquals(expected, categories);
+  }
+
+  private UnitCategory createUnitCategory(final String unitName, final PlayerID player, final GameData data) {
+    return new UnitCategory(new UnitType(unitName, data), player);
+  }
+
+}


### PR DESCRIPTION
Addresses: 
https://forums.triplea-game.org/topic/680/allow-territory-units-overflow-to-left-instead-of-right
https://forums.triplea-game.org/topic/681/group-and-sort-units-onto-placements-logically

**Functional Changes**
- Map creator placement picker allows toggling overflow direction
- Overflow direction is stored in place.txt
- Unit drawing uses overflow direction
- Improve unit placement ordering to sort by:
--- Owner
--- Infra, Land, Sea, Air
--- XML UnitList ordering

**Testing**
- Used placement picker to change Normandy overflow direction on Iron War. 
Before changes:
![image](https://user-images.githubusercontent.com/1427689/37811062-b3b5f61c-2e25-11e8-85b5-418067926cfa.png)
After direction change:
![image](https://user-images.githubusercontent.com/1427689/37811072-be48584a-2e25-11e8-993a-1e3b28dd5d51.png)
Map showing unit overflow:
![image](https://user-images.githubusercontent.com/1427689/37811078-c9aabc3c-2e25-11e8-9007-f853b7a7aff5.png)

- Tested sorting on TWW
Before:
![image](https://user-images.githubusercontent.com/1427689/37858330-653090fe-2ed1-11e8-8735-02cd7a4d3736.png)
After:
![image](https://user-images.githubusercontent.com/1427689/37858334-6be52932-2ed1-11e8-8bf2-d44f0f0ca3df.png)

