### PR TITLE
Make sure previously loaded transports are tried last

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -235,7 +235,7 @@ public class TransportTracker {
     return loadedUnits;
   }
 
-  static boolean hasTransportUnloadedInPreviousPhase(final Unit transport) {
+  public static boolean hasTransportUnloadedInPreviousPhase(final Unit transport) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     // See if transport has unloaded anywhere yet
     for (final Unit u : unloaded) {

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -192,9 +192,9 @@ public class TransportUtils {
 
   private static List<Unit> sortByTransportCapacityDescendingThenMovesDescending(final Collection<Unit> transports) {
     final List<Unit> canTransport = new ArrayList<>(transports);
-    canTransport.sort(Comparator.comparingInt(TransportTracker::getAvailableCapacity)
-        .thenComparing(TripleAUnit::get,
-            Comparator.comparingInt(TripleAUnit::getMovementLeft).reversed()));
+    canTransport.sort(Comparator.comparing(TransportTracker::hasTransportUnloadedInPreviousPhase)
+        .thenComparingInt(TransportTracker::getAvailableCapacity)
+        .thenComparing(TripleAUnit::get, Comparator.comparingInt(TripleAUnit::getMovementLeft).reversed()));
     return canTransport;
   }
 


### PR DESCRIPTION
Fixes issue reported here: https://forums.triplea-game.org/topic/493/total-world-war-december-1941-beta-2-8-0-3/163

**Bug**
After an amphibious assault, transports that didn't unload any units aren't able to be loaded in NCM (see attached game where Germany can't load in SZ27): 
[1522769365231-tww-krautz-3.zip](https://github.com/triplea-game/triplea/files/1874012/1522769365231-tww-krautz-3.zip)


**Background**
This logic was removed about 2 years ago when transport loading was enhanced as it didn't appear to be needed but actually is needed in some rare cases: https://github.com/triplea-game/triplea/pull/647/files#diff-9e673fd7f1882639b0d1e43323f11c53L142