### PR TITLE
Merge 'docs/admin/gradle_upgrade.md' into 'docs/dev/README'

### DIFF
--- a/docs/admin/gradle_upgrade.md
+++ b/docs/admin/gradle_upgrade.md
@@ -1,8 +1,0 @@
-## How to upgrade gradle
-
-- Gradle distributions can be found at: https://services.gradle.org/distributions/ (we use a '-all' version)
-- Update the gradle version in: https://github.com/triplea-game/triplea/blob/master/gradle/wrapper/gradle-wrapper.properties
-- Execute: `./gradlew wrapper`
-- Change the gradle zip back to '-all' from '-bin' in gradle-wrapper.properties
-- Commit everything
-- Do some smoke testing and submit a PR

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -171,6 +171,15 @@ Checkstyle reports can be found within the folder `build/reports/checkstyle`.
 
 You are **strongly encouraged** to run the `check` task before submitting a PR.
 
+## How to upgrade gradle
+
+- Gradle distributions can be found at: https://services.gradle.org/distributions/ (we use a '-all' version)
+- Update the gradle version in: https://github.com/triplea-game/triplea/blob/master/gradle/wrapper/gradle-wrapper.properties
+- Execute: `./gradlew wrapper`
+- Change the gradle zip back to '-all' from '-bin' in gradle-wrapper.properties
+- Commit everything
+- Do some smoke testing and submit a PR
+
 
 # Code Standards
 


### PR DESCRIPTION
## Overview
- Moves contents from one location and puts it into an existing file under a 'gradle' section.
- Dev are the ones who are more wanting to upgrade gradle compared to (sys) admins
- We do not have very much in admin section and will want to consolidate it, so this helps with that.

## Testing
n/a

## Before & After Screen Shots
n/a

## Review notes
 

-->

<!--
*** Dev***
All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md
-->
