### PR TITLE
Add a check for CompositeChange in case they have UnitHitsChange

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -487,7 +487,7 @@ public class TripleAUnit extends Unit {
         hits.put(u, combatDamage);
       }
     }
-    if (hits.size() > 0) {
+    if (!hits.isEmpty()) {
       changes.add(ChangeFactory.unitsHit(hits));
     }
     final int unitDamage = taUnit.getUnitDamage();
@@ -503,7 +503,9 @@ public class TripleAUnit extends Unit {
         damageMap.put(u, transferDamage);
       }
     }
-    changes.add(ChangeFactory.bombingUnitDamage(damageMap));
+    if (!damageMap.isEmpty()) {
+      changes.add(ChangeFactory.bombingUnitDamage(damageMap));
+    }
     return changes;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -119,11 +119,12 @@ public class DummyDelegateBridge implements IDelegateBridge {
 
   @Override
   public void addChange(final Change change) {
-    if (!(change instanceof UnitHitsChange)) {
-      return;
+    if (change instanceof UnitHitsChange) {
+      allChanges.add(change);
+      gameData.performChange(change);
+    } else if (change instanceof CompositeChange) {
+      ((CompositeChange) change).getChanges().forEach(c -> addChange(c));
     }
-    allChanges.add(change);
-    gameData.performChange(change);
   }
 
   @Override


### PR DESCRIPTION
Address issue reported here https://forums.triplea-game.org/topic/493/total-world-war-december-1941-beta-2-8-0-4/234

Essentially the battle calc wasn't processing the hit point deduction when having a damagedChangesInto unit.