### PR TITLE
Replace 'add.*If(boolean, Supplier<Component>)' with 'add.*If(Optional<Component>)'

### DIFF
--- a/game-core/src/main/java/org/triplea/client/launch/screens/LaunchScreen.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/LaunchScreen.java
@@ -39,11 +39,6 @@ public enum LaunchScreen {
     return Optional.ofNullable(previousScreen);
   }
 
-  public LaunchScreen getPreviousScreenNotOptional() {
-    return getPreviousScreen()
-        .orElseThrow(() -> new IllegalStateException("Previous screen is null for enum value: " + name()));
-  }
-
   public JComponent buildScreen() {
     return windowBuilder.get();
   }

--- a/game-core/src/main/java/org/triplea/client/launch/screens/NavigationPanelFactory.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/NavigationPanelFactory.java
@@ -68,13 +68,12 @@ public class NavigationPanelFactory {
         .flowLayout()
         .add(playButton)
         .add(Box.createHorizontalStrut(50))
-        .addIf(
-            screenWindow.getPreviousScreen().isPresent(),
-            JButtonBuilder.builder()
+        .addIf(screenWindow.getPreviousScreen()
+            .map(prevScreen -> JButtonBuilder.builder()
                 .title("Back")
-                .enabled(screenWindow.getPreviousScreen().isPresent())
-                .actionListener(() -> LaunchScreenWindow.draw(screenWindow.getPreviousScreenNotOptional()))
-                .build())
+                .enabled(true)
+                .actionListener(() -> LaunchScreenWindow.draw(prevScreen))
+                .build()))
         .add(Box.createHorizontalStrut(50))
         .add(JButtonBuilder.builder()
             .title("Quit")

--- a/game-core/src/main/java/org/triplea/client/launch/screens/staging/StagingScreen.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/staging/StagingScreen.java
@@ -1,6 +1,7 @@
 package org.triplea.client.launch.screens.staging;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
@@ -105,7 +106,8 @@ public enum StagingScreen {
                 .addNorth(gameInfoPanel(gameData))
                 .addCenter(playerAndBidSelectionTabs(gameData, this, playerSelectionModel))
                 .build())
-            .addSouthIf(chatSupport != null, chatSupport::getChatPanel)
+            .addSouthIf(Optional.ofNullable(chatSupport)
+                .map(ChatSupport::getChatPanel))
             .build())
         .build();
 

--- a/game-core/src/main/java/swinglib/JPanelBuilder.java
+++ b/game-core/src/main/java/swinglib/JPanelBuilder.java
@@ -12,7 +12,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.function.Supplier;
+import java.util.Optional;
 
 import javax.imageio.ImageIO;
 import javax.swing.BorderFactory;
@@ -307,8 +307,10 @@ public class JPanelBuilder {
     return this;
   }
 
-  public JPanelBuilder addIf(final boolean condition, final Component component) {
-    return condition ? add(component) : this;
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public JPanelBuilder addIf(final Optional<Component> component) {
+    component.ifPresent(this::add);
+    return this;
   }
 
   public JPanelBuilder add(final Component component) {
@@ -333,10 +335,9 @@ public class JPanelBuilder {
    * Assumes a border layout, adds a given component to the southern portion of the border layout
    * if the boolean parameter is true.
    */
-  public JPanelBuilder addSouthIf(final boolean condition, final Supplier<JComponent> builder) {
-    if (condition) {
-      addSouth(builder.get());
-    }
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public JPanelBuilder addSouthIf(final Optional<JComponent> component) {
+    component.ifPresent(this::addSouth);
     return this;
   }
 


### PR DESCRIPTION

With the first construct, IDE analysis really wants to highlight that the Supplier can be replaced
from a lambda, '() -> canBeNull.getSomething()' to method reference:  'canBeNull::getSomething()'

The former will be passed as a reference and would only NPE if invoked. The latter is evaluated as a parameter, which is done before the method code is executed, and we get a NPE in that case.

This works:
```
addIf(ref != null, ref -> ref.getComponent())
```
But this would NPE as parameters are evaulated, and a method reference would follow the object reference to know which method it needs to call, eg:
```
addIf(ref != null, ref::getComponent)
```

Instead to fix this we'll bake things into the arguments and combine the 'boolean arg + Supplier arg' to be a single 'optional' arg instead. By using the 'optional' `map` function, we can achieve the same effect of pulling a property off of a component only when it is not null.

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
