### PR TITLE
Fix race condition when exiting lobby client

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -220,9 +220,11 @@ public class LobbyFrame extends JFrame {
   public void shutdown() {
     setVisible(false);
     dispose();
-    new Thread(GameRunner::showMainFrame).start();
-    client.getMessenger().shutDown();
-    GameRunner.exitGameIfFinished();
+    new Thread(() -> {
+      GameRunner.showMainFrame();
+      client.getMessenger().shutDown();
+      GameRunner.exitGameIfFinished();
+    }).start();
   }
 
   private void connectionToServerLost() {


### PR DESCRIPTION
## Overview

Fixes #3793.

In a nutshell, `GameRunner#showMainFrame()` must _happen before_ `GameRunner#exitGameIfFinished()`.

## Functional Changes

None.

## Manual Testing Performed

Exited the lobby client ten times and was always returned to the main menu; no instances where the application exited completely.