### PR TITLE
Remove AA attack limit of half dice side value

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -82,11 +82,10 @@ public class DiceRoll implements Externalizable {
         chosenDiceSize = uaDiceSides;
       }
     }
-    if (highestAttack > chosenDiceSize / 2 && chosenDiceSize > 1) {
-      // TODO: sadly the whole low luck section falls apart if AA are hitting at greater than half the
-      // value of dice, and I don't feel like rewriting it
-      highestAttack = chosenDiceSize / 2;
-    }
+    // TODO: determine if there are bugs in LL if AA hit at greater than half of dice value
+    // if (highestAttack > chosenDiceSize / 2 && chosenDiceSize > 1) {
+    // highestAttack = chosenDiceSize / 2;
+    // }
     return Tuple.of(highestAttack, chosenDiceSize);
   }
 


### PR DESCRIPTION
Remove check that limits aa attack to half of dice sides as it isn't clear as to why that is done. Given that check exists, no existing maps should have a value greater than half so should have no negative impact.

Here is the original commit that added that code: https://github.com/triplea-game/triplea/commit/8a5f0e2c43a013d14f695050cfd340ecc70f98be#diff-b277d7a65530ad0e35446534517831f9

@veqryn Any background on this? Its a bit hard to follow why that AA attack cap is needed. It looked like there was originally some sort of "groupSize" used when rolling LL but that seems to not exist anymore: https://github.com/triplea-game/triplea/commit/8a5f0e2c43a013d14f695050cfd340ecc70f98be#diff-b277d7a65530ad0e35446534517831f9R126