### PR TITLE
Filter out infra units from hit point calculation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -65,6 +65,9 @@ public class BattleCalculator {
         .thenComparing(UnitComparator.getLowestToHighestMovementComparator()));
   }
 
+  /**
+   * Find total remaining hit points of units.
+   */
   public static int getTotalHitpointsLeft(final Collection<Unit> units) {
     if (units == null || units.isEmpty()) {
       return 0;
@@ -72,8 +75,10 @@ public class BattleCalculator {
     int totalHitPoints = 0;
     for (final Unit u : units) {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
-      totalHitPoints += ua.getHitPoints();
-      totalHitPoints -= u.getHits();
+      if (!ua.getIsInfrastructure()) {
+        totalHitPoints += ua.getHitPoints();
+        totalHitPoints -= u.getHits();
+      }
     }
     return totalHitPoints;
   }


### PR DESCRIPTION
Infra units can participate in battles but they have 0 HP and are either captured/destroyed if no other units remain. Fix the HP calculation and display in BC.

Example of HoH where cannon are infra:
![image](https://user-images.githubusercontent.com/1427689/38596107-51face62-3d15-11e8-8b99-e5db6f483d4d.png)
