### PR TITLE
Remove setup panel shutdown listeners.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -85,16 +85,6 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     return text.getText();
   }
 
-  void shutDown() {
-    if (chat != null) {
-      chat.removeChatListener(this);
-      cleanupKeyMap();
-    }
-    chat = null;
-    this.setVisible(false);
-    this.removeAll();
-  }
-
   void setChat(final Chat chat) {
     Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       if (chat != null) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -72,18 +72,6 @@ public class ChatPanel extends JPanel implements IChatPanel {
   }
 
   @Override
-  public void shutDown() {
-    // get first, before below turns it null
-    final Chat chat = getChat();
-    chatMessagePanel.shutDown();
-    chatPlayerPanel.shutDown();
-    if (chat != null) {
-      // now shut down
-      chat.shutdown();
-    }
-  }
-
-  @Override
   public void setChat(final Chat chat) {
     chatMessagePanel.setChat(chat);
     chatPlayerPanel.setChat(chat);

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -74,16 +74,6 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
     hiddenPlayers.add(name);
   }
 
-  void shutDown() {
-    if (chat != null) {
-      chat.removeChatListener(this);
-      chat.getStatusManager().removeStatusListener(statusListener);
-    }
-    chat = null;
-    this.setVisible(false);
-    this.removeAll();
-  }
-
   public void setChat(final Chat chat) {
     if (this.chat != null) {
       this.chat.removeChatListener(this);

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -66,15 +66,6 @@ public class HeadlessChat implements IChatListener, IChatPanel {
   public void updatePlayerList(final Collection<INode> players) {}
 
   @Override
-  public void shutDown() {
-    if (chat != null) {
-      chat.removeChatListener(this);
-      chat.shutdown();
-    }
-    chat = null;
-  }
-
-  @Override
   public void setChat(final Chat chat) {
     if (this.chat != null) {
       this.chat.removeChatListener(this);

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatPanel.java
@@ -10,8 +10,6 @@ import javax.swing.DefaultListCellRenderer;
 public interface IChatPanel {
   boolean isHeadless();
 
-  void shutDown();
-
   void setChat(final Chat chat);
 
   Chat getChat();

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -531,9 +531,6 @@ public class HeadlessGameServer {
     Optional.ofNullable(setupPanelModel)
         .ifPresent(model -> model.getPanel().cancel());
 
-    if (gameSelectorModel != null && gameSelectorModel.getGameData() != null) {
-      gameSelectorModel.getGameData().clearAllListeners();
-    }
     System.out.println("Shutdown Script Finished.");
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -528,16 +528,6 @@ public class HeadlessGameServer {
       logger.log(Level.SEVERE, "Failed to stop game", e);
     }
     try {
-      if (setupPanelModel != null) {
-        final ISetupPanel setup = setupPanelModel.getPanel();
-        if (setup instanceof HeadlessServerSetup) {
-          setup.shutDown();
-        }
-      }
-    } catch (final Exception e) {
-      logger.log(Level.SEVERE, "Failed to shutdown setup panel", e);
-    }
-    try {
       if (gameSelectorModel != null && gameSelectorModel.getGameData() != null) {
         gameSelectorModel.getGameData().clearAllListeners();
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -527,16 +528,12 @@ public class HeadlessGameServer {
     } catch (final Exception e) {
       logger.log(Level.SEVERE, "Failed to stop game", e);
     }
-    try {
-      if (gameSelectorModel != null && gameSelectorModel.getGameData() != null) {
-        gameSelectorModel.getGameData().clearAllListeners();
-      }
-    } catch (final Exception e) {
-      logger.log(Level.SEVERE, "Failed to clear all game data listeners", e);
+    Optional.ofNullable(setupPanelModel)
+        .ifPresent(model -> model.getPanel().cancel());
+
+    if (gameSelectorModel != null && gameSelectorModel.getGameData() != null) {
+      gameSelectorModel.getGameData().clearAllListeners();
     }
-    instance = null;
-    setupPanelModel = null;
-    game = null;
     System.out.println("Shutdown Script Finished.");
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -64,13 +64,6 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   }
 
   @Override
-  public void shutDown() {
-    model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
-    model.shutDown();
-    lobbyWatcher.shutDown();
-  }
-
-  @Override
   public void cancel() {
     model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
     model.cancel();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -271,7 +271,7 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   /**
-   * Same as @{code shutdown()} but keeps chat alive.
+   * Resets stats and nulls out references, keeps chat alive.
    */
   public void cancel() {
     if (messenger == null) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -271,25 +271,6 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   /**
-   * Nulls everything out and flags everything for shutdown.
-   */
-  // TODO: do we really have to null everything out?? can we just null out the gameSelectorModel?
-  public void shutDown() {
-    if (messenger == null) {
-      return;
-    }
-    objectStreamFactory.setData(null);
-    messenger.shutDown();
-    chatPanel.shutDown();
-    gameSelectorModel.setGameData(null);
-    gameSelectorModel.setCanSelect(false);
-    hostIsHeadlessBot = false;
-    gameSelectorModel.setIsHostHeadlessBot(false);
-    gameSelectorModel.setClientModelForHostBots(null);
-    messenger.removeErrorListener(this);
-  }
-
-  /**
    * Same as @{code shutdown()} but keeps chat alive.
    */
   public void cancel() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -132,16 +132,6 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     headless = (interactionMode == InteractionMode.HEADLESS);
   }
 
-  public void shutDown() {
-    gameSelectorModel.deleteObserver(gameSelectorObserver);
-    if (serverMessenger != null) {
-      chatController.deactivate();
-      serverMessenger.shutDown();
-      serverMessenger.removeErrorListener(this);
-      chatPanel.shutDown();
-    }
-  }
-
   public void cancel() {
     gameSelectorModel.deleteObserver(gameSelectorObserver);
     if (serverMessenger != null) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -150,11 +150,6 @@ public class ClientSetupPanel extends SetupPanel {
   }
 
   @Override
-  public void shutDown() {
-    clientModel.shutDown();
-  }
-
-  @Override
   public void cancel() {
     clientModel.cancel();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -33,8 +33,6 @@ public interface ISetupPanel {
    */
   void cancel();
 
-  void shutDown();
-
   /**
    * Indicates we can start the game.
    */

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -53,11 +53,6 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
   }
 
   @Override
-  public void shutDown() {
-    gameSelectorModel.deleteObserver(this);
-  }
-
-  @Override
   public void cancel() {
     gameSelectorModel.deleteObserver(this);
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -170,9 +170,6 @@ public class MetaSetupPanel extends SetupPanel {
   }
 
   @Override
-  public void shutDown() {}
-
-  @Override
   public boolean showCancelButton() {
     return false;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -254,11 +254,6 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     return cached == null ? instance : cached;
   }
 
-  @Override
-  public void shutDown() {
-    gameSelectorModel.deleteObserver(this);
-  }
-
   /**
    * Called when the current game changes.
    */

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -228,13 +228,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   @Override
-  public void shutDown() {
-    model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
-    model.shutDown();
-    lobbyWatcher.shutDown();
-  }
-
-  @Override
   public void cancel() {
     model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
     model.cancel();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -100,13 +100,7 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
     setPreferredSize(initialSize);
 
     playButton.addActionListener(e -> launchAction.accept(this));
-    quitButton.addActionListener(e -> {
-      try {
-        gameSetupPanel.shutDown();
-      } finally {
-        GameRunner.quitGame();
-      }
-    });
+    quitButton.addActionListener(e -> GameRunner.quitGame());
     cancelButton.addActionListener(e -> cancelAction.run());
     setWidgetActivation();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -98,7 +98,7 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
     final JButton quitButton = JButtonBuilder.builder()
         .title("Quit")
         .toolTip("Close TripleA.")
-        .addActionListener(e -> GameRunner.quitGame())
+        .actionListener(GameRunner::quitGame)
         .build();
     final JPanel buttonsPanel = JPanelBuilder.builder()
         .borderEtched()


### PR DESCRIPTION

## Overview
On shutdown all objects which we 'close' are falling out of scope and getting cleaned up anyways. We should get the same cleanup just through normal GC and the JVM terminating.


## Functional Changes
None

## Manual Testing Performed
- Check starts screens that game quits, can launch and quit cleanly.

