### PR TITLE
Error Prone: Fix string splitter violations in PlayerID

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -120,19 +120,20 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   }
 
   /**
-   * First string is "Human" or "AI", while second string is the name of the player. Separated with a colon.
+   * First string is "Human" or "AI" or "null" (case insensitive), while second string is the name of the player;
+   * separated with a colon.
    */
-  public void setWhoAmI(final String encodedPlayerTypeAndName) {
+  public void setWhoAmI(final String encodedTypeAndName) {
     // so for example, it should be "AI:Hard (AI)"
-    final String[] s = encodedPlayerTypeAndName.split(":");
+    final String[] s = encodedTypeAndName.split(":");
     if (s.length != 2) {
       throw new IllegalStateException(String.format("whoAmI '%s' must have two strings, separated by a colon",
-          encodedPlayerTypeAndName));
+          encodedTypeAndName));
     }
     if (!(s[0].equalsIgnoreCase("AI") || s[0].equalsIgnoreCase("Human") || s[0].equalsIgnoreCase("null"))) {
       throw new IllegalStateException("whoAmI first part must be, ai or human or client");
     }
-    m_whoAmI = encodedPlayerTypeAndName;
+    m_whoAmI = encodedTypeAndName;
   }
 
   public String getWhoAmI() {

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -125,19 +127,19 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   }
 
   /**
-   * First string is "Human" or "AI" or "null" (case insensitive), while second string is the name of the player;
+   * First string is "Human" or "AI" or "null" (case insensitive), while second string is the name of the player,
    * separated with a colon. For example, it could be {@code "AI:Hard (AI)"}.
+   *
+   * @throws IllegalArgumentException If {@code encodedType} does not contain two strings separated by a colon; or if
+   *         the first string is not one of {@code "AI"}, {@code "Human"}, or {@code "null"} (case insensitive).
    */
   public void setWhoAmI(final String encodedType) {
     final List<String> tokens = tokenizeEncodedType(encodedType);
-    if (tokens.size() != 2) {
-      throw new IllegalStateException(String.format("whoAmI '%s' must have two strings, separated by a colon",
-          encodedType));
-    }
+    checkArgument(tokens.size() == 2, "whoAmI '" + encodedType + "' must have two strings, separated by a colon");
     final String typeId = tokens.get(0);
-    if (!("AI".equalsIgnoreCase(typeId) || "Human".equalsIgnoreCase(typeId) || "null".equalsIgnoreCase(typeId))) {
-      throw new IllegalStateException("whoAmI first part must be, ai or human or null");
-    }
+    checkArgument(
+        "AI".equalsIgnoreCase(typeId) || "Human".equalsIgnoreCase(typeId) || "null".equalsIgnoreCase(typeId),
+        "whoAmI '" + encodedType + "' first part must be, ai or human or null");
     m_whoAmI = encodedType;
   }
 
