### PR TITLE
Remove lobby game started, engine version and bot columns

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -71,20 +71,14 @@ class LobbyGamePanel extends JPanel {
         .setPreferredWidth(40);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.P))
         .setPreferredWidth(12);
-    gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.B))
-        .setPreferredWidth(12);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.GV))
         .setPreferredWidth(32);
-    gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.EV))
-        .setPreferredWidth(42);
-    gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Started))
-        .setPreferredWidth(55);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Status))
         .setPreferredWidth(112);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Name))
         .setPreferredWidth(156);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Comments))
-        .setPreferredWidth(130);
+        .setPreferredWidth(160);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Host))
         .setPreferredWidth(67);
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -55,7 +55,10 @@ class LobbyGamePanel extends JPanel {
     hostGame = new JButton("Host Game");
     joinGame = new JButton("Join Game");
     bootGame = new JButton("Boot Game");
-    gameTableModel = new LobbyGameTableModel(messengers.getMessenger(), messengers.getChannelMessenger(),
+    gameTableModel = new LobbyGameTableModel(
+        isAdmin(),
+        messengers.getMessenger(),
+        messengers.getChannelMessenger(),
         messengers.getRemoteMessenger());
 
     gameTable = new LobbyGameTable(gameTableModel);
@@ -73,6 +76,10 @@ class LobbyGamePanel extends JPanel {
         .setPreferredWidth(12);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.GV))
         .setPreferredWidth(32);
+    if(isAdmin()) {
+      gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Started))
+          .setPreferredWidth(55);
+    }
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Status))
         .setPreferredWidth(112);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Name))

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -76,7 +76,7 @@ class LobbyGamePanel extends JPanel {
         .setPreferredWidth(12);
     gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.GV))
         .setPreferredWidth(32);
-    if(isAdmin()) {
+    if (isAdmin()) {
       gameTable.getColumnModel().getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Started))
           .setPreferredWidth(55);
     }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
@@ -21,9 +21,9 @@ class LobbyGameTable extends JTable {
   LobbyGameTable(final LobbyGameTableModel gameTableModel) {
     super(gameTableModel);
     final TableRowSorter<LobbyGameTableModel> tableSorter = new TableRowSorter<>(gameTableModel);
-    // by default, sort newest first
-    final int dateColumn = gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Started);
-    tableSorter.setSortKeys(Collections.singletonList(new RowSorter.SortKey(dateColumn, SortOrder.DESCENDING)));
+    // by default, sort by host
+    final int hostColumn = gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Host);
+    tableSorter.setSortKeys(Collections.singletonList(new RowSorter.SortKey(hostColumn, SortOrder.DESCENDING)));
     setRowSorter(tableSorter);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -1,8 +1,5 @@
 package games.strategy.engine.lobby.client.ui;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -18,14 +15,13 @@ import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.net.GUID;
 import games.strategy.net.IMessenger;
