### PR TITLE
PR template - Uncomment template!  Add a 'functional changes' section and other cleanups.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,32 +1,21 @@
-<!--
-***Map Makers***  For help updating triplea_maps.yaml, see:
-https://docs.google.com/document/d/1FfF7N0srp9QG0_if5D-c1d1Aa1QTttdhxgm1GBh3pI4
-https://forums.triplea-game.org/topic/484/how-to-add-maps-to-triplea-downloads
--->
-
-<!--  *** Dev***Use this template:
 ## Overview
-Summary of changes and what we are accomplishing
 
-## Testing
-- Automated testing (unit testing)
+
+## Functional Changes
+
+
+## Testing Performed
 - ...
 
 ## Before & After Screen Shots
+<!-- Leave blank if no UI changes -->
 
-## Review notes
-
-Comments that would help for review
--->
+## Additional Review notes
+<!-- Add here any extra notes that would be helpful to reviewers -->
 
 <!--
-*** Dev***
-All PRs should follow the standards outlined at:
-https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md
-
-More about those standards here: 
-https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md
-
-To learn more about the process of reviewing PRs, see: 
-https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md
+Code standards and PR guidelines can be found at:
+- Code Standards: https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md
+- Code Format: https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md
+- Review Process: https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,14 @@
 
 
 ## Testing Performed
-- ...
+- ..
 
 ## Before & After Screen Shots
 <!-- Leave blank if no UI changes -->
+### Before
+
+### After
+
 
 ## Additional Review notes
 <!-- Add here any extra notes that would be helpful to reviewers -->


### PR DESCRIPTION
Notably uncomment the template. This means if we fill in the template we will not need to do anything more, like for example double check that the comment blocks have been removed : )

Added a 'functional changes' section for us to call out if something is purely refactor or not. Making this clear in the PR overview should help review.

Also of note the documentation links for dev were pruned down in text and pushed to bottom and map maker links would be moved to `triplea_maps.yaml` triplea_maps.yaml: https://github.com/triplea-game/triplea/pull/3585


### Before

The template before modification looks like this in preview:
![before](https://user-images.githubusercontent.com/12397753/42903288-38f1df50-8a86-11e8-92d7-29db6d9afce6.png)

When opening a PR, the following would be presented. Commit comments will be at the top (so we very easily can ignore this jumble of text, means it is not very useful):
![before_text](https://user-images.githubusercontent.com/12397753/42903492-dcb6b76e-8a86-11e8-8f51-a16f479a63ae.png)


### After

After this update, by default a PR looks like this in preview:
![after](https://user-images.githubusercontent.com/12397753/42903335-5e844410-8a86-11e8-8285-d0dbf7032928.png)

When opening a PR, it would look roughly like this (typically commit comments will be at top, so those would be moved to overview section):
![after_text](https://user-images.githubusercontent.com/12397753/42903520-f5d8fe50-8a86-11e8-82d0-23eab3ec038c.png)

