### PR TITLE
Add support for jpg and png file extensions for small map

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -147,7 +147,8 @@ public interface Constants {
   String UNIT_TYPE_AAGUN = "aaGun";
   String UNIT_TYPE_ARTILLERY = "artillery";
   String UNIT_TYPE_DESTROYER = "destroyer";
-  String SMALL_MAP_FILENAME = "smallMap.jpeg";
+  String SMALL_MAP_FILENAME = "smallMap";
+  String[] SMALL_MAP_EXTENSIONS = {"jpeg", "jpg", "png"};
   String MAP_NAME = "mapName";
   // new scramble property names
   String SCRAMBLE_RULES_IN_EFFECT = "Scramble Rules In Effect";

--- a/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -20,17 +20,6 @@ import games.strategy.ui.Util;
  * Is not responsible for drawing things on top of the map, such as units, routes etc.
  */
 public class MapImage {
-  private static Image loadImage(final ResourceLoader loader, final String name) {
-    final URL mapFileUrl = loader.getResource(name);
-    if (mapFileUrl == null) {
-      throw new IllegalStateException("resource not found:" + name);
-    }
-    try {
-      return ImageIO.read(mapFileUrl);
-    } catch (final IOException e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   private BufferedImage smallMapImage;
   private static Font propertyMapFont = null;
@@ -156,11 +145,29 @@ public class MapImage {
   }
 
   public void loadMaps(final ResourceLoader loader) {
-    final Image smallFromFile = loadImage(loader, Constants.SMALL_MAP_FILENAME);
+    final Image smallFromFile = loadImage(loader, Constants.SMALL_MAP_FILENAME, Constants.SMALL_MAP_EXTENSIONS);
     smallMapImage = Util.createImage(smallFromFile.getWidth(null), smallFromFile.getHeight(null), false);
     final Graphics g = smallMapImage.getGraphics();
     g.drawImage(smallFromFile, 0, 0, null);
     g.dispose();
     smallFromFile.flush();
+  }
+
+  private static Image loadImage(final ResourceLoader loader, final String name, final String[] extensions) {
+    URL mapFileUrl = null;
+    for (final String extension : extensions) {
+      mapFileUrl = loader.getResource(name + "." + extension);
+      if (mapFileUrl != null) {
+        break;
+      }
+    }
+    if (mapFileUrl == null) {
+      throw new IllegalStateException("File not found: " + name + " with extensions: " + extensions);
+    }
+    try {
+      return ImageIO.read(mapFileUrl);
+    } catch (final IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -7,6 +7,7 @@ import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.prefs.Preferences;
 
 import javax.imageio.ImageIO;
@@ -162,7 +163,7 @@ public class MapImage {
       }
     }
     if (mapFileUrl == null) {
-      throw new IllegalStateException("File not found: " + name + " with extensions: " + extensions);
+      throw new IllegalStateException("File not found: " + name + " with extensions: " + Arrays.toString(extensions));
     }
     try {
       return ImageIO.read(mapFileUrl);


### PR DESCRIPTION
Address issue here: https://forums.triplea-game.org/topic/577/large-middle-earth-queries/112

Allow .jpg and .png file extensions in addition to .jpeg for small map images.