### PR TITLE
Fix chat concurrency issue

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -439,16 +439,6 @@ public class GameRunner {
   }
 
   /**
-   * Get the chat for the game, or empty if there is no chat (eg: headless).
-   */
-  public static Optional<Chat> getChat() {
-    final ISetupPanel model = setupPanelModel.getPanel();
-    return ((model instanceof ServerSetupPanel) || (model instanceof ClientSetupPanel))
-        ? Optional.ofNullable(model.getChatPanel().getChat())
-        : Optional.empty();
-  }
-
-  /**
    * After the game has been left, call this.
    */
   public static void clientLeftGame() {

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
+import games.strategy.engine.chat.Chat;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
@@ -13,7 +16,7 @@ import games.strategy.engine.message.IRemote;
  * A game loader is responsible for telling the framework
  * what types of players are available, for creating players, and
  * starting the game.
- * The name is somewhat misleading since it doesnt actually load the
+ * The name is somewhat misleading since it doesn't actually load the
  * game data, merely performs the game specific steps for starting the game
  * and meta data needed by the engine.
  */
@@ -36,7 +39,7 @@ public interface IGameLoader extends Serializable {
   /**
    * The game is about to start.
    */
-  void startGame(IGame game, Set<IGamePlayer> players, boolean headless) throws Exception;
+  void startGame(IGame game, Set<IGamePlayer> players, boolean headless, @Nullable Chat chat) throws Exception;
 
   /**
    * Get the type of the display.
@@ -51,7 +54,7 @@ public interface IGameLoader extends Serializable {
    * Get the type of the GamePlayer.
    *
    * <p>
-   * The type must extend IRemote, and is to be used by an IRemoteManager to allow a player to be contacted remotately
+   * The type must extend IRemote, and is to be used by an IRemoteManager to allow a player to be contacted remotely
    * </p>
    */
   Class<? extends IRemote> getRemotePlayerType();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -51,7 +51,7 @@ public class LocalLauncher extends AbstractLauncher {
       final Set<IGamePlayer> gamePlayers = gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypes());
       final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers);
       game.setRandomSource(randomSource);
-      gameData.getGameLoader().startGame(game, gamePlayers, headless);
+      gameData.getGameLoader().startGame(game, gamePlayers, headless, null);
       return Optional.of(game);
     } catch (final Exception ex) {
       ClientLogger.logError("Failed to start game", ex);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -144,7 +144,7 @@ public class ServerLauncher extends AbstractLauncher {
         serverGame.setRandomSource(randomSource);
       }
       try {
-        gameData.getGameLoader().startGame(serverGame, localPlayerSet, headless);
+        gameData.getGameLoader().startGame(serverGame, localPlayerSet, headless, serverModel.getChatPanel().getChat());
       } catch (final Exception e) {
         ClientLogger.logError("Failed to launch", e);
         abortLaunch = true;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -429,8 +430,10 @@ public class ClientModel implements IMessengerErrorListener {
   public void messengerInvalid(final IMessenger messenger, final Exception reason) {
     // The self chat disconnect notification is simply so we have an on-screen notification of the disconnect.
     // In case for example there are many game windows open, it may not be clear which game disconnected.
-    GameRunner.getChat()
-        .ifPresent(chat -> chat.sendMessage("*** Was Disconnected ***", false));
+    if (chatPanel != null) {
+      Optional.ofNullable(chatPanel.getChat())
+          .ifPresent(chat -> chat.sendMessage("*** Was Disconnected ***", false));
+    }
     EventThreadJOptionPane.showMessageDialog(ui, "Connection to game host lost.\nPlease save and restart.",
         "Connection Lost!", JOptionPane.ERROR_MESSAGE);
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -342,7 +342,7 @@ public class ClientModel implements IMessengerErrorListener {
         // game will be null if we loose the connection
         if (game != null) {
           try {
-            data.getGameLoader().startGame(game, playerSet, false);
+            data.getGameLoader().startGame(game, playerSet, false, getChatPanel().getChat());
             data.testLocksOnRead();
           } catch (final Exception e) {
             ClientLogger.logError("Failed to start Game", e);

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -5,8 +5,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.chat.Chat;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.data.PlayerID;
@@ -39,6 +41,7 @@ import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.ui.display.TripleADisplay;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 
 @MapSupport
 public class TripleA implements IGameLoader {
@@ -95,7 +98,8 @@ public class TripleA implements IGameLoader {
   }
 
   @Override
-  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) {
+  public void startGame(final IGame game, final Set<IGamePlayer> players,
+      final boolean headless, @Nullable final Chat chat) {
     this.game = game;
     if (game.getData().getDelegateList().getDelegate("edit") == null) {
       // An evil hack: instead of modifying the XML, force an EditDelegate by adding one here
@@ -119,7 +123,7 @@ public class TripleA implements IGameLoader {
       // technically not needed because we won't have any "local human players" in a headless game.
       connectPlayers(players, null);
     } else {
-      final TripleAFrame frame = TripleAFrame.create(game, localPlayers);
+      final TripleAFrame frame = TripleAFrame.create(game, localPlayers, chat);
 
       SwingUtilities.invokeLater(() -> {
         LookAndFeelSwingFrameListener.register(frame);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -199,7 +199,7 @@ public class TripleAFrame extends MainGameFrame {
   private HistorySynchronizer historySyncher;
   private final UiContext uiContext;
   private final JPanel mapAndChatPanel;
-  private ChatPanel chatPanel;
+  private final ChatPanel chatPanel;
   private final CommentPanel commentPanel;
   private final JSplitPane chatSplit;
   private JSplitPane commentSplit;
@@ -304,6 +304,7 @@ public class TripleAFrame extends MainGameFrame {
       mapAndChatPanel.add(chatSplit, BorderLayout.CENTER);
     } else {
       mapAndChatPanel.add(mapPanel, BorderLayout.CENTER);
+      chatPanel = null;
     }
     gameMainPanel.setLayout(new BorderLayout());
     this.getContentPane().setLayout(new BorderLayout());
@@ -2088,5 +2089,9 @@ public class TripleAFrame extends MainGameFrame {
     return ServerGame.class.isAssignableFrom(getGame().getClass())
         ? Optional.ofNullable(((ServerGame) getGame()).getInGameLobbyWatcher())
         : Optional.empty();
+  }
+
+  public boolean hasChat() {
+    return chatPanel != null;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -81,6 +81,7 @@ import javax.swing.tree.TreeNode;
 import com.google.common.base.Preconditions;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.PlayerChatRenderer;
 import games.strategy.engine.data.Change;
@@ -219,7 +220,7 @@ public class TripleAFrame extends MainGameFrame {
   /**
    * Constructs a new instance of a TripleAFrame, but executes required IO-Operations off the EDT.
    */
-  public static TripleAFrame create(final IGame game, final LocalPlayers players) {
+  public static TripleAFrame create(final IGame game, final LocalPlayers players, @Nullable final Chat chat) {
     Preconditions.checkState(!SwingUtilities.isEventDispatchThread(), "This method must not be called on the EDT");
 
     final UiContext uiContext = new HeadedUiContext();
@@ -228,12 +229,14 @@ public class TripleAFrame extends MainGameFrame {
     uiContext.setLocalPlayers(players);
 
     final TripleAFrame frame = Interruptibles.awaitResult(() -> SwingAction
-        .invokeAndWaitResult(() -> new TripleAFrame(game, players, uiContext))).result.get();
+        .invokeAndWaitResult(() -> new TripleAFrame(game, players, uiContext, chat))).result
+        .orElseThrow(() -> new IllegalStateException("Error while instantiating TripleAFrame"));
     frame.updateStep();
     return frame;
   }
 
-  private TripleAFrame(final IGame game, final LocalPlayers players, final UiContext uiContext) {
+  private TripleAFrame(final IGame game, final LocalPlayers players,
+      final UiContext uiContext, @Nullable final Chat chat) {
     super("TripleA - " + game.getData().getGameName(), players);
     this.game = game;
     data = game.getData();
@@ -284,7 +287,7 @@ public class TripleAFrame extends MainGameFrame {
     chatSplit.setOneTouchExpandable(true);
     chatSplit.setDividerSize(8);
     chatSplit.setResizeWeight(0.95);
-    if (GameRunner.getChat().isPresent()) {
+    if (chat != null) {
       commentSplit = new JSplitPane();
       commentSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);
       commentSplit.setOneTouchExpandable(true);
@@ -292,7 +295,7 @@ public class TripleAFrame extends MainGameFrame {
       commentSplit.setResizeWeight(0.5);
       commentSplit.setTopComponent(commentPanel);
       commentSplit.setBottomComponent(null);
-      chatPanel = new ChatPanel(GameRunner.getChat().get());
+      chatPanel = new ChatPanel(chat);
       chatPanel.setPlayerRenderer(new PlayerChatRenderer(this.game, uiContext));
       final Dimension chatPrefSize = new Dimension((int) chatPanel.getPreferredSize().getWidth(), 95);
       chatPanel.setPreferredSize(chatPrefSize);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -506,6 +506,6 @@ final class ViewMenu extends JMenu {
     chatTimeBox.addActionListener(e -> frame.setShowChatTime(chatTimeBox.isSelected()));
     chatTimeBox.setSelected(false);
     add(chatTimeBox);
-    chatTimeBox.setEnabled(GameRunner.getChat().isPresent());
+    chatTimeBox.setEnabled(frame.hasChat());
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -3,6 +3,9 @@ package games.strategy.engine.xml;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
+import games.strategy.engine.chat.Chat;
 import games.strategy.engine.data.DefaultUnitFactory;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.framework.IGame;
@@ -23,7 +26,8 @@ public final class TestGameLoader implements IGameLoader {
   }
 
   @Override
-  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) {}
+  public void startGame(final IGame game, final Set<IGamePlayer> players,
+      final boolean headless, @Nullable Chat chat) {}
 
   @Override
   public Set<IGamePlayer> createPlayers(final Map<String, String> players) {


### PR DESCRIPTION
#3467 done right without the luck factor.
When delaying the creation of a TripleAFrame instance by adding in a second sleep or something, everything would've worked fine.
However computers are too fast, so I passed the already existing chat instance to the TripleAFrame instead of relying on some static method in GameRunner.
After changing the code I noticed that there were only 2 usages of this static method left, so I decided to change them ass well and removing this ugly static method.