### PR TITLE
Add data cloning method that doesn't copy history

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -103,7 +103,7 @@ public class GameData implements Serializable {
   private final TechnologyFrontier technologyFrontier = new TechnologyFrontier("allTechsForGame", this);
   private transient ResourceLoader resourceLoader;
   private IGameLoader loader;
-  private final History gameHistory = new History(this);
+  private History gameHistory = new History(this);
   private transient volatile boolean testLockIsHeld = false;
   private final List<Tuple<IAttachment, ArrayList<Tuple<String, String>>>> attachmentOrderAndValues =
       new ArrayList<>();
@@ -362,6 +362,14 @@ public class GameData implements Serializable {
     // history operations often acquire the write lock
     // and we cant acquire the write lock if we have the read lock
     return gameHistory;
+  }
+
+  public void setHistory(final History history) {
+    gameHistory = history;
+  }
+
+  public void resetHistory() {
+    gameHistory = new History(this);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -7,6 +7,7 @@ import java.io.ObjectOutputStream;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameObjectOutputStream;
+import games.strategy.engine.history.History;
 import games.strategy.io.IoUtils;
 
 /**
@@ -14,6 +15,18 @@ import games.strategy.io.IoUtils;
  */
 public final class GameDataUtils {
   private GameDataUtils() {}
+
+  /**
+   * Create a deep copy of GameData without history as it can get large.
+   * <strong>You should have the game data's write lock before calling this method</strong>
+   */
+  public static GameData cloneGameDataWithoutHistory(final GameData data, final boolean copyDelegates) {
+    final History temp = data.getHistory();
+    data.resetHistory();
+    final GameData dataCopy = cloneGameData(data, copyDelegates);
+    data.setHistory(temp);
+    return dataCopy;
+  }
 
   public static GameData cloneGameData(final GameData data) {
     return cloneGameData(data, false);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -180,13 +180,13 @@ public class ProAi extends AbstractAi {
       // Setup data copy and delegates
       GameData dataCopy;
       try {
-        data.acquireReadLock();
-        dataCopy = GameDataUtils.cloneGameData(data, true);
+        data.acquireWriteLock();
+        dataCopy = GameDataUtils.cloneGameDataWithoutHistory(data, true);
       } catch (final Throwable t) {
         ProLogger.log(Level.WARNING, "Error trying to clone game data for simulating phases", t);
         return;
       } finally {
-        data.releaseReadLock();
+        data.releaseWriteLock();
       }
       calc.setData(dataCopy);
       final PlayerID playerCopy = dataCopy.getPlayerList().getPlayerId(player.getName());

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -141,10 +141,10 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
       try {
         // make first copy, then release lock on it so game can continue (ie: we don't want to lock on it while we copy
         // it 16 times, when once is enough) don't let the data change while we make the first copy
-        data.acquireReadLock();
-        newData = GameDataUtils.cloneGameData(data, false);
+        data.acquireWriteLock();
+        newData = GameDataUtils.cloneGameDataWithoutHistory(data, false);
       } finally {
-        data.releaseReadLock();
+        data.releaseWriteLock();
       }
       currentThreads = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
       try {


### PR DESCRIPTION
Addresses some discussion from #3393 

**Functional Changes**
- Battle calc doesn't copy history from game data to reduce initial loading when opening it
- AI doesn't copy history when creating data data clone for purchase simulation

**Testing**
- Ran some AI games to make sure it doesn't throw any errors or act funny
- Tested opening the battle calc and history to ensure they still work properly. Saw a significant reduction (around 10x for the 154 round save game) in time the data takes to load into the battle calc. Even with that large save game the calc button becomes available in just a few seconds rather than 20-30 seconds.

I'd appreciate a thorough review on this one as I'm not 100% sure this is an alright thing to do and if there are any possible side effects.