### PR TITLE
Hide unit tooltips when window becomes inactive.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -2,13 +2,19 @@ package games.strategy.triplea.ui;
 
 import java.awt.MouseInfo;
 import java.awt.Point;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JComponent;
 import javax.swing.JToolTip;
 import javax.swing.Popup;
 import javax.swing.PopupFactory;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
 
 
 /**
@@ -16,6 +22,7 @@ import javax.swing.Timer;
  */
 public class MapUnitTooltipManager implements ActionListener {
   private final JComponent parent;
+  private final WindowDeactivationObserver deactivationObserver;
   private final Timer timer;
   private String text;
   private Popup popup;
@@ -25,6 +32,54 @@ public class MapUnitTooltipManager implements ActionListener {
     this.timer = new Timer(1000, this);
     this.timer.setRepeats(false);
     // Note: Timer not started yet.
+
+    // Close tooltips when the window becomes inactive - so they don't overlap opened dialogs.
+    deactivationObserver = new WindowDeactivationObserver();
+  }
+
+  private class WindowDeactivationObserver extends WindowAdapter implements AncestorListener {
+    private Window window;
+
+    public WindowDeactivationObserver() {
+      // Listen to ancestor events as the component may not have a Window yet.
+      parent.addAncestorListener(this);
+      updateWindowObserver();
+    }
+
+    private void updateWindowObserver() {
+      if (window != null) {
+        window.removeWindowListener(this);
+      }
+      window = SwingUtilities.getWindowAncestor(parent);
+      if (window != null) {
+        window.addWindowListener(this);
+      }
+    }
+
+    @Override
+    public void windowClosed(final WindowEvent e) {
+      window.removeWindowListener(this);
+    }
+
+    @Override
+    public void windowDeactivated(final WindowEvent e) {
+      updateTooltip("");
+    }
+
+    @Override
+    public void ancestorAdded(final AncestorEvent event) {
+      updateWindowObserver();
+    }
+
+    @Override
+    public void ancestorRemoved(final AncestorEvent event) {
+      updateWindowObserver();
+    }
+
+    @Override
+    public void ancestorMoved(final AncestorEvent event) {
+      updateWindowObserver();
+    }
   }
 
   /**


### PR DESCRIPTION
Improve tooltip manager to hide unit tooltips when the window
becomes inactive - e.g. because a dialog was opened.

To do this properly, we need to listen for both window events
and ancestor events - as the parent window may change - and in
particular because this is the case when the component is first
created - when it doesn't have a window yet.

Here's a screenshot of the problem before this PR.

<img width="996" alt="screen shot 2018-06-30 at 11 07 51 am" src="https://user-images.githubusercontent.com/17648/42126440-df0ddde6-7c56-11e8-9971-8370fe9c3625.png">

