### PR TITLE
Use standard exit status codes

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -68,6 +68,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.ProgressWindow;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
+import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Version;
 import javafx.application.Application;
@@ -371,7 +372,7 @@ public class GameRunner {
       final boolean allFramesClosed = Arrays.stream(Frame.getFrames())
           .noneMatch(Component::isVisible);
       if (allFramesClosed) {
-        System.exit(0);
+        ExitStatus.SUCCESS.exit();
       }
     });
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -51,6 +51,7 @@ import games.strategy.net.Messengers;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
 
 /**
@@ -321,7 +322,7 @@ public class ServerGame extends AbstractGame {
         // Try one more time
         if (!delegateExecutionManager.blockDelegateExecution(16000)) {
           System.err.println("Exiting...");
-          System.exit(1);
+          ExitStatus.FAILURE.exit();
         }
       }
     } catch (final InterruptedException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -321,7 +321,7 @@ public class ServerGame extends AbstractGame {
         // Try one more time
         if (!delegateExecutionManager.blockDelegateExecution(16000)) {
           System.err.println("Exiting...");
-          System.exit(-1);
+          System.exit(1);
         }
       }
     } catch (final InterruptedException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -555,7 +555,7 @@ public class HeadlessGameServer {
     final HeadlessGameServer server = getInstance();
     if (server == null) {
       System.err.println("Couldn't find instance.");
-      System.exit(-1);
+      System.exit(1);
     } else {
       log.info("Waiting for users to connect.");
       server.waitForUsersHeadless();
@@ -694,7 +694,7 @@ public class HeadlessGameServer {
 
     if (printUsage) {
       usage();
-      System.exit(-1);
+      System.exit(1);
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -47,6 +47,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Md5Crypt;
 import games.strategy.util.TimeManager;
@@ -253,7 +254,7 @@ public class HeadlessGameServer {
     if (hashPassword(password, salt).equals(hashedPassword)) {
       new Thread(() -> {
         log.info("Remote Shutdown Initiated.");
-        System.exit(0);
+        ExitStatus.SUCCESS.exit();
       }).start();
       return null;
     }
@@ -555,7 +556,7 @@ public class HeadlessGameServer {
     final HeadlessGameServer server = getInstance();
     if (server == null) {
       System.err.println("Couldn't find instance.");
-      System.exit(1);
+      ExitStatus.FAILURE.exit();
     } else {
       log.info("Waiting for users to connect.");
       server.waitForUsersHeadless();
@@ -694,7 +695,7 @@ public class HeadlessGameServer {
 
     if (printUsage) {
       usage();
-      System.exit(1);
+      ExitStatus.FAILURE.exit();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -20,7 +20,6 @@ import javax.swing.SwingUtilities;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.events.GameStepListener;
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -44,6 +43,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.util.ExitStatus;
 
 /**
  * Watches a game in progress, and updates the Lobby with the state of the game.
@@ -229,7 +229,7 @@ public class InGameLobbyWatcher {
                 + "The server tried to connect to your external ip: " + addressUsed;
             if (HeadlessGameServer.headless()) {
               System.out.println(message);
-              System.exit(1);
+              ExitStatus.FAILURE.exit();
             }
             final Frame parentComponent = JOptionPane.getFrameForComponent(parent);
             if (JOptionPane.showConfirmDialog(parentComponent,
@@ -237,7 +237,7 @@ public class InGameLobbyWatcher {
                 "View Help Website?", JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
               OpenFileUtility.openUrl(UrlConstants.HOSTING_GUIDE.toString());
             }
-            System.exit(1);
+            ExitStatus.FAILURE.exit();
           });
         }
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -229,7 +229,7 @@ public class InGameLobbyWatcher {
                 + "The server tried to connect to your external ip: " + addressUsed;
             if (HeadlessGameServer.headless()) {
               System.out.println(message);
-              System.exit(-1);
+              System.exit(1);
             }
             final Frame parentComponent = JOptionPane.getFrameForComponent(parent);
             if (JOptionPane.showConfirmDialog(parentComponent,
@@ -237,7 +237,7 @@ public class InGameLobbyWatcher {
                 "View Help Website?", JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
               OpenFileUtility.openUrl(UrlConstants.HOSTING_GUIDE.toString());
             }
-            System.exit(-1);
+            System.exit(1);
           });
         }
       }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
@@ -2,6 +2,8 @@ package games.strategy.engine.lobby.client.ui;
 
 import com.apple.eawt.Application;
 
+import games.strategy.util.ExitStatus;
+
 /**
  * TODO This class should be merged with games.strategy.triplea.ui.MacQuitMenuWrapper.
  */
