### PR TITLE
Render all Tiles at once

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -32,7 +32,6 @@ import games.strategy.ui.Util;
  */
 public class Tile {
   private volatile boolean isDirty = true;
-  private volatile boolean drawingStarted = false;
 
   private final Image image;
   private final Rectangle bounds;
@@ -53,10 +52,6 @@ public class Tile {
     return isDirty;
   }
 
-  public boolean hasDrawingStarted() {
-    return drawingStarted;
-  }
-
   public Image getImage() {
     return image;
   }
@@ -74,23 +69,18 @@ public class Tile {
    * </p>
    */
   public void drawImage(final GameData data, final MapData mapData) {
-    try {
-      drawingStarted = true;
-      final BufferedImage writeBuffer = Util.createImage(image.getWidth(null),
-          image.getHeight(null), true);
-      final Graphics2D g = (Graphics2D) writeBuffer.getGraphics();
-      g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-      g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-      g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-      draw(g, data, mapData);
+    final BufferedImage writeBuffer = Util.createImage(image.getWidth(null),
+        image.getHeight(null), true);
+    final Graphics2D g = (Graphics2D) writeBuffer.getGraphics();
+    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+    g.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+    g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+    draw(g, data, mapData);
 
-      final Graphics2D imageGraphics = (Graphics2D) image.getGraphics();
-      imageGraphics.drawImage(writeBuffer, new AffineTransform(), null);
-      imageGraphics.dispose();
-      g.dispose();
-    } finally {
-      drawingStarted = false;
-    }
+    final Graphics2D imageGraphics = (Graphics2D) image.getGraphics();
+    imageGraphics.drawImage(writeBuffer, new AffineTransform(), null);
+    imageGraphics.dispose();
+    g.dispose();
   }
 
   private void draw(final Graphics2D g, final GameData data, final MapData mapData) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -110,6 +110,15 @@ public class TileManager {
     }
   }
 
+  public List<Tile> getTiles() {
+    acquireLock();
+    try {
+      return new ArrayList<>(tiles);
+    } finally {
+      releaseLock();
+    }
+  }
+
   private void acquireLock() {
     LockUtil.INSTANCE.acquireLock(lock);
   }

--- a/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/screen/TileTest.java
@@ -47,26 +47,20 @@ public class TileTest {
   public void testIsDirty() {
     assertSame(image, tile.getImage());
     assertTrue(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
     tile.drawImage(null, null);
     assertFalse(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
 
     tile.addDrawable(drawable);
 
     assertTrue(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
     tile.drawImage(null, null);
     assertFalse(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
 
     tile.addDrawables(Collections.singleton(drawable));
 
     assertTrue(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
     tile.drawImage(null, null);
     assertFalse(tile.isDirty());
-    assertFalse(tile.hasDrawingStarted());
   }
 
   @Test


### PR DESCRIPTION
## Overview
This PR tries option 1 of my plan mentioned in #3539

## Functional Changes
All initial Tile Loading is now done at once, when a tile is being updated its redraw process is triggered on the next UI paint cycle.

## Manual Testing Performed
Played a short game agains the AI.
All tiles loaded without problems, no flickering was observed.
As expected, the tiles on the initial window take slightly longer to load, because they're no longer being prioritized.