### PR TITLE
Copy Map maker PR template comment to triplea_maps.yaml

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1,4 +1,9 @@
 #
+# ***Map Makers***  For help updating this file, see:
+# https://docs.google.com/document/d/1FfF7N0srp9QG0_if5D-c1d1Aa1QTttdhxgm1GBh3pI4
+# https://forums.triplea-game.org/topic/484/how-to-add-maps-to-triplea-downloads
+##
+#
 # This file is read live by the game whenever you click 'download maps'. Updating this file on the
 # github server will have immediate effect on all game installations. Be careful to not break old
 # game engine versions when adding new fields (but note, unrecognized yaml field names are simply ignored)


### PR DESCRIPTION
The commentary/links to map makers seems most appropriate on the triplea_maps.yaml file itself. 
This comment is coming from the PR template (it probably does not belong there, if a map maker gets to a PR, they probably found some help documentation. The links instead of being removed are maybe most helpful in this file).

<!--
***Map Makers***  For help updating triplea_maps.yaml, see:
https://docs.google.com/document/d/1FfF7N0srp9QG0_if5D-c1d1Aa1QTttdhxgm1GBh3pI4
https://forums.triplea-game.org/topic/484/how-to-add-maps-to-triplea-downloads
-->

<!--  *** Dev***Use this template:
## Overview
Summary of changes and what we are accomplishing

## Testing
- Automated testing (unit testing)
- ...

## Before & After Screen Shots

## Review notes

Comments that would help for review
-->

<!--
*** Dev***
All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md
-->
