### PR TITLE
Error Prone: Fix violations in Console

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -132,7 +132,7 @@ public final class Console {
       }
     });
     LOG_LEVEL_ITEMS.forEach(item -> {
-      final JMenuItem menuItem = new JRadioButtonMenuItem(item.label, item.level == logLevel);
+      final JMenuItem menuItem = new JRadioButtonMenuItem(item.label, item.level.equals(logLevel));
       menuItem.addActionListener(e -> {
         setLogLevel(item.level);
         setDefaultLogLevel(item.level);


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone MutableConstantField and ReferenceEquality rules in the `Console` class.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested changing log levels in the console works as expected.