### PR TITLE
Remove redundant final modifiers

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -83,8 +83,8 @@ public final class AvailableGames {
   private static void populateFromZip(final File map, final Map<String, URI> availableGames,
       final Set<String> availableMapFolderOrZipNames) {
     try (InputStream fis = new FileInputStream(map);
-        final ZipInputStream zis = new ZipInputStream(fis);
-        final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
+        ZipInputStream zis = new ZipInputStream(fis);
+        URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
       ZipEntry entry = zis.getNextEntry();
       while (entry != null) {
         if (entry.getName().contains("games/") && entry.getName().toLowerCase().endsWith(".xml")) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -50,7 +50,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
         cache.getParentFile().mkdirs();
       }
       try (OutputStream os = new FileOutputStream(cache);
-          final ObjectOutputStream out = new ObjectOutputStream(os)) {
+          ObjectOutputStream out = new ObjectOutputStream(os)) {
         out.writeObject(serializableMap);
       }
     } catch (final IOException e) {
@@ -66,7 +66,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
     try {
       if (cache.exists()) {
         try (InputStream is = new FileInputStream(cache);
-            final ObjectInputStream in = new ObjectInputStream(is)) {
+            ObjectInputStream in = new ObjectInputStream(is)) {
           final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
           for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
             final Serializable ser = serializedMap.get(property.getName());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -384,7 +384,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     private Map<String, IBean> loadMap() {
       if (file.exists()) {
         try (FileInputStream fin = new FileInputStream(file);
-            final ObjectInput oin = new ObjectInputStream(fin)) {
+            ObjectInput oin = new ObjectInputStream(fin)) {
           final Object o = oin.readObject();
           if (o instanceof Map) {
             final Map<?, ?> m = (Map<?, ?>) o;
@@ -425,7 +425,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     void writeToDisk() {
       synchronized (mutex) {
         try (FileOutputStream fout = new FileOutputStream(file, false);
-            final ObjectOutputStream out = new ObjectOutputStream(fout)) {
+            ObjectOutputStream out = new ObjectOutputStream(fout)) {
           out.writeObject(map);
         } catch (final IOException e) {
           log.log(Level.SEVERE, "failed to write local bean cache", e);

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -72,7 +72,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
     final Set<GameChooserEntry> entries = new HashSet<>();
 
     try (ZipFile zipFile = new ZipFile(map);
-        final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
+        URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
       final Enumeration<? extends ZipEntry> zipEntryEnumeration = zipFile.entries();
       while (zipEntryEnumeration.hasMoreElements()) {
         final ZipEntry entry = zipEntryEnumeration.nextElement();


### PR DESCRIPTION
## Overview

`final` is redundant within a try-with-resources statement.  This PR removes all such modifiers.  Occurrences were located with the regex `\Wtry\s*\([^{]*final[^{]*\{`

## Functional Changes

None.

## Manual Testing Performed

None.