### PR TITLE
Cache territory name bounds.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -217,12 +217,11 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     final Collection<PlayerID> dontSendTo = new ArrayList<>();
     dontSendTo.add(player);
 
-    final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
-    otherPlayers.remove(player);
-
     final Collection<PlayerID> targets = uaa.getActionAccept();
     sendNotificationToPlayers(targets, dontSendTo, targetNotification);
 
+    final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
+    otherPlayers.remove(player);
     otherPlayers.removeAll(targets);
     dontSendTo.addAll(targets);
     sendNotificationToPlayers(otherPlayers, dontSendTo, notification);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -198,8 +198,18 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   private void notifySuccess(final UserActionAttachment uaa) {
     // play a sound
     getSoundChannel().playSoundForAll(SoundPath.CLIP_USER_ACTION_SUCCESSFUL, player);
-    sendNotification(UserActionText.getInstance().getNotificationSucccess(uaa.getText()));
-    notifyOtherPlayers(UserActionText.getInstance().getNotificationSuccessOthers(uaa.getText()));
+    final UserActionText uat = UserActionText.getInstance();
+    sendNotification(uat.getNotificationSucccess(uaa.getText()));
+    notifyOtherPlayers(uat.getNotificationSuccessOthers(uaa.getText()), getOtherNotificationPlayers(uaa));
+  }
+
+  private Collection<PlayerID> getOtherNotificationPlayers(final UserActionAttachment uaa) {
+    if (UserActionText.getInstance().shouldNotifyAcceptersOnly()) {
+      return uaa.getActionAccept();
+    }
+    final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
+    otherPlayers.remove(player);
+    return otherPlayers;
   }
 
   /**
@@ -219,13 +229,10 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    * Send a notification to the other players involved in this action (all
    * players except the player starting the action).
    */
