### PR TITLE
Fix potential NPE

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -124,6 +124,7 @@ public class MovePanel extends AbstractMovePanel {
       final Exception nullRouteError = (new IllegalArgumentException("route is not supposed to be null"));
       ClientLogger.logQuietly(
           "Programming error, route should not be null here. Aborting sort operation and returning.", nullRouteError);
+      return;
     }
 
     final Comparator<Unit> unitComparator;


### PR DESCRIPTION
## Overview

Based on the log message, it looks like the author's original intent was to immediately return from the method at the end of this block.  Otherwise, the expression `route.isUnload()` will raise an NPE on (old) line 131.

## Functional Changes

None.

## Manual Testing Performed

None.