### PR TITLE
Avoid synchronization need when drawing

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -434,20 +434,20 @@ public class MapPanel extends ImageScrollerLargeView {
     @Override
     public void unitsChanged(final Territory territory) {
       updateCountries(Collections.singleton(territory));
-      SwingUtilities.invokeLater(() -> repaint());
+      SwingUtilities.invokeLater(MapPanel.this::repaint);
     }
 
     @Override
     public void ownerChanged(final Territory territory) {
       smallMapImageManager.updateTerritoryOwner(territory, gameData, uiContext.getMapData());
       updateCountries(Collections.singleton(territory));
-      SwingUtilities.invokeLater(() -> repaint());
+      SwingUtilities.invokeLater(MapPanel.this::repaint);
     }
 
     @Override
     public void attachmentChanged(final Territory territory) {
       updateCountries(Collections.singleton(territory));
-      SwingUtilities.invokeLater(() -> repaint());
+      SwingUtilities.invokeLater(MapPanel.this::repaint);
     }
   };
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -272,7 +272,7 @@ public class MapPanel extends ImageScrollerLargeView {
       return;
     }
     final Point p = uiContext.getMapData().getCenter(territory);
-    // when centering dont want the map to wrap around,
+    // when centering don't want the map to wrap around,
     // eg if centering on hawaii
     super.setTopLeft((int) (p.x - (getScaledWidth() / 2)), (int) (p.y - (getScaledHeight() / 2)));
   }
@@ -583,6 +583,7 @@ public class MapPanel extends ImageScrollerLargeView {
           });
         }
       }
