### PR TITLE
Fix playerToNodeListing null assertion

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -86,8 +86,7 @@ public class PlayerListing implements Serializable {
             .collect(Collectors.toMap(Entry::getKey, e -> Sets.newHashSet(e.getValue())));
 
     // make sure none of the collection values are null.
-    Preconditions.checkArgument(m_playerToNodeListing.values().stream().noneMatch(Objects::isNull),
-        m_playerToNodeListing.toString());
+    // m_playerToNodeListing is an exception, it can have null values meaning no user has chosen a given nation.
     Preconditions.checkArgument(m_playersEnabledListing.values().stream().noneMatch(Objects::isNull),
         m_playersEnabledListing.toString());
     Preconditions.checkArgument(m_localPlayerTypes.values().stream().noneMatch(Objects::isNull),

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -319,7 +319,9 @@ public class ClientModel implements IMessengerErrorListener {
       return;
     }
     objectStreamFactory.setData(data);
-    final Map<String, PlayerType> playerMapping = playersToNodes.entrySet().stream()
+    final Map<String, PlayerType> playerMapping = playersToNodes.entrySet()
+        .stream()
+        .filter(e -> e.getValue() != null)
         .filter(e -> e.getValue().equals(messenger.getLocalNode().getName()))
         .collect(Collectors.toMap(Map.Entry::getKey, e -> PlayerType.CLIENT_PLAYER));
     final Set<IGamePlayer> playerSet = data.getGameLoader().createPlayers(playerMapping);


### PR DESCRIPTION
## Overview

The assertion is incorrect, when a hosting user unselects a nation and no user is set to play that nation, then the m_playersToNodeListing has a 'null' node value. A precondition checked caught this; scanning for usages we should have fixed any potential NPEs and can remove the precondition check.

## Functional Changes
Fixes: https://github.com/triplea-game/triplea/issues/3626


## Manual Testing Performed
- verified when hosting a game, unselecting a nation does not generate an error message
