### PR TITLE
Remove 'TRIPLEA_GAME' CLI property

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -2,7 +2,6 @@ package games.strategy.engine.auto.update;
 
 import static games.strategy.engine.framework.CliProperties.DO_NOT_CHECK_FOR_UPDATES;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
 import games.strategy.engine.framework.map.download.MapDownloadController;
@@ -33,8 +32,6 @@ public class UpdateChecks {
   private static boolean shouldRun() {
     return !System.getProperty(TRIPLEA_SERVER, "false").equalsIgnoreCase("true")
         && !System.getProperty(TRIPLEA_CLIENT, "false").equalsIgnoreCase("true")
-        && !System.getProperty(DO_NOT_CHECK_FOR_UPDATES, "false").equalsIgnoreCase("true")
-        // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
-        && System.getProperty(TRIPLEA_GAME, "").isEmpty();
+        && !System.getProperty(DO_NOT_CHECK_FOR_UPDATES, "false").equalsIgnoreCase("true");
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -20,8 +20,6 @@ public final class ArgParser {
 
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {
       handleMapDownloadArg(args[0]);
-    } else if ((args.length == 1) && !args[0].contains("=")) {
-      System.setProperty(CliProperties.TRIPLEA_GAME, args[0]);
     } else {
       ArgParsingHelper.getTripleaProperties(args)
           .forEach((key, value) -> setSystemPropertyOrClientSetting((String) key, (String) value));

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -7,7 +7,6 @@ import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_HOST;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
@@ -285,10 +284,6 @@ public class GameRunner {
   private static void loadGame() {
     Preconditions.checkState(!SwingUtilities.isEventDispatchThread());
     gameSelectorModel.loadDefaultGameSameThread();
-    final String fileName = System.getProperty(TRIPLEA_GAME, "");
-    if (!fileName.isEmpty() && new File(fileName).exists()) {
-      gameSelectorModel.load(new File(fileName));
-    }
 
     final String downloadableMap = System.getProperty(TRIPLEA_MAP_DOWNLOAD, "");
     if (!downloadableMap.isEmpty()) {
@@ -328,10 +323,6 @@ public class GameRunner {
     commands.add("-D" + LOBBY_GAME_HOSTED_BY + "=" + messengers.getMessenger().getLocalNode().getName());
     if (password != null && password.length() > 0) {
       commands.add("-D" + SERVER_PASSWORD + "=" + password);
-    }
-    final String fileName = System.getProperty(TRIPLEA_GAME, "");
-    if (fileName.length() > 0) {
-      commands.add("-D" + TRIPLEA_GAME + "=" + fileName);
     }
     final String javaClass = GameRunner.class.getName();
     commands.add(javaClass);

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -8,7 +8,6 @@ import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_SUPPORT_P
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.MAP_FOLDER;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
@@ -90,17 +89,6 @@ public class HeadlessGameServer {
     }));
     availableGames = new AvailableGames();
     gameSelectorModel = new GameSelectorModel();
-    final String fileName = System.getProperty(TRIPLEA_GAME, "");
-    if (!fileName.isEmpty()) {
-      try {
-        final File file = new File(fileName);
-        if (file.exists()) {
-          gameSelectorModel.load(file);
-        }
-      } catch (final Exception e) {
-        gameSelectorModel.resetGameDataToNull();
-      }
-    }
     new Thread(() -> {
       log.info("Headless Start");
       setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
@@ -470,7 +458,7 @@ public class HeadlessGameServer {
   }
 
   private static Set<String> getProperties() {
-    return new HashSet<>(Arrays.asList(TRIPLEA_GAME,
+    return new HashSet<>(Arrays.asList(
         TRIPLEA_SERVER, TRIPLEA_PORT,
         TRIPLEA_NAME, LOBBY_HOST, LOBBY_PORT,
         LOBBY_GAME_COMMENTS, LOBBY_GAME_HOSTED_BY, LOBBY_GAME_SUPPORT_EMAIL,
@@ -629,7 +617,6 @@ public class HeadlessGameServer {
   private static void usage() {
     // TODO replace this method with the generated usage of commons-cli
     log.info("\nUsage and Valid Arguments:\n"
-        + "   " + TRIPLEA_GAME + "=<FILE_NAME>\n"
         + "   " + TRIPLEA_SERVER + "=true\n"
         + "   " + TRIPLEA_PORT + "=<PORT>\n"
         + "   " + TRIPLEA_NAME + "=<PLAYER_NAME>\n"

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -1,24 +1,17 @@
 package games.strategy.engine.framework;
 
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 
 public class ArgParserTest extends AbstractClientSettingTestCase {
-
-  @AfterEach
-  public void teardown() {
-    System.clearProperty(TRIPLEA_GAME);
-  }
 
   @Test
   public void argsTurnIntoSystemProps() {
@@ -36,14 +29,6 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     new ArgParser().handleCommandLineArgs(new String[] {"-Pa="});
     assertThat("expecting the system property to be empty string instead of null",
         System.getProperty("a"), is(""));
-  }
-
-  @Test
-  public void singleFileArgIsAssumedToBeGameProperty() {
-    new ArgParser()
-        .handleCommandLineArgs(new String[] {TestData.propValue});
-    assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
-        System.getProperty(TRIPLEA_GAME), is(TestData.propValue));
   }
 
   @Test


### PR DESCRIPTION
## Functional Changes
Remove ability to preselect a save game by passing single arg filepath of the save game to select (save game is not loaded, it is  'selected' by the game selector model when the game loads)

## Manual Testing Performed
- launched a local lobby + bot
- joined and started a game
- quit, rejoined and loaded autosave
- hosted a game locally

On each test case I instrumented the CLI arg and had some breakpoints to check values, yeah, it looks like the only time we set this property is after reading an empty value; surprising this is not used.
