### PR TITLE
Workaround a Mac bug where hosting or starting a local game will incur a 30 second delay.

### DIFF
--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -15,7 +15,7 @@ public class HeadlessServerMessenger implements IServerMessenger {
 
   public HeadlessServerMessenger() {
     try {
-      node = new Node("dummy", InetAddress.getLocalHost(), 0);
+      node = new Node("dummy", Node.getLocalHost(), 0);
     } catch (final UnknownHostException e) {
       throw new IllegalStateException(e);
     }

--- a/game-core/src/main/java/games/strategy/net/IpFinder.java
+++ b/game-core/src/main/java/games/strategy/net/IpFinder.java
@@ -49,7 +49,7 @@ public class IpFinder {
   public static InetAddress findInetAddress() throws SocketException, UnknownHostException {
     final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
     if (interfaces == null) {
-      return InetAddress.getLocalHost();
+      return Node.getLocalHost();
     }
 
     return Collections.list(interfaces).stream()
@@ -58,7 +58,7 @@ public class IpFinder {
         .flatMap(Collection::stream)
         .filter(Util.not(InetAddress::isLoopbackAddress))
         .min(getInetAddressComparator())
-        .orElse(InetAddress.getLocalHost());
+        .orElse(Node.getLocalHost());
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -70,7 +70,7 @@ public final class MacFinder {
     // the mac, we can't login to the lobby
     // First, try to get the mac address of the local host network interface
     try {
-      final InetAddress address = InetAddress.getLocalHost();
+      final InetAddress address = Node.getLocalHost();
       final NetworkInterface localHostNetworkInterface = NetworkInterface.getByInetAddress(address);
       if (localHostNetworkInterface != null) {
         final byte[] rawMac = localHostNetworkInterface.getHardwareAddress();

--- a/game-core/src/main/java/games/strategy/net/Node.java
+++ b/game-core/src/main/java/games/strategy/net/Node.java
@@ -1,5 +1,7 @@
 package games.strategy.net;
 
+import games.strategy.engine.framework.system.SystemProperties;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -21,9 +23,20 @@ public class Node implements INode, Externalizable {
 
   static {
     try {
-      NULL_NODE = new Node("NULL", InetAddress.getLocalHost(), -1);
+      NULL_NODE = new Node("NULL", getLocalHost(), -1);
     } catch (final UnknownHostException e) {
       throw new IllegalStateException(e);
+    }
+  }
+
+  public static InetAddress getLocalHost() throws UnknownHostException {
+    // On Mac, InetAddress.getLocalHost() can be extremely slow (30 seconds)
+    // due to a bug in macOS Sierra and higher. Use a work around to avoid
+    // this. See: https://thoeni.io/post/macos-sierra-java/
+    if (SystemProperties.isMac()) {
+      return InetAddress.getByName("localhost");
+    } else {
+      return InetAddress.getLocalHost();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -1,0 +1,56 @@
+package games.strategy.triplea.ui;
+
+import javax.swing.JToolTip;
+import javax.swing.PopupFactory;
+import javax.swing.Popup;
+import javax.swing.Timer;
+import java.awt.MouseInfo;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+
+/**
+ * Responsible for showing tool tips when hovering over units on the main map.
+ */
+public class MapUnitTooltipManager implements ActionListener {
+  private final MapPanel mapPanel;
+  private Timer timer;
+  private String text;
+  private Popup popup;
+
+  public MapUnitTooltipManager(MapPanel mapPanel) {
+    this.mapPanel = mapPanel;
+    this.timer = new Timer(1000, this);
+    this.timer.setRepeats(false);
+    // Note: Timer not started yet.
+  }
+
+  public void updateTooltip(String tipText) {
+    if (tipText.equals(text)) {
+      return;
+    }
+
+    if (popup != null) {
+      popup.hide();
+      popup = null;
+    }
+    text = tipText;
+
+    timer.stop();
+    if (text.length() > 0) {
+      timer.restart();
+    }
+  }
+
+  public void actionPerformed(ActionEvent e) {
+    if (text.length() > 0) {
+      final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
+      final PopupFactory popupFactory = PopupFactory.getSharedInstance();
+      final JToolTip info = new JToolTip();
+      info.setTipText("<html>" + text + "</html>");
+      popup = popupFactory.getPopup(mapPanel, info, currentPoint.x + 5, currentPoint.y + 5);
+      popup.show();
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -213,6 +213,7 @@ public class TripleAFrame extends MainGameFrame {
   private PlayerID currentStepPlayer;
   private final Map<PlayerID, Boolean> requiredTurnSeries = new HashMap<>();
   private final ThreadPool messageAndDialogThreadPool = new ThreadPool(1);
+  private final MapUnitTooltipManager tooltipManager;
   private boolean isCtrlPressed = false;
 
   /**
@@ -267,8 +268,12 @@ public class TripleAFrame extends MainGameFrame {
     final Image small = uiContext.getMapImage().getSmallMapImage();
     smallView = new MapPanelSmallView(small, model, uiContext.getMapData());
     mapPanel = new MapPanel(data, smallView, uiContext, model, this::computeScrollSpeed);
+    tooltipManager = new MapUnitTooltipManager(mapPanel);
     mapPanel.addMapSelectionListener(mapSelectionListener);
-    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> unitsBeingMousedOver = units;
+    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> {
+      unitsBeingMousedOver = units;
+      tooltipManager.updateTooltip(getUnitInfo());
+    };
     mapPanel.addMouseOverUnitListener(mouseOverUnitListener);
     // link the small and large images
     SwingUtilities.invokeLater(mapPanel::initSmallMap);
@@ -1545,6 +1550,23 @@ public class TripleAFrame extends MainGameFrame {
     };
   }
 
+  private String getUnitInfo() {
+    String unitInfo = "";
+    if (unitsBeingMousedOver != null && !unitsBeingMousedOver.isEmpty()) {
+      final Unit unit = unitsBeingMousedOver.get(0);
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (ua != null) {
+        String unitText = "Unit:";
+        if (unitsBeingMousedOver.size() != 1) {
+          unitText = unitsBeingMousedOver.size() + " Units";
+        }
+        unitInfo = "<b>" + unitText + "</b><br>" + unit.getType().getName() + ": "
+                + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
+      }
+    }
+    return unitInfo;
+  }
+
   private KeyListener getArrowKeyListener() {
     return new KeyListener() {
       @Override
@@ -1567,15 +1589,7 @@ public class TripleAFrame extends MainGameFrame {
         }
         // I for info
         if (keyCode == KeyEvent.VK_I || keyCode == KeyEvent.VK_V) {
-          String unitInfo = "";
-          if (unitsBeingMousedOver != null && !unitsBeingMousedOver.isEmpty()) {
-            final Unit unit = unitsBeingMousedOver.get(0);
-            final UnitAttachment ua = UnitAttachment.get(unit.getType());
-            if (ua != null) {
-              unitInfo = "<b>Unit:</b><br>" + unit.getType().getName() + ": "
-                  + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
-            }
-          }
+          String unitInfo = getUnitInfo();
           String terrInfo = "";
           if (territoryLastEntered != null) {
             final TerritoryAttachment ta = TerritoryAttachment.get(territoryLastEntered);


### PR DESCRIPTION
Workaround a bug on Mac where hosting or starting a local game will
incur a 30 second delay caused by InetAddress.getLocalHost().
See: https://thoeni.io/post/macos-sierra-java