### PR TITLE
Fix exception when formatting bot start time

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -1,6 +1,8 @@
 package games.strategy.engine.lobby.client.ui;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.util.ArrayList;
@@ -9,6 +11,8 @@ import java.util.Map;
 
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.ILobbyGameBroadcaster;
@@ -166,8 +170,9 @@ class LobbyGameTableModel extends AbstractTableModel {
     }
   }
 
-  private static String formatBotStartTime(final Instant instant) {
+  @VisibleForTesting
+  static String formatBotStartTime(final Instant instant) {
     return new DateTimeFormatterBuilder().appendLocalized(null, FormatStyle.SHORT).toFormatter()
-        .format(instant);
+        .format(LocalDateTime.ofInstant(instant, ZoneOffset.systemDefault()));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -1,13 +1,16 @@
 package games.strategy.engine.lobby.client.ui;
 
+import static games.strategy.test.Assertions.assertNotThrows;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,88 +28,98 @@ import games.strategy.net.INode;
 import games.strategy.test.TestUtil;
 import games.strategy.util.Tuple;
 
-@ExtendWith(MockitoExtension.class)
-public class LobbyGameTableModelTest {
+public final class LobbyGameTableModelTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class RemoveAndUpdateGameTest {
+    private LobbyGameTableModel testObj;
 
-  private LobbyGameTableModel testObj;
+    @Mock
+    private IMessenger mockMessenger;
+    @Mock
+    private IChannelMessenger mockChannelMessenger;
+    @Mock
+    private IRemoteMessenger mockRemoteMessenger;
+    @Mock
+    private ILobbyGameController mockLobbyController;
 
-  @Mock
-  private IMessenger mockMessenger;
-  @Mock
-  private IChannelMessenger mockChannelMessenger;
-  @Mock
-  private IRemoteMessenger mockRemoteMessenger;
-  @Mock
-  private ILobbyGameController mockLobbyController;
+    private Map<GUID, GameDescription> fakeGameMap;
+    private Tuple<GUID, GameDescription> fakeGame;
 
-  private Map<GUID, GameDescription> fakeGameMap;
-  private Tuple<GUID, GameDescription> fakeGame;
+    @Mock
+    private GameDescription mockGameDescription;
 
-  @Mock
-  private GameDescription mockGameDescription;
+    @Mock
+    private INode serverNode;
 
-  @Mock
-  private INode serverNode;
+    @BeforeEach
+    public void setUp() {
+      fakeGameMap = new HashMap<>();
+      fakeGame = Tuple.of(new GUID(), mockGameDescription);
+      fakeGameMap.put(fakeGame.getFirst(), fakeGame.getSecond());
 
-  @BeforeEach
-  public void setUp() {
-    fakeGameMap = new HashMap<>();
-    fakeGame = Tuple.of(new GUID(), mockGameDescription);
-    fakeGameMap.put(fakeGame.getFirst(), fakeGame.getSecond());
+      Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE))
+          .thenReturn(mockLobbyController);
+      Mockito.when(mockLobbyController.listGames()).thenReturn(fakeGameMap);
+      testObj = new LobbyGameTableModel(true, mockMessenger, mockChannelMessenger, mockRemoteMessenger);
+      Mockito.verify(mockLobbyController, Mockito.times(1)).listGames();
 
-    Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE))
-        .thenReturn(mockLobbyController);
-    Mockito.when(mockLobbyController.listGames()).thenReturn(fakeGameMap);
-    testObj = new LobbyGameTableModel(true, mockMessenger, mockChannelMessenger, mockRemoteMessenger);
-    Mockito.verify(mockLobbyController, Mockito.times(1)).listGames();
+      MessageContext.setSenderNodeForThread(serverNode);
+      Mockito.when(mockMessenger.getServerNode()).thenReturn(serverNode);
+      TestUtil.waitForSwingThreads();
+      assertThat("games are loaded on init", testObj.getRowCount(), is(1));
+    }
 
-    MessageContext.setSenderNodeForThread(serverNode);
-    Mockito.when(mockMessenger.getServerNode()).thenReturn(serverNode);
-    TestUtil.waitForSwingThreads();
-    assertThat("games are loaded on init", testObj.getRowCount(), is(1));
+    @Test
+    public void updateGame() {
+      final int commentColumnIndex = testObj.getColumnIndex(LobbyGameTableModel.Column.Comments);
+      assertThat(testObj.getValueAt(0, commentColumnIndex), nullValue());
+
+      final String newComment = "comment";
+      final GameDescription newDescription = new GameDescription();
+      newDescription.setComment(newComment);
+
+      testObj.getLobbyGameBroadcaster().gameUpdated(fakeGame.getFirst(), newDescription);
+      TestUtil.waitForSwingThreads();
+      assertThat(testObj.getRowCount(), is(1));
+      assertThat(testObj.getValueAt(0, commentColumnIndex), is(newComment));
+    }
+
+    @Test
+    public void updateGameAddsIfDoesNotExist() {
+      testObj.getLobbyGameBroadcaster().gameUpdated(new GUID(), new GameDescription());
+      TestUtil.waitForSwingThreads();
+      assertThat(testObj.getRowCount(), is(2));
+    }
+
+    @Test
+    public void updateGameWithNullGuidIsIgnored() {
+      testObj.getLobbyGameBroadcaster().gameUpdated(null, new GameDescription());
+      TestUtil.waitForSwingThreads();
+      assertThat("expect row count to remain 1, null guid is bogus data",
+          testObj.getRowCount(), is(1));
+    }
+
+    @Test
+    public void removeGame() {
+      testObj.getLobbyGameBroadcaster().gameRemoved(fakeGame.getFirst());
+      TestUtil.waitForSwingThreads();
+      assertThat(testObj.getRowCount(), is(0));
+    }
+
+    @Test
+    public void removeGameThatDoesNotExistIsIgnored() {
+      testObj.getLobbyGameBroadcaster().gameRemoved(new GUID());
+      TestUtil.waitForSwingThreads();
+      assertThat(testObj.getRowCount(), is(1));
+    }
   }
 
