### PR TITLE
Checkstyle: Fix missing Javadoc violations

### DIFF
--- a/game-core/src/main/java/org/triplea/client/ui/javafx/controls/TripleACheckBoxSkin.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/controls/TripleACheckBoxSkin.java
@@ -8,6 +8,17 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Rectangle;
 
+/**
+ * A skin that renders a check box as a box with an image for the selected state.
+ *
+ * <p>
+ * The following CSS classes are used to control the rendering:
+ * </p>
+ * <ul>
+ * <li>{@code .box}: The base check box.</li>
+ * <li>{@code .mark}: The image displayed on top of the box when the check box is selected.</li>
+ * </ul>
+ */
 public class TripleACheckBoxSkin extends SkinBase<CheckBox> {
 
   private final StackPane pane = new StackPane();

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -12,6 +12,19 @@ import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SettingType;
 import javafx.scene.layout.Region;
 
+/**
+ * Binds a {@link ClientSetting} to a JavaFX UI component. This is done by adding an enum element. As part of that the
+ * corresponding UI component, a {@link SelectionComponent} is specified. This then automatically adds the setting to
+ * the settings window.
+ *
+ * <p>
+ * UI component construction is delegated to {@link JavaFxSelectionComponentFactory}.
+ * </p>
+ * <p>
+ * There is a 1:n relationship between {@link SelectionComponent} and {@link ClientSetting}, though typically it will be
+ * 1:1, and not all {@link ClientSetting}s will be available in the UI.
+ * </p>
+ */
 public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region> {
   AI_PAUSE_DURATION_BINDING(
       SettingType.AI,

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -36,6 +36,14 @@ import games.strategy.util.PointFileReaderWriter;
 import lombok.extern.java.Log;
 import tools.util.ToolArguments;
 
+/**
+ * The auto-placement finder map making tool.
+ *
+ * <p>
+ * This tool will attempt to automatically calculate appropriate unit placement locations for each territory on a given
+ * map. It will generate a {@code places.txt} file containing the unit placement locations.
+ * </p>
+ */
 @Log
 public final class AutoPlacementFinder {
   private int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;

--- a/game-core/src/main/java/tools/image/FileOpen.java
+++ b/game-core/src/main/java/tools/image/FileOpen.java
@@ -7,6 +7,9 @@ import javax.swing.JOptionPane;
 
 import games.strategy.engine.framework.system.SystemProperties;
 
+/**
+ * A file chooser for use by map making tools to prompt the user to select a file to open.
+ */
 public class FileOpen {
   private File file;
 

--- a/game-core/src/main/java/tools/image/FileSave.java
+++ b/game-core/src/main/java/tools/image/FileSave.java
@@ -9,6 +9,9 @@ import com.google.common.base.Strings;
 
 import games.strategy.engine.framework.system.SystemProperties;
 
+/**
+ * A file chooser for use by map making tools to prompt the user to select a file to save.
+ */
 public class FileSave {
   private final File file;
 

--- a/game-core/src/main/java/tools/map/making/MapProperties.java
+++ b/game-core/src/main/java/tools/map/making/MapProperties.java
@@ -104,6 +104,14 @@ public class MapProperties {
     return unitsScale;
   }
 
+  /**
+   * Sets the value of the {@code units.scale} map property.
+   *
+   * <p>
+   * The implementation accounts for small rounding errors when {@code value} is one of the standard units scale
+   * values: 0.5, 0.5625, 0.6666, 0.75, 0.8333, 0.875, 1.0, 1.25.
+   * </p>
+   */
   public void setUnitsScale(final double value) {
     final double dvalue = Math.max(0.0, Math.min(2.0, value));
     if (Math.abs(1.25 - dvalue) < 0.01) {

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -58,6 +58,14 @@ import tools.image.FileOpen;
 import tools.image.FileSave;
 import tools.util.ToolArguments;
 
+/**
+ * The placement picker map making tool.
+ *
+ * <p>
+ * This tool will allow you to manually specify unit placement locations for each territory on a given map. It will
+ * generate a {@code places.txt} file containing the unit placement locations.
+ * </p>
+ */
 @Log
 public final class PlacementPicker {
   private int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocMethod and JavadocType rules by adding missing Javadocs.  Changes to the proposed Javadocs are welcome.

## Functional Changes

None.  **This PR only contains Javadoc changes; there are no code changes.**

## Manual Testing Performed

None.