### PR TITLE
Increase default memory from 1GB to 2GB

### DIFF
--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -60,8 +60,8 @@
       <includedFiles />
       <unextractableFiles />
       <vmOptionsFile mode="content" overwriteMode="3" fileMode="644">
-        <content>-Xmx1G
--Xms1G</content>
+        <content>-Xmx2G
+-Xms2G</content>
       </vmOptionsFile>
       <customScript mode="1" file="">
         <content />


### PR DESCRIPTION
Some of the larger maps like TWW need more than 1GB to run well.

It would also be good to not overwrite the .vmoptions file when upgrading TripleA. If someone wants to do some build script voodoo to add that as well :)