### PR TITLE
Move Integration annotation to test-common project

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
-import games.strategy.test.Integration;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 @Integration

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -12,6 +12,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.IChannelMessenger;
@@ -25,7 +26,6 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
 import games.strategy.sound.SoundPath;
-import games.strategy.test.Integration;
 
 @Integration
 public final class ChatIntegrationTest {

--- a/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherIntegrationTest.java
@@ -4,8 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
-import games.strategy.test.Integration;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 @Integration

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
@@ -18,7 +19,6 @@ import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
-import games.strategy.test.Integration;
 
 @Integration
 public final class ClientLoginIntegrationTest {

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.stubbing.Answer;
+import org.triplea.test.common.Integration;
 
 import games.strategy.engine.config.lobby.TestLobbyPropertyReaders;
 import games.strategy.engine.lobby.server.db.Database;
@@ -27,7 +28,6 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
-import games.strategy.test.Integration;
 import games.strategy.util.Util;
 
 @Integration

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/AbstractControllerTestCase.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/AbstractControllerTestCase.java
@@ -1,7 +1,8 @@
 package games.strategy.engine.lobby.server.db;
 
+import org.triplea.test.common.Integration;
+
 import games.strategy.engine.config.lobby.TestLobbyPropertyReaders;
-import games.strategy.test.Integration;
 
 /**
  * Superclass for fixtures that test a DAO implementation.

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -10,9 +10,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.triplea.test.common.Integration;
+
 import games.strategy.engine.lobby.server.TestUserUtils;
 import games.strategy.engine.lobby.server.User;
-import games.strategy.test.Integration;
 import games.strategy.util.function.ThrowingConsumer;
 
 /**

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/AccessLogControllerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/AccessLogControllerIntegrationTest.java
@@ -10,11 +10,11 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
 import games.strategy.engine.lobby.server.TestUserUtils;
 import games.strategy.engine.lobby.server.User;
 import games.strategy.engine.lobby.server.login.UserType;
-import games.strategy.test.Integration;
 
 @Integration
 public final class AccessLogControllerIntegrationTest extends AbstractControllerTestCase {

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -8,8 +8,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
-import games.strategy.test.Integration;
 import games.strategy.util.Util;
 
 @Integration

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/EmailLimitIntegrationTest.java
@@ -8,11 +8,11 @@ import java.sql.SQLException;
 
 import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import org.triplea.test.common.Integration;
 
 import com.google.common.base.Strings;
 
 import games.strategy.engine.config.lobby.TestLobbyPropertyReaders;
-import games.strategy.test.Integration;
 import games.strategy.util.Util;
 
 /**

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/db/UserControllerIntegrationTest.java
@@ -14,10 +14,10 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import org.triplea.test.common.Integration;
 
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.engine.lobby.server.userDB.DBUser;
-import games.strategy.test.Integration;
 import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 import org.mindrot.jbcrypt.BCrypt;
+import org.triplea.test.common.Integration;
 
 import games.strategy.engine.config.lobby.TestLobbyPropertyReaders;
 import games.strategy.engine.lobby.common.LobbyConstants;
@@ -30,7 +31,6 @@ import games.strategy.engine.lobby.server.db.UserController;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MacFinder;
-import games.strategy.test.Integration;
 import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 

--- a/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -16,8 +16,8 @@ import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.triplea.test.common.Integration;
 
-import games.strategy.test.Integration;
 import games.strategy.util.Interruptibles;
 
 @Integration

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.0'
 
     compile "org.hamcrest:java-hamcrest:$hamcrestVersion"
+    compile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 }

--- a/test-common/src/main/java/org/triplea/test/common/Integration.java
+++ b/test-common/src/main/java/org/triplea/test/common/Integration.java
@@ -1,4 +1,4 @@
-package games.strategy.test;
+package org.triplea.test.common;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;


### PR DESCRIPTION
## Overview

Moves the `@Integration` annotation to the `test-common` project.

## Functional Changes

None.

## Manual Testing Performed

Verified the `test` task continues to run only unit tests.  Likewise, verified the `integTest` task continues to run only integration tests.