### PR TITLE
Checkstyle: Enable FinalLocalVariable and FinalParameters rules

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -244,5 +244,12 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="FinalLocalVariable">
+            <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF"/>
+            <property name="validateEnhancedForLoopVariable" value="true"/>
+        </module>
+        <module name="FinalParameters">
+            <property name="tokens" value="CTOR_DEF,FOR_EACH_CLAUSE,LITERAL_CATCH,METHOD_DEF"/>
+        </module>
     </module>
 </module>

--- a/game-core/gradle.properties
+++ b/game-core/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=1280
+checkstyleMainMaxWarnings=1314
 checkstyleTestMaxWarnings=2

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -58,7 +58,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
 
   private void setIconMap() {
     final PlayerManager playerManager = game.getPlayerManager();
-    PlayerList playerList;
+    final PlayerList playerList;
     game.getData().acquireReadLock();
     try {
       playerList = game.getData().getPlayerList();

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -156,7 +156,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param territory referring territory
    * @param distance maximal distance of the neighboring territories
    */
-  public Set<Territory> getNeighbors(final Territory territory, int distance) {
+  public Set<Territory> getNeighbors(final Territory territory, final int distance) {
     if (distance < 0) {
       throw new IllegalArgumentException("Distance must be positive not:" + distance);
     }
@@ -167,7 +167,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (distance == 1) {
       return start;
     }
-    final Set<Territory> neighbors = getNeighbors(start, new HashSet<>(start), --distance);
+    final Set<Territory> neighbors = getNeighbors(start, new HashSet<>(start), distance - 1);
     neighbors.remove(territory);
     return neighbors;
   }
@@ -176,7 +176,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * Returns all neighbors within a certain distance of the starting territory that match the condition.
    * Does NOT include the original/starting territory in the returned Set.
    */
-  public Set<Territory> getNeighbors(final Territory territory, int distance, final Predicate<Territory> cond) {
+  public Set<Territory> getNeighbors(final Territory territory, final int distance, final Predicate<Territory> cond) {
     if (distance < 0) {
       throw new IllegalArgumentException("Distance must be positive not:" + distance);
     }
@@ -187,7 +187,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (distance == 1) {
       return start;
     }
-    final Set<Territory> neighbors = getNeighbors(start, new HashSet<>(start), --distance, cond);
+    final Set<Territory> neighbors = getNeighbors(start, new HashSet<>(start), distance - 1, cond);
     neighbors.remove(territory);
     return neighbors;
   }
@@ -215,7 +215,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     return neighbors;
   }
 
-  private Set<Territory> getNeighbors(final Set<Territory> frontier, final Set<Territory> searched, int distance,
+  private Set<Territory> getNeighbors(final Set<Territory> frontier, final Set<Territory> searched, final int distance,
       @Nullable final Predicate<Territory> cond) {
     if (distance == 0) {
       return searched;
@@ -226,7 +226,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         .filter(t -> !searched.contains(t))
         .collect(Collectors.toSet());
     searched.addAll(newFrontier);
-    return getNeighbors(newFrontier, searched, --distance, cond);
+    return getNeighbors(newFrontier, searched, distance - 1, cond);
   }
 
   private Set<Territory> getNeighbors(final Set<Territory> frontier, final Set<Territory> searched,

--- a/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -1,5 +1,9 @@
 package games.strategy.engine.data;
 
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
 public class Territory extends NamedAttachable implements NamedUnitHolder, Comparable<Territory> {
   private static final long serialVersionUID = -6390555051736721082L;
   private final boolean m_water;
@@ -44,11 +48,8 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
     return m_owner;
   }
 
-  public void setOwner(PlayerID newOwner) {
-    if (newOwner == null) {
-      newOwner = PlayerID.NULL_PLAYERID;
-    }
-    m_owner = newOwner;
+  public void setOwner(final @Nullable PlayerID owner) {
+    m_owner = Optional.ofNullable(owner).orElse(PlayerID.NULL_PLAYERID);
     getData().notifyTerritoryOwnerChanged(this);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -171,7 +171,7 @@ public class ClientGame extends AbstractGame {
       remoteMessenger.unregisterRemote(getRemoteStepAdvancerName(channelMessenger.getLocalNode()));
       vault.shutDown();
       for (final IGamePlayer gp : gamePlayers.values()) {
-        PlayerID player;
+        final PlayerID player;
         gameData.acquireReadLock();
         try {
           player = gameData.getPlayerList().getPlayerId(gp.getName());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -144,11 +144,8 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     }
   }
 
-  public void setRemoteModelListener(IRemoteModelListener listener) {
-    if (listener == null) {
-      listener = IRemoteModelListener.NULL_LISTENER;
-    }
-    remoteModelListener = listener;
+  public void setRemoteModelListener(final @Nullable IRemoteModelListener listener) {
+    remoteModelListener = Optional.ofNullable(listener).orElse(IRemoteModelListener.NULL_LISTENER);
   }
 
   public void setLocalPlayerType(final String player, final PlayerType type) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerType.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerType.java
@@ -58,7 +58,7 @@ public enum PlayerType {
   private final boolean visible;
   private final Function<String, IGamePlayer> playerFactory;
 
-  PlayerType(String label, Function<String, IGamePlayer> playerFactory) {
+  PlayerType(final String label, final Function<String, IGamePlayer> playerFactory) {
     this(label, true, playerFactory);
   }
 
@@ -75,10 +75,10 @@ public enum PlayerType {
   }
 
   /**
-   * Each PlayerType is backed by an @{code IGamePlayer} instance. Given a playername this method
-   * will create the corresponding @{code IGamePlayer} instance.
+   * Each PlayerType is backed by an {@code IGamePlayer} instance. Given a player name this method
+   * will create the corresponding {@code IGamePlayer} instance.
    */
-  public IGamePlayer createPlayerWithName(String name) {
+  public IGamePlayer createPlayerWithName(final String name) {
     return playerFactory.apply(name);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -326,7 +326,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       enabledCheckBox.addActionListener(disablePlayerActionListener);
       // this gets updated later
       enabledCheckBox.setSelected(true);
-      String[] playerTypes = PlayerType.playerTypes();
+      final String[] playerTypes = PlayerType.playerTypes();
       type = new JComboBox<>(playerTypes);
       String previousSelection = reloadSelections.get(playerName);
       if (previousSelection.equalsIgnoreCase("Client")) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -131,7 +131,7 @@ public class MainPanel extends JPanel implements Observer, ScreenChangeListener 
    * This method will 'change' screens, swapping out one setup panel for another.
    */
   @Override
-  public void screenChangeEvent(ISetupPanel panel) {
+  public void screenChangeEvent(final ISetupPanel panel) {
     gameSetupPanel = panel;
     gameSetupPanelHolder.removeAll();
     gameSetupPanelHolder.add(panel.getDrawable(), BorderLayout.CENTER);

--- a/game-core/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/game-core/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -27,15 +27,14 @@ class SocketWriteData {
   // how many times we called write before we finished writing ourselves
   private int writeCalls = 0;
 
-  SocketWriteData(final byte[] data, int count) {
+  SocketWriteData(final byte[] data, final int count) {
     content = ByteBuffer.allocate(count);
     content.put(data, 0, count);
     size = ByteBuffer.allocate(4);
     if (count < 0 || count > SocketReadData.MAX_MESSAGE_SIZE) {
       throw new IllegalStateException("Invalid message size:" + count);
     }
-    count = count ^ SocketReadData.MAGIC;
-    size.putInt(count);
+    size.putInt(count ^ SocketReadData.MAGIC);
     size.flip();
     content.flip();
   }

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -54,7 +54,7 @@ public class TripleA implements IGameLoader {
         .collect(Collectors.toSet());
   }
 
-  private static IGamePlayer toGamePlayer(Map.Entry<String, PlayerType> namePlayerType) {
+  private static IGamePlayer toGamePlayer(final Map.Entry<String, PlayerType> namePlayerType) {
     return namePlayerType.getValue()
         .createPlayerWithName(namePlayerType.getKey());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -184,7 +184,7 @@ public class ProAi extends AbstractAi {
       ProLogger.info("Starting simulation for purchase phase");
 
       // Setup data copy and delegates
-      GameData dataCopy;
+      final GameData dataCopy;
       try {
         data.acquireWriteLock();
         dataCopy = GameDataUtils.cloneGameDataWithoutHistory(data, true);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -466,7 +466,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     m_directOwnershipTerritories = null;
   }
 
-  private void setUnitPresence(String value) throws GameParseException {
+  private void setUnitPresence(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 1) {
       throw new GameParseException("unitPresence must have at least 2 fields. Format value=unit1 count=number, or "
@@ -484,8 +484,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         throw new GameParseException("No unit called: " + unitTypeToProduce + thisErrorMsg());
       }
     }
-    value = value.replaceFirst(s[0] + ":", "");
-    m_unitPresence.put(value, n);
+    m_unitPresence.put(value.replaceFirst(s[0] + ":", ""), n);
   }
 
   private void setUnitPresence(final IntegerMap<String> value) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -188,7 +188,7 @@ public abstract class TechAdvance extends NamedAttachable {
    */
   private static Tuple<List<TechAdvance>, List<TechAdvance>> getWW2v3CategoriesWithTheirAdvances(final GameData data) {
     data.acquireReadLock();
-    List<TechAdvance> allAdvances;
+    final List<TechAdvance> allAdvances;
     try {
       allAdvances = new ArrayList<>(data.getTechnologyFrontier().getTechs());
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -179,7 +179,7 @@ public class BattleDisplay extends JPanel {
     } else {
       casualtyPanel = casualtiesInstantPanelAttacker;
     }
-    Map<Unit, Collection<Unit>> dependentsMap;
+    final Map<Unit, Collection<Unit>> dependentsMap;
     gameData.acquireReadLock();
     try {
       dependentsMap = BattleCalculator.getDependents(killedUnits);
@@ -187,7 +187,7 @@ public class BattleDisplay extends JPanel {
       gameData.releaseReadLock();
     }
     final Collection<Unit> dependentUnitsReturned = new ArrayList<>();
-    for (Collection<Unit> dependentCollection : dependentsMap.values()) {
+    for (final Collection<Unit> dependentCollection : dependentsMap.values()) {
       dependentUnitsReturned.addAll(dependentCollection);
     }
     for (final UnitCategory category : UnitSeperator.categorize(killedUnits, dependentsMap, false, false)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -135,7 +135,7 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitDamage damaged, final UnitEnable disabled) {
     final Optional<ImageIcon> image = getUnitImageFactory().getIcon(type, player, damaged == UnitDamage.DAMAGED,
         disabled == UnitEnable.DISABLED);
-    JLabel label = image.map(JLabel::new).orElseGet(JLabel::new);
+    final JLabel label = image.map(JLabel::new).orElseGet(JLabel::new);
     MapUnitTooltipManager.setUnitTooltip(label, type, player, 1);
     return label;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -380,28 +380,28 @@ public class MapPanel extends ImageScrollerLargeView {
     return gameData.getMap().getTerritory(name);
   }
 
-  private double normalizeX(double x) {
+  private double normalizeX(final double x) {
     if (!uiContext.getMapData().scrollWrapX()) {
       return x;
     }
     final int imageWidth = (int) getImageDimensions().getWidth();
     if (x < 0) {
-      x += imageWidth;
+      return x + imageWidth;
     } else if (x > imageWidth) {
-      x -= imageWidth;
+      return x - imageWidth;
     }
     return x;
   }
 
-  private double normalizeY(double y) {
+  private double normalizeY(final double y) {
     if (!uiContext.getMapData().scrollWrapY()) {
       return y;
     }
     final int imageHeight = (int) getImageDimensions().getHeight();
     if (y < 0) {
-      y += imageHeight;
+      return y + imageHeight;
     } else if (y > imageHeight) {
-      y -= imageHeight;
+      return y - imageHeight;
     }
     return y;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -453,7 +453,7 @@ public class MovePanel extends AbstractMovePanel {
     sortUnitsToMove(best, route);
     Collections.reverse(best);
     List<Unit> bestWithDependents = addMustMoveWith(best);
-    MoveValidationResult allResults;
+    final MoveValidationResult allResults;
     getData().acquireReadLock();
     try {
       allResults = AbstractMoveDelegate.validateMove(moveType, bestWithDependents, route, getCurrentPlayer(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -180,7 +180,7 @@ public class TechPanel extends ActionPanel {
 
     final int pus = currentPlayer.getResources().getQuantity(Constants.PUS);
     // see if anyone will help us to pay
-    Collection<PlayerID> helpPay;
+    final Collection<PlayerID> helpPay;
     final PlayerAttachment pa = PlayerAttachment.get(currentPlayer);
     if (pa != null) {
       helpPay = pa.getHelpPayTechCost();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -81,7 +81,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     }
     add(new JLabel(labelText));
     gameData.acquireReadLock();
-    Collection<Unit> unitsInTerritory;
+    final Collection<Unit> unitsInTerritory;
     try {
       unitsInTerritory = territory.getUnits().getUnits();
     } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1423,9 +1423,9 @@ public class TripleAFrame extends MainGameFrame {
     } finally {
       data.releaseReadLock();
     }
-    int round;
-    String stepDisplayName;
-    PlayerID player;
+    final int round;
+    final String stepDisplayName;
+    final PlayerID player;
     data.acquireReadLock();
     try {
       round = data.getSequence().getRound();

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -388,7 +388,7 @@ public class HistoryLog extends JFrame {
   }
 
   public void printTerritorySummary(final HistoryNode printNode, final GameData data) {
-    Collection<Territory> territories;
+    final Collection<Territory> territories;
     final PlayerID player = getPlayerId(printNode);
     data.acquireReadLock();
     try {
@@ -402,8 +402,8 @@ public class HistoryLog extends JFrame {
   }
 
   private void printTerritorySummary(final GameData data) {
-    Collection<Territory> territories;
-    PlayerID player;
+    final Collection<Territory> territories;
+    final PlayerID player;
     data.acquireReadLock();
     try {
       player = data.getSequence().getStep().getPlayerId();
@@ -421,7 +421,7 @@ public class HistoryLog extends JFrame {
       printTerritorySummary(data);
       return;
     }
-    Collection<Territory> territories;
+    final Collection<Territory> territories;
     data.acquireReadLock();
     try {
       territories = data.getMap().getTerritories();
@@ -478,8 +478,8 @@ public class HistoryLog extends JFrame {
 
   public void printProductionSummary(final GameData data) {
     final PrintWriter logWriter = printWriter;
-    Collection<PlayerID> players;
-    Resource pus;
+    final Collection<PlayerID> players;
+    final Resource pus;
     data.acquireReadLock();
     try {
       pus = data.getResourceList().getResource(Constants.PUS);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -401,7 +401,7 @@ final class ExportMenu extends JMenu {
     final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Setup Charts", e -> {
       final JFrame frame = new JFrame("Export Setup Charts");
       frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-      GameData clonedGameData;
+      final GameData clonedGameData;
       gameData.acquireReadLock();
       try {
         clonedGameData = GameDataUtils.cloneGameData(gameData);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -97,7 +97,7 @@ public class TileManager {
       final List<Tile> tilesInBounds = new ArrayList<>();
       for (final Tile tile : tiles) {
         final Rectangle tileBounds = tile.getBounds();
-        for (AffineTransform transform : translations) {
+        for (final AffineTransform transform : translations) {
           if (transform.createTransformedShape(tileBounds).intersects(bounds)) {
             tilesInBounds.add(tile);
             break;
@@ -162,7 +162,7 @@ public class TileManager {
           tile.addDrawable(new BaseMapDrawable(x, y, uiContext));
           tile.addDrawable(new ReliefMapDrawable(x, y, uiContext));
         }
-        for (Territory territory : data.getMap().getTerritories()) {
+        for (final Territory territory : data.getMap().getTerritories()) {
           clearTerritory(territory);
           drawTerritory(territory, data, mapData);
         }
@@ -194,7 +194,7 @@ public class TileManager {
         if (territories == null) {
           return;
         }
-        for (Territory territory : territories) {
+        for (final Territory territory : territories) {
           updateTerritory(territory, data, mapData);
         }
       } finally {
@@ -229,7 +229,7 @@ public class TileManager {
     if (drawables == null || drawables.isEmpty()) {
       return;
     }
-    for (Tile tile : territoryTiles.get(territory.getName())) {
+    for (final Tile tile : territoryTiles.get(territory.getName())) {
       tile.removeDrawables(drawables);
     }
     allUnitDrawables.removeAll(drawables);
@@ -285,7 +285,7 @@ public class TileManager {
       drawing.add(new VcDrawable(territory));
     }
     // add to the relevant tiles
-    for (Tile tile : getTiles(mapData.getBoundingRect(territory.getName()))) {
+    for (final Tile tile : getTiles(mapData.getBoundingRect(territory.getName()))) {
       drawnOn.add(tile);
       tile.addDrawables(drawing);
     }
@@ -330,7 +330,7 @@ public class TileManager {
           category.getDisabled(), overflow, territory.getName(), uiContext);
       drawing.add(drawable);
       allUnitDrawables.add(drawable);
-      for (Tile tile : getTiles(
+      for (final Tile tile : getTiles(
           new Rectangle(lastPlace.x, lastPlace.y, uiContext.getUnitImageFactory().getUnitImageWidth(),
               uiContext.getUnitImageFactory().getUnitImageHeight()))) {
         tile.addDrawable(drawable);

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -305,11 +305,10 @@ public class ImageScrollerLargeView extends JComponent {
    * @param value The new scale value. Constrained to the bounds of no less than 0.15 and no greater than 1.
    *        If out of bounds the nearest boundary value is used.
    */
-  public void setScale(double value) {
+  public void setScale(final double value) {
     // we want the ratio to be a multiple of 1/256
     // so that the tiles have integer widths and heights
-    value = ((int) (value * 256)) / ((double) 256);
-    scale = value;
+    scale = ((int) (value * 256)) / ((double) 256);
     refreshBoxSize();
   }
 

--- a/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/game-core/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -252,14 +252,13 @@ public final class PointFileReaderWriter {
   }
 
   @VisibleForTesting
-  static void readStream(final InputStream stream, Consumer<String> lineParser)
-      throws IOException {
+  static void readStream(final InputStream stream, final Consumer<String> lineParser) throws IOException {
     try (Reader inputStreamReader = new InputStreamReader(new CloseShieldInputStream(stream), StandardCharsets.UTF_8);
         BufferedReader reader = new BufferedReader(inputStreamReader)) {
       reader.lines()
           .filter(current -> current.trim().length() != 0)
           .forEachOrdered(lineParser);
-    } catch (IllegalArgumentException e) {
+    } catch (final IllegalArgumentException e) {
       throw new IOException(e);
     }
   }

--- a/game-core/src/main/java/swinglib/GridBagHelper.java
+++ b/game-core/src/main/java/swinglib/GridBagHelper.java
@@ -88,7 +88,7 @@ public final class GridBagHelper {
     return nextConstraint(Anchor.WEST, Fill.NONE);
   }
 
-  GridBagConstraints nextConstraint(Anchor anchor, Fill fill) {
+  GridBagConstraints nextConstraint(final Anchor anchor, final Fill fill) {
     final int x = elementCount % columns;
     final int y = elementCount / columns;
 
@@ -156,7 +156,7 @@ public final class GridBagHelper {
     private final int weightX;
     private final int weightY;
 
-    Fill(int gridBagConstraintValue) {
+    Fill(final int gridBagConstraintValue) {
       this(gridBagConstraintValue, 0, 0);
     }
   }

--- a/game-core/src/main/java/swinglib/JPanelBuilder.java
+++ b/game-core/src/main/java/swinglib/JPanelBuilder.java
@@ -315,7 +315,7 @@ public class JPanelBuilder {
     return flowLayout(FlowLayoutJustification.DEFAULT);
   }
 
-  public JPanelBuilder flowLayout(FlowLayoutJustification flowLayoutDirection) {
+  public JPanelBuilder flowLayout(final FlowLayoutJustification flowLayoutDirection) {
     layout = flowLayoutDirection.layoutSupplier.get();
     return this;
   }
@@ -487,15 +487,15 @@ public class JPanelBuilder {
     GridBagHelper.Anchor anchor = Anchor.WEST;
 
 
-    PanelProperties(BorderLayoutPosition borderLayoutPosition) {
+    PanelProperties(final BorderLayoutPosition borderLayoutPosition) {
       this.borderLayoutPosition = borderLayoutPosition;
     }
 
-    PanelProperties(ColumnSpan columnSpan) {
+    PanelProperties(final ColumnSpan columnSpan) {
       this.columnSpan = columnSpan;
     }
 
-    PanelProperties(Anchor anchor, Fill fill) {
+    PanelProperties(final Anchor anchor, final Fill fill) {
       this.anchor = anchor;
       this.fill = fill;
     }

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -105,7 +105,7 @@ public final class ConnectionFinder {
       mapFolderLocation = polyFile.getParentFile();
     }
     final Map<String, List<Area>> territoryAreas = new HashMap<>();
-    Map<String, List<Polygon>> mapOfPolygons;
+    final Map<String, List<Polygon>> mapOfPolygons;
     try (InputStream in = new FileInputStream(polyFile)) {
       mapOfPolygons = PointFileReaderWriter.readOneToManyPolygons(in);
       for (final Entry<String, List<Polygon>> entry : mapOfPolygons.entrySet()) {

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
@@ -30,12 +30,12 @@ class PlayerTypeTest {
 
   @Test
   void createPlayerWithName() {
-    String testName = "example";
+    final String testName = "example";
 
     stream(PlayerType.values())
         .filter(playerType -> playerType != PlayerType.BATTLE_CALC_DUMMY)
         .forEach(playerType -> {
-          IGamePlayer result = playerType.createPlayerWithName(testName);
+          final IGamePlayer result = playerType.createPlayerWithName(testName);
           assertThat(
               "The player type should match after construction, input type: " + playerType,
               result.getPlayerType(),

--- a/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -23,7 +23,7 @@ public final class TestGameLoader implements IGameLoader {
 
   @Override
   public void startGame(final IGame game, final Set<IGamePlayer> players,
-      final boolean headless, @Nullable Chat chat) {}
+      final boolean headless, final @Nullable Chat chat) {}
 
   @Override
   public Set<IGamePlayer> createPlayers(final Map<String, PlayerType> players) {

--- a/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
@@ -19,7 +19,7 @@ public class AbstractConditionsAttachmentTest {
         private static final long serialVersionUID = -40443726954483090L;
 
         @Override
-        public void validate(GameData data) {}
+        public void validate(final GameData data) {}
       };
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
@@ -134,8 +134,7 @@ public class UnitAttachmentTest {
     assertEquals(Tuple.of(falseString, expected2), mapReference.get(from + ":" + to));
   }
 
-
-  private String concatWithColon(String... args) {
+  private static String concatWithColon(final String... args) {
     return Arrays.stream(args).collect(Collectors.joining(":"));
   }
 }


### PR DESCRIPTION
## Overview

Enables the Checkstyle FinalLocalVariable and FinalParameters rules.  They are configured to enforce usage of `final` in the following cases:

* Constructor parameters
* Method parameters
* Catch block parameter
* For-each loop variable
* Local variables that are not modified after initialization

I fixed low-hanging violations as part of this PR (e.g. parameters and local variables that were already effectively `final`, or assignments that could be inlined).  For the remainder (~30), I simply bumped the Checkstyle thresholds until we can address them in the future, as they will require a bit more scrutiny and testing.

## Functional Changes

None.

## Manual Testing Performed

None.