### PR TITLE
Set Rendering Hints correctly.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -202,11 +202,6 @@ public class HeadedUiContext extends AbstractUiContext {
   }
 
   @Override
-  public void resetDrawTerritoryBordersAgain() {
-    extraTerritoryBorderLevel = OptionalExtraBorderLevel.LOW;
-  }
-
-  @Override
   public void setDrawTerritoryBordersAgainToMedium() {
     extraTerritoryBorderLevel = OptionalExtraBorderLevel.MEDIUM;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
@@ -117,9 +117,6 @@ public class HeadlessUiContext extends AbstractUiContext {
   public void setDrawTerritoryBordersAgain(final OptionalExtraBorderLevel level) {}
 
   @Override
-  public void resetDrawTerritoryBordersAgain() {}
-
-  @Override
   public void setDrawTerritoryBordersAgainToMedium() {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -499,8 +499,13 @@ public class MapPanel extends ImageScrollerLargeView {
    * @param g The graphics context on which to draw the map; must not be {@code null}.
    */
   public void drawMapImage(final Graphics g) {
+    final Graphics2D graphics = (Graphics2D) checkNotNull(g);
+    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+    graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
+        RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+    graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
     final Rectangle2D.Double bounds = new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight());
-    drawTiles((Graphics2D) checkNotNull(g), gameData, bounds);
+    drawTiles(graphics, gameData, bounds);
     try {
       // This makes use of the FIFO queue the executor uses
       executor.submit(() -> drawTiles((Graphics2D) checkNotNull(g), gameData, bounds)).get();
@@ -514,6 +519,10 @@ public class MapPanel extends ImageScrollerLargeView {
   @Override
   public void paint(final Graphics g) {
     final Graphics2D g2d = (Graphics2D) g;
+    g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+    g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
+        RenderingHints.VALUE_ALPHA_INTERPOLATION_DEFAULT);
+    g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
     super.paint(g2d);
     g2d.clip(new Rectangle2D.Double(0, 0, getImageWidth() * scale, getImageHeight() * scale));
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(MapPanel.class.getName()), Level.FINER, "Paint");

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -624,20 +624,7 @@ public class MapPanel extends ImageScrollerLargeView {
   public void setScale(final double newScale) {
     super.setScale(newScale);
     // setScale will check bounds, and normalize the scale correctly
-    final double normalizedScale = scale;
-    final OptionalExtraBorderLevel drawBorderOption = uiContext.getDrawTerritoryBordersAgain();
-    // so what is happening here is that when we zoom out, the territory borders get blurred or even removed
-    // so we have a special setter to have them be drawn a second time, on top of the relief tiles
-    if (normalizedScale >= 1) {
-      if (drawBorderOption != OptionalExtraBorderLevel.LOW) {
-        uiContext.resetDrawTerritoryBordersAgain();
-      }
-    } else {
-      if (drawBorderOption == OptionalExtraBorderLevel.LOW) {
-        uiContext.setDrawTerritoryBordersAgainToMedium();
-      }
-    }
-    uiContext.setScale(normalizedScale);
+    uiContext.setScale(scale);
     repaint();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -96,8 +96,6 @@ public interface UiContext {
 
   void setDrawTerritoryBordersAgain(OptionalExtraBorderLevel level);
 
-  void resetDrawTerritoryBordersAgain();
-
   void setDrawTerritoryBordersAgainToMedium();
 
   void setShowTerritoryEffects(boolean showTerritoryEffects);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -33,11 +33,6 @@ public abstract class MapTileDrawable implements IDrawable {
     if (img == null) {
       return;
     }
-    final RenderingHints hints = graphics.getRenderingHints();
-    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
-    graphics.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
-    graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
     graphics.drawImage(img, x * TileManager.TILE_SIZE - bounds.x, y * TileManager.TILE_SIZE - bounds.y, null);
-    graphics.setRenderingHints(hints);
   }
 }


### PR DESCRIPTION
Fixes #3518
This makes the engine use a better scaling algorithm than "NEAREST_NEIGHBOUR", which makes the scaled version look good again.
Before at 80% (posted by @ron-murhammer ):
![Before 80%](https://user-images.githubusercontent.com/1427689/42413265-79542ad2-81e2-11e8-9c2f-e200c26a518a.png)
After at 80%:
![After 80%](https://user-images.githubusercontent.com/8350879/42414266-e3305a62-8231-11e8-86ef-a5f600833bb0.png)

Side Note: I noticed that downscaling the images in real-time does really affect performance when doing it using the Bicubic algorithm.
That's why I resorted to Bilinear as a tradeoff between quality and performance.
The screenshots setting however maxes all the settings out because for those images half a second more total processing time doesn't matter.
