### PR TITLE
Remove unnecessary synchronize block

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -80,9 +80,7 @@ public class GameSelectorModel extends Observable {
         newData = GameDataManager.loadGame(file);
       }
       if (newData != null) {
-        synchronized (this) {
-          fileName = file.getName();
-        }
+        fileName = file.getName();
         setGameData(newData);
       }
     } catch (final EngineVersionException e) {


### PR DESCRIPTION
## Overview
Hard to see the logic for why it is needed:
- Syncing on otherwise atomic operations.
- Does not look correct if needed, the scope of the lock would need to be larger
- Other access to same variable are not locked.


## Functional Changes
none

## Manual Testing Performed
none

