### PR TITLE
Checkstyle: Fix missing Javadoc violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
@@ -4,6 +4,9 @@ import java.awt.Image;
 
 import games.strategy.triplea.ui.UiContext;
 
+/**
+ * Draws a base map tile.
+ */
 public class BaseMapDrawable extends MapTileDrawable {
   public BaseMapDrawable(final int x, final int y, final UiContext uiContext) {
     super(x, y, uiContext);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -16,6 +16,10 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws a black outline around the associated territory and draws diagonal stripes over the territory interior if a
+ * battle is pending within the territory.
+ */
 public class BattleDrawable extends TerritoryDrawable implements IDrawable {
   private final String territoryName;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
@@ -9,6 +9,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws the blockade image for the associated territory.
+ */
 public class BlockadeZoneDrawable implements IDrawable {
   private final String location;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -12,6 +12,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws the capitol marker (large flag) image for the associated territory.
+ */
 public class CapitolMarkerDrawable implements IDrawable {
   private final String player;
   private final String location;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -12,7 +12,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
-// Rewritten class to use country markers rather than shading for Convoy Centers/Routes.
+/**
+ * Draws the convoy flag image for the associated territory.
+ */
 public class ConvoyZoneDrawable implements IDrawable {
   private final String player;
   private final String location;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
@@ -9,6 +9,9 @@ import java.awt.geom.AffineTransform;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws a custom image at a given point on the map.
+ */
 public class DecoratorDrawable implements IDrawable {
   private final Point point;
   private final Image image;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
@@ -10,6 +10,10 @@ import java.util.Optional;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * A service responsible for drawing a single layer of the map. The map is rendered as a sequence of layers (or
+ * levels). The lowest layer is drawn first with each successive layer drawn on top of it.
+ */
 public interface IDrawable {
   int BASE_MAP_LEVEL = 1;
   int POLYGONS_LEVEL = 2;
@@ -50,5 +54,3 @@ public interface IDrawable {
     image.ifPresent(image1 -> graphics.drawImage(image1, location.x - bounds.x, location.y - bounds.y, null));
   }
 }
-
-

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -14,7 +14,10 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
-// Class to use 'Faded' country markers for Kamikaze Zones.
+/**
+ * Draws the faded flag image of the original owner for the associated territory. Intended only for use with kamikaze
+ * zones.
+ */
 public class KamikazeZoneDrawable implements IDrawable {
   private final String location;
   private final UiContext uiContext;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -10,6 +10,11 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws a black outline around the associated territory and draws a solid color over the territory interior. The
+ * color is based on the territory owner and whether or not the territory is impassable. Intended only for use with land
+ * territories.
+ */
 public class LandTerritoryDrawable extends TerritoryDrawable implements IDrawable {
   private final String territoryName;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -11,6 +11,9 @@ import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TileManager;
 
+/**
+ * Superclass for {@link IDrawable} implementations that draws a single rectangular map tile.
+ */
 public abstract class MapTileDrawable implements IDrawable {
   protected boolean noImage = false;
   protected final int x;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
@@ -12,6 +12,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 
+/**
+ * Draws a black outline around the associated territory.
+ */
 public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
   private final String territoryName;
   private final OptionalExtraBorderLevel level;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
@@ -5,6 +5,9 @@ import java.awt.Image;
 import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.ui.UiContext;
 
+/**
+ * Draws a relief map tile.
+ */
 public class ReliefMapDrawable extends MapTileDrawable {
   public ReliefMapDrawable(final int x, final int y, final UiContext uiContext) {
     super(x, y, uiContext);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
@@ -12,6 +12,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 
+/**
+ * Draws a black outline around the associated territory. Intended only for use with water territories (sea zones).
+ */
 public class SeaZoneOutlineDrawable implements IDrawable {
   private final String territoryName;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
@@ -11,6 +11,10 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.Util;
 
+/**
+ * Superclass for {@link IDrawable} implementations that draws a black outline around a territory and uses an instance
+ * of {@link Paint} provided by the subclass to fill the territory interior.
+ */
 public abstract class TerritoryDrawable {
   protected static void draw(final Rectangle bounds, final Graphics2D graphics, final MapData mapData,
       final Territory territory, final Paint territoryPaint) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
@@ -9,6 +9,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws a territory effect image at a given point on the map.
+ */
 public class TerritoryEffectDrawable implements IDrawable {
   private final TerritoryEffect effect;
   private final Point point;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -19,6 +19,9 @@ import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws the name, comments, and production value for the associated territory.
+ */
 public class TerritoryNameDrawable implements IDrawable {
   private final String territoryName;
   private final UiContext uiContext;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
@@ -9,6 +9,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
+/**
+ * Draws the victory city image for the associated territory.
+ */
 public class VcDrawable implements IDrawable {
   private final Territory location;
 


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocMethod and JavadocType rules by adding missing Javadocs.  Changes to the proposed Javadocs are welcome.

## Functional Changes

None.  **This PR only contains Javadoc changes; there are no code changes.**

## Manual Testing Performed

None.