### PR TITLE
Recalc image correctly if not available

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -28,11 +28,12 @@ public class ImageFactory {
   }
 
   protected Image getImage(final String key, final boolean throwIfNotFound) {
-    if (!images.containsKey(key)) {
+    if (!images.containsKey(key) || (throwIfNotFound && images.get(key) == null)) {
       final URL url = resourceLoader.getResource(key);
-      if (url == null && throwIfNotFound) {
-        throw new IllegalStateException("Image Not Found:" + key);
-      } else if (url == null) {
+      if (url == null) {
+        if (throwIfNotFound) {
+          throw new IllegalStateException("Image Not Found:" + key);
+        }
         images.put(key, null);
         return null;
       }


### PR DESCRIPTION
Should fix #3473
This way the getImage method should never return null or throw an exception