### PR TITLE
Map creator launch within the same process

### DIFF
--- a/docs/map_making/map_and_map_skin_making_overview.md
+++ b/docs/map_making/map_and_map_skin_making_overview.md
@@ -196,15 +196,10 @@ Files:
 </p>
 <br>
 <p>
-	Now for the map creator.
-	<br>To run the map creator, you can start TripleA, then click "Engine Preferences", then click "Map Creator".
-	<br>Alternatively, you can run it by command line:
-	<b>How to run the Map Creator</b>
+<h3>Now for the map creator</h3>
+<p>
+    To run the map creator, you can start TripleA, then click "Run Map Creator".
 </p>
-<pre><code>cd bin<br>java -Xmx512m -classpath triplea.jar util/image/MapCreator</code></pre>
-<br>Example:
-<br><img src="https://cloud.githubusercontent.com/assets/12397753/21297550/3c3b3ad2-c537-11e6-91d3-da344e2fb4f1.png" alt="map image">
-<br>
 <p>
 	Now that it is running, you will see a simple screen with some options on the left, and some options in the middle.
 	<br>The first button will load this html tutorial you are reading now.

--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -19,13 +19,6 @@ import games.strategy.engine.framework.system.SystemProperties;
  */
 public class ProcessRunnerUtil {
 
-  public static void runClass(final Class<?> mainClass) {
-    final List<String> commands = new ArrayList<>();
-    populateBasicJavaArgs(commands);
-    commands.add(mainClass.getName());
-    exec(commands);
-  }
-
   public static void populateBasicJavaArgs(final List<String> commands) {
     populateBasicJavaArgs(commands, SystemProperties.getJavaClassPath());
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -4,6 +4,7 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.Map;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -104,7 +105,7 @@ public class MetaSetupPanel extends SetupPanel {
 
     final JButton mapCreator = JButtonBuilder.builder()
         .title("Run the Map Creator")
-        .actionListener(() -> ProcessRunnerUtil.runClass(MapCreator.class))
+        .actionListener(MapCreator::openMapCreatorWindow)
         .build();
 
     add(mapCreator, new GridBagConstraints(0, 9, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,

--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -58,16 +58,8 @@ public class MapCreator extends JFrame {
   private final JPanel panel4 = new JPanel();
 
   /**
-   * Entry point for the map-making utilities application.
+   * Opens a map creator window.
    */
-  public static void main(final String[] args) throws Exception {
-    SwingAction.invokeAndWait(() -> {
-      ClientSetting.initialize();
-      LookAndFeel.setupLookAndFeel();
-    });
-    openMapCreatorWindow();
-  }
-
   public static void openMapCreatorWindow() {
     Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       final MapCreator creator = new MapCreator();
@@ -110,10 +102,10 @@ public class MapCreator extends JFrame {
     part3.addActionListener(SwingAction.of("Part 3", e -> setupMainPanel(panel3)));
     part4.addActionListener(SwingAction.of("Part 4", e -> setupMainPanel(panel4)));
     // set up the menu actions
-    final Action exitAction = SwingAction.of("Exit", e -> System.exit(0));
-    exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
+    final Action closeAction = SwingAction.of("Close", e -> this.dispose());
+    closeAction.putValue(Action.SHORT_DESCRIPTION, "Close Window");
     // set up the menu items
-    final JMenuItem exitItem = new JMenuItem(exitAction);
+    final JMenuItem exitItem = new JMenuItem(closeAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();
     setJMenuBar(menuBar);

--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -29,6 +29,7 @@ import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
+import games.strategy.util.Interruptibles;
 import tools.image.AutoPlacementFinder;
 import tools.image.CenterPicker;
 import tools.image.DecorationPlacer;
@@ -63,12 +64,17 @@ public class MapCreator extends JFrame {
     SwingAction.invokeAndWait(() -> {
       ClientSetting.initialize();
       LookAndFeel.setupLookAndFeel();
+    });
+    openMapCreatorWindow();
+  }
 
+  public static void openMapCreatorWindow() {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
       final MapCreator creator = new MapCreator();
       creator.setSize(800, 600);
       creator.setLocationRelativeTo(null);
       creator.setVisible(true);
-    });
+    }));
   }
 
   private MapCreator() {


### PR DESCRIPTION
## Overview
Instead of using ProcessRunnerUtil to launch a `MapCreator` window, we can simply launch the window within the same process. 

## Functional Changes
- 'exit' button on map creator window converted to a 'close' button
- At a system level the map creator will be run within the same java process as the main client app.

## Manual Testing Performed
- Checked before and after that the map creator launched and looked the same
- Verified the updated close window behavior of the map creator
- Did a `grep -r` for MapCreator, found no references in scripting

