### PR TITLE
Replace unused LobbyServer object with static method

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -19,7 +19,7 @@ import games.strategy.util.Version;
  * A lobby server provides the following functionality:
  * </p>
  * <ul>
- * <li>A registry of servers available to host games.
+ * <li>A registry of servers available to host games.</li>
  * <li>A room where players can find opponents and generally chat.</li>
  * </ul>
  */

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -1,8 +1,6 @@
 package games.strategy.engine.lobby.server;
 
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.StatusManager;
@@ -17,18 +15,11 @@ public final class LobbyServer {
   public static final String ADMIN_USERNAME = "Admin";
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
-  private static final Logger logger = Logger.getLogger(LobbyServer.class.getName());
 
   private LobbyServer() {}
 
-  static void start(final LobbyPropertyReader lobbyPropertyReader) {
-    final IServerMessenger server;
-    try {
-      server = ServerMessenger.newInstanceForLobby(ADMIN_USERNAME, lobbyPropertyReader);
-    } catch (final IOException ex) {
-      logger.log(Level.SEVERE, ex.toString());
-      throw new IllegalStateException(ex.getMessage());
-    }
+  static void start(final LobbyPropertyReader lobbyPropertyReader) throws IOException {
+    final IServerMessenger server = ServerMessenger.newInstanceForLobby(ADMIN_USERNAME, lobbyPropertyReader);
     final Messengers messengers = new Messengers(server);
     server.setLoginValidator(new LobbyLoginValidator(lobbyPropertyReader));
     // setup common objects

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -9,6 +9,7 @@ import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
+import games.strategy.sound.ClipPlayer;
 import games.strategy.util.Version;
 
 public final class LobbyServer {
@@ -19,6 +20,8 @@ public final class LobbyServer {
   private LobbyServer() {}
 
   static void start(final LobbyPropertyReader lobbyPropertyReader) throws IOException {
+    ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
+
     final IServerMessenger server = ServerMessenger.newInstanceForLobby(ADMIN_USERNAME, lobbyPropertyReader);
     final Messengers messengers = new Messengers(server);
     server.setLoginValidator(new LobbyLoginValidator(lobbyPropertyReader));

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -12,6 +12,17 @@ import games.strategy.net.ServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.util.Version;
 
+/**
+ * A lobby server.
+ *
+ * <p>
+ * A lobby server provides the following functionality:
+ * </p>
+ * <ul>
+ * <li>A registry of servers available to host games.
+ * <li>A room where players can find opponents and generally chat.</li>
+ * </ul>
+ */
 public final class LobbyServer {
   public static final String ADMIN_USERNAME = "Admin";
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
@@ -19,6 +30,14 @@ public final class LobbyServer {
 
   private LobbyServer() {}
 
+  /**
+   * Starts a new lobby server using the properties given by {@code lobbyPropertyReader}.
+   *
+   * <p>
+   * This method returns immediately after the lobby server is started; it does not block while the lobby server is
+   * running.
+   * </p>
+   */
   static void start(final LobbyPropertyReader lobbyPropertyReader) throws IOException {
     ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -13,13 +13,15 @@ import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
 import games.strategy.util.Version;
 
-public class LobbyServer {
+public final class LobbyServer {
   public static final String ADMIN_USERNAME = "Admin";
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
   private static final Logger logger = Logger.getLogger(LobbyServer.class.getName());
 
-  LobbyServer(final LobbyPropertyReader lobbyPropertyReader) {
+  private LobbyServer() {}
+
+  static void start(final LobbyPropertyReader lobbyPropertyReader) {
     final IServerMessenger server;
     try {
       server = ServerMessenger.newInstanceForLobby(ADMIN_USERNAME, lobbyPropertyReader);

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -28,7 +28,7 @@ public final class LobbyRunner {
       log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
       LobbyServer.start(lobbyPropertyReader);
       log.info("Lobby started");
-    } catch (final RuntimeException e) {
+    } catch (final Exception e) {
       log.log(Level.SEVERE, "Failed to start lobby", e);
       ExitStatus.FAILURE.exit();
     }

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -4,7 +4,6 @@ import java.util.logging.Level;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
-import games.strategy.sound.ClipPlayer;
 import games.strategy.util.ExitStatus;
 import lombok.extern.java.Log;
 
@@ -21,8 +20,6 @@ public final class LobbyRunner {
    */
   public static void main(final String[] args) {
     try {
-      ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
-
       final LobbyPropertyReader lobbyPropertyReader =
           new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
       log.info("Starting lobby on port " + lobbyPropertyReader.getPort());

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -26,7 +26,7 @@ public final class LobbyRunner {
       final LobbyPropertyReader lobbyPropertyReader =
           new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
       log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
-      new LobbyServer(lobbyPropertyReader);
+      LobbyServer.start(lobbyPropertyReader);
       log.info("Lobby started");
     } catch (final RuntimeException e) {
       log.log(Level.SEVERE, "Failed to start lobby", e);


### PR DESCRIPTION
## Overview

The primary purpose of this PR is to get rid of an unused object warning on the `LobbyServer` instance created by `LobbyRunner`.  As `LobbyServer` has no state, and all logic is contained in its constructor, I converted it to a non-instantiable class with a single static `start()` method.

I made a few small refactoring changes while I was here.  Please see the second and subsequent commits for context.

## Functional Changes

None.

## Manual Testing Performed

Verified I could start a local lobby (using both the IDE and build artifact) and connect to it.