### PR TITLE
Set max units to buy to 10000 if the cost is 0 to avoid errors

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -159,11 +159,11 @@ public class ResourceCollection extends GameDataComponent {
   }
 
   /**
-   * @return will return 10000 if it can fit more times than 10000. will return Integer MaxValue if cost is zero.
+   * Returns 10,000 if it can fit more times than 10000 or if cost is zero.
    */
   public int fitsHowOften(final IntegerMap<Resource> cost) {
     if (cost.size() == 0 || (cost.totalValues() <= 0 && cost.isPositive())) {
-      return Integer.MAX_VALUE;
+      return 10000;
     }
     final ResourceCollection resources = new ResourceCollection(getData(), m_resources);
     for (int i = 0; i <= 10000; i++) {
@@ -174,8 +174,6 @@ public class ResourceCollection extends GameDataComponent {
         return i;
       }
     }
-    // throw new IllegalArgumentException("Unlimited purchases shouldn't be possible");
-    // System.out.println("Can purchase more than 10,000 of unit - Unlimited purchases shouldn't be possible");
     return 10000;
   }
 


### PR DESCRIPTION
Address https://forums.triplea-game.org/topic/758/zero-cost-production

Fix purchase/repair to set max units to 10000 for 0 cost just like it does if more than 10000 can be purchased. This avoids an error that was throw when 1 is added to Integer.MAX_VALUE.