### PR TITLE
Fix console log level equality check

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -32,7 +32,7 @@ public class Console {
   private final JFrame frame = new JFrame("TripleA Console");
 
   public Console() {
-    final Level logLevel = ClientSetting.LOGGING_VERBOSITY.value().equals(Level.ALL)
+    final Level logLevel = ClientSetting.LOGGING_VERBOSITY.value().equals(Level.ALL.getName())
         ? Level.INFO
         : Level.WARNING;
     LogManager.getLogManager().getLogger("").setLevel(logLevel);


### PR DESCRIPTION
## Overview

Changing the console log level to `ALL` does not result in records below `WARNING` level being reported in the console.  The applicable check is incorrectly comparing a `String` to a `LogLevel`.  This PR converts the `LogLevel` to a `String` for proper comparison to the client setting.

## Functional Changes

None.

## Manual Testing Performed

Verified that `INFO` logs are now displayed in the console when changing the console log level to `ALL`.