### PR TITLE
Create first class data type 'PlayerType'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -124,7 +124,8 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     // so for example, it should be "AI:Hard (AI)"
     final String[] s = encodedPlayerTypeAndName.split(":");
     if (s.length != 2) {
-      throw new IllegalStateException("whoAmI must have two strings, separated by a colon");
+      throw new IllegalStateException(String.format("whoAmI '%s' must have two strings, separated by a colon",
+          encodedPlayerTypeAndName));
     }
     if (!(s[0].equalsIgnoreCase("AI") || s[0].equalsIgnoreCase("Human") || s[0].equalsIgnoreCase("null"))) {
       throw new IllegalStateException("whoAmI first part must be, ai or human or client");

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -9,8 +9,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.google.common.base.MoreObjects;
+import lombok.ToString;
 
+/**
+ * Wrapper around the set of players in a game to provide utility functions and methods.
+ */
+@ToString
 public class PlayerList extends GameDataComponent implements Iterable<PlayerID> {
   private static final long serialVersionUID = -3895068111754745446L;
   // maps String playerName -> PlayerID
@@ -45,9 +49,6 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
     return m_players.get(name);
   }
 
-  /**
-   * @return a new arraylist copy of the players.
-   */
   public List<PlayerID> getPlayers() {
     return new ArrayList<>(m_players.values());
   }
@@ -73,12 +74,5 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
       playersEnabledListing.put(p.getName(), !p.getIsDisabled());
     }
     return playersEnabledListing;
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("players", m_players)
-        .toString();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.data.IUnitFactory;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.IRemote;
@@ -21,20 +22,13 @@ import games.strategy.engine.message.IRemote;
  * and meta data needed by the engine.
  */
 public interface IGameLoader extends Serializable {
-  String CLIENT_PLAYER_TYPE = "Client";
-
-  /**
-   * Return an array of player types that can play on the server.
-   */
-  String[] getServerPlayerTypes();
-
   /**
    * Create the players. Given a map of playerName -> type,
-   * where type is one of the Strings returned by a getServerPlayerTypes() or IGameLoader.CLIENT_PLAYER_TYPE.
+   * where type is one of the Strings returned by a getServerPlayerTypes() or PlayerType.CLIENT_PLAYER.
    *
    * @return a Set of GamePlayers
    */
-  Set<IGamePlayer> createPlayers(Map<String, String> players);
+  Set<IGamePlayer> createPlayers(Map<String, PlayerType> players);
 
   /**
    * The game is about to start.

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -30,6 +30,7 @@ import games.strategy.engine.delegate.IPersistentDelegate;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.IObserverWaitingToJoin;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.history.DelegateHistoryWriter;
@@ -584,9 +585,9 @@ public class ServerGame extends AbstractGame {
               player.getName()
                   + ((player.getName().endsWith("s") || player.getName().endsWith("ese")
                       || player.getName().endsWith("ish")) ? " are" : " is")
-                  + " now being played by: " + player.getType());
+                  + " now being played by: " + player.getPlayerType().getLabel());
       final PlayerID p = data.getPlayerList().getPlayerId(player.getName());
-      final String newWhoAmI = ((isHuman ? "Human" : "AI") + ":" + player.getType());
+      final String newWhoAmI = ((isHuman ? "Human" : "AI") + ":" + player.getPlayerType().getLabel());
       if (!p.getWhoAmI().equals(newWhoAmI)) {
         change.add(ChangeFactory.changePlayerWhoAmIChange(p, newWhoAmI));
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -8,7 +8,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import games.strategy.engine.framework.startup.ui.PlayerType;
+import games.strategy.triplea.NetworkData;
 import games.strategy.util.Version;
 
 /**
@@ -19,6 +22,7 @@ import games.strategy.util.Version;
  * (updated by veqryn to be the object that, besides game options, determines the starting setup for game. ie: who is
  * playing what)
  */
+@NetworkData
 public class PlayerListing implements Serializable {
   // keep compatability with older versions
   private static final long serialVersionUID = -8913538086737733980L;
@@ -39,15 +43,19 @@ public class PlayerListing implements Serializable {
    * Creates a new instance of PlayerListing.
    */
   public PlayerListing(final Map<String, String> playerToNodeListing, final Map<String, Boolean> playersEnabledListing,
-      final Map<String, String> localPlayerTypes, final Version gameVersion, final String gameName,
+      final Map<String, PlayerType> localPlayerTypes, final Version gameVersion, final String gameName,
       final String gameRound, final Collection<String> playersAllowedToBeDisabled,
       final Map<String, Collection<String>> playerNamesAndAlliancesInTurnOrder) {
     m_playerToNodeListing =
         playerToNodeListing == null ? new HashMap<>() : new HashMap<>(playerToNodeListing);
     m_playersEnabledListing = playersEnabledListing == null ? new HashMap<>()
         : new HashMap<>(playersEnabledListing);
-    m_localPlayerTypes =
-        localPlayerTypes == null ? new HashMap<>() : new HashMap<>(localPlayerTypes);
+    m_localPlayerTypes = (localPlayerTypes == null)
+        ? new HashMap<>()
+        : localPlayerTypes.entrySet()
+            .stream()
+            // convert Map<String,PlayerType> -> Map<String,String>
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel()));
     m_playersAllowedToBeDisabled =
         playersAllowedToBeDisabled == null ? new HashSet<>() : new HashSet<>(playersAllowedToBeDisabled);
     m_gameVersion = gameVersion;
@@ -98,7 +106,10 @@ public class PlayerListing implements Serializable {
     return m_gameRound;
   }
 
-  public Map<String, String> getLocalPlayerTypes() {
-    return m_localPlayerTypes;
+  public Map<String, PlayerType> getLocalPlayerTypeMap() {
+    return m_localPlayerTypes.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> PlayerType.fromLabel(e.getValue())));
   }
+
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LauncherFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LauncherFactory.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.local.PlayerCountrySelection;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.random.PlainRandomSource;
 
 /**
@@ -21,7 +22,7 @@ public class LauncherFactory {
       final GameSelectorModel gameSelectorModel,
       final Collection<? extends PlayerCountrySelection> playerRows) {
 
-    final Map<String, String> playerTypes = playerRows.stream()
+    final Map<String, PlayerType> playerTypes = playerRows.stream()
         .collect(Collectors.toMap(PlayerCountrySelection::getPlayerName, PlayerCountrySelection::getPlayerType));
 
     final Map<String, Boolean> playersEnabled = playerRows.stream()

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -18,6 +18,9 @@ import games.strategy.net.HeadlessServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.util.Interruptibles;
 
+/**
+ * Launcher for a local or a client game. A launcher will start the game UI and begin game play.
+ */
 public class LocalLauncher extends AbstractLauncher {
   private final IRandomSource randomSource;
   private final PlayerListing playerListing;
@@ -48,7 +51,8 @@ public class LocalLauncher extends AbstractLauncher {
     try {
       gameData.doPreGameStartDataModifications(playerListing);
       final Messengers messengers = new Messengers(new HeadlessServerMessenger());
-      final Set<IGamePlayer> gamePlayers = gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypes());
+      final Set<IGamePlayer> gamePlayers =
+          gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypeMap());
       final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers);
       game.setRandomSource(randomSource);
       gameData.getGameLoader().startGame(game, gamePlayers, headless, null);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -121,7 +121,7 @@ public class ServerLauncher extends AbstractLauncher {
       abortLaunch = testShouldWeAbort();
       final byte[] gameDataAsBytes = gameData.toBytes();
       final Set<IGamePlayer> localPlayerSet =
-          gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypes());
+          gameData.getGameLoader().createPlayers(playerListing.getLocalPlayerTypeMap());
       final Messengers messengers = new Messengers(messenger, remoteMessenger, channelMessenger);
       serverGame = new ServerGame(gameData, localPlayerSet, remotePlayers, messengers);
       serverGame.setInGameLobbyWatcher(inGameLobbyWatcher);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/local/PlayerCountrySelection.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/local/PlayerCountrySelection.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.framework.startup.launcher.local;
 
+import games.strategy.engine.framework.startup.ui.PlayerType;
+
 /**
  * Represents the data behind a player selected country, who is playing the country, which country, etc.
  */
@@ -7,8 +9,7 @@ public interface PlayerCountrySelection {
 
   String getPlayerName();
 
-  // TODO: convert return value of getPlayerType() to an enum
-  String getPlayerType();
+  PlayerType getPlayerType();
 
 
   boolean isPlayerEnabled();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -39,7 +39,6 @@ import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.network.ui.ChangeGameOptionsClientAction;
 import games.strategy.engine.framework.network.ui.ChangeGameToSaveGameClientAction;
@@ -49,6 +48,7 @@ import games.strategy.engine.framework.network.ui.SetMapClientAction;
 import games.strategy.engine.framework.startup.launcher.IServerReady;
 import games.strategy.engine.framework.startup.login.ClientLogin;
 import games.strategy.engine.framework.startup.ui.ClientOptions;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.framework.ui.background.WaitWindow;
 import games.strategy.engine.gamePlayer.IGamePlayer;
@@ -338,9 +338,9 @@ public class ClientModel implements IMessengerErrorListener {
       return;
     }
     objectStreamFactory.setData(data);
-    final Map<String, String> playerMapping = playersToNodes.entrySet().stream()
+    final Map<String, PlayerType> playerMapping = playersToNodes.entrySet().stream()
         .filter(e -> e.getValue().equals(messenger.getLocalNode().getName()))
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> IGameLoader.CLIENT_PLAYER_TYPE));
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> PlayerType.CLIENT_PLAYER));
     final Set<IGamePlayer> playerSet = data.getGameLoader().createPlayers(playerMapping);
     final Messengers messengers = new Messengers(messenger, remoteMessenger, channelMessenger);
     game = new ClientGame(data, playerSet, players, messengers);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -67,7 +67,7 @@ public class ClientSetupPanel extends SetupPanel {
     final Set<String> playerNames = playerNamesAndAlliancesInTurnOrder.keySet();
     for (final String name : playerNames) {
       final PlayerRow playerRow = new PlayerRow(name, playerNamesAndAlliancesInTurnOrder.get(name),
-          IGameLoader.CLIENT_PLAYER_TYPE, enabledPlayers.get(name));
+          enabledPlayers.get(name));
       playerRows.add(playerRow);
       SwingUtilities.invokeLater(() -> playerRow.update(players.get(name), disableable.contains(name)));
     }
