### PR TITLE
Static analysis: Fix unused auto-closeable resource warning

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -92,9 +92,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
       throws IOException {
     final HttpDelete httpDelete = new HttpDelete(tripleAForumURL + "/api/v2/users/" + userId + "/tokens/" + token);
     addTokenHeader(httpDelete, token);
-    try (CloseableHttpResponse ignored = client.execute(httpDelete)) {
-      // ignore errors, execute and then close
-    }
+    client.execute(httpDelete).close(); // ignore errors, execute and then close
   }
 
   private int getUserId(final CloseableHttpClient client) throws IOException {


### PR DESCRIPTION
## Overview

Fixes the following static analysis warning:

```
/.../game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java:95: warning: [try] auto-closeable resource ignored is never referenced in body of corresponding try statement
    try (CloseableHttpResponse ignored = client.execute(httpDelete)) {
```

The fix proposed in this PR is to simply inline the `close()` call.  If this is objectionable, the other alternative is to apply `@SuppressWarnings("try")` at method scope (it unfortunately is ignored if applied at variable scope).

## Functional Changes

None.

## Manual Testing Performed

None.