### PR TITLE
Fix freeze when loading big savegames

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1435,8 +1435,8 @@ public class TripleAFrame extends MainGameFrame {
     });
     if (player != null && !player.isNull()) {
       CompletableFuture.supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
-      .thenApplyAsync(ImageIcon::new)
-      .thenAccept(icon -> SwingUtilities.invokeLater(() -> this.round.setIcon(icon)));
+        .thenApplyAsync(ImageIcon::new)
+        .thenAccept(icon -> SwingUtilities.invokeLater(() -> this.round.setIcon(icon)));
       lastStepPlayer = currentStepPlayer;
       currentStepPlayer = player;
     }
@@ -1744,11 +1744,11 @@ public class TripleAFrame extends MainGameFrame {
         @Override
         public void actionPerformed(final ActionEvent ae) {
           JOptionPane.showMessageDialog(TripleAFrame.this,
-              "Please first left click on the spot you want to save from, Then right click and select 'Save Game From "
-                  + "History'"
+              "Please first left click on the spot you want to save from, Then right click and select "
+                  + "'Save Game From History'"
                   + "\n\nIt is recommended that when saving the game from the History panel:"
-                  + "\n * Your CURRENT GAME is at the start of some player's turn, and that no moves have been made and "
-                  + "no actions taken yet."
+                  + "\n * Your CURRENT GAME is at the start of some player's turn, and that no moves have been made "
+                  + "and no actions taken yet."
                   + "\n * The point in HISTORY that you are trying to save at, is at the beginning of a player's turn, "
                   + "or the beginning of a round."
                   + "\nSaving at any other point, could potentially create errors."


### PR DESCRIPTION
After loading the savegame provided #3393 I noticed, that the loading screen freezes for 10+ seconds when loading a big savegame.
This PR fixes the biggeste freeze. There's still a smaller one, but I'll have a look at that one either in another PR or in the coming dates as part of this PR.

I recommend reviewing this PR with whitespace changes ignored