### PR TITLE
Remove extraneous library from installers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,39 +14,30 @@ addons:
       # python for map file splitter
       - python3
       - python3-yaml
-install:
+install: 
  - echo "create database ta_users" | psql -h localhost -U postgres
  - ./gradlew flywayMigrate
 before_script: ./.travis/setup_gpg
-script:
-- ./gradlew --parallel check jacocoTestReport
+script: ./gradlew --parallel check jacocoTestReport
 after_success:
-## if checkstyle violation counts are lower, submit a automatic PR to update the current violation count.
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
-## Update engine property file in-place, append build number. eg: "engine_version = 1.9.0.0" -> "engine_version = 1.9.0.0.1234"
-- ENGINE_VERSION="1.9.0.0.${TRAVIS_BUILD_NUMBER}"
-- LOBBY_VERSION="$ENGINE_VERSION"
-- sed -i "s/^\(engine_version\s*=\).*/\1 ${ENGINE_VERSION}/" game-core/game_engine.properties
 - ./.travis/install_install4j
-- ./gradlew -PengineVersion="$ENGINE_VERSION" generateInstallerReleases
-- ./gradlew -PengineVersion="$ENGINE_VERSION" generateZipReleases
+- ENGINE_VERSION="$(grep engine_version game-core/game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
+- LOBBY_VERSION="1.9.0.0.$TRAVIS_BUILD_NUMBER"
+- ./gradlew -PengineVersion="$ENGINE_VERSION" release
 - ./.travis/generate_artifact_checksums
-## push tag triggers 'deploy' to occur, files listed in 'deploy.files' are uploaded to github releases.
 - ./.travis/push_tag $ENGINE_VERSION
-## Live update maps list on website, read the maps in 'triplea_maps.yaml' and commit updated data files
-## to website json data directory.
 - ./.travis/push_maps
 deploy:
   provider: releases
   api_key:
     secure: nxaqYrkXLGL3W20/eCnf63DLjMrQAhEuW44jggh1/nI383goa+u6w0bBtWCxRdVzos7t4dpVfS6+kv6oIHacm9zVA+RYrqy5opzCJhq8lmXVVRijbALzUeiFif2HURMaKWj0ynRNVlAyBHzazPTLZVWywifpdSubSkuMWkl20cmuKu/Hg3c1EC9se3OYhhTHx3Hya7xSrctrDEYLsEBAUZzkKfscqRVqwwltS88CgIMtRISDpSBGrtH0t1uAH6NitTSguGgb+QEpqnELcRLymX2G1yzMA4Xr5c/L34MfbBKf8vIuG9t411xYuLoyKoUbroTWxSnPwlSy6PHz+QJ7UCXbDkATOGO3chxlKxglppvI/G3n2YP5Zf2dAaDlHblpvarh55i/4i4sKB2AbvvzkIHrQJwUgmLCbpN8/Vp9GWcGkd6i5U7F8tNInCs6ttX3oGvGOfYEXs02Ctyiea4LAqk4S7GZTuV2QXqxXglL4eRIwZ4UETiwgoAAtHma63Eq7+9t2ykMlk7zAK96FGwJrB97wa08aPuSxL94IYEBmn9Ht/vKXRiNQMvpnfp4rWQtL3cqbVyYAg5EjKb4PsBmnb91+RXtnWFOY1RpZGt8sPXYd+KZYzN1BXTFJEpaLLsIDN6r7nMcAvJDUmucaM+m7giPXz1ZBGAic3UBM1qMCgI=
   file_glob: true
