### PR TITLE
Create ErrorMessage and Console after L&F initialized

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -109,6 +109,7 @@ public class GameRunner {
         "UI client launcher invoked from headless environment. This is current prohibited by design to "
             + "avoid UI rendering errors in the headless environment.");
 
+    ErrorHandler.registerExceptionHandler();
     ClientSetting.initialize();
 
     if (!ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
@@ -123,7 +124,6 @@ public class GameRunner {
               }
               console.append(formatter.format(logMsg));
             }));
-        ErrorHandler.registerExceptionHandler();
         ErrorMessage.enable();
       }));
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -109,21 +109,23 @@ public class GameRunner {
         "UI client launcher invoked from headless environment. This is current prohibited by design to "
             + "avoid UI rendering errors in the headless environment.");
 
-    ErrorHandler.registerExceptionHandler();
     ClientSetting.initialize();
 
     if (!ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
-      final Console console = new Console();
-      final SimpleFormatter formatter = new SimpleFormatter();
-      LogManager.getLogManager().getLogger("").addHandler(new ConsoleHandler(
-          logMsg -> {
-            if (logMsg.getLevel().intValue() > Level.INFO.intValue()) {
-              ErrorMessage.show(logMsg.getMessage());
-            }
-            console.append(formatter.format(logMsg));
-          }));
-      ErrorMessage.enable();
-      Interruptibles.await(() -> SwingAction.invokeAndWait(LookAndFeel::setupLookAndFeel));
+      Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
+        LookAndFeel.setupLookAndFeel();
+        final Console console = new Console();
+        final SimpleFormatter formatter = new SimpleFormatter();
+        LogManager.getLogManager().getLogger("").addHandler(new ConsoleHandler(
+            logMsg -> {
+              if (logMsg.getLevel().intValue() > Level.INFO.intValue()) {
+                ErrorMessage.show(logMsg.getMessage());
+              }
+              console.append(formatter.format(logMsg));
+            }));
+        ErrorHandler.registerExceptionHandler();
+        ErrorMessage.enable();
+      }));
     }
     new ArgParser().handleCommandLineArgs(args);
 


### PR DESCRIPTION
## Overview

Fixes a regression caused by #3715 (see #2925).

* The `ErrorMessage` and `Console` constructors create UI components.  Thus, they should be created on the EDT.
* UI component creation must be done after the L&F is initialized.  Otherwise, those components will use the default L&F rather than the user's selected L&F.

## Functional Changes

None.

## Before & After Screen Shots

### Before

![error-dialog-before](https://user-images.githubusercontent.com/4826349/43797354-224ceed2-9a55-11e8-853d-570ddb11680c.png)

![console-before](https://user-images.githubusercontent.com/4826349/43797364-2691b84c-9a55-11e8-923c-c815bb91329d.png)

### After

![error-dialog-after](https://user-images.githubusercontent.com/4826349/43797372-2bdae206-9a55-11e8-8448-18a5981eb13f.png)

![console-after](https://user-images.githubusercontent.com/4826349/43797376-2ee75a42-9a55-11e8-9a4d-231dc03ed999.png)