### PR TITLE
Show a unit tooltip when mouse-overing units on main map after 1s.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -4,6 +4,7 @@ import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.JComponent;
 import javax.swing.JToolTip;
 import javax.swing.Popup;
 import javax.swing.PopupFactory;
@@ -14,20 +15,24 @@ import javax.swing.Timer;
  * Responsible for showing tool tips when hovering over units on the main map.
  */
 public class MapUnitTooltipManager implements ActionListener {
-  private final MapPanel mapPanel;
-  private Timer timer;
+  private final JComponent parent;
+  private final Timer timer;
   private String text;
   private Popup popup;
 
-  public MapUnitTooltipManager(MapPanel mapPanel) {
-    this.mapPanel = mapPanel;
+  public MapUnitTooltipManager(final JComponent parent) {
+    this.parent = parent;
     this.timer = new Timer(1000, this);
     this.timer.setRepeats(false);
     // Note: Timer not started yet.
   }
 
-  /** Updates the tooltip. */
-  public void updateTooltip(String tipText) {
+  /**
+   * Updates the tooltip. The tooltip will show after 1s without another update if the text is not empty.
+   *
+   * @param tipText The tooltip text to set or the empty string if it should be hidden.
+   */
+  public void updateTooltip(final String tipText) {
     if (tipText.equals(text)) {
       return;
     }
@@ -45,13 +50,13 @@ public class MapUnitTooltipManager implements ActionListener {
   }
 
   @Override
-  public void actionPerformed(ActionEvent e) {
+  public void actionPerformed(final ActionEvent e) {
     if (text.length() > 0) {
       final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
       final PopupFactory popupFactory = PopupFactory.getSharedInstance();
       final JToolTip info = new JToolTip();
       info.setTipText("<html>" + text + "</html>");
-      popup = popupFactory.getPopup(mapPanel, info, currentPoint.x + 5, currentPoint.y + 5);
+      popup = popupFactory.getPopup(parent, info, currentPoint.x + 5, currentPoint.y + 5);
       popup.show();
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -1,13 +1,13 @@
 package games.strategy.triplea.ui;
 
-import javax.swing.JToolTip;
-import javax.swing.PopupFactory;
-import javax.swing.Popup;
-import javax.swing.Timer;
 import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.JToolTip;
+import javax.swing.Popup;
+import javax.swing.PopupFactory;
+import javax.swing.Timer;
 
 
 /**
@@ -26,6 +26,7 @@ public class MapUnitTooltipManager implements ActionListener {
     // Note: Timer not started yet.
   }
 
+  /** Updates the tooltip. */
   public void updateTooltip(String tipText) {
     if (tipText.equals(text)) {
       return;
@@ -43,6 +44,7 @@ public class MapUnitTooltipManager implements ActionListener {
     }
   }
 
+  @Override
   public void actionPerformed(ActionEvent e) {
     if (text.length() > 0) {
       final Point currentPoint = MouseInfo.getPointerInfo().getLocation();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -1,0 +1,56 @@
+package games.strategy.triplea.ui;
+
+import javax.swing.JToolTip;
+import javax.swing.PopupFactory;
+import javax.swing.Popup;
+import javax.swing.Timer;
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+
+/**
+ * Responsible for showing tool tips when hovering over units on the main map.
+ */
+public class MapUnitTooltipManager implements ActionListener {
+  private final MapPanel mapPanel;
+  private Timer timer;
+  private String text;
+  private Popup popup;
+
+  public MapUnitTooltipManager(MapPanel mapPanel) {
+    this.mapPanel = mapPanel;
+    this.timer = new Timer(1000, this);
+    this.timer.setRepeats(false);
+    // Note: Timer not started yet.
+  }
+
+  public void updateTooltip(String tipText) {
+    if (tipText.equals(text)) {
+      return;
+    }
+
+    if (popup != null) {
+      popup.hide();
+      popup = null;
+    }
+    text = tipText;
+
+    timer.stop();
+    if (text.length() > 0) {
+      timer.restart();
+    }
+  }
+
+  public void actionPerformed(ActionEvent e) {
+    if (text.length() > 0) {
+      final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
+      final PopupFactory popupFactory = PopupFactory.getSharedInstance();
+      final JToolTip info = new JToolTip();
+      info.setTipText("<html>" + text + "</html>");
+      popup = popupFactory.getPopup(mapPanel, info, currentPoint.x + 5, currentPoint.y + 5);
+      popup.show();
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -213,6 +213,7 @@ public class TripleAFrame extends MainGameFrame {
   private PlayerID currentStepPlayer;
   private final Map<PlayerID, Boolean> requiredTurnSeries = new HashMap<>();
   private final ThreadPool messageAndDialogThreadPool = new ThreadPool(1);
+  private final MapUnitTooltipManager tooltipManager;
   private boolean isCtrlPressed = false;
 
   /**
@@ -267,8 +268,12 @@ public class TripleAFrame extends MainGameFrame {
     final Image small = uiContext.getMapImage().getSmallMapImage();
     smallView = new MapPanelSmallView(small, model, uiContext.getMapData());
     mapPanel = new MapPanel(data, smallView, uiContext, model, this::computeScrollSpeed);
+    tooltipManager = new MapUnitTooltipManager(mapPanel);
     mapPanel.addMapSelectionListener(mapSelectionListener);
-    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> unitsBeingMousedOver = units;
+    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> {
+      unitsBeingMousedOver = units;
+      tooltipManager.updateTooltip(getUnitInfo());
+    };
     mapPanel.addMouseOverUnitListener(mouseOverUnitListener);
     // link the small and large images
     SwingUtilities.invokeLater(mapPanel::initSmallMap);
@@ -1545,6 +1550,23 @@ public class TripleAFrame extends MainGameFrame {
     };
   }
 
+  private String getUnitInfo() {
+    String unitInfo = "";
+    if (unitsBeingMousedOver != null && !unitsBeingMousedOver.isEmpty()) {
+      final Unit unit = unitsBeingMousedOver.get(0);
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (ua != null) {
+        String unitText = "Unit:";
+        if (unitsBeingMousedOver.size() != 1) {
+          unitText = unitsBeingMousedOver.size() + " Units";
+        }
+        unitInfo = "<b>" + unitText + "</b><br>" + unit.getType().getName() + ": "
+                + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
+      }
+    }
+    return unitInfo;
+  }
+
   private KeyListener getArrowKeyListener() {
     return new KeyListener() {
       @Override
@@ -1567,15 +1589,7 @@ public class TripleAFrame extends MainGameFrame {
         }
         // I for info
         if (keyCode == KeyEvent.VK_I || keyCode == KeyEvent.VK_V) {
-          String unitInfo = "";
-          if (unitsBeingMousedOver != null && !unitsBeingMousedOver.isEmpty()) {
-            final Unit unit = unitsBeingMousedOver.get(0);
-            final UnitAttachment ua = UnitAttachment.get(unit.getType());
-            if (ua != null) {
-              unitInfo = "<b>Unit:</b><br>" + unit.getType().getName() + ": "
-                  + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
-            }
-          }
+          String unitInfo = getUnitInfo();
           String terrInfo = "";
           if (territoryLastEntered != null) {
             final TerritoryAttachment ta = TerritoryAttachment.get(territoryLastEntered);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -270,11 +270,10 @@ public class TripleAFrame extends MainGameFrame {
     mapPanel = new MapPanel(data, smallView, uiContext, model, this::computeScrollSpeed);
     tooltipManager = new MapUnitTooltipManager(mapPanel);
     mapPanel.addMapSelectionListener(mapSelectionListener);
-    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> {
+    mapPanel.addMouseOverUnitListener((units, territory, me) -> {
       unitsBeingMousedOver = units;
       tooltipManager.updateTooltip(getUnitInfo());
-    };
-    mapPanel.addMouseOverUnitListener(mouseOverUnitListener);
+    });
     // link the small and large images
     SwingUtilities.invokeLater(mapPanel::initSmallMap);
     mapAndChatPanel = new JPanel();
@@ -1551,20 +1550,16 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   private String getUnitInfo() {
-    String unitInfo = "";
     if (unitsBeingMousedOver != null && !unitsBeingMousedOver.isEmpty()) {
       final Unit unit = unitsBeingMousedOver.get(0);
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (ua != null) {
-        String unitText = "Unit:";
-        if (unitsBeingMousedOver.size() != 1) {
-          unitText = unitsBeingMousedOver.size() + " Units";
-        }
-        unitInfo = "<b>" + unitText + "</b><br>" + unit.getType().getName() + ": "
+        final String unitText = unitsBeingMousedOver.size() == 1 ? "Unit:" : (unitsBeingMousedOver.size() + " Units");
+        return "<b>" + unitText + "</b><br>" + unit.getType().getName() + ": "
                 + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
       }
     }
-    return unitInfo;
+    return "";
   }
 
   private KeyListener getArrowKeyListener() {
@@ -1589,7 +1584,7 @@ public class TripleAFrame extends MainGameFrame {
         }
         // I for info
         if (keyCode == KeyEvent.VK_I || keyCode == KeyEvent.VK_V) {
-          String unitInfo = getUnitInfo();
+          final String unitInfo = getUnitInfo();
           String terrInfo = "";
           if (territoryLastEntered != null) {
             final TerritoryAttachment ta = TerritoryAttachment.get(territoryLastEntered);


### PR DESCRIPTION
This is helpful for new players as well as players trying out new maps that have custom units.

The tooltip delay is set to 1 second, so it shouldn't be too intrusive.