### PR TITLE
Only display support type if game has multiple support types

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2829,12 +2829,13 @@ public class UnitAttachment extends DefaultAttachment {
     if (supports.size() > 3) {
       tuples.add(Tuple.of("Can Provide Support to Units", ""));
     } else if (supports.size() > 0) {
+      final boolean moreThanOneSupportType = UnitSupportAttachment.get(getData()).size() > 1;
       for (final UnitSupportAttachment support : supports) {
         if (support.getUnitType() == null || support.getUnitType().isEmpty()) {
           continue;
         }
         final StringBuilder sb = new StringBuilder();
-        sb.append(support.getBonus()).append(" ").append(support.getBonusType())
+        sb.append(support.getBonus()).append(moreThanOneSupportType ? " " + support.getBonusType() : "")
             .append(support.getStrength() && support.getRoll() ? " Power & Rolls"
                 : (support.getStrength() ? " Power" : " Rolls"))
             .append(" to ").append(support.getNumber())


### PR DESCRIPTION
## Overview
Addresses post: https://forums.triplea-game.org/topic/942/unit-tooltip-improvements-poll/68

## Functional Changes
Unit tooltip only displays support type if game has multiple support types (primarily used to avoid showing "ArtyOld" for simple maps).

## Manual Testing Performed
- Tested tooltips on 270BC and revised

