### PR TITLE
Ai add land transports

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -62,6 +62,8 @@ public class ProPurchaseOption {
   @Getter
   private final boolean isTransport;
   @Getter
+  private final boolean isLandTransport;
+  @Getter
   private final boolean isCarrier;
   @Getter
   private final int carrierCapacity;
@@ -107,6 +109,7 @@ public class ProPurchaseOption {
     isSub = unitAttachment.getIsSub();
     isDestroyer = unitAttachment.getIsDestroyer();
     isTransport = unitAttachment.getTransportCapacity() > 0;
+    isLandTransport = unitAttachment.isLandTransport();
     isCarrier = unitAttachment.getCarrierCapacity() > 0;
     carrierCapacity = unitAttachment.getCarrierCapacity() * quantity;
     transportEfficiency = (double) unitAttachment.getTransportCapacity() / cost;
@@ -208,8 +211,9 @@ public class ProPurchaseOption {
 
   private double calculateLandDistanceFactor(final int enemyDistance) {
     final double distance = Math.max(0, enemyDistance - 1.5);
+    final int moveValue = isLandTransport ? (movement + 1) : movement;
     // 1, 2, 2.5, 2.75, etc
-    final double moveFactor = 1 + 2 * (Math.pow(2, movement - 1) - 1) / Math.pow(2, movement - 1);
+    final double moveFactor = 1 + 2 * (Math.pow(2, moveValue - 1) - 1) / Math.pow(2, moveValue - 1);
     return Math.pow(moveFactor, distance / 5);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -174,6 +174,10 @@ public class ProTerritory {
     this.maxUnits.add(unit);
   }
 
+  void addMaxUnits(final List<Unit> units) {
+    this.maxUnits.addAll(units);
+  }
+
   public Territory getTerritory() {
     return territory;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -704,10 +704,13 @@ public class ProTerritoryManager {
 
           // Populate territories with land units
           if (moveMap.containsKey(potentialTerritory)) {
-            moveMap.get(potentialTerritory).addMaxUnit(myLandUnit);
+            final List<Unit> unitsToAdd = ProTransportUtils.findBestUnitsToLandTransport(myLandUnit, startTerritory,
+                moveMap.get(potentialTerritory).getMaxUnits());
+            moveMap.get(potentialTerritory).addMaxUnits(unitsToAdd);
           } else {
             final ProTerritory moveTerritoryData = new ProTerritory(potentialTerritory);
-            moveTerritoryData.addMaxUnit(myLandUnit);
+            final List<Unit> unitsToAdd = ProTransportUtils.findBestUnitsToLandTransport(myLandUnit, startTerritory);
+            moveTerritoryData.addMaxUnits(unitsToAdd);
             moveMap.put(potentialTerritory, moveTerritoryData);
           }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.Matches;
@@ -487,4 +488,9 @@ public class ProMatches {
             .and(Matches.unitIsBeingTransported().negate())
             .test(u);
   }
+
+  public static Predicate<Unit> unitHasLessMovementThan(final Unit unit) {
+    return u -> TripleAUnit.get(u).getMovementLeft() < TripleAUnit.get(unit).getMovementLeft();
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -101,8 +101,6 @@ public class ProMoveUtils {
               ProMatches.territoryCanMoveAirUnitsAndNoAa(player, data, isCombatMove));
         }
         if (route == null) {
-          System.out.println(data.getSequence().getRound() + "-" + data.getSequence().getStep().getName()
-              + ": route is null " + startTerritory + " to " + t + ", units=" + unitList);
           ProLogger.warn(data.getSequence().getRound() + "-" + data.getSequence().getStep().getName()
               + ": route is null " + startTerritory + " to " + t + ", units=" + unitList);
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -157,6 +157,9 @@ public class ProTransportUtils {
     return findBestUnitsToLandTransport(unit, t, new ArrayList<>());
   }
 
+  /**
+   * Check if unit is can land transport and if there are any unused units that could be transported.
+   */
   public static List<Unit> findBestUnitsToLandTransport(final Unit unit, final Territory t,
       final List<Unit> usedUnits) {
     if (usedUnits.contains(unit)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -3,19 +3,23 @@ package games.strategy.triplea.ai.pro.util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.ai.AiUtils;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
+import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AirMovementValidator;
@@ -95,27 +99,7 @@ public class ProTransportUtils {
       units.removeAll(unitsToIgnore);
 
       // Sort units by attack
-      units.sort((o1, o2) -> {
-
-        // Very rough way to add support power
-        final Set<UnitSupportAttachment> supportAttachments1 = UnitSupportAttachment.get(o1.getType());
-        int maxSupport1 = 0;
-        for (final UnitSupportAttachment usa : supportAttachments1) {
-          if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport1) {
-            maxSupport1 = usa.getBonus();
-          }
-        }
-        final int attack1 = UnitAttachment.get(o1.getType()).getAttack(player) + maxSupport1;
-        final Set<UnitSupportAttachment> supportAttachments2 = UnitSupportAttachment.get(o2.getType());
-        int maxSupport2 = 0;
-        for (final UnitSupportAttachment usa : supportAttachments2) {
-          if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport2) {
-            maxSupport2 = usa.getBonus();
-          }
-        }
-        final int attack2 = UnitAttachment.get(o2.getType()).getAttack(player) + maxSupport2;
-        return attack2 - attack1;
-      });
+      units.sort(getDecreasingAttackComparator(player));
 
       // Get best units that can be loaded
       selectedUnits.addAll(selectUnitsToTransportFromList(transport, units));
@@ -146,6 +130,80 @@ public class ProTransportUtils {
       transportCost += UnitAttachment.get(unit.getType()).getTransportCost();
     }
     return transportCost;
+  }
+
+  public static List<Unit> getUnitsToAdd(final Unit unit, final Map<Territory, ProTerritory> moveMap) {
+    return getUnitsToAdd(unit, new ArrayList<>(), moveMap);
+  }
+
+  public static List<Unit> getUnitsToAdd(final Unit unit, final List<Unit> alreadyMovedUnits,
+      final Map<Territory, ProTerritory> moveMap) {
+    final List<Unit> movedUnits = getMovedUnits(alreadyMovedUnits, moveMap);
+    return findBestUnitsToLandTransport(unit, ProData.unitTerritoryMap.get(unit),
+        movedUnits);
+  }
+
+  public static List<Unit> getMovedUnits(final List<Unit> alreadyMovedUnits,
+      final Map<Territory, ProTerritory> attackMap) {
+    final List<Unit> movedUnits = new ArrayList<>(alreadyMovedUnits);
+    movedUnits.addAll(attackMap.values().stream()
+        .map(ProTerritory::getAllDefenders)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList()));
+    return movedUnits;
+  }
+
+  public static List<Unit> findBestUnitsToLandTransport(final Unit unit, final Territory t) {
+    return findBestUnitsToLandTransport(unit, t, new ArrayList<>());
+  }
+
+  public static List<Unit> findBestUnitsToLandTransport(final Unit unit, final Territory t,
+      final List<Unit> usedUnits) {
+    if (usedUnits.contains(unit)) {
+      return new ArrayList<>();
+    }
+    final PlayerID player = unit.getOwner();
+    final List<Unit> units = t.getUnits().getMatches(Matches.unitIsOwnedBy(player)
+        .and(Matches.unitIsLandTransportable()).and(ProMatches.unitHasLessMovementThan(unit)));
+    units.removeAll(usedUnits);
+    if (Matches.unitIsLandTransport().negate().test(unit) || !TechAttachment.isMechanizedInfantry(player)
+        || units.isEmpty()) {
+      return Collections.singletonList(unit);
+    }
+    units.sort(Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
+        .thenComparing(getDecreasingAttackComparator(player)));
+    final List<Unit> results = new ArrayList<Unit>();
+    results.add(unit);
+    if (Matches.unitIsLandTransportWithoutCapacity().test(unit)) {
+      results.add(units.get(0));
+    } else {
+      results.addAll(selectUnitsToTransportFromList(unit, units));
+    }
+    return results;
+  }
+
+  private static Comparator<Unit> getDecreasingAttackComparator(final PlayerID player) {
+    return (o1, o2) -> {
+
+      // Very rough way to add support power
+      final Set<UnitSupportAttachment> supportAttachments1 = UnitSupportAttachment.get(o1.getType());
+      int maxSupport1 = 0;
+      for (final UnitSupportAttachment usa : supportAttachments1) {
+        if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport1) {
+          maxSupport1 = usa.getBonus();
+        }
+      }
+      final int attack1 = UnitAttachment.get(o1.getType()).getAttack(player) + maxSupport1;
+      final Set<UnitSupportAttachment> supportAttachments2 = UnitSupportAttachment.get(o2.getType());
+      int maxSupport2 = 0;
+      for (final UnitSupportAttachment usa : supportAttachments2) {
+        if (usa.getAllied() && usa.getOffence() && usa.getBonus() > maxSupport2) {
+          maxSupport2 = usa.getBonus();
+        }
+      }
+      final int attack2 = UnitAttachment.get(o2.getType()).getAttack(player) + maxSupport2;
+      return attack2 - attack1;
+    };
   }
 
   public static List<Unit> getAirThatCantLandOnCarrier(final PlayerID player, final Territory t,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -455,7 +455,7 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner());
   }
 
-  static Predicate<Unit> unitIsLandTransport() {
+  public static Predicate<Unit> unitIsLandTransport() {
     return unit -> UnitAttachment.get(unit.getType()).getIsLandTransport();
   }
 
@@ -463,7 +463,7 @@ public final class Matches {
     return unit -> unitIsLandTransport().and(unitCanTransport()).test(unit);
   }
 
-  static Predicate<Unit> unitIsLandTransportWithoutCapacity() {
+  public static Predicate<Unit> unitIsLandTransportWithoutCapacity() {
     return unit -> unitIsLandTransport().and(unitCanTransport().negate()).test(unit);
   }
 


### PR DESCRIPTION
Add AI support for moving units with land transports. Here is a 27 round test game on Iron War showing the AI moving them and not having any errors: 
[1527297106541-ironwarai.zip](https://github.com/triplea-game/triplea/files/2041218/1527297106541-ironwarai.zip)
