### PR TITLE
Add bot startup check for map folder.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -679,7 +679,7 @@ public class HeadlessGameServer {
     boolean printUsage = false;
 
     final String mapFolder = ClientSetting.MAP_FOLDER_OVERRIDE.value();
-    if(mapFolder.isEmpty() || !(new File(mapFolder).exists()) || !(new File(mapFolder).isDirectory()) ) {
+    if (mapFolder.isEmpty() || !(new File(mapFolder).exists()) || !(new File(mapFolder).isDirectory())) {
       log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: " + mapFolder);
       printUsage = true;
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import games.strategy.debug.DebugUtils;
 import games.strategy.engine.chat.Chat;
@@ -678,6 +677,13 @@ public class HeadlessGameServer {
 
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
+
+    final String mapFolder = ClientSetting.MAP_FOLDER_OVERRIDE.value();
+    if(mapFolder.isEmpty() || !(new File(mapFolder).exists()) || !(new File(mapFolder).isDirectory()) ) {
+      log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: " + mapFolder);
+      printUsage = true;
+    }
+
     final String playerName = System.getProperty(TRIPLEA_NAME, "");
     final String hostName = System.getProperty(LOBBY_GAME_HOSTED_BY, "");
     if (playerName.length() < 7 || hostName.length() < 7 || !hostName.equals(playerName)


### PR DESCRIPTION
## Overview
Update bot startup checks to halt startup if map folder does not exist.

## Manual Testing Performed
- Verified bot crashes at startup when map folder DNE, and when the folder does exist the bot gets past the new startup check

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![before](https://user-images.githubusercontent.com/12397753/43217715-328f1f1c-8ff7-11e8-9a75-1e6d5f7ecf3c.png)

### After
![after](https://user-images.githubusercontent.com/12397753/43217533-c36a7136-8ff6-11e8-91ff-37eb6f364ab0.png)
