### PR TITLE
Add check for territory effects blocking units for route finding

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -905,10 +905,8 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryEffectsAllowUnits(final Collection<Unit> units) {
-    return t -> {
-      return units.stream()
-          .noneMatch(Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)));
-    };
+    return t -> units.stream()
+        .noneMatch(Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)));
   }
 
   public static Predicate<Territory> territoryIsNotImpassable() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -904,6 +904,13 @@ public final class Matches {
     };
   }
 
+  public static Predicate<Territory> territoryEffectsAllowUnits(final Collection<Unit> units) {
+    return t -> {
+      return units.stream()
+          .noneMatch(Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)));
+    };
+  }
+
   public static Predicate<Territory> territoryIsNotImpassable() {
     return territoryIsImpassable().negate();
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1430,6 +1430,7 @@ public class MoveValidator {
     // no impassable or restricted territories
     final Predicate<Territory> noImpassable =
         PredicateBuilder.of(Matches.territoryIsPassableAndNotRestricted(player, data))
+            .and(Matches.territoryEffectsAllowUnits(units))
             // if we have air or land, we don't want to move over territories owned by players who's
             // relationships will not let us move into them
             .andIf(hasAir, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))


### PR DESCRIPTION
## Overview
Addresses feature request: https://forums.triplea-game.org/topic/945/improve-route-finder-to-consider-territory-effects

## Functional Changes
- Added territory effect check for route finding

## Manual Testing Performed
- Tested Large Middle Earth units that can and can't move through mountains
- Tested a few standard maps like revised to ensure no side effects

## Before & After Screen Shots
Shows a unit that can't move through mountains prioritizing non-mountains territories with route finding.

### Before
![image](https://user-images.githubusercontent.com/1427689/43435552-1e7c5910-9446-11e8-9195-f137f4410743.png)

### After
![image](https://user-images.githubusercontent.com/1427689/43435586-491185a6-9446-11e8-83e1-1960857bb366.png)


