### PR TITLE
Update mouse hover state when map is scrolled.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -9,7 +9,9 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.MouseInfo;
 import java.awt.Point;
+import java.awt.PointerInfo;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.event.MouseAdapter;
@@ -189,26 +191,16 @@ public class MapPanel extends ImageScrollerLargeView {
     addMouseMotionListener(new MouseMotionAdapter() {
       @Override
       public void mouseMoved(final MouseEvent e) {
-        final MouseDetails md = convert(e);
-        final double scaledMouseX = e.getX() / scale;
-        final double scaledMouseY = e.getY() / scale;
-        final double x = normalizeX(scaledMouseX + getXOffset());
-        final double y = normalizeY(scaledMouseY + getYOffset());
-        final Territory terr = getTerritory(x, y);
-        if (!Objects.equals(terr, currentTerritory)) {
-          currentTerritory = terr;
-          notifyMouseEntered(terr);
-        }
-        notifyMouseMoved(terr, md);
-        final Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, gameData);
-        if (unitsChanged(tuple)) {
-          currentUnits = tuple;
-          if (tuple == null) {
-            notifyMouseEnterUnit(Collections.emptyList(), getTerritory(x, y), md);
-          } else {
-            notifyMouseEnterUnit(tuple.getSecond(), tuple.getFirst(), md);
-          }
-        }
+      updateMouseHoverState(convert(e), e.getX(), e.getY());
+      }
+    });
+    // When map is scrolled, update information about what we're hovering over.
+    model.addObserver((object, arg) -> {
+      final PointerInfo pointer = MouseInfo.getPointerInfo();
+      if (pointer != null) {
+        final Point loc = pointer.getLocation();
+        SwingUtilities.convertPointFromScreen(loc, MapPanel.this);
+        updateMouseHoverState(null, loc.x, loc.y);
       }
     });
     addScrollListener((x2, y2) -> SwingUtilities.invokeLater(this::repaint));
@@ -219,6 +211,30 @@ public class MapPanel extends ImageScrollerLargeView {
       clearPendingDrawOperations();
       executor.shutdown();
     });
+  }
+
+  private void updateMouseHoverState(final MouseDetails md, final int mouseX, final int mouseY) {
+    final double scaledMouseX = mouseX / scale;
+    final double scaledMouseY = mouseY / scale;
+    final double x = normalizeX(scaledMouseX + getXOffset());
+    final double y = normalizeY(scaledMouseY + getYOffset());
+    final Territory terr = getTerritory(x, y);
+    if (!Objects.equals(terr, currentTerritory)) {
+      currentTerritory = terr;
+      notifyMouseEntered(terr);
+    }
+    if (md != null) {
+      notifyMouseMoved(terr, md);
+    }
+    final Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, gameData);
+    if (unitsChanged(tuple)) {
+      currentUnits = tuple;
+      if (tuple == null) {
+        notifyMouseEnterUnit(Collections.emptyList(), getTerritory(x, y), md);
+      } else {
+        notifyMouseEnterUnit(tuple.getSecond(), tuple.getFirst(), md);
+      }
+    }
   }
 
   private void recreateTiles(final GameData data, final UiContext uiContext) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -191,7 +191,7 @@ public class MapPanel extends ImageScrollerLargeView {
     addMouseMotionListener(new MouseMotionAdapter() {
       @Override
       public void mouseMoved(final MouseEvent e) {
-      updateMouseHoverState(convert(e), e.getX(), e.getY());
+        updateMouseHoverState(convert(e), e.getX(), e.getY());
       }
     });
     // When map is scrolled, update information about what we're hovering over.
@@ -525,9 +525,9 @@ public class MapPanel extends ImageScrollerLargeView {
     try {
       // This makes use of the FIFO queue the executor uses
       executor.submit(() -> drawTiles((Graphics2D) checkNotNull(g), gameData, bounds)).get();
-    } catch(final ExecutionException e) {
+    } catch (final ExecutionException e) {
       throw new IllegalStateException(e);
-    } catch (InterruptedException e) {
+    } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }
   }


### PR DESCRIPTION
## Overview
Update mouse hover state when map is scrolled.

## Functional Changes

With this change, tooltips don't stick around after you scrolled
away from the units you were hovering over.

## Manual Testing Performed
- Hover over a unit and scroll the map using the trackpad. The tooltip should disappear.
- Scroll back so cursor is over a unit again. Tooltip should appear.