### PR TITLE
Improve unit tooltips.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
@@ -24,6 +24,19 @@ public class DefaultNamed extends GameDataComponent implements Named {
     return m_name;
   }
 
+  private static String capitalizeFirst(final String s) {
+    return s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+  }
+
+  /**
+   * Returns a capitalized name.
+   *
+   * @return A capitalized name.
+   */
+  public String getNameCapitalized() {
+    return capitalizeFirst(m_name);
+  }
+
   @Override
   public boolean equals(final Object other) {
     if (other instanceof Named) {

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -23,10 +23,6 @@ import games.strategy.triplea.util.TuvUtils;
 class UnitInformation {
   private GameData data;
 
-  private static String capitalizeFirst(final String s) {
-    return (s.length() > 0) ? Character.toUpperCase(s.charAt(0)) + s.substring(1) : s;
-  }
-
   void saveToFile(final PrintGenerationData printData, final Map<UnitType, UnitAttachment> unitInfoMap) {
     data = printData.getData();
     printData.getOutDir().mkdir();
@@ -50,7 +46,7 @@ class UnitInformation {
         if (currentType.getName().equals(Constants.UNIT_TYPE_AAGUN)) {
           unitInformation.write(currentType.getName() + ",");
         } else {
-          unitInformation.write(capitalizeFirst(currentType.getName()) + ",");
+          unitInformation.write(currentType.getNameCapitalized() + ",");
         }
         unitInformation.write(getCostInformation(currentType) + ",");
         unitInformation.write(currentAttachment.getMovement(PlayerID.NULL_PLAYERID) + ","

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -17,7 +17,6 @@ import javax.swing.Timer;
 import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
 
-import com.sun.xml.internal.ws.util.StringUtils;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -113,7 +112,7 @@ public class MapUnitTooltipManager implements ActionListener {
   public static String getTooltipTextForUnit(final UnitType unitType, final PlayerID player, final int count) {
     final UnitAttachment ua = UnitAttachment.get(unitType);
     final String firstLine = String.format("<b>%s%s (%s)</b><br />", count == 1 ? "" : (count + " "),
-            StringUtils.capitalize(unitType.getName()), player.getName());
+            unitType.getNameCapitalized(), player.getName());
     return firstLine + ua.toStringShortAndOnlyImportantDifferences(player, true, false);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -17,6 +17,7 @@ import javax.swing.Timer;
 import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
 
+import com.sun.xml.internal.ws.util.StringUtils;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -33,7 +34,8 @@ public class MapUnitTooltipManager implements ActionListener {
 
   public MapUnitTooltipManager(final JComponent parent) {
     this.parent = parent;
-    this.timer = new Timer(1000, this);
+    // Timeout to show tooltip is 2 seconds.
+    this.timer = new Timer(2000, this);
     this.timer.setRepeats(false);
     // Note: Timer not started yet.
 
@@ -106,13 +108,13 @@ public class MapUnitTooltipManager implements ActionListener {
    * @param player The owner of the unit.
    * @param count The number of units.
    *
-   * @return The tooltip text or an empty string
+   * @return The tooltip text.
    */
-  public static String getTooltipTextForUnit(UnitType unitType, final PlayerID player, int count) {
+  public static String getTooltipTextForUnit(final UnitType unitType, final PlayerID player, final int count) {
     final UnitAttachment ua = UnitAttachment.get(unitType);
-    final String unitText = count == 1 ? "Unit:" : (count + " Units");
-    return "<b>" + unitText + "</b><br>" + unitType.getName() + ": "
-            + ua.toStringShortAndOnlyImportantDifferences(player, true, false);
+    final String firstLine = String.format("<b>%s%s (%s)</b><br />", count == 1 ? "" : (count + " "),
+            StringUtils.capitalize(unitType.getName()), player.getName());
+    return firstLine + ua.toStringShortAndOnlyImportantDifferences(player, true, false);
   }
 
   /**
@@ -144,7 +146,7 @@ public class MapUnitTooltipManager implements ActionListener {
       final PopupFactory popupFactory = PopupFactory.getSharedInstance();
       final JToolTip info = new JToolTip();
       info.setTipText("<html>" + text + "</html>");
-      popup = popupFactory.getPopup(parent, info, currentPoint.x + 5, currentPoint.y + 5);
+      popup = popupFactory.getPopup(parent, info, currentPoint.x + 20, currentPoint.y - 20);
       popup.show();
     }
   }


### PR DESCRIPTION
- Adjusts delay to 2s per feedback.
- Changes first line to have the unit name and the country.
- Changes tooltip location to be better placed.

Before:
![screen shot 2018-07-03 at 9 25 29 pm](https://user-images.githubusercontent.com/17648/42251876-ffbbde7c-7f07-11e8-9331-a162da4a24cd.png)

After:
![screen shot 2018-07-03 at 9 21 19 pm](https://user-images.githubusercontent.com/17648/42251881-0218c522-7f08-11e8-8edd-0d68c33d015e.png)
