### PR TITLE
Fix flaky TestFX test

### DIFF
--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -5,17 +5,14 @@ import static org.testfx.matcher.base.NodeMatchers.hasChildren;
 import static org.testfx.matcher.base.NodeMatchers.isInvisible;
 import static org.testfx.matcher.base.NodeMatchers.isVisible;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
-import org.testfx.api.FxToolkit;
-import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.ApplicationTest;
 
 import games.strategy.triplea.settings.ClientSetting;
+import javafx.stage.Stage;
 
-@ExtendWith(ApplicationExtension.class)
-public class TripleAApplicationTest {
+final class TripleAApplicationTest extends ApplicationTest {
 
   static {
     System.setProperty("testfx.robot", "glass");
@@ -25,12 +22,14 @@ public class TripleAApplicationTest {
     System.setProperty("testfx.setup.timeout", String.valueOf(30_000));
   }
 
-
-  @BeforeAll
-  public static void setup() throws Exception {
+  @Override
+  public void init() {
     ClientSetting.setPreferences(new MemoryPreferences());
-    FxToolkit.registerPrimaryStage();
-    FxToolkit.setupApplication(TripleA.class);
+  }
+
+  @Override
+  public void start(final Stage stage) throws Exception {
+    new TripleA().start(stage);
   }
 
   @Test

--- a/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
+++ b/game-core/src/test/java/org/triplea/client/ui/javafx/TripleAApplicationTest.java
@@ -22,7 +22,7 @@ public class TripleAApplicationTest {
     System.setProperty("testfx.headless", String.valueOf(true));
     System.setProperty("prism.order", "sw");
     System.setProperty("prism.text", "t2k");
-    System.setProperty("testfx.setup.timeout", String.valueOf(10000));
+    System.setProperty("testfx.setup.timeout", String.valueOf(30_000));
   }
 
 


### PR DESCRIPTION
## Overview

`TripleAApplicationTest` seems to intermittently fail on Travis due to a timeout several times per week.  The test is configured to give it up to 10 seconds to complete setting up the application.  On my VM, the setup seems to take 5-6 seconds.  I'm assuming that, in a pristine environment like Travis, 10 seconds may be borderline depending on how busy the build container host is.

On my feature branch, I got the test to timeout on the first try.  I then bumped the timeout to 30 seconds and ran 10 more builds.  All completed without a test timeout.  So I'll take that as confirmation of the above theory for the time being. :smile:

In the second commit, I did a small refactoring unrelated to the timeout.  `ApplicationExtension` always creates a default application, which we immediately overwrite with the `TripleA` application.  Using the `ApplicationTest` superclass, no default application is created.  In addition, `ApplicationTest` creates a default stage, so that is one less thing the fixture has to do.

## Functional Changes

None.

## Manual Testing Performed

None.