### PR TITLE
Console: Use radio button instead of check box for log levels

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -10,11 +10,11 @@ import java.util.logging.LogManager;
 
 import javax.swing.AbstractButton;
 import javax.swing.Action;
-import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JToggleButton;
@@ -132,7 +132,7 @@ public final class Console {
       }
     });
     LOG_LEVEL_ITEMS.forEach(item -> {
-      final JMenuItem menuItem = new JCheckBoxMenuItem(item.label, item.level == logLevel);
+      final JMenuItem menuItem = new JRadioButtonMenuItem(item.label, item.level == logLevel);
       menuItem.addActionListener(e -> {
         setLogLevel(item.level);
         setDefaultLogLevel(item.level);


### PR DESCRIPTION
## Overview

As recommended [here](https://github.com/triplea-game/triplea/pull/3786#issuecomment-412371577).

## Functional Changes

None.

## Manual Testing Performed

None.

## Before & After Screen Shots

### Before

![console-before](https://user-images.githubusercontent.com/4826349/44008686-1f814234-9e74-11e8-939b-584670d296c0.png)

### After

![console-after](https://user-images.githubusercontent.com/4826349/44008691-248b84a6-9e74-11e8-943c-0951da6fb2c4.png)