### PR TITLE
Release ProTerritoryManager instances at the end of each phase

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -148,7 +148,9 @@ class ProCombatMoveAi {
     ProLogger.info("Logging results");
     logAttackMoves(attackOptions);
 
-    return territoryManager.getAttackOptions().getTerritoryMap();
+    final Map<Territory, ProTerritory> result = territoryManager.getAttackOptions().getTerritoryMap();
+    territoryManager = null;
+    return result;
   }
 
   void doMove(final Map<Territory, ProTerritory> attackMap, final IMoveDelegate moveDel, final GameData data,

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -166,6 +166,7 @@ class ProNonCombatMoveAi {
     ProLogger.info("Logging results");
     logAttackMoves(prioritizedTerritories);
 
+    territoryManager = null;
     return factoryMoveMap;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -216,6 +216,8 @@ class ProPurchaseAi {
     if (error != null) {
       ProLogger.warn("Purchase error: " + error);
     }
+
+    territoryManager = null;
     return purchaseTerritories;
   }
 
@@ -309,6 +311,8 @@ class ProPurchaseAi {
     if (error != null) {
       ProLogger.warn("Purchase error: " + error);
     }
+
+    territoryManager = null;
     return purchaseTerritories;
   }
 
@@ -406,6 +410,8 @@ class ProPurchaseAi {
 
     // Place isConstruction land units (needs separated since placeDelegate.getPlaceableUnits doesn't handle combined)
     placeLandUnits(prioritizedLandTerritories, placeDelegate, true);
+
+    territoryManager = null;
   }
 
   private void findDefendersInPlaceTerritories(final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {


### PR DESCRIPTION
I ran a game of Iron War locally with all Hard AI and took a heap dump around round 20. It showed that each Hard AI player was holding 25-30 MB which when you have ~20 players is fairly significant. This makes sure to release the ProTerritoryManager instances after each phase as they aren't needed then.

This is primarily a short term resolution as I'm looking to restructure the AI some so that each phase is just instantiated when its needed but that requires some refactoring as some of them hold data across phases at the moment.