### PR TITLE
Concurrency issues

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -15,6 +15,8 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
@@ -38,8 +40,13 @@ public class Tile {
       Comparator.comparingInt(IDrawable::getLevel));
 
   Tile(final Rectangle bounds) {
+    this(bounds, Util.createImage((int) bounds.getWidth(), (int) bounds.getHeight(), true));
+  }
+
+  @VisibleForTesting
+  Tile(final Rectangle bounds, final Image image) {
     this.bounds = bounds;
-    image = Util.createImage((int) bounds.getWidth(), (int) bounds.getHeight(), true);
+    this.image = image;
   }
 
   public boolean isDirty() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -96,7 +96,8 @@ public class Tile {
   }
 
   void addDrawables(final Collection<IDrawable> drawables) {
-    drawables.forEach(this::addDrawable);
+    contents.addAll(drawables);
+    isDirty = true;
   }
 
   void addDrawable(final IDrawable d) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -8,13 +8,12 @@ import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -35,7 +34,8 @@ public class Tile {
 
   private final Image image;
   private final Rectangle bounds;
-  private final SortedMap<Integer, List<IDrawable>> contents = Collections.synchronizedSortedMap(new TreeMap<>());
+  private final Queue<IDrawable> contents = new PriorityBlockingQueue<>(1,
+      Comparator.comparingInt(IDrawable::getLevel));
 
   Tile(final Rectangle bounds) {
     this.bounds = bounds;
@@ -87,10 +87,9 @@ public class Tile {
   private void draw(final Graphics2D g, final GameData data, final MapData mapData) {
     final Stopwatch stopWatch = new Stopwatch(Logger.getLogger(Tile.class.getName()), Level.FINEST,
         "Drawing Tile at" + bounds);
-    for (final List<IDrawable> list : contents.values()) {
-      for (final IDrawable drawable : list) {
-        drawable.draw(bounds, data, g, mapData);
-      }
+    final Queue<IDrawable> clone = new PriorityBlockingQueue<>(contents);
+    while (!clone.isEmpty()) {
+      clone.remove().draw(bounds, data, g, mapData);
     }
     isDirty = false;
     stopWatch.done();
@@ -101,13 +100,12 @@ public class Tile {
   }
 
   void addDrawable(final IDrawable d) {
-    contents.computeIfAbsent(d.getLevel(),
-        l -> Collections.synchronizedList(new ArrayList<>())).add(d);
+    contents.add(d);
     isDirty = true;
   }
 
   void removeDrawables(final Collection<IDrawable> c) {
-    contents.values().forEach(l -> l.removeAll(c));
+    contents.removeAll(c);
     isDirty = true;
   }
 
@@ -117,9 +115,7 @@ public class Tile {
   }
 
   List<IDrawable> getDrawables() {
-    return contents.values().stream()
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
+    return new ArrayList<>(contents);
   }
 
   public Rectangle getBounds() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -136,6 +137,8 @@ public class TileManager {
           tiles.add(new Tile(new Rectangle(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE)));
         }
       }
+    } catch (final RuntimeException e) {
+      ClientLogger.logError("Error creating Tile", e);
     } finally {
       releaseLock();
     }

--- a/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
@@ -14,6 +14,10 @@ import java.awt.Image;
 import java.awt.Rectangle;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,17 +71,26 @@ public class TileTest {
 
   @Test
   public void testDrawOrder() {
-    final IDrawable drawable2 = mock(IDrawable.class);
-    when(drawable.getLevel()).thenReturn(1);
-    when(drawable2.getLevel()).thenReturn(2);
-    tile.addDrawable(drawable2);
-    tile.addDrawable(drawable);
+    final List<IDrawable> drawables = IntStream
+        .range(0, 10)
+        .mapToObj(this::createMockWithLevel)
+        .collect(Collectors.toList());
+    Collections.shuffle(drawables);
+    tile.addDrawables(drawables);
     final GameData data = mock(GameData.class);
     final MapData mapData = mock(MapData.class);
-    final InOrder inOrder = Mockito.inOrder(drawable, drawable2);
+    final InOrder inOrder = Mockito.inOrder(drawables.toArray());
     tile.drawImage(data, mapData);
-    inOrder.verify(drawable).draw(eq(rect), eq(data), any(), eq(mapData));
-    inOrder.verify(drawable2).draw(eq(rect), eq(data), any(), eq(mapData));
+    drawables.sort(Comparator.comparingInt(IDrawable::getLevel));
+    for (final IDrawable drawable : drawables) {
+      inOrder.verify(drawable).draw(eq(rect), eq(data), any(), eq(mapData));
+    }
+  }
+
+  private IDrawable createMockWithLevel(final int level) {
+    final IDrawable drawable = mock(IDrawable.class);
+    when(drawable.getLevel()).thenReturn(level);
+    return drawable;
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
@@ -1,0 +1,105 @@
+package games.strategy.triplea.ui.screen;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.ui.mapdata.MapData;
+import games.strategy.triplea.ui.screen.drawable.IDrawable;
+
+public class TileTest {
+
+  private final Image image = mock(Image.class);
+  private final Graphics2D graphics = mock(Graphics2D.class);
+  private final Rectangle rect = new Rectangle(100, 100);
+  private final Tile tile = new Tile(rect, image);
+  private final IDrawable drawable = mock(IDrawable.class);
+
+  @BeforeEach
+  public void setup() {
+    when(image.getGraphics()).thenReturn(graphics);
+    when(image.getWidth(any())).thenReturn(100);
+    when(image.getHeight(any())).thenReturn(100);
+  }
+
+  @Test
+  public void testIsDirty() {
+    assertSame(image, tile.getImage());
+    assertTrue(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+    tile.drawImage(null, null);
+    assertFalse(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+
+    tile.addDrawable(drawable);
+
+    assertTrue(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+    tile.drawImage(null, null);
+    assertFalse(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+
+    tile.addDrawables(Collections.singleton(drawable));
+
+    assertTrue(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+    tile.drawImage(null, null);
+    assertFalse(tile.isDirty());
+    assertFalse(tile.hasDrawingStarted());
+  }
+
+  @Test
+  public void testDrawOrder() {
+    final IDrawable drawable2 = mock(IDrawable.class);
+    when(drawable.getLevel()).thenReturn(1);
+    when(drawable2.getLevel()).thenReturn(2);
+    tile.addDrawable(drawable2);
+    tile.addDrawable(drawable);
+    final GameData data = mock(GameData.class);
+    final MapData mapData = mock(MapData.class);
+    final InOrder inOrder = Mockito.inOrder(drawable, drawable2);
+    tile.drawImage(data, mapData);
+    inOrder.verify(drawable).draw(eq(rect), eq(data), any(), eq(mapData));
+    inOrder.verify(drawable2).draw(eq(rect), eq(data), any(), eq(mapData));
+  }
+
+  @Test
+  public void testDrawableInsertAndRemoval() {
+    final IDrawable drawable2 = mock(IDrawable.class);
+    tile.addDrawable(drawable);
+    tile.addDrawables(Collections.singleton(drawable2));
+    assertEquals(Arrays.asList(drawable, drawable2), tile.getDrawables());
+    tile.removeDrawables(Collections.singleton(drawable2));
+    assertEquals(Collections.singletonList(drawable), tile.getDrawables());
+    tile.removeDrawables(Collections.singleton(drawable));
+    assertEquals(Collections.emptyList(), tile.getDrawables());
+    tile.addDrawables(Arrays.asList(drawable, drawable2));
+    tile.clear();
+    assertEquals(Collections.emptyList(), tile.getDrawables());
+  }
+
+  @Test
+  public void testCorrectBounds() {
+    assertSame(rect, tile.getBounds());
+    final Tile tile = new Tile(rect);
+    assertEquals(rect.width, tile.getImage().getWidth(null));
+    assertEquals(rect.height, tile.getImage().getHeight(null));
+  }
+}


### PR DESCRIPTION
Fix #3557
I really don't get why there were ConcurrentModificationExceptions on a synchronized map.
However PriorityBlockingQueue should once and for all fix this issue, with the downside that we need to make a copy in order to correctly iterate in-order over it.
However all in all a heap is a well-suited data structure for this problem.

Also added a catch block because I noticed Exceptions on the ThreadPool might just get not logged at all otherwise.