### PR TITLE
Wrap Exceptions instead of modifying the Trace

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/message/ConnectionLostException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/ConnectionLostException.java
@@ -13,4 +13,8 @@ public class ConnectionLostException extends MessengerException {
   public ConnectionLostException(final String message) {
     super(message);
   }
+
+  public ConnectionLostException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/message/ConnectionLostException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/ConnectionLostException.java
@@ -11,6 +11,6 @@ public class ConnectionLostException extends MessengerException {
   private static final long serialVersionUID = -5310065420171098696L;
 
   public ConnectionLostException(final String message) {
-    super(message, new Exception("Invoker Stack"));
+    super(message);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
@@ -6,16 +6,7 @@ package games.strategy.engine.message;
 public class MessengerException extends RuntimeException {
   private static final long serialVersionUID = 1058615494612307887L;
 
-  MessengerException(final String message, final Throwable cause) {
-    super(message, cause);
-  }
-
-  /**
-   * We were created in a thread that is not related to the remote
-   * that called the method. This allows us to see the stack trace of
-   * the invoker.
-   */
-  void fillInInvokerStackTrace() {
-    getCause().setStackTrace(Thread.currentThread().getStackTrace());
+  MessengerException(final String message) {
+    super(message);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
@@ -9,4 +9,8 @@ public class MessengerException extends RuntimeException {
   MessengerException(final String message) {
     super(message);
   }
+
+  MessengerException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteNotFoundException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteNotFoundException.java
@@ -21,6 +21,6 @@ public class RemoteNotFoundException extends MessengerException {
   private static final long serialVersionUID = 7169515572485196188L;
 
   public RemoteNotFoundException(final String string) {
-    super(string, new IllegalStateException("remote not found"));
+    super(string);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -51,32 +51,25 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
 
     final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);
     if (response.getException() != null) {
-      if (response.getException() instanceof MessengerException) {
-        final MessengerException cle = (MessengerException) response.getException();
-        cle.fillInInvokerStackTrace();
-      } else {
-        // do not chain the exception, we want to keep whatever the original exception's class was, so just add our
-        // bit to the stack
-        // trace.
-        final Throwable throwable = response.getException();
-        final StackTraceElement[] exceptionTrace = throwable.getStackTrace();
-        final Exception ourException =
-            new Exception(throwable.getMessage() + " exception in response from other system");
-        // Thread.currentThread().getStackTrace();
-        final StackTraceElement[] ourTrace = ourException.getStackTrace();
-        if (exceptionTrace != null && ourTrace != null) {
-          final StackTraceElement[] combinedTrace = new StackTraceElement[(exceptionTrace.length + ourTrace.length)];
-          int i = 0;
-          for (final StackTraceElement element : exceptionTrace) {
-            combinedTrace[i] = element;
-            i++;
-          }
-          for (final StackTraceElement element : ourTrace) {
-            combinedTrace[i] = element;
-            i++;
-          }
-          throwable.setStackTrace(combinedTrace);
+      // do not chain the exception, we want to keep whatever the original exception's class was, so just add our
+      // bit to the stack
+      // trace.
+      final Throwable throwable = response.getException();
+      final StackTraceElement[] exceptionTrace = throwable.getStackTrace();
+      final Exception ourException = new Exception(throwable.getMessage() + " exception in response from other system");
+      final StackTraceElement[] ourTrace = ourException.getStackTrace();
+      if (exceptionTrace != null && ourTrace != null) {
+        final StackTraceElement[] combinedTrace = new StackTraceElement[(exceptionTrace.length + ourTrace.length)];
+        int i = 0;
+        for (final StackTraceElement element : exceptionTrace) {
+          combinedTrace[i] = element;
+          i++;
         }
+        for (final StackTraceElement element : ourTrace) {
+          combinedTrace[i] = element;
+          i++;
+        }
+        throwable.setStackTrace(combinedTrace);
       }
       throw response.getException();
     }

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -21,7 +21,7 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
 
   public UnifiedInvocationHandler(final UnifiedMessenger messenger, final String endPointName,
       final boolean ignoreResults, final Class<?> remoteType) {
-    // equality and hash code are bassed on end point name
+    // equality and hash code are based on end point name
     super(endPointName);
     this.messenger = messenger;
     this.endPointName = endPointName;
@@ -30,7 +30,7 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
   }
 
   @Override
-  public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+  public Object invoke(final Object proxy, final Method method, final Object[] args) {
     if (super.shouldHandle(method, args)) {
       return super.handle(method, args);
     }
@@ -51,27 +51,7 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
 
     final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);
     if (response.getException() != null) {
-      // do not chain the exception, we want to keep whatever the original exception's class was, so just add our
-      // bit to the stack
-      // trace.
-      final Throwable throwable = response.getException();
-      final StackTraceElement[] exceptionTrace = throwable.getStackTrace();
-      final Exception ourException = new Exception(throwable.getMessage() + " exception in response from other system");
-      final StackTraceElement[] ourTrace = ourException.getStackTrace();
-      if (exceptionTrace != null && ourTrace != null) {
-        final StackTraceElement[] combinedTrace = new StackTraceElement[(exceptionTrace.length + ourTrace.length)];
-        int i = 0;
-        for (final StackTraceElement element : exceptionTrace) {
-          combinedTrace[i] = element;
-          i++;
-        }
-        for (final StackTraceElement element : ourTrace) {
-          combinedTrace[i] = element;
-          i++;
-        }
-        throwable.setStackTrace(combinedTrace);
-      }
-      throw response.getException();
+      throw new RuntimeException("Exception on remote", response.getException());
     }
     return response.getRVal();
   }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -64,7 +64,7 @@ public class UnifiedMessenger {
   public UnifiedMessenger(final IMessenger messenger) {
     this.messenger = messenger;
     this.messenger.addMessageListener(UnifiedMessenger.this::messageReceived);
-    this.messenger.addErrorListener((messenger1, reason) -> UnifiedMessenger.this.messengerInvalid());
+    this.messenger.addErrorListener((messenger1, reason) -> this.messengerInvalid(reason));
     if (this.messenger.isServer()) {
       hub = new UnifiedMessengerHub(this.messenger, this);
     }
@@ -75,12 +75,12 @@ public class UnifiedMessenger {
     return hub;
   }
 
-  private void messengerInvalid() {
+  private void messengerInvalid(final Throwable cause) {
     synchronized (pendingLock) {
       for (final GUID id : pendingInvocations.keySet()) {
         final CountDownLatch latch = pendingInvocations.remove(id);
         latch.countDown();
-        results.put(id, new RemoteMethodCallResults(new ConnectionLostException("Connection Lost")));
+        results.put(id, new RemoteMethodCallResults(cause));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -63,8 +63,8 @@ public class UnifiedMessenger {
    */
   public UnifiedMessenger(final IMessenger messenger) {
     this.messenger = messenger;
-    this.messenger.addMessageListener(UnifiedMessenger.this::messageReceived);
-    this.messenger.addErrorListener((messenger1, reason) -> this.messengerInvalid(reason));
+    this.messenger.addMessageListener(this::messageReceived);
+    this.messenger.addErrorListener((messenger1, reason) -> messengerInvalid(reason));
     if (this.messenger.isServer()) {
       hub = new UnifiedMessengerHub(this.messenger, this);
     }

--- a/game-core/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Decoder.java
@@ -76,9 +76,9 @@ class Decoder {
           if (!running || s == null || s.isInputShutdown()) {
             continue;
           }
-          final QuarantineConversation converstation = quarantine.get(data.getChannel());
-          if (converstation != null) {
-            sendQuarantine(data.getChannel(), converstation, header);
+          final QuarantineConversation conversation = quarantine.get(data.getChannel());
+          if (conversation != null) {
+            sendQuarantine(data.getChannel(), conversation, header);
           } else {
             if (nioSocket.getLocalNode() == null) {
               throw new IllegalStateException("we are writing messages, but no local node");
@@ -90,8 +90,7 @@ class Decoder {
           }
         } catch (final IOException | RuntimeException e) {
           // we are reading from memory here
-          // there should be no network errors, something
-          // is odd
+          // there should be no network errors, something is odd
           logger.log(Level.SEVERE, "error reading object", e);
           errorReporter.error(data.getChannel(), e);
         }

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -237,7 +237,7 @@ public class RemoteMessengerTest {
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
       final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(serverUnifiedMessenger);
       final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
-      final Semaphore semaphore = new Semaphore(0, true);
+      final Semaphore semaphore = new Semaphore(0);
       final IFoo foo = () -> {
         semaphore.release();
         Interruptibles.await(semaphore::acquire);

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -246,8 +246,8 @@ public class RemoteMessengerTest {
       serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
       assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
       final CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-          final IFoo remoteFoo = (IFoo) serverRemoteMessenger.getRemote(test);
-          remoteFoo.foo();
+        final IFoo remoteFoo = (IFoo) serverRemoteMessenger.getRemote(test);
+        remoteFoo.foo();
       });
       // Wait for each other
       Interruptibles.await(semaphore::acquire);

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -2,9 +2,8 @@ package games.strategy.engine.message.unifiedmessenger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -12,10 +11,10 @@ import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,25 +93,15 @@ public class RemoteMessengerTest {
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     remoteMessenger.unregisterRemote("test");
-    try {
-      remote.increment(1);
-      fail("No exception thrown");
-    } catch (final RemoteNotFoundException rme) {
-      // this is what we expect
-    }
+    assertThrows(RemoteNotFoundException.class, () -> remote.increment(1));
   }
 
   @Test
   public void testNoRemote() {
     final RemoteName test = new RemoteName(ITestRemote.class, "test");
-    try {
-      remoteMessenger.getRemote(test);
-      final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
-      remote.testVoid();
-      fail("No exception thrown");
-    } catch (final RemoteNotFoundException rme) {
-      // this is what we expect
-    }
+    remoteMessenger.getRemote(test);
+    final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
+    assertThrows(RemoteNotFoundException.class, remote::testVoid);
   }
 
   @Test
@@ -125,21 +114,13 @@ public class RemoteMessengerTest {
   }
 
   @Test
-  public void testException() throws Exception {
+  public void testException() {
     final TestRemote testRemote = new TestRemote();
     final RemoteName test = new RemoteName(ITestRemote.class, "test");
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
-    try {
-      remote.throwException();
-    } catch (final Exception e) {
-      // this is what we want
-      if (e.getMessage().equals(TestRemote.EXCEPTION_STRING)) {
-        return;
-      }
-      throw e;
-    }
-    fail("No exception thrown");
+    final Exception e = assertThrows(Exception.class, remote::throwException);
+    assertEquals(TestRemote.EXCEPTION_STRING, e.getMessage());
   }
 
   @Test
@@ -254,43 +235,23 @@ public class RemoteMessengerTest {
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
       final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(serverUnifiedMessenger);
       final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
-      final CountDownLatch latch = new CountDownLatch(1);
-      final AtomicBoolean started = new AtomicBoolean(false);
-      final IFoo foo = new IFoo() {
-        @Override
-        public void foo() {
-          started.set(true);
-          Interruptibles.await(latch);
-        }
+      final Semaphore semaphore = new Semaphore(0, true);
+      final IFoo foo = () -> {
+        semaphore.release();
+        Interruptibles.await(semaphore::acquire);
       };
       clientRemoteMessenger.registerRemote(foo, test);
       serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
       assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
-      final AtomicReference<ConnectionLostException> rme = new AtomicReference<>(null);
-      final Thread t = new Thread(() -> {
-        try {
+      final CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
           final IFoo remoteFoo = (IFoo) serverRemoteMessenger.getRemote(test);
           remoteFoo.foo();
-        } catch (final ConnectionLostException e) {
-          rme.set(e);
-        }
       });
-      t.start();
-      // wait for the thread to start
-      while (started.get() == false) {
-        Interruptibles.sleep(1);
-      }
-      Interruptibles.sleep(20);
-      // TODO: we are getting a RemoteNotFoundException because the client is disconnecting before the invoke goes out
-      // completely
-      // Perhaps this situation should be changed to a ConnectionLostException or something else?
+      Interruptibles.await(semaphore::acquire);
       client.shutDown();
-      // when the client shutdowns, this should wake up.
-      // and an error should be thrown
-      // give the thread a chance to execute
-      t.join(200);
-      latch.countDown();
-      assertNotNull(rme.get());
+      semaphore.release();
+      final Exception e = assertThrows(ExecutionException.class, future::get);
+      assertTrue(ConnectionLostException.class.isInstance(e.getCause()));
     } finally {
       shutdownServerAndClient(server, client);
     }


### PR DESCRIPTION
I'm currently working on figuring out why a specific error is logged when trying to host a bot (not me, someone else).
However I noticed this terrible piece of code that confused me, and is effectively useless.
This is a real stacktrace:
```
games.strategy.engine.message.ConnectionLostException: Connection Lost
        at games.strategy.engine.message.unifiedmessenger.UnifiedMessenger.messengerInvalid(UnifiedMessenger.java:86)
        at games.strategy.engine.message.unifiedmessenger.UnifiedMessenger.lambda$new$1(UnifiedMessenger.java:69)
        at games.strategy.net.ClientMessenger.socketError(ClientMessenger.java:231)
        at games.strategy.net.nio.NioSocket.error(NioSocket.java:91)
        at games.strategy.net.nio.NioReader.loop(NioReader.java:127)
        at java.lang.Thread.run(Unknown Source)
Caused by: java.lang.Exception: Invoker Stack
        at java.lang.Thread.getStackTrace(Unknown Source)
        at games.strategy.engine.message.MessengerException.fillInInvokerStackTrace(MessengerException.java:19)
        at games.strategy.engine.message.UnifiedInvocationHandler.invoke(UnifiedInvocationHandler.java:56)
        at com.sun.proxy.$Proxy4.updateGame(Unknown Source)
        at games.strategy.engine.framework.startup.ui.InGameLobbyWatcher.postUpdate(InGameLobbyWatcher.java:281)
        at games.strategy.engine.framework.startup.ui.InGameLobbyWatcher.updatePlayerCount(InGameLobbyWatcher.java:270)
        at games.strategy.engine.framework.startup.ui.InGameLobbyWatcher$1.connectionAdded(InGameLobbyWatcher.java:207)
        at games.strategy.net.ServerMessenger.notifyConnectionsChanged(ServerMessenger.java:504)
        at games.strategy.net.ServerMessenger.socketUnqaurantined(ServerMessenger.java:662)
        at games.strategy.net.nio.NioSocket.unquarantine(NioSocket.java:85)
        at games.strategy.net.nio.Decoder.sendQuarantine(Decoder.java:116)
        at games.strategy.net.nio.Decoder.loop(Decoder.java:81)
        ... 1 more
```

What you'd expect from this stacktrace is that the Caused By part would have all the information about the root cause that's being wrapped somewhere else, but if you look deeper into the code something else is happening.
##### What's supposed to happen
From the javadoc the fillInInvokerStackTrace should replace the real stacktrace with the invokers stack trace, e.g the stack of the other parties computer
##### What really happens
Because there's only a single call to the fill method in the entire codebase the CauseBy stack will always be the same (apart from line numbers and future refatorings) and lead to the method call itself instead of the exception (what one would expect), so this part is completely useless.
That's why removing it is probably the best option.

I recommend reviewing with whitespace changes ignored.

UPDATE:
Turns out this mechanism is just a dirty workaround for exception wrapping to keep the original exception type. I changed the behaviour for now so the exception is simply being wrapped to avoid confusion. If this breaks too much (I don't think that'll happen), we can easily revert this change to the old "append stacktrace" behaviour, but no special treatments of any exception type.
Also the client's Exception is now being sent over the network instead of some sort of placeholder exception to allow for easier debugging. A Stacktrace doesn't contain any sensitive information, unless somewhere in the code we paste something stupid into the message we should be save. This PR requires some manual testing though, I'm not trusting the tests for this one, especially because I modified them to just work 😅 