### PR TITLE
PBEM: Restore "Also Post After Combat Move" checkbox state when loading save game

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -131,6 +131,7 @@ public class EmailSenderEditor extends EditorPanel {
       // new Insets(0, 0,
       // bottomSpace, 0), 0, 0));
     }
+    alsoPostAfterCombatMove.setSelected(genericEmailSender.getAlsoPostAfterCombatMove());
     setupListeners();
   }
 


### PR DESCRIPTION
## Overview

Fixes https://forums.triplea-game.org/topic/957/pbem-pbf-combat-move-check-box .

This bug has apparently been present since 2012, when the Also Post After Combat Move feature was first introduced in a672e8b1a.  The corresponding PBF panel has correctly initialized the checkbox since the same commit.

## Functional Changes

Initialize PBEM **Also Post After Combat Move** checkbox selection state from save game.  

## Manual Testing Performed

Saved a game with **Also Post After Combat Move** checked.  Verified that loading the save game correctly selects the checkbox.