### PR TITLE
GameSelectorPanel cleanup iteration

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameToSaveGameClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameToSaveGameClientAction.java
@@ -1,11 +1,10 @@
 package games.strategy.engine.framework.network.ui;
 
 import java.awt.event.ActionEvent;
-import java.io.File;
 
 import javax.swing.AbstractAction;
 
-import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
+import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameFileSelector;
 import games.strategy.net.IClientMessenger;
 
 /**
@@ -22,10 +21,7 @@ public class ChangeGameToSaveGameClientAction extends AbstractAction {
 
   @Override
   public void actionPerformed(final ActionEvent e) {
-    final File file = GameSelectorPanel.selectGameFile();
-    if (file == null || !file.exists()) {
-      return;
-    }
-    clientMessenger.changeToGameSave(file, file.getName());
+    GameFileSelector.selectGameFile()
+        .ifPresent(file -> clientMessenger.changeToGameSave(file, file.getName()));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -1,0 +1,40 @@
+package games.strategy.engine.framework.startup.ui.panels.main.game.selector;
+
+import java.awt.FileDialog;
+import java.io.File;
+import java.util.Optional;
+
+import games.strategy.engine.framework.GameDataFileUtils;
+import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.triplea.settings.ClientSetting;
+
+/**
+ * Utility class containing swing logic to show a file prompt to user. Used for selecting saved games.
+ */
+public final class GameFileSelector {
+  private GameFileSelector() {
+
+  }
+
+  /**
+   * Opens up a UI pop-up allowing user to select a game file. Returns nothing if user closes the pop-up.
+   */
+  public static Optional<File> selectGameFile() {
+    if (SystemProperties.isMac()) {
+      final FileDialog fileDialog = GameRunner.newFileDialog();
+      fileDialog.setMode(FileDialog.LOAD);
+      fileDialog.setDirectory(new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value()).getPath());
+      fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
+      fileDialog.setVisible(true);
+      final String fileName = fileDialog.getFile();
+      final String dirName = fileDialog.getDirectory();
+
+
+      return Optional.ofNullable(fileName)
+          .map(name -> new File(dirName, fileName));
+    }
+    return GameRunner.showSaveGameFileChooser();
+  }
+
+}

--- a/game-core/src/main/java/swinglib/JButtonBuilder.java
+++ b/game-core/src/main/java/swinglib/JButtonBuilder.java
@@ -3,6 +3,7 @@ package swinglib;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Font;
+import java.util.Optional;
 
 import javax.swing.JButton;
 import javax.swing.UIManager;
@@ -39,15 +40,14 @@ public class JButtonBuilder {
    * Values that must be set: title, actionlistener
    */
   public JButton build() {
-    Preconditions.checkNotNull(title);
-    Preconditions.checkState(!enabled || actionListener != null,
-        "Was enabled? " + enabled + ", action listener == null? " + (actionListener == null));
+    checkNotNull(title);
 
     final JButton button = new JButton(title);
     if (toolTip != null) {
       button.setToolTipText(toolTip);
     }
-    button.addActionListener(e -> actionListener.run());
+    Optional.ofNullable(actionListener)
+        .ifPresent(listener -> button.addActionListener(e -> listener.run()));
     button.setEnabled(enabled);
 
     if (biggerFont > 0) {


### PR DESCRIPTION
## Overview
- Inline methods and combine #updateGameData with #setWidgetActivation
- Extract static game file selection functionality to GameFileSelector
- Update API on game file selection to return optional instead of nullable
- Instanitate class variables at the class level where possible instead of constructor
- Break up boolean parameter'd save method, broke up cleanly between the 'true' and 'false' cases

## Functional Changes
none

## Manual Testing Performed
- checked game selector panel UI for unintended differences
- verified game selector panel functionality still worked

