### PR TITLE
Simplify always null parameter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -91,7 +91,7 @@ public class HeadlessGameServer {
     }
     new Thread(() -> {
       log.info("Headless Start");
-      setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel, null);
+      setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
       setupPanelModel.showSelectType();
       log.info("Waiting for users to connect.");
       waitForUsersHeadless();

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -1,36 +1,25 @@
 package games.strategy.engine.framework.headlessGameServer;
 
-import java.awt.Component;
-
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
-import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 
 /**
  * Setup panel model for headless server.
  */
 public class HeadlessServerSetupPanelModel extends SetupPanelModel {
-  protected final Component ui;
-
-  public HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel, final Component ui) {
+  HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel) {
     super(gameSelectorModel);
-    this.ui = ui;
   }
 
   @Override
   public void showSelectType() {
     final ServerModel model = new ServerModel(gameSelectorModel, this, ServerModel.InteractionMode.HEADLESS);
-    if (!model.createServerMessenger(ui)) {
+    if (!model.createServerMessenger(null)) {
       model.cancel();
       return;
     }
-    if (ui == null) {
-      final HeadlessServerSetup serverSetup = new HeadlessServerSetup(model, gameSelectorModel);
-      setGameTypePanel(serverSetup);
-    } else {
-      final ServerSetupPanel serverSetupPanel = new ServerSetupPanel(model, gameSelectorModel);
-      setGameTypePanel(serverSetupPanel);
-    }
+    final HeadlessServerSetup serverSetup = new HeadlessServerSetup(model, gameSelectorModel);
+    setGameTypePanel(serverSetup);
   }
 }


### PR DESCRIPTION
## Overview

Previously some time ago we allowed for a UI to be used with bot instances. To make it easier to manage bots and since nobody had been using that UI for some time, the 'bot UI' was removed. This PR fixes up a conditional block that was designed for this, today though the `ui` variable is always null and so we end up always executing only one of the two code paths.

## Functional Changes
- none

## Manual Testing Performed
- executed the code by launching bot (then hit other unrelated errors)

## Additional Review notes
- submitting this for PR while looking into bot start-up issues. 