### PR TITLE
Remove write only system properties

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -85,8 +85,6 @@ public class GameRunner {
 
   // not arguments:
   public static final int PORT = 3300;
-  // do not include this in the getProperties list. they are only for loading an old savegame.
-  public static final String OLD_EXTENSION = ".old";
 
   public static final int MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME = 20;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -466,20 +466,6 @@ public class HeadlessGameServer {
     }
   }
 
-  public static void resetLobbyHostOldExtensionProperties() {
-    for (final String property : getProperties()) {
-      if (LOBBY_HOST.equals(property)
-          || LOBBY_PORT.equals(property)
-          || LOBBY_GAME_HOSTED_BY.equals(property)) {
-        // for these 3 properties, we clear them after hosting, but back them up.
-        final String oldValue = System.getProperty(property + GameRunner.OLD_EXTENSION);
-        if (oldValue != null) {
-          System.setProperty(property, oldValue);
-        }
-      }
-    }
-  }
-
   private static Set<String> getProperties() {
     return new HashSet<>(Arrays.asList(TRIPLEA_GAME,
         TRIPLEA_SERVER, TRIPLEA_PORT,

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -55,7 +55,6 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     System.out.println("Restarting lobby watcher");
     shutDownLobbyWatcher();
     Interruptibles.sleep(3000);
-    HeadlessGameServer.resetLobbyHostOldExtensionProperties();
     createLobbyWatcher();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -95,10 +95,6 @@ public class InGameLobbyWatcher {
     System.clearProperty(LOBBY_HOST);
     System.clearProperty(LOBBY_PORT);
     System.clearProperty(LOBBY_GAME_HOSTED_BY);
-    // add them as temporary properties (in case we load an old savegame and need them again)
-    System.setProperty(LOBBY_HOST + GameRunner.OLD_EXTENSION, host);
-    System.setProperty(LOBBY_PORT + GameRunner.OLD_EXTENSION, port);
-    System.setProperty(LOBBY_GAME_HOSTED_BY + GameRunner.OLD_EXTENSION, hostedBy);
     final IConnectionLogin login = challengeProperties -> {
       final Map<String, String> properties = new HashMap<>();
       properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -85,7 +85,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     System.out.println("Restarting lobby watcher");
     shutDownLobbyWatcher();
     Interruptibles.sleep(1000);
-    HeadlessGameServer.resetLobbyHostOldExtensionProperties();
     createLobbyWatcher();
   }
 


### PR DESCRIPTION
## Overview

We have some code that comments we store some system props before clearing them in the headless case so we can load save games, but we never read those property values except only to save them. That implies this is actually dead functionality and the commentary is misleading (so we can remove this code)


## Functional Changes
- none

## Manual Testing Performed
- none