-import games.strategy.util.TimeManager;
 import games.strategy.util.Tuple;
 
 class LobbyGameTableModel extends AbstractTableModel {
   private static final long serialVersionUID = 6399458368730633993L;
 
   enum Column {
-    Host, Name, GV, Round, Players, P, B, EV, Started, Status, Comments, GUID
+    Host, Name, GV, Round, Players, P, Status, Comments, GUID
   }
 
   private final IMessenger messenger;
@@ -148,26 +144,16 @@ class LobbyGameTableModel extends AbstractTableModel {
         return description.getPlayerCount();
       case P:
         return (description.getPassworded() ? "*" : "");
-      case B:
-        return description.isBot() ? "-" : "";
       case GV:
         return description.getGameVersion();
-      case EV:
-        return description.getEngineVersion();
       case Status:
         return description.getStatus();
       case Comments:
         return description.getComment();
-      case Started:
-        return formatBotStartTime(description.getStartDateTime());
       case GUID:
         return gameList.get(rowIndex).getFirst();
       default:
         throw new IllegalStateException("Unknown column:" + column);
     }
-  }
-
-  private static String formatBotStartTime(final Instant instant) {
-    return TimeManager.getLocalizedTimeWithoutSeconds(LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -125,10 +125,10 @@ class LobbyGameTableModel extends AbstractTableModel {
 
   @Override
   public int getColumnCount() {
-    int hiddenColumns = admin ? 0 : -1;
+    final int adminHiddenColumns = admin ? 0 : -1;
     // -1 so we don't display the guid
     // -1 again if we are not admin to hide the 'started' column
-    return Column.values().length - 1 + hiddenColumns;
+    return Column.values().length - 1 + adminHiddenColumns;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -21,7 +21,11 @@ import games.strategy.net.Node;
  */
 public class GameDescription implements Externalizable, Cloneable {
   private static final long serialVersionUID = 508593169141567546L;
-
+  
+  /**
+   * Represents the game states displayed to users looking at the list of available
+   * lobby games.
+   */
   public enum GameStatus {
     LAUNCHING {
       @Override
@@ -45,6 +49,12 @@ public class GameDescription implements Externalizable, Cloneable {
 
   private INode hostedBy;
   private int port;
+
+  /**
+   * Represents when the game started, used to be displayed on lobby table, now no longer.
+   * @deprecated No longer used, waiting for non-compatible change opportunity to remove.
+   */
+  @Deprecated
   private Instant startDateTime;
   private String gameName;
   private int playerCount;
@@ -54,6 +64,13 @@ public class GameDescription implements Externalizable, Cloneable {
   private String hostName;
   private String comment;
   private boolean passworded;
+  /**
+   * Engine version, used to be useful when multiple engine versions were in same lobby,
+   * now that lobby has homogonous versions and should going forward, this column is no
+   * longer useful.
+   * @deprecated No longer used, waiting for non-compatible change opportunity to remove.
+   */
+  @Deprecated
   private String engineVersion;
   private String gameVersion;
   private String botSupportEmail = (HeadlessGameServer.getInstance() != null)

--- a/game-core/src/main/java/games/strategy/util/TimeManager.java
+++ b/game-core/src/main/java/games/strategy/util/TimeManager.java
@@ -30,18 +30,6 @@ public class TimeManager {
   }
 
   /**
-   * Returns a String representing this {@link LocalDateTime}.
-   * Based on where you live this might be either for example 13:45 or 1:45pm.
-   *
-   * @param dateTime The LocalDateTime representing the desired time
-   * @return The formatted String
-   */
-  public static String getLocalizedTimeWithoutSeconds(final LocalDateTime dateTime) {
-    return new DateTimeFormatterBuilder().appendLocalized(null, FormatStyle.SHORT).toFormatter()
-        .format(dateTime);
-  }
-
-  /**
    * Replacement for {@code Date.toString}.
    *
    * @param dateTime The DateTime which should be formatted

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -57,7 +57,7 @@ public class LobbyGameTableModelTest {
     Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE))
         .thenReturn(mockLobbyController);
     Mockito.when(mockLobbyController.listGames()).thenReturn(fakeGameMap);
-    testObj = new LobbyGameTableModel(mockMessenger, mockChannelMessenger, mockRemoteMessenger);
+    testObj = new LobbyGameTableModel(true, mockMessenger, mockChannelMessenger, mockRemoteMessenger);
     Mockito.verify(mockLobbyController, Mockito.times(1)).listGames();
 
     MessageContext.setSenderNodeForThread(serverNode);


### PR DESCRIPTION
## Overview
Cleaning up some columns that have become less useful. Discussed in forums here: 

## Functional Changes
- updates to lobby available-game table, removed columns
- add some extra space to lobby comments column


## Manual Testing Performed
- launched a local lobby and bot, connected to it to verify the UI and connected to bot host for some quick smoke testing

## Before & After Screen Shots
### Before
![before](https://user-images.githubusercontent.com/12397753/43680271-91a66004-97eb-11e8-98b7-84c06956be37.png)


### After
![after](https://user-images.githubusercontent.com/12397753/43680273-9524ad3a-97eb-11e8-831f-1e1b14435257.png)

