### PR TITLE
Remove setWidgetActivation callbackmechanism on main screeen and enable Main Screen  buttons by default.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -35,7 +35,6 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     this.gameSelectorModel = gameSelectorModel;
     this.model.setRemoteModelListener(this);
     createLobbyWatcher();
-    setWidgetActivation();
     internalPlayerListChanged();
   }
 
@@ -62,9 +61,6 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   void shutDownLobbyWatcher() {
     lobbyWatcher.shutDown();
   }
-
-  @Override
-  public void setWidgetActivation() {}
 
   @Override
   public void shutDown() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -188,7 +188,8 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
               playersToNodeListing.put(name, null);
             }
           } else {
-            playersToNodeListing.put(name, serverMessenger.getLocalNode().getName());
+            Optional.ofNullable(serverMessenger)
+                .ifPresent(messenger -> playersToNodeListing.put(name, messenger.getLocalNode().getName()));
           }
           playerNamesAndAlliancesInTurnOrder.put(name, data.getAllianceTracker().getAlliancesPlayerIsIn(player));
           playersEnabledListing.put(name, !player.getIsDisabled());
@@ -522,9 +523,12 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
   }
 
   private void notifyChanellPlayersChanged() {
-    final IClientChannel channel =
-        (IClientChannel) channelMessenger.getChannelBroadcastor(IClientChannel.CHANNEL_NAME);
-    channel.playerListingChanged(getPlayerListingInternal());
+    Optional.ofNullable(channelMessenger)
+        .ifPresent(messenger -> {
+          final IClientChannel channel =
+              (IClientChannel) messenger.getChannelBroadcastor(IClientChannel.CHANNEL_NAME);
+          channel.playerListingChanged(getPlayerListingInternal());
+        });
   }
 
   public void takePlayer(final String playerName) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -31,12 +31,6 @@ public class SetupPanelModel extends Observable {
     return gameSelectorModel;
   }
 
-  public void setWidgetActivation() {
-    if (panel != null) {
-      panel.setWidgetActivation();
-    }
-  }
-
   public void showSelectType() {
     setGameTypePanel(new MetaSetupPanel(this));
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -151,10 +151,6 @@ public class ClientSetupPanel extends SetupPanel {
   }
 
   @Override
-  public void setWidgetActivation() {
-  }
-
-  @Override
   public void shutDown() {
     clientModel.shutDown();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -37,8 +37,6 @@ public interface ISetupPanel {
    */
   boolean canGameStart();
 
-  void setWidgetActivation();
-
   void preStartGame();
 
   void postStartGame();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -23,15 +23,11 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     gameSelectorModel = model;
     layoutPlayerComponents(this, playerTypes, gameSelectorModel.getGameData());
     setupListeners();
-    setWidgetActivation();
   }
 
   private void setupListeners() {
     gameSelectorModel.addObserver(this);
   }
-
-  @Override
-  public void setWidgetActivation() {}
 
   @Override
   public boolean showCancelButton() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -190,7 +190,6 @@ public class MainPanel extends JPanel implements Observer {
 
   private void setWidgetActivation() {
     SwingAction.invokeNowOrLater(() -> {
-      gameTypePanelModel.setWidgetActivation();
       playButton.setEnabled(gameSetupPanel != null && gameSetupPanel.canGameStart());
     });
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -50,7 +50,6 @@ public class MetaSetupPanel extends SetupPanel {
     createComponents();
     layoutComponents();
     setupListeners();
-    setWidgetActivation();
   }
 
   private void createComponents() {
@@ -161,20 +160,6 @@ public class MetaSetupPanel extends SetupPanel {
     final LobbyFrame lobbyFrame = new LobbyFrame(client, lobbyServerProperties);
     GameRunner.hideMainFrame();
     lobbyFrame.setVisible(true);
-  }
-
-  @Override
-  public void setWidgetActivation() {
-    if (model == null || model.getGameSelectorModel() == null
-        || model.getGameSelectorModel().getGameData() == null) {
-      startLocal.setEnabled(false);
-      startPbem.setEnabled(false);
-      hostGame.setEnabled(false);
-    } else {
-      startLocal.setEnabled(true);
-      startPbem.setEnabled(true);
-      hostGame.setEnabled(true);
-    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -85,7 +85,6 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     layoutComponents();
     setupListeners();
     loadAll();
-    setWidgetActivation();
   }
 
   private void createComponents() {
@@ -129,17 +128,12 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     add(localPlayerSelection, new GridBagConstraints(0, row++, 1, 1, 1.0d, 0d, GridBagConstraints.NORTHEAST,
         GridBagConstraints.NONE, new Insets(10, 0, 10, 0), 0, 0));
     layoutPlayerComponents(localPlayerPanel, playerTypes, gameSelectorModel.getGameData());
-    setWidgetActivation();
   }
 
   @Override
   public boolean showCancelButton() {
     return true;
   }
-
-
-  @Override
-  public void setWidgetActivation() {}
 
   private void setupListeners() {
     // register, so we get notified when the game model (GameData) changes (e.g if the user load a save game or selects

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -65,7 +65,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     createLobbyWatcher();
     createComponents();
     layoutComponents();
-    setWidgetActivation();
     internalPlayerListChanged();
   }
 
@@ -226,9 +225,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     invalidate();
     validate();
   }
-
-  @Override
-  public void setWidgetActivation() {}
 
   @Override
   public void shutDown() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -52,8 +52,6 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
   @Override
   public abstract boolean canGameStart();
 
-  @Override
-  public abstract void setWidgetActivation();
 
   @Override
   public void preStartGame() {}

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DisplayNameComboBoxRender.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DisplayNameComboBoxRender.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.startup.ui.editors;
 
 import java.awt.Component;
+import java.util.Optional;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JList;
@@ -15,7 +16,9 @@ class DisplayNameComboBoxRender extends DefaultListCellRenderer {
   public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
       final boolean isSelected, final boolean cellHasFocus) {
     super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-    setText(((IBean) value).getDisplayName());
+    setText(Optional.ofNullable(value)
+        .map(bean -> ((IBean) bean).getDisplayName())
+        .orElse(""));
     return this;
   }
 }


### PR DESCRIPTION
## Overview
MetaStartUpPanel disables a few of the start game button options on startup and is triggered by a callback mechanism to enable those buttons. It turns out the screens that are disabled can handle a not yet initialized game data object. There are a few NPE locations to deal with, but once dealt with we can enable the buttons at startup and remove the setWidgetActiviation callback mechanism.

This update has the benefit that the user will not need to wait for their default map to load before they can click single player, PBEM or host network game; those buttons will be immediately enabled by default.


## Testing

- An artificial delay was adding to the game loading, this allowed me to check out the game with a slow load and fix any problems: https://github.com/triplea-game/triplea/blob/master/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java#L53

## Before & After Screen Shots
Before:
![before](https://user-images.githubusercontent.com/12397753/42839875-ee476c9e-89b9-11e8-8531-15d92ec39697.gif)

After:
![after](https://user-images.githubusercontent.com/12397753/42840185-d9e537bc-89ba-11e8-8a5a-27e709af76c8.gif)

After, with slow load artificially forced:
![testing](https://user-images.githubusercontent.com/12397753/42840823-ee0ab3d2-89bc-11e8-8408-a6b0e6957eb4.gif)


## Review notes
