### PR TITLE
Error Prone: Suppress JDK obsolete violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -104,7 +104,7 @@ public class GameData implements Serializable {
   private History gameHistory = new History(this);
   private final List<Tuple<IAttachment, ArrayList<Tuple<String, String>>>> attachmentOrderAndValues =
       new ArrayList<>();
-  // TODO: change to Map/HashMap upon next incompatible release
+  @SuppressWarnings("JdkObsolete") // change to Map/HashMap upon next incompatible release
   private final Hashtable<String, TerritoryEffect> territoryEffectList = new Hashtable<>();
   private final BattleRecordsList battleRecordsList = new BattleRecordsList(this);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -29,7 +29,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 public class ExecutionStack implements Serializable {
   private static final long serialVersionUID = -8675285470515074530L;
   private IExecutable m_current;
-  // TODO: change to Deque/ArrayDeque upon next incompatible release
+  @SuppressWarnings("JdkObsolete") // change to Deque/ArrayDeque upon next incompatible release
   private final Stack<IExecutable> m_stack = new Stack<>();
 
   void execute(final IDelegateBridge bridge) {


### PR DESCRIPTION
## Overview

Suppresses violations of the Error Prone JdkObsolete rule.  All violations suppressed in this PR cannot be fixed due to the need to maintain backwards compatibility.  The obsolete types will be upgraded to modern types upon the next incompatible release.

## Functional Changes

None.

## Manual Testing Performed

None.