### PR TITLE
Fix broken House of Habsburg map description

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1896,7 +1896,7 @@
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/house_of_habsburg/archive/master.zip
   version: 4
-  img: https://raw.githubusercontent.com/triplea-maps/house_of_habsburg/master/description/MapThumbnail.png
+  img: https://raw.githubusercontent.com/triplea-maps/house_of_habsburg/master/description/MapThumbnail.jpg
   description: |
     <br>
     House of Habsburg Beta Version


### PR DESCRIPTION
The `validateYamls` task has been broken since the thumbnail image for House of Habsburg was renamed in triplea-maps/house_of_habsburg@ce65d50. This PR updates the map description to reflect the new URL.

@CrazyGerman: FYI in case you make similar changes in the future.

Also, I noticed that the thumbnail image for this map is not actually a thumbnail, but a full-size image (6138 x 4944 pix).  You might want to scale it down so the game client doesn't have to download a 12+ MiB image from the Download Maps window.