@@ -14,7 +16,7 @@ public class MacLobbyWrapper {
       if (frame != null) {
         frame.shutdown();
       } else {
-        System.exit(0);
+        ExitStatus.SUCCESS.exit();
       }
     });
   }

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -133,7 +133,7 @@ public class PbemDiceRoller implements IRandomSource {
       this.diceServer = diceServer;
       this.gameUuid = gameUuid;
       setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-      exitButton.addActionListener(e -> System.exit(-1));
+      exitButton.addActionListener(e -> System.exit(1));
       exitButton.setEnabled(false);
       reRollButton.addActionListener(e -> rollInternal());
       okButton.addActionListener(e -> closeAndReturn());

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -21,6 +21,7 @@ import javax.swing.WindowConstants;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
+import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
 
 /**
@@ -133,7 +134,7 @@ public class PbemDiceRoller implements IRandomSource {
       this.diceServer = diceServer;
       this.gameUuid = gameUuid;
       setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-      exitButton.addActionListener(e -> System.exit(1));
+      exitButton.addActionListener(e -> ExitStatus.FAILURE.exit());
       exitButton.setEnabled(false);
       reRollButton.addActionListener(e -> rollInternal());
       okButton.addActionListener(e -> closeAndReturn());

--- a/game-core/src/main/java/games/strategy/triplea/ui/MacQuitMenuWrapper.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MacQuitMenuWrapper.java
@@ -5,6 +5,8 @@ import com.apple.eawt.Application;
 import com.apple.eawt.QuitHandler;
 import com.apple.eawt.QuitResponse;
 
+import games.strategy.util.ExitStatus;
+
 /**
  * Utility class to wrap Mac OS X-specific shutdown handler.
  *
@@ -27,7 +29,7 @@ public class MacQuitMenuWrapper {
         if (shutdownFrame != null) {
           shutdownFrame.shutdown();
         } else {
-          System.exit(0);
+          ExitStatus.SUCCESS.exit();
         }
       }
     });

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -159,6 +159,7 @@ import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.EventThreadJOptionPane;
+import games.strategy.util.ExitStatus;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.LocalizeHtml;
@@ -599,7 +600,7 @@ public class TripleAFrame extends MainGameFrame {
       return;
     }
     stopGame();
-    System.exit(0);
+    ExitStatus.SUCCESS.exit();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/util/ExitStatus.java
+++ b/game-core/src/main/java/games/strategy/util/ExitStatus.java
@@ -1,0 +1,27 @@
+package games.strategy.util;
+
+/**
+ * A process exit status.
+ */
+public enum ExitStatus {
+  /** The process exited successfully (0). */
+  SUCCESS(0),
+
+  /** The process exited due to a failure (1). */
+  FAILURE(1);
+
+  private final int status;
+
+  private ExitStatus(final int status) {
+    assert status >= 0 : "exit status must be non-negative to avoid signal aliasing";
+
+    this.status = status;
+  }
+
+  /**
+   * Exits the host process with this status.
+   */
+  public void exit() {
+    System.exit(status);
+  }
+}

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.sound.ClipPlayer;
+import games.strategy.util.ExitStatus;
 import lombok.extern.java.Log;
 
 /**
@@ -29,7 +30,7 @@ public final class LobbyRunner {
       log.info("Lobby started");
     } catch (final RuntimeException e) {
       log.log(Level.SEVERE, "Failed to start lobby", e);
-      System.exit(1);
+      ExitStatus.FAILURE.exit();
     }
   }
 }


### PR DESCRIPTION
## Overview

Standardizes all failure exit codes to use `1` instead of `-1`.

Most shells interpret a process' exit status code as an unsigned 8-bit integer.  Therefore, a negative status code will be mapped to the range [128,255].  This can result in an aliasing problem, as explained below.

When a process is terminated via a signal (e.g. SIGKILL), most shells will set the process' exit status code to, for example, 128 + N, -N (where again the negative value is mapped to [128,255]), etc., where N is the signal number.  Therefore, if a process uses a negative status code, the calling shell cannot distinguish between an application-initiated termination and one due to a signal.

## Functional Changes

* Changed exit status in all failure cases to be `1` instead of `-1`.

## Refactoring Changes

* Extracted the `ExitStatus` enum to hide the exit status codes behind named constants.

## Manual Testing Performed

Tested the exit paths in the following modules:

* `GameRunner` (success path)
* `HeadlessGameServer` (success path)
* `LobbyRunner` (failure path)
* `TripleAFrame` (success path)