-  private void notifyOtherPlayers(final String notification) {
+  private void notifyOtherPlayers(final String notification, final Collection<PlayerID> otherPlayers) {
     if (!"NONE".equals(notification)) {
-      // we can send it to just uaa.getOtherPlayers(), or we can send it to all players. both are good options.
       final Collection<PlayerID> currentPlayer = new ArrayList<>();
       currentPlayer.add(player);
-      final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
-      otherPlayers.removeAll(currentPlayer);
       this.getDisplay().reportMessageToPlayers(otherPlayers, currentPlayer, notification, notification);
     }
   }
@@ -242,8 +249,9 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     final String transcriptText =
         bridge.getPlayerId().getName() + " fails on action: " + MyFormatter.attachmentNameToText(uaa.getName());
     bridge.getHistoryWriter().addChildToEvent(transcriptText);
-    sendNotification(UserActionText.getInstance().getNotificationFailure(uaa.getText()));
-    notifyOtherPlayers(UserActionText.getInstance().getNotificationFailureOthers(uaa.getText()));
+    final UserActionText uat = UserActionText.getInstance();
+    sendNotification(uat.getNotificationFailure(uaa.getText()));
+    notifyOtherPlayers(uat.getNotificationFailureOthers(uaa.getText()), getOtherNotificationPlayers(uaa));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -213,18 +213,18 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    * Send notifications to the other players (all players except the player starting the action).
    */
   private void notifyOtherPlayers(final UserActionAttachment uaa, final String notification,
-                                  final String notificationParticipants) {
+                                  final String targetNotification) {
     final Collection<PlayerID> dontSendTo = new ArrayList<>();
     dontSendTo.add(player);
 
     final Collection<PlayerID> otherPlayers = getData().getPlayerList().getPlayers();
     otherPlayers.remove(player);
 
-    final Collection<PlayerID> participants = uaa.getActionAccept();
-    sendNotificationToPlayers(participants, dontSendTo, notificationParticipants);
+    final Collection<PlayerID> targets = uaa.getActionAccept();
+    sendNotificationToPlayers(targets, dontSendTo, targetNotification);
 
-    otherPlayers.removeAll(participants);
-    dontSendTo.addAll(participants);
+    otherPlayers.removeAll(targets);
+    dontSendTo.addAll(targets);
     sendNotificationToPlayers(otherPlayers, dontSendTo, notification);
   }
 
@@ -240,7 +240,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     final UserActionText uat = UserActionText.getInstance();
     final String text = uaa.getText();
     sendNotification(uat.getNotificationSucccess(text));
-    notifyOtherPlayers(uaa, uat.getNotificationSuccessOthers(text), uat.getNotificationSuccessParticipants(text));
+    notifyOtherPlayers(uaa, uat.getNotificationSuccessOthers(text), uat.getNotificationSuccessTarget(text));
   }
 
   /**
@@ -258,7 +258,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     final UserActionText uat = UserActionText.getInstance();
     final String text = uaa.getText();
     sendNotification(uat.getNotificationFailure(text));
-    notifyOtherPlayers(uaa, uat.getNotificationFailureOthers(text), uat.getNotificationFailureParticipants(text));
+    notifyOtherPlayers(uaa, uat.getNotificationFailureOthers(text), uat.getNotificationFailureTarget(text));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -85,7 +85,7 @@ public class UserActionText {
     if (hasMessage(actionKey, TARGET_NOTIFICATION_SUCCESS)) {
       return getMessage(actionKey, TARGET_NOTIFICATION_SUCCESS);
     } else {
-      return getNotificationSuccessOthers();
+      return getNotificationSuccessOthers(actionKey);
     }
   }
 
@@ -101,7 +101,7 @@ public class UserActionText {
     if (hasMessage(actionKey, TARGET_NOTIFICATION_FAILURE)) {
       return getMessage(actionKey, TARGET_NOTIFICATION_FAILURE);
     } else {
-      return getNotificationFailureOthers();
+      return getNotificationFailureOthers(actionKey);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -26,6 +26,7 @@ public class UserActionText {
   private static final String NOTIFICATION_FAILURE = "NOTIFICATION_FAILURE";
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
+  private static final String OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY = "OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY";
 
   protected UserActionText() {
     final ResourceLoader loader = AbstractUiContext.getResourceLoader();
@@ -85,5 +86,9 @@ public class UserActionText {
 
   public String getAcceptanceQuestion(final String actionKey) {
     return getMessage(actionKey, ACCEPT_QUESTION);
+  }
+
+  public boolean shouldNotifyAcceptersOnly() {
+    return "true".equalsIgnoreCase(properties.getProperty(OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -23,10 +23,11 @@ public class UserActionText {
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
   private static final String OTHER_NOTIFICATION_SUCCESS = "OTHER_NOTIFICATION_SUCCESS";
+  private static final String PARTICIPANTS_NOTIFICATION_SUCCESS = "PARTICIPANTS_NOTIFICATION_SUCCESS";
   private static final String NOTIFICATION_FAILURE = "NOTIFICATION_FAILURE";
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
+  private static final String PARTICIPANTS_NOTIFICATION_FAILURE = "PARTICIPANTS_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
-  private static final String OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY = "OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY";
 
   protected UserActionText() {
     final ResourceLoader loader = AbstractUiContext.getResourceLoader();
@@ -60,6 +61,10 @@ public class UserActionText {
     return getString(actionKey + "." + messageKey);
   }
 
+  private boolean hasMessage(final String actionKey, final String messageKey) {
+    return properties.containsKey(actionKey + "." + messageKey);
+  }
+
   public String getButtonText(final String actionKey) {
     return getMessage(actionKey, BUTTON);
   }
@@ -76,6 +81,14 @@ public class UserActionText {
     return getMessage(actionKey, OTHER_NOTIFICATION_SUCCESS);
   }
 
+  public String getNotificationSuccessParticipants(final String actionKey) {
+    if (hasMessage(actionKey, PARTICIPANTS_NOTIFICATION_SUCCESS)) {
+      return getMessage(actionKey, PARTICIPANTS_NOTIFICATION_SUCCESS);
+    } else {
+      return getMessage(actionKey, OTHER_NOTIFICATION_SUCCESS);
+    }
+  }
+
   public String getNotificationFailure(final String actionKey) {
     return getMessage(actionKey, NOTIFICATION_FAILURE);
   }
@@ -84,11 +97,15 @@ public class UserActionText {
     return getMessage(actionKey, OTHER_NOTIFICATION_FAILURE);
   }
 
-  public String getAcceptanceQuestion(final String actionKey) {
-    return getMessage(actionKey, ACCEPT_QUESTION);
+  public String getNotificationFailureParticipants(final String actionKey) {
+    if (hasMessage(actionKey, PARTICIPANTS_NOTIFICATION_FAILURE)) {
+      return getMessage(actionKey, PARTICIPANTS_NOTIFICATION_FAILURE);
+    } else {
+      return getMessage(actionKey, OTHER_NOTIFICATION_FAILURE);
+    }
   }
 
-  public boolean shouldNotifyAcceptersOnly() {
-    return "true".equalsIgnoreCase(properties.getProperty(OTHER_NOTIFICATIONS_GO_TO_ACCEPTERS_ONLY));
+  public String getAcceptanceQuestion(final String actionKey) {
+    return getMessage(actionKey, ACCEPT_QUESTION);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -22,11 +22,11 @@ public class UserActionText {
   private static final String BUTTON = "BUTTON";
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
+  private static final String TARGET_NOTIFICATION_SUCCESS = "TARGET_NOTIFICATION_SUCCESS";
   private static final String OTHER_NOTIFICATION_SUCCESS = "OTHER_NOTIFICATION_SUCCESS";
-  private static final String PARTICIPANTS_NOTIFICATION_SUCCESS = "PARTICIPANTS_NOTIFICATION_SUCCESS";
   private static final String NOTIFICATION_FAILURE = "NOTIFICATION_FAILURE";
+  private static final String TARGET_NOTIFICATION_FAILURE = "TARGET_NOTIFICATION_FAILURE";
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
-  private static final String PARTICIPANTS_NOTIFICATION_FAILURE = "PARTICIPANTS_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
 
   protected UserActionText() {
@@ -81,11 +81,11 @@ public class UserActionText {
     return getMessage(actionKey, OTHER_NOTIFICATION_SUCCESS);
   }
 
-  public String getNotificationSuccessParticipants(final String actionKey) {
-    if (hasMessage(actionKey, PARTICIPANTS_NOTIFICATION_SUCCESS)) {
-      return getMessage(actionKey, PARTICIPANTS_NOTIFICATION_SUCCESS);
+  public String getNotificationSuccessTarget(final String actionKey) {
+    if (hasMessage(actionKey, TARGET_NOTIFICATION_SUCCESS)) {
+      return getMessage(actionKey, TARGET_NOTIFICATION_SUCCESS);
     } else {
-      return getMessage(actionKey, OTHER_NOTIFICATION_SUCCESS);
+      return getNotificationSuccessOthers();
     }
   }
 
@@ -97,11 +97,11 @@ public class UserActionText {
     return getMessage(actionKey, OTHER_NOTIFICATION_FAILURE);
   }
 
-  public String getNotificationFailureParticipants(final String actionKey) {
-    if (hasMessage(actionKey, PARTICIPANTS_NOTIFICATION_FAILURE)) {
-      return getMessage(actionKey, PARTICIPANTS_NOTIFICATION_FAILURE);
+  public String getNotificationFailureTarget(final String actionKey) {
+    if (hasMessage(actionKey, TARGET_NOTIFICATION_FAILURE)) {
+      return getMessage(actionKey, TARGET_NOTIFICATION_FAILURE);
     } else {
-      return getMessage(actionKey, OTHER_NOTIFICATION_FAILURE);
+      return getNotificationFailureOthers();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -21,6 +21,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 public class TerritoryNameDrawable implements IDrawable {
   private final String territoryName;
   private final UiContext uiContext;
+  private Rectangle territoryBounds;
 
   public TerritoryNameDrawable(final String territoryName, final UiContext uiContext) {
     this.territoryName = territoryName;
@@ -80,7 +81,10 @@ public class TerritoryNameDrawable implements IDrawable {
       x = namePlace.get().x;
       y = namePlace.get().y;
     } else {
-      final Rectangle territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
+      if (territoryBounds == null) {
+        // Cache the bounds since re-computing it is expensive.
+        territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
+      }
       x = territoryBounds.x + (int) territoryBounds.getWidth() / 2 - fm.stringWidth(territory.getName()) / 2;
       y = territoryBounds.y + (int) territoryBounds.getHeight() / 2 + fm.getAscent() / 2;
     }


### PR DESCRIPTION
## Overview

Cache territory name bounds.
    
Profiling revealed this part is expensive, because to find the
best rectangle it tests whether a bunch of different rectangles
intersect with the territory bounds.
    
Looks like it can be easily cached however.

## Functional Changes

No intended user visible changes.

## Manual Testing Performed

Load Feudal Japan and check that things still look OK. Try different zoom levels.