### PR TITLE
Don't freeze the UI when joining a game

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -181,13 +181,12 @@ public class ClientModel implements IMessengerErrorListener {
     return props;
   }
 
-  boolean createClientMessenger(Component ui) {
+  boolean createClientMessenger(final Component ui) {
+    this.ui = JOptionPane.getFrameForComponent(ui);
     gameDataOnStartup = gameSelectorModel.getGameData();
     gameSelectorModel.setCanSelect(false);
-    ui = JOptionPane.getFrameForComponent(ui);
-    this.ui = ui;
     // load in the saved name!
-    final ClientProps props = getProps(ui);
+    final ClientProps props = getProps(this.ui);
     if (props == null) {
       gameSelectorModel.setCanSelect(true);
       cancel();
@@ -199,7 +198,7 @@ public class ClientModel implements IMessengerErrorListener {
     ClientSetting.flush();
     final int port = props.getPort();
     if (port >= 65536 || port <= 0) {
-      EventThreadJOptionPane.showMessageDialog(ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE);
+      EventThreadJOptionPane.showMessageDialog(this.ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE);
       return false;
     }
     final String address = props.getHost();
@@ -207,11 +206,11 @@ public class ClientModel implements IMessengerErrorListener {
       final String mac = MacFinder.getHashedMacAddress();
       messenger = new ClientMessenger(address, port, name, mac, objectStreamFactory, new ClientLogin(this.ui));
     } catch (final CouldNotLogInException e) {
-      EventThreadJOptionPane.showMessageDialog(ui, e.getMessage());
+      EventThreadJOptionPane.showMessageDialog(this.ui, e.getMessage());
       return false;
     } catch (final Exception ioe) {
       ioe.printStackTrace(System.out);
-      EventThreadJOptionPane.showMessageDialog(ui, "Unable to connect:" + ioe.getMessage(), "Error",
+      EventThreadJOptionPane.showMessageDialog(this.ui, "Unable to connect:" + ioe.getMessage(), "Error",
           JOptionPane.ERROR_MESSAGE);
       return false;
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -63,6 +63,11 @@ public class SetupPanelModel extends Observable {
     ui.setSize(new Dimension(x, y));
   }
 
+  /**
+   * A method that establishes a connection to a remote game
+   * and displays the game start screen afterwards if the
+   * connection was successfully established.
+   */
   public void showClient(final Component ui) {
     final ClientModel model = new ClientModel(gameSelectorModel, this);
     if (Interruptibles.awaitResult(() -> GameRunner

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -9,12 +9,14 @@ import javax.swing.JPanel;
 
 import com.google.common.base.Preconditions;
 
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.ClientSetupPanel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
 import games.strategy.engine.framework.startup.ui.LocalSetupPanel;
 import games.strategy.engine.framework.startup.ui.MetaSetupPanel;
 import games.strategy.engine.framework.startup.ui.PbemSetupPanel;
 import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
+import games.strategy.util.Interruptibles;
 
 public class SetupPanelModel extends Observable {
   protected final GameSelectorModel gameSelectorModel;
@@ -63,11 +65,16 @@ public class SetupPanelModel extends Observable {
 
   public void showClient(final Component ui) {
     final ClientModel model = new ClientModel(gameSelectorModel, this);
-    if (!model.createClientMessenger(ui)) {
-      model.cancel();
-      return;
+    if (Interruptibles.awaitResult(() -> GameRunner
+        .newBackgroundTaskRunner().runInBackgroundAndReturn("Loading game...", () -> {
+      if (!model.createClientMessenger(ui)) {
+        model.cancel();
+        return false;
+      }
+      return true;
+    })).result.get()) {
+      setGameTypePanel(new ClientSetupPanel(model));
     }
-    setGameTypePanel(new ClientSetupPanel(model));
   }
 
   protected void setGameTypePanel(final ISetupPanel panel) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -72,7 +72,7 @@ public class SetupPanelModel extends Observable {
         return false;
       }
       return true;
-    })).result.get()) {
+    })).result.orElse(false)) {
       setGameTypePanel(new ClientSetupPanel(model));
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -67,12 +67,12 @@ public class SetupPanelModel extends Observable {
     final ClientModel model = new ClientModel(gameSelectorModel, this);
     if (Interruptibles.awaitResult(() -> GameRunner
         .newBackgroundTaskRunner().runInBackgroundAndReturn("Loading game...", () -> {
-      if (!model.createClientMessenger(ui)) {
-        model.cancel();
-        return false;
-      }
-      return true;
-    })).result.orElse(false)) {
+          if (!model.createClientMessenger(ui)) {
+            model.cancel();
+            return false;
+          }
+          return true;
+        })).result.orElse(false)) {
       setGameTypePanel(new ClientSetupPanel(model));
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -37,21 +37,19 @@ public class ClientSetupPanel extends SetupPanel {
   private final Insets buttonInsets = new Insets(0, 0, 0, 0);
   private final ClientModel clientModel;
   private List<PlayerRow> playerRows = Collections.emptyList();
-  private final IRemoteModelListener remoteModelListener = new IRemoteModelListener() {
-    @Override
-    public void playersTakenChanged() {}
-
-    @Override
-    public void playerListChanged() {
-      SwingUtilities.invokeLater(() -> internalPlayersChanged());
-    }
-  };
 
   public ClientSetupPanel(final ClientModel model) {
     clientModel = model;
     layoutComponents();
-    clientModel.setRemoteModelListener(remoteModelListener);
-    setWidgetActivation();
+    clientModel.setRemoteModelListener(new IRemoteModelListener() {
+      @Override
+      public void playersTakenChanged() {}
+
+      @Override
+      public void playerListChanged() {
+        internalPlayersChanged();
+      }
+    });
   }
 
   private void internalPlayersChanged() {
@@ -70,9 +68,9 @@ public class ClientSetupPanel extends SetupPanel {
       final PlayerRow playerRow = new PlayerRow(name, playerNamesAndAlliancesInTurnOrder.get(name),
           IGameLoader.CLIENT_PLAYER_TYPE, enabledPlayers.get(name));
       playerRows.add(playerRow);
-      playerRow.update(players.get(name), disableable.contains(name));
+      SwingUtilities.invokeLater(() -> playerRow.update(players.get(name), disableable.contains(name)));
     }
-    layoutComponents();
+    SwingUtilities.invokeLater(this::layoutComponents);
   }
 
   private void layoutComponents() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -43,7 +43,8 @@ public class ClientSetupPanel extends SetupPanel {
     layoutComponents();
     clientModel.setRemoteModelListener(new IRemoteModelListener() {
       @Override
-      public void playersTakenChanged() {}
+      public void playersTakenChanged() {
+      }
 
       @Override
       public void playerListChanged() {
@@ -150,7 +151,8 @@ public class ClientSetupPanel extends SetupPanel {
   }
 
   @Override
-  public void setWidgetActivation() {}
+  public void setWidgetActivation() {
+  }
 
   @Override
   public void shutDown() {


### PR DESCRIPTION
This PR moves IO network operations off the EDT to avoid freezing the UI when trying to connect to a remote game.
This is especially problematic when a bot becomes unresponsive, because then the UI may freeze completely for a long time.