### PR TITLE
Require explicit map folder for headless game server

### DIFF
--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -9,7 +9,7 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game=&#13;&#10;-Ptriplea.server=true&#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game=&#13;&#10;-Ptriplea.server=true&#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host&#13;&#10;-PmapFolder=${system_property:user.home}/triplea/downloadedMaps"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-core"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import games.strategy.debug.DebugUtils;
-import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
@@ -679,9 +678,9 @@ public class HeadlessGameServer {
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
 
-    final File mapFolder = ClientFileSystemHelper.getUserMapsFolder();
+    final File mapFolder = new File(ClientSetting.MAP_FOLDER_OVERRIDE.value());
     if (!mapFolder.isDirectory()) {
-      log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: " + mapFolder);
+      log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: '" + mapFolder + "'");
       printUsage = true;
     }
 


### PR DESCRIPTION
## Overview

Per [this comment](https://github.com/triplea-game/triplea/pull/3644#issuecomment-408949228).

## Functional Changes

* `mapFolder` CLI arg is required when starting a headless game server (same behavior as #3632).

## Manual Testing Performed

* When `mapFolder` does not exist, bot terminates.
* When `mapFolder` exists and is a directory, bot proceeds normally.