### PR TITLE
Add in-game downloaded map unzip support

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -75,8 +75,7 @@ public class ResourceLoader implements Closeable {
    *
    * <p>
    * The candidate directories are returned in order of preference. That is, a candidate directory earlier in the list
-   * should
-   * be preferred to a candidate directory later in the list assuming they both exist.
+   * should be preferred to a candidate directory later in the list assuming they both exist.
    * </p>
    *
    * @param mapName The map name; must not be {@code null}.

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -83,7 +83,8 @@ public class ResourceLoader implements Closeable {
    *
    * @return A list of candidate directories; never {@code null}.
    */
-  public static List<File> getMapDirectoryCandidates(final String mapName) {
+  @VisibleForTesting
+  static List<File> getMapDirectoryCandidates(final String mapName) {
     checkNotNull(mapName);
 
     final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -71,6 +71,32 @@ public class ResourceLoader implements Closeable {
   }
 
   /**
+   * Returns a list of candidate directories from which the specified map may be loaded.
+   *
+   * <p>
+   * The candidate directories are returned in order of preference. That is, a candidate directory earlier in the list
+   * should
+   * be preferred to a candidate directory later in the list assuming they both exist.
+   * </p>
+   *
+   * @param mapName The map name; must not be {@code null}.
+   *
+   * @return A list of candidate directories; never {@code null}.
+   */
+  public static List<File> getMapDirectoryCandidates(final String mapName) {
+    checkNotNull(mapName);
+
+    final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();
+    final String dirName = File.separator + mapName;
+    final String normalizedMapName = File.separator + normalizeMapName(mapName) + "-master";
+    return Arrays.asList(
+        new File(userMapsFolder, dirName + File.separator + "map"),
+        new File(userMapsFolder, dirName),
+        new File(userMapsFolder, normalizedMapName + File.separator + "map"),
+        new File(userMapsFolder, normalizedMapName));
+  }
+
+  /**
    * Returns a list of candidate zip files from which the specified map may be loaded.
    *
    * <p>
@@ -115,11 +141,9 @@ public class ResourceLoader implements Closeable {
     if (mapName == null) {
       return new ArrayList<>();
     }
-    // find the primary directory/file
-    final String dirName = File.separator + mapName;
+
     final List<File> candidates = new ArrayList<>();
-    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName + File.separator + "map"));
-    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName));
+    candidates.addAll(getMapDirectoryCandidates(mapName));
     candidates.addAll(getMapZipFileCandidates(mapName));
 
     final Optional<File> match = candidates.stream().filter(File::exists).findFirst();

--- a/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -19,6 +19,31 @@ import com.google.common.collect.Maps;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 public class ResourceLoaderTest extends AbstractClientSettingTestCase {
+
+  @Test
+  public void testGetMapDirectoryCandidatesIncludesNameThenMap() {
+    final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
+    assertThat(candidates, containsDirectoryEndingWith("MapName" + File.separator + "map"));
+  }
+
+  @Test
+  public void testGetMapDirectoryCandidatesIncludesName() {
+    final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
+    assertThat(candidates, containsDirectoryEndingWith("MapName"));
+  }
+
+  @Test
+  public void testGetMapDirectoryCandidatesIncludesGithubNameThenMap() {
+    final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
+    assertThat(candidates, containsDirectoryEndingWith("map_name-master" + File.separator + "map"));
+  }
+
+  @Test
+  public void testGetMapDirectoryCandidatesIncludesGithubName() {
+    final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
+    assertThat(candidates, containsDirectoryEndingWith("map_name-master"));
+  }
+
   @Test
   public void testGetMapZipFileCandidates_ShouldIncludeDefaultZipFile() {
     final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
@@ -38,6 +63,22 @@ public class ResourceLoaderTest extends AbstractClientSettingTestCase {
     final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
 
     assertThat(candidates, containsFileWithName("map_name-master.zip"));
+  }
+
+  private static Matcher<Iterable<File>> containsDirectoryEndingWith(final String name) {
+    return new TypeSafeMatcher<Iterable<File>>() {
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText("iterable containing file with name ").appendValue(name);
+      }
+
+      @Override
+      protected boolean matchesSafely(final Iterable<File> files) {
+        return StreamSupport.stream(files.spliterator(), false)
+            .map(File::getPath)
+            .anyMatch(p -> p.endsWith(name));
+      }
+    };
   }
 
   private static Matcher<Iterable<File>> containsFileWithName(final String name) {


### PR DESCRIPTION
Addresses https://forums.triplea-game.org/topic/706/open-unzipped-map

**Functional Changes**
- Adds map directory support for unzipped maps downloaded from in-game in the form of:
--- "map_name-master/map"
--- "map_name-master"

**Testing**
- Unzipped any map that was downloaded from in-game for example "blue_vs_gray-master.zip" to "blue_vs_gray-master/map"