### PR TITLE
Clean up LobbyRunner

### DIFF
--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -18,7 +18,7 @@ public final class LobbyRunner {
    * Launches a lobby instance.
    * Lobby stays running until the process is killed or the lobby is shutdown.
    */
-  public static void main(final String[] args) {
+  public static void main(final String... args) {
     try {
       ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
 

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -8,15 +8,15 @@ import games.strategy.sound.ClipPlayer;
 import lombok.extern.java.Log;
 
 /**
- * A 'main' class to launch the lobby server.
+ * Runs a lobby server.
  */
 @Log
 public final class LobbyRunner {
   private LobbyRunner() {}
 
   /**
-   * Launches a lobby instance.
-   * Lobby stays running until the process is killed or the lobby is shutdown.
+   * Entry point for running a new lobby server. The lobby server runs until the process is killed or the lobby server
+   * is shut down via administrative command.
    */
   public static void main(final String... args) {
     try {

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -10,8 +10,10 @@ import games.strategy.sound.ClipPlayer;
 /**
  * A 'main' class to launch the lobby server.
  */
-public class LobbyRunner {
+public final class LobbyRunner {
   private static final Logger logger = Logger.getLogger(LobbyRunner.class.getName());
+
+  private LobbyRunner() {}
 
   /**
    * Launches a lobby instance.

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -27,8 +27,9 @@ public final class LobbyRunner {
       log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
       new LobbyServer(lobbyPropertyReader);
       log.info("Lobby started");
-    } catch (final Exception e) {
+    } catch (final RuntimeException e) {
       log.log(Level.SEVERE, "Failed to start lobby", e);
+      System.exit(1);
     }
   }
 }

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -1,18 +1,17 @@
 package games.strategy.engine.lobby.server;
 
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.sound.ClipPlayer;
+import lombok.extern.java.Log;
 
 /**
  * A 'main' class to launch the lobby server.
  */
+@Log
 public final class LobbyRunner {
-  private static final Logger logger = Logger.getLogger(LobbyRunner.class.getName());
-
   private LobbyRunner() {}
 
   /**
@@ -25,11 +24,11 @@ public final class LobbyRunner {
 
       final LobbyPropertyReader lobbyPropertyReader =
           new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
-      logger.info("Trying to listen on port " + lobbyPropertyReader.getPort());
+      log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
       new LobbyServer(lobbyPropertyReader);
-      logger.info("Lobby started");
-    } catch (final Exception ex) {
-      logger.log(Level.SEVERE, ex.toString(), ex);
+      log.info("Lobby started");
+    } catch (final Exception e) {
+      log.log(Level.SEVERE, "Failed to start lobby", e);
     }
   }
 }


### PR DESCRIPTION
## Overview

Primarily trivial non-functional clean up of `LobbyRunner`.  Please see individual commits for context.

## Functional Changes

* Exit process with nonzero status if lobby fails to start.  Previously, the exit status was zero, preventing detection of failure by a script, for example.

## Manual Testing Performed

* Ran a local lobby and verified I could connect.
* Verified exit status is nonzero if lobby server fails to start.