### PR TITLE
Checkstyle: Fix final parameters violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -96,8 +96,7 @@ public class ChangeFactory {
     return new RemoveUnits(player.getUnits(), units);
   }
 
-  public static Change moveUnits(final Territory start, final Territory end, Collection<Unit> units) {
-    units = new ArrayList<>(units);
+  public static Change moveUnits(final Territory start, final Territory end, final Collection<Unit> units) {
     final List<Change> changes = new ArrayList<>(2);
     changes.add(removeUnits(start, units));
     changes.add(addUnits(end, units));

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -112,12 +112,10 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
   }
 
   @Override
-  public String postRequest(final int max, final int numDice, final String subjectMessage, String gameId,
+  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
       final String gameUuid) throws IOException {
-    if (gameId.trim().length() == 0) {
-      gameId = "TripleA";
-    }
-    String message = gameId + ":" + subjectMessage;
+    final String normalizedGameId = gameId.trim().isEmpty() ? "TripleA" : gameId;
+    String message = normalizedGameId + ":" + subjectMessage;
     final int maxLength = Integer.valueOf(m_props.getProperty("message.maxlength"));
     if (message.length() > maxLength) {
       message = message.substring(0, maxLength - 1);

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -478,7 +478,8 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
         .anyMatch(nodeName::equalsIgnoreCase);
   }
 
-  public String getUniqueName(String currentName) {
+  public String getUniqueName(final String initialCurrentName) {
+    String currentName = initialCurrentName;
     if (currentName.length() > 50) {
       currentName = currentName.substring(0, 50);
     }

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -478,8 +478,8 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
         .anyMatch(nodeName::equalsIgnoreCase);
   }
 
-  public String getUniqueName(final String initialCurrentName) {
-    String currentName = initialCurrentName;
+  public String getUniqueName(final String name) {
+    String currentName = name;
     if (currentName.length() > 50) {
       currentName = currentName.substring(0, 50);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -70,7 +70,7 @@ class ProNonCombatMoveAi {
     return doNonCombatMove(null, null, moveDel);
   }
 
-  Map<Territory, ProTerritory> doNonCombatMove(Map<Territory, ProTerritory> factoryMoveMap,
+  Map<Territory, ProTerritory> doNonCombatMove(final Map<Territory, ProTerritory> initialFactoryMoveMap,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories, final IMoveDelegate moveDel) {
     ProLogger.info("Starting non-combat move phase");
 
@@ -102,6 +102,7 @@ class ProNonCombatMoveAi {
         ProTerritoryValueUtils.findSeaTerritoryValues(player, territoriesThatCantBeHeld);
 
     // Prioritize territories to defend
+    Map<Territory, ProTerritory> factoryMoveMap = initialFactoryMoveMap;
     final List<ProTerritory> prioritizedTerritories = prioritizeDefendOptions(factoryMoveMap, territoryValueMap);
 
     // Determine which territories to defend and how many units each one needs
@@ -1839,13 +1840,14 @@ class ProNonCombatMoveAi {
     }
   }
 
-  private Map<Territory, ProTerritory> moveInfraUnits(Map<Territory, ProTerritory> factoryMoveMap,
+  private Map<Territory, ProTerritory> moveInfraUnits(final Map<Territory, ProTerritory> initialFactoryMoveMap,
       final Map<Unit, Set<Territory>> infraUnitMoveMap) {
     ProLogger.info("Determine where to move infra units");
 
     final Map<Territory, ProTerritory> moveMap = territoryManager.getDefendOptions().getTerritoryMap();
 
     // Move factory units
+    Map<Territory, ProTerritory> factoryMoveMap = initialFactoryMoveMap;
     if (factoryMoveMap == null) {
       ProLogger.debug("Creating factory move map");
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -67,9 +67,9 @@ class ProPurchaseAi {
     calc = ai.getCalc();
   }
 
-  int repair(int pusRemaining, final IPurchaseDelegate purchaseDelegate, final GameData data,
+  int repair(final int initialPusRemaining, final IPurchaseDelegate purchaseDelegate, final GameData data,
       final PlayerID player) {
-
+    int pusRemaining = initialPusRemaining;
     ProLogger.info("Repairing factories with PUsRemaining=" + pusRemaining);
 
     // Current data at the start of combat move

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -148,10 +149,9 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    * conditions to get the final list.
    */
   public static HashSet<ICondition> getAllConditionsRecursive(final HashSet<ICondition> startingListOfConditions,
-      HashSet<ICondition> allConditionsNeededSoFar) {
-    if (allConditionsNeededSoFar == null) {
-      allConditionsNeededSoFar = new HashSet<>();
-    }
+      final HashSet<ICondition> initialAllConditionsNeededSoFar) {
+    final HashSet<ICondition> allConditionsNeededSoFar = Optional.ofNullable(initialAllConditionsNeededSoFar)
+        .orElseGet(HashSet::new);
     allConditionsNeededSoFar.addAll(startingListOfConditions);
     for (final ICondition condition : startingListOfConditions) {
       for (final ICondition subCondition : condition.getConditions()) {
@@ -170,10 +170,9 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
    * value.
    */
   public static HashMap<ICondition, Boolean> testAllConditionsRecursive(final HashSet<ICondition> rules,
-      HashMap<ICondition, Boolean> allConditionsTestedSoFar, final IDelegateBridge delegateBridge) {
-    if (allConditionsTestedSoFar == null) {
-      allConditionsTestedSoFar = new HashMap<>();
-    }
+      final HashMap<ICondition, Boolean> initialAllConditionsTestedSoFar, final IDelegateBridge delegateBridge) {
+    final HashMap<ICondition, Boolean> allConditionsTestedSoFar = Optional.ofNullable(initialAllConditionsTestedSoFar)
+        .orElseGet(HashMap::new);
     for (final ICondition c : rules) {
       if (!allConditionsTestedSoFar.containsKey(c)) {
         testAllConditionsRecursive(new HashSet<>(c.getConditions()), allConditionsTestedSoFar, delegateBridge);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
@@ -601,7 +602,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @Override
-  public boolean isSatisfied(Map<ICondition, Boolean> testedConditions, final IDelegateBridge delegateBridge) {
+  public boolean isSatisfied(final Map<ICondition, Boolean> testedConditions, final IDelegateBridge delegateBridge) {
     if (testedConditions != null) {
       if (testedConditions.containsKey(this)) {
         return testedConditions.get(this);
@@ -612,11 +613,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final GameData data = delegateBridge.getData();
     // check meta conditions (conditions which hold other conditions)
     if (m_conditions.size() > 0) {
-      if (testedConditions == null) {
-        testedConditions = testAllConditionsRecursive(
-            getAllConditionsRecursive(new HashSet<>(m_conditions), null), null, delegateBridge);
-      }
-      objectiveMet = areConditionsMet(new ArrayList<>(m_conditions), testedConditions, m_conditionType);
+      final Map<ICondition, Boolean> actualTestedConditions = Optional.ofNullable(testedConditions)
+          .orElseGet(() -> testAllConditionsRecursive(
+              getAllConditionsRecursive(new HashSet<>(m_conditions), null), null, delegateBridge));
+      objectiveMet = areConditionsMet(new ArrayList<>(m_conditions), actualTestedConditions, m_conditionType);
     }
     // check switch (on/off)
     if (objectiveMet) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -516,10 +516,10 @@ public class UnitAttachment extends DefaultAttachment {
     return m_whenCapturedSustainsDamage;
   }
 
-  private void setDestroyedWhenCapturedBy(String value) throws GameParseException {
+  private void setDestroyedWhenCapturedBy(final String initialValue) throws GameParseException {
     // We can prefix this value with "BY" or "FROM" to change the setting. If no setting, default to "BY" since this
-    // this is called by
-    // destroyedWhenCapturedBy
+    // this is called by destroyedWhenCapturedBy
+    String value = initialValue;
     String byOrFrom = "BY";
     if (value.startsWith("BY:") && getData().getPlayerList().getPlayerId("BY") == null) {
       byOrFrom = "BY";
@@ -543,7 +543,8 @@ public class UnitAttachment extends DefaultAttachment {
     m_destroyedWhenCapturedBy = value;
   }
 
-  private void setDestroyedWhenCapturedFrom(String value) throws GameParseException {
+  private void setDestroyedWhenCapturedFrom(final String initialValue) throws GameParseException {
+    String value = initialValue;
     if (!(value.startsWith("BY:") || value.startsWith("FROM:"))) {
       value = "FROM:" + value;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -293,9 +293,13 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         .and(Matches.unitIsAirborne().negate());
   }
 
-  private static Change getNewAssignmentOfNumberLaunchedChange(int newNumberLaunched, final Collection<Unit> bases,
-      final PlayerID player, final GameData data) {
+  private static Change getNewAssignmentOfNumberLaunchedChange(
+      final int initialNewNumberLaunched,
+      final Collection<Unit> bases,
+      final PlayerID player,
+      final GameData data) {
     final CompositeChange launchedChange = new CompositeChange();
+    int newNumberLaunched = initialNewNumberLaunched;
     if (newNumberLaunched <= 0) {
       return launchedChange;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -341,8 +341,9 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     return count;
   }
 
-  private Collection<TechAdvance> getTechAdvances(int hits) {
+  private Collection<TechAdvance> getTechAdvances(final int initialHits) {
     final List<TechAdvance> available;
+    int hits = initialHits;
     if (hits > 0 && isWW2V3TechModel()) {
       available = getAvailableAdvancesForCategory(techCategory);
       hits = 1;

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -215,10 +215,11 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
   @Override
   public void setCalculateData(final PlayerID attacker, final PlayerID defender, final Territory location,
       final Collection<Unit> attacking, final Collection<Unit> defending, final Collection<Unit> bombarding,
-      final Collection<TerritoryEffect> territoryEffects, int runCount) {
+      final Collection<TerritoryEffect> territoryEffects, final int initialRunCount) {
     synchronized (mutexCalcIsRunning) {
       awaitLatch();
       isCalcSet = false;
+      int runCount = initialRunCount;
       final int workerNum = workers.size();
       final int workerRunCount = Math.max(1, (runCount / Math.max(1, workerNum)));
       for (final OddsCalculator worker : workers) {

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.BorderFactory;
@@ -617,22 +618,22 @@ class OddsCalculatorPanel extends JPanel {
     return new DecimalFormat("#0.##").format(value);
   }
 
-  private void updateDefender(List<Unit> units) {
-    if (units == null) {
-      units = Collections.emptyList();
-    }
+  private void updateDefender(final List<Unit> initialUnits) {
+    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
     final boolean isLand = isLand();
-    units = CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand, 1, false, false, false));
-    defendingUnitsPanel.init(getDefender(), units, isLand);
+    defendingUnitsPanel.init(
+        getDefender(),
+        CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand, 1, false, false, false)),
+        isLand);
   }
 
-  private void updateAttacker(List<Unit> units) {
-    if (units == null) {
-      units = Collections.emptyList();
-    }
+  private void updateAttacker(final List<Unit> initialUnits) {
+    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
     final boolean isLand = isLand();
-    units = CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(true, isLand, 1, false, false, false));
-    attackingUnitsPanel.init(getAttacker(), units, isLand);
+    attackingUnitsPanel.init(
+        getAttacker(),
+        CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(true, isLand, 1, false, false, false)),
+        isLand);
   }
 
   private boolean isLand() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -955,12 +955,10 @@ public class MovePanel extends AbstractMovePanel {
       return loadedUnits;
     }
 
-    private void deselectUnits(List<Unit> units, final Territory t, final MouseDetails me) {
+    private void deselectUnits(final List<Unit> initialUnits, final Territory t, final MouseDetails me) {
       final Collection<Unit> unitsToRemove = new ArrayList<>(selectedUnits.size());
       // we have right clicked on a unit stack in a different territory
-      if (!getFirstSelectedTerritory().equals(t)) {
-        units = Collections.emptyList();
-      }
+      final List<Unit> units = getFirstSelectedTerritory().equals(t) ? initialUnits : Collections.emptyList();
       // remove the dependent units so we don't have to micromanage them
       final List<Unit> unitsWithoutDependents = new ArrayList<>(selectedUnits);
       for (final Unit unit : selectedUnits) {
@@ -1136,9 +1134,13 @@ public class MovePanel extends AbstractMovePanel {
    * have different movement
    * Units are sorted in preferred order, so units represents the default selections.
    */
-  private boolean allowSpecificUnitSelection(final Collection<Unit> units, final Route route, boolean mustQueryUser,
+  private boolean allowSpecificUnitSelection(
+      final Collection<Unit> units,
+      final Route route,
+      final boolean initialMustQueryUser,
       final Predicate<Collection<Unit>> matchCriteria) {
     final List<Unit> candidateUnits = getFirstSelectedTerritory().getUnits().getMatches(getMovableMatch(route, units));
+    boolean mustQueryUser = initialMustQueryUser;
     if (!mustQueryUser) {
       final Set<UnitCategory> categories =
           UnitSeperator.categorize(candidateUnits, mustMoveWithDetails.getMustMoveWith(), true, false);

--- a/game-core/src/main/java/games/strategy/util/AlphanumComparator.java
+++ b/game-core/src/main/java/games/strategy/util/AlphanumComparator.java
@@ -22,8 +22,9 @@ public class AlphanumComparator implements Comparator<String>, Serializable {
   }
 
   /** Length of string is passed in for improved efficiency (only need to calculate it once). **/
-  private static String getChunk(final String s, final int slength, int marker) {
+  private static String getChunk(final String s, final int slength, final int initialMarker) {
     final StringBuilder chunk = new StringBuilder();
+    int marker = initialMarker;
     char c = s.charAt(marker);
     chunk.append(c);
     marker++;


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle FinalParameters rule.

In general, I tried to minimize the changes as much as possible simply because many of the affected methods were 100+ lines long, and they don't have comprehensive unit tests.  Therefore, I punted in many cases and just created a new local variable that copies the (now `final`) parameter.  If you see any case that can be improved in a better (and low-risk) way, please let me know.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the following scenarios:

* Local game vs. Hard AI
* Network game
* Battle calculator