### PR TITLE
Allow ".append" for appending text instead of replacing tooltip

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -72,13 +72,21 @@ public class UnitType extends NamedAttachable {
     return Objects.hashCode(getName());
   }
 
+  /**
+   * Get unit type tooltip checking for custom tooltip content.
+   */
   public String getTooltip(final PlayerID playerId) {
     final String customTip = TooltipProperties.getInstance().getToolTip(this, playerId);
-    if (customTip == null || customTip.trim().length() <= 0) {
-      return UnitAttachment.get(this).toStringShortAndOnlyImportantDifferences(
-          (playerId == null ? PlayerID.NULL_PLAYERID : playerId));
+    if (customTip != null && customTip.trim().length() > 0) {
+      return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
     }
-    return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
+    final String generated = UnitAttachment.get(this)
+        .toStringShortAndOnlyImportantDifferences((playerId == null ? PlayerID.NULL_PLAYERID : playerId));
+    final String appendedTip = TooltipProperties.getInstance().getAppendedToolTip(this, playerId);
+    if (appendedTip != null && appendedTip.trim().length() > 0) {
+      return generated + LocalizeHtml.localizeImgLinksInHtml(appendedTip.trim());
+    }
+    return generated;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -77,14 +77,14 @@ public class UnitType extends NamedAttachable {
    */
   public String getTooltip(final PlayerID playerId) {
     final String customTip = TooltipProperties.getInstance().getToolTip(this, playerId);
-    if (customTip != null && customTip.trim().length() > 0) {
-      return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
+    if (!customTip.isEmpty()) {
+      return LocalizeHtml.localizeImgLinksInHtml(customTip);
     }
     final String generated = UnitAttachment.get(this)
         .toStringShortAndOnlyImportantDifferences((playerId == null ? PlayerID.NULL_PLAYERID : playerId));
     final String appendedTip = TooltipProperties.getInstance().getAppendedToolTip(this, playerId);
-    if (appendedTip != null && appendedTip.trim().length() > 0) {
-      return generated + LocalizeHtml.localizeImgLinksInHtml(appendedTip.trim());
+    if (!appendedTip.isEmpty()) {
+      return generated + LocalizeHtml.localizeImgLinksInHtml(appendedTip);
     }
     return generated;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -46,11 +46,21 @@ public class TooltipProperties {
     return ttp;
   }
 
+  public String getAppendedToolTip(final UnitType ut, final PlayerID playerId) {
+    return getToolTip(ut, playerId, true);
+  }
+
   public String getToolTip(final UnitType ut, final PlayerID playerId) {
+    return getToolTip(ut, playerId, false);
+  }
+
+  private String getToolTip(final UnitType ut, final PlayerID playerId, final boolean isAppending) {
+    final String append = isAppending ? ".append" : "";
     final String tooltip = properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName() + "."
-        + (playerId == null ? PlayerID.NULL_PLAYERID.getName() : playerId.getName()), "");
+        + (playerId == null ? PlayerID.NULL_PLAYERID.getName() : playerId.getName()) + append, "");
     return (tooltip == null || tooltip.isEmpty())
-        ? properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName(), "")
+        ? properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName() + append, "")
         : tooltip;
   }
+
 }


### PR DESCRIPTION
Addresses https://forums.triplea-game.org/topic/942/unit-tooltip-improvements-poll/54

Added in an option for appending to the tooltip the custom text instead of replacing. Just add ".append" to the properties file keys. Example is I took original LME properties file and changed wizard to this:
```
tooltip.unit.wizard.append=Unseen<br/>Prefers Settlements
```

**Unit Help**
![image](https://user-images.githubusercontent.com/1427689/43116855-6c862158-8ecf-11e8-9e71-6ec691b8a3d5.png)
