### PR TITLE
Decouple LobbyLoginValidator from InGameLobbyWatcher

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -27,7 +27,6 @@ import games.strategy.engine.lobby.common.ILobbyGameController;
 import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
 import games.strategy.engine.lobby.server.GameDescription;
-import games.strategy.engine.lobby.server.GameDescription.GameStatus;
 import games.strategy.engine.lobby.server.RemoteHostUtils;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.RemoteMessenger;
@@ -164,9 +163,9 @@ public class InGameLobbyWatcher {
     final int playerCount = (oldWatcher == null || oldWatcher.gameDescription == null)
         ? (HeadlessGameServer.headless() ? 0 : 1)
         : oldWatcher.gameDescription.getPlayerCount();
-    final GameStatus gameStatus =
+    final GameDescription.GameStatus gameStatus =
         (oldWatcher == null || oldWatcher.gameDescription == null || oldWatcher.gameDescription.getStatus() == null)
-            ? GameStatus.WAITING_FOR_PLAYERS
+            ? GameDescription.GameStatus.WAITING_FOR_PLAYERS
             : oldWatcher.gameDescription.getStatus();
     final String gameRound =
         (oldWatcher == null || oldWatcher.gameDescription == null || oldWatcher.gameDescription.getRound() == null)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -55,7 +55,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class InGameLobbyWatcher {
-  public static final String LOBBY_WATCHER_NAME = "lobby_watcher";
   // this is the messenger used by the game
   // it is different than the messenger we use to connect to
   // the game lobby
@@ -107,7 +106,7 @@ public class InGameLobbyWatcher {
     try {
       final String mac = MacFinder.getHashedMacAddress();
       final ClientMessenger messenger = new ClientMessenger(host, Integer.parseInt(port),
-          getRealName(hostedBy) + "_" + LOBBY_WATCHER_NAME, mac, login);
+          getRealName(hostedBy) + "_" + LobbyConstants.LOBBY_WATCHER_NAME, mac, login);
       final UnifiedMessenger um = new UnifiedMessenger(messenger);
       final RemoteMessenger rm = new RemoteMessenger(um);
       final RemoteHostUtils rhu = new RemoteHostUtils(messenger.getServerNode(), gameMessenger);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -23,7 +23,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
 import games.strategy.engine.framework.startup.ui.ServerOptions;
 import games.strategy.engine.lobby.common.IModeratorController;
 import games.strategy.engine.lobby.common.LobbyConstants;
@@ -331,8 +330,8 @@ class LobbyGamePanel extends JPanel {
     final GameDescription description = gameTableModel.get(gameTable.convertRowIndexToModel(selectedIndex));
     final String hostedByName = description.getHostedBy().getName();
     return new Node(
-        (hostedByName.endsWith("_" + InGameLobbyWatcher.LOBBY_WATCHER_NAME) ? hostedByName
-            : hostedByName + "_" + InGameLobbyWatcher.LOBBY_WATCHER_NAME),
+        (hostedByName.endsWith("_" + LobbyConstants.LOBBY_WATCHER_NAME) ? hostedByName
+            : hostedByName + "_" + LobbyConstants.LOBBY_WATCHER_NAME),
         description.getHostedBy().getAddress(), description.getHostedBy().getPort());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
@@ -10,6 +10,7 @@ public final class LobbyConstants {
   public static final String ADMIN_USERNAME = "Admin";
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
+  public static final String LOBBY_WATCHER_NAME = "lobby_watcher";
   public static final RemoteName MODERATOR_CONTROLLER_REMOTE_NAME =
       new RemoteName("games.strategy.engine.lobby.server.ModeratorController:Global", IModeratorController.class);
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -16,7 +16,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
-import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
 import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.lobby.common.LobbyLoginChallengeKeys;
 import games.strategy.engine.lobby.common.LobbyLoginResponseKeys;
@@ -287,10 +286,10 @@ public final class LobbyLoginValidator implements ILoginValidator {
     }
     // If this is a lobby watcher, use a different set of validation
     if (Boolean.TRUE.toString().equals(response.get(LobbyLoginResponseKeys.LOBBY_WATCHER_LOGIN))) {
-      if (!username.endsWith(InGameLobbyWatcher.LOBBY_WATCHER_NAME)) {
+      if (!username.endsWith(LobbyConstants.LOBBY_WATCHER_NAME)) {
         return "Lobby watcher usernames must end with 'lobby_watcher'";
       }
-      final String hostName = username.substring(0, username.indexOf(InGameLobbyWatcher.LOBBY_WATCHER_NAME));
+      final String hostName = username.substring(0, username.indexOf(LobbyConstants.LOBBY_WATCHER_NAME));
 
       if (!DBUser.isValidUserName(hostName)) {
         return DBUser.getUserNameValidationErrorMessage(hostName);

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
+import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.util.Util;
 
 /*
@@ -23,7 +23,7 @@ public final class DBUser implements Serializable {
 
 
   @VisibleForTesting
-  static final Collection<String> forbiddenNameParts = Arrays.asList(InGameLobbyWatcher.LOBBY_WATCHER_NAME, "admin");
+  static final Collection<String> forbiddenNameParts = Arrays.asList(LobbyConstants.LOBBY_WATCHER_NAME, "admin");
 
   public enum Role {
     NOT_ADMIN, ADMIN
@@ -41,8 +41,8 @@ public final class DBUser implements Serializable {
       if (userName == null || !userName.matches("[0-9a-zA-Z_-]+") || userName.length() <= 2) {
         return "Names must be at least 3 characters long and can only contain alpha numeric characters, -, and _";
       }
-      if (userName.toLowerCase().contains(InGameLobbyWatcher.LOBBY_WATCHER_NAME.toLowerCase())) {
-        return InGameLobbyWatcher.LOBBY_WATCHER_NAME + " cannot be part of a name";
+      if (userName.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())) {
+        return LobbyConstants.LOBBY_WATCHER_NAME + " cannot be part of a name";
       }
       if (userName.toLowerCase().contains("admin")) {
         return "Name can't contain the word admin";

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -1,11 +1,7 @@
 package games.strategy.engine.lobby.server.userDB;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Objects;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.util.Util;
@@ -20,10 +16,6 @@ public final class DBUser implements Serializable {
   private final String m_name;
   private final String m_email;
   private final Role userRole;
-
-
-  @VisibleForTesting
-  static final Collection<String> forbiddenNameParts = Arrays.asList(LobbyConstants.LOBBY_WATCHER_NAME, "admin");
 
   public enum Role {
     NOT_ADMIN, ADMIN
@@ -44,8 +36,8 @@ public final class DBUser implements Serializable {
       if (userName.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())) {
         return LobbyConstants.LOBBY_WATCHER_NAME + " cannot be part of a name";
       }
-      if (userName.toLowerCase().contains("admin")) {
-        return "Name can't contain the word admin";
+      if (userName.toLowerCase().contains(LobbyConstants.ADMIN_USERNAME.toLowerCase())) {
+        return "Name can't contain the word " + LobbyConstants.ADMIN_USERNAME;
       }
       return null;
     }

--- a/game-core/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.lobby.common.LobbyConstants;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class DbUserTest {
@@ -81,7 +82,6 @@ public class DbUserTest {
         new DBUser(
             new DBUser.UserName(""),
             new DBUser.UserEmail(TestData.email)));
-
   }
 
   @Test
@@ -104,8 +104,9 @@ public class DbUserTest {
               DBUser.getUserNameValidationErrorMessage(invalidName), not(emptyString()));
         });
 
-    DBUser.forbiddenNameParts.forEach(
-        invalidNamePart -> {
+    Arrays.asList(
+        LobbyConstants.LOBBY_WATCHER_NAME,
+        LobbyConstants.ADMIN_USERNAME).forEach(invalidNamePart -> {
           assertThat("user names cannot contain anything from the forbidden name list",
               DBUser.isValidUserName(invalidNamePart), is(false));
           assertThat("verify we are doing a contains match to make sure "


### PR DESCRIPTION
## Overview

Decouples `LobbyLoginValidator` from `InGameLobbyWatcher` by moving the lobby watcher username suffix to `LobbyConstants`.

## Functional Changes

None.

## Refactoring Changes

* Removed an unnecessary nested import.
* Inlined the `DBUser#forbiddenNameList` field into its only dependent unit test.  No production code used this field.
* Replaced hard-coded `"admin"` username string in `DBUser` with appropriate constant from `LobbyConstants`.

## Manual Testing Performed

Verified lobby watcher starts successfully when connecting a headless game server to the lobby.