-  @Test
-  public void updateGame() {
-    final int commentColumnIndex = testObj.getColumnIndex(LobbyGameTableModel.Column.Comments);
-    assertThat(testObj.getValueAt(0, commentColumnIndex), nullValue());
-
-    final String newComment = "comment";
-    final GameDescription newDescription = new GameDescription();
-    newDescription.setComment(newComment);
-
-    testObj.getLobbyGameBroadcaster().gameUpdated(fakeGame.getFirst(), newDescription);
-    TestUtil.waitForSwingThreads();
-    assertThat(testObj.getRowCount(), is(1));
-    assertThat(testObj.getValueAt(0, commentColumnIndex), is(newComment));
-  }
-
-  @Test
-  public void updateGameAddsIfDoesNotExist() {
-    testObj.getLobbyGameBroadcaster().gameUpdated(new GUID(), new GameDescription());
-    TestUtil.waitForSwingThreads();
-    assertThat(testObj.getRowCount(), is(2));
-  }
-
-  @Test
-  public void updateGameWithNullGuidIsIgnored() {
-    testObj.getLobbyGameBroadcaster().gameUpdated(null, new GameDescription());
-    TestUtil.waitForSwingThreads();
-    assertThat("expect row count to remain 1, null guid is bogus data",
-        testObj.getRowCount(), is(1));
-  }
-
-  @Test
-  public void removeGame() {
-    testObj.getLobbyGameBroadcaster().gameRemoved(fakeGame.getFirst());
-    TestUtil.waitForSwingThreads();
-    assertThat(testObj.getRowCount(), is(0));
-  }
-
-  @Test
-  public void removeGameThatDoesNotExistIsIgnored() {
-    testObj.getLobbyGameBroadcaster().gameRemoved(new GUID());
-    TestUtil.waitForSwingThreads();
-    assertThat(testObj.getRowCount(), is(1));
+  @Nested
+  final class FormatBotStartTimeTest {
+    @Test
+    void shouldNotThrowException() {
+      assertNotThrows(() -> LobbyGameTableModel.formatBotStartTime(Instant.now()));
+    }
   }
 }


### PR DESCRIPTION
## Overview

Fixes #3740.

`Instant` doesn't support the `SHORT` time format because it doesn't provide a time zone.  Need to convert `Instant` to `LocalDateTime` before formatting.

## Functional Changes

None.

## Manual Testing Performed

Connected to lobby hosting one bot as a moderator.  No exception raised and bot start time was displayed correctly.

## Additional Review notes

Please review with whitespace changes ignored due to indentation changes in the test code.