### PR TITLE
Add usage information for lobby database Docker image

### DIFF
--- a/lobby-db/README.md
+++ b/lobby-db/README.md
@@ -133,3 +133,14 @@ Start a new lobby database container using the following command:
 ```
 $ docker run -d --name=triplea-lobby-db -p 5432:5432 triplea/lobby-db
 ```
+
+### Usage
+
+A lobby server running on the same host as the lobby database container may connect to the database using the following properties:
+
+Property | Value | Notes
+:-- | :-- | :--
+User | `postgres` |
+Password | _&lt;any&gt;_ | The lobby database is configured with authentication disabled, thus any password may be used.
+Host | `localhost` |
+Port | `5432` |


### PR DESCRIPTION
Per [this comment](https://github.com/triplea-game/triplea/pull/3504#discussion_r200829145).

Note that the password used to connect to the database is ignored because the database is configured with authentication disabled (i.e. the `POSTGRES_PASSWORD` environment variable is not set).  The following message is displayed when starting the container (from the Postgres Docker entrypoint script):

```
****************************************************
WARNING: No password has been set for the database.
         This will allow anyone with access to the
         Postgres port to access your database. In
         Docker's default configuration, this is
         effectively any other container on the same
         system.

         Use "-e POSTGRES_PASSWORD=password" to set
         it in "docker run".
****************************************************
```

Thus _any_ password can be used to connect to the database.  Hence, why the Dockerfile for this image states that it should only be used for dev/test and never for production.

The default _lobby.properties_ file in the `lobby` subproject is currently configured such that running a lobby server from a development environment will connect to a lobby database container run from this Docker image without any manual intervention on the part of the dev. That is, it Just Works.