### PR TITLE
Remove try/catch on lobby main method

### DIFF
--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -1,11 +1,8 @@
 package games.strategy.engine.lobby.server;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.io.File;
-import java.util.logging.Level;
-
-import com.google.common.base.Preconditions;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -1,6 +1,8 @@
 package games.strategy.engine.lobby.server;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.logging.Level;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
@@ -18,8 +20,14 @@ public final class LobbyRunner {
    * is shut down via administrative command.
    */
   public static void main(final String[] args) throws IOException {
+    File propertyFile = new File("config/lobby/lobby.properties");
+    if (!propertyFile.exists()) {
+      log.log(Level.SEVERE, "Could not find property file: " + propertyFile.getAbsolutePath());
+      return;
+    }
+
     final LobbyPropertyReader lobbyPropertyReader =
-        new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
+        new LobbyPropertyReader(new FilePropertyReader(propertyFile));
     log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
     LobbyServer.start(lobbyPropertyReader);
     log.info("Lobby started");

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -1,8 +1,11 @@
 package games.strategy.engine.lobby.server;
 
+import static com.google.common.base.Preconditions.*;
+
 import java.io.File;
-import java.io.IOException;
 import java.util.logging.Level;
+
+import com.google.common.base.Preconditions;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
@@ -19,12 +22,9 @@ public final class LobbyRunner {
    * Entry point for running a new lobby server. The lobby server runs until the process is killed or the lobby server
    * is shut down via administrative command.
    */
-  public static void main(final String[] args) throws IOException {
+  public static void main(final String[] args) throws Exception {
     File propertyFile = new File("config/lobby/lobby.properties");
-    if (!propertyFile.exists()) {
-      log.log(Level.SEVERE, "Could not find property file: " + propertyFile.getAbsolutePath());
-      return;
-    }
+    checkState(propertyFile.exists(), "Could not find property file: " + propertyFile.getAbsolutePath());
 
     final LobbyPropertyReader lobbyPropertyReader =
         new LobbyPropertyReader(new FilePropertyReader(propertyFile));

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -20,7 +20,7 @@ public final class LobbyRunner {
    * is shut down via administrative command.
    */
   public static void main(final String[] args) throws Exception {
-    File propertyFile = new File("config/lobby/lobby.properties");
+    final File propertyFile = new File("config/lobby/lobby.properties");
     checkState(propertyFile.exists(), "Could not find property file: " + propertyFile.getAbsolutePath());
 
     final LobbyPropertyReader lobbyPropertyReader =

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyRunner.java
@@ -1,10 +1,9 @@
 package games.strategy.engine.lobby.server;
 
-import java.util.logging.Level;
+import java.io.IOException;
 
 import games.strategy.engine.config.FilePropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
-import games.strategy.util.ExitStatus;
 import lombok.extern.java.Log;
 
 /**
@@ -18,16 +17,11 @@ public final class LobbyRunner {
    * Entry point for running a new lobby server. The lobby server runs until the process is killed or the lobby server
    * is shut down via administrative command.
    */
-  public static void main(final String[] args) {
-    try {
-      final LobbyPropertyReader lobbyPropertyReader =
-          new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
-      log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
-      LobbyServer.start(lobbyPropertyReader);
-      log.info("Lobby started");
-    } catch (final Exception e) {
-      log.log(Level.SEVERE, "Failed to start lobby", e);
-      ExitStatus.FAILURE.exit();
-    }
+  public static void main(final String[] args) throws IOException {
+    final LobbyPropertyReader lobbyPropertyReader =
+        new LobbyPropertyReader(new FilePropertyReader("config/lobby/lobby.properties"));
+    log.info("Starting lobby on port " + lobbyPropertyReader.getPort());
+    LobbyServer.start(lobbyPropertyReader);
+    log.info("Lobby started");
   }
 }


### PR DESCRIPTION
## Overview

We'll log any uncaught exceptions anyways, we do not need to explicitly log it. While here, it's also unnecessary to give an error exit status code, it's currently not used. So we can simpliyf a little bit.



## Functional Changes
- none

## Manual Testing Performed
- none
