### PR TITLE
Inline UnitFactory into IGameLoader

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitFactory.java
@@ -1,9 +1,0 @@
-package games.strategy.engine.data;
-
-/**
- * Factory for creating instances of {@link Unit}.
- */
-@FunctionalInterface
-public interface UnitFactory {
-  Unit createUnit(UnitType type, PlayerID owner, GameData data);
-}

--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -49,7 +49,7 @@ public class UnitType extends NamedAttachable {
   }
 
   private Unit create(final PlayerID owner, final boolean isTemp, final int hitsTaken, final int bombingUnitDamage) {
-    final Unit u = getData().getGameLoader().getUnitFactory().createUnit(this, owner, getData());
+    final Unit u = getData().getGameLoader().createUnit(this, owner, getData());
     u.setHits(hitsTaken);
     if (u instanceof TripleAUnit) {
       ((TripleAUnit) u).setUnitDamage(bombingUnitDamage);

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -7,7 +7,10 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import games.strategy.engine.chat.Chat;
-import games.strategy.engine.data.UnitFactory;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
@@ -55,9 +58,5 @@ public interface IGameLoader extends Serializable {
 
   void shutDown();
 
-  /**
-   * A game may use a subclass of Unit to allow associating data with a particular unit. The
-   * game does this by specifying a UnitFactory that should be used to create units.
-   */
-  UnitFactory getUnitFactory();
+  Unit createUnit(UnitType type, PlayerID owner, GameData data);
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -9,7 +9,10 @@ import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.chat.Chat;
-import games.strategy.engine.data.UnitFactory;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.LocalPlayers;
@@ -127,8 +130,6 @@ public class TripleA implements IGameLoader {
     }
   }
 
-
-
   @Override
   public Class<? extends IChannelSubscribor> getDisplayType() {
     return ITripleADisplay.class;
@@ -145,7 +146,7 @@ public class TripleA implements IGameLoader {
   }
 
   @Override
-  public UnitFactory getUnitFactory() {
-    return TripleAUnit::new;
+  public Unit createUnit(final UnitType type, final PlayerID owner, final GameData data) {
+    return new TripleAUnit(type, owner, data);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -6,8 +6,10 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import games.strategy.engine.chat.Chat;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitFactory;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.IGameLoader;
 import games.strategy.engine.framework.startup.ui.PlayerType;
@@ -53,7 +55,7 @@ public final class TestGameLoader implements IGameLoader {
   public void shutDown() {}
 
   @Override
-  public UnitFactory getUnitFactory() {
-    return Unit::new;
+  public Unit createUnit(final UnitType type, final PlayerID owner, final GameData data) {
+    return new Unit(type, owner, data);
   }
 }


### PR DESCRIPTION
## Overview

Follow-up to [this discussion](https://github.com/triplea-game/triplea/pull/3796#discussion_r209724523).

In the current state of the codebase, `UnitFactory` is just an unnecessary level of indirection to create a new unit, as each `IGameLoader` implementation provides its own anonymous implementation of `UnitFactory`.  Therefore, this PR removes the extra indirection and inlines `UnitFactory` into `IGameLoader`.

## Functional Changes

None.

## Manual Testing Performed

Verified save game compatibility:

* Loaded an old save game into this branch
* Loaded a save game created from this branch into 9687

Verified network game compatibility:

* game server (this branch) <-> game client (9687)
* game server (9687) <-> game client (this branch)