### PR TITLE
PlayerListing, ensure we create a copy of collection types before serialization

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -3,6 +3,8 @@ package games.strategy.engine.framework.message;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -11,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 
 import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.triplea.NetworkData;
@@ -44,13 +47,25 @@ public class PlayerListing implements Serializable {
   /**
    * Creates a new instance of PlayerListing.
    */
-  public PlayerListing(final Map<String, String> playerToNodeListing, final Map<String, Boolean> playersEnabledListing,
-      final Map<String, PlayerType> localPlayerTypes, final Version gameVersion, final String gameName,
-      final String gameRound, final Collection<String> playersAllowedToBeDisabled,
+  public PlayerListing(
+      final Map<String, String> playerToNodeListing,
+      final Map<String, Boolean> playersEnabledListing,
+      final Map<String, PlayerType> localPlayerTypes,
+      final Version gameVersion,
+      final String gameName,
+      final String gameRound,
+      final Collection<String> playersAllowedToBeDisabled,
       final Map<String, Collection<String>> playerNamesAndAlliancesInTurnOrder) {
 
-    m_playerToNodeListing = Optional.ofNullable(playerToNodeListing).orElse(Collections.emptyMap());
-    m_playersEnabledListing = Optional.ofNullable(playersEnabledListing).orElse(Collections.emptyMap());
+    // Note: Sets from guava immutables are not necessarily serializable (!)
+    // We use copy constructors here to avoid this problem.
+
+    m_playerToNodeListing = Optional.ofNullable(playerToNodeListing)
+        .map(HashMap::new)
+        .orElse(new HashMap<>(0));
+    m_playersEnabledListing = Optional.ofNullable(playersEnabledListing)
+        .map(HashMap::new)
+        .orElse(new HashMap<>(0));
     m_localPlayerTypes = Optional.ofNullable(localPlayerTypes.entrySet()
         .stream()
         // convert Map<String,PlayerType> -> Map<String,String>
@@ -59,9 +74,17 @@ public class PlayerListing implements Serializable {
     m_gameVersion = gameVersion;
     m_gameName = gameName;
     m_gameRound = gameRound;
-    m_playersAllowedToBeDisabled = Optional.ofNullable(playersAllowedToBeDisabled).orElse(Collections.emptySet());
-    m_playerNamesAndAlliancesInTurnOrder =
-        Optional.ofNullable(playerNamesAndAlliancesInTurnOrder).orElse(Collections.emptyMap());
+    m_playersAllowedToBeDisabled = Optional.ofNullable(playersAllowedToBeDisabled)
+        .map(HashSet::new)
+        .orElse(new HashSet<>(0));
+
+    final Map<String, Collection<String>> allianceMap =
+        Optional.ofNullable(playerNamesAndAlliancesInTurnOrder)
+            .orElse(Collections.emptyMap());
+
+    m_playerNamesAndAlliancesInTurnOrder = allianceMap.entrySet()
+        .stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> Sets.newHashSet(e.getValue())));
 
     // make sure none of the collection values are null.
     Preconditions.checkArgument(m_playerToNodeListing.values().stream().noneMatch(Objects::isNull),
@@ -75,6 +98,7 @@ public class PlayerListing implements Serializable {
     Preconditions.checkArgument(m_playerNamesAndAlliancesInTurnOrder.values().stream().noneMatch(Objects::isNull),
         m_playerNamesAndAlliancesInTurnOrder.toString());
   }
+
 
   public Collection<String> getPlayersAllowedToBeDisabled() {
     return m_playersAllowedToBeDisabled;


### PR DESCRIPTION
## Overview

Fixes: https://github.com/triplea-game/triplea/issues/3614

Problem was introduced here: https://github.com/triplea-game/triplea/pull/3592/files#diff-f72e8d0ae698abae1bbc70eb2ca08b68L59


Attempting to serialize some guava immutable sets can lead to errors later: https://github.com/triplea-game/triplea/issues/3614

This update will fix that problem, previously we created copies of collections in PlayerListing, this update restores that behavior.


## Manual Testing Performed
- verify that a server hosting updated code could accept incoming connections