### PR TITLE
Prefer jcenter over Maven Central for dependencies

### DIFF
--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -20,7 +20,7 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
Follow-up to #3299.