### PR TITLE
Explicitly specify dice server port

### DIFF
--- a/game-core/dice_servers/tripleawarclub-staging.properties
+++ b/game-core/dice_servers/tripleawarclub-staging.properties
@@ -4,6 +4,7 @@ order=11
 name=dice-staging.tripleawarclub.org (experimental BETA)
 # dice server host
 host=dice-staging.tripleawarclub.org
+port=443
 scheme=https
 # path in dice server post to post too
 path=/MARTI.php

--- a/game-core/dice_servers/tripleawarclub.properties
+++ b/game-core/dice_servers/tripleawarclub.properties
@@ -4,6 +4,7 @@ order=10
 name=dice.tripleawarclub.org
 #dice server host
 host=dice.tripleawarclub.org
+port=443
 scheme=https
 #path in dice server post to post too
 path=/MARTI.php


### PR DESCRIPTION
As discussed on the [forum](https://forums.triplea-game.org/topic/879/civil-war-3-2-4-redrum-confederate-vs-wirkey-union-2), there is a compatibility issue between the latest and current stable clients.  #3277 set the `scheme` property value to `https` for all MARTI servers.  This property is persisted in a save game created by the latest pre-release, and thus read when the save game is opened by any other client.

When the save game is opened in a stable client, the client attempts to open an HTTPS connection to the dice server using its default port of `80`.  As this port is bound to the dice server's HTTP endpoint, the TLS connection fails.

Alternatively, when the save game is opened in a pre-release client, the client attempts to open an HTTPS connection to the dice server using its default port of `-1`, which instructs the HTTP stack to use the standard default port for the specified scheme (443 in this case).  Thus, the TLS connection succeeds.

The fix is to explicitly specify the port as 443 in the dice server properties files.  This ensures that save games created by a pre-release client will have the correct dice server port instead of relying on the default port configured in code.  Thus, when such a save game is opened by a stable client, it will behave just as if it were opened by a pre-release client.

#### Testing

I created a PBF save game using `master` and verified I could reproduce the TLS error reported above  when opening the save game in 9678.  I then created a PBF save game using this branch and verified testing the dice server worked when opening the save game in 9678.

#### Notes

This change can be reverted upon the next incompatible release.