### PR TITLE
Blind NPE fix

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -37,7 +37,7 @@ public class Chat {
   // mutex used for access synchronization to nodes
   // TODO: check if this mutex is used for something else as well
   private final Object mutexNodes = new Object();
-  private final List<INode> nodes;
+  private List<INode> nodes;
   // this queue is filled ONLY in init phase when chatInitVersion is default (-1) and nodes should not be changed
   // until end of initialization synchronizes access to queue
   private final Object mutexQueue = new Object();
@@ -290,6 +290,9 @@ public class Chat {
       }
       if (version > chatInitVersion) {
         synchronized (mutexNodes) {
+          if (nodes == null) {
+            nodes = new ArrayList<>();
+          }
           nodes.add(node);
           addToNotesMap(node, tag);
           updateConnections();


### PR DESCRIPTION
We are getting a stack trace for 'nodes' being null: https://github.com/triplea-game/triplea/issues/3554

This is hard to explain given constructor initialization, maybe serialization is at play. The update here is a pretty blind NPE fix, if the nodes variable is null then we will initialize it.

## Review Note:
- this is certainly not the most satisfying fix, but it will hardly hurt and could do the trick to fix the NPE crash

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
