### PR TITLE
Error Prone: Fix string splitter violations in ModeratorController

### DIFF
--- a/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -6,6 +6,8 @@ import java.util.Date;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.engine.lobby.common.IModeratorController;
@@ -99,7 +101,7 @@ final class ModeratorController implements IModeratorController {
   @VisibleForTesting
   static String getUsernameForNode(final INode node) {
     // usernames may contain a " (n)" suffix when the same user is logged in multiple times
-    return node.getName().split(" ")[0];
+    return Iterables.get(Splitter.on(' ').split(node.getName()), 0);
   }
 
   /**


### PR DESCRIPTION
## Overview

Fixes a violation of the Error Prone StringSplitter rule in the `ModeratorController` class.  The replacement code was suggested by Error Prone.

## Functional Changes

None.

## Manual Testing Performed

None.  The enclosing method has 100% line and branch coverage from the unit tests.