### PR TITLE
Use nested test fixtures to reduce duplication in test method names

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/GameEngineVersionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/GameEngineVersionTest.java
@@ -5,59 +5,66 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
-public final class GameEngineVersionTest {
-  @Test
-  public void isCompatibleWithEngineVersion_ShouldReturnTrueWhenOtherVersionIsCompatible() {
-    Arrays.asList(
-        Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
-        Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
-        Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"))
-        .forEach(t -> assertTrue(
-            GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
-            t.getSecond()));
+final class GameEngineVersionTest {
+  @Nested
+  final class IsCompatibleWithEngineVersionTest {
+    @Test
+    void shouldReturnTrueWhenOtherVersionIsCompatible() {
+      Arrays.asList(
+          Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
+          Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
+          Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"))
+          .forEach(t -> assertTrue(
+              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
+              t.getSecond()));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
+      Arrays.asList(
+          Tuple.of(new Version(1, 2, 0, 4), "smaller point version should not be compatible"),
+          Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
+          Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should not be compatible"),
+          Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
+          Tuple.of(new Version(0, 2, 3, 4), "smaller major version should not be compatible"),
+          Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
+          .forEach(t -> assertFalse(
+              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
+              t.getSecond()));
+    }
   }
 
-  @Test
-  public void isCompatibleWithEngineVersion_ShouldReturnFalseWhenOtherVersionIsNotCompatible() {
-    Arrays.asList(
-        Tuple.of(new Version(1, 2, 0, 4), "smaller point version should not be compatible"),
-        Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
-        Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should not be compatible"),
-        Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
-        Tuple.of(new Version(0, 2, 3, 4), "smaller major version should not be compatible"),
-        Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
-        .forEach(t -> assertFalse(
-            GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
-            t.getSecond()));
-  }
+  @Nested
+  final class IsCompatibleWithMapMinimumEngineVersionTest {
+    @Test
+    void shouldReturnTrueWhenOtherVersionIsCompatible() {
+      Arrays.asList(
+          Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
+          Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
+          Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"),
+          Tuple.of(new Version(1, 2, 0, 4), "smaller point version should be compatible"),
+          Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should be compatible"),
+          Tuple.of(new Version(0, 2, 3, 4), "smaller major version should be compatible"))
+          .forEach(t -> assertTrue(
+              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
+              t.getSecond()));
+    }
 
-  @Test
-  public void isCompatibleWithMapMinimumEngineVersion_ShouldReturnTrueWhenOtherVersionIsCompatible() {
-    Arrays.asList(
-        Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
-        Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
-        Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"),
-        Tuple.of(new Version(1, 2, 0, 4), "smaller point version should be compatible"),
-        Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should be compatible"),
-        Tuple.of(new Version(0, 2, 3, 4), "smaller major version should be compatible"))
-        .forEach(t -> assertTrue(
-            GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
-            t.getSecond()));
-  }
-
-  @Test
-  public void isCompatibleWithMapMinimumEngineVersion_ShouldReturnFalseWhenOtherVersionIsNotCompatible() {
-    Arrays.asList(
-        Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
-        Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
-        Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
-        .forEach(t -> assertFalse(
-            GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
-            t.getSecond()));
+    @Test
+    void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
+      Arrays.asList(
+          Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
+          Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
+          Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
+          .forEach(t -> assertFalse(
+              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
+              t.getSecond()));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/FilePropertyReaderTest.java
@@ -34,12 +34,7 @@ public final class FilePropertyReaderTest {
   }
 
   @Test
-  public void constructorWithPath_ShouldThrowExceptionWhenFileDoesNotExist() {
-    assertThrows(IllegalArgumentException.class, () -> new FilePropertyReader("path/to/nonexistent/file"));
-  }
-
-  @Test
-  public void constructorWithFile_ShouldThrowExceptionWhenFileDoesNotExist() {
+  public void constructor_ShouldThrowExceptionWhenFileDoesNotExist() {
     assertThrows(IllegalArgumentException.class, () -> new FilePropertyReader("path/to/nonexistent/file"));
   }
 

--- a/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/MutablePropertyTest.java
@@ -5,17 +5,21 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.MutableProperty.InvalidValueException;
 
-public final class MutablePropertyTest {
-  @Test
-  public void setValue_ShouldThrowExceptionWhenValueHasWrongType() {
-    final MutableProperty<Integer> mutableProperty = MutableProperty.ofSimple(value -> {
-    }, () -> 42);
+final class MutablePropertyTest {
+  @Nested
+  final class SetValueTest {
+    @Test
+    void shouldThrowExceptionWhenValueHasWrongType() {
+      final MutableProperty<Integer> mutableProperty = MutableProperty.ofSimple(value -> {
+      }, () -> 42);
 
-    final Exception e = assertThrows(InvalidValueException.class, () -> mutableProperty.setValue(new Object()));
-    assertThat(e.getCause(), is(instanceOf(ClassCastException.class)));
+      final Exception e = assertThrows(InvalidValueException.class, () -> mutableProperty.setValue(new Object()));
+      assertThat(e.getCause(), is(instanceOf(ClassCastException.class)));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -24,15 +25,8 @@ import com.google.common.collect.Maps;
 import games.strategy.engine.framework.startup.login.HmacSha512Authenticator.ChallengePropertyNames;
 import games.strategy.engine.framework.startup.login.HmacSha512Authenticator.ResponsePropertyNames;
 
-public final class HmacSha512AuthenticatorTest {
+final class HmacSha512AuthenticatorTest {
   private static final String PASSWORD = "←PASSWORD↑WITH→UNICODE↓CHARS";
-
-  @Test
-  public void canProcessChallenge_ShouldReturnTrueWhenAllPropertiesPresent() {
-    final Map<String, String> challenge = newChallengeWithAllProperties();
-
-    assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(true));
-  }
 
   private static Map<String, String> newChallengeWithAllProperties() {
     return Maps.newHashMap(ImmutableMap.of(
@@ -46,51 +40,15 @@ public final class HmacSha512AuthenticatorTest {
     return Base64.getEncoder().encodeToString(bytes);
   }
 
-  @Test
-  public void canProcessChallenge_ShouldReturnFalseWhenNonceAbsent() {
-    final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.NONCE);
-
-    assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(false));
-  }
-
   private static Map<String, String> newChallengeWithAllPropertiesExcept(final String name) {
     final Map<String, String> challenge = newChallengeWithAllProperties();
     challenge.remove(name);
     return challenge;
   }
 
-  @Test
-  public void canProcessChallenge_ShouldReturnFalseWhenSaltAbsent() {
-    final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.SALT);
-
-    assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(false));
-  }
-
-  @Test
-  public void newChallenge_ShouldIncludeNonceAndSalt() {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-
-    assertThat(challenge, hasEntry(is(ChallengePropertyNames.NONCE), is(not(emptyString()))));
-    assertThat(challenge, hasEntry(is(ChallengePropertyNames.SALT), is(not(emptyString()))));
-  }
-
-  @Test
-  public void canProcessResponse_ShouldReturnTrueWhenAllPropertiesPresent() {
-    final Map<String, String> response = newResponseWithAllProperties();
-
-    assertThat(HmacSha512Authenticator.canProcessResponse(response), is(true));
-  }
-
   private static Map<String, String> newResponseWithAllProperties() {
     return Maps.newHashMap(ImmutableMap.of(
         ResponsePropertyNames.DIGEST, newBase64String()));
-  }
-
-  @Test
-  public void canProcessResponse_ShouldReturnFalseWhenDigestAbsent() {
-    final Map<String, String> response = newResponseWithAllPropertiesExcept(ResponsePropertyNames.DIGEST);
-
-    assertThat(HmacSha512Authenticator.canProcessResponse(response), is(false));
   }
 
   private static Map<String, String> newResponseWithAllPropertiesExcept(final String name) {
@@ -99,140 +57,204 @@ public final class HmacSha512AuthenticatorTest {
     return response;
   }
 
-  @Test
-  public void newResponse_ShouldIncludeResponseWhenChallengeContainsNonceAndSalt() throws Exception {
-    final Map<String, String> challenge = ImmutableMap.of(
-        ChallengePropertyNames.NONCE, newBase64String(),
-        ChallengePropertyNames.SALT, newBase64String());
+  @Nested
+  final class CanProcessChallengeTest {
+    @Test
+    void shouldReturnTrueWhenAllPropertiesPresent() {
+      final Map<String, String> challenge = newChallengeWithAllProperties();
 
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+      assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(true));
+    }
 
-    assertThat(response, hasEntry(is(ResponsePropertyNames.DIGEST), is(not(emptyString()))));
+    @Test
+    void shouldReturnFalseWhenNonceAbsent() {
+      final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.NONCE);
+
+      assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenSaltAbsent() {
+      final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.SALT);
+
+      assertThat(HmacSha512Authenticator.canProcessChallenge(challenge), is(false));
+    }
   }
 
-  @Test
-  public void newResponse_ShouldNotIncludeResponseWhenChallengeDoesNotContainNonce() throws Exception {
-    final Map<String, String> challenge = ImmutableMap.of(ChallengePropertyNames.SALT, newBase64String());
+  @Nested
+  final class NewChallengeTest {
+    @Test
+    void shouldIncludeNonceAndSalt() {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
 
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
-
-    assertThat(response, not(hasKey(ResponsePropertyNames.DIGEST)));
+      assertThat(challenge, hasEntry(is(ChallengePropertyNames.NONCE), is(not(emptyString()))));
+      assertThat(challenge, hasEntry(is(ChallengePropertyNames.SALT), is(not(emptyString()))));
+    }
   }
 
-  @Test
-  public void newResponse_ShouldNotIncludeResponseWhenChallengeDoesNotContainSalt() throws Exception {
-    final Map<String, String> challenge = ImmutableMap.of(ChallengePropertyNames.NONCE, newBase64String());
+  @Nested
+  final class CanProcessResponseTest {
+    @Test
+    void shouldReturnTrueWhenAllPropertiesPresent() {
+      final Map<String, String> response = newResponseWithAllProperties();
 
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+      assertThat(HmacSha512Authenticator.canProcessResponse(response), is(true));
+    }
 
-    assertThat(response, not(hasKey(ResponsePropertyNames.DIGEST)));
+    @Test
+    void shouldReturnFalseWhenDigestAbsent() {
+      final Map<String, String> response = newResponseWithAllPropertiesExcept(ResponsePropertyNames.DIGEST);
+
+      assertThat(HmacSha512Authenticator.canProcessResponse(response), is(false));
+    }
   }
 
-  @Test
-  public void decodeOptionalProperty_ShouldReturnDecodedValueWhenNamePresent() throws Exception {
-    final String name = "name";
-    final String encodedValue = newBase64String();
-    final Map<String, String> properties = ImmutableMap.of(name, encodedValue);
+  @Nested
+  final class NewResponseTest {
+    @Test
+    void shouldIncludeResponseWhenChallengeContainsNonceAndSalt() throws Exception {
+      final Map<String, String> challenge = ImmutableMap.of(
+          ChallengePropertyNames.NONCE, newBase64String(),
+          ChallengePropertyNames.SALT, newBase64String());
 
-    final byte[] actualValue = HmacSha512Authenticator.decodeOptionalProperty(properties, name);
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
 
-    assertThat(actualValue, is(Base64.getDecoder().decode(encodedValue)));
+      assertThat(response, hasEntry(is(ResponsePropertyNames.DIGEST), is(not(emptyString()))));
+    }
+
+    @Test
+    void shouldNotIncludeResponseWhenChallengeDoesNotContainNonce() throws Exception {
+      final Map<String, String> challenge = ImmutableMap.of(ChallengePropertyNames.SALT, newBase64String());
+
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+
+      assertThat(response, not(hasKey(ResponsePropertyNames.DIGEST)));
+    }
+
+    @Test
+    void shouldNotIncludeResponseWhenChallengeDoesNotContainSalt() throws Exception {
+      final Map<String, String> challenge = ImmutableMap.of(ChallengePropertyNames.NONCE, newBase64String());
+
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+
+      assertThat(response, not(hasKey(ResponsePropertyNames.DIGEST)));
+    }
   }
 
-  @Test
-  public void decodeOptionalProperty_ShouldReturnNullWhenNameAbsent() throws Exception {
-    final Map<String, String> properties = ImmutableMap.of("other name", newBase64String());
+  @Nested
+  final class DecodeOptionalPropertyTest {
+    @Test
+    void shouldReturnDecodedValueWhenNamePresent() throws Exception {
+      final String name = "name";
+      final String encodedValue = newBase64String();
+      final Map<String, String> properties = ImmutableMap.of(name, encodedValue);
 
-    final byte[] value = HmacSha512Authenticator.decodeOptionalProperty(properties, "name");
+      final byte[] actualValue = HmacSha512Authenticator.decodeOptionalProperty(properties, name);
 
-    assertThat(value, is(nullValue()));
+      assertThat(actualValue, is(Base64.getDecoder().decode(encodedValue)));
+    }
+
+    @Test
+    void shouldReturnNullWhenNameAbsent() throws Exception {
+      final Map<String, String> properties = ImmutableMap.of("other name", newBase64String());
+
+      final byte[] value = HmacSha512Authenticator.decodeOptionalProperty(properties, "name");
+
+      assertThat(value, is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueMalformed() {
+      final String name = "name";
+      final Map<String, String> properties = ImmutableMap.of(name, "NOT_A_BASE64_VALUE");
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.decodeOptionalProperty(properties, name));
+      assertThat(e.getMessage(), allOf(
+          containsString("malformed"),
+          containsString(name)));
+    }
   }
 
-  @Test
-  public void decodeOptionalProperty_ShouldThrowExceptionWhenValueMalformed() {
-    final String name = "name";
-    final Map<String, String> properties = ImmutableMap.of(name, "NOT_A_BASE64_VALUE");
+  @Nested
+  final class AuthenticateTest {
+    @Test
+    void shouldNotThrowExceptionWhenAuthenticationSucceeds() throws Exception {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
 
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.decodeOptionalProperty(properties, name));
-    assertThat(e.getMessage(), allOf(
-        containsString("malformed"),
-        containsString(name)));
+      assertNotThrows(() -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAuthenticationFails() throws Exception {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
+      final Map<String, String> response = HmacSha512Authenticator.newResponse("otherPassword", challenge);
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
+
+      assertThat(e.getMessage(), containsString("authentication failed"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenChallengeDoesNotContainNonce() throws Exception {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+
+      challenge.remove(ChallengePropertyNames.NONCE);
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
+
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(ChallengePropertyNames.NONCE)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenChallengeDoesNotContainSalt() throws Exception {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+
+      challenge.remove(ChallengePropertyNames.SALT);
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
+
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(ChallengePropertyNames.SALT)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenResponseDoesNotContainDigest() throws Exception {
+      final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
+      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+
+      response.remove(ResponsePropertyNames.DIGEST);
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
+
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(ResponsePropertyNames.DIGEST)));
+    }
   }
 
-  @Test
-  public void authenticate_ShouldNotThrowExceptionWhenAuthenticationSucceeds() throws Exception {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+  @Nested
+  final class DecodeRequiredPropertyTest {
+    @Test
+    void shouldThrowExceptionWhenNameAbsent() {
+      final String name = "name";
+      final Map<String, String> properties = ImmutableMap.of("other name", newBase64String());
 
-    assertNotThrows(() -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
-  }
-
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenAuthenticationFails() throws Exception {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-    final Map<String, String> response = HmacSha512Authenticator.newResponse("otherPassword", challenge);
-
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
-
-    assertThat(e.getMessage(), containsString("authentication failed"));
-  }
-
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenChallengeDoesNotContainNonce() throws Exception {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
-
-    challenge.remove(ChallengePropertyNames.NONCE);
-
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
-
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(ChallengePropertyNames.NONCE)));
-  }
-
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenChallengeDoesNotContainSalt() throws Exception {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
-
-    challenge.remove(ChallengePropertyNames.SALT);
-
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
-
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(ChallengePropertyNames.SALT)));
-  }
-
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenResponseDoesNotContainDigest() throws Exception {
-    final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-    final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
-
-    response.remove(ResponsePropertyNames.DIGEST);
-
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.authenticate(PASSWORD, challenge, response));
-
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(ResponsePropertyNames.DIGEST)));
-  }
-
-  @Test
-  public void decodeRequiredProperty_ShouldThrowExceptionWhenNameAbsent() {
-    final String name = "name";
-    final Map<String, String> properties = ImmutableMap.of("other name", newBase64String());
-
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> HmacSha512Authenticator.decodeRequiredProperty(properties, name));
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(name)));
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> HmacSha512Authenticator.decodeRequiredProperty(properties, name));
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(name)));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/Md5CryptAuthenticatorTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
@@ -21,26 +22,12 @@ import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.Chall
 import games.strategy.engine.framework.startup.login.Md5CryptAuthenticator.ResponsePropertyNames;
 import games.strategy.util.Md5Crypt;
 
-public final class Md5CryptAuthenticatorTest {
+final class Md5CryptAuthenticatorTest {
   private static final String PASSWORD = "←PASSWORD↑WITH→UNICODE↓CHARS";
-
-  @Test
-  public void canProcessChallenge_ShouldReturnTrueWhenAllPropertiesPresent() {
-    final Map<String, String> challenge = newChallengeWithAllProperties();
-
-    assertThat(Md5CryptAuthenticator.canProcessChallenge(challenge), is(true));
-  }
 
   private static Map<String, String> newChallengeWithAllProperties() {
     return Maps.newHashMap(ImmutableMap.of(
         ChallengePropertyNames.SALT, ""));
-  }
-
-  @Test
-  public void canProcessChallenge_ShouldReturnFalseWhenSaltAbsent() {
-    final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.SALT);
-
-    assertThat(Md5CryptAuthenticator.canProcessChallenge(challenge), is(false));
   }
 
   private static Map<String, String> newChallengeWithAllPropertiesExcept(final String name) {
@@ -49,30 +36,9 @@ public final class Md5CryptAuthenticatorTest {
     return challenge;
   }
 
-  @Test
-  public void newChallenge_ShouldIncludeSalt() {
-    final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
-
-    assertThat(challenge, hasEntry(is(ChallengePropertyNames.SALT), is(not(emptyString()))));
-  }
-
-  @Test
-  public void canProcessResponse_ShouldReturnTrueWhenAllPropertiesPresent() {
-    final Map<String, String> response = newResponseWithAllProperties();
-
-    assertThat(Md5CryptAuthenticator.canProcessResponse(response), is(true));
-  }
-
   private static Map<String, String> newResponseWithAllProperties() {
     return Maps.newHashMap(ImmutableMap.of(
         ResponsePropertyNames.DIGEST, ""));
-  }
-
-  @Test
-  public void canProcessResponse_ShouldReturnFalseWhenDigestAbsent() {
-    final Map<String, String> response = newResponseWithAllPropertiesExcept(ResponsePropertyNames.DIGEST);
-
-    assertThat(Md5CryptAuthenticator.canProcessResponse(response), is(false));
   }
 
   private static Map<String, String> newResponseWithAllPropertiesExcept(final String name) {
@@ -81,94 +47,147 @@ public final class Md5CryptAuthenticatorTest {
     return response;
   }
 
-  @Test
-  public void newResponse_ShouldIncludeResponseWhenChallengeContainsSalt() throws Exception {
-    final Map<String, String> challenge = ImmutableMap.of(
-        ChallengePropertyNames.SALT, Md5Crypt.newSalt());
+  @Nested
+  final class CanProcessChallengeTest {
+    @Test
+    void shouldReturnTrueWhenAllPropertiesPresent() {
+      final Map<String, String> challenge = newChallengeWithAllProperties();
 
-    final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
+      assertThat(Md5CryptAuthenticator.canProcessChallenge(challenge), is(true));
+    }
 
-    assertThat(response, hasEntry(is(ResponsePropertyNames.DIGEST), is(not(emptyString()))));
+    @Test
+    void shouldReturnFalseWhenSaltAbsent() {
+      final Map<String, String> challenge = newChallengeWithAllPropertiesExcept(ChallengePropertyNames.SALT);
+
+      assertThat(Md5CryptAuthenticator.canProcessChallenge(challenge), is(false));
+    }
   }
 
-  @Test
-  public void newResponse_ShouldThrowExceptionWhenChallengeDoesNotContainSalt() {
-    final Map<String, String> challenge = ImmutableMap.of();
+  @Nested
+  final class NewChallengeTest {
+    @Test
+    void shouldIncludeSalt() {
+      final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
 
-    final Exception e =
-        assertThrows(AuthenticationException.class, () -> Md5CryptAuthenticator.newResponse(PASSWORD, challenge));
-    assertThat(e.getMessage(), containsString("missing"));
+      assertThat(challenge, hasEntry(is(ChallengePropertyNames.SALT), is(not(emptyString()))));
+    }
   }
 
-  @Test
-  public void getRequiredProperty_ShouldReturnValueWhenNamePresent() throws Exception {
-    final String name = "name";
-    final String value = "value";
-    final Map<String, String> properties = ImmutableMap.of(name, value);
+  @Nested
+  final class CanProcessResponseTest {
+    @Test
+    void shouldReturnTrueWhenAllPropertiesPresent() {
+      final Map<String, String> response = newResponseWithAllProperties();
 
-    final String actualValue = Md5CryptAuthenticator.getRequiredProperty(properties, name);
+      assertThat(Md5CryptAuthenticator.canProcessResponse(response), is(true));
+    }
 
-    assertThat(actualValue, is(value));
+    @Test
+    void shouldReturnFalseWhenDigestAbsent() {
+      final Map<String, String> response = newResponseWithAllPropertiesExcept(ResponsePropertyNames.DIGEST);
+
+      assertThat(Md5CryptAuthenticator.canProcessResponse(response), is(false));
+    }
   }
 
-  @Test
-  public void getRequiredProperty_ShouldThrowExceptionWhenNameAbsent() {
-    final String name = "name";
-    final Map<String, String> properties = ImmutableMap.of("other name", "value");
+  @Nested
+  final class NewResponseTest {
+    @Test
+    void shouldIncludeResponseWhenChallengeContainsSalt() throws Exception {
+      final Map<String, String> challenge = ImmutableMap.of(
+          ChallengePropertyNames.SALT, Md5Crypt.newSalt());
 
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> Md5CryptAuthenticator.getRequiredProperty(properties, name));
+      final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(name)));
+      assertThat(response, hasEntry(is(ResponsePropertyNames.DIGEST), is(not(emptyString()))));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenChallengeDoesNotContainSalt() {
+      final Map<String, String> challenge = ImmutableMap.of();
+
+      final Exception e =
+          assertThrows(AuthenticationException.class, () -> Md5CryptAuthenticator.newResponse(PASSWORD, challenge));
+      assertThat(e.getMessage(), containsString("missing"));
+    }
   }
 
-  @Test
-  public void authenticate_ShouldNotThrowExceptionWhenAuthenticationSucceeds() throws Exception {
-    final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
-    final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
+  @Nested
+  final class GetRequiredPropertyTest {
+    @Test
+    void shouldReturnValueWhenNamePresent() throws Exception {
+      final String name = "name";
+      final String value = "value";
+      final Map<String, String> properties = ImmutableMap.of(name, value);
 
-    assertNotThrows(() -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
+      final String actualValue = Md5CryptAuthenticator.getRequiredProperty(properties, name);
+
+      assertThat(actualValue, is(value));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNameAbsent() {
+      final String name = "name";
+      final Map<String, String> properties = ImmutableMap.of("other name", "value");
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> Md5CryptAuthenticator.getRequiredProperty(properties, name));
+
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(name)));
+    }
   }
 
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenAuthenticationFails() throws Exception {
-    final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
-    final Map<String, String> response = Md5CryptAuthenticator.newResponse("otherPassword", challenge);
+  @Nested
+  final class AuthenticateTest {
+    @Test
+    void shouldNotThrowExceptionWhenAuthenticationSucceeds() throws Exception {
+      final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
+      final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
+      assertNotThrows(() -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
+    }
 
-    assertThat(e.getMessage(), containsString("authentication failed"));
-  }
+    @Test
+    void shouldThrowExceptionWhenAuthenticationFails() throws Exception {
+      final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
+      final Map<String, String> response = Md5CryptAuthenticator.newResponse("otherPassword", challenge);
 
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenChallengeDoesNotContainSalt() throws Exception {
-    final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
-    final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
 
-    challenge.remove(ChallengePropertyNames.SALT);
+      assertThat(e.getMessage(), containsString("authentication failed"));
+    }
 
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
+    @Test
+    void shouldThrowExceptionWhenChallengeDoesNotContainSalt() throws Exception {
+      final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
+      final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
 
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(ChallengePropertyNames.SALT)));
-  }
+      challenge.remove(ChallengePropertyNames.SALT);
 
-  @Test
-  public void authenticate_ShouldThrowExceptionWhenResponseDoesNotContainDigest() throws Exception {
-    final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
-    final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
 
-    response.remove(ResponsePropertyNames.DIGEST);
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(ChallengePropertyNames.SALT)));
+    }
 
-    final Exception e = assertThrows(AuthenticationException.class,
-        () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
-    assertThat(e.getMessage(), allOf(
-        containsString("missing"),
-        containsString(ResponsePropertyNames.DIGEST)));
+    @Test
+    void shouldThrowExceptionWhenResponseDoesNotContainDigest() throws Exception {
+      final Map<String, String> challenge = Md5CryptAuthenticator.newChallenge();
+      final Map<String, String> response = Md5CryptAuthenticator.newResponse(PASSWORD, challenge);
+
+      response.remove(ResponsePropertyNames.DIGEST);
+
+      final Exception e = assertThrows(AuthenticationException.class,
+          () -> Md5CryptAuthenticator.authenticate(PASSWORD, challenge, response));
+      assertThat(e.getMessage(), allOf(
+          containsString("missing"),
+          containsString(ResponsePropertyNames.DIGEST)));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/RemoteMethodCallTest.java
@@ -5,58 +5,62 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class RemoteMethodCallTest {
-  @Test
-  public void stringToClass_ShouldReturnClassOfArgWhenStringIsNull() {
-    assertThat(RemoteMethodCall.stringToClass(null, new Object()), is(Object.class));
-  }
+final class RemoteMethodCallTest {
+  @Nested
+  final class StringToClassTest {
+    @Test
+    void shouldReturnClassOfArgWhenStringIsNull() {
+      assertThat(RemoteMethodCall.stringToClass(null, new Object()), is(Object.class));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveIntegerTypeWhenStringIsInt() {
-    assertThat(RemoteMethodCall.stringToClass("int", null), is(Integer.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveIntegerTypeWhenStringIsInt() {
+      assertThat(RemoteMethodCall.stringToClass("int", null), is(Integer.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveShortTypeWhenStringIsShort() {
-    assertThat(RemoteMethodCall.stringToClass("short", null), is(Short.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveShortTypeWhenStringIsShort() {
+      assertThat(RemoteMethodCall.stringToClass("short", null), is(Short.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveByteTypeWhenStringIsByte() {
-    assertThat(RemoteMethodCall.stringToClass("byte", null), is(Byte.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveByteTypeWhenStringIsByte() {
+      assertThat(RemoteMethodCall.stringToClass("byte", null), is(Byte.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveLongTypeWhenStringIsLong() {
-    assertThat(RemoteMethodCall.stringToClass("long", null), is(Long.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveLongTypeWhenStringIsLong() {
+      assertThat(RemoteMethodCall.stringToClass("long", null), is(Long.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveFloatTypeWhenStringIsFloat() {
-    assertThat(RemoteMethodCall.stringToClass("float", null), is(Float.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveFloatTypeWhenStringIsFloat() {
+      assertThat(RemoteMethodCall.stringToClass("float", null), is(Float.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveDoubleTypeWhenStringIsDouble() {
-    assertThat(RemoteMethodCall.stringToClass("double", null), is(Double.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveDoubleTypeWhenStringIsDouble() {
+      assertThat(RemoteMethodCall.stringToClass("double", null), is(Double.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnPrimitiveBooleanTypeWhenStringIsBoolean() {
-    assertThat(RemoteMethodCall.stringToClass("boolean", null), is(Boolean.TYPE));
-  }
+    @Test
+    void shouldReturnPrimitiveBooleanTypeWhenStringIsBoolean() {
+      assertThat(RemoteMethodCall.stringToClass("boolean", null), is(Boolean.TYPE));
+    }
 
-  @Test
-  public void stringToClass_ShouldReturnClassWhenStringIsKnownClassName() {
-    assertThat(RemoteMethodCall.stringToClass("java.lang.String", null), is(String.class));
-  }
+    @Test
+    void shouldReturnClassWhenStringIsKnownClassName() {
+      assertThat(RemoteMethodCall.stringToClass("java.lang.String", null), is(String.class));
+    }
 
-  @Test
-  public void stringToClass_ShouldThrowExceptionWhenStringIsUnknownClassName() {
-    final Exception e =
-        assertThrows(IllegalStateException.class, () -> RemoteMethodCall.stringToClass("some.unknown.Type", null));
-    assertThat(e.getCause(), is(instanceOf(ClassNotFoundException.class)));
+    @Test
+    void shouldThrowExceptionWhenStringIsUnknownClassName() {
+      final Exception e =
+          assertThrows(IllegalStateException.class, () -> RemoteMethodCall.stringToClass("some.unknown.Type", null));
+      assertThat(e.getCause(), is(instanceOf(ClassNotFoundException.class)));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -65,14 +65,20 @@ public final class MatchesTest {
     };
   }
 
-  @Test
-  public void testAlways() {
-    assertTrue(Matches.always().test(VALUE));
+  @Nested
+  final class AlwaysTest {
+    @Test
+    void shouldReturnTrue() {
+      assertTrue(Matches.always().test(VALUE));
+    }
   }
 
-  @Test
-  public void testNever() {
-    assertFalse(Matches.never().test(VALUE));
+  @Nested
+  final class NeverTest {
+    @Test
+    void shouldReturnFalse() {
+      assertFalse(Matches.never().test(VALUE));
+    }
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
@@ -14,53 +15,56 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 
-public final class MyFormatterTest {
-  private final GameData gameData = new GameData();
+final class MyFormatterTest {
+  @Nested
+  final class UnitsToTextTest {
+    private final GameData gameData = new GameData();
 
-  private PlayerID newPlayerId(final String name) {
-    return new PlayerID(name, gameData);
-  }
+    private PlayerID newPlayerId(final String name) {
+      return new PlayerID(name, gameData);
+    }
 
-  private Unit newUnit(final UnitType unitType, final PlayerID owner) {
-    return new Unit(unitType, owner, gameData);
-  }
+    private Unit newUnit(final UnitType unitType, final PlayerID owner) {
+      return new Unit(unitType, owner, gameData);
+    }
 
-  private UnitType newUnitType(final String name) {
-    return new UnitType(name, gameData);
-  }
+    private UnitType newUnitType(final String name) {
+      return new UnitType(name, gameData);
+    }
 
-  @Test
-  public void unitsToText_ShouldReturnEmptyStringWhenUnitsIsEmpty() {
-    assertThat(MyFormatter.unitsToText(Collections.emptyList()), is(""));
-  }
+    @Test
+    void shouldReturnEmptyStringWhenUnitsIsEmpty() {
+      assertThat(MyFormatter.unitsToText(Collections.emptyList()), is(""));
+    }
 
-  @Test
-  public void unitsToText_ShouldReturnOneEntryPerUnitTypeAndPlayerCombination() {
-    final PlayerID playerId1 = newPlayerId("playerId1");
-    final PlayerID playerId2 = newPlayerId("playerId2");
-    final UnitType unitType1 = newUnitType("unitType1");
-    final UnitType unitType2 = newUnitType("unitType2");
-    final Collection<Unit> units = Arrays.asList(
-        newUnit(unitType1, playerId1),
-        newUnit(unitType2, playerId1),
-        newUnit(unitType1, playerId2),
-        newUnit(unitType2, playerId2));
+    @Test
+    void shouldReturnOneEntryPerUnitTypeAndPlayerCombination() {
+      final PlayerID playerId1 = newPlayerId("playerId1");
+      final PlayerID playerId2 = newPlayerId("playerId2");
+      final UnitType unitType1 = newUnitType("unitType1");
+      final UnitType unitType2 = newUnitType("unitType2");
+      final Collection<Unit> units = Arrays.asList(
+          newUnit(unitType1, playerId1),
+          newUnit(unitType2, playerId1),
+          newUnit(unitType1, playerId2),
+          newUnit(unitType2, playerId2));
 
-    assertThat(MyFormatter.unitsToText(units), is(""
-        + "1 unitType1 owned by the playerId2, "
-        + "1 unitType2 owned by the playerId2, "
-        + "1 unitType1 owned by the playerId1 "
-        + "and 1 unitType2 owned by the playerId1"));
-  }
+      assertThat(MyFormatter.unitsToText(units), is(""
+          + "1 unitType1 owned by the playerId2, "
+          + "1 unitType2 owned by the playerId2, "
+          + "1 unitType1 owned by the playerId1 "
+          + "and 1 unitType2 owned by the playerId1"));
+    }
 
-  @Test
-  public void unitsToText_ShouldPluralizeTextWhenMultipleUnitsOwnedBySamePlayer() {
-    final PlayerID playerId = newPlayerId("playerId");
-    final UnitType unitType = newUnitType("unitType");
-    final Collection<Unit> units = Arrays.asList(
-        newUnit(unitType, playerId),
-        newUnit(unitType, playerId));
+    @Test
+    void shouldPluralizeTextWhenMultipleUnitsOwnedBySamePlayer() {
+      final PlayerID playerId = newPlayerId("playerId");
+      final UnitType unitType = newUnitType("unitType");
+      final Collection<Unit> units = Arrays.asList(
+          newUnit(unitType, playerId),
+          newUnit(unitType, playerId));
 
-    assertThat(MyFormatter.unitsToText(units), is("2 unitTypes owned by the playerId"));
+      assertThat(MyFormatter.unitsToText(units), is("2 unitTypes owned by the playerId"));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,26 +24,11 @@ import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.util.IntegerMap;
 
 @ExtendWith(MockitoExtension.class)
-public final class UserActionPanelTest {
+final class UserActionPanelTest {
   @Mock
   private GameData data;
 
   private Resource pus;
-
-  @BeforeEach
-  public void setUp() {
-    pus = new Resource(Constants.PUS, data);
-  }
-
-  @Test
-  public void testCanPlayerAffordUserAction_ShouldReturnFalseWhenUserActionCostGreaterThanPlayerPUs() {
-    final PlayerID player = createPlayer();
-    final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) + 1);
-
-    final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
-
-    assertThat(canAffordUserAction, is(false));
-  }
 
   private PlayerID createPlayer() {
     final PlayerID player = new PlayerID("player", data);
@@ -60,62 +46,83 @@ public final class UserActionPanelTest {
     return userAction;
   }
 
-  @Test
-  public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostEqualToPlayerPUs() {
-    final PlayerID player = createPlayer();
-    final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus));
-
-    final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
-
-    assertThat(canAffordUserAction, is(true));
+  @BeforeEach
+  void setUp() {
+    pus = new Resource(Constants.PUS, data);
   }
 
-  @Test
-  public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostLessThanPlayerPUs() {
-    final PlayerID player = createPlayer();
-    final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) - 1);
+  @Nested
+  final class CanPlayerAffordUserActionTest {
+    @Test
+    void shouldReturnFalseWhenUserActionCostGreaterThanPlayerPUs() {
+      final PlayerID player = createPlayer();
+      final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) + 1);
 
-    final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
+      final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
 
-    assertThat(canAffordUserAction, is(true));
+      assertThat(canAffordUserAction, is(false));
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserActionCostEqualToPlayerPUs() {
+      final PlayerID player = createPlayer();
+      final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus));
+
+      final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
+
+      assertThat(canAffordUserAction, is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserActionCostLessThanPlayerPUs() {
+      final PlayerID player = createPlayer();
+      final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) - 1);
+
+      final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
+
+      assertThat(canAffordUserAction, is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserActionCostIsZeroAndPlayerPUsIsZero() {
+      final PlayerID player = createPlayer();
+      final UserActionAttachment userAction = createUserActionWithCost(0);
+
+      final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
+
+      assertThat(canAffordUserAction, is(true));
+    }
   }
 
-  @Test
-  public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostIsZeroAndPlayerPUsIsZero() {
-    final PlayerID player = createPlayer();
-    final UserActionAttachment userAction = createUserActionWithCost(0);
+  @Nested
+  final class CanSpendResourcesOnUserActionsTest {
+    @Test
+    void shouldReturnFalseWhenNoUserActionsPresent() {
+      final Collection<UserActionAttachment> userActions = Collections.emptyList();
 
-    final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
+      final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
-    assertThat(canAffordUserAction, is(true));
-  }
+      assertThat(canSpendResources, is(false));
+    }
 
-  @Test
-  public void testCanSpendResourcesOnUserActions_ShouldReturnFalseWhenNoUserActionsPresent() {
-    final Collection<UserActionAttachment> userActions = Collections.emptyList();
+    @Test
+    void shouldReturnFalseWhenNoUserActionHasCost() {
+      final Collection<UserActionAttachment> userActions =
+          Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(0));
 
-    final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
+      final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
-    assertThat(canSpendResources, is(false));
-  }
+      assertThat(canSpendResources, is(false));
+    }
 
-  @Test
-  public void testCanSpendResourcesOnUserActions_ShouldReturnFalseWhenNoUserActionHasCost() {
-    final Collection<UserActionAttachment> userActions =
-        Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(0));
+    @Test
+    void shouldReturnTrueWhenAtLeastOneUserActionHasCost() {
+      final Collection<UserActionAttachment> userActions =
+          Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(5));
 
-    final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
+      final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
-    assertThat(canSpendResources, is(false));
-  }
-
-  @Test
-  public void testCanSpendResourcesOnUserActions_ShouldReturnTrueWhenAtLeastOneUserActionHasCost() {
-    final Collection<UserActionAttachment> userActions =
-        Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(5));
-
-    final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
-
-    assertThat(canSpendResources, is(true));
+      assertThat(canSpendResources, is(true));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/ui/SwingComponentsTest.java
+++ b/game-core/src/test/java/games/strategy/ui/SwingComponentsTest.java
@@ -8,61 +8,71 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class SwingComponentsTest {
-  @Test
-  public void testAppendExtensionIfAbsent_ShouldAppendExtensionWhenExtensionAbsent() {
-    assertThat(appendExtensionIfAbsent(new File("path/file.aaa"), "bbb"), is(new File("path/file.aaa.bbb")));
-    assertThat(appendExtensionIfAbsent(new File("path/filebbb"), "bbb"), is(new File("path/filebbb.bbb")));
+final class SwingComponentsTest {
+  @Nested
+  final class AppendExtensionIfAbsentTest {
+    @Test
+    void shouldAppendExtensionWhenExtensionAbsent() {
+      assertThat(appendExtensionIfAbsent(new File("path/file.aaa"), "bbb"), is(new File("path/file.aaa.bbb")));
+      assertThat(appendExtensionIfAbsent(new File("path/filebbb"), "bbb"), is(new File("path/filebbb.bbb")));
+    }
+
+    @Test
+    void shouldNotAppendExtensionWhenExtensionPresent() {
+      assertThat(appendExtensionIfAbsent(new File("path/file.bbb"), "bbb"), is(new File("path/file.bbb")));
+    }
+
+    @Test
+    void shouldHandleExtensionThatStartsWithPeriod() {
+      assertThat(appendExtensionIfAbsent(new File("path/file.aaa"), ".bbb"), is(new File("path/file.aaa.bbb")));
+    }
+
+    @Test
+    void shouldUseCaseInsensitiveComparisonForExtension() {
+      assertThat(appendExtensionIfAbsent(new File("path/file.bBb"), "BbB"), is(new File("path/file.bBb")));
+    }
   }
 
-  @Test
-  public void testAppendExtensionIfAbsent_ShouldNotAppendExtensionWhenExtensionPresent() {
-    assertThat(appendExtensionIfAbsent(new File("path/file.bbb"), "bbb"), is(new File("path/file.bbb")));
+  @Nested
+  final class ExtensionWithLeadingPeriodTest {
+    @Test
+    void shouldReturnExtensionWithLeadingPeriod() {
+      assertThat(extensionWithLeadingPeriod(""), is(""));
+
+      assertThat(extensionWithLeadingPeriod("a"), is(".a"));
+      assertThat(extensionWithLeadingPeriod(".a"), is(".a"));
+
+      assertThat(extensionWithLeadingPeriod("aa"), is(".aa"));
+      assertThat(extensionWithLeadingPeriod(".aa"), is(".aa"));
+
+      assertThat(extensionWithLeadingPeriod("aaa"), is(".aaa"));
+      assertThat(extensionWithLeadingPeriod(".aaa"), is(".aaa"));
+
+      assertThat(extensionWithLeadingPeriod("aaa.aaa"), is(".aaa.aaa"));
+      assertThat(extensionWithLeadingPeriod(".aaa.aaa"), is(".aaa.aaa"));
+    }
   }
 
-  @Test
-  public void testAppendExtensionIfAbsent_ShouldHandleExtensionThatStartsWithPeriod() {
-    assertThat(appendExtensionIfAbsent(new File("path/file.aaa"), ".bbb"), is(new File("path/file.aaa.bbb")));
-  }
+  @Nested
+  final class ExtensionWithoutLeadingPeriodTest {
+    @Test
+    void shouldReturnExtensionWithoutLeadingPeriod() {
+      assertThat(extensionWithoutLeadingPeriod(""), is(""));
 
-  @Test
-  public void testAppendExtensionIfAbsent_ShouldUseCaseInsensitiveComparisonForExtension() {
-    assertThat(appendExtensionIfAbsent(new File("path/file.bBb"), "BbB"), is(new File("path/file.bBb")));
-  }
+      assertThat(extensionWithoutLeadingPeriod("a"), is("a"));
+      assertThat(extensionWithoutLeadingPeriod(".a"), is("a"));
 
-  @Test
-  public void testExtensionWithLeadingPeriod() {
-    assertThat(extensionWithLeadingPeriod(""), is(""));
+      assertThat(extensionWithoutLeadingPeriod("aa"), is("aa"));
+      assertThat(extensionWithoutLeadingPeriod(".aa"), is("aa"));
 
-    assertThat(extensionWithLeadingPeriod("a"), is(".a"));
-    assertThat(extensionWithLeadingPeriod(".a"), is(".a"));
+      assertThat(extensionWithoutLeadingPeriod("aaa"), is("aaa"));
+      assertThat(extensionWithoutLeadingPeriod(".aaa"), is("aaa"));
 
-    assertThat(extensionWithLeadingPeriod("aa"), is(".aa"));
-    assertThat(extensionWithLeadingPeriod(".aa"), is(".aa"));
-
-    assertThat(extensionWithLeadingPeriod("aaa"), is(".aaa"));
-    assertThat(extensionWithLeadingPeriod(".aaa"), is(".aaa"));
-
-    assertThat(extensionWithLeadingPeriod("aaa.aaa"), is(".aaa.aaa"));
-    assertThat(extensionWithLeadingPeriod(".aaa.aaa"), is(".aaa.aaa"));
-  }
-
-  @Test
-  public void testExtensionWithoutLeadingPeriod() {
-    assertThat(extensionWithoutLeadingPeriod(""), is(""));
-
-    assertThat(extensionWithoutLeadingPeriod("a"), is("a"));
-    assertThat(extensionWithoutLeadingPeriod(".a"), is("a"));
-
-    assertThat(extensionWithoutLeadingPeriod("aa"), is("aa"));
-    assertThat(extensionWithoutLeadingPeriod(".aa"), is("aa"));
-
-    assertThat(extensionWithoutLeadingPeriod("aaa"), is("aaa"));
-    assertThat(extensionWithoutLeadingPeriod(".aaa"), is("aaa"));
-
-    assertThat(extensionWithoutLeadingPeriod("aaa.aaa"), is("aaa.aaa"));
-    assertThat(extensionWithoutLeadingPeriod(".aaa.aaa"), is("aaa.aaa"));
+      assertThat(extensionWithoutLeadingPeriod("aaa.aaa"), is("aaa.aaa"));
+      assertThat(extensionWithoutLeadingPeriod(".aaa.aaa"), is("aaa.aaa"));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/util/CollectionUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/CollectionUtilsTest.java
@@ -10,51 +10,61 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class CollectionUtilsTest {
+final class CollectionUtilsTest {
   private static final Predicate<Integer> ALWAYS = it -> true;
   private static final Predicate<Integer> NEVER = it -> false;
   private static final Predicate<Integer> IS_ZERO = it -> it == 0;
 
-  @Test
-  public void testCountMatches() {
-    assertEquals(0, countMatches(Arrays.asList(), IS_ZERO));
+  @Nested
+  final class CountMatchesTest {
+    @Test
+    void shouldReturnCountOfMatches() {
+      assertEquals(0, countMatches(Arrays.asList(), IS_ZERO));
 
-    assertEquals(1, countMatches(Arrays.asList(0), IS_ZERO));
-    assertEquals(1, countMatches(Arrays.asList(-1, 0, 1), IS_ZERO));
+      assertEquals(1, countMatches(Arrays.asList(0), IS_ZERO));
+      assertEquals(1, countMatches(Arrays.asList(-1, 0, 1), IS_ZERO));
 
-    assertEquals(2, countMatches(Arrays.asList(0, 0), IS_ZERO));
-    assertEquals(2, countMatches(Arrays.asList(-1, 0, 1, 0), IS_ZERO));
+      assertEquals(2, countMatches(Arrays.asList(0, 0), IS_ZERO));
+      assertEquals(2, countMatches(Arrays.asList(-1, 0, 1, 0), IS_ZERO));
+    }
   }
 
-  @Test
-  public void testGetMatches() {
-    final Collection<Integer> input = Arrays.asList(-1, 0, 1);
+  @Nested
+  final class GetMatchesTest {
+    @Test
+    void shouldFilterOutNonMatchingElementsAndReturnAllMatches() {
+      final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-    assertEquals(Arrays.asList(), getMatches(Arrays.asList(), ALWAYS), "empty collection");
-    assertEquals(Arrays.asList(), getMatches(input, NEVER), "none match");
-    assertEquals(Arrays.asList(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
-    assertEquals(Arrays.asList(-1, 0, 1), getMatches(input, ALWAYS), "all match");
+      assertEquals(Arrays.asList(), getMatches(Arrays.asList(), ALWAYS), "empty collection");
+      assertEquals(Arrays.asList(), getMatches(input, NEVER), "none match");
+      assertEquals(Arrays.asList(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
+      assertEquals(Arrays.asList(-1, 0, 1), getMatches(input, ALWAYS), "all match");
+    }
   }
 
-  @Test
-  public void testGetNMatches() {
-    final Collection<Integer> input = Arrays.asList(-1, 0, 1);
+  @Nested
+  final class GetNMatchesTest {
+    @Test
+    void shouldFilterOutNonMatchingElementsAndReturnMaxMatches() {
+      final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-    assertEquals(Arrays.asList(), getNMatches(Arrays.asList(), 999, ALWAYS), "empty collection");
-    assertEquals(Arrays.asList(), getNMatches(input, 0, NEVER), "max = 0");
-    assertEquals(Arrays.asList(), getNMatches(input, input.size(), NEVER), "none match");
-    assertEquals(Arrays.asList(0), getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO), "some match; max < count");
-    assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO), "some match; max = count");
-    assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO), "some match; max > count");
-    assertEquals(Arrays.asList(-1, 0), getNMatches(input, input.size() - 1, ALWAYS), "all match; max < count");
-    assertEquals(Arrays.asList(-1, 0, 1), getNMatches(input, input.size(), ALWAYS), "all match; max = count");
-    assertEquals(Arrays.asList(-1, 0, 1), getNMatches(input, input.size() + 1, ALWAYS), "all match; max > count");
-  }
+      assertEquals(Arrays.asList(), getNMatches(Arrays.asList(), 999, ALWAYS), "empty collection");
+      assertEquals(Arrays.asList(), getNMatches(input, 0, NEVER), "max = 0");
+      assertEquals(Arrays.asList(), getNMatches(input, input.size(), NEVER), "none match");
+      assertEquals(Arrays.asList(0), getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO), "some match; max < count");
+      assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO), "some match; max = count");
+      assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO), "some match; max > count");
+      assertEquals(Arrays.asList(-1, 0), getNMatches(input, input.size() - 1, ALWAYS), "all match; max < count");
+      assertEquals(Arrays.asList(-1, 0, 1), getNMatches(input, input.size(), ALWAYS), "all match; max = count");
+      assertEquals(Arrays.asList(-1, 0, 1), getNMatches(input, input.size() + 1, ALWAYS), "all match; max > count");
+    }
 
-  @Test
-  public void testGetNMatches_ShouldThrowExceptionWhenMaxIsNegative() {
-    assertThrows(IllegalArgumentException.class, () -> getNMatches(Arrays.asList(-1, 0, 1), -1, ALWAYS));
+    @Test
+    void shouldThrowExceptionWhenMaxIsNegative() {
+      assertThrows(IllegalArgumentException.class, () -> getNMatches(Arrays.asList(-1, 0, 1), -1, ALWAYS));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/util/FileNameUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/FileNameUtilsTest.java
@@ -5,27 +5,34 @@ import static org.hamcrest.Matchers.is;
 
 import java.util.Collections;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class FileNameUtilsTest {
-  @Test
-  public void removeIllegalCharacters_ShouldRemoveIllegalCharacters() {
-    assertThat(FileNameUtils.removeIllegalCharacters(FileNameUtils.ILLEGAL_CHARACTERS), is(""));
+final class FileNameUtilsTest {
+  @Nested
+  final class RemoveIllegalCharactersTest {
+    @Test
+    void shouldRemoveIllegalCharacters() {
+      assertThat(FileNameUtils.removeIllegalCharacters(FileNameUtils.ILLEGAL_CHARACTERS), is(""));
+    }
+
+    @Test
+    void shouldNotRemoveLegalCharacters() {
+      assertThat(FileNameUtils.removeIllegalCharacters("AZaz09!-"), is("AZaz09!-"));
+    }
   }
 
-  @Test
-  public void removeIllegalCharacters_ShouldNotRemoveLegalCharacters() {
-    assertThat(FileNameUtils.removeIllegalCharacters("AZaz09!-"), is("AZaz09!-"));
-  }
+  @Nested
+  final class ReplaceIllegalCharactersTest {
+    @Test
+    void shouldReplaceIllegalCharacters() {
+      assertThat(FileNameUtils.replaceIllegalCharacters(FileNameUtils.ILLEGAL_CHARACTERS, '_'),
+          is(String.join("", Collections.nCopies(FileNameUtils.ILLEGAL_CHARACTERS.length(), "_"))));
+    }
 
-  @Test
-  public void replaceIllegalCharacters_ShouldReplaceIllegalCharacters() {
-    assertThat(FileNameUtils.replaceIllegalCharacters(FileNameUtils.ILLEGAL_CHARACTERS, '_'),
-        is(String.join("", Collections.nCopies(FileNameUtils.ILLEGAL_CHARACTERS.length(), "_"))));
-  }
-
-  @Test
-  public void replaceIllegalCharacters_ShouldNotReplaceLegalCharacters() {
-    assertThat(FileNameUtils.replaceIllegalCharacters("AZaz09!-", '_'), is("AZaz09!-"));
+    @Test
+    void shouldNotReplaceLegalCharacters() {
+      assertThat(FileNameUtils.replaceIllegalCharacters("AZaz09!-", '_'), is("AZaz09!-"));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
@@ -12,188 +12,201 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
 import com.google.common.collect.ImmutableMap;
 
-public final class OpenJsonUtilsTest {
+final class OpenJsonUtilsTest {
   private enum TestEnum {
     FIRST, SECOND;
   }
 
-  @Test
-  public void optEnum_ShouldReturnEnumValueWhenPresent() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", TestEnum.FIRST.toString()));
+  @Nested
+  final class OptEnumTest {
+    @Test
+    void shouldReturnEnumValueWhenPresent() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", TestEnum.FIRST.toString()));
 
-    final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
+      final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
 
-    assertThat(value, is(TestEnum.FIRST));
+      assertThat(value, is(TestEnum.FIRST));
+    }
+
+    @Test
+    void shouldReturnDefaultValueWhenAbsent() {
+      final JSONObject jsonObject = new JSONObject();
+
+      final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
+
+      assertThat(value, is(TestEnum.SECOND));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPresentButNotEnumValue() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", "unknown"));
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND));
+    }
   }
 
-  @Test
-  public void optEnum_ShouldReturnDefaultValueWhenAbsent() {
-    final JSONObject jsonObject = new JSONObject();
+  @Nested
+  final class StreamJsonArrayTest {
+    @Test
+    void shouldReturnEmptyStreamWhenJsonArrayIsEmpty() {
+      final JSONArray jsonArray = new JSONArray();
 
-    final TestEnum value = OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND);
+      final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
 
-    assertThat(value, is(TestEnum.SECOND));
+      assertThat(elements, is(empty()));
+    }
+
+    @Test
+    void shouldReturnStreamContainingJsonArrayElements() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
+
+      final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+      assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
+    }
+
+    @Test
+    void shouldNotConvertNullSentinelValue() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+
+      final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+      assertThat(elements, is(Arrays.asList(JSONObject.NULL)));
+    }
+
+    @Test
+    void shouldNotConvertJsonArrayValue() {
+      final List<Object> expectedElements = Arrays.asList(new JSONArray(Arrays.asList(42)));
+      final JSONArray jsonArray = new JSONArray(expectedElements);
+
+      final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+      assertThat(actualElements, is(expectedElements));
+    }
+
+    @Test
+    void shouldNotConvertJsonObjectValue() {
+      final List<Object> expectedElements = Arrays.asList(new JSONObject(ImmutableMap.of("name", 42)));
+      final JSONArray jsonArray = new JSONArray(expectedElements);
+
+      final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+
+      assertThat(actualElements, is(expectedElements));
+    }
   }
 
-  @Test
-  public void optEnum_ShouldThrowExceptionWhenPresentButNotEnumValue() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", "unknown"));
+  @Nested
+  final class ToListTest {
+    @Test
+    void shouldReturnEmptyListWhenJsonArrayIsEmpty() {
+      final JSONArray jsonArray = new JSONArray();
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> OpenJsonUtils.optEnum(jsonObject, TestEnum.class, "name", TestEnum.SECOND));
+      final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+      assertThat(elements, is(empty()));
+    }
+
+    @Test
+    void shouldReturnListContainingJsonArrayElements() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
+
+      final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+      assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
+    }
+
+    @Test
+    void shouldConvertNullSentinelValueToNull() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+
+      final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+      // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
+      assertThat(elements.get(0), is(nullValue()));
+    }
+
+    @Test
+    void shouldConvertJsonArrayValueToList() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONArray(Arrays.asList(42))));
+
+      final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+      assertThat(elements, is(Arrays.asList(Arrays.asList(42))));
+    }
+
+    @Test
+    void shouldConvertJsonObjectValueToMap() {
+      final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONObject(ImmutableMap.of("name", 42))));
+
+      final List<Object> elements = OpenJsonUtils.toList(jsonArray);
+
+      assertThat(elements, is(Arrays.asList(ImmutableMap.of("name", 42))));
+    }
   }
 
-  @Test
-  public void streamJsonArray_ShouldReturnEmptyStreamWhenJsonArrayIsEmpty() {
-    final JSONArray jsonArray = new JSONArray();
+  @Nested
+  final class ToMapTest {
+    @Test
+    void shouldReturnEmptyMapWhenJsonObjectHasNoProperties() {
+      final JSONObject jsonObject = new JSONObject();
 
-    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+      final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-    assertThat(elements, is(empty()));
-  }
+      assertThat(properties, is(anEmptyMap()));
+    }
 
-  @Test
-  public void streamJsonArray_ShouldReturnStreamContainingJsonArrayElements() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
+    @Test
+    void shouldReturnMapContainingJsonObjectProperties() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+          "name1", "value1",
+          "name2", 2,
+          "name3", 3.0));
 
-    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+      final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-    assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
-  }
+      assertThat(properties, is(ImmutableMap.of(
+          "name1", "value1",
+          "name2", 2,
+          "name3", 3.0)));
+    }
 
-  @Test
-  public void streamJsonArray_ShouldNotConvertNullSentinelValue() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+    @Test
+    void shouldConvertNullSentinelValueToNull() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", JSONObject.NULL));
 
-    final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+      final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-    assertThat(elements, is(Arrays.asList(JSONObject.NULL)));
-  }
+      // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
+      assertThat(properties.get("name"), is(nullValue()));
+    }
 
-  @Test
-  public void streamJsonArray_ShouldNotConvertJsonArrayValue() {
-    final List<Object> expectedElements = Arrays.asList(new JSONArray(Arrays.asList(42)));
-    final JSONArray jsonArray = new JSONArray(expectedElements);
+    @Test
+    void shouldConvertJsonArrayValueToList() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+          "name", new JSONArray(Arrays.asList(42))));
 
-    final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+      final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-    assertThat(actualElements, is(expectedElements));
-  }
+      assertThat(properties, is(ImmutableMap.of("name", Arrays.asList(42))));
+    }
 
-  @Test
-  public void streamJsonArray_ShouldNotConvertJsonObjectValue() {
-    final List<Object> expectedElements = Arrays.asList(new JSONObject(ImmutableMap.of("name", 42)));
-    final JSONArray jsonArray = new JSONArray(expectedElements);
+    @Test
+    void shouldConvertJsonObjectValueToMap() {
+      final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
+          "name", new JSONObject(ImmutableMap.of("childName", 42))));
 
-    final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
+      final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-    assertThat(actualElements, is(expectedElements));
-  }
-
-  @Test
-  public void toList_ShouldReturnEmptyListWhenJsonArrayIsEmpty() {
-    final JSONArray jsonArray = new JSONArray();
-
-    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
-
-    assertThat(elements, is(empty()));
-  }
-
-  @Test
-  public void toList_ShouldReturnListContainingJsonArrayElements() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList("text", 1, 1.0));
-
-    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
-
-    assertThat(elements, is(Arrays.asList("text", 1, 1.0)));
-  }
-
-  @Test
-  public void toList_ShouldConvertNullSentinelValueToNull() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
-
-    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
-
-    // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
-    assertThat(elements.get(0), is(nullValue()));
-  }
-
-  @Test
-  public void toList_ShouldConvertJsonArrayValueToList() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONArray(Arrays.asList(42))));
-
-    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
-
-    assertThat(elements, is(Arrays.asList(Arrays.asList(42))));
-  }
-
-  @Test
-  public void toList_ShouldConvertJsonObjectValueToMap() {
-    final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONObject(ImmutableMap.of("name", 42))));
-
-    final List<Object> elements = OpenJsonUtils.toList(jsonArray);
-
-    assertThat(elements, is(Arrays.asList(ImmutableMap.of("name", 42))));
-  }
-
-  @Test
-  public void toMap_ShouldReturnEmptyMapWhenJsonObjectHasNoProperties() {
-    final JSONObject jsonObject = new JSONObject();
-
-    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
-
-    assertThat(properties, is(anEmptyMap()));
-  }
-
-  @Test
-  public void toMap_ShouldReturnMapContainingJsonObjectProperties() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
-        "name1", "value1",
-        "name2", 2,
-        "name3", 3.0));
-
-    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
-
-    assertThat(properties, is(ImmutableMap.of(
-        "name1", "value1",
-        "name2", 2,
-        "name3", 3.0)));
-  }
-
-  @Test
-  public void toMap_ShouldConvertNullSentinelValueToNull() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of("name", JSONObject.NULL));
-
-    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
-
-    // NB: need to test using reference equality because JSONObject#NULL#equals() is defined to be equal to null
-    assertThat(properties.get("name"), is(nullValue()));
-  }
-
-  @Test
-  public void toMap_ShouldConvertJsonArrayValueToList() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
-        "name", new JSONArray(Arrays.asList(42))));
-
-    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
-
-    assertThat(properties, is(ImmutableMap.of("name", Arrays.asList(42))));
-  }
-
-  @Test
-  public void toMap_ShouldConvertJsonObjectValueToMap() {
-    final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
-        "name", new JSONObject(ImmutableMap.of("childName", 42))));
-
-    final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
-
-    assertThat(properties, is(ImmutableMap.of("name", ImmutableMap.of("childName", 42))));
+      assertThat(properties, is(ImmutableMap.of("name", ImmutableMap.of("childName", 42))));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/util/OptionalUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/OptionalUtilsTest.java
@@ -7,40 +7,44 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class OptionalUtilsTest {
-  @Test
-  public void ifPresentOrElse_ShouldInvokePresentActionWhenValueIsPresent() {
-    final Object value = new Object();
-    final AtomicBoolean presentActionInvoked = new AtomicBoolean(false);
+final class OptionalUtilsTest {
+  @Nested
+  final class IfPresentOrElseTest {
+    @Test
+    void shouldInvokePresentActionWhenValueIsPresent() {
+      final Object value = new Object();
+      final AtomicBoolean presentActionInvoked = new AtomicBoolean(false);
 
-    OptionalUtils.ifPresentOrElse(
-        Optional.of(value),
-        it -> {
-          presentActionInvoked.set(true);
-          assertThat(it, is(value));
-        },
-        () -> {
-          fail("empty action should not have been invoked");
-        });
+      OptionalUtils.ifPresentOrElse(
+          Optional.of(value),
+          it -> {
+            presentActionInvoked.set(true);
+            assertThat(it, is(value));
+          },
+          () -> {
+            fail("empty action should not have been invoked");
+          });
 
-    assertThat(presentActionInvoked.get(), is(true));
-  }
+      assertThat(presentActionInvoked.get(), is(true));
+    }
 
-  @Test
-  public void ifPresentOrElse_ShouldInvokeEmptyActionWhenValueIsAbsent() {
-    final AtomicBoolean emptyActionInvoked = new AtomicBoolean(false);
+    @Test
+    void shouldInvokeEmptyActionWhenValueIsAbsent() {
+      final AtomicBoolean emptyActionInvoked = new AtomicBoolean(false);
 
-    OptionalUtils.ifPresentOrElse(
-        Optional.empty(),
-        it -> {
-          fail("present action should not have been invoked");
-        },
-        () -> {
-          emptyActionInvoked.set(true);
-        });
+      OptionalUtils.ifPresentOrElse(
+          Optional.empty(),
+          it -> {
+            fail("present action should not have been invoked");
+          },
+          () -> {
+            emptyActionInvoked.set(true);
+          });
 
-    assertThat(emptyActionInvoked.get(), is(true));
+      assertThat(emptyActionInvoked.get(), is(true));
+    }
   }
 }


### PR DESCRIPTION
## Overview

Numerous test methods duplicate the name of the method/feature under test as a prefix on the method name.  This leads to unusually long method names in some cases.  This PR merges such related test methods under a single `@Nested` test fixture named after the method/feature under test in order to reduce the duplication.

These changes also fix several "method can be static" warnings flagged by static analysis.

## Functional Changes

None.  **This PR only contains changes to test code.**

## Refactoring Changes

For tests that were modified, I reduced the accessibility of all public members to package-private, as JUnit 5 permits.

## Manual Testing Performed

Verified the same number of unit tests are run on this branch as on `master` (with one exception; see below).

## Additional Review Notes

Please review with whitespace changes ignored, as the vast majority of changes are due to indentation.