### PR TITLE
Move call to clear current battle territory to avoid save game bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -31,7 +31,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
-import games.strategy.triplea.delegate.IBattle;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.dataObjects.BattleListing;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
@@ -451,12 +450,6 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       }
       final BattleListing battles = battleDel.getBattles();
       if (battles.isEmpty()) {
-        final IBattle battle = battleDel.getCurrentBattle();
-        if (battle != null) {
-          // this should never happen, but it happened once....
-          System.err.println("Current battle exists but is not on pending list:  " + battle.toString());
-          battleDel.fightCurrentBattle();
-        }
         return;
       }
       if (!soundPlayedAlreadyBattle) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -82,7 +82,7 @@ public class ProSimulateTurnUtils {
           delegateBridge.addChange(ChangeFactory.changeOwner(t, player));
         }
         battleDelegate.getBattleTracker().getConquered().add(t);
-        battleDelegate.getBattleTracker().removeBattle(battle);
+        battleDelegate.getBattleTracker().removeBattle(battle, data);
         final Territory updatedTerritory = data.getMap().getTerritory(t.getName());
         ProLogger.debug(
             "after changes owner=" + updatedTerritory.getOwner() + ", units=" + updatedTerritory.getUnits().getUnits());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -386,7 +386,7 @@ public class AirBattle extends AbstractBattle {
         m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     getDisplay(bridge).battleEnd(m_battleID, "Air Battle over");
     m_isOver = true;
-    m_battleTracker.removeBattle(AirBattle.this);
+    m_battleTracker.removeBattle(AirBattle.this, bridge.getData());
   }
 
   void finishBattleAndRemoveFromTrackerHeadless(final IDelegateBridge bridge) {
@@ -395,7 +395,7 @@ public class AirBattle extends AbstractBattle {
     m_battleResultDescription = BattleRecord.BattleResultDescription.NO_BATTLE;
     m_battleTracker.getBattleRecords().removeBattle(m_attacker, m_battleID);
     m_isOver = true;
-    m_battleTracker.removeBattle(AirBattle.this);
+    m_battleTracker.removeBattle(AirBattle.this, bridge.getData());
   }
 
   private void attackerRetreat(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -187,6 +187,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     battleTracker.clearEmptyAirBattleAttacks(bridge);
   }
 
+  // TODO: Remove unused method for next incompatible release
   @Override
   public String fightCurrentBattle() {
     if (currentBattle == null) {
@@ -217,10 +218,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       return "Must complete " + getFightingWord(firstPrecede) + " in " + name + " first";
     }
     currentBattle = battle;
-    // fight the battle
     battle.fight(bridge);
-    currentBattle = null;
-    // and were done
     return null;
   }
 
@@ -481,7 +479,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleId(), null, 0, 0,
             BattleRecord.BattleResultDescription.STALEMATE, results);
         battle.cancelBattle(bridge);
-        battleTracker.removeBattle(battle);
+        battleTracker.removeBattle(battle, data);
         continue;
       }
       // possibility to ignore battle altogether
@@ -493,7 +491,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleId(), null, 0, 0,
                 BattleRecord.BattleResultDescription.NO_BATTLE, results);
             battle.cancelBattle(bridge);
-            battleTracker.removeBattle(battle);
+            battleTracker.removeBattle(battle, data);
           }
           continue;
         }
@@ -507,7 +505,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleId(), null, 0, 0,
                   BattleRecord.BattleResultDescription.NO_BATTLE, results);
               battle.cancelBattle(bridge);
-              battleTracker.removeBattle(battle);
+              battleTracker.removeBattle(battle, data);
             }
             continue;
           }
@@ -518,7 +516,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleId(), null, 0, 0,
                   BattleRecord.BattleResultDescription.NO_BATTLE, results);
               battle.cancelBattle(bridge);
-              battleTracker.removeBattle(battle);
+              battleTracker.removeBattle(battle, data);
             }
             continue;
           }
@@ -530,7 +528,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleId(), null, 0, 0,
                   BattleRecord.BattleResultDescription.NO_BATTLE, results);
               battle.cancelBattle(bridge);
-              battleTracker.removeBattle(battle);
+              battleTracker.removeBattle(battle, data);
             }
           }
         }
@@ -1527,4 +1525,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   public IBattle getCurrentBattle() {
     return currentBattle;
   }
