### PR TITLE
Ai enhance neutral categorization

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -10,6 +10,10 @@ import games.strategy.triplea.delegate.Matches;
 
 public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   private static final long serialVersionUID = -2284878450555315947L;
+
+  private static final String DEFAULT_TYPE_AI = "AI";
+  private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
+
   private final boolean m_optional;
   private final boolean m_canBeDisabled;
   private final String defaultType;
@@ -174,6 +178,14 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
       currentPlayers.put(player.getName(), player.getWhoAmI().split(":")[1]);
     }
     return currentPlayers;
+  }
+
+  public boolean isDefaultTypeAi() {
+    return DEFAULT_TYPE_AI.equals(defaultType);
+  }
+
+  public boolean isDefaultTypeDoesNothing() {
+    return DEFAULT_TYPE_DOES_NOTHING.equals(defaultType);
   }
 
   public RulesAttachment getRulesAttachment() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -29,9 +29,6 @@ import games.strategy.triplea.TripleA;
  */
 public class PlayerSelectorRow implements PlayerCountrySelection {
 
-  private static final String PLAYER_TYPE_AI = "AI";
-  private static final String PLAYER_TYPE_DOES_NOTHING = "DoesNothing";
-
   private final JCheckBox enabledCheckBox;
   private final String playerName;
   private final PlayerID player;
@@ -172,9 +169,9 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
   }
 
   void setDefaultPlayerType() {
-    if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
+    if (player.isDefaultTypeAi()) {
       playerTypes.setSelectedItem(TripleA.PRO_COMPUTER_PLAYER_TYPE);
-    } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
+    } else if (player.isDefaultTypeDoesNothing()) {
       playerTypes.setSelectedItem(TripleA.DOESNOTHINGAI_COMPUTER_PLAYER_TYPE);
     } else {
       playerTypes.setSelectedItem(TripleA.HUMAN_PLAYER_TYPE);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -195,7 +195,7 @@ class ProCombatMoveAi {
 
       // Determine territory attack properties
       final int isLand = !t.isWater() ? 1 : 0;
-      final int isNeutral = (!t.isWater() && t.getOwner().isNull()) ? 1 : 0;
+      final int isNeutral = ProUtils.isNeutralLand(t) ? 1 : 0;
       final int isCanHold = patd.isCanHold() ? 1 : 0;
       final int isAmphib = patd.isNeedAmphibUnits() ? 1 : 0;
       final List<Unit> defendingUnits = CollectionUtils.getMatches(patd.getMaxEnemyDefenders(player, data),
@@ -230,7 +230,7 @@ class ProCombatMoveAi {
           * (1 + 2 * isNotNeutralAdjacentToMyCapital) * (1 - 0.9 * isNeutral);
 
       // Check if a negative value neutral territory should be attacked
-      if (attackValue <= 0 && !patd.isNeedAmphibUnits() && !t.isWater() && t.getOwner().isNull()) {
+      if (attackValue <= 0 && !patd.isNeedAmphibUnits() && ProUtils.isNeutralLand(t)) {
 
         // Determine enemy neighbor territory production value for neutral land territories
         double nearbyEnemyValue = 0;
@@ -470,7 +470,7 @@ class ProCombatMoveAi {
       }
 
       // Remove neutral and low value amphib land territories that can't be held
-      final boolean isNeutral = t.getOwner().isNull();
+      final boolean isNeutral = ProUtils.isNeutralLand(t);
       final double strengthDifference =
           ProBattleUtils.estimateStrengthDifference(t, patd.getMaxUnits(), patd.getMaxEnemyDefenders(player, data));
       if (!patd.isCanHold() && enemyAttackOptions.getMax(t) != null && !t.isWater()) {
@@ -903,7 +903,7 @@ class ProCombatMoveAi {
         }
 
         // Find attack value
-        final boolean isNeutral = (!t.isWater() && t.getOwner().isNull());
+        final boolean isNeutral = ProUtils.isNeutralLand(t);
         final int isLand = !t.isWater() ? 1 : 0;
         final int isCanHold = canHold ? 1 : 0;
         final int isCantHoldAmphib = !canHold && !patd.getAmphibAttackMap().isEmpty() ? 1 : 0;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -139,7 +139,7 @@ public class ProTerritoryManager {
       // Check strafing and using allied attack if enemy capital/factory
       boolean isEnemyCapitalOrFactory = false;
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (!t.getOwner().isNull()
+      if (!ProUtils.isNeutralLand(t)
           && ((ta != null && ta.isCapital()) || ProMatches.territoryHasInfraFactoryAndIsLand().test(t))) {
         isEnemyCapitalOrFactory = true;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -432,7 +432,7 @@ public class ProMatches {
   }
 
   private static Predicate<Unit> unitIsNeutral() {
-    return u -> u.getOwner().isNull();
+    return u -> ProUtils.isNeutralPlayer(u.getOwner());
   }
 
   static Predicate<Unit> unitIsOwnedAir(final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -30,7 +30,7 @@ public class ProTerritoryValueUtils {
     final GameData data = ProData.getData();
     final int isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).test(t) ? 1 : 0;
     double value = 3 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
-    if (!t.isWater() && t.getOwner().isNull()) {
+    if (ProUtils.isNeutralLand(t)) {
       final double strength =
           ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnits().getUnits()), new ArrayList<>(), false);
 
@@ -188,7 +188,7 @@ public class ProTerritoryValueUtils {
       }
 
       // Calculate value
-      final int isNeutral = t.getOwner().isNull() ? 1 : 0;
+      final int isNeutral = ProUtils.isNeutralLand(t) ? 1 : 0;
       final int landMassSize = 1 + data.getMap()
           .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)).size();
       final double value = Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3 * isNeutral)
@@ -237,7 +237,7 @@ public class ProTerritoryValueUtils {
           ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
       if (distance > 0) {
         double value = TerritoryAttachment.getProduction(nearbyEnemyTerritory);
-        if (nearbyEnemyTerritory.getOwner().isNull()) {
+        if (ProUtils.isNeutralLand(nearbyEnemyTerritory)) {
           value = findTerritoryAttackValue(player, nearbyEnemyTerritory) / 3; // find neutral value
         } else if (ProMatches.territoryIsAlliedLandAndHasNoEnemyNeighbors(player, data).test(nearbyEnemyTerritory)) {
           value *= 0.1; // reduce value for can't hold amphib allied territories
@@ -304,7 +304,7 @@ public class ProTerritoryValueUtils {
         if (ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld)
             .test(nearbyLandTerritory)) {
           double value = TerritoryAttachment.getProduction(nearbyLandTerritory);
-          if (nearbyLandTerritory.getOwner().isNull()) {
+          if (ProUtils.isNeutralLand(nearbyLandTerritory)) {
             value = findTerritoryAttackValue(player, nearbyLandTerritory);
           }
           nearbyLandValue += value;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
@@ -218,8 +219,10 @@ public class ProUtils {
   public static boolean isFfa(final GameData data, final PlayerID player) {
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
     final Set<PlayerID> enemies = relationshipTracker.getEnemies(player);
-    for (final PlayerID enemy : enemies) {
-      if (relationshipTracker.isAtWarWithAnyOfThesePlayers(enemy, enemies)) {
+    final Set<PlayerID> enemiesWithoutNeutrals =
+        enemies.stream().filter(p -> !isNeutralPlayer(p)).collect(Collectors.toSet());
+    for (final PlayerID enemy : enemiesWithoutNeutrals) {
+      if (relationshipTracker.isAtWarWithAnyOfThesePlayers(enemy, enemiesWithoutNeutrals)) {
         return true;
       }
     }

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProUtilsTest.java
@@ -1,0 +1,36 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.triplea.xml.TestMapGameData;
+
+public class ProUtilsTest {
+
+  @Test
+  public void testIsPassiveNeutralPlayer() throws Exception {
+    final GameData data = TestMapGameData.GLOBAL1940.getGameData();
+    final PlayerID russians = data.getPlayerList().getPlayerId("Russians");
+    assertFalse(ProUtils.isPassiveNeutralPlayer(russians));
+    final PlayerID neutralTrue = data.getPlayerList().getPlayerId("Neutral_True");
+    assertTrue(ProUtils.isPassiveNeutralPlayer(neutralTrue));
+    final PlayerID pirates = data.getPlayerList().getPlayerId("Pirates");
+    assertFalse(ProUtils.isPassiveNeutralPlayer(pirates));
+  }
+
+  @Test
+  public void testIsNeutralPlayer() throws Exception {
+    final GameData data = TestMapGameData.GLOBAL1940.getGameData();
+    final PlayerID russians = data.getPlayerList().getPlayerId("Russians");
+    assertFalse(ProUtils.isNeutralPlayer(russians));
+    final PlayerID neutralTrue = data.getPlayerList().getPlayerId("Neutral_True");
+    assertTrue(ProUtils.isNeutralPlayer(neutralTrue));
+    final PlayerID pirates = data.getPlayerList().getPlayerId("Pirates");
+    assertTrue(ProUtils.isNeutralPlayer(pirates));
+  }
+
+}

--- a/game-core/src/test/resources/ww2_g40_balanced.xml
+++ b/game-core/src/test/resources/ww2_g40_balanced.xml
@@ -1220,6 +1220,7 @@
     <player name="Neutral_Axis" optional="true"/>
     <player name="Neutral_Allies" optional="true"/>
     <player name="Neutral_True" optional="true"/>
+    <player name="Pirates" optional="true" defaultType="AI" isHidden="true"/>
     <!-- Alliances -->
     <alliance player="Russians" alliance="Allies"/>
     <alliance player="Americans" alliance="Allies"/>
@@ -1236,6 +1237,7 @@
     <alliance player="Neutral_Axis" alliance="Neutral_Axis"/>
     <alliance player="Neutral_Allies" alliance="Neutral_Allies"/>
     <alliance player="Neutral_True" alliance="Neutral_True"/>
+    <alliance player="Pirates" alliance="Pirates"/>
   </playerList>
   <unitList>
     <unit name="infantry"/>
@@ -1414,6 +1416,18 @@
       <step name="frenchNonCombatMove" delegate="move" player="French" display="Non Combat Move"/>
       <step name="frenchPlace" delegate="place" player="French"/>
       <step name="frenchEndTurn" delegate="endTurn" player="French"/>
+      <!-- French Game Sequence -->
+      <step name="piratesTech" delegate="tech" player="Pirates"/>
+      <step name="piratesTechActivation" delegate="tech_activation" player="Pirates"/>
+      <step name="piratesPurchase" delegate="purchase" player="Pirates"/>
+      <step name="piratesPolitics" delegate="politics" player="Pirates"/>
+      <step name="piratesCombatMove" delegate="move" player="Pirates"/>
+      <step name="piratesAirborneCombatMove" delegate="specialCombatMove" player="Pirates" display="Airborne Attack Move"/>
+      <step name="piratesBattle" delegate="battle" player="Pirates"/>
+      <step name="piratesNonCombatMove" delegate="move" player="Pirates" display="Non Combat Move"/>
+      <step name="piratesPlace" delegate="place" player="Pirates"/>
+      <step name="piratesEndTurn" delegate="endTurn" player="Pirates"/>
+      
       <step name="endRoundStep" delegate="endRound"/>
     </sequence>
   </gamePlay>


### PR DESCRIPTION
Address https://forums.triplea-game.org/topic/776/ai-improve-neutral-categorization

Look to expand neutral categorization from just the regular NULL player neutrals to include other types on maps such as Iron War, Caribbean Trade War, etc.

**Passive Neutrals**
- No combat move phase (includes existing NULL player neutrals)

**Active Neutrals**
- Has combat move phase
- defaultType="AI" or "DoesNothing"
- isHidden="true"
- All players that are part of said alliance must be 'Neutrals' as well

**Use These For**
- Don't trade TUV for Passive and Active neutrals (only attack if territory worth capturing)
- Don't calculate defenses against Passive neutrals