### PR TITLE
Prefer JSR-305 nullity annotations to Lombok

### DIFF
--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -1,6 +1,7 @@
 description = 'Test utility library, generic test utilities useful for TripleA projects'
 
 dependencies {
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile "org.hamcrest:java-hamcrest:$hamcrestVersion"
     compile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 

--- a/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
+++ b/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
@@ -3,11 +3,12 @@ package org.triplea.test.common;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import javax.annotation.Nonnull;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
 import lombok.Builder;
-import lombok.NonNull;
 
 /**
  * Convenience class for building a type safe hamcrest matcher.
@@ -34,9 +35,9 @@ import lombok.NonNull;
  */
 @Builder
 public class CustomMatcher<T> extends BaseMatcher<T> {
-  @NonNull
+  @Nonnull
   private final String description;
-  @NonNull
+  @Nonnull
   private final Predicate<T> checkCondition;
   @SuppressWarnings("FieldMayBeFinal")
   @Builder.Default


### PR DESCRIPTION
## Overview

Almost exclusively, we use the JSR-305 `javax.annotation.Nonnull` annotation, where needed, instead of the equivalent Lombok `lombok.NonNull` annotation.  For consistency, this PR replaces the two usages of the Lombok annotation with the JSR-305 annotation.

## Functional Changes

None.

## Manual Testing Performed

I verified Lombok produces identical bytecode for the `CustomMatcher` class constructor regardless of whether `javax.annotation.Nonnull` or `lombok.NonNull` is used.