### PR TITLE
Extract common lobby login challenge/response property keys

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -25,10 +25,10 @@ import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.lobby.common.ILobbyGameController;
 import games.strategy.engine.lobby.common.LobbyConstants;
+import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.GameDescription.GameStatus;
 import games.strategy.engine.lobby.server.RemoteHostUtils;
-import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
@@ -97,12 +97,12 @@ public class InGameLobbyWatcher {
     System.clearProperty(LOBBY_HOST);
     System.clearProperty(LOBBY_PORT);
     System.clearProperty(LOBBY_GAME_HOSTED_BY);
-    final IConnectionLogin login = challengeProperties -> {
-      final Map<String, String> properties = new HashMap<>();
-      properties.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-      properties.put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
-      properties.put(LobbyLoginValidator.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
-      return properties;
+    final IConnectionLogin login = challenge -> {
+      final Map<String, String> response = new HashMap<>();
+      response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+      response.put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+      response.put(LobbyLoginResponseKeys.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
+      return response;
     };
     try {
       final String mac = MacFinder.getHashedMacAddress();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -11,7 +11,8 @@ import javax.swing.JOptionPane;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.common.LobbyConstants;
-import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
+import games.strategy.engine.lobby.common.LobbyLoginChallengeKeys;
+import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.engine.lobby.server.login.RsaAuthenticator;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
@@ -81,15 +82,15 @@ public class LobbyLogin {
         challenge -> {
           final Map<String, String> response = new HashMap<>();
           if (anonymousLogin) {
-            response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+            response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
           } else {
-            final String salt = challenge.getOrDefault(LobbyLoginValidator.SALT_KEY, Md5Crypt.newSalt());
-            response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, hashPassword(password, salt));
+            final String salt = challenge.getOrDefault(LobbyLoginChallengeKeys.SALT, Md5Crypt.newSalt());
+            response.put(LobbyLoginResponseKeys.HASHED_PASSWORD, hashPassword(password, salt));
             if (RsaAuthenticator.canProcessChallenge(challenge)) {
               response.putAll(RsaAuthenticator.newResponse(challenge, password));
             }
           }
-          response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          response.put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
           return response;
         });
   }
@@ -164,15 +165,15 @@ public class LobbyLogin {
         MacFinder.getHashedMacAddress(),
         challenge -> {
           final Map<String, String> response = new HashMap<>();
-          response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
-          response.put(LobbyLoginValidator.EMAIL_KEY, email);
+          response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
+          response.put(LobbyLoginResponseKeys.EMAIL, email);
           // TODO: Don't send the md5-hashed password once the lobby removes the support, kept for
           // backwards-compatibility
-          response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, hashPassword(password, Md5Crypt.newSalt()));
+          response.put(LobbyLoginResponseKeys.HASHED_PASSWORD, hashPassword(password, Md5Crypt.newSalt()));
           if (RsaAuthenticator.canProcessChallenge(challenge)) {
             response.putAll(RsaAuthenticator.newResponse(challenge, password));
           }
-          response.put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          response.put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
           return response;
         });
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyLoginChallengeKeys.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyLoginChallengeKeys.java
@@ -1,0 +1,10 @@
+package games.strategy.engine.lobby.common;
+
+/**
+ * The property keys that may be present in a lobby authentication protocol challenge.
+ */
+public final class LobbyLoginChallengeKeys {
+  public static final String SALT = "SALT";
+
+  private LobbyLoginChallengeKeys() {}
+}

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyLoginResponseKeys.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyLoginResponseKeys.java
@@ -1,0 +1,15 @@
+package games.strategy.engine.lobby.common;
+
+/**
+ * The property keys that may be present in a lobby authentication protocol response.
+ */
+public final class LobbyLoginResponseKeys {
+  public static final String ANONYMOUS_LOGIN = "ANONYMOUS_LOGIN";
+  public static final String EMAIL = "EMAIL";
+  public static final String HASHED_PASSWORD = "HASHEDPWD";
+  public static final String LOBBY_VERSION = "LOBBY_VERSION";
+  public static final String LOBBY_WATCHER_LOGIN = "LOBBY_WATCHER_LOGIN";
+  public static final String REGISTER_NEW_USER = "REGISTER_USER";
+
+  private LobbyLoginResponseKeys() {}
+}

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -24,6 +24,7 @@ import org.triplea.test.common.Integration;
 
 import games.strategy.engine.config.lobby.TestLobbyPropertyReaders;
 import games.strategy.engine.lobby.common.LobbyConstants;
+import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.engine.lobby.server.db.BadWordController;
 import games.strategy.engine.lobby.server.db.Database;
 import games.strategy.engine.lobby.server.db.HashedPassword;
@@ -43,8 +44,8 @@ public class LobbyLoginValidatorIntegrationTest {
   public void testLegacyCreateNewUser() {
     final ChallengeResultFunction challengeFunction = generateChallenge(null);
     final Map<String, String> response = new HashMap<>();
-    response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
-    response.put(LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt("123"));
+    response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
+    response.put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt("123"));
     assertNull(challengeFunction.apply(challenge -> response));
     // try to create a duplicate user, should not work
     assertNotNull(challengeFunction.apply(challenge -> response));
@@ -64,8 +65,8 @@ public class LobbyLoginValidatorIntegrationTest {
     final Map<String, String> challenge = loginValidator.getChallengeProperties(name, address);
     return responseGetter -> {
       final Map<String, String> response = responseGetter.apply(challenge);
-      response.putIfAbsent(LobbyLoginValidator.EMAIL_KEY, email);
-      response.putIfAbsent(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+      response.putIfAbsent(LobbyLoginResponseKeys.EMAIL, email);
+      response.putIfAbsent(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
       return loginValidator.verifyConnection(challenge, response, name, mac, address);
     };
   }
@@ -85,7 +86,7 @@ public class LobbyLoginValidatorIntegrationTest {
     final String name = Util.createUniqueTimeStamp();
     final String password = "password";
     final Map<String, String> response = new HashMap<>();
-    response.put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
+    response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
     assertNull(generateChallenge(name, null).apply(challenge -> {
       response.putAll(RsaAuthenticator.newResponse(challenge, password));
       return response;
@@ -103,8 +104,8 @@ public class LobbyLoginValidatorIntegrationTest {
   public void testWrongVersion() {
     assertNotNull(generateChallenge(null).apply(challenge -> {
       final Map<String, String> response = new HashMap<>();
-      response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
-      response.put(LobbyLoginValidator.LOBBY_VERSION, "0.1");
+      response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+      response.put(LobbyLoginResponseKeys.LOBBY_VERSION, "0.1");
       return response;
     }));
   }
@@ -112,7 +113,7 @@ public class LobbyLoginValidatorIntegrationTest {
   @Test
   public void testAnonymousLogin() {
     final Map<String, String> response = new HashMap<>();
-    response.put(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+    response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
     assertNull(generateChallenge(null).apply(challenge -> response));
 
     // create a user, verify we can't login with a username that already exists
@@ -131,7 +132,7 @@ public class LobbyLoginValidatorIntegrationTest {
     }
     assertEquals(LobbyLoginValidator.ErrorMessages.THATS_NOT_A_NICE_NAME,
         generateChallenge(name, new HashedPassword(md5Crypt("foo"))).apply(challenge -> new HashMap<>(
-            Collections.singletonMap(LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString()))));
+            Collections.singletonMap(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString()))));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/LobbyLoginValidatorTest.java
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.config.MemoryPropertyReader;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.engine.lobby.common.LobbyConstants;
+import games.strategy.engine.lobby.common.LobbyLoginChallengeKeys;
+import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.engine.lobby.server.TestUserUtils;
 import games.strategy.engine.lobby.server.User;
 import games.strategy.engine.lobby.server.db.BadWordDao;
@@ -263,8 +265,8 @@ public final class LobbyLoginValidatorTest {
 
       private ResponseGenerator givenAuthenticationResponse() {
         return challenge -> ImmutableMap.of(
-            LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString(),
-            LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+            LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString(),
+            LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
       }
     }
 
@@ -286,10 +288,10 @@ public final class LobbyLoginValidatorTest {
 
         private ResponseGenerator givenAuthenticationResponse() {
           return challenge -> ImmutableMap.of(
-              LobbyLoginValidator.EMAIL_KEY, EMAIL,
-              LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD),
-              LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString(),
-              LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString());
+              LobbyLoginResponseKeys.EMAIL, EMAIL,
+              LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD),
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString(),
+              LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
         }
       }
 
@@ -309,10 +311,10 @@ public final class LobbyLoginValidatorTest {
 
         private ResponseGenerator givenAuthenticationResponse() {
           return challenge -> ImmutableMap.<String, String>builder()
-              .put(LobbyLoginValidator.EMAIL_KEY, EMAIL)
-              .put(LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD))
-              .put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
-              .put(LobbyLoginValidator.REGISTER_NEW_USER_KEY, Boolean.TRUE.toString())
+              .put(LobbyLoginResponseKeys.EMAIL, EMAIL)
+              .put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD))
+              .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
+              .put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString())
               .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
               .build();
         }
@@ -362,8 +364,8 @@ public final class LobbyLoginValidatorTest {
 
         private ResponseGenerator givenAuthenticationResponse() {
           return challenge -> ImmutableMap.of(
-              LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD),
-              LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+              LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD),
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
         }
       }
 
@@ -415,8 +417,8 @@ public final class LobbyLoginValidatorTest {
 
         private ResponseGenerator givenAuthenticationResponse() {
           return challenge -> ImmutableMap.<String, String>builder()
-              .put(LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD))
-              .put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
+              .put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD))
+              .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
               .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
               .build();
         }
@@ -442,13 +444,13 @@ public final class LobbyLoginValidatorTest {
         return challenge -> {
           thenChallengeShouldBeProcessableByMd5CryptAuthenticator(challenge);
           return ImmutableMap.of(
-              LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD),
-              LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+              LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD),
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
         };
       }
 
       private void thenChallengeShouldBeProcessableByMd5CryptAuthenticator(final Map<String, String> challenge) {
-        assertThat(challenge.containsKey(LobbyLoginValidator.SALT_KEY), is(true));
+        assertThat(challenge.containsKey(LobbyLoginChallengeKeys.SALT), is(true));
       }
     }
 
@@ -468,8 +470,8 @@ public final class LobbyLoginValidatorTest {
         return challenge -> {
           thenChallengeShouldBeProcessableByRsaAuthenticator(challenge);
           return ImmutableMap.<String, String>builder()
-              .put(LobbyLoginValidator.HASHED_PASSWORD_KEY, md5Crypt(PASSWORD))
-              .put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
+              .put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD))
+              .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
               .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
               .build();
         };
