### PR TITLE
Add new validator for Headless CLI params

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParsingHelper.java
@@ -10,8 +10,6 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -21,11 +19,14 @@ import lombok.NoArgsConstructor;
  * return them as part of a {@code Properties} object.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-final class ArgParsingHelper {
-  @VisibleForTesting
-  static final String TRIPLEA_PROPERTY_PREFIX = "P";
+public final class ArgParsingHelper {
+  public static final String TRIPLEA_PROPERTY_PREFIX = "P";
 
-  static Properties getTripleaProperties(final String... args) {
+  /**
+   * Parses the set of input parameters for things that look like "-Pkey=value" and will
+   * return the key/value pairs as a Properties object.
+   */
+  public static Properties getTripleaProperties(final String... args) {
     final Options options = getOptions();
     final CommandLineParser parser = new DefaultParser();
     try {

--- a/game-core/src/main/java/games/strategy/engine/framework/headless/game/server/ArgValidationResult.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headless/game/server/ArgValidationResult.java
@@ -1,0 +1,20 @@
+package games.strategy.engine.framework.headless.game.server;
+
+import java.util.List;
+
+import lombok.Singular;
+import lombok.Value;
+
+/**
+ * Class that tracks validation of CLI params, the error message list when non empty means there
+ * are errors, the error list is human-friendly-readable.
+ */
+@Value
+public class ArgValidationResult {
+  @Singular
+  private final List<String> errorMessages;
+
+  public boolean isValid() {
+    return errorMessages.isEmpty();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/headless/game/server/HeadlessGameServerCliParam.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headless/game/server/HeadlessGameServerCliParam.java
@@ -1,0 +1,85 @@
+package games.strategy.engine.framework.headless.game.server;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import games.strategy.engine.framework.ArgParsingHelper;
+import games.strategy.triplea.UrlConstants;
+import lombok.AllArgsConstructor;
+
+/**
+ * Enum that represents each CLI option that can be provided to a headless server, and for each one
+ * relevent configuration options.
+ */
+@AllArgsConstructor
+public enum HeadlessGameServerCliParam {
+
+  TRIPLEA_NAME("triplea.name"),
+
+  TRIPLEA_PORT("triplea.port"),
+
+  LOBBY_HOST("triplea.lobby.host"),
+
+  LOBBY_PORT("triplea.lobby.port"),
+
+  MAP_FOLDER("triplea.map.folder"),
+
+  LOBBY_GAME_SUPPORT_EMAIL("triplea.lobby.game.supportEmail", Required.NOT_REQUIRED),
+
+  LOBBY_GAME_SUPPORT_PASSWORD("triplea.lobby.game.supportPassword", Required.NOT_REQUIRED),
+
+  LOBBY_GAME_COMMENTS("triplea.lobby.game.comments", Required.NOT_REQUIRED),
+
+  LOBBY_GAME_RECONNECTION("triplea.lobby.game.reconnection", Required.NOT_REQUIRED),
+
+  SERVER_PASSWORD("triplea.server.password", Required.NOT_REQUIRED);
+
+  private final String label;
+  private final Required required;
+
+  HeadlessGameServerCliParam(final String label) {
+    this(label, Required.REQUIRED);
+  }
+
+  @Override
+  public String toString() {
+    return label;
+  }
+
+  /**
+   * Verify that all required args are present.
+   *
+   * @param args Expecting the raw String array provided to #main method.
+   */
+  public static ArgValidationResult validateArgs(final String... args) {
+    final Properties properties = ArgParsingHelper.getTripleaProperties(args);
+
+    return new ArgValidationResult(Arrays.stream(values())
+                .filter(param -> param.required == Required.REQUIRED)
+                .filter(param -> properties.getProperty(param.label) == null)
+                .map(param -> "Did not find param: -" + ArgParsingHelper.TRIPLEA_PROPERTY_PREFIX + param.label)
+                .collect(Collectors.toList()));
+  }
+
+  public static String exampleUsage() {
+    return example(TRIPLEA_NAME, "Auto-Von-Bot(host_name__no_spaces_allowed)")
+        + example(TRIPLEA_PORT, "4000(replace_with_your_bot_port_number)")
+        + example(LOBBY_HOST, "lobby.triplea-game.org")
+        + example(LOBBY_PORT, "3304")
+        + example(MAP_FOLDER, "/home/triplea/maps")
+        + "\nFor latest lobby host/port, check: " + UrlConstants.LOBBY_PROPS;
+  }
+
+  private static String example(final HeadlessGameServerCliParam param, final String value) {
+    return "-" + ArgParsingHelper.TRIPLEA_PROPERTY_PREFIX + param.label + "=" + value + " ";
+  }
+
+
+  private enum Required {
+    REQUIRED,
+
+    NOT_REQUIRED;
+  }
+
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -35,6 +35,8 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.headless.game.server.ArgValidationResult;
+import games.strategy.engine.framework.headless.game.server.HeadlessGameServerCliParam;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
@@ -613,8 +615,19 @@ public class HeadlessGameServer {
    * Launches a bot server. Most properties are passed via command line-like arguments.
    */
   public static void main(final String[] args) {
-    ClientSetting.initialize();
+    final ArgValidationResult validation = HeadlessGameServerCliParam.validateArgs(args);
+    if (!validation.isValid()) {
+      log.log(Level.SEVERE,
+          String.format("Failed to start, improper args: %s\n"
+                  + "Errors:\n- %s\n"
+                  + "Example usage: %s",
+              Arrays.toString(args),
+              String.join("\n- ", validation.getErrorMessages()),
+              HeadlessGameServerCliParam.exampleUsage()));
+      return;
+    }
 
+    ClientSetting.initialize();
     System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
     new ArgParser().handleCommandLineArgs(args);
     handleHeadlessGameServerArgs();


### PR DESCRIPTION
## Overview

New validator checks that all required args are present. We add this validator for now in addition to the existing validator. If the new validator catches a problem we'll see a cleaner error message with which args were missing.

Future work:
- Add a test case, in the works but depends on in-flight PR:  https://github.com/triplea-game/triplea/pull/3675
- The existing validation is overly strict compared. When we first control the usage of CLI params better we'll be able to reduce the strictness and remove the old validator.

## Functional Changes
-  error message if a required args is  missing. Definition of required is forward leaning, we still need a few additional args (enforced by existing validator), but eventually we'll be able to default those args.

## Manual Testing Performed
- launched bot server with various args to see how the validation looked


## Before & After
### Before
```
Aug 01, 2018 4:58:41 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer handleHeadlessGameServerArgs
WARNING: Invalid 'mapFolder' param, map folder must exist: ''
Aug 01, 2018 4:58:42 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer handleHeadlessGameServerArgs
WARNING: Invalid argument: triplea.name and triplea.lobby.game.hostedBy must start with "Bot" and be at least 7 characters long and be the same.
Aug 01, 2018 4:58:42 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer handleHeadlessGameServerArgs
WARNING: Invalid argument: triplea.lobby.game.comments must contain the string "automated_host".
Aug 01, 2018 4:58:42 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer handleHeadlessGameServerArgs
WARNING: Invalid argument: triplea.lobby.game.supportEmail must contain a valid email address.
Aug 01, 2018 4:58:42 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer usage
INFO: 
Usage and Valid Arguments:
   triplea.game=<FILE_NAME>
   triplea.server=true
   triplea.port=<PORT>
   triplea.name=<PLAYER_NAME>
   triplea.lobby.host=<LOBBY_HOST>
   triplea.lobby.port=<LOBBY_PORT>
   triplea.lobby.game.comments=<LOBBY_GAME_COMMENTS>
   triplea.lobby.game.hostedBy=<LOBBY_GAME_HOSTED_BY>
   triplea.lobby.game.supportEmail=<youremail@emailprovider.com>
   triplea.lobby.game.supportPassword=<password for remote actions, such as remote stop game>
   triplea.lobby.game.reconnection=<seconds between refreshing lobby connection [min 21600]>
   mapFolder=mapFolder
   You must start the Name and HostedBy with "Bot".
   Game Comments must have this string in it: "automated_host".
   You must include a support email for your host, so that you can be alerted by lobby admins when your host has an error. (For example they may email you when your host is down and needs to be restarted.)
   Support password is a remote access password that will allow lobby admins to remotely take the following actions: ban player, stop game, shutdown server. (Please email this password to one of the lobby moderators, or private message an admin on the TripleaWarClub.org website forum.)


Process finished with exit code 255
```

### After
```
Aug 01, 2018 5:20:05 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer main
SEVERE: Failed to start, improper args: []
Errors:
- Did not find param: -Ptriplea.name
- Did not find param: -Ptriplea.port
- Did not find param: -Ptriplea.lobby.host
- Did not find param: -Ptriplea.lobby.port
Example usage: -Ptriplea.name=Auto-Von-Bot(no_spaces_allowed) -Ptriplea.port=4000(replace_with_your_bot_port_number) -Ptriplea.lobby.host=lobby.triplea-game.org -Ptriplea.lobby.port=3304 
For latest lobby host/port, check: https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml
```

## Review Notes

- There is some intentional duplication of CLI parameter property names. This is setting up for yet more future work involving CLI params, the existing references will soon drop away.

