### PR TITLE
Fix Weird async issues

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -137,6 +137,19 @@ public class GameRunner {
       return;
     }
 
+    if (SystemProperties.isMac()) {
+      com.apple.eawt.Application.getApplication().setOpenURIHandler(event -> {
+        final String encoding = StandardCharsets.UTF_8.displayName();
+        try {
+          final String mapName = URLDecoder.decode(
+              event.getURI().toString().substring(ArgParser.TRIPLEA_PROTOCOL.length()), encoding);
+          SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
+        } catch (final UnsupportedEncodingException e) {
+          throw new AssertionError(encoding + " is not a supported encoding!", e);
+        }
+      });
+    }
+
     if (HttpProxy.isUsingSystemProxy()) {
       HttpProxy.updateSystemProxy();
     }
@@ -274,20 +287,6 @@ public class GameRunner {
    * welcome (launch lobby/single player game etc..) screen presented to GUI enabled clients.
    */
   public static void showMainFrame() {
-
-    if (SystemProperties.isMac()) {
-      com.apple.eawt.Application.getApplication().setOpenURIHandler(event -> {
-        final String encoding = StandardCharsets.UTF_8.displayName();
-        try {
-          final String mapName = URLDecoder.decode(
-              event.getURI().toString().substring(ArgParser.TRIPLEA_PROTOCOL.length()), encoding);
-          SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
-        } catch (final UnsupportedEncodingException e) {
-          throw new AssertionError(encoding + " is not a supported encoding!", e);
-        }
-      });
-    }
-
     SwingUtilities.invokeLater(() -> {
       mainFrame.requestFocus();
       mainFrame.toFront();

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -451,13 +451,14 @@ public class GameRunner {
    * After the game has been left, call this.
    */
   public static void clientLeftGame() {
-    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
-      // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
-      // closing of stream while unloading map resources.
-      Interruptibles.sleep(100);
-      setupPanelModel.showSelectType();
-      showMainFrame();
-    }));
+    if (SwingUtilities.isEventDispatchThread()) {
+      throw new IllegalStateException("This method must not be called from the EDT");
+    }
+    // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
+    // closing of stream while unloading map resources.
+    Interruptibles.sleep(100);
+    Interruptibles.await(() -> SwingAction.invokeAndWait(setupPanelModel::showSelectType));
+    showMainFrame();
   }
 
   public static void quitGame() {

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -300,8 +300,10 @@ public class GameRunner {
 
       if (System.getProperty(TRIPLEA_SERVER, "false").equals("true")) {
         setupPanelModel.showServer(mainFrame);
+        System.clearProperty(TRIPLEA_SERVER);
       } else if (System.getProperty(TRIPLEA_CLIENT, "false").equals("true")) {
         setupPanelModel.showClient(mainFrame);
+        System.clearProperty(TRIPLEA_CLIENT);
       }
     });
   }
@@ -310,7 +312,7 @@ public class GameRunner {
     Interruptibles.await(() -> newBackgroundTaskRunner().runInBackground("Loading game...", () -> {
       gameSelectorModel.loadDefaultGameSameThread();
       final String fileName = System.getProperty(TRIPLEA_GAME, "");
-      if (fileName.length() > 0) {
+      if (!fileName.isEmpty()) {
         gameSelectorModel.load(new File(fileName), mainFrame);
       }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -153,6 +153,7 @@ public class ClientModel implements IMessengerErrorListener {
 
   public void setRemoteModelListener(@Nonnull final IRemoteModelListener listener) {
     this.listener = Preconditions.checkNotNull(listener);
+    internalPlayerListingChanged(getServerStartup().getPlayerListing());
   }
 
   private static ClientProps getProps(final Component ui) {
@@ -379,16 +380,15 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   private void internalPlayerListingChanged(final PlayerListing listing) {
-    SwingUtilities
-        .invokeLater(() -> gameSelectorModel.clearDataButKeepGameInfo(listing.getGameName(), listing.getGameRound(),
-            listing.getGameVersion().toString()));
+    gameSelectorModel.clearDataButKeepGameInfo(listing.getGameName(), listing.getGameRound(),
+            listing.getGameVersion().toString());
     synchronized (this) {
       playersToNodes = listing.getPlayerToNodeListing();
       playersEnabledListing = listing.getPlayersEnabledListing();
       playersAllowedToBeDisabled = listing.getPlayersAllowedToBeDisabled();
       playerNamesAndAlliancesInTurnOrder = listing.getPlayerNamesAndAlliancesInTurnOrderLinkedHashMap();
     }
-    SwingUtilities.invokeLater(() -> listener.playerListChanged());
+    listener.playerListChanged();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -36,7 +36,7 @@ public class ClientSetupPanel extends SetupPanel {
   private static final long serialVersionUID = 6942605803526295372L;
   private final Insets buttonInsets = new Insets(0, 0, 0, 0);
   private final ClientModel clientModel;
-  private List<PlayerRow> playerRows = Collections.emptyList();
+  private final List<PlayerRow> playerRows = new ArrayList<>();
 
   public ClientSetupPanel(final ClientModel model) {
     clientModel = model;
@@ -48,7 +48,7 @@ public class ClientSetupPanel extends SetupPanel {
 
       @Override
       public void playerListChanged() {
-        internalPlayersChanged();
+        SwingUtilities.invokeLater(ClientSetupPanel.this::internalPlayersChanged);
       }
     });
   }
@@ -63,7 +63,7 @@ public class ClientSetupPanel extends SetupPanel {
       // clients only get to change bot settings
       disableable.clear();
     }
-    playerRows = new ArrayList<>();
+    playerRows.clear();
     final Set<String> playerNames = playerNamesAndAlliancesInTurnOrder.keySet();
     for (final String name : playerNames) {
       final PlayerRow playerRow = new PlayerRow(name, playerNamesAndAlliancesInTurnOrder.get(name),

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -614,7 +614,7 @@ public class TripleAFrame extends MainGameFrame {
       ((ClientGame) game).shutDown();
       // an ugly hack, we need a better
       // way to get the main frame
-      GameRunner.clientLeftGame();
+      new Thread(GameRunner::clientLeftGame).start();
     }
   }
 


### PR DESCRIPTION
Suppose to fix #3468 and a couple of other issues related to asynchronous execution.
Issue 1 gets "fixed" (not 100% sure, but pretty confident), by clearing a System property that launches the game directly when laucnhing, but continues to do so when leaving the game normally.
This caused a background runner to be invoked inside a background runner which likely caused the deadlock (weirdly enough it didn't happen to me)

Issue 2 was an issue that occured, because the code was now correct.
The ClientModel#createClientMessenger function queued the update playerlist trigger in the EDT which was previously executed after the creation of the ClientSetupPanel, because EVERYTHING was done on the EDT which caused it to freeze for short time periods.
When changing everything to async execution, the instantiation of ClientSetupPanel was now after the event was triggered, so the panel didn't show the selected players, until the map was re-selected.