### PR TITLE
Short class names for delegates

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -138,7 +138,7 @@ public class XmlGameElementMapper {
           .put("UserActionAttachment",
               attachmentData -> new UserActionAttachment(attachmentData.name, attachmentData.attachable,
                   attachmentData.gameData))
-          .put("TestAttachment", attachmentData -> new TestAttachment(attachmentData.name,
+          .put("games.strategy.engine.xml.TestAttachment", attachmentData -> new TestAttachment(attachmentData.name,
               attachmentData.attachable, attachmentData.gameData))
           .build();
 
@@ -165,9 +165,8 @@ public class XmlGameElementMapper {
       handleMissingObjectError("delegate", className);
       return Optional.empty();
     }
-
-    final Supplier<IDelegate> delegateFactory = delegateMap.get(bareName);
-    return Optional.of(delegateFactory.get());
+    
+    return Optional.of(delegateMap.get(bareName).get());
   }
 
   private static void handleMissingObjectError(final String typeLabel, final String value) {
@@ -179,7 +178,7 @@ public class XmlGameElementMapper {
 
   public Optional<IAttachment> getAttachment(final String javaClass, final String name, final Attachable attachable,
       final GameData data) {
-    final String bareName = javaClass.replaceAll("^games\\.strategy\\.(?:triplea\\.attachments|engine\\.xml)\\.", "");
+    final String bareName = javaClass.replaceAll("^games\\.strategy\\.triplea\\.attachments\\.", "");
     if (!attachmentMap.containsKey(bareName)) {
       handleMissingObjectError("attachment", javaClass);
       return Optional.empty();

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -165,7 +165,13 @@ public class XmlGameElementMapper {
       handleMissingObjectError("delegate", className);
       return Optional.empty();
     }
-    
+
+    if (className.startsWith("games.strategy.twoIfBySea.delegate.")) {
+      ClientLogger.logQuietly("Use of twoIfBySea delegates is discouraged "
+          + "and will be removed in a future "
+          + "version of TripleA.");
+    }
+
     return Optional.of(delegateMap.get(bareName).get());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -66,32 +66,27 @@ import games.strategy.twoIfBySea.delegate.InitDelegate;
  * </p>
  */
 public class XmlGameElementMapper {
-
-  // these keys are package protected to allow test to have access to known good keys
-  @VisibleForTesting
-  static final String BATTLE_DELEGATE_NAME = "games.strategy.triplea.delegate.BattleDelegate";
-
   /* Maps a name (given as an XML attribute value) to a supplier function that creates the corresponding delegate */
   private final ImmutableMap<String, Supplier<IDelegate>> delegateMap =
       ImmutableMap.<String, Supplier<IDelegate>>builder()
-          .put(BATTLE_DELEGATE_NAME, BattleDelegate::new)
-          .put("games.strategy.triplea.delegate.BidPlaceDelegate", BidPlaceDelegate::new)
-          .put("games.strategy.triplea.delegate.BidPurchaseDelegate", BidPurchaseDelegate::new)
-          .put("games.strategy.triplea.delegate.EndRoundDelegate", EndRoundDelegate::new)
-          .put("games.strategy.triplea.delegate.EndTurnDelegate", EndTurnDelegate::new)
-          .put("games.strategy.triplea.delegate.InitializationDelegate", InitializationDelegate::new)
-          .put("games.strategy.triplea.delegate.MoveDelegate", MoveDelegate::new)
-          .put("games.strategy.triplea.delegate.NoAirCheckPlaceDelegate", NoAirCheckPlaceDelegate::new)
-          .put("games.strategy.triplea.delegate.NoPUEndTurnDelegate", NoPUEndTurnDelegate::new)
-          .put("games.strategy.triplea.delegate.NoPUPurchaseDelegate", NoPUPurchaseDelegate::new)
-          .put("games.strategy.triplea.delegate.PlaceDelegate", PlaceDelegate::new)
-          .put("games.strategy.triplea.delegate.PoliticsDelegate", PoliticsDelegate::new)
-          .put("games.strategy.triplea.delegate.PurchaseDelegate", PurchaseDelegate::new)
-          .put("games.strategy.triplea.delegate.RandomStartDelegate", RandomStartDelegate::new)
-          .put("games.strategy.triplea.delegate.SpecialMoveDelegate", SpecialMoveDelegate::new)
-          .put("games.strategy.triplea.delegate.TechActivationDelegate", TechActivationDelegate::new)
-          .put("games.strategy.triplea.delegate.TechnologyDelegate", TechnologyDelegate::new)
-          .put("games.strategy.triplea.delegate.UserActionDelegate", UserActionDelegate::new)
+          .put("BattleDelegate", BattleDelegate::new)
+          .put("BidPlaceDelegate", BidPlaceDelegate::new)
+          .put("BidPurchaseDelegate", BidPurchaseDelegate::new)
+          .put("EndRoundDelegate", EndRoundDelegate::new)
+          .put("EndTurnDelegate", EndTurnDelegate::new)
+          .put("InitializationDelegate", InitializationDelegate::new)
+          .put("MoveDelegate", MoveDelegate::new)
+          .put("NoAirCheckPlaceDelegate", NoAirCheckPlaceDelegate::new)
+          .put("NoPUEndTurnDelegate", NoPUEndTurnDelegate::new)
+          .put("NoPUPurchaseDelegate", NoPUPurchaseDelegate::new)
+          .put("PlaceDelegate", PlaceDelegate::new)
+          .put("PoliticsDelegate", PoliticsDelegate::new)
+          .put("PurchaseDelegate", PurchaseDelegate::new)
+          .put("RandomStartDelegate", RandomStartDelegate::new)
+          .put("SpecialMoveDelegate", SpecialMoveDelegate::new)
+          .put("TechActivationDelegate", TechActivationDelegate::new)
+          .put("TechnologyDelegate", TechnologyDelegate::new)
+          .put("UserActionDelegate", UserActionDelegate::new)
           .put("games.strategy.twoIfBySea.delegate.EndTurnDelegate",
               games.strategy.twoIfBySea.delegate.EndTurnDelegate::new)
           .put("games.strategy.twoIfBySea.delegate.InitDelegate", InitDelegate::new)
@@ -165,12 +160,13 @@ public class XmlGameElementMapper {
    * Assumes a zero argument constructor.
    */
   public Optional<IDelegate> getDelegate(final String className) {
-    if (!delegateMap.containsKey(className)) {
+    final String bareName = className.replaceAll("^games\\.strategy\\.triplea\\.delegate\\.", "");
+    if (!delegateMap.containsKey(bareName)) {
       handleMissingObjectError("delegate", className);
       return Optional.empty();
     }
 
-    final Supplier<IDelegate> delegateFactory = delegateMap.get(className);
+    final Supplier<IDelegate> delegateFactory = delegateMap.get(bareName);
     return Optional.of(delegateFactory.get());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -168,8 +168,7 @@ public class XmlGameElementMapper {
 
     if (className.startsWith("games.strategy.twoIfBySea.delegate.")) {
       ClientLogger.logQuietly("Use of twoIfBySea delegates is discouraged "
-          + "and will be removed in a future "
-          + "version of TripleA.");
+          + "and will be removed in a future version of TripleA.");
     }
 
     return Optional.of(delegateMap.get(bareName).get());

--- a/game-core/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
@@ -53,7 +53,7 @@ public class XmlGameElementMapperTest {
 
   @Test
   public void getDelegateHappyCase() {
-    final Optional<IDelegate> resultObject = testObj.getDelegate(XmlGameElementMapper.BATTLE_DELEGATE_NAME);
+    final Optional<IDelegate> resultObject = testObj.getDelegate("games.strategy.triplea.delegate.BattleDelegate");
     assertThat(resultObject.isPresent(), is(true));
     assertThat(resultObject.get(), instanceOf(BattleDelegate.class));
   }


### PR DESCRIPTION
This Sounds like a straight forward change, but I'd like to hear your opinion about it, because it consists of 3 different parts that I want your opinion on.
1. Allow short hand names for delegates in `games.strategy.triplea.delegate`, because of the name conflicts for delegates in `games.strategy.twoIfbySea.delegate`, those names need to be spelled out regardless of this change (because usage of those delegates [is rare](https://github.com/search?p=1&q=org%3Atriplea-maps+twoIfBySea&type=Code&utf8=%E2%9C%93))
2. Noticing that we have a special TestDelegate type that is only being invoked by test code (or at least this is what I hope to be happening with this name). I didn't add a short version for that, and made the behaviour of attachments consistent with this, because there's also a special TestAttachment class. However this strongly hints at either a flaw with testing (test attachments should be only available for test cases and not for production code), or bad naming (why is it a **Test**Attachment then?)
3. As a consequence of 1) and based on the [feedback of this thread](https://forums.triplea-game.org/topic/595/short-attachment-names) add a warning for any maps that use twoIfBySea delegates and inform the potential map maker that those shouldn't be used. ("Will be removed in a future version of TripleA")

/cc @DanVanAtta @ron-murhammer @ssoloff