### PR TITLE
Integrate lobby-db project with root release task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ before_deploy:
 - sed -i "s/^\(engine_version\s*=\).*/\1 ${ENGINE_VERSION}/" game-core/game_engine.properties
 - ./.travis/install_install4j
 - ./gradlew -PengineVersion="$ENGINE_VERSION" -PlobbyVersion="$LOBBY_VERSION" release
-- ./gradlew lobbyDbRelease
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 ## push tag triggers 'deploy' to occur, files listed in 'deploy.files' are uploaded to github releases.

--- a/.travis/collect_artifacts
+++ b/.travis/collect_artifacts
@@ -9,4 +9,3 @@ readonly ARTIFACTS_DIR=./build/artifacts
 mkdir -p ${ARTIFACTS_DIR}
 
 cp -v ./**/build/artifacts/* ${ARTIFACTS_DIR}
-cp -v ./lobby-db/build/distributions/migrations.zip ${ARTIFACTS_DIR}

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ subprojects {
         hamcrestVersion = '2.0.0.0'
         junitJupiterVersion = '5.1.0'
         mockitoVersion = '2.19.1'
+
+        artifactsDir = file("$buildDir/artifacts")
     }
 
     apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -34,14 +34,14 @@ subprojects {
         hamcrestVersion = '2.0.0.0'
         junitJupiterVersion = '5.1.0'
         mockitoVersion = '2.19.1'
-
-        artifactsDir = file("$buildDir/artifacts")
     }
 
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'java'
     apply plugin: 'net.ltgt.errorprone'
+
+    apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
 
     repositories {
         jcenter()

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -9,7 +9,6 @@ description = 'TripleA is a free online turn based strategy game and board game 
 mainClassName = 'games.strategy.engine.framework.GameRunner'
 
 ext {
-    artifactsDir = file("$buildDir/artifacts")
     releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -146,23 +146,13 @@ task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
 
 task release(group: 'release', dependsOn: [generateZipReleases, generateInstallerReleases]) {
     doLast {
-        def artifacts = [
+        publishArtifacts([
             file("$distsDir/triplea-${version}-all_platforms.zip"),
             file("$releasesDir/TripleA_${version}_macos.dmg"),
             file("$releasesDir/TripleA_${version}_unix.sh"),
             file("$releasesDir/TripleA_${version}_windows-32bit.exe"),
             file("$releasesDir/TripleA_${version}_windows-64bit.exe")
-        ]
-        artifacts.each {
-            if (!it.exists()) {
-                throw new GradleException("artifact '$it' does not exist")
-            }
-        }
-
-        copy {
-            from artifacts
-            into artifactsDir
-        }
+        ])
     }
 }
 

--- a/gradle/scripts/release.gradle
+++ b/gradle/scripts/release.gradle
@@ -1,0 +1,12 @@
+ext.publishArtifacts = { artifacts ->
+    artifacts.each {
+        if (!it.exists()) {
+            throw new GradleException("artifact '$it' does not exist")
+        }
+    }
+
+    copy {
+        from artifacts
+        into file("$buildDir/artifacts")
+    }
+}

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -17,7 +17,7 @@ flyway {
 }
 
 task lobbyDbMigrationScripts(type: Zip, group: 'release') {
-    from "$projectDir/src/main/resources/db/migration/"
+    from 'src/main/resources/db/migration'
     include '*.sql'
     archiveName 'migrations.zip'
 }

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -23,4 +23,19 @@ task lobbyDbMigrationScripts(type: Zip, group: 'release') {
 }
 
 task release(group: 'release', dependsOn: lobbyDbMigrationScripts) {
+    doLast {
+        def artifacts = [
+            file("$distsDir/migrations.zip"),
+        ]
+        artifacts.each {
+            if (!it.exists()) {
+                throw new GradleException("artifact '$it' does not exist")
+            }
+        }
+
+        copy {
+            from artifacts
+            into artifactsDir
+        }
+    }
 }

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -24,18 +24,8 @@ task lobbyDbMigrationScripts(type: Zip, group: 'release') {
 
 task release(group: 'release', dependsOn: lobbyDbMigrationScripts) {
     doLast {
-        def artifacts = [
-            file("$distsDir/migrations.zip"),
-        ]
-        artifacts.each {
-            if (!it.exists()) {
-                throw new GradleException("artifact '$it' does not exist")
-            }
-        }
-
-        copy {
-            from artifacts
-            into artifactsDir
-        }
+        publishArtifacts([
+            file("$distsDir/migrations.zip")
+        ])
     }
 }

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -16,8 +16,11 @@ flyway {
     password = 'postgres'
 }
 
-task lobbyDbRelease(type: Zip, group: 'release') {
-    from "${projectDir}/src/main/resources/db/migration/"
+task lobbyDbMigrationScripts(type: Zip, group: 'release') {
+    from "$projectDir/src/main/resources/db/migration/"
     include '*.sql'
     archiveName 'migrations.zip'
+}
+
+task release(group: 'release', dependsOn: lobbyDbMigrationScripts) {
 }

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -5,11 +5,6 @@ plugins {
 
 description = 'TripleA Lobby'
 mainClassName = 'games.strategy.engine.lobby.server.LobbyRunner'
-
-ext {
-    artifactsDir = file("$buildDir/artifacts")
-}
-
 version = project.hasProperty('lobbyVersion') ? project.lobbyVersion : 'dev'
 
 jar {

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -36,18 +36,8 @@ task lobbyServer(type: Zip, group: 'release', dependsOn: shadowJar) {
 
 task release(group: 'release', dependsOn: lobbyServer) {
     doLast {
-        def artifacts = [
-            file("$distsDir/triplea-$version-server.zip"),
-        ]
-        artifacts.each {
-            if (!it.exists()) {
-                throw new GradleException("artifact '$it' does not exist")
-            }
-        }
-
-        copy {
-            from artifacts
-            into artifactsDir
-        }
+        publishArtifacts([
+            file("$distsDir/triplea-$version-server.zip")
+        ])
     }
 }


### PR DESCRIPTION
## Overview

The Travis build currently requires us to run both the `release` and `lobbyDbRelease` tasks in order to generate all build artifacts.  This PR modifies the `lobby-db` buildscript so that its artifacts are generated as part of the `release` task, thus removing the need to run the `lobbyDbRelease` task explicitly during the Travis build.

## Functional Changes

None.

## Refactoring Changes

* Renamed the `lobbyDbRelease` task to `lobbyDbMigrationScripts` now that it is composed within the `release` task.
* ~Extracted the `artifactsDir` property from multiple subprojects to the common subproject configuration in the root buildscript.~
* Extracted a new function, `publishArtifacts()`, to encapsulate the duplicated behavior of copying the subproject artifacts to `$buildDir/artifacts` for pick up by the Travis artifact globber.

## Manual Testing Performed

Created a release branch in my fork from this branch to verify all artifacts are still published as expected:

![release-artifacts](https://user-images.githubusercontent.com/4826349/43987857-fe5440fe-9cf5-11e8-9273-80e711c24660.png)