### PR TITLE
Create lobby-db zip artifact with migration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_deploy:
 - sed -i "s/^\(engine_version\s*=\).*/\1 ${ENGINE_VERSION}/" game-core/game_engine.properties
 - ./.travis/install_install4j
 - ./gradlew -PengineVersion="$ENGINE_VERSION" -PlobbyVersion="$LOBBY_VERSION" release
+- ./gradlew zipMigrationFiles
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 ## push tag triggers 'deploy' to occur, files listed in 'deploy.files' are uploaded to github releases.

--- a/.travis/collect_artifacts
+++ b/.travis/collect_artifacts
@@ -6,5 +6,7 @@
 
 readonly ARTIFACTS_DIR=./build/artifacts
 
-mkdir -p $ARTIFACTS_DIR
-cp ./**/build/artifacts/* $ARTIFACTS_DIR
+mkdir -p ${ARTIFACTS_DIR}
+
+cp -v ./**/build/artifacts/* ${ARTIFACTS_DIR}
+cp -v ./lobby-db/build/distributions/migrations.zip ${ARTIFACTS_DIR}

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -16,3 +16,7 @@ flyway {
   password = 'postgres'
 }
 
+task zipMigrationFiles(type: Zip, group: 'release') {
+  baseName = "migrations"
+  from('src/main/resources/db/migration')
+}


### PR DESCRIPTION
This PR will post the FlyWay lobby-DB migration files to Github releases. This will allow infrastructure to download those files and execute migrations on demand.
