### PR TITLE
Error Prone: Fix string splitter violations in attachments

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -5,6 +5,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
 import games.strategy.engine.data.annotations.InternalDoNotExport;
 import games.strategy.triplea.Constants;
 
@@ -23,6 +26,8 @@ import games.strategy.triplea.Constants;
  */
 public abstract class DefaultAttachment extends GameDataComponent implements IAttachment {
   private static final long serialVersionUID = -1985116207387301730L;
+  private static final Splitter COLON_SPLITTER = Splitter.on(':');
+
   @InternalDoNotExport
   private Attachable m_attachedTo;
   @InternalDoNotExport
@@ -80,6 +85,12 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
       return false;
     }
     throw new IllegalArgumentException("Attachments: " + value + " is not a valid boolean");
+  }
+
+  protected static String[] splitOnColon(final String value) {
+    checkNotNull(value);
+
+    return Iterables.toArray(COLON_SPLITTER.split(value), String.class);
   }
 
   protected String thisErrorMsg() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -61,7 +61,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       m_conditions = new ArrayList<>();
     }
     final Collection<PlayerID> playerIDs = getData().getPlayerList().getPlayers();
-    for (final String subString : conditions.split(":")) {
+    for (final String subString : splitOnColon(conditions)) {
       m_conditions.add(playerIDs.stream()
           .map(p -> p.getAttachment(subString))
           .map(RulesAttachment.class::cast)
@@ -234,7 +234,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   protected void setChance(final String chance) throws GameParseException {
-    final String[] s = chance.split(":");
+    final String[] s = splitOnColon(chance);
     try {
       final int i = getInt(s[0]);
       final int j = getInt(s[1]);
@@ -262,11 +262,11 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   public int getChanceToHit() {
-    return getInt(getChance().split(":")[0]);
+    return getInt(splitOnColon(getChance())[0]);
   }
 
   public int getChanceDiceSides() {
-    return getInt(getChance().split(":")[1]);
+    return getInt(splitOnColon(getChance())[1]);
   }
 
   private void setChanceIncrementOnFailure(final int value) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -129,7 +129,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       m_movementRestrictionTerritories = null;
       return;
     }
-    m_movementRestrictionTerritories = value.split(":");
+    m_movementRestrictionTerritories = splitOnColon(value);
     validateNames(m_movementRestrictionTerritories);
   }
 
@@ -165,7 +165,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   private void setProductionPerXTerritories(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
           "productionPerXTerritories cannot be empty or have more than two fields" + thisErrorMsg());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -63,7 +63,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
 
   private void setPlayers(final String names) throws GameParseException {
     final PlayerList pl = getData().getPlayerList();
-    for (final String p : names.split(":")) {
+    for (final String p : splitOnColon(names)) {
       final PlayerID player = pl.getPlayerId(p);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + p + thisErrorMsg());
@@ -203,7 +203,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       return;
     }
     m_turns = new HashMap<>();
-    final String[] s = rounds.split(":");
+    final String[] s = splitOnColon(rounds);
     if (s.length < 1) {
       throw new GameParseException("Empty turn list" + thisErrorMsg());
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -117,7 +117,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   private void setWhen(final String when) throws GameParseException {
-    final String[] s = when.split(":");
+    final String[] s = splitOnColon(when);
     if (s.length != 2) {
       throw new GameParseException("when must exist in 2 parts: \"before/after:stepName\"." + thisErrorMsg());
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -99,7 +99,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private void setCostResources(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
           "costResources cannot be empty or have more than two fields: " + value + thisErrorMsg());
@@ -134,7 +134,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private void setActionAccept(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -84,7 +84,7 @@ public class CanalAttachment extends DefaultAttachment {
       return;
     }
     final HashSet<Territory> terrs = new HashSet<>();
-    for (final String name : landTerritories.split(":")) {
+    for (final String name : splitOnColon(landTerritories)) {
       final Territory territory = getData().getMap().getTerritory(name);
       if (territory == null) {
         throw new IllegalStateException("Canals: No territory called: " + name + thisErrorMsg());
@@ -121,7 +121,7 @@ public class CanalAttachment extends DefaultAttachment {
       m_excludedUnits.addAll(getData().getUnitTypeList().getAllUnitTypes());
       return;
     }
-    for (final String name : value.split(":")) {
+    for (final String name : splitOnColon(value)) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(name);
       if (ut == null) {
         throw new IllegalStateException("Canals: No UnitType called: " + name + thisErrorMsg());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -82,7 +82,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setPlacementLimit(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 3) {
       throw new GameParseException("placementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
@@ -121,7 +121,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setMovementLimit(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 3) {
       throw new GameParseException("movementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
@@ -160,7 +160,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setAttackingLimit(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 3) {
       throw new GameParseException("attackingLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
@@ -256,7 +256,7 @@ public class PlayerAttachment extends DefaultAttachment {
     if (m_suicideAttackTargets == null) {
       m_suicideAttackTargets = new HashSet<>();
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
@@ -279,7 +279,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setSuicideAttackResources(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("suicideAttackResources must have exactly 2 fields" + thisErrorMsg());
     }
@@ -363,7 +363,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setGiveUnitControl(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -387,7 +387,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -411,7 +411,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setShareTechnology(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -435,7 +435,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setHelpPayTechCost(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -74,7 +74,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   private void setRelationshipChange(final String relChange) throws GameParseException {
-    final String[] s = relChange.split(":");
+    final String[] s = splitOnColon(relChange);
     if (s.length != 3) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:newRelation\n" + thisErrorMsg());
@@ -112,7 +112,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   public Set<PlayerID> getOtherPlayers() {
     final Set<PlayerID> otherPlayers = new LinkedHashSet<>();
     for (final String relationshipChange : m_relationshipChange) {
-      final String[] s = relationshipChange.split(":");
+      final String[] s = splitOnColon(relationshipChange);
       otherPlayers.add(getData().getPlayerList().getPlayerId(s[0]));
       otherPlayers.add(getData().getPlayerList().getPlayerId(s[1]));
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -197,7 +197,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     if (integerCost.equals(PROPERTY_DEFAULT)) {
       m_upkeepCost = PROPERTY_DEFAULT;
     } else {
-      final String[] s = integerCost.split(":");
+      final String[] s = splitOnColon(integerCost);
       if (s.length < 1 || s.length > 2) {
         throw new GameParseException("upkeepCost must have either 1 or 2 fields" + thisErrorMsg());
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -155,7 +155,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_destroyedTUV = null;
       return;
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("destroyedTUV must have 2 fields, value=currentRound/allRounds, count= the amount "
           + "of TUV that this player must destroy" + thisErrorMsg());
@@ -180,7 +180,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   private void setBattle(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 5) {
       throw new GameParseException(
           "battle must have at least 5 fields, attacker:defender:resultType:round:territory1..." + thisErrorMsg());
@@ -235,7 +235,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    * @param value should be a string containing: "player:player:relationship"
    */
   private void setRelationship(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 3 || s.length > 4) {
       throw new GameParseException(
           "relationship should have value=\"playername1:playername2:relationshiptype:numberOfRoundsExisting\""
@@ -280,7 +280,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_alliedOwnershipTerritories = null;
       return;
     }
-    m_alliedOwnershipTerritories = value.split(":");
+    m_alliedOwnershipTerritories = splitOnColon(value);
     validateNames(m_alliedOwnershipTerritories);
   }
 
@@ -302,7 +302,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_alliedExclusionTerritories = null;
       return;
     }
-    m_alliedExclusionTerritories = value.split(":");
+    m_alliedExclusionTerritories = splitOnColon(value);
     validateNames(m_alliedExclusionTerritories);
   }
 
@@ -323,7 +323,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_directExclusionTerritories = null;
       return;
     }
-    m_directExclusionTerritories = value.split(":");
+    m_directExclusionTerritories = splitOnColon(value);
     validateNames(m_directExclusionTerritories);
   }
 
@@ -345,7 +345,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_enemyExclusionTerritories = null;
       return;
     }
-    m_enemyExclusionTerritories = value.split(":");
+    m_enemyExclusionTerritories = splitOnColon(value);
     validateNames(m_enemyExclusionTerritories);
   }
 
@@ -366,7 +366,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_directPresenceTerritories = null;
       return;
     }
-    m_directPresenceTerritories = value.split(":");
+    m_directPresenceTerritories = splitOnColon(value);
     validateNames(m_directPresenceTerritories);
   }
 
@@ -387,7 +387,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_alliedPresenceTerritories = null;
       return;
     }
-    m_alliedPresenceTerritories = value.split(":");
+    m_alliedPresenceTerritories = splitOnColon(value);
     validateNames(m_alliedPresenceTerritories);
   }
 
@@ -408,7 +408,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_enemyPresenceTerritories = null;
       return;
     }
-    m_enemyPresenceTerritories = value.split(":");
+    m_enemyPresenceTerritories = splitOnColon(value);
     validateNames(m_enemyPresenceTerritories);
   }
 
@@ -430,7 +430,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_enemySurfaceExclusionTerritories = null;
       return;
     }
-    m_enemySurfaceExclusionTerritories = value.split(":");
+    m_enemySurfaceExclusionTerritories = splitOnColon(value);
     validateNames(m_enemySurfaceExclusionTerritories);
   }
 
@@ -451,7 +451,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_directOwnershipTerritories = null;
       return;
     }
-    m_directOwnershipTerritories = value.split(":");
+    m_directOwnershipTerritories = splitOnColon(value);
     validateNames(m_directOwnershipTerritories);
   }
 
@@ -468,7 +468,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   private void setUnitPresence(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 1) {
       throw new GameParseException("unitPresence must have at least 2 fields. Format value=unit1 count=number, or "
           + "value=unit1:unit2:unit3 count=number" + thisErrorMsg());
@@ -513,7 +513,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_atWarPlayers = null;
       return;
     }
-    final String[] s = players.split(":");
+    final String[] s = splitOnColon(players);
     if (s.length < 1) {
       throw new GameParseException("Empty enemy list" + thisErrorMsg());
     }
@@ -554,7 +554,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_techs = null;
       return;
     }
-    final String[] s = newTechs.split(":");
+    final String[] s = splitOnColon(newTechs);
     if (s.length < 1) {
       throw new GameParseException("Empty tech list" + thisErrorMsg());
     }
@@ -763,7 +763,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     }
     // check for battle stats
     if (objectiveMet && m_destroyedTUV != null) {
-      final String[] s = m_destroyedTUV.split(":");
+      final String[] s = splitOnColon(m_destroyedTUV);
       final int requiredDestroyedTuv = getInt(s[0]);
       if (requiredDestroyedTuv >= 0) {
         final boolean justCurrentRound = s[1].equals("currentRound");
@@ -782,7 +782,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       final BattleRecordsList brl = data.getBattleRecordsList();
       final int round = data.getSequence().getRound();
       for (final Tuple<String, List<Territory>> entry : m_battle) {
-        final String[] type = entry.getFirst().split(":");
+        final String[] type = splitOnColon(entry.getFirst());
         // they could be "any", and if they are "any" then this would be null, which is good!
         final PlayerID attacker = data.getPlayerList().getPlayerId(type[0]);
         final PlayerID defender = data.getPlayerList().getPlayerId(type[1]);
@@ -845,7 +845,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    */
   private boolean checkRelationships() {
     for (final String encodedRelationCheck : m_relationship) {
-      final String[] relationCheck = encodedRelationCheck.split(":");
+      final String[] relationCheck = splitOnColon(encodedRelationCheck);
       final PlayerID p1 = getData().getPlayerList().getPlayerId(relationCheck[0]);
       final PlayerID p2 = getData().getPlayerList().getPlayerId(relationCheck[1]);
       final int relationshipsExistance = Integer.parseInt(relationCheck[3]);
@@ -915,7 +915,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             if (uc == null || uc.equals("ANY") || uc.equals("any")) {
               hasEnough = allUnits.size() >= unitsNeeded;
             } else {
-              final Set<UnitType> typesAllowed = data.getUnitTypeList().getUnitTypes(uc.split(":"));
+              final Set<UnitType> typesAllowed = data.getUnitTypeList().getUnitTypes(splitOnColon(uc));
               hasEnough =
                   CollectionUtils.getMatches(allUnits, Matches.unitIsOfTypes(typesAllowed)).size() >= unitsNeeded;
             }
@@ -990,7 +990,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           if (uc == null || uc.equals("ANY") || uc.equals("any")) {
             hasLess = allUnits.size() <= unitsMax;
           } else {
-            final Set<UnitType> typesAllowed = data.getUnitTypeList().getUnitTypes(uc.split(":"));
+            final Set<UnitType> typesAllowed = data.getUnitTypeList().getUnitTypes(splitOnColon(uc));
             hasLess = CollectionUtils.getMatches(allUnits, Matches.unitIsOfTypes(typesAllowed)).size() <= unitsMax;
           }
           if (!hasLess) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -115,7 +115,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   @VisibleForTesting
   String[] splitAndValidate(final String name, final String value) throws GameParseException {
-    final String[] stringArray = value.split(":");
+    final String[] stringArray = splitOnColon(value);
     if (value.isEmpty() || stringArray.length > 2) {
       throw new GameParseException(
           String.format("%s cannot be empty or have more than two fields %s", name, thisErrorMsg()));
@@ -408,7 +408,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setRocketDiceNumber(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("rocketDiceNumber must have two fields" + thisErrorMsg());
     }
@@ -480,7 +480,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setUnitAbilitiesGained(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 2) {
       throw new GameParseException(
           "unitAbilitiesGained must list the unit type, then all abilities gained" + thisErrorMsg());
@@ -579,7 +579,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setAirborneTypes(final String value) throws GameParseException {
-    for (final String unit : value.split(":")) {
+    for (final String unit : splitOnColon(value)) {
       m_airborneTypes.add(getUnitType(unit));
     }
   }
@@ -630,7 +630,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setAirborneBases(final String value) throws GameParseException {
-    for (final String u : value.split(":")) {
+    for (final String u : splitOnColon(value)) {
       m_airborneBases.add(getUnitType(u));
     }
   }
@@ -657,7 +657,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setAirborneTargettedByAa(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 2) {
       throw new GameParseException("airborneTargettedByAA must have at least two fields" + thisErrorMsg());
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -233,7 +233,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (m_resources == null) {
       m_resources = new ResourceCollection(getData());
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     final int amount = getInt(s[0]);
     if (s[1].equals(Constants.PUS)) {
       throw new GameParseException("Please set PUs using production, not resource" + thisErrorMsg());
@@ -406,7 +406,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setChangeUnitOwners(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -432,7 +432,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -456,7 +456,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setWhenCapturedByGoesTo(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException(
           "whenCapturedByGoesTo must have 2 player names separated by a colon" + thisErrorMsg());
@@ -483,7 +483,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setTerritoryEffect(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String name : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(name);
       if (effect != null) {
@@ -510,7 +510,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (value.length() <= 0) {
       return;
     }
-    for (final String subString : value.split(":")) {
+    for (final String subString : splitOnColon(value)) {
       final Territory territory = getData().getMap().getTerritory(subString);
       if (territory == null) {
         throw new GameParseException("No territory called:" + subString + thisErrorMsg());
@@ -689,7 +689,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       sb.append("Captured By -> Ownership Goes To");
       sb.append(br);
       for (final String value : m_whenCapturedByGoesTo) {
-        final String[] s = value.split(":");
+        final String[] s = splitOnColon(value);
         sb.append(s[0]).append(" -> ").append(s[1]);
         sb.append(br);
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -81,7 +81,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
 
   @InternalDoNotExport
   private void setCombatEffect(final String combatEffect, final boolean defending) throws GameParseException {
-    final String[] s = combatEffect.split(":");
+    final String[] s = splitOnColon(combatEffect);
     if (s.length < 2) {
       throw new GameParseException(
           "combatDefenseEffect and combatOffenseEffect must have a count and at least one unitType" + thisErrorMsg());
@@ -107,7 +107,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   private void setNoBlitz(final String noBlitzUnitTypes) throws GameParseException {
-    final String[] s = noBlitzUnitTypes.split(":");
+    final String[] s = splitOnColon(noBlitzUnitTypes);
     if (s.length < 1) {
       throw new GameParseException("noBlitz must have at least one unitType" + thisErrorMsg());
     }
@@ -133,7 +133,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   private void setUnitsNotAllowed(final String unitsNotAllowedUnitTypes) throws GameParseException {
-    final String[] s = unitsNotAllowedUnitTypes.split(":");
+    final String[] s = splitOnColon(unitsNotAllowedUnitTypes);
     if (s.length < 1) {
       throw new GameParseException("unitsNotAllowed must have at least one unitType" + thisErrorMsg());
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -283,7 +283,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   private void setActivateTrigger(final String value) throws GameParseException {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 6) {
       throw new GameParseException(
           "activateTrigger must have 6 parts: triggerName:numberOfTimes:useUses:testUses:testConditions:testChance"
@@ -362,7 +362,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_productionRule = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (s.length != 2) {
       throw new GameParseException("Invalid productionRule declaration: " + prop + thisErrorMsg());
     }
@@ -427,7 +427,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTech(final String techs) throws GameParseException {
-    for (final String subString : techs.split(":")) {
+    for (final String subString : splitOnColon(techs)) {
       TechAdvance ta = getData().getTechnologyFrontier().getAdvanceByProperty(subString);
       if (ta == null) {
         ta = getData().getTechnologyFrontier().getAdvanceByName(subString);
@@ -456,7 +456,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_availableTech = null;
       return;
     }
-    final String[] s = techs.split(":");
+    final String[] s = splitOnColon(techs);
     if (s.length < 2) {
       throw new GameParseException(
           "Invalid tech availability: " + techs + " should be category:techs" + thisErrorMsg());
@@ -504,7 +504,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_support = null;
       return;
     }
-    final String[] s = sup.split(":");
+    final String[] s = splitOnColon(sup);
     for (int i = 0; i < s.length; i++) {
       boolean add = true;
       if (s[i].startsWith("-")) {
@@ -561,7 +561,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setRelationshipChange(final String relChange) throws GameParseException {
-    final String[] s = relChange.split(":");
+    final String[] s = splitOnColon(relChange);
     if (s.length != 4) {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:oldRelation:newRelation\n" + thisErrorMsg());
@@ -601,7 +601,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setUnitType(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
@@ -628,7 +628,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_unitAttachmentName = null;
       return;
     }
-    final String[] s = name.split(":");
+    final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
           "unitAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
@@ -672,7 +672,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_unitProperty = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (m_unitProperty == null) {
       m_unitProperty = new ArrayList<>();
     }
@@ -694,7 +694,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritories(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final Territory terr = getData().getMap().getTerritory(element);
       if (terr == null) {
@@ -721,7 +721,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_territoryAttachmentName = null;
       return;
     }
-    final String[] s = name.split(":");
+    final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
           "territoryAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
@@ -765,7 +765,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_territoryProperty = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (m_territoryProperty == null) {
       m_territoryProperty = new ArrayList<>();
     }
@@ -787,7 +787,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setPlayers(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerId(element);
       if (player == null) {
@@ -814,7 +814,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_playerAttachmentName = null;
       return;
     }
-    final String[] s = name.split(":");
+    final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
           "playerAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
@@ -874,7 +874,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_playerProperty = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (m_playerProperty == null) {
       m_playerProperty = new ArrayList<>();
     }
@@ -896,7 +896,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setRelationshipTypes(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final RelationshipType relation = getData().getRelationshipTypeList().getRelationshipType(element);
       if (relation == null) {
@@ -923,7 +923,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_relationshipTypeAttachmentName = null;
       return;
     }
-    final String[] s = name.split(":");
+    final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
           "relationshipTypeAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
@@ -965,7 +965,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_relationshipTypeProperty = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (m_relationshipTypeProperty == null) {
       m_relationshipTypeProperty = new ArrayList<>();
     }
@@ -988,7 +988,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private void setTerritoryEffects(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(element);
       if (effect == null) {
@@ -1015,7 +1015,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_territoryEffectAttachmentName = null;
       return;
     }
-    final String[] s = name.split(":");
+    final String[] s = splitOnColon(name);
     if (s.length != 2) {
       throw new GameParseException(
           "territoryEffectAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
@@ -1057,7 +1057,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_territoryEffectProperty = null;
       return;
     }
-    final String[] s = prop.split(":");
+    final String[] s = splitOnColon(prop);
     if (m_territoryEffectProperty == null) {
       m_territoryEffectProperty = new ArrayList<>();
     }
@@ -1087,7 +1087,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_placement = null;
       return;
     }
-    final String[] s = place.split(":");
+    final String[] s = splitOnColon(place);
     if (s.length < 1) {
       throw new GameParseException("Empty placement list" + thisErrorMsg());
     }
@@ -1145,7 +1145,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_removeUnits == null) {
       m_removeUnits = new HashMap<>();
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 1) {
       throw new GameParseException("Empty removeUnits list" + thisErrorMsg());
     }
@@ -1214,7 +1214,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       m_purchase = null;
       return;
     }
-    final String[] s = place.split(":");
+    final String[] s = splitOnColon(place);
     if (s.length < 1) {
       throw new GameParseException("Empty purchase list" + thisErrorMsg());
     }
@@ -1257,7 +1257,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   private void setChangeOwnership(final String value) throws GameParseException {
     // territory:oldOwner:newOwner:booleanConquered
     // can have "all" for territory and "any" for oldOwner
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 4) {
       throw new GameParseException(
           "changeOwnership must have 4 fields: territory:oldOwner:newOwner:booleanConquered" + thisErrorMsg());
@@ -1799,7 +1799,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         t.use(bridge);
       }
       for (final String relationshipChange : t.getRelationshipChange()) {
-        final String[] s = relationshipChange.split(":");
+        final String[] s = splitOnColon(relationshipChange);
         final PlayerID player1 = data.getPlayerList().getPlayerId(s[0]);
         final PlayerID player2 = data.getPlayerList().getPlayerId(s[1]);
         final RelationshipType currentRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
@@ -1954,7 +1954,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         triggerAttachment.use(bridge);
       }
       triggerAttachment.getProductionRule().stream()
-          .map(s -> s.split(":"))
+          .map(s -> splitOnColon(s))
           .forEach(array -> {
             final ProductionFrontier front = data.getProductionFrontierList().getProductionFrontier(array[0]);
             final String rule = array[1];
@@ -2058,7 +2058,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         t.use(bridge);
       }
       for (final String value : t.getChangeOwnership()) {
-        final String[] s = value.split(":");
+        final String[] s = splitOnColon(value);
         final Collection<Territory> territories = new ArrayList<>();
         if (s[0].equalsIgnoreCase("all")) {
           territories.addAll(data.getMap().getTerritories());
@@ -2284,7 +2284,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         }
         final HashSet<TriggerAttachment> toFireSet = new HashSet<>();
         toFireSet.add(toFire);
-        final String[] options = tuple.getSecond().split(":");
+        final String[] options = splitOnColon(tuple.getSecond());
         final int numberOfTimesToFire = getInt(options[0]);
         final boolean useUsesToFire = getBool(options[1]);
         final boolean testUsesToFire = getBool(options[2]);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -357,7 +357,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setCanBeGivenByTerritoryTo(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -383,7 +383,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setCanBeCapturedOnEnteringBy(final String value) throws GameParseException {
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -407,7 +407,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setWhenHitPointsDamagedChangesInto(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 3) {
       throw new GameParseException(
           "setWhenHitPointsDamagedChangesInto must have damage:translateAttributes:unitType " + thisErrorMsg());
@@ -438,7 +438,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setWhenHitPointsRepairedChangesInto(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 3) {
       throw new GameParseException(
           "setWhenHitPointsRepairedChangesInto must have damage:translateAttributes:unitType " + thisErrorMsg());
@@ -470,7 +470,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   @VisibleForTesting
   void setWhenCapturedChangesInto(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length < 5 || s.length % 2 == 0) {
       throw new GameParseException("whenCapturedChangesInto must have 5 or more values, "
           + "playerFrom:playerTo:keepAttributes:unitType:howMany "
@@ -528,7 +528,7 @@ public class UnitAttachment extends DefaultAttachment {
       byOrFrom = "FROM";
       value = value.replaceFirst("FROM:", "");
     }
-    final String[] temp = value.split(":");
+    final String[] temp = splitOnColon(value);
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
@@ -773,7 +773,7 @@ public class UnitAttachment extends DefaultAttachment {
       m_unitPlacementRestrictions = null;
       return;
     }
-    m_unitPlacementRestrictions = value.split(":");
+    m_unitPlacementRestrictions = splitOnColon(value);
   }
 
   private void setUnitPlacementRestrictions(final String[] value) {
@@ -791,7 +791,7 @@ public class UnitAttachment extends DefaultAttachment {
   // no m_ variable for this, since it is the inverse of m_unitPlacementRestrictions
   // we might as well just use m_unitPlacementRestrictions
   private void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
-    final Collection<Territory> allowedTerritories = getListedTerritories(value.split(":"));
+    final Collection<Territory> allowedTerritories = getListedTerritories(splitOnColon(value));
     final Collection<Territory> restrictedTerritories = new HashSet<>(getData().getMap().getTerritories());
     restrictedTerritories.removeAll(allowedTerritories);
     m_unitPlacementRestrictions = restrictedTerritories.stream()
@@ -800,7 +800,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setRepairsUnits(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0) {
       throw new GameParseException("repairsUnits cannot be empty" + thisErrorMsg());
     }
@@ -834,7 +834,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setSpecial(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String option : s) {
       if (!(option.equals("none") || option.equals("canOnlyPlaceInOriginalTerritories"))) {
         throw new GameParseException("special does not allow: " + option + thisErrorMsg());
@@ -860,7 +860,7 @@ public class UnitAttachment extends DefaultAttachment {
       m_canInvadeOnlyFrom = null;
       return;
     }
-    final String[] canOnlyInvadeFrom = value.split(":");
+    final String[] canOnlyInvadeFrom = splitOnColon(value);
     if (canOnlyInvadeFrom[0].toLowerCase().equals("none")) {
       m_canInvadeOnlyFrom = new String[] {"none"};
       return;
@@ -893,7 +893,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setRequiresUnits(final String value) {
-    m_requiresUnits.add(value.split(":"));
+    m_requiresUnits.add(splitOnColon(value));
   }
 
   private void setRequiresUnits(final List<String[]> value) {
@@ -909,7 +909,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setRequiresUnitsToMove(final String value) throws GameParseException {
-    final String[] array = value.split(":");
+    final String[] array = splitOnColon(value);
     if (array.length == 0) {
       throw new GameParseException("requiresUnitsToMove must have at least 1 unit type" + thisErrorMsg());
     }
@@ -935,7 +935,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setWhenCombatDamaged(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (!(s.length == 3 || s.length == 4)) {
       throw new GameParseException(
           "whenCombatDamaged must have 3 or 4 parts: value=effect:optionalNumber, count=integer:integer"
@@ -993,7 +993,7 @@ public class UnitAttachment extends DefaultAttachment {
     for (final UnitType ut : canReceive) {
       final Collection<String> receives = UnitAttachment.get(ut).getReceivesAbilityWhenWith();
       for (final String receive : receives) {
-        final String[] s = receive.split(":");
+        final String[] s = splitOnColon(receive);
         if (filterForAbility != null && !filterForAbility.equals(s[0])) {
           continue;
         }
@@ -1650,7 +1650,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setGivesMovement(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
     }
@@ -1678,7 +1678,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setConsumesUnits(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("consumesUnits must have two fields" + thisErrorMsg());
     }
@@ -1708,7 +1708,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setCreatesUnitsList(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException("createsUnitsList cannot be empty or have more than two fields" + thisErrorMsg());
     }
@@ -1738,7 +1738,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setCreatesResourcesList(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length <= 0 || s.length > 2) {
       throw new GameParseException(
           "createsResourcesList cannot be empty or have more than two fields" + thisErrorMsg());
@@ -1766,7 +1766,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setFuelCost(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("fuelCost must have two fields" + thisErrorMsg());
     }
@@ -1796,7 +1796,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setFuelFlatCost(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("fuelFlatCost must have two fields" + thisErrorMsg());
     }
@@ -1869,7 +1869,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (m_bombingTargets == null) {
       m_bombingTargets = new HashSet<>();
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
@@ -2179,7 +2179,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (m_targetsAA == null) {
       m_targetsAA = new HashSet<>();
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
@@ -2211,7 +2211,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setWillNotFireIfPresent(final String value) throws GameParseException {
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
@@ -2275,7 +2275,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (ut == null) {
       throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("movementLimit must have 2 fields, value and count" + thisErrorMsg());
     }
@@ -2310,7 +2310,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (ut == null) {
       throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("attackingLimit must have 2 fields, value and count" + thisErrorMsg());
     }
@@ -2345,7 +2345,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (ut == null) {
       throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
     }
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException("placementLimit must have 2 fields, value and count" + thisErrorMsg());
     }
@@ -2522,7 +2522,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (!m_receivesAbilityWhenWith.isEmpty()) {
       for (final String value : m_receivesAbilityWhenWith) {
         // first is ability, second is unit that we get it from
-        final String[] s = value.split(":");
+        final String[] s = splitOnColon(value);
         if (s.length != 2) {
           throw new GameParseException("receivesAbilityWhenWith must have 2 parts, 'ability:unit'" + thisErrorMsg());
         }
@@ -2860,8 +2860,8 @@ public class UnitAttachment extends DefaultAttachment {
     if (!getReceivesAbilityWhenWith().isEmpty()) {
       if (getReceivesAbilityWhenWith().size() <= 2) {
         for (final String ability : getReceivesAbilityWhenWith()) {
-          tuples
-              .add(Tuple.of("Receives Ability", ability.split(":")[0] + " when Paired with " + ability.split(":")[1]));
+          final String[] s = splitOnColon(ability);
+          tuples.add(Tuple.of("Receives Ability", s[0] + " when Paired with " + s[1]));
         }
       } else {
         tuples.add(Tuple.of("Receives Abilities when Paired with Other Units", ""));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -85,7 +85,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
       return;
     }
     m_unitType = new HashSet<>();
-    for (final String element : names.split(":")) {
+    for (final String element : splitOnColon(names)) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
         throw new GameParseException("Could not find unitType. name:" + element + thisErrorMsg());
@@ -110,7 +110,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_allied = false;
     m_enemy = false;
-    for (final String element : faction.split(":")) {
+    for (final String element : splitOnColon(faction)) {
       if (element.equalsIgnoreCase("allied")) {
         m_allied = true;
       } else if (element.equalsIgnoreCase("enemy")) {
@@ -137,7 +137,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_defence = false;
     m_offence = false;
-    for (final String element : side.split(":")) {
+    for (final String element : splitOnColon(side)) {
       if (element.equalsIgnoreCase("defence")) {
         m_defence = true;
       } else if (element.equalsIgnoreCase("offence")) {
@@ -166,7 +166,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
     m_roll = false;
     m_strength = false;
-    for (final String element : dice.split(":")) {
+    for (final String element : splitOnColon(dice)) {
       if (element.equalsIgnoreCase("roll")) {
         m_roll = true;
       } else if (element.equalsIgnoreCase("strength")) {
@@ -221,7 +221,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   private void setPlayers(final String names) throws GameParseException {
-    final String[] s = names.split(":");
+    final String[] s = splitOnColon(names);
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerId(element);
       if (player == null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -53,7 +53,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
 
   private void setActivateTrigger(final String value) throws GameParseException {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
-    final String[] s = value.split(":");
+    final String[] s = splitOnColon(value);
     if (s.length != 6) {
       throw new GameParseException(
           "activateTrigger must have 6 parts: triggerName:numberOfTimes:useUses:testUses:testConditions:testChance"
@@ -119,7 +119,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
       }
       final HashSet<TriggerAttachment> toFireSet = new HashSet<>();
       toFireSet.add(toFire);
-      final String[] options = tuple.getSecond().split(":");
+      final String[] options = splitOnColon(tuple.getSecond());
       final int numberOfTimesToFire = getInt(options[0]);
       final boolean useUsesToFire = getBool(options[1]);
       final boolean testUsesToFire = getBool(options[2]);


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in attachment classes.  This was done by extracting a method to the common superclass `DefaultAttachment` to be used by all attachments for splitting a string on a colon, and then updating all applicable call sites to use this new method.  Finally, I converted the method implementation from `String#split()` to use Guava's `Splitter`.

To minimize the chance of regressions, I preserved the result of the split operation as a `String[]` rather than use a `List<String>`, as typically returned by `Splitter`.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested a few maps (WW2v3, TWW, WAW, and Big World) to ensure there were no errors while parsing.

## Additional Review Notes

Please view with whitespace changes ignored to avoid indentation noise in `DefaultAttachmentTest`.