### PR TITLE
Remove unnecessary optional, 'localPlayerTypes' variable is never null

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -69,7 +69,7 @@ public class PlayerListing implements Serializable {
     m_localPlayerTypes = localPlayerTypes.entrySet()
         .stream()
         // convert Map<String,PlayerType> -> Map<String,String>
-        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel());
+        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel()));
     m_gameVersion = gameVersion;
     m_gameName = gameName;
     m_gameRound = gameRound;

--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -66,11 +66,10 @@ public class PlayerListing implements Serializable {
     m_playersEnabledListing = Optional.ofNullable(playersEnabledListing)
         .map(HashMap::new)
         .orElseGet(HashMap::new);
-    m_localPlayerTypes = Optional.ofNullable(localPlayerTypes.entrySet()
+    m_localPlayerTypes = localPlayerTypes.entrySet()
         .stream()
         // convert Map<String,PlayerType> -> Map<String,String>
-        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel())))
-        .orElse(Collections.emptyMap());
+        .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel());
     m_gameVersion = gameVersion;
     m_gameName = gameName;
     m_gameRound = gameRound;


### PR DESCRIPTION
## Functional Changes
- none

## Manual Testing Performed
- none, but traced down the call paths and verified we get empty hash maps and never null
