### PR TITLE
Fix broken headless game server (bot) Eclipse launch configuration

### DIFF
--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -7,8 +7,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game.host.console=true &#13;&#10;-Ptriplea.game= -Ptriplea.server=true &#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game=&#13;&#10;-Ptriplea.server=true&#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-core"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -98,7 +98,7 @@ public final class ClientFileSystemHelper {
   }
 
   /**
-   * Returns location of the folder containing downloaded TripleA maps.
+   * Returns location of the folder containing downloaded TripleA maps. The folder will be created if it does not exist.
    *
    * @return Folder where maps are downloaded and stored. Default location is relative
    *         to users home folder and not the engine install folder, this allows it to be

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import games.strategy.debug.DebugUtils;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
@@ -678,8 +679,8 @@ public class HeadlessGameServer {
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
 
-    final String mapFolder = ClientSetting.MAP_FOLDER_OVERRIDE.value();
-    if (mapFolder.isEmpty() || !(new File(mapFolder).exists()) || !(new File(mapFolder).isDirectory())) {
+    final File mapFolder = ClientFileSystemHelper.getUserMapsFolder();
+    if (!mapFolder.isDirectory()) {
       log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: " + mapFolder);
       printUsage = true;
     }


### PR DESCRIPTION
## Overview

Running a local headless game server (bot) using the Eclipse launch configuration broke recently due to #3609 and #3632.  This PR restores the ability to run a bot in a dev environment using this launch configuration:

- Removed the now-deprecated `triplea.game.host.console` CLI parameter from the launch configuration.
- Modified the map folder existence check in `HeadlessGameServer` to take the default location into account.  Without this change, the launch configuration would have to specify the `mapFolder` CLI parameter explicitly, which would be awkward (see review notes at end).

## Functional Changes

- If `mapFolder` is not specified via the CLI, the default map folder is used (currently _~/triplea/downloadedMaps_).
- If the map folder does not exist, it will be created (same behavior as client).

## Manual Testing Performed

Using a bot:

- Verified that if the map folder does not exist, it is created.
- Verified that if the map folder does exist, but it is a file rather than a directory, the bot terminates as before.

## Additional Review Notes

The launch configuration could be modified to explicitly specify `mapFolder` in a machine-independent way using Eclipse variables.  Presumably, it would be set to match the current default map folder: _~/triplea/downloadedMaps_.  However, that means if the default map folder is ever changed in code, it would also have to be changed here, as well.  I didn't go that route because, in addition to the DRY violation, it seems preferable to use `ClientFileSystemHelper#getUserMapsFolder()` instead of accessing `ClientSetting#MAP_FOLDER_OVERRIDE` directly.