### PR TITLE
Add resources to user and political actions

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -179,7 +179,11 @@ public class ResourceCollection extends GameDataComponent {
 
   @Override
   public String toString() {
-    return toString(m_resources, getData(), ", ");
+    return toString(m_resources, getData());
+  }
+
+  public static String toString(final IntegerMap<Resource> resources, final GameData data) {
+    return toString(resources, data, ", ");
   }
 
   private static String toString(final IntegerMap<Resource> resources, final GameData data,

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -635,7 +635,7 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
               .test(action)) {
             continue;
           }
-          if (action.getCostPu() > 0 && action.getCostPu() > id.getResources().getQuantity(Constants.PUS)) {
+          if (!id.getResources().has(action.getCostResources())) {
             continue;
           }
           i++;

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -4,14 +4,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Predicate;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Resource;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
-import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
 
 /**
@@ -52,7 +54,7 @@ public class AiPoliticalUtils {
       }
       if (isFree(nextAction)) {
         acceptableActions.add(nextAction);
-      } else if (CollectionUtils.countMatches(validActions, Matches.politicalActionHasCostBetween(0, 0)) > 1) {
+      } else if (CollectionUtils.countMatches(validActions, politicalActionHasNoResourceCost()) > 1) {
         if (Math.random() < .9 && isAcceptableCost(nextAction, id, data)) {
           acceptableActions.add(nextAction);
         }
@@ -63,6 +65,10 @@ public class AiPoliticalUtils {
       }
     }
     return acceptableActions;
+  }
+
+  private static Predicate<PoliticalActionAttachment> politicalActionHasNoResourceCost() {
+    return paa -> paa.getCostResources().isEmpty();
   }
 
   private static boolean wantToPerFormActionTowardsWar(final PoliticalActionAttachment nextAction, final PlayerID id,
@@ -115,7 +121,7 @@ public class AiPoliticalUtils {
   }
 
   private static boolean isFree(final PoliticalActionAttachment nextAction) {
-    return nextAction.getCostPu() <= 0;
+    return nextAction.getCostResources().isEmpty();
   }
 
   private static boolean isAcceptableCost(final PoliticalActionAttachment nextAction, final PlayerID player,
@@ -123,6 +129,7 @@ public class AiPoliticalUtils {
     // if we have 21 or more PUs and the cost of the action is l0% or less of our total money, then it is an acceptable
     // price.
     final float production = AbstractEndTurnDelegate.getProduction(data.getMap().getTerritoriesOwnedBy(player), data);
-    return production >= 21 && (nextAction.getCostPu()) <= ((production / 10));
+    final Resource r = data.getResourceList().getResource(Constants.PUS);
+    return production >= 21 && (nextAction.getCostResources().getInt(r)) <= ((production / 10));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.ai.AiPoliticalUtils;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.data.ProTerritoryManager;
@@ -152,7 +151,7 @@ class ProPoliticsAi {
               .test(action)) {
             continue;
           }
-          if (action.getCostPu() > 0 && action.getCostPu() > player.getResources().getQuantity(Constants.PUS)) {
+          if (!player.getResources().has(action.getCostResources())) {
             continue;
           }
           i++;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -112,7 +112,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     m_costResources.put(r, n);
   }
 
-  private void setCostResources(final IntegerMap<Resource> value) {
+  public void setCostResources(final IntegerMap<Resource> value) {
     m_costResources = value;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -28,6 +28,9 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
   protected String m_text = "";
+  /**
+   * @deprecated Replaced by costResources.
+   */
   @Deprecated
   protected int m_costPU = 0;
   // cost in any resources to attempt this action
@@ -101,7 +104,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
-          "costResources cannot be empty or have more than two fields" + thisErrorMsg());
+          "costResources cannot be empty or have more than two fields: " + value + thisErrorMsg());
     }
     final String resourceToProduce = s[1];
     final Resource r = getData().getResourceList().getResource(resourceToProduce);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1960,11 +1960,6 @@ public final class Matches {
     return uaa -> uaa.hasAttemptsLeft() && uaa.canPerform(testedConditions);
   }
 
-  public static Predicate<PoliticalActionAttachment> politicalActionHasCostBetween(final int greaterThanEqualTo,
-      final int lessThanEqualTo) {
-    return paa -> paa.getCostPu() >= greaterThanEqualTo && paa.getCostPu() <= lessThanEqualTo;
-  }
-
   static Predicate<Unit> unitCanOnlyPlaceInOriginalTerritories() {
     return u -> {
       final UnitAttachment ua = UnitAttachment.get(u.getType());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -23,6 +23,9 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.UserActionText;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Contains validation and logic to change game data for UserActionAttachments.
+ */
 @MapSupport
 public class UserActionDelegate extends BaseTripleADelegate implements IUserActionDelegate {
   public UserActionDelegate() {}

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -26,6 +26,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.engine.data.RelationshipTypeList;
+import games.strategy.engine.data.ResourceCollection;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
@@ -74,20 +75,20 @@ public class PoliticsPanel extends ActionPanel {
       overviewScroll.setPreferredSize(new Dimension(
           (overviewScroll.getPreferredSize().width > availWidth ? availWidth
               : (overviewScroll.getPreferredSize().width
-              + (overviewScroll.getPreferredSize().height > availHeightOverview ? 20 : 0))),
+                  + (overviewScroll.getPreferredSize().height > availHeightOverview ? 20 : 0))),
           (overviewScroll.getPreferredSize().height > availHeightOverview ? availHeightOverview
               : (overviewScroll.getPreferredSize().height + (validPoliticalActions.isEmpty() ? 26 : 0)
-              + (overviewScroll.getPreferredSize().width > availWidth ? 20 : 0)))));
+                  + (overviewScroll.getPreferredSize().width > availWidth ? 20 : 0)))));
 
       final JScrollPane choiceScroll = new JScrollPane(politicalActionButtonPanel(politicalChoiceDialog));
       choiceScroll.setBorder(BorderFactory.createEmptyBorder());
       choiceScroll.setPreferredSize(new Dimension(
           (choiceScroll.getPreferredSize().width > availWidth ? availWidth
               : (choiceScroll.getPreferredSize().width
-              + (choiceScroll.getPreferredSize().height > availHeightChoice ? 20 : 0))),
+                  + (choiceScroll.getPreferredSize().height > availHeightChoice ? 20 : 0))),
           (choiceScroll.getPreferredSize().height > availHeightChoice ? availHeightChoice
               : (choiceScroll.getPreferredSize().height)
-              + (choiceScroll.getPreferredSize().width > availWidth ? 20 : 0))));
+                  + (choiceScroll.getPreferredSize().width > availWidth ? 20 : 0))));
 
       final JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, overviewScroll, choiceScroll);
       splitPane.setOneTouchExpandable(true);
