### PR TITLE
Show unit tooltips in even more places.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -809,6 +809,8 @@ public class BattleDisplay extends JPanel {
 
   private static final class TableData {
     static final TableData NULL = new TableData();
+    private PlayerID player;
+    private UnitType unitType;
     private int count;
     private Optional<ImageIcon> icon;
 
@@ -816,7 +818,9 @@ public class BattleDisplay extends JPanel {
 
     TableData(final PlayerID player, final int count, final UnitType type, final boolean damaged,
         final boolean disabled, final UiContext uiContext) {
+      this.player = player;
       this.count = count;
+      this.unitType = type;
       icon = uiContext.getUnitImageFactory().getIcon(type, player, damaged, disabled);
     }
 
@@ -824,9 +828,11 @@ public class BattleDisplay extends JPanel {
       if (count == 0) {
         stamp.setText("");
         stamp.setIcon(null);
+        stamp.setToolTipText(null);
       } else {
         stamp.setText("x" + count);
         icon.ifPresent(stamp::setIcon);
+        MapUnitTooltipManager.setUnitTooltip(stamp, unitType, player, count);
       }
     }
   }
@@ -891,6 +897,9 @@ public class BattleDisplay extends JPanel {
                 damaged && category.hasDamageOrBombingUnitDamage(), disabled && category.getDisabled());
         final JLabel unit = unitImage.map(JLabel::new).orElseGet(JLabel::new);
         panel.add(unit);
+        // Add a tooltip, with a count of 1 so that the tooltip doesn't have a number label (so it won't get out of date
+        // when units are killed.)
+        MapUnitTooltipManager.setUnitTooltip(unit, category.getType(), category.getOwner(), 1);
         for (final UnitOwner owner : category.getDependents()) {
           unit.add(uiContext.createUnitImageJLabel(owner.getType(), owner.getOwner()));
         }

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -142,7 +142,9 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitDamage damaged, final UnitEnable disabled) {
     final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, damaged == UnitDamage.DAMAGED,
         disabled == UnitEnable.DISABLED);
-    return image.map(JLabel::new).orElseGet(JLabel::new);
+    JLabel label = image.map(JLabel::new).orElseGet(JLabel::new);
+    MapUnitTooltipManager.setUnitTooltip(label, type, player, 1);
+    return label;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -89,14 +89,14 @@ public class MapUnitTooltipManager implements ActionListener {
   /**
    * Sets the tooltip text on the specified label based on the passed parameters.
    *
-   * @param label The label whose tooltip text property will be set.
+   * @param component The component whose tooltip text property will be set.
    * @param unitType The type of unit.
    * @param player The owner of the unit.
    * @param count The number of units.
    */
-  public static void setUnitTooltip(JLabel label, UnitType unitType, final PlayerID player, int count) {
+  public static void setUnitTooltip(JComponent component, UnitType unitType, final PlayerID player, int count) {
     final String text = getTooltipTextForUnit(unitType, player, count);
-    label.setToolTipText("<html>" + text + "</html>");
+    component.setToolTipText("<html>" + text + "</html>");
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -466,6 +466,8 @@ final class UnitChooser extends JPanel {
       UnitChooserEntryIcon(final boolean forceDamaged, final UiContext uiContext) {
         this.forceDamaged = forceDamaged;
         this.uiContext = uiContext;
+        MapUnitTooltipManager.setUnitTooltip(this, category.getType(), category.getOwner(),
+                category.getUnits().size());
       }
 
       @Override


### PR DESCRIPTION
Unit tooltips will now be shown in combat UI, including casualties
selector and select units to move UI (when double clicking).