### PR TITLE
Clear OOL cache on both server and client games for every phase

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -18,6 +18,7 @@ import games.strategy.engine.random.IRemoteRandom;
 import games.strategy.engine.random.RemoteRandom;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.util.Interruptibles;
 
 public class ClientGame extends AbstractGame {
@@ -101,6 +102,7 @@ public class ClientGame extends AbstractGame {
         if (!loadedFromSavedGame) {
           gameData.getHistory().getHistoryWriter().startNextStep(stepName, delegateName, player, displayName);
         }
+        BattleCalculator.clearOolCache();
         notifyGameStepListeners(stepName, delegateName, player, round, displayName);
       }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -31,7 +31,6 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
-import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.triplea.delegate.BattleDelegate;
 import games.strategy.triplea.delegate.DelegateFinder;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -133,7 +132,6 @@ public class ProAi extends AbstractAi {
   protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data,
       final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOolCache();
     ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     calc.setData(data);
@@ -156,7 +154,6 @@ public class ProAi extends AbstractAi {
   protected void purchase(final boolean purchaseForBid, final int pusToSpend, final IPurchaseDelegate purchaseDelegate,
       final GameData data, final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOolCache();
     ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     if (pusToSpend <= 0) {
@@ -251,7 +248,6 @@ public class ProAi extends AbstractAi {
   protected void place(final boolean bid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
       final PlayerID player) {
     final long start = System.currentTimeMillis();
-    BattleCalculator.clearOolCache();
     ProLogUi.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     initializeData();
     purchaseAi.place(storedPurchaseTerritories, placeDelegate);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -44,7 +44,7 @@ public abstract class AbstractDelegate implements IDelegate {
    */
   @Override
   public void start() {
-    // nothing to do here
+    BattleCalculator.clearOolCache();
   }
 
   /**


### PR DESCRIPTION
Address #3366 

**Functional Changes**
- Clear OOL cache at the start of every delegate for both server and client
- Remove AI specific OOL cache clear at the start of move/purchase/place delegates since its now covered by start of every delegate

**Testing**
- I was able to reproduce the unbounded growth of the OOL cache on TWW locally by playing essentially 1 round and seeing it incrementally grow to ~100MB. Implemented this change and retested and saw that the cache cleared after each phase and stayed small even after 1 round of TWW. I tested an AI game as well to make sure it properly cleared the OOL cache as it was already doing.