### PR TITLE
PBF v2 migration

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -41,7 +41,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
       final String token = getToken(client, userId);
       try {
         post(client, token, "### " + title + "\n" + summary);
-        turnSummaryRef = "Sucessfully posted!";
+        turnSummaryRef = "Successfully posted!";
         return true;
       } finally {
         deleteToken(client, userId, token);
@@ -54,7 +54,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
   }
 
   private void post(final CloseableHttpClient client, final String token, final String text) throws IOException {
-    final HttpPost post = new HttpPost(tripleAForumURL + "/api/v1/topics/" + getTopicId());
+    final HttpPost post = new HttpPost(tripleAForumURL + "/api/v2/topics/" + getTopicId());
     addTokenHeader(post, token);
     post.setEntity(new UrlEncodedFormEntity(
         Collections.singletonList(new BasicNameValuePair("content",
@@ -70,7 +70,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
   }
 
   private String uploadSaveGame(final CloseableHttpClient client, final String token) throws IOException {
-    final HttpPost fileUpload = new HttpPost(tripleAForumURL + "/api/v1/util/upload");
+    final HttpPost fileUpload = new HttpPost(tripleAForumURL + "/api/v2/util/upload");
     fileUpload.setEntity(MultipartEntityBuilder.create()
         .addBinaryBody("files[]", saveGameFile, ContentType.APPLICATION_OCTET_STREAM, saveGameFileName)
         .build());
@@ -88,7 +88,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
 
   private static void deleteToken(final CloseableHttpClient client, final int userId, final String token)
       throws IOException {
-    final HttpDelete httpDelete = new HttpDelete(tripleAForumURL + "/api/v1/users/" + userId + "/tokens/" + token);
+    final HttpDelete httpDelete = new HttpDelete(tripleAForumURL + "/api/v2/users/" + userId + "/tokens/" + token);
     addTokenHeader(httpDelete, token);
     try (CloseableHttpResponse response = client.execute(httpDelete)) {
       final int code = response.getStatusLine().getStatusCode();
@@ -138,7 +138,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
   }
 
   private String getToken(final CloseableHttpClient client, final int userId) throws IOException {
-    final HttpPost post = new HttpPost(tripleAForumURL + "/api/v1/users/" + userId + "/tokens");
+    final HttpPost post = new HttpPost(tripleAForumURL + "/api/v2/users/" + userId + "/tokens");
     post.setEntity(new UrlEncodedFormEntity(
         Collections.singletonList(newPasswordParameter()),
         StandardCharsets.UTF_8));


### PR DESCRIPTION
This PR migrates the code we use to do PBF posts to v2 of the API (basically find-and-replacing `v1` with `v2`, because the breaking changes didn't affect us.).

The second commit of this PR changes the behaviour of the PBF login slightly:
We are no longer able to login using email/password, we need to use username/password.
The benefit of this change is that we no longer need to rely on a third party plugin to do the authentification for us, which could be abandoned from one day to another, in theory.

In any case we should notify everyone playing PBF of this change.

Once a new version gets stable after this PR is being merged, we should consider uninstalling the `nodebb-plugin-ns-login` plugin package from the forum.

##### Unrelated
[JDK 11 will ship with a built-in HTTP Client](http://openjdk.java.net/jeps/321) aiming to have less overhead and to be faster than HTTP Components.
It'll work completely asynchronous, so we might want to change our current model to use the advantages of that in the future.