### PR TITLE
Remove unused CLI props: server observer join wait time and start game sync

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -24,8 +24,5 @@ public class CliProperties {
   public static final String LOBBY_GAME_RECONNECTION = "triplea.lobby.game.reconnection";
   public static final String DO_NOT_CHECK_FOR_UPDATES = "triplea.doNotCheckForUpdates";
 
-  public static final String TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME = "triplea.server.startGameSyncWaitTime";
-  public static final String TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME = "triplea.server.observerJoinWaitTime";
-
   public static final String MAP_FOLDER = "mapFolder";
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -18,8 +18,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_STARTED;
 
 import java.awt.Component;
@@ -332,8 +330,6 @@ public class GameRunner {
         + "   " + LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
         + "   " + LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
         + LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
-        + "   " + TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME + "=<seconds to wait for all clients to start the game>\n"
-        + "   " + TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME + "=<seconds to wait for an observer joining the game>\n"
         + "   " + MAP_FOLDER + "=mapFolder"
         + "\n"
         + "   You must start the Name and HostedBy with \"Bot\".\n"

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -12,8 +12,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME;
 
 import java.io.File;
 import java.io.InputStream;
@@ -485,7 +483,6 @@ public class HeadlessGameServer {
         TRIPLEA_NAME, LOBBY_HOST, LOBBY_PORT,
         LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY, LOBBY_GAME_SUPPORT_EMAIL,
         LOBBY_GAME_SUPPORT_PASSWORD, LOBBY_GAME_RECONNECTION,
-        TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME, TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
         MAP_FOLDER));
   }
 
@@ -666,10 +663,6 @@ public class HeadlessGameServer {
         + "   " + LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
         + "   " + LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
         + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
-        + "   " + TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME
-        + "=<seconds to wait for all clients to start the game>\n"
-        + "   " + TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME
-        + "=<seconds to wait for an observer joining the game>\n"
         + "   " + MAP_FOLDER + "=mapFolder"
         + "\n"
         + "   You must start the Name and HostedBy with \"Bot\".\n"


### PR DESCRIPTION
## Overview
Remove props are set up to read from CLI args, but we do not do anything with them, so they can be removed.

## Functional Changes
No system changes, the usage text will no longer print out information about the no longer used parameters.

## Manual Testing Performed
none