@@ -151,7 +153,6 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
 
   public Type getPlayerType() {
     final List<String> tokens = tokenizeEncodedType(m_whoAmI);
-    assert tokens.size() == 2;
     return new Type(tokens.get(0), tokens.get(1));
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -128,10 +128,10 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
 
   /**
    * First string is "Human" or "AI" or "null" (case insensitive), while second string is the name of the player,
-   * separated with a colon. For example, it could be {@code "AI:Hard (AI)"}.
+   * separated with a colon. For example, it could be "AI:Hard (AI)".
    *
    * @throws IllegalArgumentException If {@code encodedType} does not contain two strings separated by a colon; or if
-   *         the first string is not one of {@code "AI"}, {@code "Human"}, or {@code "null"} (case insensitive).
+   *         the first string is not one of "AI", "Human", or "null" (case insensitive).
    */
   public void setWhoAmI(final String encodedType) {
     final List<String> tokens = tokenizeEncodedType(encodedType);
@@ -227,13 +227,13 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   @EqualsAndHashCode
   public static final class Type {
     /**
-     * The type identifier. One of {@code "AI"}, {@code "Human"}, or {@code "null"}. Case is not guaranteed, so
-     * comparisons should be case-insensitive.
+     * The type identifier. One of "AI", "Human", or "null". Case is not guaranteed, so comparisons should be
+     * case-insensitive.
      */
     public final String id;
 
     /**
-     * The display name of the type (e.g. {@code "Hard (AI)"}).
+     * The display name of the type (e.g. "Hard (AI)").
      */
     public final String name;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -22,7 +22,7 @@ public class PlayersPanel {
     for (final String player : game.getPlayerManager().getPlayers()) {
       final PlayerID playerId = game.getData().getPlayerList().getPlayerId(player);
       if (playerId.isAi()) {
-        panel.add(new JLabel(playerId.getWhoAmI().split(":")[1] + " is " + playerId.getName(), JLabel.RIGHT));
+        panel.add(new JLabel(playerId.getPlayerType().name + " is " + playerId.getName(), JLabel.RIGHT));
       } else {
         panel.add(
             new JLabel(game.getPlayerManager().getNode(player).getName() + " is " + playerId.getName(), JLabel.RIGHT));

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -80,13 +80,13 @@ final class PlayerIdTest {
     }
 
     private void assertThrowsDoesNotHaveExactlyTwoTokensException(final Executable executable) {
-      final Exception e = assertThrows(IllegalStateException.class, executable);
+      final Exception e = assertThrows(IllegalArgumentException.class, executable);
       assertThat(e.getMessage(), containsString("two strings"));
     }
 
     @Test
     void shouldThrowExceptionWhenTypeIdIsIllegal() {
-      final Exception e = assertThrows(IllegalStateException.class, () -> playerId.setWhoAmI("otherTypeId:Patton"));
+      final Exception e = assertThrows(IllegalArgumentException.class, () -> playerId.setWhoAmI("otherTypeId:Patton"));
       assertThat(e.getMessage(), containsString("ai or human or null"));
     }
   }

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -11,8 +11,25 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import games.strategy.util.Tuple;
+
 final class PlayerIdTest {
   private final PlayerID playerId = new PlayerID("name", new GameData());
+
+  @Nested
+  final class GetTypeAndNameTest {
+    @Test
+    void shouldReturnTypeAndName() {
+      Arrays.asList(
+          Tuple.of("AI", "Hard (AI)"),
+          Tuple.of("Human", "Patton"),
+          Tuple.of("null", "Bot")).forEach(typeAndName -> {
+            playerId.setWhoAmI(typeAndName.getFirst() + ":" + typeAndName.getSecond());
+
+            assertThat(playerId.getTypeAndName(), is(typeAndName));
+          });
+    }
+  }
 
   @Nested
   final class IsAiTest {
@@ -70,7 +87,7 @@ final class PlayerIdTest {
     @Test
     void shouldThrowExceptionWhenTypeIsIllegal() {
       final Exception e = assertThrows(IllegalStateException.class, () -> playerId.setWhoAmI("otherType:Patton"));
-      assertThat(e.getMessage(), containsString("ai or human or client"));
+      assertThat(e.getMessage(), containsString("ai or human or null"));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -17,16 +17,16 @@ final class PlayerIdTest {
   private final PlayerID playerId = new PlayerID("name", new GameData());
 
   @Nested
-  final class GetTypeAndNameTest {
+  final class GetPlayerTypeTest {
     @Test
-    void shouldReturnTypeAndName() {
+    void shouldReturnType() {
       Arrays.asList(
           Tuple.of("AI", "Hard (AI)"),
           Tuple.of("Human", "Patton"),
-          Tuple.of("null", "Bot")).forEach(typeAndName -> {
-            playerId.setWhoAmI(typeAndName.getFirst() + ":" + typeAndName.getSecond());
+          Tuple.of("null", "Bot")).forEach(idAndName -> {
+            playerId.setWhoAmI(idAndName.getFirst() + ":" + idAndName.getSecond());
 
-            assertThat(playerId.getTypeAndName(), is(typeAndName));
+            assertThat(playerId.getPlayerType(), is(new PlayerID.Type(idAndName.getFirst(), idAndName.getSecond())));
           });
     }
   }
@@ -37,8 +37,8 @@ final class PlayerIdTest {
     void shouldReturnTrueWhenTypeIsAi() {
       Arrays.asList(
           "AI:Hard (AI)",
-          "ai:hard (ai)").forEach(encodedTypeAndName -> {
-            playerId.setWhoAmI(encodedTypeAndName);
+          "ai:hard (ai)").forEach(encodedType -> {
+            playerId.setWhoAmI(encodedType);
 
             assertThat(playerId.isAi(), is(true));
           });
@@ -48,8 +48,8 @@ final class PlayerIdTest {
     void shouldReturnFalseWhenTypeIsNotAi() {
       Arrays.asList(
           "Human:Patton",
-          "null:Bot").forEach(encodedTypeAndName -> {
-            playerId.setWhoAmI(encodedTypeAndName);
+          "null:Bot").forEach(encodedType -> {
+            playerId.setWhoAmI(encodedType);
 
             assertThat(playerId.isAi(), is(false));
           });
@@ -59,22 +59,22 @@ final class PlayerIdTest {
   @Nested
   final class SetWhoAmITest {
     @Test
-    void shouldSetWhoAmIWhenEncodedValueIsLegal() {
+    void shouldSetWhoAmIWhenEncodedTypeIsLegal() {
       Arrays.asList(
           "AI:Hard (AI)",
           "ai:Hard (AI)",
           "Human:Patton",
           "huMAN:Patton",
           "null:Bot",
-          "NulL:Bot").forEach(encodedTypeAndName -> {
-            playerId.setWhoAmI(encodedTypeAndName);
+          "NulL:Bot").forEach(encodedType -> {
+            playerId.setWhoAmI(encodedType);
 
-            assertThat(playerId.getWhoAmI(), is(encodedTypeAndName));
+            assertThat(playerId.getWhoAmI(), is(encodedType));
           });
     }
 
     @Test
-    void shouldThrowExceptionWhenEncodedValueDoesNotContainExactlyTwoTokens() {
+    void shouldThrowExceptionWhenEncodedTypeDoesNotContainExactlyTwoTokens() {
       assertThrowsDoesNotHaveExactlyTwoTokensException(() -> playerId.setWhoAmI("Patton"));
       assertThrowsDoesNotHaveExactlyTwoTokensException(() -> playerId.setWhoAmI("Human:Patton:Third"));
     }
@@ -85,8 +85,8 @@ final class PlayerIdTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenTypeIsIllegal() {
-      final Exception e = assertThrows(IllegalStateException.class, () -> playerId.setWhoAmI("otherType:Patton"));
+    void shouldThrowExceptionWhenTypeIdIsIllegal() {
+      final Exception e = assertThrows(IllegalStateException.class, () -> playerId.setWhoAmI("otherTypeId:Patton"));
       assertThat(e.getMessage(), containsString("ai or human or null"));
     }
   }

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import games.strategy.util.Tuple;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 final class PlayerIdTest {
   private final PlayerID playerId = new PlayerID("name", new GameData());
@@ -88,6 +89,14 @@ final class PlayerIdTest {
     void shouldThrowExceptionWhenTypeIdIsIllegal() {
       final Exception e = assertThrows(IllegalArgumentException.class, () -> playerId.setWhoAmI("otherTypeId:Patton"));
       assertThat(e.getMessage(), containsString("ai or human or null"));
+    }
+  }
+
+  @Nested
+  final class TypeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(PlayerID.Type.class).verify();
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -1,0 +1,76 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+final class PlayerIdTest {
+  private final PlayerID playerId = new PlayerID("name", new GameData());
+
+  @Nested
+  final class IsAiTest {
+    @Test
+    void shouldReturnTrueWhenTypeIsAi() {
+      Arrays.asList(
+          "AI:Hard (AI)",
+          "ai:hard (ai)").forEach(encodedTypeAndName -> {
+            playerId.setWhoAmI(encodedTypeAndName);
+
+            assertThat(playerId.isAi(), is(true));
+          });
+    }
+
+    @Test
+    void shouldReturnFalseWhenTypeIsNotAi() {
+      Arrays.asList(
+          "Human:Patton",
+          "null:Bot").forEach(encodedTypeAndName -> {
+            playerId.setWhoAmI(encodedTypeAndName);
+
+            assertThat(playerId.isAi(), is(false));
+          });
+    }
+  }
+
+  @Nested
+  final class SetWhoAmITest {
+    @Test
+    void shouldSetWhoAmIWhenEncodedValueIsLegal() {
+      Arrays.asList(
+          "AI:Hard (AI)",
+          "ai:Hard (AI)",
+          "Human:Patton",
+          "huMAN:Patton",
+          "null:Bot",
+          "NulL:Bot").forEach(encodedTypeAndName -> {
+            playerId.setWhoAmI(encodedTypeAndName);
+
+            assertThat(playerId.getWhoAmI(), is(encodedTypeAndName));
+          });
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEncodedValueDoesNotContainExactlyTwoTokens() {
+      assertThrowsDoesNotHaveExactlyTwoTokensException(() -> playerId.setWhoAmI("Patton"));
+      assertThrowsDoesNotHaveExactlyTwoTokensException(() -> playerId.setWhoAmI("Human:Patton:Third"));
+    }
+
+    private void assertThrowsDoesNotHaveExactlyTwoTokensException(final Executable executable) {
+      final Exception e = assertThrows(IllegalStateException.class, executable);
+      assertThat(e.getMessage(), containsString("two strings"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTypeIsIllegal() {
+      final Exception e = assertThrows(IllegalStateException.class, () -> playerId.setWhoAmI("otherType:Patton"));
+      assertThat(e.getMessage(), containsString("ai or human or client"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in `PlayerID` and one violation outside `PlayerID` that is dependent on the `PlayerID` method that is the focus of this change.

## Functional Changes

* Changed `PlayerID#setWhoAmI()` to throw `IllegalArgumentException` instead of `IllegalStateException` when receiving an invalid argument.  I didn't see any upstream code that depended on this method throwing a specific type of exception.

## Manual Testing Performed

* None for core change, but characterization tests were added for the affected `PlayerID` methods before making any changes.  The `setWhoAmI()`, `isAi()`, and `getPlayerType()` methods now have 100% line and branch coverage.
* Verified the **Network > Show Who is Who** command still displays the same information (when AI players are present) before and after this change.