### PR TITLE
Extend properties to allow for ordering for unit icons

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
@@ -1,0 +1,57 @@
+package games.strategy.triplea.ui;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Properties;
+import java.util.Set;
+
+
+/**
+ * An extension of Properties which maintains properties file order.
+ */
+public class OrderedProperties extends Properties {
+
+  private static final long serialVersionUID = 7458143419297149318L;
+
+  private final Set<Object> keys = new LinkedHashSet<>();
+
+  @Override
+  public Enumeration<?> propertyNames() {
+    return Collections.enumeration(keys);
+  }
+
+  @Override
+  public synchronized Enumeration<Object> elements() {
+    return Collections.enumeration(keys);
+  }
+
+  @Override
+  public Enumeration<Object> keys() {
+    return Collections.enumeration(keys);
+  }
+
+  @Override
+  public Set<Object> keySet() {
+    return keys;
+  }
+
+  @Override
+  public synchronized Object put(final Object key, final Object value) {
+    keys.add(key);
+    return super.put(key, value);
+  }
+
+  @Override
+  public synchronized Object remove(final Object key) {
+    keys.remove(key);
+    return super.remove(key);
+  }
+
+  @Override
+  public synchronized void clear() {
+    keys.clear();
+    super.clear();
+  }
+
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
@@ -26,7 +26,7 @@ public abstract class PropertyFile {
       .expireAfterWrite(10, TimeUnit.SECONDS)
       .build();
 
-  protected final Properties properties = new Properties();
+  protected final Properties properties = new OrderedProperties();
 
   PropertyFile(final String fileName, final ResourceLoader loader) {
     final URL url = loader.getResource(fileName);

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
@@ -54,25 +52,26 @@ public class UnitIconProperties extends PropertyFile {
   }
 
   /**
-   * Get all unit icon images for given player and unit type that are currently true.
+   * Get all unit icon images for given player and unit type that are currently true, ensuring order
+   * from the properties file.
    */
   public List<String> getImagePaths(final String player, final String unitType, final GameData data) {
     final List<String> imagePaths = new ArrayList<>();
     final String gameName =
         FileNameUtils.replaceIllegalCharacters(data.getGameName(), '_').replaceAll(" ", "_");
     final String startOfKey = gameName + "." + player + "." + unitType;
-    for (final Entry<Object, Object> entry : properties.entrySet()) {
+    for (final Object key : properties.keySet()) {
       try {
-        final String key = entry.getKey().toString();
-        final String[] keyParts = key.split(";");
+        final String keyString = key.toString();
+        final String[] keyParts = keyString.split(";");
         if (startOfKey.equals(keyParts[0])) {
           if (keyParts.length == 2) {
             final ICondition condition = AbstractPlayerRulesAttachment.getCondition(player, keyParts[1], data);
             if (conditionsStatus.get(condition)) {
-              imagePaths.add(entry.getValue().toString());
+              imagePaths.add(properties.get(key).toString());
             }
           } else {
-            imagePaths.add(entry.getValue().toString());
+            imagePaths.add(properties.get(key).toString());
           }
         }
       } catch (final Exception e) {
@@ -81,10 +80,6 @@ public class UnitIconProperties extends PropertyFile {
       }
     }
     return imagePaths;
-  }
-
-  public Set<Entry<Object, Object>> entrySet() {
-    return properties.entrySet();
   }
 
   public boolean testIfConditionsHaveChanged(final GameData data) {


### PR DESCRIPTION
All property file entries to be retrieved in the order they are listed in the file. Without this, a parameter would need added to each line to ensure the order is correct when adding unit icons to units as they can overlap so need added in the proper order: https://forums.triplea-game.org/topic/493/total-world-war-december-1941-beta-2-8-0-4/271
