### PR TITLE
Decouple ServerMessenger from LobbyLoginValidator

### DIFF
--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -34,7 +34,6 @@ import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.engine.lobby.server.db.Database;
 import games.strategy.engine.lobby.server.db.MutedMacController;
 import games.strategy.engine.lobby.server.db.MutedUsernameController;
-import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
 import games.strategy.engine.message.HubInvoke;
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteName;
@@ -181,7 +180,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   private boolean isLobby() {
-    return loginValidator instanceof LobbyLoginValidator;
+    return database != null;
   }
 
   private boolean isGame() {


### PR DESCRIPTION
## Overview

One-line change to decouple `ServerMessenger` from `LobbyLoginValidator`.  It is a prerequisite for moving `LobbyLoginValidator` to the `lobby` project.

## Functional Changes

None.

## Manual Testing Performed

Verified chat worked with a lobby server and game server running from this branch using clients from this branch and 9687.