### PR TITLE
Unit icons

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -80,6 +80,9 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     return rulesAttachment;
   }
 
+  /**
+   * Get condition attachment for the given player and condition name.
+   */
   public static ICondition getCondition(final String playerName, final String conditionName,
       final GameData data) {
     final PlayerID player = data.getPlayerList().getPlayerId(playerName);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -116,9 +116,6 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       System.err.println("Condition attachment does not exist: " + conditionName);
       return null;
     }
-    if (!ICondition.class.isAssignableFrom(attachment.getClass())) {
-      throw new IllegalStateException("(wtf??) attachment is not an ICondition: " + attachment.getName());
-    }
     return (ICondition) attachment;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
@@ -1,8 +1,9 @@
 package games.strategy.triplea.image;
 
 import java.awt.Image;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.UnitIconProperties;
@@ -17,15 +18,11 @@ public class UnitIconImageFactory extends ImageFactory {
   public UnitIconImageFactory() {}
 
   public List<Image> getImages(final String player, final String unitType, final GameData data) {
-    final List<Image> images = new ArrayList<>();
-    final List<String> imagePaths = UnitIconProperties.getInstance(data).getImagePaths(player, unitType, data);
-    for (final String imagePath : imagePaths) {
-      final Image image = getImage(PREFIX + imagePath, false);
-      if (image != null) {
-        images.add(image);
-      }
-    }
-    return images;
+    return UnitIconProperties.getInstance(data).getImagePaths(player, unitType, data)
+        .stream()
+        .map(imagePath -> getImage(PREFIX + imagePath, false))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
@@ -1,0 +1,31 @@
+package games.strategy.triplea.image;
+
+import java.awt.Image;
+import java.util.ArrayList;
+import java.util.List;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ui.UnitIconProperties;
+
+/**
+ * Retrieves and caches unit icon images.
+ */
+public class UnitIconImageFactory extends ImageFactory {
+  private static final String PREFIX = "unitIcons/";
+
+  /** Creates new FlagIconImageFactory. */
+  public UnitIconImageFactory() {}
+
+  public List<Image> getImages(final String player, final String unitType, final GameData data) {
+    final List<Image> images = new ArrayList<>();
+    final List<String> imagePaths = UnitIconProperties.getInstance(data).getImagePaths(player, unitType, data);
+    for (final String imagePath : imagePaths) {
+      final Image image = getImage(PREFIX + imagePath, false);
+      if (image != null) {
+        images.add(image);
+      }
+    }
+    return images;
+  }
+
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -27,6 +27,7 @@ import games.strategy.triplea.image.PuImageFactory;
 import games.strategy.triplea.image.ResourceImageFactory;
 import games.strategy.triplea.image.TerritoryEffectImageFactory;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.image.UnitIconImageFactory;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable.OptionalExtraBorderLevel;
@@ -42,6 +43,7 @@ public class HeadedUiContext extends AbstractUiContext {
   protected final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
   protected final TerritoryEffectImageFactory territoryEffectImageFactory = new TerritoryEffectImageFactory();
   protected final MapImage mapImage;
+  protected final UnitIconImageFactory unitIconImageFactory = new UnitIconImageFactory();
   protected final FlagIconImageFactory flagIconImageFactory = new FlagIconImageFactory();
   protected DiceImageFactory diceImageFactory;
   protected final PuImageFactory puImageFactory = new PuImageFactory();
@@ -88,6 +90,7 @@ public class HeadedUiContext extends AbstractUiContext {
     // TODO: separate scale for resources
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);
+    unitIconImageFactory.setResourceLoader(resourceLoader);
     flagIconImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
     tileImageFactory.setMapDir(resourceLoader);
@@ -155,6 +158,11 @@ public class HeadedUiContext extends AbstractUiContext {
   @Override
   public MapImage getMapImage() {
     return mapImage;
+  }
+
+  @Override
+  public UnitIconImageFactory getUnitIconImageFactory() {
+    return unitIconImageFactory;
   }
 
   @Override
@@ -239,4 +247,5 @@ public class HeadedUiContext extends AbstractUiContext {
       ClientLogger.logQuietly("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
   }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.image.PuImageFactory;
 import games.strategy.triplea.image.ResourceImageFactory;
 import games.strategy.triplea.image.TerritoryEffectImageFactory;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.image.UnitIconImageFactory;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable.OptionalExtraBorderLevel;
@@ -76,6 +77,11 @@ public class HeadlessUiContext extends AbstractUiContext {
 
   @Override
   public MapImage getMapImage() {
+    return null;
+  }
+
+  @Override
+  public UnitIconImageFactory getUnitIconImageFactory() {
     return null;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
@@ -1,47 +1,29 @@
 package games.strategy.triplea.ui;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.time.Instant;
-import java.util.Optional;
-import java.util.Properties;
 
-import games.strategy.debug.ClientLogger;
-import games.strategy.triplea.ResourceLoader;
-import games.strategy.util.UrlStreams;
+/**
+ * Loads notification messages from notifications.properties.
+ */
+public class NotificationMessages extends PropertyFile {
 
-/** TODO: copy paste overlap with PoliticsText.java */
-public class NotificationMessages {
-  // Filename
   private static final String PROPERTY_FILE = "notifications.properties";
   private static final String SOUND_CLIP_SUFFIX = "_sounds";
-  private static NotificationMessages nm = null;
+
+  private static NotificationMessages instance = null;
   private static Instant timestamp = Instant.EPOCH;
-  private final Properties properties = new Properties();
 
   protected NotificationMessages() {
-    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
-    final URL url = loader.getResource(PROPERTY_FILE);
-    if (url != null) {
-      final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-      if (inputStream.isPresent()) {
-        try {
-          properties.load(inputStream.get());
-        } catch (final IOException e) {
-          ClientLogger.logError("Error reading " + PROPERTY_FILE, e);
-        }
-      }
-    }
+    super(PROPERTY_FILE);
   }
 
   public static NotificationMessages getInstance() {
     // cache properties for 10 seconds
-    if (nm == null || timestamp.plusSeconds(10).isBefore(Instant.now())) {
-      nm = new NotificationMessages();
+    if (instance == null || timestamp.plusSeconds(10).isBefore(Instant.now())) {
+      instance = new NotificationMessages();
       timestamp = Instant.now();
     }
-    return nm;
+    return instance;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
@@ -1,0 +1,40 @@
+package games.strategy.triplea.ui;
+
+import java.time.Instant;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * Loads objective text from objectives.properties.
+ */
+public class ObjectiveProperties extends PropertyFile {
+
+  private static final String PROPERTY_FILE = "objectives.properties";
+  private static final String OBJECTIVES_PANEL_NAME = "Objectives.Panel.Name";
+  static final String GROUP_PROPERTY = "TABLEGROUP";
+
+
+  private static ObjectiveProperties instance = null;
+  private static Instant timestamp = Instant.EPOCH;
+
+  protected ObjectiveProperties() {
+    super(PROPERTY_FILE);
+  }
+
+  public static ObjectiveProperties getInstance() {
+    // cache properties for 1 second
+    if (instance == null || timestamp.plusSeconds(1).isBefore(Instant.now())) {
+      instance = new ObjectiveProperties();
+      timestamp = Instant.now();
+    }
+    return instance;
+  }
+
+  public String getName() {
+    return properties.getProperty(ObjectiveProperties.OBJECTIVES_PANEL_NAME, "Objectives");
+  }
+
+  public Set<Entry<Object, Object>> entrySet() {
+    return properties.entrySet();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsText.java
@@ -1,25 +1,13 @@
 package games.strategy.triplea.ui;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.time.Instant;
-import java.util.Optional;
-import java.util.Properties;
-
-import games.strategy.triplea.ResourceLoader;
-import games.strategy.util.UrlStreams;
 
 /**
  * Returns a bunch of messages from politicstext.properties
- * TODO: copy paste overlap with NotifcationMessages.java
  */
-public class PoliticsText {
-  // Filename
+public class PoliticsText extends PropertyFile {
+
   private static final String PROPERTY_FILE = "politicstext.properties";
-  private static PoliticsText pt = null;
-  private static Instant timestamp = Instant.EPOCH;
-  private final Properties properties = new Properties();
   private static final String BUTTON = "BUTTON";
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
@@ -28,37 +16,20 @@ public class PoliticsText {
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
 
-  protected PoliticsText() {
-    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
-    final URL url = loader.getResource(PROPERTY_FILE);
+  private static PoliticsText instance = null;
+  private static Instant timestamp = Instant.EPOCH;
 
-    if (url != null) {
-      final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-      if (inputStream.isPresent()) {
-        try {
-          properties.load(inputStream.get());
-        } catch (final IOException e) {
-          System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
-        }
-      }
-    }
+  protected PoliticsText() {
+    super(PROPERTY_FILE);
   }
 
   public static PoliticsText getInstance() {
     // cache properties for 10 seconds
-    if (pt == null || timestamp.plusSeconds(10).isBefore(Instant.now())) {
-      pt = new PoliticsText();
+    if (instance == null || timestamp.plusSeconds(10).isBefore(Instant.now())) {
+      instance = new PoliticsText();
       timestamp = Instant.now();
     }
-    return pt;
-  }
-
-  private String getString(final String value) {
-    return properties.getProperty(value, "NO: " + value + " set.");
-  }
-
-  private String getMessage(final String politicsKey, final String messageKey) {
-    return getString(politicsKey + "." + messageKey);
+    return instance;
   }
 
   public String getButtonText(final String politicsKey) {
@@ -66,26 +37,35 @@ public class PoliticsText {
   }
 
   public String getDescription(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.DESCRIPTION);
+    return getMessage(politicsKey, DESCRIPTION);
   }
 
   public String getNotificationSucccess(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.NOTIFICATION_SUCCESS);
+    return getMessage(politicsKey, NOTIFICATION_SUCCESS);
   }
 
   public String getNotificationSuccessOthers(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.OTHER_NOTIFICATION_SUCCESS);
+    return getMessage(politicsKey, OTHER_NOTIFICATION_SUCCESS);
   }
 
   public String getNotificationFailure(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.NOTIFICATION_FAILURE);
+    return getMessage(politicsKey, NOTIFICATION_FAILURE);
   }
 
   public String getNotificationFailureOthers(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.OTHER_NOTIFICATION_FAILURE);
+    return getMessage(politicsKey, OTHER_NOTIFICATION_FAILURE);
   }
 
   public String getAcceptanceQuestion(final String politicsKey) {
-    return getMessage(politicsKey, PoliticsText.ACCEPT_QUESTION);
+    return getMessage(politicsKey, ACCEPT_QUESTION);
   }
+
+  private String getMessage(final String politicsKey, final String messageKey) {
+    return getString(politicsKey + "." + messageKey);
+  }
+
+  private String getString(final String value) {
+    return properties.getProperty(value, "NO: " + value + " set.");
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
@@ -10,8 +10,11 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.util.UrlStreams;
 
-/** TODO: copy paste overlap with PoliticsText.java */
-public class PropertyFile {
+
+/**
+ * Common property file class which should be extended.
+ */
+public abstract class PropertyFile {
 
   protected final Properties properties = new Properties();
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
@@ -1,0 +1,33 @@
+package games.strategy.triplea.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Optional;
+import java.util.Properties;
+
+import games.strategy.debug.ClientLogger;
+import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
+
+/** TODO: copy paste overlap with PoliticsText.java */
+public class PropertyFile {
+
+  protected final Properties properties = new Properties();
+
+  protected PropertyFile(final String fileName) {
+    final ResourceLoader loader = AbstractUiContext.getResourceLoader();
+    final URL url = loader.getResource(fileName);
+    if (url != null) {
+      final Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try {
+          properties.load(inputStream.get());
+        } catch (final IOException e) {
+          ClientLogger.logError("Error reading " + fileName, e);
+        }
+      }
+    }
+  }
+
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.image.PuImageFactory;
 import games.strategy.triplea.image.ResourceImageFactory;
 import games.strategy.triplea.image.TerritoryEffectImageFactory;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.image.UnitIconImageFactory;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable.OptionalExtraBorderLevel;
@@ -60,6 +61,8 @@ public interface UiContext {
   TerritoryEffectImageFactory getTerritoryEffectImageFactory();
 
   MapImage getMapImage();
+
+  UnitIconImageFactory getUnitIconImageFactory();
 
   FlagIconImageFactory getFlagImageFactory();
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -62,6 +62,9 @@ public class UnitIconProperties extends PropertyFile {
     return instance;
   }
 
+  /**
+   * Get all unit icon images for given player and unit type that are currently true.
+   */
   public List<String> getImagePaths(final String player, final String unitType, final GameData data) {
     final List<String> imagePaths = new ArrayList<>();
     final String gameName =

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -1,0 +1,111 @@
+package games.strategy.triplea.ui;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.attachments.AbstractConditionsAttachment;
+import games.strategy.triplea.attachments.AbstractPlayerRulesAttachment;
+import games.strategy.triplea.attachments.ICondition;
+import games.strategy.util.FileNameUtils;
+
+/**
+ * Loads objective text from objectives.properties.
+ */
+public class UnitIconProperties extends PropertyFile {
+
+  private static final String PROPERTY_FILE = "unit_icons.properties";
+
+  private static UnitIconProperties instance = null;
+  private static Instant timestamp = Instant.EPOCH;
+  private static Map<ICondition, Boolean> conditionsStatus = new HashMap<>();
+
+  protected UnitIconProperties(final GameData data) {
+    super(PROPERTY_FILE);
+    final String gameName =
+        FileNameUtils.replaceIllegalCharacters(data.getGameName(), '_').replaceAll(" ", "_").concat(".");
+    for (final String key : properties.stringPropertyNames()) {
+      if (!key.startsWith(gameName)) {
+        continue;
+      }
+      try {
+        final String[] unitInfoAndCondition = key.split(";");
+        final String[] unitInfo = unitInfoAndCondition[0].split("\\.");
+        if (unitInfoAndCondition.length != 2) {
+          continue;
+        }
+        final ICondition condition =
+            AbstractPlayerRulesAttachment.getCondition(unitInfo[1], unitInfoAndCondition[1], data);
+        if (condition != null) {
+          conditionsStatus.put(condition, false);
+        }
+      } catch (final Exception e) {
+        System.err.println("unit_icons.properties keys must be: <game_name>.<player>.<unit_type>;attachmentName OR "
+            + "if always true: <game_name>.<player>.<unit_type>");
+      }
+    }
+    conditionsStatus = getTestedConditions(data);
+  }
+
+  public static UnitIconProperties getInstance(final GameData data) {
+    // cache properties for 10 seconds
+    if (instance == null || timestamp.plusSeconds(10).isBefore(Instant.now())) {
+      instance = new UnitIconProperties(data);
+      timestamp = Instant.now();
+    }
+    return instance;
+  }
+
+  public List<String> getImagePaths(final String player, final String unitType, final GameData data) {
+    final List<String> imagePaths = new ArrayList<>();
+    final String gameName =
+        FileNameUtils.replaceIllegalCharacters(data.getGameName(), '_').replaceAll(" ", "_");
+    final String startOfKey = gameName + "." + player + "." + unitType;
+    for (final Entry<Object, Object> entry : properties.entrySet()) {
+      try {
+        final String key = entry.getKey().toString();
+        final String[] keyParts = key.split(";");
+        if (startOfKey.equals(keyParts[0])) {
+          if (keyParts.length == 2) {
+            final ICondition condition = AbstractPlayerRulesAttachment.getCondition(player, keyParts[1], data);
+            if (conditionsStatus.get(condition)) {
+              imagePaths.add(entry.getValue().toString());
+            }
+          } else {
+            imagePaths.add(entry.getValue().toString());
+          }
+        }
+      } catch (final Exception e) {
+        System.err.println("unit_icons.properties keys must be: <game_name>.<player>.<unit_type>;attachmentName OR "
+            + "if always true: <game_name>.<player>.<unit_type>");
+      }
+    }
+    return imagePaths;
+  }
+
+  public Set<Entry<Object, Object>> entrySet() {
+    return properties.entrySet();
+  }
+
+  public boolean testIfConditionsHaveChanged(final GameData data) {
+    final Map<ICondition, Boolean> testedConditions = getTestedConditions(data);
+    if (!testedConditions.equals(conditionsStatus)) {
+      conditionsStatus = testedConditions;
+      return true;
+    }
+    return false;
+  }
+
+  private static Map<ICondition, Boolean> getTestedConditions(final GameData data) {
+    final HashSet<ICondition> allConditionsNeeded =
+        AbstractConditionsAttachment.getAllConditionsRecursive(new HashSet<>(conditionsStatus.keySet()), null);
+    return AbstractConditionsAttachment.testAllConditionsRecursive(allConditionsNeeded, null,
+        new ObjectiveDummyDelegateBridge(data));
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -104,25 +104,20 @@ public class UnitsDrawer implements IDrawable {
           // If unit is not in the "excluded list" it will get drawn
           if (maxRange != 0) {
             final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
-            final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;// centered flag in the middle
-            final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4
-                - 5;// centered flag in the middle moved it 1/2 - 5 down
+            final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
+            final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
             graphics.drawImage(flag, (placementPoint.x - bounds.x) + xoffset, (placementPoint.y - bounds.y) + yoffset,
                 null);
           }
-          drawUnit(graphics, img.get(), bounds);
+          drawUnit(graphics, img.get(), bounds, data);
           break;
         case NEXT_TO:
-          drawUnit(graphics, img.get(), bounds);
+          drawUnit(graphics, img.get(), bounds, data);
           // If unit is not in the "excluded list" it will get drawn
           if (maxRange != 0) {
             final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
-            final int xoffset = img.get().getWidth(null) - flag.getWidth(
-                null);// If someone wants to put more effort in this, he could add an algorithm to calculate the real
-            final int yoffset =
-                img.get().getHeight(null) - flag.getHeight(null);// lower right corner - transparency/alpha channel etc.
-            // currently the flag is drawn in the lower right corner of the image's bounds -> offsets on some unit
-            // images
+            final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
+            final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
             // This Method draws the Flag in the lower right corner of the unit image. Since the position is the upper
             // left corner we have to move the picture up by the height and left by the width.
             graphics.drawImage(flag, (placementPoint.x - bounds.x) + xoffset, (placementPoint.y - bounds.y) + yoffset,
@@ -133,8 +128,9 @@ public class UnitsDrawer implements IDrawable {
           throw new AssertionError("unknown unit flag draw mode: " + drawUnitNationMode);
       }
     } else {
-      img.ifPresent(image -> drawUnit(graphics, image, bounds));
+      img.ifPresent(image -> drawUnit(graphics, image, bounds, data));
     }
+
     // more then 1 unit of this category
     if (count != 1) {
       final int stackSize = mapData.getDefaultUnitsStackSize();
@@ -189,8 +185,15 @@ public class UnitsDrawer implements IDrawable {
   /**
    * This draws the given image onto the given graphics object.
    */
-  private void drawUnit(final Graphics2D graphics, final Image image, final Rectangle bounds) {
+  private void drawUnit(final Graphics2D graphics, final Image image, final Rectangle bounds, final GameData data) {
     graphics.drawImage(image, placementPoint.x - bounds.x, placementPoint.y - bounds.y, null);
+
+    // draw unit icons in top right corner
+    final List<Image> unitIcons = uiContext.getUnitIconImageFactory().getImages(playerName, unitType, data);
+    for (final Image unitIcon : unitIcons) {
+      final int xoffset = image.getWidth(null) - unitIcon.getWidth(null);
+      graphics.drawImage(unitIcon, (placementPoint.x - bounds.x) + xoffset, (placementPoint.y - bounds.y), null);
+    }
   }
 
   private void displayHitDamage(final Rectangle bounds, final Graphics2D graphics) {


### PR DESCRIPTION
Addresses https://forums.triplea-game.org/topic/882/unit-icons-inserted-by-conditions

**Changes**
- Refactored property file classes 
- New property file class for unit_icons.properties
- New image factory for unitIcons/
- Logic to draw unit icons on top of units
- Logic to check when unit icon conditions change

**Tested (TWW)**
- Created property file (unit_icons.properties): 
```
Total_World_War__December_1941_BETA.Germany.germanNavalFighter=air.png
Total_World_War__December_1941_BETA.Germany.germanFighter;conditionAttachmentgermanImprovedFighters=air.png
```
- Create unit icon image (map/unitIcons/air.png): 
![air](https://user-images.githubusercontent.com/1427689/41137786-a90c7b1e-6aa2-11e8-9e99-c09597259e31.PNG)
- TEST: Unit icon is applied to german naval fighters on game started
- TEST: Unit icon is applied to german fighters when Germany researches and activates Improved Fighters
