### PR TITLE
Fix Mockito strictness warnings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/ProductionFrontierList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionFrontierList.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class ProductionFrontierList extends GameDataComponent {
   private static final long serialVersionUID = -7565214499087021809L;
   private final Map<String, ProductionFrontier> m_productionFrontiers = new HashMap<>();
@@ -12,7 +14,8 @@ public class ProductionFrontierList extends GameDataComponent {
     super(data);
   }
 
-  protected void addProductionFrontier(final ProductionFrontier pf) {
+  @VisibleForTesting
+  public void addProductionFrontier(final ProductionFrontier pf) {
     m_productionFrontiers.put(pf.getName(), pf);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionRuleList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionRuleList.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 public class ProductionRuleList extends GameDataComponent {
   private static final long serialVersionUID = -5313215563006788188L;
   private final Map<String, ProductionRule> m_productionRules = new HashMap<>();
@@ -12,7 +14,8 @@ public class ProductionRuleList extends GameDataComponent {
     super(data);
   }
 
-  protected void addProductionRule(final ProductionRule pf) {
+  @VisibleForTesting
+  public void addProductionRule(final ProductionRule pf) {
     m_productionRules.put(pf.getName(), pf);
   }
 

--- a/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -14,14 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.triplea.settings.GameSetting;
 
 public final class ClientFileSystemHelperTest {
   @ExtendWith(MockitoExtension.class)
-  @MockitoSettings(strictness = Strictness.WARN)
   @Nested
   public final class GetFolderContainingFileWithNameTest {
     @Mock
@@ -39,15 +36,12 @@ public final class ClientFileSystemHelperTest {
 
     @BeforeEach
     public void setUp() {
-      when(file.isFile()).thenReturn(true);
-      when(startFolder.getParentFile()).thenReturn(parentFolder);
       when(file.getName()).thenReturn("filename.ext");
-      when(parentFolder.getName()).thenReturn("parent");
-      when(startFolder.getName()).thenReturn("start");
     }
 
     @Test
     public void shouldReturnStartFolderWhenStartFolderContainsFile() throws Exception {
+      when(file.isFile()).thenReturn(true);
       when(startFolder.listFiles()).thenReturn(new File[] {file});
 
       assertThat(getFolderContainingFileWithName(), is(startFolder));
@@ -55,6 +49,8 @@ public final class ClientFileSystemHelperTest {
 
     @Test
     public void shouldReturnAncestorFolderWhenAncestorFolderContainsFile() throws Exception {
+      when(file.isFile()).thenReturn(true);
+      when(startFolder.getParentFile()).thenReturn(parentFolder);
       when(startFolder.listFiles()).thenReturn(new File[0]);
       when(parentFolder.listFiles()).thenReturn(new File[] {file});
 
@@ -63,6 +59,7 @@ public final class ClientFileSystemHelperTest {
 
     @Test
     public void shouldThrowExceptionWhenNoFolderContainsFile() {
+      when(startFolder.getParentFile()).thenReturn(parentFolder);
       when(startFolder.listFiles()).thenReturn(new File[0]);
       when(parentFolder.listFiles()).thenReturn(new File[0]);
 

--- a/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.engine.framework.map.download.DownloadUtils;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
@@ -71,7 +69,6 @@ public class LobbyServerPropertiesFetcherTest {
   }
 
   @ExtendWith(MockitoExtension.class)
-  @MockitoSettings(strictness = Strictness.WARN)
   @Nested
   public final class GetTestOverridePropertiesTest {
     @Mock
@@ -87,7 +84,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     private void givenTestLobbyHostIsSet() {
-      givenTestLobbyHostIsSetTo("host");
+      when(testLobbyHostSetting.isSet()).thenReturn(true);
     }
 
     private void givenTestLobbyHostIsSetTo(final String host) {
@@ -100,7 +97,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     private void givenTestLobbyPortIsSet() {
-      givenTestLobbyPortIsSetTo(0);
+      when(testLobbyPortSetting.isSet()).thenReturn(true);
     }
 
     private void givenTestLobbyPortIsSetTo(final int port) {

--- a/game-core/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,14 +17,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.WARN)
 public class UnitCollectionTest {
 
   @Mock
@@ -61,10 +59,6 @@ public class UnitCollectionTest {
   public void setup() {
     unitTypeOne = new UnitType("Unit Type 1", mockGameData);
     unitTypeTwo = new UnitType("Unit Type 2", mockGameData);
-    final UnitTypeList unitTypeList = new UnitTypeList(mockGameData);
-    unitTypeList.addUnitType(unitTypeOne);
-    unitTypeList.addUnitType(unitTypeTwo);
-    Mockito.when(mockGameData.getUnitTypeList()).thenReturn(unitTypeList);
 
     unitCollection = new UnitCollection(defaultPlayerId, mockGameData);
 
@@ -294,10 +288,18 @@ public class UnitCollectionTest {
 
   @Test
   public void getUnitsByType() {
+    givenUnitTypeList();
     final UnitCollection allDefaultPlayerUnitCollection = addAllDefaultPlayerUnitsToUnitCollection(unitCollection);
     final IntegerMap<UnitType> unitsByType = allDefaultPlayerUnitCollection.getUnitsByType();
     assertThat(unitsByType.getInt(unitTypeOne), is(equalTo(unitCountDefaultPlayerUnitTypeOne)));
     assertThat(unitsByType.getInt(unitTypeTwo), is(equalTo(unitCountDefaultPlayerUnitTypeTwo)));
+  }
+
+  private void givenUnitTypeList() {
+    final UnitTypeList unitTypeList = new UnitTypeList(mockGameData);
+    unitTypeList.addUnitType(unitTypeOne);
+    unitTypeList.addUnitType(unitTypeTwo);
+    when(mockGameData.getUnitTypeList()).thenReturn(unitTypeList);
   }
 
   @Test
@@ -316,6 +318,7 @@ public class UnitCollectionTest {
 
   @Test
   public void getUnitsWithUnityByTypeIntegerMap() {
+    givenUnitTypeList();
     final UnitCollection allDefaultPlayerUnitCollection = addAllDefaultPlayerUnitsToUnitCollection(unitCollection);
     final IntegerMap<UnitType> unitsByType = allDefaultPlayerUnitCollection.getUnitsByType();
     final Collection<Unit> expAllUnitsOfDefaultPlayer = allDefaultPlayerUnitCollection.getUnits(unitsByType);

--- a/game-core/src/test/java/games/strategy/engine/data/util/ResourceCollectionUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/util/ResourceCollectionUtilsTest.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.util;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -15,8 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
@@ -26,7 +23,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.util.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.WARN)
 public final class ResourceCollectionUtilsTest {
   @Mock
   private GameData data;
@@ -77,7 +73,7 @@ public final class ResourceCollectionUtilsTest {
 
   @Test
   public void testExcludeByNames_ShouldExcludeSpecifiedResources() {
-    givenGameResources(pus, techTokens, vps);
+    givenGameResources(pus, vps);
     final ResourceCollection unfiltered = createResourceCollection(pus, techTokens, vps);
 
     final ResourceCollection filtered = ResourceCollectionUtils.exclude(unfiltered, pus.getName(), vps.getName());
@@ -89,7 +85,6 @@ public final class ResourceCollectionUtilsTest {
 
   private void givenGameResources(final Resource... resources) {
     final ResourceList gameResources = mock(ResourceList.class);
-    doReturn(null).when(gameResources).getResource(anyString());
     for (final Resource resource : resources) {
       doReturn(resource).when(gameResources).getResource(resource.getName());
     }
@@ -99,7 +94,7 @@ public final class ResourceCollectionUtilsTest {
   @Test
   public void testExcludeByNames_ShouldIgnoreUnregisteredResourceNames() {
     final Resource gold = createResource("gold");
-    givenGameResources(pus);
+    givenGameResources();
     final ResourceCollection unfiltered = createResourceCollection(pus);
 
     final ResourceCollection filtered = ResourceCollectionUtils.exclude(unfiltered, gold.getName());
@@ -110,7 +105,7 @@ public final class ResourceCollectionUtilsTest {
   @Test
   public void testGetProductionResources_ShouldIncludeAllResourcesExceptTechTokensAndVPs() {
     final Resource gold = createResource("gold");
-    givenGameResources(gold, pus, techTokens, vps);
+    givenGameResources(techTokens, vps);
     final ResourceCollection unfiltered = createResourceCollection(gold, pus, techTokens, vps);
 
     final ResourceCollection filtered = ResourceCollectionUtils.getProductionResources(unfiltered);

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.engine.framework.map.download.MapDownloadController.DownloadedMaps;
 import games.strategy.engine.framework.map.download.MapDownloadController.TutorialMapPreferences;
@@ -122,11 +120,9 @@ public final class MapDownloadControllerTest {
       assertThat(outOfDateMapNames, not(contains(mapName)));
     }
 
-    @MockitoSettings(strictness = Strictness.WARN)
     @Test
     public void shouldExcludeMapWhenDownloadIsNull() {
       final Collection<DownloadFileDescription> downloads = givenDownload(null);
-      givenDownloadedMapVersionIs(version1);
 
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.ILobbyGameController;
@@ -62,16 +60,10 @@ public class LobbyGameTableModelTest {
     testObj = new LobbyGameTableModel(mockMessenger, mockChannelMessenger, mockRemoteMessenger);
     Mockito.verify(mockLobbyController, Mockito.times(1)).listGames();
 
-
     MessageContext.setSenderNodeForThread(serverNode);
     Mockito.when(mockMessenger.getServerNode()).thenReturn(serverNode);
     TestUtil.waitForSwingThreads();
-  }
-
-  @MockitoSettings(strictness = Strictness.WARN)
-  @Test
-  public void gamesAreLoadedOnInit() {
-    assertThat(testObj.getRowCount(), is(1));
+    assertThat("games are loaded on init", testObj.getRowCount(), is(1));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -48,12 +46,13 @@ public class SaveFunctionTest {
   private void givenValidationResults(final boolean first, final boolean second) {
     Mockito.when(mockBinding.isValid()).thenReturn(first);
     Mockito.when(mockBinding.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
-    Mockito.when(mockSetting.value()).thenReturn("");
+    if (first) {
+      Mockito.when(mockSetting.value()).thenReturn("");
+    }
     Mockito.when(mockBinding2.isValid()).thenReturn(second);
     Mockito.when(mockBinding2.readValues()).thenReturn(ImmutableMap.of(mockSetting, "abc"));
   }
 
-  @MockitoSettings(strictness = Strictness.WARN)
   @Test
   public void messageOnNotValidResultIsWarning() {
     givenValidationResults(false, false);

--- a/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -14,20 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
-import games.strategy.engine.data.ResourceList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.util.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.WARN)
 public final class UserActionPanelTest {
   @Mock
   private GameData data;
@@ -41,19 +36,12 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnFalseWhenUserActionCostGreaterThanPlayerPUs() {
-    givenGameHasPuResource();
     final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) + 1);
 
     final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
 
     assertThat(canAffordUserAction, is(false));
-  }
-
-  private void givenGameHasPuResource() {
-    final ResourceList gameResources = mock(ResourceList.class);
-    when(gameResources.getResource(pus.getName())).thenReturn(pus);
-    when(data.getResourceList()).thenReturn(gameResources);
   }
 
   private PlayerID createPlayer() {
@@ -74,7 +62,6 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostEqualToPlayerPUs() {
-    givenGameHasPuResource();
     final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus));
 
@@ -85,7 +72,6 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostLessThanPlayerPUs() {
-    givenGameHasPuResource();
     final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) - 1);
 
@@ -96,7 +82,6 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostIsZeroAndPlayerPUsIsZero() {
-    givenGameHasPuResource();
     final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(0);
 


### PR DESCRIPTION
## Overview

Follow-up to #3587.  Fixes Mockito strictness warnings and re-enables strictness violations as errors.

## Functional Changes

None.  Only test code changes (except bumping visibility on two production methods to support testing).

## Manual Testing Performed

None.