### PR TITLE
Map Drawing cleanup

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -524,7 +524,7 @@ public class MapPanel extends ImageScrollerLargeView {
   public void paint(final Graphics g) {
     final Graphics2D g2d = (Graphics2D) g;
     super.paint(g2d);
-    g2d.clip(new Rectangle2D.Double(0, 0, (getImageWidth() * scale), (getImageHeight() * scale)));
+    g2d.clip(new Rectangle2D.Double(0, 0, getImageWidth() * scale, getImageHeight() * scale));
     int x = model.getX();
     int y = model.getY();
     final List<Tile> images = new ArrayList<>();
@@ -573,15 +573,14 @@ public class MapPanel extends ImageScrollerLargeView {
     if (routeDescription != null) {
       routeDrawer.drawRoute(g2d, routeDescription, movementLeftForCurrentUnits, movementFuelCost,
           uiContext.getResourceImageFactory());
-
     }
     // used to keep strong references to what is on the screen so it wont be garbage collected
     // other references to the images are weak references
     this.images.clear();
     this.images.addAll(images);
     if (highlightedUnits != null) {
-      for (final Entry<Territory, List<Unit>> entry : highlightedUnits.entrySet()) {
-        final Set<UnitCategory> categories = UnitSeperator.categorize(entry.getValue());
+      for (final List<Unit> value : highlightedUnits.values()) {
+        final Set<UnitCategory> categories = UnitSeperator.categorize(value);
         for (final UnitCategory category : categories) {
           final List<Unit> territoryUnitsOfSameCategory = category.getUnits();
           if (territoryUnitsOfSameCategory.isEmpty()) {
@@ -660,14 +659,12 @@ public class MapPanel extends ImageScrollerLargeView {
     }
   }
 
-  private void drawTiles(final Graphics2D g, final List<Tile> images, final GameData data, Rectangle2D.Double bounds,
-      final List<Tile> undrawn) {
-    final List<Tile> tileList = tileManager.getTiles(bounds);
-    bounds = new Rectangle2D.Double(bounds.getX(), bounds.getY(), bounds.getHeight(), bounds.getWidth());
-    for (final Tile tile : tileList) {
-      final Image img;
+  private void drawTiles(final Graphics2D g, final List<Tile> images, final GameData data,
+      final Rectangle2D.Double bounds, final List<Tile> undrawn) {
+    for (final Tile tile : tileManager.getTiles(bounds)) {
       tile.acquireLock();
       try {
+        final Image img;
         if (tile.isDirty()) {
           // take what we can get to avoid screen flicker
           undrawn.add(tile);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -532,7 +532,7 @@ public class MapPanel extends ImageScrollerLargeView {
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(MapPanel.class.getName()), Level.FINER, "Paint");
     // make sure we use the same data for the entire paint
     final GameData data = gameData;
-    // if the map fits on screen, dont draw any overlap
+    // if the map fits on screen, don't draw any overlap
     final boolean fitAxisX = !mapWidthFitsOnScreen() && uiContext.getMapData().scrollWrapX();
     final boolean fitAxisY = !mapHeightFitsOnScreen() && uiContext.getMapData().scrollWrapY();
     if (fitAxisX || fitAxisY) {
@@ -580,8 +580,7 @@ public class MapPanel extends ImageScrollerLargeView {
     this.images.addAll(images);
     if (highlightedUnits != null) {
       for (final List<Unit> value : highlightedUnits.values()) {
-        final Set<UnitCategory> categories = UnitSeperator.categorize(value);
-        for (final UnitCategory category : categories) {
+        for (final UnitCategory category : UnitSeperator.categorize(value)) {
           final List<Unit> territoryUnitsOfSameCategory = category.getUnits();
           if (territoryUnitsOfSameCategory.isEmpty()) {
             continue;
@@ -594,10 +593,9 @@ public class MapPanel extends ImageScrollerLargeView {
           final Optional<Image> image = uiContext.getUnitImageFactory().getHighlightImage(category.getType(),
               category.getOwner(), category.hasDamageOrBombingUnitDamage(), category.getDisabled());
           if (image.isPresent()) {
-            final AffineTransform t = new AffineTransform();
-            t.translate(normalizeX(r.getX() - getXOffset()) * scale, normalizeY(r.getY() - getYOffset()) * scale);
-            t.scale(scale, scale);
-            g2d.drawImage(image.get(), t, this);
+            final AffineTransform transform = AffineTransform.getScaleInstance(scale, scale);
+            transform.translate(normalizeX(r.getX() - getXOffset()), normalizeY(r.getY() - getYOffset()));
+            g2d.drawImage(image.get(), transform, this);
           }
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -41,7 +41,7 @@ public class Tile {
     this.x = x;
     this.y = y;
     this.scale = scale;
-    image = createBlankImage();
+    image = Util.createImage((int) (bounds.getWidth() * scale), (int) (bounds.getHeight() * scale), true);
   }
 
   public boolean isDirty() {
@@ -76,10 +76,6 @@ public class Tile {
     } finally {
       releaseLock();
     }
-  }
-
-  private BufferedImage createBlankImage() {
-    return Util.createImage((int) (bounds.getWidth() * scale), (int) (bounds.getHeight() * scale), true);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -1,8 +1,6 @@
 package games.strategy.triplea.ui.screen;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Rectangle;
@@ -28,8 +26,6 @@ import games.strategy.ui.Util;
 
 public class Tile {
   public static final LockUtil LOCK_UTIL = LockUtil.INSTANCE;
-  private static final boolean DRAW_DEBUG = false;
-  private static final Logger logger = Logger.getLogger(Tile.class.getName());
 
   // allow the gc to implement memory management
   private SoftReference<Image> imageRef;
@@ -119,7 +115,8 @@ public class Tile {
     } else {
       scaled = unscaled;
     }
-    final Stopwatch stopWatch = new Stopwatch(logger, Level.FINEST, "Drawing Tile at" + bounds);
+    final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(Tile.class.getName()), Level.FINEST,
+        "Drawing Tile at" + bounds);
     // clear
     g.setColor(Color.BLACK);
     g.fill(new Rectangle(0, 0, TileManager.TILE_SIZE, TileManager.TILE_SIZE));
@@ -128,15 +125,6 @@ public class Tile {
       drawable.draw(bounds, data, g, mapData, unscaled, scaled);
     }
     isDirty = false;
-    // draw debug graphics
-    if (DRAW_DEBUG) {
-      g.setColor(Color.PINK);
-      final Rectangle r = new Rectangle(1, 1, TileManager.TILE_SIZE - 2, TileManager.TILE_SIZE - 2);
-      g.setStroke(new BasicStroke(1));
-      g.draw(r);
-      g.setFont(new Font("Ariel", Font.BOLD, 25));
-      g.drawString(x + " " + y, 40, 40);
-    }
     stopWatch.done();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -166,8 +167,8 @@ public class TileManager {
     try {
       // create our tiles
       tiles = new ArrayList<>();
-      for (int x = 0; (x) * TILE_SIZE < bounds.width; x++) {
-        for (int y = 0; (y) * TILE_SIZE < bounds.height; y++) {
+      for (int x = 0; x * TILE_SIZE < bounds.width; x++) {
+        for (int y = 0; y * TILE_SIZE < bounds.height; y++) {
           tiles.add(new Tile(new Rectangle(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE), x, y,
               uiContext.getScale()));
         }
@@ -195,8 +196,9 @@ public class TileManager {
         }
         // add the decorations
         final Map<Image, List<Point>> decorations = mapData.getDecorations();
-        for (final Image img : decorations.keySet()) {
-          for (final Point p : decorations.get(img)) {
+        for (final Entry<Image, List<Point>> entry : decorations.entrySet()) {
+          final Image img = entry.getKey();
+          for (final Point p : entry.getValue()) {
             final DecoratorDrawable drawable = new DecoratorDrawable(p, img);
             final Rectangle bounds = new Rectangle(p.x, p.y, img.getWidth(null), img.getHeight(null));
             for (final Tile t : getTiles(bounds)) {


### PR DESCRIPTION
This does some cleanup in drawing-related classes.
I'm not 100% sure if the second commit works without keeping any references after closing the map panel.
A Tile object _should_ no longer be referenced once a TripleAFrame gets disposed. I couldn't see any big difference in memory usage.