### PR TITLE
Prevent NPE during combat with edit mode enabled.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.ui;
 
 import java.awt.Dimension;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -47,21 +47,16 @@ public class DicePanel extends JPanel {
       removeAll();
       for (int i = 1; i <= data.getDiceSides(); i++) {
         final int index = i;
-        final List<Die> dice = Optional.ofNullable(diceRoll)
-            .map(roll -> roll.getRolls(index))
-            .orElse(Collections.emptyList());
-        if (dice.isEmpty()) {
-          continue;
-        }
-        add(new JLabel("Rolled at " + (i) + ":"));
-        add(create(diceRoll.getRolls(i)));
+        Optional.ofNullable(diceRoll)
+            .ifPresent(roll -> {
+              add(new JLabel("Rolled at " + (index) + ":"));
+              add(create(roll.getRolls(index)));
+            });
       }
       add(Box.createVerticalGlue());
-      final String hitCount = Optional.ofNullable(diceRoll)
+      add(new JLabel("Total hits: " + Optional.ofNullable(diceRoll)
           .map(DiceRoll::getHits)
-          .map(String::valueOf)
-          .orElse("0");
-      add(new JLabel("Total hits:" + hitCount));
+          .orElse(0)));
       validate();
       invalidate();
       repaint();

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -1,7 +1,9 @@
 package games.strategy.triplea.ui;
 
 import java.awt.Dimension;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -44,7 +46,10 @@ public class DicePanel extends JPanel {
     SwingAction.invokeNowOrLater(() -> {
       removeAll();
       for (int i = 1; i <= data.getDiceSides(); i++) {
-        final List<Die> dice = diceRoll.getRolls(i);
+        final int index = i;
+        final List<Die> dice = Optional.ofNullable(diceRoll)
+            .map(roll -> roll.getRolls(index))
+            .orElse(Collections.emptyList());
         if (dice.isEmpty()) {
           continue;
         }
@@ -52,7 +57,11 @@ public class DicePanel extends JPanel {
         add(create(diceRoll.getRolls(i)));
       }
       add(Box.createVerticalGlue());
-      add(new JLabel("Total hits:" + diceRoll.getHits()));
+      final String hitCount = Optional.ofNullable(diceRoll)
+          .map(DiceRoll::getHits)
+          .map(String::valueOf)
+          .orElse("0");
+      add(new JLabel("Total hits:" + hitCount));
       validate();
       invalidate();
       repaint();

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui;
 import java.awt.Dimension;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -44,14 +45,13 @@ public class DicePanel extends JPanel {
   public void setDiceRoll(final DiceRoll diceRoll) {
     SwingAction.invokeNowOrLater(() -> {
       removeAll();
-      for (int i = 1; i <= data.getDiceSides(); i++) {
-        final int index = i;
-        Optional.ofNullable(diceRoll)
-            .ifPresent(roll -> {
-              add(new JLabel("Rolled at " + (index) + ":"));
-              add(create(roll.getRolls(index)));
-            });
-      }
+
+      Optional.ofNullable(diceRoll)
+          .ifPresent(roll -> IntStream.rangeClosed(1, data.getDiceSides())
+              .forEach(index -> {
+                add(new JLabel("Rolled at " + index + ":"));
+                add(create(roll.getRolls(index)));
+              }));
       add(Box.createVerticalGlue());
       add(new JLabel("Total hits: " + Optional.ofNullable(diceRoll)
           .map(DiceRoll::getHits)


### PR DESCRIPTION
## Overview
When edit mode is enabled the dice rolled comes in as null, this goes on to cause NPE's in DicePanel#setDiceRoll. Avoiding the null references and defaulting to zero works, combat proceeds to conclusion afterwards.

## Functional Changes
- Fix NPE when starting combat in edit mode

## Manual Testing Performed
- Ran through a combat phase with edit mode on


## Additional Review notes
- this save game can be used to repro: https://github.com/triplea-game/triplea/files/2243410/autosaveAfterAmericansCombatMove.zip
  - load the save in single player
  - on game launch, enable edit mode
  - continue the game and proceed to play through combat.
  - note: before this patch there is a NPE during combat.
