### PR TITLE
Run test-common project tests during Gradle build

### DIFF
--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -73,3 +73,7 @@ jacocoTestReport {
         html.enabled = true
     }
 }
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
## Overview

Currently, tests in the `test-common` project are not run during the Gradle build due to a configuration error (Gradle is using the legacy JUnit (3/4) runner rather than the JUnit platform (5) runner for this project).  This PR corrects the configuration.

## Functional Changes

None.

## Manual Testing Performed

Verified a failing test in the `test-common` project will fail the Gradle build.