### PR TITLE
Use invokeAndWait instead of invokeLater to force repaint of units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -458,7 +458,11 @@ public class MapPanel extends ImageScrollerLargeView {
       if (!playersWithTechChange.isEmpty()
           || UnitIconProperties.getInstance(gameData).testIfConditionsHaveChanged(gameData)) {
         tileManager.resetTiles(gameData, uiContext.getMapData());
-        SwingUtilities.invokeLater(() -> repaint());
+        try {
+          SwingUtilities.invokeAndWait(() -> repaint());
+        } catch (final Exception e) {
+          // ignore failed repaint
+        }
       }
     }
 


### PR DESCRIPTION
Having issues with units not repainting after unit icon is triggered: https://forums.triplea-game.org/topic/882/unit-icons-added-by-conditions/29