### PR TITLE
Do not exit process when closing Map Creator window

### DIFF
--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -69,7 +69,7 @@ public class MapCreator extends JFrame {
 
   private MapCreator() {
     super("TripleA Map Creator");
-    setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+    setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     // components
     mainPanel = new JPanel();
     final JPanel sidePanel = new JPanel();
@@ -100,7 +100,7 @@ public class MapCreator extends JFrame {
     part3.addActionListener(SwingAction.of("Part 3", e -> setupMainPanel(panel3)));
     part4.addActionListener(SwingAction.of("Part 4", e -> setupMainPanel(panel4)));
     // set up the menu actions
-    final Action closeAction = SwingAction.of("Close", e -> this.dispose());
+    final Action closeAction = SwingAction.of("Close", e -> dispose());
     closeAction.putValue(Action.SHORT_DESCRIPTION, "Close Window");
     // set up the menu items
     final JMenuItem exitItem = new JMenuItem(closeAction);


### PR DESCRIPTION
## Overview

#3606 changed the Map Creator to run in-process.  Now, when you close the Map Creator window using the system close button (X), it exits the process, thus terminating the TripleA client.  This PR changes the behavior of the system close button to simply dispose of the Map Creator window.

## Functional Changes

None.

## Manual Testing Performed

I verified that clicking the system close button on the Map Creator window closes the Map Creator window but does not exit the process.