### PR TITLE
Checkstyle: Fix final local variable violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TerritoryOverLayDrawable.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.IDrawable;
+import games.strategy.ui.Util;
 
 class TerritoryOverLayDrawable implements IDrawable {
   enum Operation {
@@ -37,18 +38,16 @@ class TerritoryOverLayDrawable implements IDrawable {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     graphics.setColor(color);
-    for (Polygon polygon : polys) {
-      // if we dont have to draw, dont
+    for (final Polygon polygon : polys) {
       if (!polygon.intersects(bounds) && !polygon.contains(bounds)) {
         continue;
       }
-      // use a copy since we will move the polygon
-      polygon = new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
-      polygon.translate(-bounds.x, -bounds.y);
+
+      final Polygon translatedPolygon = Util.translatePolygon(polygon, -bounds.x, -bounds.y);
       if (operation == Operation.FILL) {
-        graphics.fillPolygon(polygon);
+        graphics.fillPolygon(translatedPolygon);
       } else {
-        graphics.drawPolygon(polygon);
+        graphics.drawPolygon(translatedPolygon);
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -491,10 +491,8 @@ public class TileManager {
     }
     graphics.setStroke(new BasicStroke(10));
     graphics.setColor(Color.RED);
-    for (Polygon poly : mapData.getPolygons(selected)) {
-      poly = new Polygon(poly.xpoints, poly.ypoints, poly.npoints);
-      poly.translate(-bounds.x, -bounds.y);
-      graphics.drawPolygon(poly);
+    for (final Polygon polygon : mapData.getPolygons(selected)) {
+      graphics.drawPolygon(Util.translatePolygon(polygon, -bounds.x, -bounds.y));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
@@ -9,6 +9,7 @@ import java.util.List;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
+import games.strategy.ui.Util;
 
 public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
   private final String territoryName;
@@ -23,16 +24,13 @@ public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
-    for (Polygon polygon : polys) {
-      // if we dont have to draw, dont
+    graphics.setColor(Color.BLACK);
+    for (final Polygon polygon : polys) {
       if (!polygon.intersects(bounds) && !polygon.contains(bounds)) {
         continue;
       }
-      // use a copy since we will move the polygon
-      polygon = new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
-      polygon.translate(-bounds.x, -bounds.y);
-      graphics.setColor(Color.BLACK);
-      graphics.drawPolygon(polygon);
+
+      graphics.drawPolygon(Util.translatePolygon(polygon, -bounds.x, -bounds.y));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
@@ -9,6 +9,7 @@ import java.util.List;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
+import games.strategy.ui.Util;
 
 public class SeaZoneOutlineDrawable implements IDrawable {
   private final String territoryName;
@@ -21,16 +22,13 @@ public class SeaZoneOutlineDrawable implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData) {
     final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
-    for (Polygon polygon : polys) {
-      // if we dont have to draw, dont
+    graphics.setColor(Color.BLACK);
+    for (final Polygon polygon : polys) {
       if (!polygon.intersects(bounds) && !polygon.contains(bounds)) {
         continue;
       }
-      // use a copy since we will move the polygon
-      polygon = new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
-      polygon.translate(-bounds.x, -bounds.y);
-      graphics.setColor(Color.BLACK);
-      graphics.drawPolygon(polygon);
+
+      graphics.drawPolygon(Util.translatePolygon(polygon, -bounds.x, -bounds.y));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
@@ -9,23 +9,22 @@ import java.util.List;
 
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
+import games.strategy.ui.Util;
 
 public abstract class TerritoryDrawable {
   protected static void draw(final Rectangle bounds, final Graphics2D graphics, final MapData mapData,
       final Territory territory, final Paint territoryPaint) {
     final List<Polygon> polys = mapData.getPolygons(territory);
-    for (Polygon polygon : polys) {
-      // if we dont have to draw, dont
+    for (final Polygon polygon : polys) {
       if (!polygon.intersects(bounds) && !polygon.contains(bounds)) {
         continue;
       }
-      // use a copy since we will move the polygon
-      polygon = new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
-      polygon.translate(-bounds.x, -bounds.y);
+
+      final Polygon translatedPolygon = Util.translatePolygon(polygon, -bounds.x, -bounds.y);
       graphics.setPaint(territoryPaint);
-      graphics.fillPolygon(polygon);
+      graphics.fillPolygon(translatedPolygon);
       graphics.setColor(Color.BLACK);
-      graphics.drawPolygon(polygon);
+      graphics.drawPolygon(translatedPolygon);
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-core/src/main/java/games/strategy/ui/Util.java
@@ -1,5 +1,7 @@
 package games.strategy.ui;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
@@ -19,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * A collection of methods useful for rendering the UI.
+ */
 public final class Util {
   public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
 
@@ -158,5 +163,17 @@ public final class Util {
    */
   public static boolean isTerritoryNameIndicatingWater(final String territoryName) {
     return territoryName.endsWith(TERRITORY_SEA_ZONE_INFIX) || territoryName.startsWith(TERRITORY_SEA_ZONE_INFIX);
+  }
+
+  /**
+   * Returns a new polygon that is a copy of {@code polygon} translated by {@code deltaX} along the x-axis and by
+   * {@code deltaY} along the y-axis.
+   */
+  public static Polygon translatePolygon(final Polygon polygon, final int deltaX, final int deltaY) {
+    checkNotNull(polygon);
+
+    final Polygon translatedPolygon = new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
+    translatedPolygon.translate(deltaX, deltaY);
+    return translatedPolygon;
   }
 }

--- a/game-core/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/game-core/src/main/java/tools/image/ReliefImageBreaker.java
@@ -183,10 +183,8 @@ public final class ReliefImageBreaker {
     final int width = bounds.width;
     final int height = bounds.height;
     final BufferedImage alphaChannelImage = Util.createImage(bounds.width, bounds.height, true);
-    for (Polygon item : mapData.getPolygons(territory)) {
-      item = new Polygon(item.xpoints, item.ypoints, item.npoints);
-      item.translate(-bounds.x, -bounds.y);
-      alphaChannelImage.getGraphics().fillPolygon(item);
+    for (final Polygon polygon : mapData.getPolygons(territory)) {
+      alphaChannelImage.getGraphics().fillPolygon(Util.translatePolygon(polygon, -bounds.x, -bounds.y));
     }
     final GraphicsConfiguration localGraphicSystem =
         GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();

--- a/game-core/src/test/java/games/strategy/ui/UtilTest.java
+++ b/game-core/src/test/java/games/strategy/ui/UtilTest.java
@@ -1,0 +1,34 @@
+package games.strategy.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.awt.Polygon;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public final class UtilTest {
+  @Nested
+  public final class TranslatePolygonTest {
+    private final Polygon polygon = new Polygon(new int[] {1, 2, 3}, new int[] {4, 5, 6}, 3);
+
+    @Test
+    public void shouldTranslatePolygonBySpecifiedDisplacement() {
+      final Polygon translatedPolygon = Util.translatePolygon(polygon, 2, -5);
+
+      assertThat(translatedPolygon.xpoints, is(new int[] {3, 4, 5}));
+      assertThat(translatedPolygon.ypoints, is(new int[] {-1, 0, 1}));
+      assertThat(translatedPolygon.npoints, is(3));
+    }
+
+    @Test
+    public void shouldNotModifyOriginalPolygon() {
+      Util.translatePolygon(polygon, 2, -5);
+
+      assertThat(polygon.xpoints, is(new int[] {1, 2, 3}));
+      assertThat(polygon.ypoints, is(new int[] {4, 5, 6}));
+      assertThat(polygon.npoints, is(3));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle FinalLocalVariable rule.

## Functional Changes

None.

## Refactoring Changes

* Extracted a new method to translate a `Polygon` to hide the mutability of `Polygon#translate()`.
## Manual Testing Performed

I loaded three maps (Classic, TWW, and WaW) to verify there were no obvious problems with the rendered tiles.