@@ -171,13 +171,10 @@ public class ClientSetupPanel extends SetupPanel {
     private final JLabel playerNameLabel = new JLabel();
     private final JLabel playerLabel = new JLabel();
     private JComponent playerComponent = new JLabel();
-    private final String localPlayerType;
     private final JLabel alliance;
 
-    PlayerRow(final String playerName, final Collection<String> playerAlliances, final String localPlayerType,
-        final boolean enabled) {
+    PlayerRow(final String playerName, final Collection<String> playerAlliances, final boolean enabled) {
       playerNameLabel.setText(playerName);
-      this.localPlayerType = localPlayerType;
       enabledCheckBox.addActionListener(disablePlayerActionListener);
       enabledCheckBox.setSelected(enabled);
       alliance = new JLabel(playerAlliances.contains(playerName) ? "" : playerAlliances.toString());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -348,7 +348,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     // create local launcher
     final String gameUuid = (String) gameSelectorModel.getGameData().getProperties().get(GameData.GAME_UUID);
     final PbemDiceRoller randomSource = new PbemDiceRoller((IRemoteDiceServer) diceServerEditor.getBean(), gameUuid);
-    final Map<String, String> playerTypes = new HashMap<>();
+    final Map<String, PlayerType> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
     for (final PlayerSelectorRow player : this.playerTypes) {
       playerTypes.put(player.getPlayerName(), player.getPlayerType());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -21,7 +21,6 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.startup.launcher.local.PlayerCountrySelection;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.TripleA;
 
 /**
  * Represents a player selection row worth of data, during initial setup this is a row where a player can choose
@@ -46,7 +45,7 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
   PlayerSelectorRow(final List<PlayerSelectorRow> playerRows, final PlayerID player,
       final Map<String, String> reloadSelections, final Collection<String> disableable,
       final HashMap<String, Boolean> playersEnablementListing, final Collection<String> playerAlliances,
-      final String[] types, final SetupPanel parent, final GameProperties gameProperties) {
+      final SetupPanel parent, final GameProperties gameProperties) {
     this.disableable = disableable;
     this.parent = parent;
     playerName = player.getName();
@@ -60,11 +59,11 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
         if (enabledCheckBox.isSelected()) {
           enabled = true;
           // the 1st in the list should be human
-          playerTypes.setSelectedItem(types[0]);
+          playerTypes.setSelectedItem(PlayerType.HUMAN_PLAYER);
         } else {
           enabled = false;
           // the 2nd in the list should be Weak AI
-          playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 1))]);
+          playerTypes.setSelectedItem(PlayerType.WEAK_AI);
         }
         setWidgetActivation();
       }
@@ -73,12 +72,12 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
     enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
     enabledCheckBox.setEnabled(disableable.contains(playerName));
 
-    playerTypes = new JComboBox<>(types);
+    playerTypes = new JComboBox<>(PlayerType.playerTypes());
     String previousSelection = reloadSelections.get(playerName);
     if (previousSelection.equalsIgnoreCase("Client")) {
-      previousSelection = types[0];
+      previousSelection = PlayerType.HUMAN_PLAYER.name();
     }
-    if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
+    if (Arrays.asList(PlayerType.playerTypes()).contains(previousSelection)) {
       playerTypes.setSelectedItem(previousSelection);
     } else {
       setDefaultPlayerType();
@@ -170,11 +169,11 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
 
   void setDefaultPlayerType() {
     if (player.isDefaultTypeAi()) {
-      playerTypes.setSelectedItem(TripleA.PRO_COMPUTER_PLAYER_TYPE);
+      playerTypes.setSelectedItem(PlayerType.PRO_AI.getLabel());
     } else if (player.isDefaultTypeDoesNothing()) {
-      playerTypes.setSelectedItem(TripleA.DOESNOTHINGAI_COMPUTER_PLAYER_TYPE);
+      playerTypes.setSelectedItem(PlayerType.DOES_NOTHING_AI.getLabel());
     } else {
-      playerTypes.setSelectedItem(TripleA.HUMAN_PLAYER_TYPE);
+      playerTypes.setSelectedItem(PlayerType.HUMAN_PLAYER.getLabel());
     }
   }
 
@@ -184,8 +183,8 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
   }
 
   @Override
-  public String getPlayerType() {
-    return (String) playerTypes.getSelectedItem();
+  public PlayerType getPlayerType() {
+    return PlayerType.fromLabel(String.valueOf(playerTypes.getSelectedItem()));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerType.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerType.java
@@ -1,0 +1,97 @@
+package games.strategy.engine.framework.startup.ui;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+import games.strategy.engine.gamePlayer.IGamePlayer;
+import games.strategy.triplea.TripleAPlayer;
+import games.strategy.triplea.ai.fast.FastAi;
+import games.strategy.triplea.ai.pro.ProAi;
+import games.strategy.triplea.ai.weak.DoesNothingAi;
+import games.strategy.triplea.ai.weak.WeakAi;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * PlayerType indicates what kind of entity is controlling a player, whether an AI, human,
+ * or a remote (network) player.
+ */
+@AllArgsConstructor
+public enum PlayerType {
+  HUMAN_PLAYER("Human", nationName -> new TripleAPlayer(nationName) {
+    @Override
+    public PlayerType getPlayerType() {
+      return PlayerType.HUMAN_PLAYER;
+    }
+  }),
+
+  WEAK_AI("Easy (AI)", WeakAi::new),
+
+  FAST_AI("Fast (AI)", FastAi::new),
+
+  PRO_AI("Hard (AI)", ProAi::new),
+
+  DOES_NOTHING_AI("Does Nothing (AI)", DoesNothingAi::new),
+
+  /**
+   * A hidden player type to represent network connected players.
+   */
+  CLIENT_PLAYER("Client", false, nationName -> new TripleAPlayer(nationName) {
+    @Override
+    public PlayerType getPlayerType() {
+      return PlayerType.CLIENT_PLAYER;
+    }
+  }),
+
+  /**
+   * A 'dummy' player type used for battle calc.
+   */
+  BATTLE_CALC_DUMMY("None (AI)", false, name -> {
+    throw new UnsupportedOperationException(
+        "Fail fast - bad configuration, should instantiate dummy player type only for battle calc");
+  });
+
+  @Getter
+  private final String label;
+  @Getter(AccessLevel.PRIVATE)
+  private final boolean visible;
+  private final Function<String, IGamePlayer> playerFactory;
+
+  PlayerType(String label, Function<String, IGamePlayer> playerFactory) {
+    this(label, true, playerFactory);
+  }
+
+  /**
+   * Returns the set of player types that users can select.
+   * 
+   * @return Human readable player type labels.
+   */
+  public static String[] playerTypes() {
+    return Arrays.stream(values())
+        .filter(PlayerType::isVisible)
+        .map(enumValue -> enumValue.label)
+        .toArray(String[]::new);
+  }
+
+  /**
+   * Each PlayerType is backed by an @{code IGamePlayer} instance. Given a playername this method
+   * will create the corresponding @{code IGamePlayer} instance.
+   */
+  public IGamePlayer createPlayerWithName(String name) {
+    return playerFactory.apply(name);
+  }
+
+  /**
+   * Converter function, each player type has a label, this method will convert from a given label
+   * value to the corresponding enum.
+   *
+   * @throws IllegalStateException Thrown if the given label does not match any in the current enum.
+   */
+  public static PlayerType fromLabel(final String label) {
+    return Arrays.stream(values())
+        .filter(enumValue -> enumValue.label.equals(label))
+        .findAny()
+        .orElseThrow(() -> new IllegalStateException("could not find PlayerType: " + label));
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -305,8 +305,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     final Set<String> playerNames = playerNamesAndAlliancesInTurnOrder.keySet();
     for (final String name : playerNames) {
       final PlayerRow newPlayerRow =
-          new PlayerRow(name, reloadSelections, playerNamesAndAlliancesInTurnOrder.get(name),
-              gameSelectorModel.getGameData().getGameLoader().getServerPlayerTypes());
+          new PlayerRow(name, reloadSelections, playerNamesAndAlliancesInTurnOrder.get(name));
       playerRows.add(newPlayerRow);
       newPlayerRow.update(players, playersEnabled);
     }
@@ -321,10 +320,9 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     private final JCheckBox enabledCheckBox;
     private final JComboBox<String> type;
     private final JLabel alliance;
-    private final String[] types;
 
     PlayerRow(final String playerName, final Map<String, String> reloadSelections,
-        final Collection<String> playerAlliances, final String[] types) {
+        final Collection<String> playerAlliances) {
       nameLabel = new JLabel(playerName);
       playerLabel = new JLabel(model.getMessenger().getLocalNode().getName());
       localCheckBox = new JCheckBox();
@@ -334,19 +332,19 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       enabledCheckBox.addActionListener(disablePlayerActionListener);
       // this gets updated later
       enabledCheckBox.setSelected(true);
-      this.types = types;
-      type = new JComboBox<>(types);
+      String[] playerTypes = PlayerType.playerTypes();
+      type = new JComboBox<>(playerTypes);
       String previousSelection = reloadSelections.get(playerName);
       if (previousSelection.equalsIgnoreCase("Client")) {
-        previousSelection = types[0];
+        previousSelection = playerTypes[0];
       }
-      if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
+      if (!(previousSelection.equals("no_one")) && Arrays.asList(playerTypes).contains(previousSelection)) {
         type.setSelectedItem(previousSelection);
-        model.setLocalPlayerType(nameLabel.getText(), (String) type.getSelectedItem());
+        model.setLocalPlayerType(nameLabel.getText(), PlayerType.fromLabel((String) type.getSelectedItem()));
       } else if (playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
         // the 4th in the list should be Pro AI (Hard AI)
-        type.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-        model.setLocalPlayerType(nameLabel.getText(), (String) type.getSelectedItem());
+        type.setSelectedItem(PlayerType.PRO_AI.getLabel());
+        model.setLocalPlayerType(nameLabel.getText(), PlayerType.PRO_AI);
       }
       if (playerAlliances.contains(playerName)) {
         alliance = new JLabel();
@@ -354,7 +352,8 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
         alliance = new JLabel(playerAlliances.toString());
       }
       type.addActionListener(
-          e -> model.setLocalPlayerType(nameLabel.getText(), (String) type.getSelectedItem()));
+          e -> model.setLocalPlayerType(nameLabel.getText(),
+              PlayerType.fromLabel((String) type.getSelectedItem())));
     }
 
     public JComboBox<String> getType() {
@@ -417,12 +416,10 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       public void actionPerformed(final ActionEvent e) {
         if (enabledCheckBox.isSelected()) {
           model.enablePlayer(nameLabel.getText());
-          // the 1st in the list should be human
-          type.setSelectedItem(types[0]);
+          type.setSelectedItem(PlayerType.HUMAN_PLAYER);
         } else {
           model.disablePlayer(nameLabel.getText());
-          // the 2nd in the list should be Weak AI
-          type.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 1))]);
+          type.setSelectedItem(PlayerType.WEAK_AI.name());
         }
         setWidgetActivation();
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -81,7 +81,6 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
     final Collection<String> disableable = data.getPlayerList().getPlayersThatMayBeDisabled();
     final HashMap<String, Boolean> playersEnablementListing = data.getPlayerList().getPlayersEnabledListing();
     final Map<String, String> reloadSelections = PlayerID.currentPlayers(data);
-    final String[] playerTypes = data.getGameLoader().getServerPlayerTypes();
     final List<PlayerID> players = data.getPlayerList().getPlayers();
 
     int gridx = 0;
@@ -97,7 +96,7 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
     final JLabel nameLabel = new JLabel("Name");
     panel.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    final JComboBox<String> setAllTypes = new JComboBox<>(playerTypes);
+    final JComboBox<String> setAllTypes = new JComboBox<>(PlayerType.playerTypes());
     setAllTypes.insertItemAt(SET_ALL_DEFAULT_LABEL, 0);
     setAllTypes.setSelectedIndex(-1);
     panel.add(setAllTypes, new GridBagConstraints(gridx, gridy - 1, 1, 1, 0, 0, GridBagConstraints.WEST,
@@ -126,7 +125,7 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
     for (final PlayerID player : players) {
       final PlayerSelectorRow selector =
           new PlayerSelectorRow(playerRows, player, reloadSelections, disableable, playersEnablementListing,
-              data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
+              data.getAllianceTracker().getAlliancesPlayerIsIn(player),  this, data.getProperties());
       playerRows.add(selector);
       if (!player.isHidden()) {
         selector.layout(++gridy, panel);

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.gamePlayer;
 
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 
 /**
  * A player of the game.
@@ -16,14 +17,11 @@ public interface IGamePlayer extends IRemotePlayer {
   void initialize(IPlayerBridge bridge, PlayerID id);
 
   /**
-   * @return The name of the game player (what nation we are).
+   * Returns the nation name.
    */
   String getName();
 
-  /**
-   * @return The type of player we are (human or a kind of ai).
-   */
-  String getType();
+  PlayerType getPlayerType();
 
   /**
    * Start the given step. stepName appears as it does in the game xml file.

--- a/game-core/src/main/java/games/strategy/triplea/NetworkData.java
+++ b/game-core/src/main/java/games/strategy/triplea/NetworkData.java
@@ -1,0 +1,13 @@
+package games.strategy.triplea;
+
+/**
+ * Indicates a class is serialized over network and has compatibility considerations.
+ * With such classes there is a magic call to 'readObject' and 'writeObject'. Unless these methods
+ * are overriden (see: serialization proxy pattern), then the non-transient variable names and types
+ * must be kept the same.
+ *
+ * NeworkData annotated classes do not have a method constraints, they are not necessarily called by reflection
+ * or RMI, so we just need to be sure these classes can be serialized and deserialized between different game versions.
+ */
+public @interface NetworkData {
+}

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -22,6 +22,7 @@ import games.strategy.engine.data.RepairRule;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.net.GUID;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
@@ -57,13 +58,14 @@ import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Tuple;
+import lombok.Getter;
 
 /**
  * As a rule, nothing that changes GameData should be in here.
  * It should be using a Change done in a delegate, and done through an IDelegate, which we get through
  * getPlayerBridge().getRemote()
  */
-public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements ITripleAPlayer {
+public abstract class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements ITripleAPlayer {
   private boolean soundPlayedAlreadyCombatMove = false;
   private boolean soundPlayedAlreadyNonCombatMove = false;
   private boolean soundPlayedAlreadyPurchase = false;
@@ -72,9 +74,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   private boolean soundPlayedAlreadyEndTurn = false;
   private boolean soundPlayedAlreadyPlacement = false;
 
-  /** Creates new TripleAPlayer. */
-  public TripleAPlayer(final String name, final String type) {
-    super(name, type);
+  public TripleAPlayer(final String name) {
+    super(name);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -74,8 +74,8 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
 
   private static final Logger logger = Logger.getLogger(AbstractAi.class.getName());
 
-  public AbstractAi(final String name, final String type) {
-    super(name, type);
+  public AbstractAi(final String name) {
+    super(name);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/FastAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/FastAi.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ai.fast;
 
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.oddsCalculator.ta.IOddsCalculator;
@@ -12,8 +13,8 @@ public class FastAi extends ProAi {
   // Odds estimator
   private static final IOddsCalculator estimator = new FastOddsEstimator();
 
-  public FastAi(final String name, final String type) {
-    super(name, type);
+  public FastAi(final String name) {
+    super(name);
   }
 
   @Override
@@ -21,4 +22,8 @@ public class FastAi extends ProAi {
     calc = new ProOddsCalculator(estimator);
   }
 
+  @Override
+  public PlayerType getPlayerType() {
+    return PlayerType.FAST_AI;
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.framework.GameDataUtils;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.AbstractAi;
@@ -74,8 +75,8 @@ public class ProAi extends AbstractAi {
   private List<PoliticalActionAttachment> storedPoliticalActions;
   private List<Territory> storedStrafingTerritories;
 
-  public ProAi(final String name, final String type) {
-    super(name, type);
+  public ProAi(final String name) {
+    super(name);
     initializeCalc();
     combatMoveAi = new ProCombatMoveAi(this);
     nonCombatMoveAi = new ProNonCombatMoveAi(this);
@@ -88,6 +89,11 @@ public class ProAi extends AbstractAi {
     storedPurchaseTerritories = null;
     storedPoliticalActions = null;
     storedStrafingTerritories = new ArrayList<>();
+  }
+
+  @Override
+  public PlayerType getPlayerType() {
+    return PlayerType.PRO_AI;
   }
 
   protected void initializeCalc() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
@@ -14,8 +15,14 @@ import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 
 public class DoesNothingAi extends AbstractAi {
-  public DoesNothingAi(final String name, final String type) {
-    super(name, type);
+
+  public DoesNothingAi(final String name) {
+    super(name);
+  }
+
+  @Override
+  public PlayerType getPlayerType() {
+    return PlayerType.DOES_NOTHING_AI;
   }
 
   @Override
@@ -23,7 +30,7 @@ public class DoesNothingAi extends AbstractAi {
       final GameData data, final PlayerID player) {
     // spend whatever we have
     if (!player.getResources().isEmpty()) {
-      (new WeakAi(this.getName(), this.getType())).purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
+      (new WeakAi(this.getName())).purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
     }
     pause();
   }
@@ -44,7 +51,7 @@ public class DoesNothingAi extends AbstractAi {
       final PlayerID player) {
     // place whatever we have
     if (!player.getUnits().isEmpty()) {
-      (new WeakAi(this.getName(), this.getType())).place(placeForBid, placeDelegate, data, player);
+      (new WeakAi(this.getName())).place(placeForBid, placeDelegate, data, player);
     }
     pause();
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -24,6 +24,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
@@ -48,9 +49,15 @@ import games.strategy.util.IntegerMap;
  */
 public class WeakAi extends AbstractAi {
 
-  public WeakAi(final String name, final String type) {
-    super(name, type);
+  public WeakAi(final String name) {
+    super(name);
   }
+
+  @Override
+  public PlayerType getPlayerType() {
+    return PlayerType.WEAK_AI;
+  }
+
 
   @Override
   protected void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -320,7 +320,7 @@ abstract class AbstractBattle implements IBattle {
   protected static ITripleAPlayer getRemote(final PlayerID player, final IDelegateBridge bridge) {
     // if its the null player, return a do nothing proxy
     if (player.isNull()) {
-      return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+      return new WeakAi(player.getName());
     }
     return (ITripleAPlayer) bridge.getRemotePlayer(player);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -122,7 +122,7 @@ public abstract class AbstractDelegate implements IDelegate {
    * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote:
    * <p>
    * if (player.isNull()) {
-   * return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+   * return new WeakAi(player.getName(), TripleA.WEAK_AI);
    * }
    * return bridge.getRemotePlayer(player);
    * </p>

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.TripleA;
 import games.strategy.triplea.ai.weak.WeakAi;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.player.ITripleAPlayer;
@@ -26,7 +25,6 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
    * Creates a new instance of the Delegate.
    */
   public BaseTripleADelegate() {
-    super();
   }
 
   /**
@@ -119,7 +117,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   protected static ITripleAPlayer getRemotePlayer(final PlayerID player, final IDelegateBridge bridge) {
     // if its the null player, return a do nothing proxy
     if (player.isNull()) {
-      return new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE);
+      return new WeakAi(player.getName());
     }
     return (ITripleAPlayer) bridge.getRemotePlayer(player);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -468,7 +468,7 @@ public class BattleCalculator {
     final GameData data = bridge.getData();
     final boolean isEditMode = BaseEditDelegate.getEditMode(data);
     final ITripleAPlayer tripleaPlayer = player.isNull()
-        ? new WeakAi(player.getName(), TripleA.WEAK_COMPUTER_PLAYER_TYPE)
+        ? new WeakAi(player.getName())
         : (ITripleAPlayer) bridge.getRemotePlayer(player);
     final Map<Unit, Collection<Unit>> dependents = headLess ? Collections.emptyMap() : getDependents(targetsToPickFrom);
     if (isEditMode && !headLess) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -41,9 +41,9 @@ public class DummyDelegateBridge implements IDelegateBridge {
       final List<Unit> attackerOrderOfLosses, final List<Unit> defenderOrderOfLosses,
       final boolean attackerKeepOneLandUnit, final int retreatAfterRound, final int retreatAfterXUnitsLeft,
       final boolean retreatWhenOnlyAirLeft) {
-    attackingPlayer = new DummyPlayer(this, true, "battle calc dummy", "None (AI)", attackerOrderOfLosses,
+    attackingPlayer = new DummyPlayer(this, true, "battle calc dummy", attackerOrderOfLosses,
         attackerKeepOneLandUnit, retreatAfterRound, retreatAfterXUnitsLeft, retreatWhenOnlyAirLeft);
-    defendingPlayer = new DummyPlayer(this, false, "battle calc dummy", "None (AI)", defenderOrderOfLosses, false,
+    defendingPlayer = new DummyPlayer(this, false, "battle calc dummy", defenderOrderOfLosses, false,
         retreatAfterRound, -1, false);
     gameData = data;
     this.attacker = attacker;

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.net.GUID;
 import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.AiUtils;
@@ -36,10 +37,10 @@ class DummyPlayer extends AbstractAi {
   private final List<Unit> orderOfLosses;
 
   DummyPlayer(final DummyDelegateBridge dummyDelegateBridge, final boolean attacker, final String name,
-      final String type, final List<Unit> orderOfLosses, final boolean keepAtLeastOneLand,
+      final List<Unit> orderOfLosses, final boolean keepAtLeastOneLand,
       final int retreatAfterRound,
       final int retreatAfterXUnitsLeft, final boolean retreatWhenOnlyAirLeft) {
-    super(name, type);
+    super(name);
     this.keepAtLeastOneLand = keepAtLeastOneLand;
     this.retreatAfterRound = retreatAfterRound;
     this.retreatAfterXUnitsLeft = retreatAfterXUnitsLeft;
@@ -47,6 +48,11 @@ class DummyPlayer extends AbstractAi {
     bridge = dummyDelegateBridge;
     isAttacker = attacker;
     this.orderOfLosses = orderOfLosses;
+  }
+
+  @Override
+  public PlayerType getPlayerType() {
+    return PlayerType.BATTLE_CALC_DUMMY;
   }
 
   private MustFightBattle getBattle() {

--- a/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
@@ -18,20 +18,14 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
   @Getter
   private final String name; // what nation are we playing? ex: "Americans"
   @Getter
-  private final String type; // what are we? ex: "Human" or "AI"
-  @Getter
   private PlayerID playerId;
   @Getter
   private IPlayerBridge playerBridge;
   private boolean isStoppedGame = false;
 
-  /**
-   * @param name
-   *        - the name of the player.
-   */
-  public AbstractBasePlayer(final String name, final String type) {
+
+  public AbstractBasePlayer(final String name) {
     this.name = name;
-    this.type = type;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
@@ -11,12 +11,8 @@ import games.strategy.triplea.ui.MainGameFrame;
 public abstract class AbstractHumanPlayer<T extends MainGameFrame> extends AbstractBasePlayer {
   protected T ui;
 
-  /**
-   * @param name
-   *        - the name of the player.
-   */
-  public AbstractHumanPlayer(final String name, final String type) {
-    super(name, type);
+  public AbstractHumanPlayer(final String name) {
+    super(name);
   }
 
   public final void setFrame(final T frame) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.display.IDisplay;
 import games.strategy.engine.framework.IGameModifiedChannel;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.gamePlayer.IRemotePlayer;
 import games.strategy.engine.history.DelegateHistoryWriter;
 import games.strategy.engine.history.IDelegateHistoryWriter;
@@ -41,7 +42,7 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
   private final DelegateHistoryWriter writer = new DelegateHistoryWriter(new DummyGameModifiedChannel());
   private final GameData gameData;
   private final ObjectivePanelDummyPlayer dummyAi =
-      new ObjectivePanelDummyPlayer("objective panel dummy", "None (AI)");
+      new ObjectivePanelDummyPlayer("objective panel dummy");
 
   public ObjectiveDummyDelegateBridge(final GameData data) {
     gameData = data;
@@ -144,8 +145,8 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
   }
 
   static class ObjectivePanelDummyPlayer extends AbstractAi {
-    public ObjectivePanelDummyPlayer(final String name, final String type) {
-      super(name, type);
+    public ObjectivePanelDummyPlayer(final String name) {
+      super(name);
     }
 
     @Override
@@ -228,6 +229,10 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
         final Collection<Unit> bombers) {
       throw new UnsupportedOperationException();
     }
-  }
 
+    @Override
+    public PlayerType getPlayerType() {
+      return PlayerType.BATTLE_CALC_DUMMY;
+    }
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.framework.IGameLoader;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.net.GUID;
 import games.strategy.triplea.TripleAPlayer;
@@ -113,7 +113,7 @@ public class TripleADisplay implements ITripleADisplay {
         // if we have any local players, we are not an observer
         isObserver = false;
         if (player instanceof TripleAPlayer) {
-          if (IGameLoader.CLIENT_PLAYER_TYPE.equals(player.getType())) {
+          if (player.getPlayerType() == PlayerType.CLIENT_PLAYER) {
             isClient = true;
           } else {
             isHost = true;

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
@@ -1,0 +1,82 @@
+package games.strategy.engine.framework.startup.ui;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsCollectionContaining;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.gamePlayer.IGamePlayer;
+import javazoom.jl.player.Player;
+
+class PlayerTypeTest {
+
+  @Test
+  void playerTypes() {
+    assertThat(
+        "Ensure we do not have an example invisible player type in the selection list",
+        asList(PlayerType.playerTypes()),
+        Matchers.not(IsCollectionContaining.hasItem(PlayerType.CLIENT_PLAYER.getLabel())));
+
+    assertThat(
+        "Ensure we have a visible player type in the selection list",
+        asList(PlayerType.playerTypes()),
+        IsCollectionContaining.hasItem(PlayerType.HUMAN_PLAYER.getLabel()));
+
+  }
+
+  @Test
+  void createPlayerWithName() {
+    String testName = "example";
+
+    stream(PlayerType.values())
+        .filter(playerType -> playerType != PlayerType.BATTLE_CALC_DUMMY)
+        .forEach(playerType -> {
+          IGamePlayer result = playerType.createPlayerWithName(testName);
+          assertThat(
+              "The player type should match after construction, input type: " + playerType,
+              result.getPlayerType(),
+              is(playerType));
+          assertThat(
+              "The name is a passed in parameter, this should still match after construction",
+              result.getName(),
+              is(testName));
+        });
+  }
+
+  @Test
+  void fromLabel() {
+    assertThrows(IllegalStateException.class, () -> PlayerType.fromLabel("invalid_label_type"));
+
+    stream(PlayerType.values())
+        .forEach(playerType -> assertThat(
+            "Make sure that we can reconstruct each player type from its label",
+            PlayerType.fromLabel(playerType.getLabel()),
+            is(playerType)));
+  }
+
+  @Test
+  void getLabel() {
+    assertThat(
+        "All player type labels should be unique, count of unique labels should match total",
+        stream(PlayerType.values())
+            .map(PlayerType::getLabel)
+            .distinct()
+            .count(),
+        is(Long.valueOf(PlayerType.values().length)));
+
+    assertThat(
+        "No label should be empty ",
+        stream(PlayerType.values())
+            .map(PlayerType::getLabel)
+            .anyMatch(String::isEmpty),
+        is(false));
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.DefaultUnitFactory;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.IGameLoader;
+import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.IRemote;
@@ -21,16 +22,11 @@ public final class TestGameLoader implements IGameLoader {
   private static final long serialVersionUID = -8019996788216172034L;
 
   @Override
-  public String[] getServerPlayerTypes() {
-    return null;
-  }
-
-  @Override
   public void startGame(final IGame game, final Set<IGamePlayer> players,
       final boolean headless, @Nullable Chat chat) {}
 
   @Override
-  public Set<IGamePlayer> createPlayers(final Map<String, String> players) {
+  public Set<IGamePlayer> createPlayers(final Map<String, PlayerType> players) {
     return null;
   }
 


### PR DESCRIPTION
## Overview
- Converts 'Stringly' PlayerType to [an enum](https://github.com/triplea-game/triplea/compare/master...DanVanAtta:player_type?expand=1#diff-00ce6386f0221bacf719a69f91e59fd5).  Of note, not all player types were defined in one location and not all are selectable. Notably we have a hidden network type and a dummy type used for battle calc.
- Introduce a new [`@NetworkData`](https://github.com/triplea-game/triplea/compare/master...DanVanAtta:player_type?expand=1#diff-9e88a1d54fd4c3d70f25ceafb474f685) annotation after checking network compatibility. This is to document classes that are serialized and their only compatibility concern is that the fields are the same name and type. This is to distinguish this from concern from say the RMI calls that have dependencies on method names. As such it was safe to remove methods from #PlayerList for example, but changing data type was not safe.



## Functional Changes
None

## Testing Performed
- launch a network game with latest release, selected one of each AI and let a slot open, launched a second instance from this branch, connected, took the last player slot, and played through a round.
- Did vice versa, with this branch being network host, and connecting player on latest release
- joined lobby with this branch, second instance with latest release, connected bot a bot and played through to a battle

## Additional Review notes
- note the new compatibility marker annotation convention with `NetworkData`

