### PR TITLE
Remove RouteCalculator public constructor

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
@@ -15,17 +15,15 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 
-@AllArgsConstructor(access =  AccessLevel.PUBLIC)
+/**
+ * Utility class to calculate a smooth route to draw on the map.
+ */
 @Builder
-public class RouteCalculator {
-
-  public final boolean isInfiniteY;
-  public final boolean isInfiniteX;
-
+public final class RouteCalculator {
+  private final boolean isInfiniteX;
+  private final boolean isInfiniteY;
   private final int mapWidth;
   private final int mapHeight;
 

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
@@ -119,11 +119,12 @@ public class ImageScrollerSmallView extends JComponent {
     final double height = model.getBoxHeight() * ratioY;
     final Rectangle2D.Double mapBounds = new Rectangle2D.Double(0, 0,
         model.getMaxWidth() * ratioX, model.getMaxHeight() * ratioY);
-    final RouteCalculator calculator = new RouteCalculator(
-        model.getScrollY(),
-        model.getScrollX(),
-        (int) Math.round(mapBounds.width),
-        (int) Math.round(mapBounds.height));
+    final RouteCalculator calculator = RouteCalculator.builder()
+        .isInfiniteY(model.getScrollY())
+        .isInfiniteX(model.getScrollX())
+        .mapWidth((int) Math.round(mapBounds.width))
+        .mapHeight((int) Math.round(mapBounds.height))
+        .build();
     final Rectangle2D.Double rect = new Rectangle2D.Double(
         x % mapBounds.width, y % mapBounds.height,
         width, height);


### PR DESCRIPTION
## Overview

Addresses a comment from the #3725 code review.  Removes the `RouteCalculator` public constructor to force all clients to use the corresponding builder.  This avoids potential aliasing of the constructor parameters due to the non-standard order of the `isInfiniteX` and `isInfiniteY` parameters.

## Functional Changes

None.

## Manual Testing Performed

Verified small map is still drawn as expected.