### PR TITLE
Fix tooltips on casualties screen.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -489,33 +489,15 @@ final class UnitChooser extends JPanel {
       }
 
       @Override
-      public int getWidth() {
-        // we draw a unit symbol for each dependent
-        return uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + category.getDependents().size());
-      }
-
-      @Override
-      public int getHeight() {
-        return uiContext.getUnitImageFactory().getUnitImageHeight();
-      }
-
-      @Override
-      public Dimension getMaximumSize() {
-        return getDimension();
-      }
-
-      @Override
       public Dimension getMinimumSize() {
-        return getDimension();
+        return getPreferredSize();
       }
 
       @Override
       public Dimension getPreferredSize() {
-        return getDimension();
-      }
-
-      Dimension getDimension() {
-        return new Dimension(getWidth(), getHeight());
+        final int width = uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + category.getDependents().size());
+        final int height = uiContext.getUnitImageFactory().getUnitImageHeight();
+        return new Dimension(width, height);
       }
     }
   }


### PR DESCRIPTION
Previously, UnitChooserEntryIcon would override getWidth() and
getHeight() to always return a fixed size - but being placed in
a GridBag layout it would actually have a different size while
returning a fixed size. This caused problems with Swing's
TooltipManager which would still receive mouseEntered() events
based on the true size but would not show a tooltip if the
cursor position was outside of the returned getWidth().

This change makes the code only return a minimum and preferred
size, which fixes the issue. It also fixes a clipping issue for
units that are wider than 48px - such as Battleships on some
maps.

Clipping issue before:
<img width="439" alt="screen shot 2018-07-06 at 8 32 12 pm" src="https://user-images.githubusercontent.com/17648/42406790-c60d333e-817c-11e8-982a-6e450d9d5a29.png">

Here's what it looks after:
<img width="439" alt="screen shot 2018-07-07 at 12 29 28 am" src="https://user-images.githubusercontent.com/17648/42406791-d3a129ce-817c-11e8-9e69-90accc085279.png">
