### PR TITLE
Output shadow jar to a different folder

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -19,6 +19,7 @@ ext {
     releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")
+    shadowLibsDir = file("$buildDir/shadowLibs")
 
     gameEnginePropertiesFile = file('game_engine.properties')
 }
@@ -141,7 +142,7 @@ task integTest(type: Test) {
 }
 
 shadowJar {
-    destinationDir = libsDir
+    destinationDir = shadowLibsDir
     baseName = 'triplea'
     classifier = 'all'
     version = version

--- a/game-core/build.install4j
+++ b/game-core/build.install4j
@@ -28,7 +28,7 @@
       <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <dirEntry mountPoint="23" file="build/libs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="23" file="build/shadowLibs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
       <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">


### PR DESCRIPTION
Modify installer build script to only pull libraries from the shadow
libs folder instead of the standard libs folder.

-----------

This is a cherry-pick of: https://github.com/triplea-game/triplea/pull/3316; with thanks to @ssoloff for supplying a fix. I was able to verify that this locally fixes the double jar, on travis given the new folders we should hopefully put this one to bed.


<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
