### PR TITLE
Simplify Route#getMovementCost to #numberOfSteps

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -171,16 +171,6 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * Returns the total cost of the route including modifications due to territoryEffects and territoryConnections.
-   *
-   * @param u unit that is moving on this route
-   */
-  public int getMovementCost(final Unit u) {
-    // TODO implement me
-    return m_steps.size();
-  }
-
-  /**
    * Returns the number of steps in this route. Does not include start.
    */
   public int numberOfSteps() {
@@ -383,16 +373,8 @@ public class Route implements Serializable, Iterable<Territory> {
         || !getAllTerritories().stream().allMatch(Matches.territoryIsWater());
   }
 
-  public int getLargestMovementCost(final Collection<Unit> units) {
-    int largestCost = 0;
-    for (final Unit unit : units) {
-      largestCost = Math.max(largestCost, getMovementCost(unit));
-    }
-    return largestCost;
-  }
-
   public int getMovementLeft(final Unit unit) {
-    return ((TripleAUnit) unit).getMovementLeft() - getMovementCost(unit);
+    return ((TripleAUnit) unit).getMovementLeft() - numberOfSteps();
   }
 
   public static Change getFuelChanges(final Collection<Unit> units, final Route route, final PlayerID player,
@@ -494,7 +476,7 @@ public class Route implements Serializable, Iterable<Territory> {
     }
     final UnitAttachment ua = UnitAttachment.get(unit.getType());
     resources.add(ua.getFuelCost());
-    resources.multiply(getMovementCost(unit));
+    resources.multiply(numberOfSteps());
     if (!ignoreFlat && Matches.unitHasNotBeenChargedFlatFuelCost().test(unit)) {
       resources.add(ua.getFuelFlatCost());
       chargedFlatFuelCost = true;

--- a/game-core/src/main/java/games/strategy/engine/data/RouteScripted.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RouteScripted.java
@@ -14,8 +14,6 @@ import java.util.List;
 public class RouteScripted extends Route {
   private static final long serialVersionUID = 604474811874966546L;
 
-  public RouteScripted() {}
-
   /**
    * Shameless cheating. Making a fake route, so as to handle battles properly without breaking battleTracker protected
    * status or
@@ -26,22 +24,10 @@ public class RouteScripted extends Route {
     super(terr);
   }
 
-  public RouteScripted(final Territory start, final Territory... route) {
-    super(start, route);
-  }
-
   @Override
   public void add(final Territory t) {
     // maybe we don't check for loops?
     super.add(t);
-  }
-
-  @Override
-  public int getMovementCost(final Unit u) {
-    if (super.getMovementCost(u) <= 0) {
-      return 1;
-    }
-    return super.getMovementCost(u);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -552,13 +552,14 @@ public class AirMovementValidator {
     if (areNeutralsPassableByAir) {
       final Route neutralViolatingRoute = data.getMap().getRoute(currentSpot, landingSpot,
           Matches.airCanFlyOver(player, data, areNeutralsPassableByAir));
-      return (neutralViolatingRoute != null && neutralViolatingRoute.getMovementCost(unit) <= movementLeft
-          && getNeutralCharge(data, neutralViolatingRoute) <= player.getResources().getQuantity(Constants.PUS));
+      return ((neutralViolatingRoute != null)
+          && (neutralViolatingRoute.numberOfSteps() <= movementLeft)
+          && (getNeutralCharge(data, neutralViolatingRoute) <= player.getResources().getQuantity(Constants.PUS)));
     }
 
     final Route noNeutralRoute = data.getMap().getRoute(currentSpot, landingSpot,
         Matches.airCanFlyOver(player, data, areNeutralsPassableByAir));
-    return noNeutralRoute != null && noNeutralRoute.getMovementCost(unit) <= movementLeft;
+    return (noNeutralRoute != null) && (noNeutralRoute.numberOfSteps() <= movementLeft);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1468,7 +1468,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       while (possibleIter.hasNext()) {
         final Route route = data.getMap().getRoute(currentTerr, possibleIter.next(),
             Matches.airCanFlyOver(alliedPlayer, data, areNeutralsPassableByAir));
-        if (route == null || route.getMovementCost(strandedAir.iterator().next()) > maxDistance) {
+        if ((route == null) || (route.numberOfSteps() > maxDistance)) {
           possibleIter.remove();
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1038,7 +1038,7 @@ public final class Matches {
   public static Predicate<Unit> unitHasEnoughMovementForRoute(final Route route) {
     return unit -> {
       int left = TripleAUnit.get(unit).getMovementLeft();
-      int movementcost = route.getMovementCost(unit);
+      int movementcost = route.numberOfSteps();
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       final PlayerID player = unit.getOwner();
       if (ua.getIsAir()) {
@@ -1050,7 +1050,7 @@ public final class Matches {
         if (route.getEnd() != null) {
           taEnd = TerritoryAttachment.get(route.getEnd());
         }
-        movementcost = route.getMovementCost(unit);
+        movementcost = route.numberOfSteps();
         if (taStart != null && taStart.getAirBase()) {
           left++;
         }
@@ -1060,7 +1060,7 @@ public final class Matches {
       }
       final GameStep stepName = unit.getData().getSequence().getStep();
       if (ua.getIsSea() && stepName.getDisplayName().equals("Non Combat Move")) {
-        movementcost = route.getMovementCost(unit);
+        movementcost = route.numberOfSteps();
         // If a zone adjacent to the starting and ending sea zones
         // are allied navalbases, increase the range.
         // TODO Still need to be able to handle stops on the way
@@ -2083,7 +2083,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanScrambleOnRouteDistance(final Route route) {
-    return unit -> UnitAttachment.get(unit.getType()).getMaxScrambleDistance() >= route.getMovementCost(unit);
+    return unit -> UnitAttachment.get(unit.getType()).getMaxScrambleDistance() >= route.numberOfSteps();
   }
 
   static Predicate<Unit> unitCanIntercept() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -305,7 +305,7 @@ public class MovePerformer implements Serializable {
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
     for (final Unit baseUnit : CollectionUtils.getMatches(units, Matches.unitIsOwnedBy(id))) {
       final TripleAUnit unit = (TripleAUnit) baseUnit;
-      int moved = route.getMovementCost(unit);
+      int moved = route.numberOfSteps();
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       if (ua.getIsAir()) {
         if (taRouteStart != null && taRouteStart.getAirBase()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1165,7 +1165,7 @@ public class MoveValidator {
 
   private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
     return CollectionUtils.getMatches(units,
-        Matches.unitIsAirTransportable().and(u -> TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u)
+        Matches.unitIsAirTransportable().and(u -> (TripleAUnit.get(u).getMovementLeft() < route.numberOfSteps())
             || route.crossesWater() || route.getEnd().isWater()));
   }
 
@@ -1463,11 +1463,9 @@ public class MoveValidator {
         landRoute =
             data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsLand().and(noImpassableOrRestricted));
       }
-      if (landRoute != null
-          && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
-              || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsLand())))) {
+      if ((landRoute != null)
+          && forceLandOrSeaRoute
+          && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsLand())) {
         defaultRoute = landRoute;
         mustGoLand = true;
       }
@@ -1477,11 +1475,9 @@ public class MoveValidator {
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
           data.getMap().getRoute_IgnoreEnd(start, end, Matches.territoryIsWater().and(noImpassableOrRestricted));
-      if (waterRoute != null
-          && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
-              || (forceLandOrSeaRoute
-                  && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsSea())))) {
+      if ((waterRoute != null)
+          && forceLandOrSeaRoute
+          && unitsWhichAreNotBeingTransportedOrDependent.stream().anyMatch(Matches.unitIsSea())) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }
@@ -1513,9 +1509,7 @@ public class MoveValidator {
         testMatch = t.and(noImpassableOrRestricted);
       }
       final Route testRoute = data.getMap().getRoute_IgnoreEnd(start, end, testMatch);
-      if (testRoute != null
-          && testRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) {
+      if (testRoute != null) {
         return testRoute;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -66,15 +66,14 @@ public class UnitComparator {
   public static Comparator<Unit> getMovableUnitsComparator(final List<Unit> units, final Route route) {
     final Comparator<Unit> decreasingCapacityComparator = getDecreasingCapacityComparator(units);
     return (u1, u2) -> {
-
       // Ensure units have enough movement
       final int left1 = TripleAUnit.get(u1).getMovementLeft();
       final int left2 = TripleAUnit.get(u2).getMovementLeft();
       if (route != null) {
-        if (left1 >= route.getMovementCost(u1) && left2 < route.getMovementCost(u2)) {
+        if ((left1 >= route.numberOfSteps()) && (left2 < route.numberOfSteps())) {
           return -1;
         }
-        if (left1 < route.getMovementCost(u1) && left2 >= route.getMovementCost(u2)) {
+        if ((left1 < route.numberOfSteps()) && (left2 >= route.numberOfSteps())) {
           return 1;
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -343,7 +343,7 @@ public class MovePanel extends AbstractMovePanel {
     }
     if (route != null) {
       final Predicate<Unit> enoughMovement = u -> BaseEditDelegate.getEditMode(getData())
-          || TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
+          || (TripleAUnit.get(u).getMovementLeft() >= route.numberOfSteps());
 
       if (route.isUnload()) {
         final Predicate<Unit> notLandAndCanMove = enoughMovement.and(Matches.unitIsNotLand());


### PR DESCRIPTION
## Overview

Noticed a TODO to implement the behavior and investigated. We had this TODO from the start. It turns out the value returned from #getMovementCost' is a constant, this means any code that call 'getMovementCost' can potentially be simplified.


## Functional Changes
- none

## Manual Testing Performed
- quick smoke testing, connected to a bot, launched a 270BC and fought through a combat
