### PR TITLE
Update unit categorization logic to allow AA to be in other land options

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -116,7 +116,7 @@ public class ProPurchaseOption {
       costPerHitPoint = ((double) cost) / hitPoints;
     }
     hitPointEfficiency =
-        (hitPoints + 0.1 * attack * 6 / data.getDiceSides() + 0.2 * defense * 6 / data.getDiceSides()) / cost;
+        (hitPoints + 0.2 * attack * 6 / data.getDiceSides() + 0.2 * defense * 6 / data.getDiceSides()) / cost;
     attackEfficiency = (1 + hitPoints)
         * (hitPoints + attack * 6 / data.getDiceSides() + 0.5 * defense * 6 / data.getDiceSides()) / cost;
     defenseEfficiency = (1 + hitPoints)

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -76,18 +76,21 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         factoryOptions.add(ppo);
         ProLogger.debug("Factory: " + ppo);
-      } else if (Matches.unitTypeIsAaForBombingThisUnitOnly().test(unitType)) {
-        final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
-        aaOptions.add(ppo);
-        ProLogger.debug("AA: " + ppo);
       } else if (Matches.unitTypeIsLand().test(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
-        landFodderOptions.add(ppo);
-        if (ppo.getAttack() >= ppo.getDefense() || ppo.isAttackSupport() || ppo.getMovement() > 1) {
+        if (!Matches.unitTypeIsInfrastructure().test(unitType)) {
+          landFodderOptions.add(ppo);
+        }
+        if ((ppo.getAttack() > 0 || ppo.isAttackSupport())
+            && (ppo.getAttack() >= ppo.getDefense() || ppo.getMovement() > 1)) {
           landAttackOptions.add(ppo);
         }
-        if (ppo.getDefense() >= ppo.getAttack() || ppo.isDefenseSupport() || ppo.getMovement() > 1) {
+        if ((ppo.getDefense() > 0 || ppo.isDefenseSupport())
+            && (ppo.getDefense() >= ppo.getAttack() || ppo.getMovement() > 1)) {
           landDefenseOptions.add(ppo);
+        }
+        if (Matches.unitTypeIsAaForBombingThisUnitOnly().test(unitType)) {
+          aaOptions.add(ppo);
         }
         ProLogger.debug("Land: " + ppo);
       } else if (Matches.unitTypeIsAir().test(unitType)) {


### PR DESCRIPTION
Primarily address some issues with AI not categorizing AA units properly on Iron War.
