### PR TITLE
Error Prone: Suppress ImmutableEnumChecker for Enum singletons

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -26,6 +26,7 @@ import swinglib.JPanelBuilder;
  * to be user friendly, clicking 'show details' would show full details of all error messages.
  * </p>
  */
+@SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
 public enum ErrorMessage {
   INSTANCE;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -367,6 +367,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
    * This is used to store settings which are not game related, and should therefore not go into the options cache
    * This is often used by editors to remember previous values
    */
+  @SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
   private enum LocalBeanCache {
     INSTANCE;
     private final File file;

--- a/game-core/src/main/java/games/strategy/thread/LockUtil.java
+++ b/game-core/src/main/java/games/strategy/thread/LockUtil.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
  * you are considering your ambitious multi-threaded code a mistake, and you are trying to limit the damage.
  * </p>
  */
+@SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
 public enum LockUtil {
   INSTANCE;
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -39,6 +39,7 @@ import swinglib.JTextAreaBuilder;
  *
  * @see ClientSetting
  */
+@SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
 public enum SettingsWindow {
   INSTANCE;
 


### PR DESCRIPTION
## Overview

Suppresses violations of the Error Prone ImmutableEnumChecker rule in cases where the Enum is used to implement the _Singleton_ pattern, as recommended in _Effective Java_, Item 3.

## Functional Changes

None.

## Manual Testing Performed

None.