### PR TITLE
Remove redundant RemoteName constructor

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
@@ -11,7 +11,7 @@ public final class LobbyConstants {
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
   public static final RemoteName MODERATOR_CONTROLLER_REMOTE_NAME =
-      new RemoteName(IModeratorController.class, "games.strategy.engine.lobby.server.ModeratorController:Global");
+      new RemoteName("games.strategy.engine.lobby.server.ModeratorController:Global", IModeratorController.class);
 
   private LobbyConstants() {}
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/RemoteHostUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/RemoteHostUtils.java
@@ -13,8 +13,9 @@ public class RemoteHostUtils implements IRemoteHostUtils {
   private final IServerMessenger serverMessenger;
 
   public static RemoteName getRemoteHostUtilsName(final INode node) {
-    return new RemoteName(IRemoteHostUtils.class,
-        "games.strategy.engine.lobby.server.RemoteHostUtils:" + node.toString());
+    return new RemoteName(
+        "games.strategy.engine.lobby.server.RemoteHostUtils:" + node.toString(),
+        IRemoteHostUtils.class);
   }
 
   public RemoteHostUtils(final INode serverNode, final IServerMessenger gameServerMessenger) {

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
@@ -7,15 +7,15 @@ public class RemoteName {
   private final String name;
   private final Class<?> clazz;
 
-  public RemoteName(final String name, final Class<?> class1) {
-    if (class1 == null) {
+  public RemoteName(final String name, final Class<?> clazz) {
+    if (clazz == null) {
       throw new IllegalArgumentException("Class cannot be null. Remote Name: " + name);
     }
-    if (!class1.isInterface()) {
+    if (!clazz.isInterface()) {
       throw new IllegalArgumentException("Not an interface. Remote Name: " + name);
     }
     this.name = name;
-    clazz = class1;
+    this.clazz = clazz;
   }
 
   public Class<?> getClazz() {

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
@@ -1,8 +1,11 @@
 package games.strategy.engine.message;
 
+import lombok.Getter;
+
 /**
  * Description for a Channel or a Remote end point.
  */
+@Getter
 public class RemoteName {
   private final String name;
   private final Class<?> clazz;
@@ -16,14 +19,6 @@ public class RemoteName {
     }
     this.name = name;
     this.clazz = clazz;
-  }
-
-  public Class<?> getClazz() {
-    return clazz;
-  }
-
-  public String getName() {
-    return name;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
@@ -7,10 +7,6 @@ public class RemoteName {
   private final String name;
   private final Class<?> clazz;
 
-  public RemoteName(final Class<?> class1, final String name) {
-    this(name, class1);
-  }
-
   public RemoteName(final String name, final Class<?> class1) {
     if (class1 == null) {
       throw new IllegalArgumentException("Class cannot be null. Remote Name: " + name);

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
@@ -1,12 +1,15 @@
 package games.strategy.engine.message;
 
+import javax.annotation.concurrent.Immutable;
+
 import lombok.Getter;
 
 /**
  * Description for a Channel or a Remote end point.
  */
 @Getter
-public class RemoteName {
+@Immutable
+public final class RemoteName {
   private final String name;
   private final Class<?> clazz;
 

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -50,7 +50,7 @@ public class ChannelMessengerTest {
 
   @Test
   public void testLocalCall() {
-    final RemoteName descriptor = new RemoteName(IChannelBase.class, "testLocalCall");
+    final RemoteName descriptor = new RemoteName("testLocalCall", IChannelBase.class);
     serverChannelMessenger.registerChannelSubscriber(new ChannelSubscribor(), descriptor);
     final IChannelBase subscribor = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(descriptor);
     subscribor.testNoParams();
@@ -60,7 +60,7 @@ public class ChannelMessengerTest {
 
   @Test
   public void testRemoteCall() {
-    final RemoteName testRemote = new RemoteName(IChannelBase.class, "testRemote");
+    final RemoteName testRemote = new RemoteName("testRemote", IChannelBase.class);
     final ChannelSubscribor subscribor1 = new ChannelSubscribor();
     serverChannelMessenger.registerChannelSubscriber(subscribor1, testRemote);
     assertHasChannel(testRemote, unifiedMessengerHub);
@@ -79,7 +79,7 @@ public class ChannelMessengerTest {
   public void testMultipleClients() throws Exception {
     // set up the client and server
     // so that the client has 1 subscribor, and the server knows about it
-    final RemoteName test = new RemoteName(IChannelBase.class, "test");
+    final RemoteName test = new RemoteName("test", IChannelBase.class);
     final ChannelSubscribor client1Subscribor = new ChannelSubscribor();
     clientChannelMessenger.registerChannelSubscriber(client1Subscribor, test);
     assertHasChannel(test, unifiedMessengerHub);
@@ -94,8 +94,8 @@ public class ChannelMessengerTest {
 
   @Test
   public void testMultipleChannels() {
-    final RemoteName testRemote2 = new RemoteName(IChannelBase.class, "testRemote2");
-    final RemoteName testRemote3 = new RemoteName(IChannelBase.class, "testRemote3");
+    final RemoteName testRemote2 = new RemoteName("testRemote2", IChannelBase.class);
+    final RemoteName testRemote3 = new RemoteName("testRemote3", IChannelBase.class);
     final ChannelSubscribor subscribor2 = new ChannelSubscribor();
     clientChannelMessenger.registerChannelSubscriber(subscribor2, testRemote2);
     final ChannelSubscribor subscribor3 = new ChannelSubscribor();

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -69,7 +69,7 @@ public class RemoteMessengerTest {
   @Test
   public void testRegisterUnregister() {
     final TestRemote testRemote = new TestRemote();
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.registerRemote(testRemote, test);
     assertTrue(remoteMessenger.hasLocalImplementor(test));
     remoteMessenger.unregisterRemote(test);
@@ -79,7 +79,7 @@ public class RemoteMessengerTest {
   @Test
   public void testMethodCall() {
     final TestRemote testRemote = new TestRemote();
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     assertEquals(2, remote.increment(1));
@@ -89,7 +89,7 @@ public class RemoteMessengerTest {
   @Test
   public void testExceptionThrownWhenUnregisteredRemote() {
     final TestRemote testRemote = new TestRemote();
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     remoteMessenger.unregisterRemote("test");
@@ -99,7 +99,7 @@ public class RemoteMessengerTest {
 
   @Test
   public void testNoRemote() {
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.getRemote(test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     final Exception e = assertThrows(RuntimeException.class, remote::testVoid);
@@ -109,7 +109,7 @@ public class RemoteMessengerTest {
   @Test
   public void testVoidMethodCall() {
     final TestRemote testRemote = new TestRemote();
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     remote.testVoid();
@@ -118,7 +118,7 @@ public class RemoteMessengerTest {
   @Test
   public void testException() {
     final TestRemote testRemote = new TestRemote();
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     remoteMessenger.registerRemote(testRemote, test);
     final ITestRemote remote = (ITestRemote) remoteMessenger.getRemote(test);
     final Exception e = assertThrows(Exception.class, remote::throwException);
@@ -127,7 +127,7 @@ public class RemoteMessengerTest {
 
   @Test
   public void testRemoteCall() throws Exception {
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
@@ -171,7 +171,7 @@ public class RemoteMessengerTest {
 
   @Test
   public void testRemoteCall2() throws Exception {
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
@@ -199,7 +199,7 @@ public class RemoteMessengerTest {
   public void testShutDownClient() throws Exception {
     // when the client shutdown, remotes created
     // on the client should not be visible on server
-    final RemoteName test = new RemoteName(ITestRemote.class, "test");
+    final RemoteName test = new RemoteName("test", ITestRemote.class);
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {
@@ -225,7 +225,7 @@ public class RemoteMessengerTest {
   public void testMethodReturnsOnWait() throws Exception {
     // when the client shutdown, remotes created
     // on the client should not be visible on server
-    final RemoteName test = new RemoteName(IFoo.class, "test");
+    final RemoteName test = new RemoteName("test", IFoo.class);
     ServerMessenger server = null;
     ClientMessenger client = null;
     try {


### PR DESCRIPTION
## Overview

`RemoteName` has two two-parameter constructors, the only difference being the parameter order is swapped.  This PR removes the least-used constructor and changes all affected call sites to use the remaining constructor.

## Functional Changes

None.

## Refactoring Changes

* Renamed constructor parameter to match field name.
* Use Lombok `@Getter` to generate field accessors.
* Mark class `final` and `@Immutable`.

## Manual Testing Performed

None.