### PR TITLE
Replace alpha with saturation to fix conquer territory bug coloring

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -79,7 +79,7 @@ public class MapData implements Closeable {
   public static final String PROPERTY_MAP_MAPBLENDS = "map.mapBlends";
   public static final String PROPERTY_MAP_MAPBLENDMODE = "map.mapBlendMode";
   public static final String PROPERTY_MAP_MAPBLENDALPHA = "map.mapBlendAlpha";
-  public static final String PROPERTY_MAP_SMALLMAPTERRITORYTALPHA = "smallMap.territory.alpha";
+  public static final String PROPERTY_MAP_SMALLMAPTERRITORYSATURATION = "smallMap.territory.saturation";
   public static final String PROPERTY_MAP_SMALLMAPUNITSIZE = "smallMap.unit.size";
   public static final String PROPERTY_MAP_SMALLMAPVIEWERBORDERCOLOR = "smallMap.viewer.borderColor";
   public static final String PROPERTY_MAP_SMALLMAPVIEWERFILLCOLOR = "smallMap.viewer.fillColor";
@@ -415,8 +415,8 @@ public class MapData implements Closeable {
     return Boolean.parseBoolean(mapProperties.getProperty(PROPERTY_MAP_USETERRITORYEFFECTMARKERS, "false"));
   }
 
-  public float getSmallMapTerritoryAlpha() {
-    return Float.parseFloat(mapProperties.getProperty(PROPERTY_MAP_SMALLMAPTERRITORYTALPHA, "1.0f"));
+  public float getSmallMapTerritorySaturation() {
+    return Float.parseFloat(mapProperties.getProperty(PROPERTY_MAP_SMALLMAPTERRITORYSATURATION, "1.0f"));
   }
 
   public int getSmallMapUnitSize() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -74,9 +74,8 @@ public class SmallMapImageManager {
       g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
       g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
       g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-      g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, mapData.getSmallMapTerritoryAlpha()));
       final LandTerritoryDrawable drawable = new LandTerritoryDrawable(t.getName());
-      drawable.draw(bounds, data, g, mapData);
+      drawable.draw(bounds, data, g, mapData, mapData.getSmallMapTerritorySaturation());
       g.dispose();
     }
     // scale it down

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -21,6 +21,9 @@ public class LandTerritoryDrawable extends TerritoryDrawable implements IDrawabl
     draw(bounds, data, graphics, mapData, 1.0f);
   }
 
+  /**
+   * Determine territory color and set saturation to then draw the territory.
+   */
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final float saturation) {
     final Territory territory = data.getMap().getTerritory(territoryName);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -18,14 +18,23 @@ public class LandTerritoryDrawable extends TerritoryDrawable implements IDrawabl
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
+    draw(bounds, data, graphics, mapData, 1.0f);
+  }
+
+  public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
+      final float saturation) {
     final Territory territory = data.getMap().getTerritory(territoryName);
-    final Color territoryColor;
+    Color territoryColor;
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     if (ta != null && ta.getIsImpassable()) {
       territoryColor = mapData.impassableColor();
     } else {
       territoryColor = mapData.getPlayerColor(territory.getOwner().getName());
     }
+    final float[] values =
+        Color.RGBtoHSB(territoryColor.getRed(), territoryColor.getGreen(), territoryColor.getBlue(), null);
+    values[1] = values[1] * saturation;
+    territoryColor = Color.getHSBColor(values[0], values[1], values[2]);
     draw(bounds, graphics, mapData, territory, territoryColor);
   }
 


### PR DESCRIPTION
Issues reported here: https://forums.triplea-game.org/topic/888/large-middle-earth-official-thread/233

Follow up of #3453 to fix a bug where the color of conquered territories on the minimap is incorrect due to the alpha when drawing over top of the old one.