### PR TITLE
Static analysis: Fix method can be static warnings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -12,10 +12,12 @@ import games.strategy.triplea.settings.ClientSetting;
 public final class ArgParser {
   static final String TRIPLEA_PROTOCOL = "triplea:";
 
+  private ArgParser() {}
+
   /**
    * Move command line arguments to system properties or client settings.
    */
-  public void handleCommandLineArgs(final String[] args) {
+  public static void handleCommandLineArgs(final String[] args) {
     ClientSetting.MAP_FOLDER_OVERRIDE.save(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue);
 
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -17,7 +17,7 @@ public final class ArgParser {
   /**
    * Move command line arguments to system properties or client settings.
    */
-  public static void handleCommandLineArgs(final String[] args) {
+  public static void handleCommandLineArgs(final String... args) {
     ClientSetting.MAP_FOLDER_OVERRIDE.save(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue);
 
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -127,7 +127,7 @@ public class GameRunner {
         ErrorMessage.enable();
       }));
     }
-    new ArgParser().handleCommandLineArgs(args);
+    ArgParser.handleCommandLineArgs(args);
 
     if (SystemProperties.isMac()) {
       com.apple.eawt.Application.getApplication().setOpenURIHandler(event -> {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -600,7 +600,7 @@ public class HeadlessGameServer {
 
     ClientSetting.initialize();
     System.setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
-    new ArgParser().handleCommandLineArgs(args);
+    ArgParser.handleCommandLineArgs(args);
     handleHeadlessGameServerArgs();
     ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
     try {

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework;
 
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_MAP_DOWNLOAD;
-
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -26,7 +25,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     assertThat("check precondition, system property for our test key should not be set yet.",
         System.getProperty(TestData.propKey), nullValue());
 
-    new ArgParser().handleCommandLineArgs(TestData.sampleArgInput);
+    ArgParser.handleCommandLineArgs(TestData.sampleArgInput);
 
     assertThat("system property should now be set to our test value",
         System.getProperty(TestData.propKey), is(TestData.propValue));
@@ -34,15 +33,14 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void emptySystemPropertiesCanBeSet() {
-    new ArgParser().handleCommandLineArgs(new String[] {"-Pa="});
+    ArgParser.handleCommandLineArgs(new String[] {"-Pa="});
     assertThat("expecting the system property to be empty string instead of null",
         System.getProperty("a"), is(""));
   }
 
   @Test
   public void singleFileArgIsAssumedToBeGameProperty() {
-    new ArgParser()
-        .handleCommandLineArgs(new String[] {TestData.propValue});
+    ArgParser.handleCommandLineArgs(new String[] {TestData.propValue});
     assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
         System.getProperty(TRIPLEA_GAME), is(TestData.propValue));
   }
@@ -50,8 +48,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsAssumedToBeMapDownloadProperty() {
     final String testUrl = "triplea:" + TestData.propValue;
-    new ArgParser()
-        .handleCommandLineArgs(new String[] {testUrl});
+    ArgParser.handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it's assumed to mean we are specifying the 'map download property'",
         System.getProperty(TRIPLEA_MAP_DOWNLOAD), is(TestData.propValue));
@@ -60,8 +57,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsUrlDecoded() {
     final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
-    new ArgParser()
-        .handleCommandLineArgs(new String[] {testUrl});
+    ArgParser.handleCommandLineArgs(new String[] {testUrl});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it should be properly URL-decoded as it's probably coming from a browser",
         System.getProperty(TRIPLEA_MAP_DOWNLOAD), is("Something with spaces and Special chars 🤔"));
@@ -69,7 +65,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void install4jSwitchesAreIgnored() {
-    new ArgParser().handleCommandLineArgs(new String[] {"-console"});
+    ArgParser.handleCommandLineArgs(new String[] {"-console"});
   }
 
   @Test
@@ -77,7 +73,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
     final String mapFolderPath = "/path/to/maps";
 
-    new ArgParser().handleCommandLineArgs(new String[] {
+    ArgParser.handleCommandLineArgs(new String[] {
         "-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolderPath});
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));
@@ -87,7 +83,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
 
-    new ArgParser().handleCommandLineArgs(new String[0]);
+    ArgParser.handleCommandLineArgs(new String[0]);
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue));
   }

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -33,14 +33,14 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void emptySystemPropertiesCanBeSet() {
-    ArgParser.handleCommandLineArgs(new String[] {"-Pa="});
+    ArgParser.handleCommandLineArgs("-Pa=");
     assertThat("expecting the system property to be empty string instead of null",
         System.getProperty("a"), is(""));
   }
 
   @Test
   public void singleFileArgIsAssumedToBeGameProperty() {
-    ArgParser.handleCommandLineArgs(new String[] {TestData.propValue});
+    ArgParser.handleCommandLineArgs(TestData.propValue);
     assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
         System.getProperty(TRIPLEA_GAME), is(TestData.propValue));
   }
@@ -48,7 +48,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsAssumedToBeMapDownloadProperty() {
     final String testUrl = "triplea:" + TestData.propValue;
-    ArgParser.handleCommandLineArgs(new String[] {testUrl});
+    ArgParser.handleCommandLineArgs(testUrl);
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it's assumed to mean we are specifying the 'map download property'",
         System.getProperty(TRIPLEA_MAP_DOWNLOAD), is(TestData.propValue));
@@ -57,7 +57,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   @Test
   public void singleUrlArgIsUrlDecoded() {
     final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
-    ArgParser.handleCommandLineArgs(new String[] {testUrl});
+    ArgParser.handleCommandLineArgs(testUrl);
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it should be properly URL-decoded as it's probably coming from a browser",
         System.getProperty(TRIPLEA_MAP_DOWNLOAD), is("Something with spaces and Special chars 🤔"));
@@ -65,7 +65,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void install4jSwitchesAreIgnored() {
-    ArgParser.handleCommandLineArgs(new String[] {"-console"});
+    ArgParser.handleCommandLineArgs("-console");
   }
 
   @Test
@@ -73,8 +73,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
     final String mapFolderPath = "/path/to/maps";
 
-    ArgParser.handleCommandLineArgs(new String[] {
-        "-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolderPath});
+    ArgParser.handleCommandLineArgs("-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolderPath);
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));
   }
@@ -83,7 +82,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
     ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
 
-    ArgParser.handleCommandLineArgs(new String[0]);
+    ArgParser.handleCommandLineArgs();
 
     assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue));
   }


### PR DESCRIPTION
## Overview

The `ArgParser#handleCommandLineArgs()` method can be made static, as identified by static analysis.

## Functional Changes

None.

## Refactoring Changes

I changed the parameter type from `String[]` to `String...` to reduce the boilerplate array creation in the unit tests.

## Manual Testing Performed

None.