+
+  public void clearCurrentBattle(final IBattle battle) {
+    if (battle.equals(currentBattle)) {
+      currentBattle = null;
+    }
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -50,6 +50,10 @@ import games.strategy.util.PredicateBuilder;
 import games.strategy.util.Tuple;
 import games.strategy.util.Util;
 
+
+/**
+ * Delegate to track and fight all battles.
+ */
 @MapSupport
 @AutoSave(beforeStepStart = true, afterStepEnd = true)
 public class BattleDelegate extends BaseTripleADelegate implements IBattleDelegate {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1033,6 +1033,9 @@ public class BattleTracker implements Serializable {
     }
   }
 
+  /**
+   * Removes battle from pending list, any dependencies, and clears current battle.
+   */
   public void removeBattle(final IBattle battle, final GameData data) {
     if (battle != null) {
       for (final IBattle current : getBlocked(battle)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1040,7 +1040,10 @@ public class BattleTracker implements Serializable {
       }
       m_pendingBattles.remove(battle);
       m_foughBattles.add(battle.getTerritory());
-      DelegateFinder.battleDelegate(data).clearCurrentBattle(battle);
+      final BattleDelegate battleDelegate = DelegateFinder.battleDelegate(data);
+      if (battleDelegate != null) {
+        battleDelegate.clearCurrentBattle(battle);
+      }
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1034,7 +1034,7 @@ public class BattleTracker implements Serializable {
   }
 
   /**
-   * Removes battle from pending list, any dependencies, and clears current battle.
+   * Remove battle from pending list, dependencies, and clear current battle.
    */
   public void removeBattle(final IBattle battle, final GameData data) {
     if (battle != null) {
@@ -1043,9 +1043,10 @@ public class BattleTracker implements Serializable {
       }
       m_pendingBattles.remove(battle);
       m_foughBattles.add(battle.getTerritory());
-      final BattleDelegate battleDelegate = DelegateFinder.battleDelegate(data);
-      if (battleDelegate != null) {
-        battleDelegate.clearCurrentBattle(battle);
+      try {
+        DelegateFinder.battleDelegate(data).clearCurrentBattle(battle);
+      } catch (final IllegalStateException e) {
+        // ignore as can't find battle delegate
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -158,8 +158,7 @@ public class BattleTracker implements Serializable {
   private boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
-    for (final Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>> t
-        : m_relationshipChangesThisTurn) {
+    for (final Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
       final Tuple<PlayerID, PlayerID> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
         if (!players.getSecond().equals(p2)) {
@@ -683,7 +682,7 @@ public class BattleTracker implements Serializable {
         getBattleRecords().addResultToBattle(id, bombingBattle.getBattleId(), null, 0, 0,
             BattleRecord.BattleResultDescription.NO_BATTLE, results);
         bombingBattle.cancelBattle(bridge);
-        removeBattle(bombingBattle);
+        removeBattle(bombingBattle, data);
         throw new IllegalStateException(
             "Bombing Raids should be dealt with first! Be sure the battle has dependencies set correctly!");
       }
@@ -1034,13 +1033,14 @@ public class BattleTracker implements Serializable {
     }
   }
 
-  public void removeBattle(final IBattle battle) {
+  public void removeBattle(final IBattle battle, final GameData data) {
     if (battle != null) {
       for (final IBattle current : getBlocked(battle)) {
         removeDependency(current, battle);
       }
       m_pendingBattles.remove(battle);
       m_foughBattles.add(battle.getTerritory());
+      DelegateFinder.battleDelegate(data).clearCurrentBattle(battle);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -60,7 +60,7 @@ public class FinishedBattle extends AbstractBattle {
       m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
           m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     }
-    m_battleTracker.removeBattle(this);
+    m_battleTracker.removeBattle(this, bridge.getData());
     m_isOver = true;
   }
 
@@ -149,7 +149,7 @@ public class FinishedBattle extends AbstractBattle {
               m_attackerLostTUV, m_defenderLostTUV, BattleRecord.BattleResultDescription.LOST,
               new BattleResults(this, m_data));
         }
-        m_battleTracker.removeBattle(this);
+        m_battleTracker.removeBattle(this, bridge.getData());
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -76,7 +76,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
   private final Collection<Unit> m_attackingWaitingToDie = new ArrayList<>();
   private Set<Territory> m_attackingFrom = new HashSet<>();
-  private Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
+  private final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
   private final Collection<Unit> m_defendingWaitingToDie = new ArrayList<>();
   // keep track of all the units that die in the battle to show in the history window
   private final Collection<Unit> m_killed = new ArrayList<>();
@@ -2586,7 +2586,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void endBattle(final IDelegateBridge bridge) {
     clearWaitingToDieAndDamagedChangesInto(bridge);
     m_isOver = true;
-    m_battleTracker.removeBattle(this);
+    m_battleTracker.removeBattle(this, bridge.getData());
 
     // Must clear transportedby for allied air on carriers for both attacking units and retreating units
     final CompositeChange clearAlliedAir =
@@ -2676,7 +2676,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             m_attackerLostTUV, m_defenderLostTUV, BattleRecord.BattleResultDescription.LOST,
             new BattleResults(this, m_data));
       }
-      m_battleTracker.removeBattle(this);
+      m_battleTracker.removeBattle(this, m_data);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -92,11 +92,7 @@ public class NonFightingBattle extends DependentBattle {
     }
     m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
         m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
-    end();
-  }
-
-  private void end() {
-    m_battleTracker.removeBattle(this);
+    m_battleTracker.removeBattle(this, m_data);
     m_isOver = true;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -291,7 +291,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
         m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     m_isOver = true;
-    m_battleTracker.removeBattle(StrategicBombingRaidBattle.this);
+    m_battleTracker.removeBattle(StrategicBombingRaidBattle.this, m_data);
   }
 
   private void end(final IDelegateBridge bridge) {
@@ -315,7 +315,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
         m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     m_isOver = true;
-    m_battleTracker.removeBattle(this);
+    m_battleTracker.removeBattle(this, m_data);
   }
 
   private void showBattle(final IDelegateBridge bridge) {


### PR DESCRIPTION
Addresses #3377 

**Functional Changes**
- Moved call to clear current battle territory to`BattleTracker` where it remove the battle from the pending list to prevent it being remove from pending but still think its the current battle which leads to "Must Finish Battle" error