### PR TITLE
Checkstyle: Fix Javadoc violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/health/check/SystemCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/health/check/SystemCheck.java
@@ -15,6 +15,8 @@ public class SystemCheck {
   private final Optional<Exception> exception;
 
   /**
+   * Initializes a new instance of the SystemCheck class.
+   *
    * @param msg Message that is printed along with success/fail, should describe what the system check did.
    * @param r The runnable that represents the system check, should verify that an action can be performed.
    */
@@ -32,21 +34,21 @@ public class SystemCheck {
   }
 
   /**
-   * @return True if the system check (Runnable constructor arg) completed without exception.
+   * Returns true if the system check (Runnable constructor arg) completed without exception.
    */
   public boolean wasSuccess() {
     return result;
   }
 
   /**
-   * @return A status message indicating if the system check passed or succeeded.
+   * Returns a status message indicating if the system check passed or succeeded.
    */
   public String getResultMessage() {
     return msg + ": " + result;
   }
 
   /**
-   * @return Any exceptions that may have happened while executing the system check.
+   * Returns any exception that may have happened while executing the system check.
    */
   public Optional<Exception> getException() {
     return exception;

--- a/game-core/src/main/java/games/strategy/engine/chat/IStatusController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IStatusController.java
@@ -16,7 +16,7 @@ public interface IStatusController extends IRemote {
   void setStatus(String newStatus);
 
   /**
-   * @return The status for all nodes.
+   * Returns the status for all nodes.
    */
   Map<INode, String> getAllStatus();
 }

--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
@@ -109,6 +109,7 @@ public final class LobbyServerPropertiesFetcher {
   }
 
   /**
+   * Downloads the lobby properties file from the specified URL and returns the parsed properties.
    *
    * @param lobbyPropFileUrl The taret URL to scrape for a lobby properties file.
    * @param currentVersion Our current engine version. The properties file can contain

--- a/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -63,7 +63,7 @@ public class AllianceTracker implements Serializable {
   }
 
   /**
-   * @return a set of all the games alliances, this will return an empty set if you aren't using alliances.
+   * Returns a set of all the games alliances, this will return an empty set if you aren't using alliances.
    */
   public Set<String> getAlliances() {
     return new HashSet<>(alliances.values());

--- a/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -18,6 +18,8 @@ public class ChangeAttachmentChange extends Change {
   }
 
   /**
+   * Initializes a new instance of the ChangeAttachmentChange class.
+   *
    * @param attachment An attachment object which we will update via reflexion
    * @param newValue The new value for the property
    * @param property The property by String name.

--- a/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
@@ -51,7 +51,7 @@ public class CompositeChange extends Change {
   }
 
   /**
-   * @return true if this change is empty, or composed of empty changes.
+   * Returns true if this change is empty, or composed of empty changes.
    */
   @Override
   public boolean isEmpty() {

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -87,7 +87,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   }
 
   /**
-   * @return null or the toString() of the field value.
+   * Returns null or the toString() of the field value.
    */
   public String getRawPropertyString(final String property) {
     return getProperty(property)

--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -160,7 +160,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return a collection of all units in the game.
+   * Returns a collection of all units in the game.
    */
   public UnitsList getUnits() {
     // ensureLockHeld();
@@ -168,14 +168,14 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return list of Players in the game.
+   * Returns list of Players in the game.
    */
   public PlayerList getPlayerList() {
     return playerList;
   }
 
   /**
-   * @return list of resources available in the game.
+   * Returns list of resources available in the game.
    */
   public ResourceList getResourceList() {
     ensureLockHeld();
@@ -183,7 +183,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return list of production Frontiers for this game.
+   * Returns list of production Frontiers for this game.
    */
   public ProductionFrontierList getProductionFrontierList() {
     ensureLockHeld();
@@ -191,7 +191,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return list of Production Rules for the game.
+   * Returns list of Production Rules for the game.
    */
   public ProductionRuleList getProductionRuleList() {
     ensureLockHeld();
@@ -199,14 +199,14 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return The Technology Frontier for this game.
+   * Returns the Technology Frontier for this game.
    */
   public TechnologyFrontier getTechnologyFrontier() {
     return technologyFrontier;
   }
 
   /**
-   * @return The list of production Frontiers for this game.
+   * Returns the list of production Frontiers for this game.
    */
   public RepairFrontierList getRepairFrontierList() {
     ensureLockHeld();
@@ -214,7 +214,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return The list of Production Rules for the game.
+   * Returns the list of Production Rules for the game.
    */
   public RepairRuleList getRepairRuleList() {
     ensureLockHeld();
@@ -222,7 +222,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return The Alliance Tracker for the game.
+   * Returns the Alliance Tracker for the game.
    */
   public AllianceTracker getAllianceTracker() {
     ensureLockHeld();
@@ -230,8 +230,8 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return whether we should throw an error if changes to this game data are made outside of the swing
-   *         event thread.
+   * Returns whether we should throw an error if changes to this game data are made outside of the swing
+   * event thread.
    */
   public boolean areChangesOnlyInSwingEventThread() {
     return forceInSwingEventThread;
@@ -405,8 +405,8 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return boolean, whether readWriteLock is missing
-   *         This can happen in very odd circumstances while deserializing.
+   * Indicates whether readWriteLock is missing.
+   * This can happen in very odd circumstances while deserializing.
    */
   private boolean readWriteLockMissing() {
     return readWriteLock == null;
@@ -439,9 +439,8 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return all relationshipTypes that are valid in this game, default there is the NullRelation (relation with the
-   *         Nullplayer / Neutral)
-   *         and the SelfRelation (Relation with yourself) all other relations are mapdesigner defined.
+   * Returns all relationshipTypes that are valid in this game, default there is the NullRelation (relation with the
+   * Null player / Neutral) and the SelfRelation (Relation with yourself) all other relations are map designer defined.
    */
   public RelationshipTypeList getRelationshipTypeList() {
     ensureLockHeld();
@@ -449,7 +448,7 @@ public class GameData implements Serializable {
   }
 
   /**
-   * @return a tracker which tracks all current relationships that exist between all players.
+   * Returns a tracker which tracks all current relationships that exist between all players.
    */
   public RelationshipTracker getRelationshipTracker() {
     ensureLockHeld();

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -110,17 +110,19 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns the territory with the given name, or null if no territory can be found (case sensitive).
+   *
    * @param s name of the searched territory (case sensitive)
-   * @return the territory with the given name, or null if no territory can be found (case sensitive).
    */
   public Territory getTerritory(final String s) {
     return m_territoryLookup.get(s);
   }
 
   /**
+   * Returns all adjacent neighbors of the starting territory.
+   * Does NOT include the original/starting territory in the returned Set.
+   *
    * @param t referring territory
-   * @return All adjacent neighbors of the starting territory.
-   *         Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory t) {
     // ok since all entries in connections are already unmodifiable
@@ -132,10 +134,11 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns all adjacent neighbors of the starting territory that match the condition.
+   * Does NOT include the original/starting territory in the returned Set.
+   *
    * @param t referring territory
    * @param cond condition the neighboring territories have to match
-   * @return All adjacent neighbors of the starting territory that match the condition.
-   *         Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory t, @Nullable final Predicate<Territory> cond) {
     if (cond == null) {
@@ -147,10 +150,11 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns all neighbors within a certain distance of the starting territory that match the condition.
+   * Does NOT include the original/starting territory in the returned Set.
+   *
    * @param territory referring territory
    * @param distance maximal distance of the neighboring territories
-   * @return All neighbors within a certain distance of the starting territory that match the condition.
-   *         Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory territory, int distance) {
     if (distance < 0) {
@@ -169,8 +173,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * @return All neighbors within a certain distance of the starting territory that match the condition.
-   *         Does NOT include the original/starting territory in the returned Set.
+   * Returns all neighbors within a certain distance of the starting territory that match the condition.
+   * Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory territory, int distance, final Predicate<Territory> cond) {
     if (distance < 0) {
@@ -189,9 +193,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * @return All neighbors within a certain distance of the starting territory set that match the condition.
-   *         Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
-   *         other.
+   * Returns all neighbors within a certain distance of the starting territory set that match the condition.
+   * Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
+   * other.
    */
   public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance,
       final Predicate<Territory> cond) {
@@ -201,9 +205,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * @return All neighbors within a certain distance of the starting territory set.
-   *         Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
-   *         other.
+   * Returns all neighbors within a certain distance of the starting territory set.
+   * Does NOT include the original/starting territories in the returned Set, even if they are neighbors of each
+   * other.
    */
   public Set<Territory> getNeighbors(final Set<Territory> frontier, final int distance) {
     final Set<Territory> neighbors = getNeighbors(frontier, new HashSet<>(frontier), distance);
@@ -231,20 +235,22 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns the shortest route between two territories or null if no route exists.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the shortest route between two territories or null if no route exists.
    */
   public Route getRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.territoryIsLandOrWater());
   }
 
   /**
+   * Returns the shortest route between two territories so that covered territories match the condition
+   * or null if no route exists.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
    * @param cond condition that covered territories of the route must match
-   * @return the shortest route between two territories so that covered territories match the condition
-   *         or null if no route exists.
    */
   public Route getRoute(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
     if (t1 == t2) {
@@ -257,18 +263,20 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns the shortest land route between two territories or null if no route exists.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the shortest land route between two territories or null if no route exists.
    */
   public Route getLandRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.territoryIsLand());
   }
 
   /**
+   * Returns the shortest water route between two territories or null if no route exists.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the shortest water route between two territories or null if no route exists.
    */
   public Route getWaterRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.territoryIsWater());
@@ -313,20 +321,22 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns the distance between two territories or -1 if they are not connected.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the distance between two territories or -1 if they are not connected.
    */
   public int getDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.territoryIsLandOrWater());
   }
 
   /**
+   * Returns the distance between two territories where the covered territories of the route satisfy the condition
+   * or -1 if they are not connected.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
    * @param cond condition that covered territories of the route must match
-   * @return the distance between two territories where the covered territories of the route satisfy the condition
-   *         or -1 if they are not connected.
    */
   public int getDistance(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
     if (t1.equals(t2)) {
@@ -374,29 +384,32 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Returns the land distance between two territories or -1 if they are not connected.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the land distance between two territories or -1 if they are not connected.
    */
   public int getLandDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.territoryIsLand());
   }
 
   /**
+   * Returns the water distance between two territories or -1 if they are not connected.
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
-   * @return the water distance between two territories or -1 if they are not connected.
    */
   public int getWaterDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.territoryIsWater());
   }
 
   /**
+   * Returns the distance between two territories where the covered territories of the route (except the end) satisfy
+   * the condition or -1 if they are not connected. (Distance includes to the end)
+   *
    * @param t1 start territory of the route
    * @param t2 end territory of the route
    * @param cond condition that covered territories of the route must match EXCEPT FOR THE END
-   * @return the distance between two territories where the covered territories of the route (except the end) satisfy
-   *         the condition or -1 if they are not connected. (Distance includes to the end)
    */
   public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2,
       final Predicate<Territory> cond) {
@@ -419,8 +432,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
+   * Indicates whether each territory is connected to the preceding territory.
+   *
    * @param route route containing the territories in question
-   * @return whether each territory is connected to the preceding territory.
    */
   public boolean isValidRoute(final Route route) {
     Territory previous = null;

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -758,10 +758,6 @@ public final class GameParser {
         .forEach(data.getUnitTypeList()::addUnitType);
   }
 
-  /**
-   * @param root
-   *        root node containing the playerList.
-   */
   private void parsePlayerList(final Element root) {
     final PlayerList playerList = data.getPlayerList();
     for (final Element current : getChildren("player", root)) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -89,6 +89,8 @@ public class GameSequence extends GameDataComponent implements Iterable<GameStep
   }
 
   /**
+   * Moves to the next step.
+   *
    * @return boolean whether the round has changed.
    */
   public synchronized boolean next() {

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -46,9 +46,10 @@ public class PlayerManager {
   }
 
   /**
+   * Indicates the given node is playing as anyone.
+   *
    * @param node
    *        referring node
-   * @return whether the given node playing as anyone.
    */
   public boolean isPlaying(final INode node) {
     return playerMapping.containsValue(node);

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
@@ -14,11 +14,12 @@ public class RelationshipInterpreter extends GameDataComponent {
   }
 
   /**
+   * Indicates whether player p1 is allied to player p2.
+   *
    * @param p1
    *        first referring player
    * @param p2
    *        second referring player
-   * @return whether player p1 is allied to player p2.
    */
   public boolean isAllied(final PlayerID p1, final PlayerID p2) {
     return Matches.relationshipTypeIsAllied().test((getRelationshipType(p1, p2)));
@@ -68,11 +69,12 @@ public class RelationshipInterpreter extends GameDataComponent {
   }
 
   /**
+   * Indicates whether player1 is neutral to player2.
+   *
    * @param p1
    *        player1
    * @param p2
    *        player2
-   * @return whether player1 is neutral to player2.
    */
   public boolean isNeutral(final PlayerID p1, final PlayerID p2) {
     return Matches.relationshipTypeIsNeutral().test((getRelationshipType(p1, p2)));

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -109,8 +109,8 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * @return site of the relationshipTypeList, be aware that the standard size = 4 (Allied, War, Self and Null
-   *         Relation).
+   * Returns size of the relationshipTypeList, be aware that the standard size = 4 (Allied, War, Self and Null
+   * Relation).
    */
   public int size() {
     return m_relationshipTypes.size();

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -15,7 +15,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   private final HashMap<String, RelationshipType> m_relationshipTypes = new HashMap<>();
 
   /**
-   * convenience method to return the RELATIONSHIP_TYPE_SELF relation (the relation you have with yourself)
+   * Convenience method to return the RELATIONSHIP_TYPE_SELF relation (the relation you have with yourself).
    *
    * @return the relation one has with oneself.
    */
@@ -24,7 +24,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * convenience method to return the RELATIONSHIP_TYPE_NULL relation (the relation you have with the Neutral Player)
+   * Convenience method to return the RELATIONSHIP_TYPE_NULL relation (the relation you have with the Neutral Player).
    *
    * @return the relation one has with the Neutral.
    */

--- a/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -105,7 +105,7 @@ public class ResourceCollection extends GameDataComponent {
   }
 
   /**
-   * @return new ResourceCollection containing the difference between both collections.
+   * Returns new ResourceCollection containing the difference between both collections.
    */
   public ResourceCollection difference(final ResourceCollection otherCollection) {
     final ResourceCollection returnCollection = new ResourceCollection(getData(), m_resources);
@@ -239,6 +239,8 @@ public class ResourceCollection extends GameDataComponent {
   }
 
   /**
+   * Adds {@code times - 1} copies of each resource in this collection.
+   *
    * @param times
    *        multiply this Collection times times.
    */

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -132,7 +132,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return start territory for this route.
+   * Returns start territory for this route.
    */
   public Territory getStart() {
     return m_start;
@@ -171,8 +171,9 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
+   * Returns the total cost of the route including modifications due to territoryEffects and territoryConnections.
+   *
    * @param u unit that is moving on this route
-   * @return the total cost of the route including modifications due to territoryEffects and territoryConnections.
    */
   public int getMovementCost(final Unit u) {
     // TODO implement me
@@ -180,23 +181,23 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return The number of steps in this route. Does not include start.
+   * Returns the number of steps in this route. Does not include start.
    */
   public int numberOfSteps() {
     return m_steps.size();
   }
 
   /**
-   * @return The number of steps in this route. DOES include start.
+   * Returns the number of steps in this route. DOES include start.
    */
   public int numberOfStepsIncludingStart() {
     return this.getAllTerritories().size();
   }
 
   /**
+   * Returns territory we will be in after the i'th step for this route has been made.
+   *
    * @param i step number
-   * @return territory we will be in after the i'th step for this route has
-   *         been made.
    */
   public Territory getTerritoryAtStep(final int i) {
     return m_steps.get(i);
@@ -213,8 +214,9 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
+   * Indicates whether all territories in this route match the given match (start and end territories are not tested).
+   *
    * @param match referring match
-   * @return whether all territories in this route match the given match (start and end territories are not tested).
    */
   public boolean allMatchMiddleSteps(final Predicate<Territory> match, final boolean defaultWhenNoMiddleSteps) {
     final List<Territory> middle = getMiddleSteps();
@@ -230,8 +232,9 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
+   * Returns all territories in this route match the given match (start territory is not tested).
+   *
    * @param match referring match
-   * @return all territories in this route match the given match (start territory is not tested).
    */
   public Collection<Territory> getMatches(final Predicate<Territory> match) {
     return CollectionUtils.getMatches(m_steps, match);
@@ -254,7 +257,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return collection of all territories in this route, without the start.
+   * Returns collection of all territories in this route, without the start.
    */
   public List<Territory> getSteps() {
     if (numberOfSteps() > 0) {
@@ -264,7 +267,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return collection of all territories in this route without the start or the end.
+   * Returns collection of all territories in this route without the start or the end.
    */
   public List<Territory> getMiddleSteps() {
     if (numberOfSteps() > 1) {
@@ -274,7 +277,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return last territory in the route.
+   * Returns last territory in the route.
    */
   public Territory getEnd() {
     if (m_steps.isEmpty()) {
@@ -289,14 +292,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether this route has any steps.
+   * Indicates whether this route has any steps.
    */
   public boolean hasSteps() {
     return !m_steps.isEmpty();
   }
 
   /**
-   * @return whether this route has no steps.
+   * Indicates whether this route has no steps.
    */
   public boolean hasNoSteps() {
     return !hasSteps();
@@ -345,14 +348,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether this route has more then one step.
+   * Indicates whether this route has more then one step.
    */
   public boolean hasMoreThenOneStep() {
     return m_steps.size() > 1;
   }
 
   /**
-   * @return whether there are territories before the end where the territory is owned by null and is not sea.
+   * Indicates whether there are territories before the end where the territory is owned by null and is not sea.
    */
   public boolean hasNeutralBeforeEnd() {
     for (final Territory current : getMiddleSteps()) {
@@ -365,14 +368,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether there is some water in the route including start and end.
+   * Indicates whether there is some water in the route including start and end.
    */
   public boolean hasWater() {
     return getStart().isWater() || getSteps().stream().anyMatch(Matches.territoryIsWater());
   }
 
   /**
-   * @return whether there is some land in the route including start and end.
+   * Indicates whether there is some land in the route including start and end.
    */
   public boolean hasLand() {
     return !getStart().isWater()

--- a/game-core/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
+++ b/game-core/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
@@ -2,7 +2,8 @@ package games.strategy.engine.data;
 
 
 /**
- * Annotation to mark magic 'writeReplace' methods that are used to support the serialization proxy pattern:
+ * Annotation to mark magic 'writeReplace' methods that are used to support the serialization proxy pattern. See the
+ * following references:
  *
  * <ul>
  * <li>https://github.com/triplea-game/triplea/issues/814</li>

--- a/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -38,7 +38,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   }
 
   /**
-   * @return The territory owner; will be {@link PlayerID#NULL_PLAYERID} if the territory is not owned.
+   * Returns the territory owner; will be {@link PlayerID#NULL_PLAYERID} if the territory is not owned.
    */
   public PlayerID getOwner() {
     return m_owner;

--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -79,11 +79,12 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
+   * Returns up to count units of a given type currently in the collection.
+   *
    * @param type
    *        referring unit type
    * @param maxUnits
    *        maximal number of units
-   * @return up to count units of a given type currently in the collection.
    */
   public Collection<Unit> getUnits(final UnitType type, final int maxUnits) {
     if (maxUnits == 0) {
@@ -105,9 +106,10 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
+   * Returns collection of units of each type up to max.
+   *
    * @param types
    *        map of unit types
-   * @return collection of units of each type up to max.
    */
   public Collection<Unit> getUnits(final IntegerMap<UnitType> types) {
     final Collection<Unit> units = new ArrayList<>();
@@ -122,7 +124,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
-   * @return integer map of UnitType.
+   * Returns integer map of UnitType.
    */
   public IntegerMap<UnitType> getUnitsByType() {
     final IntegerMap<UnitType> units = new IntegerMap<>();
@@ -136,9 +138,10 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
+   * Returns map of UnitType (only of units for the specified player).
+   *
    * @param id
    *        referring player ID
-   * @return map of UnitType (only of units for the specified player).
    */
   public IntegerMap<UnitType> getUnitsByType(final PlayerID id) {
     final IntegerMap<UnitType> count = new IntegerMap<>();
@@ -157,7 +160,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
-   * @return a Set of all players who have units in this collection.
+   * Returns a Set of all players who have units in this collection.
    */
   public Set<PlayerID> getPlayersWithUnits() {
     // note nulls are handled by PlayerID.NULL_PLAYERID
@@ -165,7 +168,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   /**
-   * @return The count of units each player has in this collection.
+   * Returns the count of units each player has in this collection.
    */
   public IntegerMap<PlayerID> getPlayerUnitCounts() {
     final IntegerMap<PlayerID> count = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -48,7 +48,7 @@ import games.strategy.triplea.delegate.UserActionDelegate;
 import games.strategy.twoIfBySea.delegate.InitDelegate;
 
 /**
- * This class creates objects referred to by game XMLs via the 'javaClass' property, eg:
+ * This class creates objects referred to by game XMLs via the 'javaClass' property. For example:
  *
  * <pre>
  * &lt;attachment name="territoryAttachment" attachTo="Rason"

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -10,6 +10,8 @@ import javax.swing.JComponent;
 import javax.swing.JTable;
 
 /**
+ * User editable property representing a collection.
+ *
  * @param <T> The type of elements in the collection.
  */
 public class CollectionProperty<T> extends AEditableProperty {
@@ -17,6 +19,8 @@ public class CollectionProperty<T> extends AEditableProperty {
   private List<T> m_values;
 
   /**
+   * Initializes a new instance of the CollectionProperty class.
+   *
    * @param name
    *        name of the property.
    * @param description

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -21,6 +21,8 @@ public class ComboProperty<T> extends AEditableProperty {
   private T value;
 
   /**
+   * Initializes a new instance of the ComboProperty class.
+   *
    * @param name name of the property.
    * @param defaultValue default string value
    * @param possibleValues collection of values

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -73,10 +73,11 @@ public class GameProperties extends GameDataComponent {
   }
 
   /**
+   * Returns property with key or null if property is not contained in the list.
+   * (The object returned should not be modified, as modifications will not appear globally.)
+   *
    * @param key
    *        referring key
-   * @return property with key or null if property is not contained in the list
-   *         (The object returned should not be modified, as modifications will not appear globally.)
    */
   public Object get(final String key) {
     if (editableProperties.containsKey(key)) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -21,7 +21,7 @@ public interface IEditableProperty {
   Object getValue();
 
   /**
-   * @return is the object a valid object for setting as our value.
+   * Indicates the object is a valid object for setting as our value.
    */
   boolean validate(Object value);
 
@@ -36,7 +36,7 @@ public interface IEditableProperty {
   void setValue(Object value) throws ClassCastException;
 
   /**
-   * @return component used to edit this property.
+   * Returns the component used to edit this property.
    */
   JComponent getEditorComponent();
 

--- a/game-core/src/main/java/games/strategy/engine/delegate/AutoSave.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/AutoSave.java
@@ -12,19 +12,19 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface AutoSave {
   /**
-   * Should we auto save before the step starts?
+   * Indicates we should auto save before the step starts.
    */
   boolean beforeStepStart() default false;
 
   /**
-   * Should we auto save after the step starts?
+   * Indicates we should auto save after the step starts.
    * Useful for the EndTurnDelegate in PBEM/PBF which allows the autosave before the "Done" button is clicked.
    * Still a problem if the "User Report" is on though - doesn't save until "OK" is clicked.
    */
   boolean afterStepStart() default false;
 
   /**
-   * Should we auto save after the step starts?
+   * Indicates we should auto save after the step starts.
    */
   boolean afterStepEnd() default false;
 }

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -61,10 +61,9 @@ public interface IDelegate {
   void loadState(final Serializable state);
 
   /**
-   * @return The remote type of this delegate for use
-   *         by a RemoteMessenger (Class must be an interface that extends IRemote.
-   *         If the return value is null, then it indicates that this
-   *         delegate should not be used as in IRemote.)
+   * Returns the remote type of this delegate for use by a RemoteMessenger.
+   * (Class must be an interface that extends IRemote. If the return value is null, then it indicates that this delegate
+   * should not be used as in IRemote.)
    */
   Class<? extends IRemote> getRemoteType();
 

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -95,7 +95,7 @@ public interface IDelegateBridge {
   ISound getSoundChannelBroadcaster();
 
   /**
-   * @return The properties for this step.
+   * Returns the properties for this step.
    */
   Properties getStepProperties();
 

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -21,7 +21,7 @@ import games.strategy.sound.ISound;
  */
 public interface IDelegateBridge {
   /**
-   * equivalent to getRemotePlayer(getPlayerID())
+   * Equivalent to getRemotePlayer(getPlayerID()).
    *
    * @return remote for the current player.
    */

--- a/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
+++ b/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
@@ -11,6 +11,8 @@ public interface IDisplay extends IChannelSubscribor {
   void shutDown();
 
   /**
+   * Initializes the display.
+   *
    * @deprecated Kept around for backwards compatibility.
    */
   @Deprecated

--- a/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -72,6 +72,8 @@ public abstract class AbstractGame implements IGame {
   }
 
   /**
+   * Notifies game step listeners that a game step has changed.
+   *
    * @param stepName
    *        step name.
    * @param delegateName

--- a/game-core/src/main/java/games/strategy/engine/framework/IGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGame.java
@@ -68,7 +68,7 @@ public interface IGame {
   boolean isGameOver();
 
   /**
-   * @return a listing of who is playing who.
+   * Returns a listing of who is playing who.
    */
   PlayerManager getPlayerManager();
 

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
@@ -18,6 +18,8 @@ public interface IGameModifiedChannel extends IChannelSubscribor {
   void addChildToEvent(final String text, final Object renderingData);
 
   /**
+   * Invoked when a game step has changed.
+   *
    * @param loadedFromSavedGame
    *        - true if the game step has changed because we were loaded from a saved game.
    */

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -82,6 +82,8 @@ public class ServerGame extends AbstractGame {
   private volatile boolean delegateExecutionStopped = false;
 
   /**
+   * Initializes a new instance of the ServerGame class.
+   *
    * @param data
    *        game data.
    * @param localPlayers

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -99,7 +99,7 @@ public class DownloadFileDescription {
   }
 
   /**
-   * @return Name of the zip file.
+   * Returns the name of the zip file.
    */
   String getMapZipFileName() {
     return (url != null && url.contains("/")) ? url.substring(url.lastIndexOf('/') + 1, url.length()) : "";

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
@@ -14,6 +14,8 @@ public interface IClientChannel extends IChannelSubscribor {
   void playerListingChanged(PlayerListing listing);
 
   /**
+   * Invoked when all players have been selected. This event indicates the game is ready to start.
+   *
    * @param players
    *        who is playing who.
    */

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
@@ -9,7 +9,7 @@ import games.strategy.net.INode;
 
 public interface IServerStartupRemote extends IRemote {
   /**
-   * @return a listing of the players in the game.
+   * Returns a listing of the players in the game.
    */
   PlayerListing getPlayerListing();
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -75,7 +75,7 @@ public class InGameLobbyWatcher {
   private final IMessengerErrorListener messengerErrorListener;
 
   /**
-   * Reads SystemProperties to see if we should connect to a lobby server
+   * Reads SystemProperties to see if we should connect to a lobby server.
    *
    * <p>
    * After creation, those properties are cleared, since we should watch the first start game.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -411,7 +411,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     }
 
     /**
-     * adds a new Serializable to the cache
+     * Adds a new Serializable to the cache.
      *
      * @param key the key the serializable should be stored under. Take care not to override a serializable stored by
      *        other code it is generally a good ide to use fully qualified class names, getClass().getCanonicalName() as

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
@@ -30,7 +30,7 @@ public abstract class EditorPanel extends JPanel {
   }
 
   /**
-   * registers a listener for editor changes
+   * Registers a listener for editor changes.
    *
    * @param listener
    *        the listener. be aware that the oldValue and newValue properties of the PropertyChangeEvent

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -18,6 +18,8 @@ import games.strategy.util.Interruptibles;
  */
 public class PropertiesSelector {
   /**
+   * Displays a property selection window.
+   * 
    * @param parent
    *        parent component
    * @param properties

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
@@ -10,7 +10,7 @@ import games.strategy.engine.message.IRemote;
  */
 public interface IRemotePlayer extends IRemote {
   /**
-   * @return The id of this player. This id is initialized by the initialize method in IGamePlayer.
+   * Returns the id of this player. This id is initialized by the initialize method in IGamePlayer.
    */
   PlayerID getPlayerId();
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -30,7 +30,7 @@ public class LobbyLogin {
   }
 
   /**
-   * Attempt to login to the LobbyServer
+   * Attempt to login to the LobbyServer.
    *
    * <p>
    * If we could not login, return null.

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -55,7 +55,7 @@ public class LobbyServerProperties {
   }
 
   /**
-   * @return True if the server is available. If not then see <code>serverErrorMessage</code>
+   * Returns true if the server is available. If not then see <code>serverErrorMessage</code>
    */
   public boolean isServerAvailable() {
     return serverErrorMessage.isEmpty();

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
@@ -27,6 +27,8 @@ public interface IModeratorController extends IRemote {
   void banUsername(INode node, @Nullable Date banExpires);
 
   /**
+   * Ban the IP address of the given INode.
+   *
    * @param node The node to ban.
    * @param banExpires {@code null} for a permanent ban.
    *
@@ -58,6 +60,8 @@ public interface IModeratorController extends IRemote {
   void muteUsername(INode node, @Nullable Date muteExpires);
 
   /**
+   * Mute the IP address of the given INode.
+   *
    * @param node The node to mute.
    * @param muteExpires {@code null} for a permanent mute.
    *

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/db/UserDao.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/db/UserDao.java
@@ -5,12 +5,12 @@ import games.strategy.engine.lobby.server.userDB.DBUser;
 public interface UserDao {
 
   /**
-   * @return null if the user does not exist.
+   * Returns null if the user does not exist.
    */
   HashedPassword getPassword(String username);
 
   /**
-   * @return null if the user does not exist or the user has no legacy password stored.
+   * Returns null if the user does not exist or the user has no legacy password stored.
    */
   HashedPassword getLegacyPassword(String username);
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -116,7 +116,7 @@ public final class DBUser implements Serializable {
   }
 
   /**
-   * Example usage:
+   * Returns an error message String if {@code userName} is not valid; otherwise {@code null}. Example usage:
    *
    * <pre>
    * <code>

--- a/game-core/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
@@ -70,22 +70,26 @@ package games.strategy.engine.message;
  */
 public interface IRemoteMessenger {
   /**
+   * Returns a remote reference to the registered remote.
+   *
    * @param name
    *        the name the remote is registered under.
-   * @return a remote reference to the registered remote.
    */
   IRemote getRemote(RemoteName name);
 
   /**
+   * Returns a remote reference to the registered remote.
+   *
    * @param name
    *        the name the remote is registered under.
    * @param ignoreResults
    *        whether we need to wait for the results or not
-   * @return a remote reference to the registered remote.
    */
   IRemote getRemote(RemoteName name, boolean ignoreResults);
 
   /**
+   * Registers the specified remote under the given name.
+   *
    * @param implementor
    *        An object that implements remoteInterface.
    * @param name

--- a/game-core/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.message;
 
 /**
- * Very similar to RMI
+ * Very similar to RMI.
  *
  * <p>
  * Objects can be registered with a remote messenger under a public name and

--- a/game-core/src/main/java/games/strategy/engine/message/InvocationInProgress.java
+++ b/game-core/src/main/java/games/strategy/engine/message/InvocationInProgress.java
@@ -23,7 +23,7 @@ class InvocationInProgress {
   }
 
   /**
-   * @return true if there are no more results to process.
+   * Returns true if there are no more results to process.
    */
   boolean process(final HubInvocationResults hubresults, final INode from) {
     if (hubresults.results == null) {

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -46,30 +46,18 @@ public class RemoteMethodCall implements Externalizable {
     methodNumber = RemoteInterfaceHelper.getNumber(methodName, argTypes, remoteInterface);
   }
 
-  /**
-   * @return Returns the channelName.
-   */
   public String getRemoteName() {
     return remoteName;
   }
 
-  /**
-   * @return Returns the methodName.
-   */
   public String getMethodName() {
     return methodName;
   }
 
-  /**
-   * @return Returns the args.
-   */
   public Object[] getArgs() {
     return args;
   }
 
-  /**
-   * @return Returns the argTypes.
-   */
   public Class<?>[] getArgTypes() {
     return stringsToClasses(argTypes, args);
   }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -69,6 +69,8 @@ class EndPoint {
   }
 
   /**
+   * Adds the specified implementation of this end point's remote interface.
+   *
    * @return is this the first implementor.
    */
   public boolean addImplementor(final Object implementor) {
@@ -89,6 +91,8 @@ class EndPoint {
   }
 
   /**
+   * Removes the specified implementation of this end point's remote interface.
+   *
    * @return we have no more implementors.
    */
   boolean removeImplementor(final Object implementor) {

--- a/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -240,7 +240,7 @@ public class GenericEmailSender implements IEmailSender {
 
   /**
    * Set the send timeout, after the Email sender is connected to the SMTP server this is the maximum amount of time
-   * it will wait before aborting the send operation
+   * it will wait before aborting the send operation.
    *
    * @param timeout
    *        the timeout in milli seconds. The default is 60 seconds (60000 milli seconds)

--- a/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -86,7 +86,7 @@ public class PBEMMessagePoster implements Serializable {
   }
 
   /**
-   * Post summary to form and/or email, and writes the action performed to the history writer
+   * Post summary to form and/or email, and writes the action performed to the history writer.
    *
    * @param historyWriter
    *        the history writer (which has no effect since save game has already be generated...) // todo (kg)

--- a/game-core/src/main/java/games/strategy/engine/random/IRandomSource.java
+++ b/game-core/src/main/java/games/strategy/engine/random/IRandomSource.java
@@ -6,6 +6,8 @@ package games.strategy.engine.random;
 public interface IRandomSource {
 
   /**
+   * Returns a single random number.
+   *
    * @param annotation Used by dice servers as the email subject when dice roll results are emailed. Active for
    *        PBEM games. @see HttpDiceRollerDialog
    */

--- a/game-core/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
@@ -15,6 +15,8 @@ public interface IRemoteDiceServer extends IBean {
   /**
    * Given the html page returned from postRequest, return the dice []
    * throw an InvocationTargetException to indicate an error message to be returned.
+   *
+   * @throws IOException If there was an error parsing the string.
    */
   int[] getDice(String string, int count) throws IOException, InvocationTargetException;
 

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -114,6 +114,8 @@ public class PbemDiceRoller implements IRandomSource {
     private Window owner;
 
     /**
+     * Initializes a new instance of the HttpDiceRollerDialog class.
+     *
      * @param owner
      *        owner frame.
      * @param sides

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -155,10 +155,6 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
     return m_props.getProperty("infotext");
   }
 
-  /**
-   * @throws IOException
-   *         if there was an error parsing the string.
-   */
   @Override
   public int[] getDice(final String string, final int count) throws IOException, InvocationTargetException {
     final String errorStartString = m_props.getProperty("error.start");

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -213,7 +213,7 @@ public class Vault {
   }
 
   /**
-   * Allow all data associated with the given vault id to be released and garbage collected
+   * Allow all data associated with the given vault id to be released and garbage collected.
    *
    * <p>
    * An id can be released by any node.

--- a/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
@@ -22,9 +22,6 @@ public class VaultID implements Serializable {
     m_generatedOn = generatedOn;
   }
 
-  /**
-   * @return Returns the generatedOn.
-   */
   INode getGeneratedOn() {
     return m_generatedOn;
   }

--- a/game-core/src/main/java/games/strategy/net/ILoginValidator.java
+++ b/game-core/src/main/java/games/strategy/net/ILoginValidator.java
@@ -14,6 +14,8 @@ public interface ILoginValidator {
   Map<String, String> getChallengeProperties(String userName, SocketAddress remoteAddress);
 
   /**
+   * Validates a login attempt.
+   *
    * @param propertiesReadFromClient
    *        - client properties written by the client after receiving the challange string.
    * @param remoteAddress

--- a/game-core/src/main/java/games/strategy/net/IMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IMessenger.java
@@ -66,7 +66,7 @@ public interface IMessenger {
   boolean isServer();
 
   /**
-   * @return local node if we are a server node.
+   * Returns the local node if we are a server node.
    */
   INode getServerNode();
 

--- a/game-core/src/main/java/games/strategy/net/INode.java
+++ b/game-core/src/main/java/games/strategy/net/INode.java
@@ -20,22 +20,22 @@ import java.net.InetSocketAddress;
  */
 public interface INode extends Serializable, Comparable<INode> {
   /**
-   * @return The display/user name for the node.
+   * Returns the display/user name for the node.
    */
   String getName();
 
   /**
-   * @return The address for the node as seen by the server.
+   * Returns the address for the node as seen by the server.
    */
   InetAddress getAddress();
 
   /**
-   * @return The port for the node as seen by the server.
+   * Returns the port for the node as seen by the server.
    */
   int getPort();
 
   /**
-   * @return The address for the node as seen by the server.
+   * Returns the address for the node as seen by the server.
    */
   InetSocketAddress getSocketAddress();
 }

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -44,7 +44,7 @@ public interface IServerMessenger extends IMessenger {
   void notifyUsernameMiniBanningOfPlayer(String username, Instant expires);
 
   /**
-   * @return The hashed MAC address for the user with the specified name or {@code null} if unknown.
+   * Returns the hashed MAC address for the user with the specified name or {@code null} if unknown.
    */
   @Nullable
   String getPlayerMac(String name);

--- a/game-core/src/main/java/games/strategy/net/OpenFileUtility.java
+++ b/game-core/src/main/java/games/strategy/net/OpenFileUtility.java
@@ -51,7 +51,7 @@ public final class OpenFileUtility {
   }
 
   /**
-   * Opens the specified web page in the user's default browser
+   * Opens the specified web page in the user's default browser.
    *
    * @param url A URL of a web page (ex: "http://www.google.com/")
    */

--- a/game-core/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/game-core/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -49,6 +49,8 @@ class SocketWriteData {
   }
 
   /**
+   * Writes any pending data to the specified channel.
+   *
    * @return true if the write has written the entire message.
    */
   boolean write(final SocketChannel channel) throws IOException {

--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -250,6 +250,8 @@ public class ClipPlayer {
   }
 
   /**
+   * Plays the specified player-specific clip.
+   * 
    * @param clipPath - the folder containing sound clips to be played. One of the sound clip files will be chosen at
    *        random.
    * @param playerId - the name of the player, or null
@@ -353,6 +355,8 @@ public class ClipPlayer {
   }
 
   /**
+   * Returns a collection of clip files found at the specified location.
+   *
    * @param resourceAndPathUrl
    *        (URL uses '/', not File.separator or '\')
    */

--- a/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
@@ -10,6 +10,8 @@ class SoundOptionCheckBox extends BooleanProperty {
   final String clipName;
 
   /**
+   * Initializes a new instance of the SoundOptionsCheckBox class.
+   *
    * @param clipName
    *        sound file name.
    * @param title

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -17,6 +17,8 @@ import games.strategy.engine.framework.ui.PropertiesSelector;
 public final class SoundOptions {
 
   /**
+   * Adds the "Sound Options" menu item to the specified menu.
+   *
    * @param parentMenu
    *        menu where to add the menu item "Sound Options".
    */

--- a/game-core/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundProperties.java
@@ -51,7 +51,7 @@ class SoundProperties {
   }
 
   /**
-   * @return The string property, or null if not found.
+   * Returns the string property, or null if not found.
    */
   String getProperty(final String key) {
     return properties.getProperty(key);

--- a/game-core/src/main/java/games/strategy/triplea/NetworkData.java
+++ b/game-core/src/main/java/games/strategy/triplea/NetworkData.java
@@ -6,8 +6,10 @@ package games.strategy.triplea;
  * are overriden (see: serialization proxy pattern), then the non-transient variable names and types
  * must be kept the same.
  *
+ * <p>
  * NeworkData annotated classes do not have a method constraints, they are not necessarily called by reflection
  * or RMI, so we just need to be sure these classes can be serialized and deserialized between different game versions.
+ * </p>
  */
 public @interface NetworkData {
 }

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -222,11 +222,11 @@ public class ResourceLoader implements Closeable {
   }
 
   /**
+   * Returns the URL of the resource at the specified path or {@code null} if the resource does not exist.
+   *
    * @param inputPath
    *        (The name of a resource is a '/'-separated path name that identifies the resource. Do not use '\' or
    *        File.separator)
-   *
-   * @return The resource URL or {@code null} if the resource does not exist.
    */
   public @Nullable URL getResource(final String inputPath) {
     final String path = resourceLocationTracker.getMapPrefix() + inputPath;
@@ -244,8 +244,8 @@ public class ResourceLoader implements Closeable {
   }
 
   /**
-   * @return An input stream for the specified resource or {@code null} if the resource does not exist. The caller is
-   *         responsible for closing the returned input stream.
+   * Returns an input stream for the specified resource or {@code null} if the resource does not exist. The caller is
+   * responsible for closing the returned input stream.
    *
    * @throws IllegalStateException If the specified resource exists but the input stream cannot be opened.
    */

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -18,6 +18,7 @@ class ResourceLocationTracker {
   private final String mapPrefix;
 
   /**
+   * Initializes a new instance of the ResourceLocationTracker class.
    *
    * @param mapName Used to construct any special resource loading path prefixes, used as needed depending upon which
    *        resources are in the path

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
@@ -25,7 +25,7 @@ import games.strategy.util.CollectionUtils;
 public class AiUtils {
 
   /**
-   * @return a comparator that sorts cheaper units before expensive ones.
+   * Returns a comparator that sorts cheaper units before expensive ones.
    */
   public static Comparator<Unit> getCostComparator() {
     return Comparator.comparingInt(o -> getCost(o.getType(), o.getOwner(), o.getData()));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -252,7 +252,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   /**
-   * @return The number you need to roll to get the action to succeed format "1:10" for 10% chance.
+   * Returns the number you need to roll to get the action to succeed format "1:10" for 10% chance.
    */
   private String getChance() {
     return m_chance;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -59,7 +59,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   /**
-   * DO NOT REMOVE THIS (or else you will break a lot of older xmls)
+   * DO NOT REMOVE THIS (or else you will break a lot of older xmls).
    *
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -69,6 +69,8 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   /**
+   * Returns the attached rule attachments.
+   *
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */
   @Deprecated
@@ -77,6 +79,8 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   /**
+   * Resets (clears) the attached rule attachments.
+   *
    * @deprecated please use setConditions, getConditions, clearConditions, instead.
    */
   @Deprecated

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -29,6 +29,8 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
   protected String m_text = "";
   /**
+   * The cost in PUs to attempt this action.
+   *
    * @deprecated Replaced by costResources.
    */
   @Deprecated
@@ -54,22 +56,18 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return true if there is no condition to this action or if the condition is satisfied.
+   * Indicates there is no condition to this action or if the condition is satisfied.
    */
   public boolean canPerform(final HashMap<ICondition, Boolean> testedConditions) {
     return m_conditions == null || isSatisfied(testedConditions);
   }
 
-  /**
-   * @param text
-   *        the Key that is used in politicstext.properties or other .properties for all the texts
-   */
   private void setText(final String text) {
     m_text = text;
   }
 
   /**
-   * @return The Key that is used in politicstext.properties or other .properties for all the texts.
+   * Returns the Key that is used in politicstext.properties or other .properties for all the texts.
    */
   public String getText() {
     return m_text;
@@ -152,7 +150,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return a list of players that must accept this action before it takes effect.
+   * Returns a list of players that must accept this action before it takes effect.
    */
   public List<PlayerID> getActionAccept() {
     return m_actionAccept;
@@ -163,6 +161,8 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
+   * Sets the amount of times you can try this Action per Round.
+   *
    * @param s
    *        the amount of times you can try this Action per Round.
    */
@@ -177,7 +177,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return The amount of times you can try this Action per Round.
+   * Returns the amount of times you can try this Action per Round.
    */
   private int getAttemptsPerTurn() {
     return m_attemptsPerTurn;
@@ -187,10 +187,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     m_attemptsPerTurn = 1;
   }
 
-  /**
-   * @param attempts
-   *        left this turn.
-   */
   private void setAttemptsLeftThisTurn(final int attempts) {
     m_attemptsLeftThisTurn = attempts;
   }
@@ -199,9 +195,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     setAttemptsLeftThisTurn(getInt(attempts));
   }
 
-  /**
-   * @return attempts that are left this turn.
-   */
   private int getAttemptsLeftThisTurn() {
     return m_attemptsLeftThisTurn;
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -107,7 +107,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   /**
-   * @return a set of all other players involved in this PoliticalAction.
+   * Returns a set of all other players involved in this PoliticalAction.
    */
   public Set<PlayerID> getOtherPlayers() {
     final Set<PlayerID> otherPlayers = new LinkedHashSet<>();
@@ -121,7 +121,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   /**
-   * @return gets the valid actions for this player.
+   * Returns the valid actions for this player.
    */
   public static Collection<PoliticalActionAttachment> getValidActions(final PlayerID player,
       final HashMap<ICondition, Boolean> testedConditions, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -91,9 +91,8 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   /**
-   * @return The ArcheType of this relationshipType, this really shouldn't be called, typically you should call
-   *         isNeutral, isAllied or
-   *         isWar().
+   * Returns the ArcheType of this relationshipType, this really shouldn't be called, typically you should call
+   * isNeutral, isAllied or isWar().
    */
   public String getArcheType() {
     return m_archeType;
@@ -367,21 +366,21 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   /**
-   * @return whether this relationship is based on the WAR_ARCHETYPE.
+   * Indicates whether this relationship is based on the WAR_ARCHETYPE.
    */
   public boolean isWar() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_WAR);
   }
 
   /**
-   * @return whether this relationship is based on the ALLIED_ARCHETYPE.
+   * Indicates whether this relationship is based on the ALLIED_ARCHETYPE.
    */
   public boolean isAllied() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_ALLIED);
   }
 
   /**
-   * @return whether this relationship is based on the NEUTRAL_ARCHETYPE.
+   * Indicates whether this relationship is based on the NEUTRAL_ARCHETYPE.
    */
   public boolean isNeutral() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_NEUTRAL);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -840,7 +840,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   /**
-   * checks if all relationship requirements are set
+   * Checks if all relationship requirements are set.
    *
    * @return whether all relationships as are required are set correctly.
    */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -71,6 +71,8 @@ public class TechAttachment extends DefaultAttachment {
   }
 
   /**
+   * Initializes a new instance of the TechAttachment class.
+   *
    * @deprecated Since many maps do not include a tech attachment for each player (and no maps include tech attachments
    *             for the Null
    *             Player),

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3131,12 +3131,16 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   /**
+   * Parses the specified value and sets whether or not the unit is a paratroop.
+   *
    * @deprecated does nothing, kept to avoid breaking maps, do not remove.
    */
   @Deprecated
   private void setIsParatroop(@SuppressWarnings("unused") final String s) {}
 
   /**
+   * Parses the specified value and sets whether or not the unit is mechanized.
+   *
    * @deprecated does nothing, used to keep compatibility with older xml files, do not remove.
    */
   @Deprecated

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -152,7 +152,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   }
 
   /**
-   * @return gets the valid actions for this player.
+   * Returns the valid actions for this player.
    */
   public static Collection<UserActionAttachment> getValidActions(final PlayerID player,
       final HashMap<ICondition, Boolean> testedConditions) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -119,7 +119,7 @@ public abstract class AbstractDelegate implements IDelegate {
   /**
    * You should override this class with some variation of the following code (changing the AI to be something
    * meaningful if needed)
-   * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote:
+   * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote.
    * <p>
    * if (player.isNull()) {
    * return new WeakAi(player.getName(), TripleA.WEAK_AI);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -154,11 +154,12 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   /**
+   * Returns the route that a unit used to move into the given territory.
+   *
    * @param unit
    *        referring unit.
    * @param end
    *        target territory
-   * @return the route that a unit used to move into the given territory
    */
   public Route getRouteUsedToMoveInto(final Unit unit, final Territory end) {
     return AbstractMoveDelegate.getRouteUsedToMoveInto(movesToUndo, unit, end);
@@ -210,7 +211,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   /**
-   * @return The number of PUs that have been lost by bombing, rockets, etc.
+   * Returns the number of PUs that have been lost by bombing, rockets, etc.
    */
   public abstract int pusAlreadyLost(final Territory t);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -124,8 +124,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Returns a COPY of the collection of units that are produced at territory t.
+   *
    * @param t territory of interest.
-   * @return a COPY of the collection of units that are produced at territory t
    */
   protected Collection<Unit> getAlreadyProduced(final Territory t) {
     // this list might be modified later
@@ -146,7 +147,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * @return The actual produced variable, allowing direct editing of the variable.
+   * Returns the actual produced variable, allowing direct editing of the variable.
    */
   protected final Map<Territory, Collection<Unit>> getProduced() {
     return produced;
@@ -275,6 +276,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Places the specified units in the specified territory.
+   *
    * @param producer
    *        territory that produces the new units.
    * @param placeableUnits
@@ -1203,7 +1206,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * @return gets the production of the territory.
+   * Returns the production of the territory.
    */
   protected int getProduction(final Territory territory) {
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
@@ -1211,6 +1214,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Calculates how many of each of the specified construction units can be placed in the specified territory.
+   *
    * @param to
    *        referring territory.
    * @param units
@@ -1333,16 +1338,16 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Returns a predicate that indicates whether the territory contains one of the required combos of units
+   * (and if 'doNotCountNeighbors' is false, and unit is Sea unit, will return true if an adjacent land
+   * territory has one of the required combos as well).
+   *
    * @param to
    *        - Territory we are testing for required units
    * @param doNotCountNeighbors
    *        - If false, and 'to' is water, then we will test neighboring land territories to see if they have any of the
    *        required units as
    *        well.
-   * @return - Whether the territory contains one of the required combos of units
-   *         (and if 'doNotCountNeighbors' is false, and unit is Sea unit, will return true if an adjacent land
-   *         territory has one of the
-   *         required combos as well).
    */
   public Predicate<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory to, final boolean doNotCountNeighbors) {
     return unitWhichRequiresUnits -> {
@@ -1479,9 +1484,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Returns a collection of units that were there in the specified territory at start of turn.
+   *
    * @param to
    *        referring territory.
-   * @return collection of units that were there at start of turn
    */
   public Collection<Unit> unitsAtStartOfStepInTerritory(final Territory to) {
     if (to == null) {
@@ -1510,9 +1516,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
+   * Indicates whether there was an owned unit capable of producing, in this territory at the start of this phase/step.
+   *
    * @param to referring territory.
    * @param player PlayerID
-   * @return whether there was an owned unit capable of producing, in this territory at the start of this phase/step
    */
   public boolean wasOwnedUnitThatCanProduceUnitsOrIsFactoryInTerritoryAtStartOfStep(final Territory to,
       final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -523,13 +523,14 @@ public class AirMovementValidator {
   }
 
   /**
+   * Returns the combination of units that fly here and the existing owned units.
+   *
    * @param units
    *        the units flying this route.
    * @param route
    *        the route flown
    * @param player
    *        the player owning the units
-   * @return the combination of units that fly here and the existing owned units
    */
   private static List<Unit> getAirUnitsToValidate(final Collection<Unit> units, final Route route,
       final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -564,7 +564,7 @@ public class AirMovementValidator {
   }
 
   /**
-   * Can this airunit reach safe land at this point in the route?
+   * Indicates this airunit reach safe land at this point in the route.
    *
    * @param unit
    *        the airunit in question

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -450,6 +450,8 @@ public class BattleCalculator {
   }
 
   /**
+   * Selects casualties for the specified battle.
+   *
    * @param battleId
    *        may be null if we are not in a battle (eg, if this is an aa fire due to moving).
    */
@@ -970,35 +972,35 @@ public class BattleCalculator {
   }
 
   /**
-   * @return Can transports be used as cannon fodder.
+   * Indicates transports can be used as cannon fodder.
    */
   private static boolean isTransportCasualtiesRestricted(final GameData data) {
     return Properties.getTransportCasualtiesRestricted(data);
   }
 
   /**
-   * @return Random AA Casualties - casualties randomly assigned.
+   * Indicates AA casualties are randomly assigned.
    */
   private static boolean isRandomAaCasualties(final GameData data) {
     return Properties.getRandomAaCasualties(data);
   }
 
   /**
-   * @return Roll AA Individually - roll against each aircraft.
+   * Indicates AA is rolled against each aircraft.
    */
   private static boolean isRollAaIndividually(final GameData data) {
     return Properties.getRollAaIndividually(data);
   }
 
   /**
-   * @return Choose AA - attacker selects casualties.
+   * Indicates attacker selects AA casualties.
    */
   private static boolean isChooseAa(final GameData data) {
     return Properties.getChooseAaCasualties(data);
   }
 
   /**
-   * @return Can the attacker retreat non-amphibious units.
+   * Indicates the attacker can retreat non-amphibious units.
    */
   private static boolean isPartialAmphibiousRetreat(final GameData data) {
     return Properties.getPartialAmphibiousRetreat(data);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -84,9 +84,10 @@ public class BattleTracker implements Serializable {
       new ArrayList<>();
 
   /**
+   * Indicates whether a battle is to be fought in the given territory.
+   *
    * @param t
    *        referring territory.
-   * @return whether a battle is to be fought in the given territory
    */
   public boolean hasPendingBattle(final Territory t, final boolean bombing) {
     return getPendingBattle(t, bombing, null) != null;
@@ -97,9 +98,10 @@ public class BattleTracker implements Serializable {
   }
 
   /**
+   * Indicates whether territory was conquered.
+   *
    * @param t
    *        referring territory.
-   * @return whether territory was conquered
    */
   public boolean wasConquered(final Territory t) {
     return m_conquered.contains(t);
@@ -110,9 +112,10 @@ public class BattleTracker implements Serializable {
   }
 
   /**
+   * Indicates whether territory was conquered by blitz.
+   *
    * @param t
    *        referring territory.
-   * @return whether territory was conquered by blitz
    */
   public boolean wasBlitzed(final Territory t) {
     return m_blitzed.contains(t);
@@ -965,9 +968,10 @@ public class BattleTracker implements Serializable {
   }
 
   /**
+   * Returns a collection of territories where battles are pending.
+   *
    * @param bombing
    *        whether only battles where there is bombing.
-   * @return a collection of territories where battles are pending
    */
   public Collection<Territory> getPendingBattleSites(final boolean bombing) {
     final Collection<IBattle> pending = new HashSet<>(m_pendingBattles);
@@ -997,9 +1001,10 @@ public class BattleTracker implements Serializable {
   }
 
   /**
+   * Returns the battle that must occur before dependent can occur.
+   *
    * @param blocked
    *        the battle that is blocked.
-   * @return the battle that must occur before dependent can occur
    */
   public Collection<IBattle> getDependentOn(final IBattle blocked) {
     final Collection<IBattle> dependent = m_dependencies.get(blocked);
@@ -1010,9 +1015,10 @@ public class BattleTracker implements Serializable {
   }
 
   /**
+   * Returns the battles that cannot occur until the given battle occurs.
+   *
    * @param blocking
    *        the battle that is blocking the other battles.
-   * @return the battles that cannot occur until the given battle occurs
    */
   public Collection<IBattle> getBlocked(final IBattle blocking) {
     return m_dependencies.keySet().stream()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -31,7 +31,7 @@ public abstract class DependentBattle extends AbstractBattle {
   public abstract Map<Territory, Collection<Unit>> getAttackingFromMap();
 
   /**
-   * @return territories where there are amphibious attacks.
+   * Returns territories where there are amphibious attacks.
    */
   public abstract Collection<Territory> getAmphibiousAttackTerritories();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -394,6 +394,8 @@ public class DiceRoll implements Externalizable {
   }
 
   /**
+   * Returns the power (strength) and rolls for each of the specified units.
+   *
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle.
    */
@@ -410,6 +412,8 @@ public class DiceRoll implements Externalizable {
   }
 
   /**
+   * Returns the power (strength) and rolls for each of the specified units.
+   *
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle.
    */
@@ -1053,6 +1057,8 @@ public class DiceRoll implements Externalizable {
   }
 
   /**
+   * Initializes a new instance of the DiceRoll class.
+   *
    * @param dice int[] the dice, 0 based
    * @param hits int - the number of hits
    * @param rollAt int - what we roll at, [0,Constants.MAX_DICE]
@@ -1094,6 +1100,8 @@ public class DiceRoll implements Externalizable {
   }
 
   /**
+   * Returns all rolls that are equal to the specified value.
+   *
    * @param rollAt
    *        the strength of the roll, eg infantry roll at 2, expecting a
    *        number in [1,6]

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -121,7 +121,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
   }
 
   /**
-   * @return gets the production of the territory, ignores whether the territory was an original factory.
+   * Returns the production of the territory, ignores whether the territory was an original factory.
    */
   protected int getProduction(final Territory territory) {
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -272,6 +272,8 @@ public class GameStepPropertiesHelper {
   }
 
   /**
+   * Returns the collection of players whose units can be repaired by the specified player.
+   *
    * @return a set of player ids. if argument player is not null this set will definitely include that player, but if
    *         not the set could be
    *         empty. never null.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -76,7 +76,7 @@ public interface IBattle extends Serializable {
   BattleType getBattleType();
 
   /**
-   * @return territory this battle is occurring in.
+   * Returns the territory this battle is occurring in.
    */
   Territory getTerritory();
 
@@ -89,7 +89,7 @@ public interface IBattle extends Serializable {
   void fight(IDelegateBridge bridge);
 
   /**
-   * @return whether this battle is over or not.
+   * Indicates whether this battle is over or not.
    */
   boolean isOver();
 
@@ -117,7 +117,7 @@ public interface IBattle extends Serializable {
   void addBombardingUnit(Unit u);
 
   /**
-   * @return whether battle is amphibious.
+   * Indicates whether battle is amphibious.
    */
   boolean isAmphibious();
 
@@ -144,32 +144,32 @@ public interface IBattle extends Serializable {
   boolean isEmpty();
 
   /**
-   * @return units which are dependent on the given units.
+   * Returns units which are dependent on the given units.
    */
   Collection<Unit> getDependentUnits(Collection<Unit> units);
 
   /**
-   * @return units which are actually assaulting amphibiously.
+   * Returns units which are actually assaulting amphibiously.
    */
   Collection<Unit> getAmphibiousLandAttackers();
 
   /**
-   * @return units which are actually bombarding.
+   * Returns units which are actually bombarding.
    */
   Collection<Unit> getBombardingUnits();
 
   /**
-   * @return what round this battle is in.
+   * Returns what round this battle is in.
    */
   int getBattleRound();
 
   /**
-   * @return units which are attacking.
+   * Returns units which are attacking.
    */
   Collection<Unit> getAttackingUnits();
 
   /**
-   * @return units which are defending.
+   * Returns units which are defending.
    */
   Collection<Unit> getDefendingUnits();
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1363,13 +1363,13 @@ public final class Matches {
   }
 
   /**
+   * Returns a predicate that tests the TripleAUnit getTransportedBy value (also tests for para-troopers, and for
+   * dependent allied fighters sitting as cargo on a ship).
+   *
    * @param units Referring unit.
    * @param currentPlayer Current player
    * @param data Game data.
    * @param forceLoadParatroopersIfPossible Should we load paratroopers? (if not, we assume they are already loaded).
-   *
-   * @return Predicate that tests the TripleAUnit getTransportedBy value (also tests for para-troopers, and for
-   *         dependent allied fighters sitting as cargo on a ship).
    */
   public static Predicate<Unit> unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(final Collection<Unit> units,
       final PlayerID currentPlayer, final GameData data,
@@ -1497,15 +1497,16 @@ public final class Matches {
   }
 
   /**
+   * Returns a predicate that will return true if the territory contains a unit that can repair this unit
+   * (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can
+   * repair this unit.)
+   *
    * @param territory
    *        referring territory
    * @param player
    *        referring player
    * @param data
    *        game data
-   * @return Predicate that will return true if the territory contains a unit that can repair this unit
-   *         (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can
-   *         repair this unit.)
    */
   public static Predicate<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
@@ -1569,15 +1570,16 @@ public final class Matches {
   }
 
   /**
+   * Returns a predicate that will return true if the territory contains a unit that can give bonus movement to this
+   * unit (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can give
+   * bonus movement to this unit.)
+   *
    * @param territory
    *        referring territory
    * @param player
    *        referring player
    * @param data
    *        game data
-   * @return Predicate that will return true if the territory contains a unit that can give bonus movement to this unit
-   *         (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can give
-   *         bonus movement to this unit.)
    */
   public static Predicate<Unit> unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2191,6 +2191,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   /**
+   * Returns only the relevant non-combatant units present in the specified collection.
+   *
    * @return a collection containing all the combatants in units non
    *         combatants include such things as factories, aaguns, land units
    *         in a water battle.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -232,7 +232,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
 
   /**
    * Let the player know he is being charged for money or that he hasn't got
-   * enough money
+   * enough money.
    *
    * @param paa
    *        the actionattachment the player is notified about
@@ -249,7 +249,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   }
 
   /**
-   * Subtract money from the players wallet
+   * Subtract money from the players wallet.
    *
    * @param paa
    *        the politicalactionattachment this the money is charged for.
@@ -292,7 +292,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   }
 
   /**
-   * Let all players involved in this action know the action was successful
+   * Let all players involved in this action know the action was successful.
    *
    * @param paa the political action attachment that just succeeded.
    */

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -363,6 +363,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   }
 
   /**
+   * Executes the specified action.
+   *
    * @param paa
    *        the action to check if it succeeds
    * @return true if the action succeeds, usually because the die-roll succeeded.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -183,7 +183,8 @@ public abstract class TechAdvance extends NamedAttachable {
   }
 
   /**
-   * @return first is air&naval, second is land&production.
+   * Returns a tuple, where the first element contains air &amp; naval tech advances, and the second element contains
+   * land &amp; production tech advances.
    */
   private static Tuple<List<TechAdvance>, List<TechAdvance>> getWW2v3CategoriesWithTheirAdvances(final GameData data) {
     data.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -136,6 +136,8 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   }
 
   /**
+   * Executes the specified action.
+   *
    * @param uaa
    *        the action to check if it succeeds
    * @return true if the action succeeds, usually because the die-roll succeeded.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyDetails.java
@@ -9,7 +9,7 @@ public class CasualtyDetails extends CasualtyList {
   private final boolean m_autoCalculated;
 
   /**
-   * Creates new SelectCasualtyMessage
+   * Creates new SelectCasualtyMessage.
    *
    * @param killed
    *        killed units

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
@@ -38,7 +38,7 @@ public class CasualtyList implements Serializable {
   }
 
   /**
-   * @return list of killed units.
+   * Returns the list of killed units.
    */
   public List<Unit> getKilled() {
     return m_killed;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
@@ -31,7 +31,7 @@ public class PlaceableUnits implements Serializable {
   }
 
   /**
-   * @return -1 if no limit.
+   * Returns the maximum number of units that can be placed or -1 if no limit.
    */
   public int getMaxUnits() {
     return m_maxUnits;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
@@ -20,14 +20,14 @@ public class TechResults implements Serializable {
   }
 
   /**
-   * @return whether there was an error.
+   * Indicates whether there was an error.
    */
   public boolean isError() {
     return m_errorString != null;
   }
 
   /**
-   * @return string error or null if no error occurred (use isError to see if there was an error).
+   * Returns string error or null if no error occurred (use isError to see if there was an error).
    */
   public String getErrorString() {
     return m_errorString;
@@ -72,9 +72,6 @@ public class TechResults implements Serializable {
     return m_rolls;
   }
 
-  /**
-   * @return a List of Strings.
-   */
   public List<String> getAdvances() {
     return m_advances;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
@@ -19,6 +19,8 @@ public interface IAbstractMoveDelegate<T> extends IRemote, IDelegate {
   List<T> getMovesMade();
 
   /**
+   * Undoes the move at the specified index.
+   *
    * @param moveIndex
    *        - an index in the list getMovesMade.
    * @return an error string if the move could not be undone, null otherwise

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -9,6 +9,8 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 
 public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePlacement> {
   /**
+   * Places the specified units in the specified territry.
+   *
    * @param units
    *        units to place.
    * @param at
@@ -39,9 +41,9 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
   PlaceableUnits getPlaceableUnits(Collection<Unit> units, Territory at);
 
   /**
-   * @return The number of placements made so far.
-   *         this is not the number of units placed, but the number
-   *         of times we have made successful placements.
+   * Returns the number of placements made so far.
+   * this is not the number of units placed, but the number
+   * of times we have made successful placements.
    */
   int getPlacementsMade();
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -9,7 +9,7 @@ import games.strategy.triplea.delegate.dataObjects.BattleListing;
 
 public interface IBattleDelegate extends IRemote, IDelegate {
   /**
-   * @return The battles currently waiting to be fought.
+   * Returns the battles currently waiting to be fought.
    */
   BattleListing getBattles();
 
@@ -32,12 +32,12 @@ public interface IBattleDelegate extends IRemote, IDelegate {
   String fightCurrentBattle();
 
   /**
-   * @return The location of the currently being fought battle, or null if no battle is in progress.
+   * Returns the location of the currently being fought battle, or null if no battle is in progress.
    */
   Territory getCurrentBattleTerritory();
 
   /**
-   * @return The current battle if there is one, or null if there is no current battle in progress.
+   * Returns the current battle if there is one, or null if there is no current battle in progress.
    */
   IBattle getCurrentBattle();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -14,6 +14,8 @@ import games.strategy.triplea.delegate.UndoableMove;
  */
 public interface IMoveDelegate extends IAbstractMoveDelegate<UndoableMove>, IAbstractForumPosterDelegate {
   /**
+   * Moves the specified units along the specified route.
+   *
    * @param units
    *        - the units to move.
    * @param route
@@ -25,6 +27,8 @@ public interface IMoveDelegate extends IAbstractMoveDelegate<UndoableMove>, IAbs
   String move(Collection<Unit> units, Route route, Collection<Unit> transportsThatCanBeLoaded);
 
   /**
+   * Moves the specified units along the specified route accounting for dependents.
+   *
    * @param units
    *        - the units to move.
    * @param route

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -11,6 +11,8 @@ import games.strategy.util.IntegerMap;
 
 public interface IPurchaseDelegate extends IRemote, IDelegate {
   /**
+   * Purchases the specified units.
+   *
    * @param productionRules
    *        - units maps ProductionRule -> count.
    * @return null if units bought, otherwise an error message

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/ITechDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/ITechDelegate.java
@@ -9,6 +9,8 @@ import games.strategy.util.IntegerMap;
 
 public interface ITechDelegate extends IRemote, IDelegate {
   /**
+   * Rolls for the specified tech.
+   *
    * @param rollCount
    *        the number of tech rolls
    * @param techToRollFor

--- a/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -164,7 +164,7 @@ public final class TileImageFactory {
   }
 
   /**
-   * @return compatibleImage This method produces a blank white tile for use in blending.
+   * This method produces a blank white tile for use in blending.
    */
   private static BufferedImage makeMissingBaseTile(final BufferedImage input) {
     final BufferedImage compatibleImage =

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -13,32 +13,18 @@ public class PrintGenerationData {
    */
   PrintGenerationData() {}
 
-  /**
-   * @return The outDir.
-   */
   File getOutDir() {
     return outDir;
   }
 
-  /**
-   * @param outDir
-   *        the outDir to set.
-   */
   void setOutDir(final File outDir) {
     this.outDir = outDir;
   }
 
-  /**
-   * @return The data.
-   */
   protected GameData getData() {
     return gameData;
   }
 
-  /**
-   * @param data
-   *        the data to set.
-   */
   protected void setData(final GameData data) {
     gameData = data;
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
@@ -26,7 +26,7 @@ public interface GameSettingUiBinding<T> {
   Map<GameSetting, String> readValues();
 
   /**
-   * @return Helpful description message of what values are valid.
+   * Returns helpful description message of what values are valid.
    */
   String validValueDescription();
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -6,7 +6,7 @@ import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 
 /**
- * Executes a 'save' action
+ * Executes a 'save' action.
  * <p>
  * Input: set of settings
  * Output: SaveResult with message and dialog code, which can be used to create a confirmation or a warning dialog.

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
@@ -38,7 +38,7 @@ public abstract class AbstractStatPanel extends JPanel {
   public abstract void setGameData(final GameData data);
 
   /**
-   * @return all the alliances with more than one player.
+   * Returns all the alliances with more than one player.
    */
   public Collection<String> getAlliances() {
     return getAllianceMap().keySet();

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -210,7 +210,7 @@ public class ActionButtons extends JPanel {
   }
 
   /**
-   * Blocks until the user selects a political action to attempt
+   * Blocks until the user selects a political action to attempt.
    *
    * @return null if no action was picked.
    */
@@ -220,7 +220,7 @@ public class ActionButtons extends JPanel {
   }
 
   /**
-   * Blocks until the user selects a user action to attempt
+   * Blocks until the user selects a user action to attempt.
    *
    * @return null if no action was picked.
    */

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -83,7 +83,7 @@ public abstract class ActionPanel extends JPanel {
   }
 
   /**
-   * Release the latch acquired by waitOnNewLatch()
+   * Release the latch acquired by waitOnNewLatch().
    *
    * <p>
    * This method will crossed on entering this method.

--- a/game-core/src/main/java/games/strategy/triplea/ui/JButtonDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/JButtonDialog.java
@@ -30,7 +30,7 @@ public class JButtonDialog {
   }
 
   /**
-   * Show a new modal dialog and block until the user press a button of closes the dialog
+   * Show a new modal dialog and block until the user press a button of closes the dialog.
    *
    * @param frame
    *        the frame owner

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -160,7 +160,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Centripetal parameterization
+   * Centripetal parameterization.
    *
    * <p>
    * Check <a href="http://stackoverflow.com/a/37370620/5769952">http://stackoverflow.com/a/37370620/5769952</a> for
@@ -280,7 +280,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws a smooth curve through the given array of points
+   * Draws a smooth curve through the given array of points.
    *
    * <p>
    * This algorithm is called Spline-Interpolation

--- a/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -38,7 +38,7 @@ public class MouseDetails {
   }
 
   /**
-   * @return this point is in the map co-ordinates, unscaled.
+   * Returns this point is in the map coordinates, unscaled.
    */
   public Point getMapPoint() {
     return new Point((int) x, (int) y);

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -37,7 +37,7 @@ public class PoliticalStateOverview extends JPanel {
   private final Set<Triple<PlayerID, PlayerID, RelationshipType>> editChanges = new HashSet<>();
 
   /**
-   * Constructs this panel
+   * Constructs this panel.
    *
    * @param data
    *        gamedata to get the info from

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -39,6 +39,8 @@ public class SimpleUnitPanel extends JPanel {
   }
 
   /**
+   * Adds units to the panel based on the specified production rules.
+   *
    * @param units
    *        a HashMap in the form ProductionRule -> number of units
    *        assumes that each production rule has 1 result, which is simple the number of units.
@@ -56,6 +58,8 @@ public class SimpleUnitPanel extends JPanel {
   }
 
   /**
+   * Adds units to the panel based on the specified repair rules.
+   *
    * @param units
    *        a HashMap in the form RepairRule -> number of units
    *        assumes that each repair rule has 1 result, which is simply the number of units.
@@ -82,6 +86,8 @@ public class SimpleUnitPanel extends JPanel {
   }
 
   /**
+   * Adds units to the panel based on the specified unit categories.
+   *
    * @param categories
    *        a collection of UnitCategories.
    */

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -551,6 +551,8 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   /**
+   * Sets the map scale.
+   *
    * @param value a number between 10 and 200.
    */
   public void setScale(final double value) {
@@ -558,7 +560,7 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   /**
-   * @return a scale between 10 and 200.
+   * Returns a scale between 10 and 200.
    */
   private double getScale() {
     return getMapPanel().getScale() * 100;

--- a/game-core/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
@@ -59,6 +59,8 @@ public interface ITripleADisplay extends IDisplay {
       final Collection<Unit> amphibiousLandAttackers);
 
   /**
+   * Displays the steps for the specified battle.
+   *
    * @param battleId
    *        - the battle we are listing steps for.
    * @param steps

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -306,9 +306,10 @@ public class HistoryPanel extends JPanel {
   }
 
   /**
+   * Indicates whether the expanded path list contains a descendant of parentPath.
+   *
    * @param parentPath
    *        tree path for which descendants should be check.
-   * @return whether the expanded path list contains a descendant of parentPath
    */
   private boolean stayExpandedContainsDescendantOf(final TreePath parentPath) {
     for (final TreePath currentPath : stayExpandedPaths) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/DefaultColors.java
@@ -22,6 +22,8 @@ final class DefaultColors {
   private final Iterator<Color> colorIterator = COLORS.iterator();
 
   /**
+   * Returns the next available default color.
+   *
    * @throws NoSuchElementException If the available default colors have been exhausted.
    */
   Color nextColor() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -511,8 +511,8 @@ public class MapData implements Closeable {
   }
 
   /**
-   * @return a Set of territory names as Strings. generally this shouldnt be
-   *         used, instead you should use aGameData.getMap().getTerritories()
+   * Returns a Set of territory names as Strings. generally this shouldn't be
+   * used, instead you should use aGameData.getMap().getTerritories()
    */
   public Set<String> getTerritories() {
     return polys.keySet();

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -68,8 +68,10 @@ public class Tile {
    * copies the resulting pixels to the stored image and disposes
    * the resources afterwards.
    *
+   * <p>
    * This is to ensure we don't draw the Tile mid-generating
    * without having to synchronize it.
+   * </p>
    */
   public void drawImage(final GameData data, final MapData mapData) {
     try {

--- a/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -313,7 +313,7 @@ public class TuvUtils {
   }
 
   /**
-   * Return the total unit value
+   * Return the total unit value.
    *
    * @param units
    *        A collection of units
@@ -331,7 +331,7 @@ public class TuvUtils {
   }
 
   /**
-   * Return the total unit value for a certain player and his allies
+   * Return the total unit value for a certain player and his allies.
    *
    * @param units
    *        A collection of units

--- a/game-core/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
@@ -15,7 +15,7 @@ import games.strategy.util.CollectionUtils;
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {
   /**
-   * @return gets the production of the territory, ignores whether the territory was an original factory.
+   * Returns the production of the territory, ignores whether the territory was an original factory.
    */
   @Override
   protected int getProduction(final Territory territory) {

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -300,6 +300,8 @@ public class ImageScrollerLargeView extends JComponent {
   }
 
   /**
+   * Sets the view scale.
+   *
    * @param value The new scale value. Constrained to the bounds of no less than 0.15 and no greater than 1.
    *        If out of bounds the nearest boundary value is used.
    */

--- a/game-core/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/game-core/src/main/java/games/strategy/ui/SwingComponents.java
@@ -386,7 +386,7 @@ public class SwingComponents {
   /**
    * Runs the specified task on a background thread while displaying a progress dialog.
    *
-   * @param<T> The type of the task result.
+   * @param <T> The type of the task result.
    *
    * @param frame The {@code Frame} from which the progress dialog is displayed or {@code null} to use a shared, hidden
    *        frame as the owner of the progress dialog.

--- a/game-core/src/main/java/games/strategy/util/IntegerMap.java
+++ b/game-core/src/main/java/games/strategy/util/IntegerMap.java
@@ -164,7 +164,7 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
   }
 
   /**
-   * @return The sum of all keys.
+   * Returns the sum of all keys.
    */
   public int totalValues() {
     return mapValues.values().stream()

--- a/game-core/src/main/java/games/strategy/util/UnhandledSwitchCaseException.java
+++ b/game-core/src/main/java/games/strategy/util/UnhandledSwitchCaseException.java
@@ -22,6 +22,8 @@ public class UnhandledSwitchCaseException extends RuntimeException {
   private static final long serialVersionUID = 3537849919628576439L;
 
   /**
+   * Initializes a new instance of the UnhandledSwitchCaseException class.
+   *
    * @param unhandledValue The switch value that fell thru to a 'default' clause of a switch statement.
    */
   public UnhandledSwitchCaseException(final Object unhandledValue) {

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/DownloadPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/DownloadPane.java
@@ -13,6 +13,8 @@ class DownloadPane extends VBox {
   private final TripleA triplea;
 
   /**
+   * Initializes a new instance of the DownloadPane class.
+   *
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/MainMenuPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/MainMenuPane.java
@@ -56,6 +56,8 @@ class MainMenuPane extends BorderPane {
   private VBox mainOptions;
 
   /**
+   * Initializes a new instance of the MainMenuPane class.
+   *
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
@@ -36,6 +36,8 @@ class SettingsPane extends StackPane {
 
 
   /**
+   * Initializes a new instance of the SettingsPane class.
+   *
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */

--- a/game-core/src/main/java/swinglib/JDialogBuilder.java
+++ b/game-core/src/main/java/swinglib/JDialogBuilder.java
@@ -16,7 +16,7 @@ import com.google.common.base.Strings;
 import games.strategy.ui.SwingAction;
 
 /**
- * Example usage:
+ * Builder for Swing dialogs. Example usage:
  * <code><pre>
  *   JDialog dialog = JDialogBuilder.builder()
  *     .parentFrame(parent)

--- a/game-core/src/main/java/swinglib/JTextAreaBuilder.java
+++ b/game-core/src/main/java/swinglib/JTextAreaBuilder.java
@@ -6,7 +6,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 /**
- * Example usage:
+ * Builder for Swing text areas. Example usage:
  * <code><pre>
  *   JTextAreaBuilder textArea = JTextAreaBuilder.builder()
  *     .text(setting.description)

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -54,6 +54,8 @@ public final class AutoPlacementFinder {
   }
 
   /**
+   * Runs the auto-placement finder tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-core/src/main/java/tools/image/CenterPicker.java
@@ -51,6 +51,8 @@ public final class CenterPicker {
   private CenterPicker() {}
 
   /**
+   * Runs the center picker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -101,6 +101,8 @@ public final class DecorationPlacer {
   private DecorationPlacer() {}
 
   /**
+   * Runs the decoration placer tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/FileSave.java
+++ b/game-core/src/main/java/tools/image/FileSave.java
@@ -27,6 +27,8 @@ public class FileSave {
   }
 
   /**
+   * Initializes a new instance of the FileSave class with the specified file selection mode and selected file.
+   *
    * @param fileSelectionMode The type of files to be displayed. Must be one of {@link JFileChooser#FILES_ONLY},
    *        {@link JFileChooser#DIRECTORIES_ONLY}, or {@link JFileChooser#FILES_AND_DIRECTORIES}.
    */
@@ -36,6 +38,9 @@ public class FileSave {
   }
 
   /**
+   * Initializes a new instance of the FileSave class with the specified file selection mode, selected file, and file
+   * filter.
+   *
    * @param fileSelectionMode The type of files to be displayed. Must be one of {@link JFileChooser#FILES_ONLY},
    *        {@link JFileChooser#DIRECTORIES_ONLY}, or {@link JFileChooser#FILES_AND_DIRECTORIES}.
    */

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -63,6 +63,8 @@ public final class PolygonGrabber {
   private PolygonGrabber() {}
 
   /**
+   * Runs the polygon grabber tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/game-core/src/main/java/tools/image/ReliefImageBreaker.java
@@ -48,6 +48,8 @@ public final class ReliefImageBreaker {
   private ReliefImageBreaker() {}
 
   /**
+   * Runs the relief image breaker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/TileImageBreaker.java
+++ b/game-core/src/main/java/tools/image/TileImageBreaker.java
@@ -42,6 +42,8 @@ public final class TileImageBreaker {
   private TileImageBreaker() {}
 
   /**
+   * Runs the tile image breaker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/image/TileImageReconstructor.java
+++ b/game-core/src/main/java/tools/image/TileImageReconstructor.java
@@ -50,6 +50,8 @@ public final class TileImageReconstructor {
   private TileImageReconstructor() {}
 
   /**
+   * Runs the tile image reconstructor tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -65,6 +65,8 @@ public final class ConnectionFinder {
   private ConnectionFinder() {}
 
   /**
+   * Runs the connection finder tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/map/making/ImageShrinker.java
+++ b/game-core/src/main/java/tools/map/making/ImageShrinker.java
@@ -33,6 +33,8 @@ public final class ImageShrinker {
   private ImageShrinker() {}
 
   /**
+   * Runs the image shrinker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -76,6 +76,8 @@ public final class MapPropertiesMaker {
   }
 
   /**
+   * Runs the map properties maker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -74,6 +74,8 @@ public final class PlacementPicker {
   }
 
   /**
+   * Runs the placement picker tool.
+   *
    * @throws IllegalStateException If not invoked on the EDT.
    */
   public static void run(final String[] args) {
@@ -527,6 +529,8 @@ public final class PlacementPicker {
     }
 
     /**
+     * Updates tool state based on the specified mouse event.
+     *
      * <ul>
      * <li>Left button: Start in territory.</li>
      * <li>Left button + control: Add point.</li>

--- a/game-core/src/test/java/games/strategy/engine/config/MemoryPropertyReader.java
+++ b/game-core/src/test/java/games/strategy/engine/config/MemoryPropertyReader.java
@@ -22,6 +22,8 @@ public final class MemoryPropertyReader extends AbstractPropertyReader {
   }
 
   /**
+   * Initializes a new instance of the MemoryPropertyReader class from the specified properties.
+   *
    * @throws IllegalArgumentException If {@code properties} contains a {@code null} key or value.
    */
   public MemoryPropertyReader(final Map<String, String> properties) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -315,6 +315,8 @@ public class AirThatCantLandUtilTest {
   }
 
   /**
+   * Returns a new dummy player.
+   *
    * @deprecated Use a mock object instead.
    */
   @Deprecated


### PR DESCRIPTION
## Overview

This PR fixes violations of the following Checkstyle rules:

* JavadocParagraph
* JavadocTagContinuationIndentation
* SummaryJavadoc (missing ending period)
* SummaryJavadoc (missing summary)

In a very few cases, I removed violating Javadocs that appeared to be IDE-generated and provided no value.

## Functional Changes

None.

This PR only contains Javadoc changes.  **There are no code changes.**

## Manual Testing Performed

None.