### PR TITLE
Migrate CliProperty 'gameStarted' to static state from System property.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -14,7 +14,6 @@ public class CliProperties {
   public static final String TRIPLEA_PORT = "triplea.port";
   public static final String TRIPLEA_NAME = "triplea.name";
   public static final String SERVER_PASSWORD = "triplea.server.password";
-  public static final String TRIPLEA_STARTED = "triplea.started";
   public static final String LOBBY_HOST = "triplea.lobby.host";
   public static final String LOBBY_PORT = "triplea.lobby.port";
   public static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -18,7 +18,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_STARTED;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -105,7 +104,7 @@ public class GameRunner {
   private static final Set<String> COMMAND_LINE_ARGS = new HashSet<>(Arrays.asList(
       TRIPLEA_GAME, TRIPLEA_MAP_DOWNLOAD, TRIPLEA_SERVER, TRIPLEA_CLIENT,
       TRIPLEA_HOST, TRIPLEA_PORT, TRIPLEA_NAME, SERVER_PASSWORD,
-      TRIPLEA_STARTED, LOBBY_PORT, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
+      LOBBY_PORT, LOBBY_HOST, LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY,
       DO_NOT_CHECK_FOR_UPDATES, MAP_FOLDER));
 
 

--- a/game-core/src/main/java/games/strategy/engine/framework/GameState.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameState.java
@@ -1,0 +1,18 @@
+package games.strategy.engine.framework;
+
+/**
+ * Holder for static 'game started' state.
+ */
+public enum GameState {
+  ;
+
+  private static boolean started = false;
+
+  public static void setStarted() {
+    started = true;
+  }
+
+  public static boolean notStarted() {
+    return !started;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -4,7 +4,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_STARTED;
 
 import java.awt.Component;
 import java.io.IOException;
@@ -39,6 +38,7 @@ import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.GameState;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.network.ui.ChangeGameOptionsClientAction;
 import games.strategy.engine.framework.network.ui.ChangeGameToSaveGameClientAction;
@@ -166,12 +166,12 @@ public class ClientModel implements IMessengerErrorListener {
 
   private static ClientProps getProps(final Component ui) {
     if (System.getProperty(TRIPLEA_CLIENT, "false").equals("true")
-        && System.getProperty(TRIPLEA_STARTED, "").isEmpty()) {
+        && GameState.notStarted()) {
       final ClientProps props = new ClientProps();
       props.setHost(System.getProperty(TRIPLEA_HOST));
       props.setName(System.getProperty(TRIPLEA_NAME));
       props.setPort(Integer.parseInt(System.getProperty(TRIPLEA_PORT)));
-      System.setProperty(TRIPLEA_STARTED, "true");
+      GameState.setStarted();
       return props;
     }
     // load in the saved name!

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -4,7 +4,6 @@ import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_STARTED;
 
 import java.awt.Component;
 import java.io.BufferedInputStream;
@@ -46,6 +45,7 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.GameState;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
@@ -190,14 +190,14 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
 
   private Optional<ServerConnectionProps> getServerProps(final Component ui) {
     if (System.getProperty(TRIPLEA_SERVER, "false").equals("true")
-        && System.getProperty(TRIPLEA_STARTED, "").isEmpty()) {
+        && GameState.notStarted()) {
       final ServerConnectionProps props = new ServerConnectionProps();
       props.setName(System.getProperty(TRIPLEA_NAME));
       props.setPort(Integer.parseInt(System.getProperty(TRIPLEA_PORT)));
       if (System.getProperty(SERVER_PASSWORD) != null) {
         props.setPassword(System.getProperty(SERVER_PASSWORD));
       }
-      System.setProperty(TRIPLEA_STARTED, "true");
+      GameState.setStarted();
       return Optional.of(props);
     }
     final String playername = ClientSetting.PLAYER_NAME.value();


### PR DESCRIPTION
## Overview

- 'gameStarted' is not actually a CLI arg, we use it as a system property to communicate data state from one place to another.
- The update here moves the 'game started' data from a static map to be behind a static method. The main goal is to get it out of CliProperties as it does not belong, hence the static state problem is not fully fixed but we get an improvement here and CliProperties is evacuated of the one property that is not used on CLI.


## Functional Changes
- None

## Manual Testing Performed
- Did some quick smoke testing that could host a game and connect to that hosted game with another instance.