@@ -508,8 +510,8 @@ public final class LobbyLoginValidatorTest {
 
       private ResponseGenerator givenAuthenticationResponse() {
         return challenge -> ImmutableMap.of(
-            LobbyLoginValidator.ANONYMOUS_LOGIN, Boolean.TRUE.toString(),
-            LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+            LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString(),
+            LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
       }
     }
 
@@ -540,7 +542,7 @@ public final class LobbyLoginValidatorTest {
 
       private ResponseGenerator givenAuthenticationResponse() {
         return challenge -> ImmutableMap.<String, String>builder()
-            .put(LobbyLoginValidator.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
+            .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
             .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
             .build();
       }

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
@@ -13,8 +13,6 @@ import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.engine.lobby.common.LobbyLoginChallengeKeys;
-import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.security.TestSecurityUtils;
 
 public final class RsaAuthenticatorTest {
@@ -31,8 +29,8 @@ public final class RsaAuthenticatorTest {
     assertTrue(RsaAuthenticator.canProcessResponse(singletonMap(RsaAuthenticator.ENCRYPTED_PASSWORD_KEY, "")));
 
     // Adding a completely unrelated key shouldn't change the outcome
-    assertFalse(RsaAuthenticator.canProcessResponse(singletonMap(LobbyLoginResponseKeys.HASHED_PASSWORD, "")));
-    assertFalse(RsaAuthenticator.canProcessChallenge(singletonMap(LobbyLoginChallengeKeys.SALT, "")));
+    assertFalse(RsaAuthenticator.canProcessResponse(singletonMap("someOtherResponseKey", "")));
+    assertFalse(RsaAuthenticator.canProcessChallenge(singletonMap("someOtherChallengeKey", "")));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/login/RsaAuthenticatorTest.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.common.LobbyLoginChallengeKeys;
+import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.security.TestSecurityUtils;
 
 public final class RsaAuthenticatorTest {
@@ -29,8 +31,8 @@ public final class RsaAuthenticatorTest {
     assertTrue(RsaAuthenticator.canProcessResponse(singletonMap(RsaAuthenticator.ENCRYPTED_PASSWORD_KEY, "")));
 
     // Adding a completely unrelated key shouldn't change the outcome
-    assertFalse(RsaAuthenticator.canProcessResponse(singletonMap(LobbyLoginValidator.HASHED_PASSWORD_KEY, "")));
-    assertFalse(RsaAuthenticator.canProcessChallenge(singletonMap(LobbyLoginValidator.SALT_KEY, "")));
+    assertFalse(RsaAuthenticator.canProcessResponse(singletonMap(LobbyLoginResponseKeys.HASHED_PASSWORD, "")));
+    assertFalse(RsaAuthenticator.canProcessChallenge(singletonMap(LobbyLoginChallengeKeys.SALT, "")));
   }
 
   @Test


### PR DESCRIPTION
## Overview

Extracts common lobby login challenge/response property keys in `LobbyLoginValidator` to the new `LobbyLoginChallengeKeys` and `LobbyLoginResponseKeys` classes in the `g.s.engine.lobby.common` package.  This decoupling is a prerequisite to move `LobbyLoginValidator` to the `lobby` project.

## Functional Changes

None.

## Manual Testing Performed

Tested registered user logins (both successful and failed), anonymous user logins, and bot logins in the following scenarios:

* server (this branch), lobby client (this branch)
* server (this branch), lobby client (9687)
* server (this branch), headless game server (this branch)
* server (this branch), headless game server (9687)
* server (10663), lobby client (this branch)
* server (10663), headless game server (this branch)