### PR TITLE
Round zoom level instead of truncating it

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -130,7 +130,7 @@ final class ViewMenu extends JMenu {
       model.setMaximum(100);
       model.setMinimum(15);
       model.setStepSize(1);
-      model.setValue((int) (frame.getMapPanel().getScale() * 100));
+      model.setValue((int) Math.round(frame.getMapPanel().getScale() * 100));
       final JSpinner spinner = new JSpinner(model);
       final JPanel panel = new JPanel();
       panel.setLayout(new BorderLayout());


### PR DESCRIPTION
## Overview

Restores a bug fix from #3482 that was pointed out during the #3725 code review.

## Functional Changes

None (only affects value displayed in UI).

## Manual Testing Performed

* Change zoom level to 15% (which, due to discretization, gets mapped to 14.84375% internally).
* Re-open zoom level dialog and verify zoom level is initialized to `15` (prior to this change it was `14`).