@@ -221,8 +222,9 @@ public class PoliticsPanel extends ActionPanel {
     return panel;
   }
 
-  private static String getActionButtonText(final PoliticalActionAttachment paa) {
-    final String costString = paa.getCostPu() == 0 ? "" : "[" + paa.getCostPu() + " PU] ";
+  private String getActionButtonText(final PoliticalActionAttachment paa) {
+    final String costString = paa.getCostResources().isEmpty() ? ""
+        : "[" + ResourceCollection.toString(paa.getCostResources(), getData()) + "] ";
     return costString + PoliticsText.getInstance().getButtonText(paa.getText());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -27,9 +27,9 @@ import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.ResourceCollection;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
 import games.strategy.ui.SwingAction;
@@ -141,7 +141,7 @@ public class UserActionPanel extends ActionPanel {
 
   @VisibleForTesting
   static boolean canSpendResourcesOnUserActions(final Collection<UserActionAttachment> userActions) {
-    return userActions.stream().anyMatch(userAction -> userAction.getCostPu() > 0);
+    return userActions.stream().anyMatch(userAction -> !userAction.getCostResources().isEmpty());
   }
 
   private JPanel getUserActionButtonPanel(final JDialog parent) {
@@ -186,7 +186,7 @@ public class UserActionPanel extends ActionPanel {
 
   @VisibleForTesting
   static boolean canPlayerAffordUserAction(final PlayerID player, final UserActionAttachment userAction) {
-    return userAction.getCostPu() <= player.getResources().getQuantity(Constants.PUS);
+    return player.getResources().has(userAction.getCostResources());
   }
 
   /**
@@ -217,8 +217,9 @@ public class UserActionPanel extends ActionPanel {
     return panel;
   }
 
-  private static String getActionButtonText(final UserActionAttachment paa) {
-    final String costString = paa.getCostPu() == 0 ? "" : "[" + paa.getCostPu() + " PU] ";
+  private String getActionButtonText(final UserActionAttachment paa) {
+    final String costString = paa.getCostResources().isEmpty() ? ""
+        : "[" + ResourceCollection.toString(paa.getCostResources(), getData()) + "] ";
     return costString + UserActionText.getInstance().getButtonText(paa.getText());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -23,6 +23,7 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.ResourceList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
+import games.strategy.util.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
 public final class UserActionPanelTest {
@@ -61,7 +62,11 @@ public final class UserActionPanelTest {
 
   private UserActionAttachment createUserActionWithCost(final int costInPUs) {
     final UserActionAttachment userAction = new UserActionAttachment("userAction", mock(Attachable.class), data);
-    userAction.setCostPu(costInPUs);
+    if (costInPUs > 0) {
+      final IntegerMap<Resource> cost = new IntegerMap<>();
+      cost.put(pus, costInPUs);
+      userAction.setCostResources(cost);
+    }
     return userAction;
   }
 


### PR DESCRIPTION
Addresses: https://forums.triplea-game.org/topic/418/expand-useractionattachment-politicalactionattachment-to-all-resources

Functional Changes
- New user and political action option "costResources" to allow resource costs other than PUs and update necessary delegate, display, and AI logic

Test
- Tested on Iron War by updating XML with:
```
        <attachment name="userActionAttachment_6_Finland_receives_financial_support" attachTo="Germany" javaClass="games.strategy.triplea.attachments.UserActionAttachment" type="player">
            <option name="conditions" value="conditionAttachment_Finland_receives_financial_support"/>
            <option name="activateTrigger" value="triggerAttachment_Finland_receives_financial_support-1:1:false:false:false:false"/>
            <option name="activateTrigger" value="triggerAttachment_Finland_receives_financial_support-2:1:false:false:false:false"/>
            <option name="text" value="Germany_Finland_10_PUs"/>
            <option name="costResources" value="10:PUs"/>
            <option name="costResources" value="2:Iron"/>
            <option name="costResources" value="1:Fuel"/>
            <option name="attemptsPerTurn" value="1"/>
        </attachment>
```
![image](https://user-images.githubusercontent.com/1427689/41391545-e959ca06-6f60-11e8-9666-29db47ac5564.png)