+      final Image image = tile.getImage();
       final List<AffineTransform> transforms = MapScrollUtil.getPossibleTranslations(
           model.getScrollX(), model.getScrollY(), model.getMaxWidth(), model.getMaxHeight());
       for (final AffineTransform transform : transforms) {
@@ -591,7 +592,7 @@ public class MapPanel extends ImageScrollerLargeView {
         viewTransformation.translate(-bounds.getX(), -bounds.getY());
         viewTransformation.translate(tile.getBounds().x, tile.getBounds().y);
         viewTransformation.concatenate(transform);
-        graphics.drawImage(tile.getImage(), viewTransformation, this);
+        graphics.drawImage(image, viewTransformation, this);
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -22,7 +22,13 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
 import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
-
+/**
+ * A class representing a Tile of the Map and storing the image to be rendered
+ * on the screen.
+ * This class doesn't guarantee to be Thread-Safe although
+ * it's safe to use this class between multiple Threads
+ * which might cause outdated Images which is totally fine.
+ */
 public class Tile {
   private volatile boolean isDirty = true;
   private final AtomicBoolean drawingStarted = new AtomicBoolean(false);
@@ -48,6 +54,16 @@ public class Tile {
     return image;
   }
 
+  /**
+   * This method draws an image based on the provided GameData and MapData.
+   * It first creates an empty image with the same size and properties
+   * as the image field, applies all of the drawing operations to it
+   * copies the resulting pixels to the stored image and disposes
+   * the resources afterwards.
+   *
+   * This is to ensure we don't draw the Tile mid-generating
+   * without having to synchronize it.
+   */
   public void drawImage(final GameData data, final MapData mapData) {
     try {
       if (drawingStarted.getAndSet(true)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -8,6 +8,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -23,13 +24,12 @@ import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
 
 public class Tile {
-  final Object mutex = new Object();
   private volatile boolean isDirty = true;
   private final AtomicBoolean drawingStarted = new AtomicBoolean(false);
 
   private final Image image;
   private final Rectangle bounds;
-  private final SortedMap<Integer, List<IDrawable>> contents = new TreeMap<>();
+  private final SortedMap<Integer, List<IDrawable>> contents = Collections.synchronizedSortedMap(new TreeMap<>());
 
   Tile(final Rectangle bounds) {
     this.bounds = bounds;
@@ -61,9 +61,7 @@ public class Tile {
       g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
       draw(g, data, mapData);
       final Graphics2D imageGraphics = (Graphics2D) image.getGraphics();
-      synchronized (mutex) {
-        imageGraphics.drawImage(writeBuffer, new AffineTransform(), null);
-      }
+      imageGraphics.drawImage(writeBuffer, new AffineTransform(), null);
       imageGraphics.dispose();
       g.dispose();
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -4,11 +4,14 @@ import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -20,12 +23,12 @@ import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
 
 public class Tile {
+  final Object mutex = new Object();
   private volatile boolean isDirty = true;
-  private volatile boolean drawingStarted = false;
+  private final AtomicBoolean drawingStarted = new AtomicBoolean(false);
 
   private final Image image;
   private final Rectangle bounds;
-  private final Object mutex = new Object();
   private final SortedMap<Integer, List<IDrawable>> contents = new TreeMap<>();
 
   Tile(final Rectangle bounds) {
@@ -38,7 +41,7 @@ public class Tile {
   }
 
   public boolean hasDrawingStarted() {
-    return drawingStarted;
+    return drawingStarted.get();
   }
 
   public Image getImage() {
@@ -46,20 +49,25 @@ public class Tile {
   }
 
   public void drawImage(final GameData data, final MapData mapData) {
-    if (isDirty) {
-      synchronized (mutex) {
-        try {
-          drawingStarted = true;
-          final Graphics2D g = (Graphics2D) image.getGraphics();
-          g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-          g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-          g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-          draw(g, data, mapData);
-          g.dispose();
-        } finally {
-          drawingStarted = false;
-        }
+    try {
+      if (drawingStarted.getAndSet(true)) {
+        return;
       }
+      final BufferedImage writeBuffer = Util.createImage(image.getWidth(null),
+          image.getHeight(null), true);
+      final Graphics2D g = (Graphics2D) writeBuffer.getGraphics();
+      g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+      g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+      g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+      draw(g, data, mapData);
+      final Graphics2D imageGraphics = (Graphics2D) image.getGraphics();
+      synchronized (mutex) {
+        imageGraphics.drawImage(writeBuffer, new AffineTransform(), null);
+      }
+      imageGraphics.dispose();
+      g.dispose();
+    } finally {
+      drawingStarted.set(false);
     }
   }
 
@@ -80,32 +88,24 @@ public class Tile {
   }
 
   void addDrawable(final IDrawable d) {
-    synchronized (mutex){
-      contents.computeIfAbsent(d.getLevel(), l -> new ArrayList<>()).add(d);
-      isDirty = true;
-    }
+    contents.computeIfAbsent(d.getLevel(), l -> new ArrayList<>()).add(d);
+    isDirty = true;
   }
 
   void removeDrawables(final Collection<IDrawable> c) {
-    synchronized (mutex){
-      contents.values().forEach(l -> l.removeAll(c));
-      isDirty = true;
-    }
+    contents.values().forEach(l -> l.removeAll(c));
+    isDirty = true;
   }
 
   void clear() {
-    synchronized (mutex){
-      contents.clear();
-      isDirty = true;
-    }
+    contents.clear();
+    isDirty = true;
   }
 
   List<IDrawable> getDrawables() {
-    synchronized (mutex){
-      return contents.values().stream()
-          .flatMap(Collection::stream)
-          .collect(Collectors.toList());
-    }
+    return contents.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   public Rectangle getBounds() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -22,6 +22,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
 import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
+
 /**
  * A class representing a Tile of the Map and storing the image to be rendered
  * on the screen.

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -68,7 +68,7 @@ public class TileManager {
   private static final Logger logger = Logger.getLogger(TileManager.class.getName());
   public static final int TILE_SIZE = 256;
 
-  private List<Tile> tiles = new ArrayList<>();
+  private final List<Tile> tiles = new ArrayList<>();
   private final Lock lock = new ReentrantLock();
   private final Map<String, IDrawable> territoryOverlays = new HashMap<>();
   private final Map<String, Set<IDrawable>> territoryDrawables = new HashMap<>();
@@ -130,8 +130,7 @@ public class TileManager {
   public void createTiles(final Rectangle bounds) {
     acquireLock();
     try {
-      // create our tiles
-      tiles = new ArrayList<>();
+      tiles.clear();
       for (int x = 0; x * TILE_SIZE < bounds.width; x++) {
         for (int y = 0; y * TILE_SIZE < bounds.height; y++) {
           tiles.add(new Tile(new Rectangle(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE)));
@@ -147,12 +146,14 @@ public class TileManager {
     try {
       acquireLock();
       try {
-        for (Tile tile : tiles) {
-          tile.clear();
-          final int x = tile.getBounds().x / TILE_SIZE;
-          final int y = tile.getBounds().y / TILE_SIZE;
-          tile.addDrawable(new BaseMapDrawable(x, y, uiContext));
-          tile.addDrawable(new ReliefMapDrawable(x, y, uiContext));
+        for (final Tile tile : tiles) {
+          synchronized (tile.mutex) {
+            tile.clear();
+            final int x = tile.getBounds().x / TILE_SIZE;
+            final int y = tile.getBounds().y / TILE_SIZE;
+            tile.addDrawable(new BaseMapDrawable(x, y, uiContext));
+            tile.addDrawable(new ReliefMapDrawable(x, y, uiContext));
+          }
         }
         for (Territory territory : data.getMap().getTerritories()) {
           clearTerritory(territory);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -147,13 +147,11 @@ public class TileManager {
       acquireLock();
       try {
         for (final Tile tile : tiles) {
-          synchronized (tile.mutex) {
-            tile.clear();
-            final int x = tile.getBounds().x / TILE_SIZE;
-            final int y = tile.getBounds().y / TILE_SIZE;
-            tile.addDrawable(new BaseMapDrawable(x, y, uiContext));
-            tile.addDrawable(new ReliefMapDrawable(x, y, uiContext));
-          }
+          tile.clear();
+          final int x = tile.getBounds().x / TILE_SIZE;
+          final int y = tile.getBounds().y / TILE_SIZE;
+          tile.addDrawable(new BaseMapDrawable(x, y, uiContext));
+          tile.addDrawable(new ReliefMapDrawable(x, y, uiContext));
         }
         for (Territory territory : data.getMap().getTerritories()) {
           clearTerritory(territory);


### PR DESCRIPTION
This PR does:
1. Make the Tile code no longer rely on a "self-coded" lock algorithm that's explicitly not working well with Multi-Threading
2. Use a Buffer-Image to allow to draw without synchronization with the benefit of not drawing unfinished images (might fix flickering issue, if not I need to synchronize adding IDrawables in bulk, because currently the lock is only being acquired for individual add and remove operations)
