### PR TITLE
Reduce calls to deprecated TechAttachment constructor

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
@@ -83,13 +83,13 @@ public class DelegateTest {
   public void setUp() throws Exception {
     gameData = TestMapGameData.DELEGATE_TEST.getGameData();
     british = GameDataTestUtil.british(gameData);
-    british.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
+    addTechAttachment(british);
     japanese = GameDataTestUtil.japanese(gameData);
-    japanese.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
+    addTechAttachment(japanese);
     russians = GameDataTestUtil.russians(gameData);
-    russians.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
+    addTechAttachment(russians);
     germans = GameDataTestUtil.germans(gameData);
-    germans.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
+    addTechAttachment(germans);
     northSea = gameData.getMap().getTerritory("North Sea Zone");
     blackSea = gameData.getMap().getTerritory("Black Sea Zone");
     uk = gameData.getMap().getTerritory("United Kingdom");
@@ -145,6 +145,12 @@ public class DelegateTest {
     bomber = GameDataTestUtil.bomber(gameData);
     carrier = GameDataTestUtil.carrier(gameData);
     pus = gameData.getResourceList().getResource("PUs");
+  }
+
+  private void addTechAttachment(final PlayerID player) {
+    player.addAttachment(
+        Constants.TECH_ATTACHMENT_NAME,
+        new TechAttachment(Constants.TECH_ATTACHMENT_NAME, player, gameData));
   }
 
   public void assertValid(final String string) {


### PR DESCRIPTION
## Overview

Replaces calls to the deprecated `TechAttachment` default constructor in test code with the standard three-parameter constructor.

## Functional Changes

None.

## Manual Testing Performed

None.