-  file:
+  file: 
     - game-core/build/artifacts/*
     - lobby/build/distributions/lobby-$LOBBY_VERSION-server.zip
-  ## This is set to true to not delete artifacts between the 'before-deploy' and 'deploy' steps
   skip_cleanup: true
   prerelease: true
   on:
@@ -63,3 +54,4 @@ notifications:
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
+

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -9,7 +9,7 @@
 
 ## Major releases
 - Can send new game clients to a new lobby: https://github.com/triplea-game/triplea/blob/master/lobby_server.yaml
-- Change the version number in the travis build file: https://github.com/triplea-game/triplea/blob/master/.travis.yml
+- Change the version number in the game_engine.properties file: https://github.com/triplea-game/triplea/blob/master/game_engine.properties
 - Trigger game client notifications: https://github.com/triplea-game/triplea/blob/master/latest_version.properties
 - Update partner sites:  
   - http://www.freewarefiles.com/TripleA_program_56699.html  
@@ -17,6 +17,9 @@
 - Post to forums:
   - https://forums.triplea-game.org/category/1/announcements
   - http://www.axisandallies.org/forums/index.php?board=53.0
+
+
+
 
 
 # Server Ops

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -19,6 +19,7 @@ ext {
     releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")
+    shadowLibsDir = file("$buildDir/shadowLibs")
 
     gameEnginePropertiesFile = file('game_engine.properties')
     gameEnginePropertiesArtifactFile = file("$rootFilesDir/${gameEnginePropertiesFile.name}")
@@ -153,7 +154,7 @@ task integTest(type: Test, dependsOn: [compileIntegTestJava]) {
 }
 
 shadowJar {
-    destinationDir = libsDir
+    destinationDir = shadowLibsDir
     baseName = 'triplea'
     classifier = 'all'
     version = version

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -21,6 +21,7 @@ ext {
     rootFilesDir = file("$buildDir/rootFiles")
 
     gameEnginePropertiesFile = file('game_engine.properties')
+    gameEnginePropertiesArtifactFile = file("$rootFilesDir/${gameEnginePropertiesFile.name}")
 }
 
 def getEngineVersion() {
@@ -31,11 +32,12 @@ def getEngineVersion() {
     def props = new Properties()
     gameEnginePropertiesFile.withInputStream { props.load(it) }
     def devEngineVersion = props.getProperty('engine_version')
-    if (!devEngineVersion) {
-        throw new GradleException("unable to determine engine version: "
-                + "you must define either the project property 'engineVersion' or the game engine property 'engine_version'")
+    if (devEngineVersion) {
+        return "${devEngineVersion}.dev"
     }
-    return "${devEngineVersion}"
+
+    throw new GradleException("unable to determine engine version: "
+        + "you must define either the project property 'engineVersion' or the game engine property 'engine_version'")
 }
 
 def remoteFile(url) {
@@ -179,6 +181,35 @@ task downloadAssets(group: 'release') {
     }
 }
 
+task prepareGameEngineProperties() {
+    group = 'release'
+    description = 'Updates the game engine properties with final values for distribution.'
+
+    doLast {
+        copy {
+            from gameEnginePropertiesFile
+            into gameEnginePropertiesArtifactFile.parent
+        }
+        ant.propertyfile(file: gameEnginePropertiesArtifactFile) {
+            entry key: 'engine_version', value: version
+        }
+    }
+}
+
+task allPlatform(type: Zip, group: 'release', dependsOn: [shadowJar, prepareGameEngineProperties]) {
+    classifier 'all_platforms'
+    ['assets', 'dice_servers'].each { folder ->
+        from(folder) {
+            into(folder)
+        }
+    }
+    from(gameEnginePropertiesArtifactFile)
+    from(shadowJar.outputs) {
+        into('bin')
+    }
+}
+
+task generateZipReleases(group: 'release', dependsOn: [allPlatform]) {}
 
 import com.install4j.gradle.Install4jTask
 task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
@@ -189,7 +220,7 @@ task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAsse
     }
 }
 
-task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]) {
+task prepareInstallers(group: 'release', dependsOn: [generateInstallers]) {
     doLast {
         ant.chmod(dir: releasesDir, perm: '+x', includes: '*.sh')
         def artifacts = [
@@ -211,21 +242,7 @@ task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]
     }
 }
 
-
-task allPlatform(type: Zip, group: 'release', dependsOn: [shadowJar]) {
-    classifier 'all_platforms'
-    ['assets', 'dice_servers'].each { folder ->
-        from(folder) {
-            into(folder)
-        }
-    }
-    from(gameEnginePropertiesFile)
-    from(shadowJar.outputs) {
-        into('bin')
-    }
-}
-
-task generateZipReleases(group: 'release', dependsOn: [allPlatform]) {
+task prepareArtifacts(group: 'release', dependsOn: [generateZipReleases, allPlatform]) {
     doLast {
         def artifacts = [
             file("$distsDir/game-core-$version-all_platforms.zip"),
@@ -246,6 +263,7 @@ task generateZipReleases(group: 'release', dependsOn: [allPlatform]) {
     }
 }
 
+task release(group: 'release', dependsOn: [prepareInstallers, prepareArtifacts]) {}
 
 gradle.taskGraph.whenReady { graph ->
     graph.getAllTasks().any({

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -34,7 +34,7 @@
       <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <fileEntry mountPoint="22" file="game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="22" file="./build/rootFiles/game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
     </entries>
     <components />
   </files>

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -28,7 +28,7 @@
       <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <dirEntry mountPoint="23" file="build/libs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="23" file="build/shadowLibs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
       <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">

--- a/game-core/game_engine.properties
+++ b/game-core/game_engine.properties
@@ -3,4 +3,4 @@
 ## If updating this file, remember to save a backup
 ## first.
 
-engine_version = 1.9.0.0.dev
+engine_version = 1.9.0.0


### PR DESCRIPTION
Fixes #3296 and #3314.

I'm not going to have time to follow up on this PR, so please close it or make use of it however you wish.  I'm just offering it as an alternative solution to the increased installer size problem.

I reverted #3300 in the first commit to start with a clean slate because I didn't have time to figure out if there were any new issues to work around.  The actual fix is a three-line change in the second commit.

The root cause is that, since #3232, the `check` task (most likely one of its dependencies) is generating the _game-core/build/libs/game-core-*.jar_ file.  The `release` (or, in #3300, `generateInstallerReleases`) task then dumps the shadow jar in the same folder (as happened prior to #3296 was reported).  The install4j script simply pulls in every file from _game-core/build/libs_, and thus picks up both jars.

(**EDIT:** The root cause of the new _game-core-*.jar_ file appearing with #3232 is because the `game-core` project now has a dependent project: `lobby`.  Therefore, when `lobby` is built, it causes the `game-core:jar` task to be run so the inter-project dependencies can be resolved.)

Unfortunately, install4j does not appear to support wildcard matching when pulling in a directory (other than some primitive extension exclusion mechanism).  So, the approach taken in this PR is to output the shadow jar to a separate folder, and then point install4j there.

#### Testing

I ran a full release build on my fork, and the installer sizes appear to be back to normal:

![release-artifact-sizes](https://user-images.githubusercontent.com/4826349/37883033-1f63043e-3076-11e8-8ac5-5368b333e3d7.png)

(Note that the lobby installer is missing in the above screenshot, but it looks like that happened with #3232, as well.)

I smoke tested the portable and Unix installers and was able to start a local game with both.