### PR TITLE
Simplify Tile Rendering code

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -38,6 +38,8 @@ public class ImageFactory {
         return null;
       }
       try {
+        // We're implementing our own caching system
+        ImageIO.setUseCache(false);
         images.put(key, ImageIO.read(url));
       } catch (final IOException e) {
         throw new IllegalStateException(e);

--- a/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -150,7 +150,7 @@ public final class TileImageFactory {
     if ((!showMapBlends || !showReliefImages) && url == null) {
       return null;
     }
-    return loadImage(url, fileName, true, true, true);
+    return loadImage(url, fileName);
   }
 
   public Image getReliefTile(final int a, final int b) {
@@ -176,14 +176,13 @@ public final class TileImageFactory {
     return compatibleImage;
   }
 
-  private Image loadImage(final URL imageLocation, final String fileName, final boolean transparent,
-      final boolean cache, final boolean scale) {
-    return (showMapBlends && showReliefImages && transparent)
-        ? loadBlendedImage(fileName, cache, scale)
-        : loadUnblendedImage(imageLocation, fileName, transparent, cache, scale);
+  private Image loadImage(final URL imageLocation, final String fileName) {
+    return (showMapBlends && showReliefImages)
+        ? loadBlendedImage(fileName)
+        : loadUnblendedImage(imageLocation, fileName);
   }
 
-  private Image loadBlendedImage(final String fileName, final boolean cache, final boolean scaled) {
+  private Image loadBlendedImage(final String fileName) {
     BufferedImage reliefFile = null;
     BufferedImage baseFile = null;
     // The relief tile
@@ -235,21 +234,16 @@ public final class TileImageFactory {
       g2.setComposite(blendComposite);
       g2.drawImage(baseFile, 0, 0, null);
       final SoftReference<Image> ref = new SoftReference<>(blendedImage);
-      if (cache) {
-        imageCache.put(fileName, ref);
-      }
+      imageCache.put(fileName, ref);
       return blendedImage;
     }
 
     final SoftReference<Image> ref = new SoftReference<>(baseFile);
-    if (cache) {
-      imageCache.put(fileName, ref);
-    }
+    imageCache.put(fileName, ref);
     return baseFile;
   }
 
-  private Image loadUnblendedImage(final URL imageLocation, final String fileName, final boolean transparent,
-      final boolean cache, final boolean scaled) {
+  private Image loadUnblendedImage(final URL imageLocation, final String fileName) {
     Image image;
     try {
       final Stopwatch loadingImages = new Stopwatch(logger, Level.FINE, "Loading image:" + imageLocation);
@@ -262,7 +256,7 @@ public final class TileImageFactory {
       // this step is a significant bottle neck in the image drawing process
       // we should try to find a way to avoid it, and load the
       // png directly as the right type
-      image = Util.createImage(fromFile.getWidth(null), fromFile.getHeight(null), transparent);
+      image = Util.createImage(fromFile.getWidth(null), fromFile.getHeight(null), true);
       final Graphics2D g = (Graphics2D) image.getGraphics();
       g.drawImage(fromFile, 0, 0, null);
       g.dispose();
@@ -272,9 +266,7 @@ public final class TileImageFactory {
       ClientLogger.logError("Could not load image, url: " + imageLocation.toString(), e);
       image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
     }
-    if (cache) {
-      imageCache.put(fileName, new SoftReference<>(image));
-    }
+    imageCache.put(fileName, new SoftReference<>(image));
     return image;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -141,7 +141,7 @@ public final class TileImageFactory {
     if (resourceLoader.getResource(fileName) == null) {
       return null;
     }
-    return getImage(fileName, false);
+    return getImage(fileName, true);
   }
 
   public Image getUnscaledUncachedBaseTile(final int x, final int y) {
@@ -150,7 +150,7 @@ public final class TileImageFactory {
     if (url == null) {
       return null;
     }
-    return loadImage(url, fileName, false, false, false);
+    return loadImage(url, fileName, true, false, false);
   }
 
   private static String getBaseTileImageName(final int x, final int y) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -64,12 +64,6 @@ public class HeadedUiContext extends AbstractUiContext {
   }
 
   @Override
-  public void setScale(final double scale) {
-    super.setScale(scale);
-    tileImageFactory.setScale(scale);
-  }
-
-  @Override
   protected void internalSetMapDir(final String dir, final GameData data) {
     final Stopwatch stopWatch = new Stopwatch(logger, Level.FINE, "Loading UI Context");
     resourceLoader = ResourceLoader.getMapResourceLoader(dir);
@@ -94,7 +88,6 @@ public class HeadedUiContext extends AbstractUiContext {
     flagIconImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
     tileImageFactory.setMapDir(resourceLoader);
-    tileImageFactory.setScale(scale);
     // load map data
     mapImage.loadMaps(resourceLoader);
     mapDir = dir;

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -522,9 +522,7 @@ public class MapPanel extends ImageScrollerLargeView {
     super.paint(g2d);
     g2d.clip(new Rectangle2D.Double(0, 0, getImageWidth() * scale, getImageHeight() * scale));
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(MapPanel.class.getName()), Level.FINER, "Paint");
-    final Rectangle2D.Double mainBounds = new Rectangle2D
-        .Double(model.getX(), model.getY(), getScaledWidth(), getScaledHeight());
-    drawTiles(g2d, gameData, mainBounds);
+    drawTiles(g2d, gameData, new Rectangle2D.Double(model.getX(), model.getY(), getScaledWidth(), getScaledHeight()));
     if (routeDescription != null && mouseShadowImage != null && routeDescription.getEnd() != null) {
       final AffineTransform t = new AffineTransform();
       t.translate(scale * normalizeX(routeDescription.getEnd().getX() - getXOffset()),

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -636,7 +636,6 @@ public class MapPanel extends ImageScrollerLargeView {
       }
     }
     uiContext.setScale(normalizedScale);
-    recreateTiles(getData(), uiContext);
     repaint();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -522,7 +522,8 @@ public class MapPanel extends ImageScrollerLargeView {
     super.paint(g2d);
     g2d.clip(new Rectangle2D.Double(0, 0, getImageWidth() * scale, getImageHeight() * scale));
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(MapPanel.class.getName()), Level.FINER, "Paint");
-    final Rectangle2D.Double mainBounds = new Rectangle2D.Double(model.getX(), model.getY(), getScaledWidth(), getScaledHeight());
+    final Rectangle2D.Double mainBounds = new Rectangle2D
+        .Double(model.getX(), model.getY(), getScaledWidth(), getScaledHeight());
     drawTiles(g2d, gameData, mainBounds);
     if (routeDescription != null && mouseShadowImage != null && routeDescription.getEnd() != null) {
       final AffineTransform t = new AffineTransform();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -611,7 +611,12 @@ public class MapPanel extends ImageScrollerLargeView {
       if (tile.isDirty()) {
         if (!tile.hasDrawingStarted()) {
           executor.execute(() -> {
-            tile.getImage(data, uiContext.getMapData());
+            try {
+              data.acquireReadLock();
+              tile.getImage(data, uiContext.getMapData());
+            } finally {
+              data.releaseReadLock();
+            }
             SwingUtilities.invokeLater(this::repaint);
           });
         }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -588,12 +588,8 @@ public class MapPanel extends ImageScrollerLargeView {
           final AffineTransform viewTransformation = new AffineTransform();
           viewTransformation.scale(scale, scale);
           viewTransformation.translate(-bounds.getX(), -bounds.getY());
-          viewTransformation.translate(tile.getBounds().x,tile.getBounds().y);
+          viewTransformation.translate(tile.getBounds().x, tile.getBounds().y);
           viewTransformation.concatenate(transform);
-          // Tile scaling is done by the tiles themselves
-          // Should be changed in the future to allow for seamless scaling
-          // to all sizes
-          viewTransformation.scale(1 / scale, 1 / scale);
           graphics.drawImage(img, viewTransformation, this);
         }
       }
@@ -694,7 +690,7 @@ public class MapPanel extends ImageScrollerLargeView {
         final UnitsDrawer drawer = new UnitsDrawer(category.getUnits().size(), category.getType().getName(),
             category.getOwner().getName(), place, category.getDamaged(), category.getBombingDamage(),
             category.getDisabled(), false, "", uiContext);
-        drawer.draw(bounds, gameData, g, uiContext.getMapData(), null, null);
+        drawer.draw(bounds, gameData, g, uiContext.getMapData());
         i++;
       }
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -506,11 +506,9 @@ public class MapPanel extends ImageScrollerLargeView {
       final Collection<Tile> tileList = tileManager.getTiles(bounds);
       for (final Tile tile : tileList) {
         final Image img = tile.getImage(gameData, uiContext.getMapData());
-        if (img != null) {
-          final AffineTransform t = new AffineTransform();
-          t.translate((tile.getBounds().x - bounds.getX()) * scale, (tile.getBounds().y - bounds.getY()) * scale);
-          g2d.drawImage(img, t, this);
-        }
+        final AffineTransform t = AffineTransform.getTranslateInstance(
+            (tile.getBounds().x - bounds.getX()) * scale,(tile.getBounds().y - bounds.getY()) * scale);
+        g2d.drawImage(img, t, this);
       }
     } finally {
       gameData.releaseReadLock();
@@ -622,8 +620,9 @@ public class MapPanel extends ImageScrollerLargeView {
         }
       } else {
         final Image img = tile.getImage(data, uiContext.getMapData());
-        final AffineTransform t = new AffineTransform();
-        t.translate(scale * (tile.getBounds().x - bounds.getX()), scale * (tile.getBounds().y - bounds.getY()));
+        final AffineTransform t = AffineTransform.getTranslateInstance(
+            scale * (tile.getBounds().x - bounds.getX()),
+            scale * (tile.getBounds().y - bounds.getY()));
         g.drawImage(img, t, this);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -609,10 +609,12 @@ public class MapPanel extends ImageScrollerLargeView {
   private void drawTiles(final Graphics2D g, final GameData data, final Rectangle2D.Double bounds) {
     for (final Tile tile : tileManager.getTiles(bounds)) {
       if (tile.isDirty()) {
-        executor.execute(() -> {
-          tile.getImage(data, uiContext.getMapData());
-          SwingUtilities.invokeLater(this::repaint);
-        });
+        if (!tile.hasDrawingStarted()) {
+          executor.execute(() -> {
+            tile.getImage(data, uiContext.getMapData());
+            SwingUtilities.invokeLater(this::repaint);
+          });
+        }
       } else {
         final Image img = tile.getImage(data, uiContext.getMapData());
         final AffineTransform t = new AffineTransform();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -51,7 +51,7 @@ import games.strategy.engine.data.events.TerritoryListener;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.ui.logic.RouteCalculator;
+import games.strategy.triplea.ui.logic.MapScrollUtil;
 import games.strategy.triplea.ui.screen.SmallMapImageManager;
 import games.strategy.triplea.ui.screen.Tile;
 import games.strategy.triplea.ui.screen.TileManager;
@@ -581,8 +581,8 @@ public class MapPanel extends ImageScrollerLargeView {
         }
       } else {
         final Image img = tile.getImage(data, uiContext.getMapData());
-        final List<AffineTransform> transforms = new RouteCalculator(model.getScrollY(), model.getScrollX(),
-            model.getMaxWidth(), model.getMaxHeight()).getPossibleTranslations();
+        final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(
+            model.getScrollX(), model.getScrollY(), model.getMaxWidth(), model.getMaxHeight());
         for (final AffineTransform transform : transforms) {
           final AffineTransform viewTransformation = new AffineTransform();
           viewTransformation.scale(scale, scale);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -552,15 +552,14 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   /**
-   * @param value
-   *        a number between 15 and 100.
+   * @param value a number between 10 and 200.
    */
   public void setScale(final double value) {
     getMapPanel().setScale(value / 100);
   }
 
   /**
-   * @return a scale between 15 and 100.
+   * @return a scale between 10 and 200.
    */
   private double getScale() {
     return getMapPanel().getScale() * 100;

--- a/game-core/src/main/java/games/strategy/triplea/ui/logic/MapScrollUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/logic/MapScrollUtil.java
@@ -1,0 +1,57 @@
+package games.strategy.triplea.ui.logic;
+
+import java.awt.geom.AffineTransform;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Helper class to deal with infinitely scrolling maps.
+ */
+public class MapScrollUtil {
+  /**
+   * Creates an unmodifiable List of possible translations on the given map.
+   * If a map has "fixed borders" i.e. you can't infinitely scroll along at least one axis
+   * the returned list will just contain a single identity {@linkplain AffineTransform}.
+   *
+   * <p>
+   * If the map however is infinitely scrolling along an axis, the amount of {@linkplain AffineTransform}s
+   * will multiply by 3.
+   * Each {@linkplain AffineTransform} is a translation by a multiple (between -1 and 1) of mapHeight/mapWidth.
+   * </p>
+   *
+   * @param isInfiniteX True if the map wraps left and right
+   * @param isInfiniteY True if the map wraps top and bottom
+   * @param mapWidth Unscaled width of the map
+   * @param mapHeight Unscaled height of the map
+   *
+   * @return An unmodifiable List containing 9-1 {@linkplain AffineTransform}s
+   */
+  public static List<AffineTransform> getPossibleTranslations(
+      final boolean isInfiniteX,
+      final boolean isInfiniteY,
+      final int mapWidth,
+      final int mapHeight) {
+    final List<AffineTransform> result = new ArrayList<>(3); // 3 is probably the most common value
+    result.add(new AffineTransform());
+    if (isInfiniteX && isInfiniteY) {
+      result.addAll(Arrays.asList(
+          AffineTransform.getTranslateInstance(-mapWidth, -mapHeight),
+          AffineTransform.getTranslateInstance(-mapWidth, +mapHeight),
+          AffineTransform.getTranslateInstance(+mapWidth, -mapHeight),
+          AffineTransform.getTranslateInstance(+mapWidth, +mapHeight)));
+    }
+    if (isInfiniteX) {
+      result.addAll(Arrays.asList(
+          AffineTransform.getTranslateInstance(-mapWidth, 0),
+          AffineTransform.getTranslateInstance(+mapWidth, 0)));
+    }
+    if (isInfiniteY) {
+      result.addAll(Arrays.asList(
+          AffineTransform.getTranslateInstance(0, -mapHeight),
+          AffineTransform.getTranslateInstance(0, +mapHeight)));
+    }
+    return Collections.unmodifiableList(result);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
@@ -21,6 +21,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 
+/**
+ * Utility class to calculate a smooth route to draw on the map.
+ */
 @AllArgsConstructor(access =  AccessLevel.PUBLIC)
 @Builder
 public class RouteCalculator {
@@ -73,7 +76,9 @@ public class RouteCalculator {
    *         size may vary
    */
   public List<Point2D> getPossiblePoints(final Point2D point) {
-    return getPossibleTranslations().stream()
+    return MapScrollUtil
+        .getPossibleTranslations(isInfiniteX, isInfiniteY, mapWidth, mapHeight)
+        .stream()
         .map(t -> t.transform(point, null))
         .collect(Collectors.toList());
   }
@@ -128,45 +133,10 @@ public class RouteCalculator {
    */
   public List<Path2D> getAllNormalizedLines(final double[] xcoords, final double[] ycoords) {
     final Path2D path = getNormalizedLines(xcoords, ycoords);
-    return getPossibleTranslations().stream()
+    return MapScrollUtil
+        .getPossibleTranslations(isInfiniteX, isInfiniteY, mapWidth, mapHeight)
+        .stream()
         .map(t -> new Path2D.Double(path, t))
         .collect(Collectors.toList());
-  }
-
-
-  /**
-   * Creates an unmodifiable List of possible translations on the given map.
-   * If a map has "fixed borders" i.e. you can't infinitely scroll along at least one axis
-   * the returned list will just contain a single identity {@linkplain AffineTransform}.
-   *
-   * <p>
-   * If the map however is infinitely scrolling along an axis, the amount of {@linkplain AffineTransform}s
-   * will multiply by 3.
-   * Each {@linkplain AffineTransform} is a translation by a multiple (between -1 and 1) of mapHeight/mapWidth.
-   * </p>
-   *
-   * @return An unmodifiable List containing 9-1 {@linkplain AffineTransform}s
-   */
-  public List<AffineTransform> getPossibleTranslations() {
-    final List<AffineTransform> result = new ArrayList<>(3); // 3 is probably the most common value
-    result.add(new AffineTransform());
-    if (isInfiniteX && isInfiniteY) {
-      result.addAll(Arrays.asList(
-          AffineTransform.getTranslateInstance(-mapWidth, -mapHeight),
-          AffineTransform.getTranslateInstance(-mapWidth, +mapHeight),
-          AffineTransform.getTranslateInstance(+mapWidth, -mapHeight),
-          AffineTransform.getTranslateInstance(+mapWidth, +mapHeight)));
-    }
-    if (isInfiniteX) {
-      result.addAll(Arrays.asList(
-          AffineTransform.getTranslateInstance(-mapWidth, 0),
-          AffineTransform.getTranslateInstance(+mapWidth, 0)));
-    }
-    if (isInfiniteY) {
-      result.addAll(Arrays.asList(
-          AffineTransform.getTranslateInstance(0, -mapHeight),
-          AffineTransform.getTranslateInstance(0, +mapHeight)));
-    }
-    return Collections.unmodifiableList(result);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
@@ -24,12 +24,11 @@ import lombok.Builder;
 /**
  * Utility class to calculate a smooth route to draw on the map.
  */
-@AllArgsConstructor(access =  AccessLevel.PUBLIC)
 @Builder
 public class RouteCalculator {
 
-  public final boolean isInfiniteY;
   public final boolean isInfiniteX;
+  public final boolean isInfiniteY;
 
   private final int mapWidth;
   private final int mapHeight;

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -126,8 +126,8 @@ final class ViewMenu extends JMenu {
   private void addZoomMenu() {
     final Action mapZoom = SwingAction.of("Map Zoom", e -> {
       final SpinnerNumberModel model = new SpinnerNumberModel();
-      model.setMaximum(100);
-      model.setMinimum(15);
+      model.setMaximum(200);
+      model.setMinimum(10);
       model.setStepSize(1);
       model.setValue((int)Math.round(frame.getMapPanel().getScale() * 100));
       final JSpinner spinner = new JSpinner(model);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -129,7 +129,7 @@ final class ViewMenu extends JMenu {
       model.setMaximum(100);
       model.setMinimum(15);
       model.setStepSize(1);
-      model.setValue((int) (frame.getMapPanel().getScale() * 100));
+      model.setValue((int)Math.round(frame.getMapPanel().getScale() * 100));
       final JSpinner spinner = new JSpinner(model);
       final JPanel panel = new JPanel();
       panel.setLayout(new BorderLayout());

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -76,7 +76,7 @@ public class SmallMapImageManager {
       g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, mapData.getSmallMapTerritoryAlpha()));
       final LandTerritoryDrawable drawable = new LandTerritoryDrawable(t.getName());
-      drawable.draw(bounds, data, g, mapData, null, null);
+      drawable.draw(bounds, data, g, mapData);
       g.dispose();
     }
     // scale it down

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.util.List;
 
 import games.strategy.engine.data.GameData;
@@ -34,8 +33,7 @@ class TerritoryOverLayDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     graphics.setColor(color);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -87,9 +87,6 @@ public class Tile {
     }
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(Tile.class.getName()), Level.FINEST,
         "Drawing Tile at" + bounds);
-    // clear
-    g.setColor(Color.BLACK);
-    g.fill(new Rectangle(0, 0, TileManager.TILE_SIZE, TileManager.TILE_SIZE));
     for (final List<IDrawable> list : contents.values()) {
       for (final IDrawable drawable : list) {
         drawable.draw(bounds, data, g, mapData, unscaled, scaled);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -30,14 +30,12 @@ public class Tile {
 
   private final Image image;
   private final Rectangle bounds;
-  private final double scale;
   private final Lock lock = new ReentrantLock();
   private final SortedMap<Integer, List<IDrawable>> contents = new TreeMap<>();
 
-  Tile(final Rectangle bounds, final double scale) {
+  Tile(final Rectangle bounds) {
     this.bounds = bounds;
-    this.scale = scale;
-    image = Util.createImage((int) (bounds.getWidth() * scale), (int) (bounds.getHeight() * scale), true);
+    image = Util.createImage((int) bounds.getWidth(), (int) bounds.getHeight(), true);
   }
 
   public boolean isDirty() {
@@ -76,20 +74,11 @@ public class Tile {
   }
 
   private void draw(final Graphics2D g, final GameData data, final MapData mapData) {
-    final AffineTransform unscaled = g.getTransform();
-    final AffineTransform scaled;
-    if (scale != 1) {
-      scaled = new AffineTransform();
-      scaled.scale(scale, scale);
-      g.setTransform(scaled);
-    } else {
-      scaled = unscaled;
-    }
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(Tile.class.getName()), Level.FINEST,
         "Drawing Tile at" + bounds);
     for (final List<IDrawable> list : contents.values()) {
       for (final IDrawable drawable : list) {
-        drawable.draw(bounds, data, g, mapData, unscaled, scaled);
+        drawable.draw(bounds, data, g, mapData);
       }
     }
     isDirty = false;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -8,7 +8,6 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -33,7 +32,7 @@ public class Tile {
   private final Rectangle bounds;
   private final double scale;
   private final Lock lock = new ReentrantLock();
-  private final SortedMap<Integer, List<IDrawable>> contents = Collections.synchronizedSortedMap(new TreeMap<>());
+  private final SortedMap<Integer, List<IDrawable>> contents = new TreeMap<>();
 
   Tile(final Rectangle bounds, final double scale) {
     this.bounds = bounds;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -27,6 +27,7 @@ import games.strategy.ui.Util;
 
 public class Tile {
   private volatile boolean isDirty = true;
+  private volatile boolean drawingStarted = false;
 
   private final Image image;
   private final Rectangle bounds;
@@ -44,6 +45,10 @@ public class Tile {
     return isDirty;
   }
 
+  public boolean hasDrawingStarted() {
+    return drawingStarted;
+  }
+
   private void acquireLock() {
     LockUtil.INSTANCE.acquireLock(lock);
   }
@@ -56,6 +61,7 @@ public class Tile {
     if (isDirty) {
       try {
         acquireLock();
+        drawingStarted = true;
         final Graphics2D g = (Graphics2D) image.getGraphics();
         g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
@@ -63,6 +69,7 @@ public class Tile {
         draw(g, data, mapData);
         g.dispose();
       } finally {
+        drawingStarted = false;
         releaseLock();
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -134,7 +134,7 @@ public class TileManager {
       tiles = new ArrayList<>();
       for (int x = 0; x * TILE_SIZE < bounds.width; x++) {
         for (int y = 0; y * TILE_SIZE < bounds.height; y++) {
-          tiles.add(new Tile(new Rectangle(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE), uiContext.getScale()));
+          tiles.add(new Tile(new Rectangle(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE)));
         }
       }
     } finally {
@@ -474,12 +474,12 @@ public class TileManager {
       if (drawer.getLevel() == IDrawable.TERRITORY_TEXT_LEVEL) {
         continue;
       }
-      drawer.draw(bounds, data, graphics, mapData, null, null);
+      drawer.draw(bounds, data, graphics, mapData);
     }
     if (!drawOutline) {
       final Color c = selected.isWater() ? Color.RED : Color.BLACK;
       final TerritoryOverLayDrawable told = new TerritoryOverLayDrawable(c, selected.getName(), 100, Operation.FILL);
-      told.draw(bounds, data, graphics, mapData, null, null);
+      told.draw(bounds, data, graphics, mapData);
     }
     graphics.setStroke(new BasicStroke(10));
     graphics.setColor(Color.RED);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -9,6 +9,7 @@ import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +39,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.ui.UiContext;
+import games.strategy.triplea.ui.logic.RouteCalculator;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TerritoryOverLayDrawable.Operation;
 import games.strategy.triplea.ui.screen.drawable.BaseMapDrawable;
@@ -80,63 +82,26 @@ public class TileManager {
 
   /**
    * Selects tiles which fall into rectangle bounds.
+   * Normalizes the rectangle if it exceeds the maps bounds.
    *
-   * @param bounds
-   *        rectangle for selection
+   * @param bounds rectangle for selection
    * @return tiles which fall into the rectangle
    */
   public List<Tile> getTiles(final Rectangle2D bounds) {
-    // if the rectangle exceeds the map dimensions we to do shift the rectangle and check for each shifted rectangle as
-    // well as the original
-    // rectangle
     final MapData mapData = uiContext.getMapData();
     final Dimension mapDimensions = mapData.getMapDimensions();
-    final boolean testXshift =
-        (mapData.scrollWrapX() && (bounds.getMaxX() > mapDimensions.width || bounds.getMinX() < 0));
-    final boolean testYshift =
-        (mapData.scrollWrapY() && (bounds.getMaxY() > mapDimensions.height || bounds.getMinY() < 0));
-    Rectangle2D boundsXshift = null;
-    if (testXshift) {
-      if (bounds.getMinX() < 0) {
-        boundsXshift = new Rectangle((int) bounds.getMinX() + mapDimensions.width, (int) bounds.getMinY(),
-            (int) bounds.getWidth(), (int) bounds.getHeight());
-      } else {
-        boundsXshift = new Rectangle((int) bounds.getMinX() - mapDimensions.width, (int) bounds.getMinY(),
-            (int) bounds.getWidth(), (int) bounds.getHeight());
-      }
-    }
-    Rectangle2D boundsYshift = null;
-    if (testYshift) {
-      if (bounds.getMinY() < 0) {
-        boundsYshift = new Rectangle((int) bounds.getMinX(), (int) bounds.getMinY() + mapDimensions.height,
-            (int) bounds.getWidth(), (int) bounds.getHeight());
-      } else {
-        boundsYshift = new Rectangle((int) bounds.getMinX(), (int) bounds.getMinY() - mapDimensions.height,
-            (int) bounds.getWidth(), (int) bounds.getHeight());
-      }
-    }
     acquireLock();
     try {
+      final List<AffineTransform> translations = new RouteCalculator(mapData.scrollWrapY(), mapData.scrollWrapX(),
+          mapDimensions.width, mapDimensions.height)
+          .getPossibleTranslations();
       final List<Tile> tilesInBounds = new ArrayList<>();
       for (final Tile tile : tiles) {
         final Rectangle tileBounds = tile.getBounds();
-        if (bounds.contains(tileBounds) || tileBounds.intersects(bounds)) {
-          tilesInBounds.add(tile);
-        }
-      }
-      if (boundsXshift != null) {
-        for (final Tile tile : tiles) {
-          final Rectangle tileBounds = tile.getBounds();
-          if (boundsXshift.contains(tileBounds) || tileBounds.intersects(boundsXshift)) {
+        for (AffineTransform transform : translations) {
+          if (transform.createTransformedShape(tileBounds).intersects(bounds)) {
             tilesInBounds.add(tile);
-          }
-        }
-      }
-      if (boundsYshift != null) {
-        for (final Tile tile : tiles) {
-          final Rectangle tileBounds = tile.getBounds();
-          if (boundsYshift.contains(tileBounds) || tileBounds.intersects(boundsYshift)) {
-            tilesInBounds.add(tile);
+            break;
           }
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -33,6 +33,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.thread.LockUtil;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -146,11 +147,11 @@ public class TileManager {
   }
 
   private void acquireLock() {
-    Tile.LOCK_UTIL.acquireLock(lock);
+    LockUtil.INSTANCE.acquireLock(lock);
   }
 
   private void releaseLock() {
-    Tile.LOCK_UTIL.releaseLock(lock);
+    LockUtil.INSTANCE.releaseLock(lock);
   }
 
   Collection<UnitsDrawer> getUnitDrawables() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -39,7 +39,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.ui.UiContext;
-import games.strategy.triplea.ui.logic.RouteCalculator;
+import games.strategy.triplea.ui.logic.MapScrollUtil;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TerritoryOverLayDrawable.Operation;
 import games.strategy.triplea.ui.screen.drawable.BaseMapDrawable;
@@ -92,9 +92,8 @@ public class TileManager {
     final Dimension mapDimensions = mapData.getMapDimensions();
     acquireLock();
     try {
-      final List<AffineTransform> translations = new RouteCalculator(mapData.scrollWrapY(), mapData.scrollWrapX(),
-          mapDimensions.width, mapDimensions.height)
-          .getPossibleTranslations();
+      final List<AffineTransform> translations = MapScrollUtil.getPossibleTranslations(
+          mapData.scrollWrapX(), mapData.scrollWrapY(), mapDimensions.width, mapDimensions.height);
       final List<Tile> tilesInBounds = new ArrayList<>();
       for (final Tile tile : tiles) {
         final Rectangle tileBounds = tile.getBounds();

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -7,7 +7,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
-import java.awt.geom.AffineTransform;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -76,8 +75,7 @@ public class UnitsDrawer implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
 
     // If there are too many Units at one point a black line is drawn to make clear which units belong to where
     if (overflow) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
@@ -11,9 +11,7 @@ public class BaseMapDrawable extends MapTileDrawable {
 
   @Override
   public MapTileDrawable getUnscaledCopy() {
-    final BaseMapDrawable copy = new BaseMapDrawable(x, y, uiContext);
-    copy.unscaled = true;
-    return copy;
+    return new BaseMapDrawable(x, y, uiContext);
   }
 
   @Override
@@ -21,12 +19,7 @@ public class BaseMapDrawable extends MapTileDrawable {
     if (noImage) {
       return null;
     }
-    final Image image;
-    if (unscaled) {
-      image = uiContext.getTileImageFactory().getUnscaledUncachedBaseTile(x, y);
-    } else {
-      image = uiContext.getTileImageFactory().getBaseTile(x, y);
-    }
+    final Image image = uiContext.getTileImageFactory().getBaseTile(x, y);
     if (image == null) {
       noImage = true;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -5,7 +5,6 @@ import java.awt.GradientPaint;
 import java.awt.Graphics2D;
 import java.awt.Paint;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -24,8 +23,7 @@ public class BattleDrawable extends TerritoryDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Set<PlayerID> players = new HashSet<>();
     for (final Unit u : data.getMap().getTerritory(territoryName).getUnits()) {
       if (!TripleAUnit.get(u).getSubmerged()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui.screen.drawable;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
@@ -18,8 +17,7 @@ public class BlockadeZoneDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     // Find blockade.png from misc folder
     final Point point = mapData.getBlockadePlacementPoint(data.getMap().getTerritory(location));
     drawImage(graphics, mapData.getBlockadeImage(), point, bounds);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -28,8 +27,7 @@ public class CapitolMarkerDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     // Changed back to use Large flags
     final Image img = uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerId(player));
     final Point point = mapData.getCapitolMarkerLocation(data.getMap().getTerritory(location));

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -26,8 +26,7 @@ public class ConvoyZoneDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Image img;
     if (mapData.useNation_convoyFlags()) {
       img = uiContext.getFlagImageFactory().getConvoyFlag(data.getPlayerList().getPlayerId(player));

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -20,8 +19,7 @@ public class DecoratorDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     graphics.drawImage(image, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
@@ -32,16 +32,7 @@ public interface IDrawable {
     LOW, MEDIUM, HIGH
   }
 
-  /**
-   * Draw the tile
-   * If the graphics are scaled, then unscaled and scaled will be non null.
-   *
-   * <p>
-   * The affine transform will be set to the scaled version.
-   * </p>
-   */
-  void draw(Rectangle bounds, GameData data, Graphics2D graphics, MapData mapData, AffineTransform unscaled,
-      AffineTransform scaled);
+  void draw(Rectangle bounds, GameData data, Graphics2D graphics, MapData mapData);
 
   int getLevel();
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -26,8 +25,7 @@ public class KamikazeZoneDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     // Change so only original owner gets the kamikazi zone marker
     final Territory terr = data.getMap().getTerritory(location);
     final TerritoryAttachment ta = TerritoryAttachment.get(terr);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui.screen.drawable;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
@@ -18,8 +17,7 @@ public class LandTerritoryDrawable extends TerritoryDrawable implements IDrawabl
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final Color territoryColor;
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -16,13 +16,11 @@ public abstract class MapTileDrawable implements IDrawable {
   protected final int x;
   protected final int y;
   protected final UiContext uiContext;
-  protected boolean unscaled;
 
   protected MapTileDrawable(final int x, final int y, final UiContext uiContext) {
     this.x = x;
     this.y = y;
     this.uiContext = uiContext;
-    unscaled = false;
   }
 
   public abstract MapTileDrawable getUnscaledCopy();
@@ -30,41 +28,16 @@ public abstract class MapTileDrawable implements IDrawable {
   protected abstract Image getImage();
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Image img = getImage();
     if (img == null) {
       return;
     }
-    final Object oldRenderingValue = graphics.getRenderingHint(RenderingHints.KEY_RENDERING);
-    final Object oldAlphaValue = graphics.getRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION);
-    final Object oldInterpolationValue = graphics.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
+    final RenderingHints hints = graphics.getRenderingHints();
     graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
     graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
     graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-    // the tile images are already scaled
-    if (unscaled != null) {
-      graphics.setTransform(unscaled);
-    }
     graphics.drawImage(img, x * TileManager.TILE_SIZE - bounds.x, y * TileManager.TILE_SIZE - bounds.y, null);
-    if (unscaled != null) {
-      graphics.setTransform(scaled);
-    }
-    if (oldAlphaValue == null) {
-      graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
-          RenderingHints.VALUE_ALPHA_INTERPOLATION_DEFAULT);
-    } else {
-      graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, oldAlphaValue);
-    }
-    if (oldRenderingValue == null) {
-      graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_DEFAULT);
-    } else {
-      graphics.setRenderingHint(RenderingHints.KEY_RENDERING, oldRenderingValue);
-    }
-    if (oldInterpolationValue == null) {
-      graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-    } else {
-      graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, oldInterpolationValue);
-    }
+    graphics.setRenderingHints(hints);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.util.List;
 
 import games.strategy.engine.data.GameData;
@@ -21,8 +20,7 @@ public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     for (Polygon polygon : polys) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
@@ -12,9 +12,7 @@ public class ReliefMapDrawable extends MapTileDrawable {
 
   @Override
   public MapTileDrawable getUnscaledCopy() {
-    final ReliefMapDrawable copy = new ReliefMapDrawable(x, y, uiContext);
-    copy.unscaled = true;
-    return copy;
+    return new ReliefMapDrawable(x, y, uiContext);
   }
 
   @Override
@@ -25,12 +23,7 @@ public class ReliefMapDrawable extends MapTileDrawable {
     if (!TileImageFactory.getShowReliefImages()) {
       return null;
     }
-    final Image image;
-    if (unscaled) {
-      image = uiContext.getTileImageFactory().getUnscaledUncachedReliefTile(x, y);
-    } else {
-      image = uiContext.getTileImageFactory().getReliefTile(x, y);
-    }
+    final Image image = uiContext.getTileImageFactory().getReliefTile(x, y);
     if (image == null) {
       noImage = true;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.util.List;
 
 import games.strategy.engine.data.GameData;
@@ -19,8 +18,7 @@ public class SeaZoneOutlineDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     for (Polygon polygon : polys) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui.screen.drawable;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TerritoryEffect;
@@ -20,8 +19,7 @@ public class TerritoryEffectDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     drawImage(graphics, mapData.getTerritoryEffectImage(effect.getName()), point, bounds);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -6,7 +6,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,8 +28,7 @@ public class TerritoryNameDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final boolean drawFromTopLeft = mapData.drawNamesFromTopLeft();

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui.screen.drawable;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.geom.AffineTransform;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
@@ -17,8 +16,7 @@ public class VcDrawable implements IDrawable {
   }
 
   @Override
-  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
-      final AffineTransform unscaled, final AffineTransform scaled) {
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
 
     final Point point = mapData.getVcPlacementPoint(location);
     drawImage(graphics, mapData.getVcImage(), point, bounds);

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -304,12 +304,6 @@ public class ImageScrollerLargeView extends JComponent {
    *        If out of bounds the nearest boundary value is used.
    */
   public void setScale(double value) {
-    if (value < 0.15) {
-      value = 0.15;
-    }
-    if (value > 1) {
-      value = 1;
-    }
     // we want the ratio to be a multiple of 1/256
     // so that the tiles have integer widths and heights
     value = ((int) (value * 256)) / ((double) 256);

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
@@ -16,7 +16,7 @@ import java.awt.geom.Rectangle2D;
 import javax.swing.JComponent;
 import javax.swing.border.EtchedBorder;
 
-import games.strategy.triplea.ui.logic.RouteCalculator;
+import games.strategy.triplea.ui.logic.MapScrollUtil;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 /**
@@ -119,16 +119,16 @@ public class ImageScrollerSmallView extends JComponent {
     final double height = model.getBoxHeight() * ratioY;
     final Rectangle2D.Double mapBounds = new Rectangle2D.Double(0, 0,
         model.getMaxWidth() * ratioX, model.getMaxHeight() * ratioY);
-    final RouteCalculator calculator = new RouteCalculator(
-        model.getScrollY(),
-        model.getScrollX(),
-        (int) Math.round(mapBounds.width),
-        (int) Math.round(mapBounds.height));
     final Rectangle2D.Double rect = new Rectangle2D.Double(
         x % mapBounds.width, y % mapBounds.height,
         width, height);
     g.setClip(mapBounds);
-    calculator.getPossibleTranslations().stream()
+    MapScrollUtil.getPossibleTranslations(
+        model.getScrollX(),
+        model.getScrollY(),
+        (int) Math.round(mapBounds.width),
+        (int) Math.round(mapBounds.height))
+        .stream()
         .map(t -> t.createTransformedShape(rect))
         .map(Shape::getBounds2D)
         .forEach(r -> drawFilledRect(r, g));

--- a/game-core/src/test/java/games/strategy/triplea/ui/logic/MapScrollUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/logic/MapScrollUtilTest.java
@@ -1,0 +1,59 @@
+package games.strategy.triplea.ui.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.geom.AffineTransform;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+public class MapScrollUtilTest {
+
+  @Test
+  public void testWithXWrapOnly() {
+    final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(true, false, 9876, 2345);
+    assertEquals(3, transforms.size());
+    assertTrue(transforms.stream().anyMatch(transCriteria(-9876, 0)));
+    assertTrue(transforms.stream().anyMatch(AffineTransform::isIdentity));
+    assertTrue(transforms.stream().anyMatch(transCriteria(9876, 0)));
+  }
+
+  @Test
+  public void testWithYWrapOnly() {
+    final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(false, true, 1234, 5678);
+    assertEquals(3, transforms.size());
+    assertTrue(transforms.stream().anyMatch(transCriteria(0, -5678)));
+    assertTrue(transforms.stream().anyMatch(AffineTransform::isIdentity));
+    assertTrue(transforms.stream().anyMatch(transCriteria(0, 5678)));
+  }
+
+  @Test
+  public void testWithXAndYWrap() {
+    final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(true, true, 2345, 6789);
+    assertEquals(9, transforms.size());
+    assertTrue(transforms.stream().anyMatch(transCriteria(-2345, -6789)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(0, -6789)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(2345, -6789)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(-2345, 0)));
+    assertTrue(transforms.stream().anyMatch(AffineTransform::isIdentity));
+    assertTrue(transforms.stream().anyMatch(transCriteria(2345, 0)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(-2345, 6789)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(0, 6789)));
+    assertTrue(transforms.stream().anyMatch(transCriteria(2345, 6789)));
+  }
+
+  @Test
+  public void testWithoutWrap() {
+    final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(false, false, 8765, 4321);
+    assertEquals(1, transforms.size());
+    assertTrue(transforms.get(0).isIdentity());
+  }
+
+  private Predicate<AffineTransform> transCriteria(final int xoffset, final int yoffset) {
+    return trans -> trans.getTranslateX() == xoffset
+          && trans.getTranslateY() == yoffset
+          && trans.getType() == AffineTransform.TYPE_TRANSLATION;
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
@@ -157,7 +157,8 @@ public class RouteCalculatorTest {
     final double[] testData = new double[1000];
     Arrays.setAll(testData, Double::valueOf);
     final List<Path2D> paths = routeCalculator.getAllNormalizedLines(testData, testData);
-    final Iterator<AffineTransform> transforms = routeCalculator.getPossibleTranslations().iterator();
+    final Iterator<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(
+        true, true, 1000, 1000).iterator();
     // This method looks more complicated than it actually is.
     // It checks whether all given points are contained in the returned paths
     // Unfortunately Path2D#contains does not work for whatever reason


### PR DESCRIPTION
I originally wanted to change the data structure for the tiles to a heap.
However after realizing that the iterator returned by PriorityQueue doesn't guarantee any particular order this idea was quickly dumped again.
However I realized a lot of issues with the current rendering code, so I decided to simplify it.
~I also wanted to simplify the code in the MapPanel#paint(Graphics) method, however that turned out to be a lot trickier than I expected so I ended up not changing it.~
UPDATE: Ended up changing it

Deleted code is debugged code!

BTW. Did a lot of manual testing. Tile Rendering Performance is about the same as before, no notable difference, except for the fact that you can see the individual tiles rendering after each other instead of the appearing all at the same time due to better lock acquirement.

UPDATE 2:
Ok, so this PR got a lot bigger now. What started as a small improvement, ended up being a big modification to the drawing code.
This enables us to have a dynamic zoom feature, because the tiles no longer need to be 100% redrawn when zooming.
To demo this I lifted the zoom limit to 200% max and 10% min so people can try it out.
A map with a low zoom setting looks _slightly_ different now. See examples below.
Also less code in general to maintain.

Before:
![Before](https://user-images.githubusercontent.com/8350879/42004225-433031a0-7a6f-11e8-9062-57ffb7ab53dc.png)
After:
![After](https://user-images.githubusercontent.com/8350879/42004155-ee98ef9c-7a6e-11e8-88a6-c620ccbc54f3.png)
200% Zoom:
![200% Zoom](https://user-images.githubusercontent.com/8350879/42004371-e5c50094-7a6f-11e8-9b74-4f17263362b1.png)
Also huge shoutout to @Heppisorus for providing an awesome map to test a lot of individual tiles (had a problem which only occurs by chance ^^)
