### PR TITLE
Cache territory name bounds.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -21,6 +21,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 public class TerritoryNameDrawable implements IDrawable {
   private final String territoryName;
   private final UiContext uiContext;
+  private Rectangle territoryBounds;
 
   public TerritoryNameDrawable(final String territoryName, final UiContext uiContext) {
     this.territoryName = territoryName;
@@ -80,7 +81,10 @@ public class TerritoryNameDrawable implements IDrawable {
       x = namePlace.get().x;
       y = namePlace.get().y;
     } else {
-      final Rectangle territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
+      if (territoryBounds == null) {
+        // Cache the bounds since re-computing it is expensive.
+        territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
+      }
       x = territoryBounds.x + (int) territoryBounds.getWidth() / 2 - fm.stringWidth(territory.getName()) / 2;
       y = territoryBounds.y + (int) territoryBounds.getHeight() / 2 + fm.getAscent() / 2;
     }


### PR DESCRIPTION
## Overview
Cache territory name bounds.

Profiling revealed this part is expensive, because to find the
best rectangle it tests whether a bunch of different rectangles
intersect with the territory bounds.

Looks like it can be easily cached however.

## Functional Changes

No user visible changes intended.

## Manual Testing Performed
- Load Feudal Japan map and check that map names render OK. Change zoom levels.
- Changing font sizes: On World at War map, try changing font size - for example from 12 to 20 and check that Kamchatka territory's name's location changes appropriately with the size change.