### PR TITLE
Allow period in unit names

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -30,7 +30,7 @@ public class UnitIconProperties extends PropertyFile {
       }
       try {
         final String[] unitInfoAndCondition = key.split(";");
-        final String[] unitInfo = unitInfoAndCondition[0].split("\\.");
+        final String[] unitInfo = unitInfoAndCondition[0].split("\\.", 3);
         if (unitInfoAndCondition.length != 2) {
           continue;
         }


### PR DESCRIPTION
Limit unit icon parsing split on periods to 3 parts so unit names can have periods in them.