### PR TITLE
Extract remaining common build configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'net.ltgt.errorprone' version '0.0.15' apply false
 }
 
@@ -7,6 +8,10 @@ apply from: 'gradle/scripts/yaml.gradle'
 
 ext {
     schemasDir = file('config/triplea/schemas')
+}
+
+check {
+    dependsOn 'validateYamls'
 }
 
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {
@@ -20,14 +25,15 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
     }
 }
 
-check {
-    dependsOn 'validateYamls'
-}
-
 subprojects {
+    group = 'triplea'
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+
     ext {
         hamcrestVersion = '2.0.0.0'
         junitJupiterVersion = '5.1.0'
+        lombokVersion = '1.18.0'
         mockitoVersion = '2.19.1'
     }
 

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -1,12 +1,10 @@
 plugins {
     id 'application'
-    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
     id 'com.install4j.gradle' version '7.0.1'
     id 'de.undercouch.download' version '3.4.3'
 }
 
-group = 'triplea'
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = 'games.strategy.engine.framework.GameRunner'
 
@@ -47,9 +45,6 @@ def remoteFile(url) {
 
 version = getEngineVersion()
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 jar {
     manifest {
         attributes 'Main-Class': mainClassName, 'TripleA-Version': version
@@ -73,7 +68,8 @@ dependencies {
     compile 'commons-cli:commons-cli:1.4'
     compile remoteFile('https://github.com/kirill-grouchnikov/substance/raw/f894ef784a2ac20acf13e6ed2c7c26123399787b/drop/8.0.02/substance-8.0.02.jar')
 
-    compileOnly 'org.projectlombok:lombok:1.18.0'
+    compileOnly "org.projectlombok:lombok:$lombokVersion"
+
     runtime remoteFile('https://github.com/kirill-grouchnikov/substance/raw/f894ef784a2ac20acf13e6ed2c7c26123399787b/drop/8.0.02/trident-1.5.00.jar')
 
     testCompile project(':test-common')
@@ -121,7 +117,6 @@ task downloadAssets(group: 'release') {
         }
     }
 }
-
 
 import com.install4j.gradle.Install4jTask
 task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -1,23 +1,23 @@
 buildscript {
-  dependencies {
-    classpath 'com.h2database:h2:1.4.197'
-    classpath 'org.postgresql:postgresql:42.2.2'
-  }
+    dependencies {
+        classpath 'com.h2database:h2:1.4.197'
+        classpath 'org.postgresql:postgresql:42.2.2'
+    }
 }
 
 plugins {
-  id "org.flywaydb.flyway" version "5.1.4"
+    id 'org.flywaydb.flyway' version '5.1.4'
 }
 
 flyway {
-  driver = 'org.postgresql.Driver'
-  url= 'jdbc:postgresql://localhost:5432/ta_users'
-  user = 'postgres'
-  password = 'postgres'
+    driver = 'org.postgresql.Driver'
+    url= 'jdbc:postgresql://localhost:5432/ta_users'
+    user = 'postgres'
+    password = 'postgres'
 }
 
 task lobbyDbRelease(type: Zip, group: 'release') {
-   from "${projectDir}/src/main/resources/db/migration/"
-   include '*.sql'
-   archiveName 'migrations.zip'
+    from "${projectDir}/src/main/resources/db/migration/"
+    include '*.sql'
+    archiveName 'migrations.zip'
 }

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -1,12 +1,8 @@
 plugins {
     id 'application'
-    id 'com.github.ben-manes.versions' version '0.20.0'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.install4j.gradle' version '7.0.1'
-    id 'de.undercouch.download' version '3.4.3'
 }
 
-group = 'triplea'
 description = 'TripleA Lobby'
 mainClassName = 'games.strategy.engine.lobby.server.LobbyRunner'
 
@@ -15,9 +11,6 @@ ext {
 }
 
 version = project.hasProperty('lobbyVersion') ? project.lobbyVersion : 'dev'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
 
 jar {
     manifest {
@@ -28,7 +21,7 @@ jar {
 dependencies {
     compile project(':game-core')
 
-    compileOnly 'org.projectlombok:lombok:1.18.0'
+    compileOnly "org.projectlombok:lombok:$lombokVersion"
 }
 
 shadowJar {

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -1,19 +1,8 @@
-plugins {
-    id 'com.github.ben-manes.versions' version '0.20.0'
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.install4j.gradle' version '7.0.1'
-    id 'de.undercouch.download' version '3.4.3'
-}
-
-group = 'triplea'
 description = 'Test utility library, generic test utilities useful for TripleA projects'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.0'
-
     compile "org.hamcrest:java-hamcrest:$hamcrestVersion"
     compile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+
+    compileOnly "org.projectlombok:lombok:$lombokVersion"
 }


### PR DESCRIPTION
## Overview

Extracts the remaining common build configuration to the root project buildscript.  In addition, any unnecessary build configuration that was leftover was removed.

The second commit is pretty much just a whitespace change to re-indent the `lobby-db` buildscript to use indentation consistent with the other buildscripts.

## Functional Changes

None.

## Manual Testing Performed

Ran the `release` and `lobbyDbRelease` tasks locally and verified all expected build artifacts were produced.