### PR TITLE
Add default implementation for deprecated method

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/common/IModeratorController.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/IModeratorController.java
@@ -130,11 +130,16 @@ public interface IModeratorController extends IRemote {
    * You cannot change the password of an anonymous node, and you cannot change the password for an admin user.
    * </p>
    *
+   * @param node The node whose password is to be set.
+   * @param hashedPassword The new hashed password.
+   *
    * @deprecated Remove usages of this. Does not make sense for moderators to be able to reset passwords of logged
    *             in users.
    */
   @Deprecated
-  String setPassword(INode node, String hashedPassword);
+  default @Nullable String setPassword(final INode node, final String hashedPassword) {
+    return "";
+  }
 
   String getInformationOn(INode node);
 

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -409,11 +409,6 @@ final class ModeratorController implements IModeratorController {
     return remoteHostUtils.getConnections();
   }
 
-  @Override
-  public String setPassword(final INode node, final String hashedPassword) {
-    return "";
-  }
-
   void register(final IRemoteMessenger messenger) {
     messenger.registerRemote(this, LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
   }


### PR DESCRIPTION
## Overview

Moves the implementation of `IModeratorController#setPassword()` from the `ModeratorController` class into a default implementation on `IModeratorController` itself.  There is already precedent for adding a default implementation for deprecated methods (e.g. see `banIp()` in the same interface).

This also removes a compiler warning about `ModeratorController` implementing a deprecated method.

## Functional Changes

None.

## Manual Testing Performed

None.