### PR TITLE
Add a helper class for arg parsing.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -3,112 +3,49 @@ package games.strategy.engine.framework;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Set;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
-import com.google.common.base.Joiner;
 
 import games.strategy.triplea.settings.ClientSetting;
 
 /**
- * Command line argument parser for the various TripleA applications.
+ * Command line argument parser, parses args formatted as: "-Pkey=value".
  */
 public final class ArgParser {
   static final String TRIPLEA_PROTOCOL = "triplea:";
-  private static final String TRIPLEA_PROPERTY_PREFIX = "P";
-  private final Set<String> availableProperties;
-
-  public ArgParser(final Set<String> availableProperties) {
-    this.availableProperties = availableProperties;
-  }
 
   /**
    * Move command line arguments to system properties or client settings.
-   *
-   * @return Return true if all args were valid and accepted, false otherwise.
    */
-  public boolean handleCommandLineArgs(final String[] args) {
+  public void handleCommandLineArgs(final String[] args) {
     ClientSetting.MAP_FOLDER_OVERRIDE.save(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue);
-    final Options options = getOptions();
-    final CommandLineParser parser = new DefaultParser();
+
+    if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {
+      handleMapDownloadArg(args[0]);
+    } else if ((args.length == 1) && !args[0].contains("=")) {
+      System.setProperty(CliProperties.TRIPLEA_GAME, args[0]);
+    } else {
+      ArgParsingHelper.getTripleaProperties(args)
+          .forEach((key, value) -> setSystemPropertyOrClientSetting((String) key, (String) value));
+    }
+  }
+
+  private void handleMapDownloadArg(final String arg) {
+    final String encoding = StandardCharsets.UTF_8.displayName();
     try {
-      final CommandLine cli = parser.parse(options, args);
-      if (!cli.getOptionProperties(TRIPLEA_PROPERTY_PREFIX).entrySet().stream().allMatch(
-          entry -> setSystemPropertyOrClientSetting((String) entry.getKey(), (String) entry.getValue()))) {
-        return false;
-      }
-
-      // Parse remaining options
-      parseRemaining(cli.getArgs());
-
-    } catch (final ParseException e) {
-      throw new IllegalArgumentException(e);
-    }
-    ClientSetting.flush();
-    return true;
-  }
-
-  private void parseRemaining(final String[] remainingArgs) {
-    if (remainingArgs.length == 1) {
-      if (remainingArgs[0].startsWith(TRIPLEA_PROTOCOL)) {
-        final String encoding = StandardCharsets.UTF_8.displayName();
-        try {
-          setSystemPropertyOrClientSetting(CliProperties.TRIPLEA_MAP_DOWNLOAD,
-              URLDecoder.decode(remainingArgs[0].substring(TRIPLEA_PROTOCOL.length()), encoding));
-        } catch (final UnsupportedEncodingException e) {
-          throw new AssertionError(encoding + " is not a supported encoding!", e);
-        }
-      } else {
-        setSystemPropertyOrClientSetting(CliProperties.TRIPLEA_GAME, remainingArgs[0]);
-      }
-    } else if (remainingArgs.length > 1) {
-      throw new IllegalArgumentException("Too much arguments: " + Arrays.toString(remainingArgs));
+      setSystemPropertyOrClientSetting(CliProperties.TRIPLEA_MAP_DOWNLOAD,
+          URLDecoder.decode(arg.substring(TRIPLEA_PROTOCOL.length()), encoding));
+    } catch (final UnsupportedEncodingException e) {
+      throw new AssertionError(encoding + " is not a supported encoding!", e);
     }
   }
 
-  private Options getOptions() {
-    final Options options = new Options();
-    options.addOption(Option.builder(TRIPLEA_PROPERTY_PREFIX)
-        .argName("key=value")
-        .hasArgs()
-        .numberOfArgs(2)
-        .valueSeparator()
-        .desc("Assign the given value to the given property key.\nValid keys are : "
-            + Joiner.on(",\n").join(availableProperties))
-        .build());
-    // See https://github.com/triplea-game/triplea/pull/2574 for more information
-    options.addOption(Option.builder("console").build());
-    return options;
-  }
-
-  private boolean setSystemPropertyOrClientSetting(
+  private void setSystemPropertyOrClientSetting(
       final String key,
       final String value) {
-    if (!availableProperties.contains(key)) {
-      System.out.println(String.format("Key %s is unknown", key));
-      return false;
-    }
 
-    if (!handleGameSetting(key, value)) {
+    if (CliProperties.MAP_FOLDER.equals(key)) {
+      ClientSetting.MAP_FOLDER_OVERRIDE.saveAndFlush(value);
+    } else {
       System.setProperty(key, value);
     }
-
-    System.out.println(key + ":" + value);
-    return true;
-  }
-
-  private static boolean handleGameSetting(final String key, final String value) {
-    if (CliProperties.MAP_FOLDER.equals(key)) {
-      ClientSetting.MAP_FOLDER_OVERRIDE.save(value);
-      return true;
-    }
-    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
@@ -1,0 +1,51 @@
+package games.strategy.engine.framework;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+
+/**
+ * A helper class for parsing args. Looks for args beginning with "-P" and will
+ * return them as part of a {@code Properties} object.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ArgParsingHelper {
+  @VisibleForTesting
+  static final String TRIPLEA_PROPERTY_PREFIX = "P";
+
+  public static Properties getTripleaProperties(final String... args) {
+    final Options options = getOptions();
+    final CommandLineParser parser = new DefaultParser();
+    try {
+      final CommandLine cli = parser.parse(options, args);
+      return cli.getOptionProperties(TRIPLEA_PROPERTY_PREFIX);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException("Failed to parse args: " + Arrays.asList(args), e);
+    }
+  }
+
+  private static Options getOptions() {
+    final Options options = new Options();
+    options.addOption(Option.builder(TRIPLEA_PROPERTY_PREFIX)
+        .argName("key=value")
+        .hasArgs()
+        .numberOfArgs(2)
+        .valueSeparator()
+        .build());
+    // See https://github.com/triplea-game/triplea/pull/2574 for more information
+    options.addOption(Option.builder("console").build());
+    return options;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
@@ -21,17 +21,17 @@ import lombok.NoArgsConstructor;
  * return them as part of a {@code Properties} object.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ArgParsingHelper {
+final class ArgParsingHelper {
   @VisibleForTesting
   static final String TRIPLEA_PROPERTY_PREFIX = "P";
 
-  public static Properties getTripleaProperties(final String... args) {
+  static Properties getTripleaProperties(final String... args) {
     final Options options = getOptions();
     final CommandLineParser parser = new DefaultParser();
     try {
       final CommandLine cli = parser.parse(options, args);
       return cli.getOptionProperties(TRIPLEA_PROPERTY_PREFIX);
-    } catch (ParseException e) {
+    } catch (final ParseException e) {
       throw new IllegalArgumentException("Failed to parse args: " + Arrays.asList(args), e);
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
@@ -32,7 +32,7 @@ final class ArgParsingHelper {
       final CommandLine cli = parser.parse(options, args);
       return cli.getOptionProperties(TRIPLEA_PROPERTY_PREFIX);
     } catch (final ParseException e) {
-      throw new IllegalArgumentException("Failed to parse args: " + Arrays.asList(args), e);
+      throw new IllegalArgumentException("Failed to parse args: " + Arrays.toString(args), e);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -1,15 +1,10 @@
 package games.strategy.engine.framework;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.framework.CliProperties.DO_NOT_CHECK_FOR_UPDATES;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_HOSTED_BY;
-import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_RECONNECTION;
-import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_SUPPORT_EMAIL;
-import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_SUPPORT_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
-import static games.strategy.engine.framework.CliProperties.MAP_FOLDER;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
@@ -18,7 +13,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_STARTED;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -34,10 +28,8 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -102,13 +94,6 @@ public class GameRunner {
   private static final SetupPanelModel setupPanelModel = new SetupPanelModel(gameSelectorModel);
   private static JFrame mainFrame;
 
-  private static final Set<String> COMMAND_LINE_ARGS = new HashSet<>(Arrays.asList(
-      TRIPLEA_GAME, TRIPLEA_MAP_DOWNLOAD, TRIPLEA_SERVER, TRIPLEA_CLIENT,
-      TRIPLEA_HOST, TRIPLEA_PORT, TRIPLEA_NAME, SERVER_PASSWORD,
-      TRIPLEA_STARTED, LOBBY_PORT, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
-      DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER));
-
-
   /**
    * Launches the "main" TripleA gui enabled game client.
    * No args will launch a client, additional args can be supplied to specify additional behavior.
@@ -126,10 +111,7 @@ public class GameRunner {
       });
     }
 
-    if (!new ArgParser(COMMAND_LINE_ARGS).handleCommandLineArgs(args)) {
-      usage();
-      return;
-    }
+    new ArgParser().handleCommandLineArgs(args);
 
     if (SystemProperties.isMac()) {
       com.apple.eawt.Application.getApplication().setOpenURIHandler(event -> {
@@ -314,35 +296,6 @@ public class GameRunner {
       SwingUtilities.invokeLater(() -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(downloadableMap));
     }
   }
-
-  private static void usage() {
-    System.out.println("\nUsage and Valid Arguments:\n"
-        + "   " + TRIPLEA_GAME + "=<FILE_NAME>\n"
-        + "   " + TRIPLEA_SERVER + "=true\n"
-        + "   " + TRIPLEA_PORT + "=<PORT>\n"
-        + "   " + TRIPLEA_NAME + "=<PLAYER_NAME>\n"
-        + "   " + LOBBY_HOST + "=<LOBBY_HOST>\n"
-        + "   " + LOBBY_PORT + "=<LOBBY_PORT>\n"
-        + "   " + LOBBY_GAME_COMMENTS + "=<LOBBY_GAME_COMMENTS>\n"
-        + "   " + LOBBY_GAME_HOSTED_BY + "=<LOBBY_GAME_HOSTED_BY>\n"
-        + "   " + LOBBY_GAME_SUPPORT_EMAIL + "=<youremail@emailprovider.com>\n"
-        + "   " + LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
-        + "   " + LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
-        + LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
-        + "   " + MAP_FOLDER + "=mapFolder"
-        + "\n"
-        + "   You must start the Name and HostedBy with \"Bot\".\n"
-        + "   Game Comments must have this string in it: \"automated_host\".\n"
-        + "   You must include a support email for your host, so that you can be alerted by lobby admins when your "
-        + "host has an error."
-        + " (For example they may email you when your host is down and needs to be restarted.)\n"
-        + "   Support password is a remote access password that will allow lobby admins to remotely take the "
-        + "following actions: ban player, stop game, shutdown server."
-        + " (Please email this password to one of the lobby moderators, or private message an admin on the "
-        + "TripleaWarClub.org website forum.)\n");
-  }
-
-
 
   public static Image getGameIcon(final Window frame) {
     Image img = null;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -632,12 +632,7 @@ public class HeadlessGameServer {
     ClientSetting.initialize();
 
     System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
-    // TODO: get properties from a configuration file instead of CLI.
-    if (!new ArgParser(getProperties()).handleCommandLineArgs(args)) {
-      usage();
-      return;
-    }
-
+    new ArgParser().handleCommandLineArgs(args);
     handleHeadlessGameServerArgs();
     ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
     try {

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -1,17 +1,11 @@
 package games.strategy.engine.framework;
 
-import static games.strategy.engine.framework.CliProperties.MAP_FOLDER;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +14,6 @@ import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 
 public class ArgParserTest extends AbstractClientSettingTestCase {
-
 
   @AfterEach
   public void teardown() {
@@ -32,26 +25,22 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     assertThat("check precondition, system property for our test key should not be set yet.",
         System.getProperty(TestData.propKey), nullValue());
 
-    final boolean result = new ArgParser(TestData.samplePropertyNameSet).handleCommandLineArgs(TestData.sampleArgInput);
+    new ArgParser().handleCommandLineArgs(TestData.sampleArgInput);
 
-    assertThat("prop key was supplied as an available value, "
-        + " which was passed as a test value - everything should "
-        + "have parsed well, expect true result",
-        result, is(true));
     assertThat("system property should now be set to our test value",
         System.getProperty(TestData.propKey), is(TestData.propValue));
   }
 
   @Test
   public void emptySystemPropertiesCanBeSet() {
-    new ArgParser(Collections.singleton("a")).handleCommandLineArgs(new String[] {"-Pa="});
+    new ArgParser().handleCommandLineArgs(new String[] {"-Pa="});
     assertThat("expecting the system property to be empty string instead of null",
         System.getProperty("a"), is(""));
   }
 
   @Test
   public void singleFileArgIsAssumedToBeGameProperty() {
-    new ArgParser(Collections.singleton(TRIPLEA_GAME))
+    new ArgParser()
         .handleCommandLineArgs(new String[] {TestData.propValue});
     assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
         System.getProperty(TRIPLEA_GAME), is(TestData.propValue));
@@ -60,7 +49,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsAssumedToBeMapDownloadProperty() {
     final String testUrl = "triplea:" + TestData.propValue;
-    new ArgParser(Collections.singleton(TRIPLEA_MAP_DOWNLOAD))
+    new ArgParser()
         .handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it's assumed to mean we are specifying the 'map download property'",
@@ -70,7 +59,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsUrlDecoded() {
     final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
-    new ArgParser(Collections.singleton(TRIPLEA_MAP_DOWNLOAD))
+    new ArgParser()
         .handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it should be properly URL-decoded as it's probably coming from a browser",
@@ -79,22 +68,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void install4jSwitchesAreIgnored() {
-    assertThat(new ArgParser(Collections.emptySet()).handleCommandLineArgs(new String[] {"-console"}), is(true));
-  }
-
-  @Test
-  public void returnFalseIfWeCannotMapKeysToAvailableSet() {
-    final Set<String> validKeys = new HashSet<>(Arrays.asList("a", "b"));
-    Arrays.asList(
-        new String[] {"-PnotMapped="},
-        new String[] {"-PnotMapped=test"},
-        new String[] {"-PnotMapped=test", "-Pa=valid"},
-        new String[] {"-Pa=valid", "-PnotMapped=test"},
-        new String[] {"-Pa=valid", "-PnotMapped=test", "-Pb=valid"},
-        new String[] {"-Pa=valid", "-Pb=valid", "-PnotMapped=test"})
-        .forEach(invalidInput -> assertThat("A key in the input is not in the valid key set, expecting this to be seen"
-            + "as invalid: " + Arrays.asList(invalidInput),
-            new ArgParser(validKeys).handleCommandLineArgs(invalidInput), is(false)));
+    new ArgParser().handleCommandLineArgs(new String[] {"-console"});
   }
 
   @Test
@@ -102,7 +76,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
     final String mapFolderPath = "/path/to/maps";
 
-    new ArgParser(Collections.singleton(MAP_FOLDER))
+    new ArgParser()
         .handleCommandLineArgs(new String[] {"-PmapFolder=" + mapFolderPath});
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));
@@ -112,7 +86,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
 
-    new ArgParser(Collections.emptySet()).handleCommandLineArgs(new String[0]);
+    new ArgParser().handleCommandLineArgs(new String[0]);
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue));
   }
@@ -121,6 +95,5 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     String propKey = "key";
     String propValue = "value";
     String[] sampleArgInput = new String[] {"-P" + propKey + "=" + propValue};
-    Set<String> samplePropertyNameSet = Collections.singleton(propKey);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParsingHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParsingHelperTest.java
@@ -1,0 +1,26 @@
+package games.strategy.engine.framework;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+class ArgParsingHelperTest {
+
+  private static final String arg = "arg";
+  private static final String value = "test_value";
+  private static final String hiddenKey = "hiddenDoesNotBelongWithDashP";
+
+  @Test
+  void getTripleaProperties() {
+    final Properties properties = ArgParsingHelper.getTripleaProperties(
+        "-" + ArgParsingHelper.TRIPLEA_PROPERTY_PREFIX + arg + "=" + value,
+        hiddenKey + "=hiddenValueAsKeyDidNotStartWithDashP");
+
+    assertThat(properties.getProperty(arg), is(value));
+    assertThat(properties.getProperty(hiddenKey), nullValue());
+  }
+}


### PR DESCRIPTION

## Overview
Eventually ArgParser.java will be dropped and the helper is all we'll need, so this is setting up for a migration step where we can remove ArgParser.java.

## Functional Changes
none

## Manual Testing Performed
- basic smoke testing, launched a headless bot, hosted a game


## Additional Review notes
- Note the usage text in GameRunner was removed:
  - it's geared for the headless server, this seems to be a copy/paste artifact legacy
  - We typically do not launch GameRunner with CLI, HeadlessServer, but not GameRunner. When it is GameRunner launched with CLI args it is an internal usage. In this case a `usage` text in not appropriate. To really put the nail in the GameRunner `usage` text coffin, the check that would display it only is shown when there are unrecognized args. That is an example of convenient but not appropriate, it was easy to check for extra args, but it really is not a helpful validation (we are interested in required but missing, or invalid values, knowing we submitted extra args is not so useful).
- CLI parsing only returns false if there are unrecognized args. For bots most of the useful parsing is done later, so we can safely have `ArgParser` just be a straight parser and not do validation.
