### PR TITLE
MainPanel gridbag and component cleanup

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -4,9 +4,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
@@ -29,6 +26,9 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
 import games.strategy.ui.SwingAction;
+import swinglib.GridBagHelper;
+import swinglib.JButtonBuilder;
+import swinglib.JPanelBuilder;
 
 /**
  * When the game launches, the MainFrame is loaded which will contain
@@ -40,14 +40,26 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
   private static final long serialVersionUID = -5548760379892913464L;
   private static final Dimension initialSize = new Dimension(800, 620);
 
-  private final JButton playButton;
-  private final JButton cancelButton;
-  private ISetupPanel gameSetupPanel;
-  private final JPanel gameSetupPanelHolder;
-  private JPanel chatPanelHolder;
-  private final JPanel mainPanel = new JPanel();
-  private final JSplitPane chatSplit;
+  private final JButton playButton = JButtonBuilder.builder()
+      .title("Play")
+      .toolTip("<html>Start your game! <br>"
+          + "If not enabled, then you must select a way to play your game first: <br>"
+          + "Play Online, or Local Game, or PBEM, or Host Networked.</html>")
+      .build();
+  private final JButton cancelButton = JButtonBuilder.builder()
+      .title("Cancel")
+      .build();
 
+  private final JPanel gameSetupPanelHolder = JPanelBuilder.builder()
+      .borderLayout()
+      .build();
+  private final JPanel mainPanel;
+  private final JSplitPane chatSplit;
+  private final JPanel chatPanelHolder = JPanelBuilder.builder()
+      .borderLayout()
+      .preferredHeight(62)
+      .build();
+  private ISetupPanel gameSetupPanel;
   private boolean isChatShowing;
   private final Supplier<Optional<IChatPanel>> chatPanelSupplier;
 
@@ -61,53 +73,47 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
       final Supplier<Optional<IChatPanel>> chatPanelSupplier,
       final Runnable cancelAction) {
     this.chatPanelSupplier = chatPanelSupplier;
-    playButton = new JButton("Play");
-    playButton.setToolTipText("<html>Start your game! <br>"
-        + "If not enabled, then you must select a way to play your game first: <br>"
-        + "Play Online, or Local Game, or PBEM, or Host Networked.</html>");
-    final JButton quitButton = new JButton("Quit");
-    quitButton.setToolTipText("Close TripleA.");
-    cancelButton = new JButton("Cancel");
-    cancelButton.setToolTipText("Go back to main screen.");
+    playButton.addActionListener(e -> launchAction.accept(this));
+    cancelButton.addActionListener(e -> cancelAction.run());
+
     gameSelectorPanel.setBorder(new EtchedBorder());
-    gameSetupPanelHolder = new JPanel();
-    gameSetupPanelHolder.setLayout(new BorderLayout());
     final JScrollPane gameSetupPanelScroll = new JScrollPane(gameSetupPanelHolder);
     gameSetupPanelScroll.setBorder(BorderFactory.createEmptyBorder());
-    chatPanelHolder = new JPanel();
-    chatPanelHolder.setLayout(new BorderLayout());
     chatSplit = new JSplitPane();
     chatSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);
     chatSplit.setResizeWeight(0.8);
     chatSplit.setOneTouchExpandable(false);
     chatSplit.setDividerSize(5);
 
-    final JPanel buttonsPanel = new JPanel();
-    buttonsPanel.setBorder(new EtchedBorder());
-    buttonsPanel.setLayout(new FlowLayout(FlowLayout.CENTER));
-    buttonsPanel.add(playButton);
-    buttonsPanel.add(quitButton);
+    mainPanel = JPanelBuilder.builder()
+        .borderEmpty()
+        .gridBagLayout(2)
+        .add(gameSelectorPanel, GridBagHelper.Anchor.WEST, GridBagHelper.Fill.VERTICAL)
+        .add(gameSetupPanelScroll, GridBagHelper.Anchor.CENTER, GridBagHelper.Fill.VERTICAL_AND_HORIZONTAL)
+        .build();
+
     setLayout(new BorderLayout());
-    mainPanel.setLayout(new GridBagLayout());
-    mainPanel.setBorder(BorderFactory.createEmptyBorder());
-    gameSetupPanelHolder.setLayout(new BorderLayout());
-    mainPanel.add(gameSelectorPanel, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.VERTICAL, new Insets(0, 0, 0, 0), 0, 0));
-    mainPanel.add(gameSetupPanelScroll, new GridBagConstraints(1, 0, 1, 1, 1, 1, GridBagConstraints.CENTER,
-        GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
     addChat();
+
+    final JButton quitButton = JButtonBuilder.builder()
+        .title("Quit")
+        .toolTip("Close TripleA.")
+        .actionListener(() -> {
+          try {
+            gameSetupPanel.shutDown();
+          } finally {
+            GameRunner.quitGame();
+          }
+        })
+        .build();
+    final JPanel buttonsPanel = JPanelBuilder.builder()
+        .borderEtched()
+        .flowLayout(JPanelBuilder.FlowLayoutJustification.CENTER)
+        .add(playButton)
+        .add(quitButton)
+        .build();
     add(buttonsPanel, BorderLayout.SOUTH);
     setPreferredSize(initialSize);
-
-    playButton.addActionListener(e -> launchAction.accept(this));
-    quitButton.addActionListener(e -> {
-      try {
-        gameSetupPanel.shutDown();
-      } finally {
-        GameRunner.quitGame();
-      }
-    });
-    cancelButton.addActionListener(e -> cancelAction.run());
     setWidgetActivation();
   }
 
@@ -117,15 +123,9 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
     chatPanelHolder.removeAll();
     final IChatPanel chat = chatPanelSupplier.get().orElse(null);
     if (chat != null && !chat.isHeadless()) {
-      chatPanelHolder = new JPanel();
-      chatPanelHolder.setLayout(new BorderLayout());
-      chatPanelHolder.setPreferredSize(new Dimension(chatPanelHolder.getPreferredSize().width, 62));
-
       chatPanelHolder.add((Component) chat, BorderLayout.CENTER);
-
       chatSplit.setTopComponent(mainPanel);
       chatSplit.setBottomComponent(chatPanelHolder);
-
       add(chatSplit, BorderLayout.CENTER);
     } else {
       add(mainPanel, BorderLayout.CENTER);

--- a/game-core/src/main/java/org/triplea/client/launch/screens/NavigationPanelFactory.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/NavigationPanelFactory.java
@@ -26,7 +26,6 @@ public class NavigationPanelFactory {
     final JButton playButton = JButtonBuilder.builder()
         .biggerFont()
         .title("Play")
-        .enabled(true)
         .actionListener(() -> {
           playButtonAction.run();
           gameStartedCallback.gameIsStarted();
@@ -40,7 +39,6 @@ public class NavigationPanelFactory {
         .add(Box.createHorizontalStrut(50))
         .add(JButtonBuilder.builder()
             .title("Back")
-            .enabled(true)
             .actionListener(() -> LaunchScreenWindow.draw(previousScreen))
             .build())
         .add(Box.createHorizontalStrut(50))
@@ -60,7 +58,7 @@ public class NavigationPanelFactory {
     final JButton playButton = JButtonBuilder.builder()
         .biggerFont()
         .title("Play")
-        .enabled(false)
+        .disabled()
         .build();
 
     return JPanelBuilder.builder()
@@ -71,7 +69,6 @@ public class NavigationPanelFactory {
         .addIf(screenWindow.getPreviousScreen()
             .map(prevScreen -> JButtonBuilder.builder()
                 .title("Back")
-                .enabled(true)
                 .actionListener(() -> LaunchScreenWindow.draw(prevScreen))
                 .build()))
         .add(Box.createHorizontalStrut(50))

--- a/game-core/src/main/java/org/triplea/client/launch/screens/PlayByForumSetup.java
+++ b/game-core/src/main/java/org/triplea/client/launch/screens/PlayByForumSetup.java
@@ -38,7 +38,7 @@ class PlayByForumSetup {
 
     final JButton viewForumButton = JButtonBuilder.builder()
         .title("View Forum")
-        .enabled(false)
+        .disabled()
         .actionListener(
             () -> OpenFileUtility.openUrl(UrlConstants.TRIPLEA_FORUM.toString() + "/topic/" + topicIdField.getText()))
         .build();
@@ -46,7 +46,7 @@ class PlayByForumSetup {
 
     final JButton testPostButton = JButtonBuilder.builder()
         .title("Test Post")
-        .enabled(false)
+        .disabled()
         .actionListener(() -> {
         })
         .build();

--- a/game-core/src/main/java/swinglib/JButtonBuilder.java
+++ b/game-core/src/main/java/swinglib/JButtonBuilder.java
@@ -3,6 +3,7 @@ package swinglib;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Font;
+import java.util.Optional;
 
 import javax.swing.JButton;
 import javax.swing.UIManager;
@@ -24,7 +25,7 @@ public class JButtonBuilder {
   private String title;
   private String toolTip;
   private Runnable actionListener;
-  private boolean enabled = false;
+  private boolean enabled = true;
   private boolean selected = false;
   private int biggerFont = 0;
 
@@ -39,15 +40,14 @@ public class JButtonBuilder {
    * Values that must be set: title, actionlistener
    */
   public JButton build() {
-    Preconditions.checkNotNull(title);
-    Preconditions.checkState(!enabled || actionListener != null,
-        "Was enabled? " + enabled + ", action listener == null? " + (actionListener == null));
+    checkNotNull(title);
 
     final JButton button = new JButton(title);
     if (toolTip != null) {
       button.setToolTipText(toolTip);
     }
-    button.addActionListener(e -> actionListener.run());
+    Optional.ofNullable(actionListener)
+        .ifPresent(listener -> button.addActionListener(e -> listener.run()));
     button.setEnabled(enabled);
 
     if (biggerFont > 0) {
@@ -119,15 +119,14 @@ public class JButtonBuilder {
    */
   public JButtonBuilder actionListener(final Runnable actionListener) {
     this.actionListener = checkNotNull(actionListener);
-    enabled = true;
     return this;
   }
 
   /**
    * Whether the button can be clicked on or not.
    */
-  public JButtonBuilder enabled(final boolean enabled) {
-    this.enabled = enabled;
+  public JButtonBuilder disabled() {
+    enabled = false;
     return this;
   }
 }


### PR DESCRIPTION
## Overview
- Move initialization of components in MainPanel to class declaration (from constructor).
- Use simplified panel builder grid bag support for MainPanel grid bag layout. Needed to wire settings for anchor and fill settings to the gridbag helper
- Simplify button builder API, enable by default. We also drop enforcement that the button action be defined at construction time. In our case we need a parameter value to define the button action, so its useful to construct the button first and set the action later.


## Functional Changes
None

## Manual Testing Performed
- Verified game selector UI on main panel looked good after these updates. 

## Before & After Screen Shots
no changes

## Additional Review notes
- There is a good bit of added code to the swing builders. Some of it is API cleanups, beyond that we enable additional FlowLayout constructors and to specify gridbag anchors and fill. Of note we get a type safe API for these and do not need to rely on Swing magic integer values.
