### PR TITLE
Add ability for notifications to only go to accepters.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -198,8 +198,18 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   private void notifySuccess(final UserActionAttachment uaa) {
     // play a sound
     getSoundChannel().playSoundForAll(SoundPath.CLIP_USER_ACTION_SUCCESSFUL, player);
-    sendNotification(UserActionText.getInstance().getNotificationSucccess(uaa.getText()));
-    notifyOtherPlayers(UserActionText.getInstance().getNotificationSuccessOthers(uaa.getText()));
+    final UserActionText uat = UserActionText.getInstance();
+    sendNotification(uat.getNotificationSucccess(uaa.getText()));
+    notifyOtherPlayers(uat.getNotificationSuccessOthers(uaa.getText()), getOtherNotificationPlayers(uaa));
+  }
+
+  private Collection<PlayerID> getOtherNotificationPlayers(final UserActionAttachment uaa) {
+    if (UserActionText.getInstance().shouldNotifyAcceptersOnly()) {
+      return uaa.getActionAccept();
+    }
+    final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
+    otherPlayers.remove(player);
+    return otherPlayers;
   }
 
   /**
@@ -219,13 +229,10 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    * Send a notification to the other players involved in this action (all
    * players except the player starting the action).
    */
-  private void notifyOtherPlayers(final String notification) {
+  private void notifyOtherPlayers(final String notification, final Collection<PlayerID> otherPlayers) {
     if (!"NONE".equals(notification)) {
-      // we can send it to just uaa.getOtherPlayers(), or we can send it to all players. both are good options.
       final Collection<PlayerID> currentPlayer = new ArrayList<>();
       currentPlayer.add(player);
-      final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
-      otherPlayers.removeAll(currentPlayer);
       this.getDisplay().reportMessageToPlayers(otherPlayers, currentPlayer, notification, notification);
     }
   }
@@ -242,8 +249,9 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     final String transcriptText =
         bridge.getPlayerId().getName() + " fails on action: " + MyFormatter.attachmentNameToText(uaa.getName());
     bridge.getHistoryWriter().addChildToEvent(transcriptText);
-    sendNotification(UserActionText.getInstance().getNotificationFailure(uaa.getText()));
-    notifyOtherPlayers(UserActionText.getInstance().getNotificationFailureOthers(uaa.getText()));
+    final UserActionText uat = UserActionText.getInstance();
+    sendNotification(uat.getNotificationFailure(uaa.getText()));
+    notifyOtherPlayers(uat.getNotificationFailureOthers(uaa.getText()), getOtherNotificationPlayers(uaa));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -26,6 +26,7 @@ public class UserActionText {
   private static final String NOTIFICATION_FAILURE = "NOTIFICATION_FAILURE";
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
+  private static final String OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY = "OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY";
 
   protected UserActionText() {
     final ResourceLoader loader = AbstractUiContext.getResourceLoader();
@@ -85,5 +86,9 @@ public class UserActionText {
 
   public String getAcceptanceQuestion(final String actionKey) {
     return getMessage(actionKey, ACCEPT_QUESTION);
+  }
+
+  public boolean shouldNotifyAcceptersOnly() {
+    return "true".equalsIgnoreCase(properties.getProperty(OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY));
   }
 }


### PR DESCRIPTION
This allows for fixing https://github.com/triplea-game/triplea/issues/3558
with a corresponding change to the Feudal Japan map setting the new property.