### PR TITLE
Fix bot NPE, do not call #panelChangeListener unless it has been set.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.startup.mc;
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 import javax.swing.JPanel;
@@ -88,8 +89,8 @@ public class SetupPanelModel {
     }
     this.panel = panel;
 
-
-    panelChangeListener.screenChangeEvent(panel);
+    Optional.ofNullable(panelChangeListener)
+        .ifPresent(listener -> listener.screenChangeEvent(panel));
   }
 
   public ISetupPanel getPanel() {


### PR DESCRIPTION
## Overview
Testing the headless case we've a regression in master (mea culpa). This update will fix an update where we removed observable for an explicit listener. Previously the observable case had 0 listeners, the updated case where expected 1 listener should have been coded as 0 or 1 listeners. 

## Functional Changes
- no longer seeing startup NPE described in: https://github.com/triplea-game/triplea/issues/3629

