### PR TITLE
Prepare DBUser for move to common package

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -8,9 +8,8 @@ import games.strategy.util.Util;
 
 // TODO: move this class to lobby.common upon next incompatible release; it is shared between client and server
 
-/*
- * Note, the DBUser data type is passed between lobby and client.
- * TODO: annotate this class and others to identify them. Longer term drop the reflection.
+/**
+ * A lobby user.
  */
 public final class DBUser implements Serializable {
   private static final long serialVersionUID = -5289923058375302916L;
@@ -19,11 +18,14 @@ public final class DBUser implements Serializable {
   private final String m_email;
   private final Role userRole;
 
+  /**
+   * The user's role within the lobby.
+   */
   public enum Role {
     NOT_ADMIN, ADMIN
   }
 
-  /** Value object with validation methods. */
+  /** User name value object with validation methods. */
   public static class UserName {
     public final String userName;
 
@@ -45,8 +47,9 @@ public final class DBUser implements Serializable {
     }
   }
 
-
-
+  /**
+   * User email value object with validation methods.
+   */
   public static class UserEmail {
     public final String userEmail;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -1,16 +1,19 @@
 package games.strategy.engine.lobby.server.userDB;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.util.Util;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 // TODO: move this class to lobby.common upon next incompatible release; it is shared between client and server
 
 /**
  * A lobby user.
  */
+@EqualsAndHashCode
+@ToString
 public final class DBUser implements Serializable {
   private static final long serialVersionUID = -5289923058375302916L;
 
@@ -130,31 +133,5 @@ public final class DBUser implements Serializable {
    */
   public static String getUserNameValidationErrorMessage(final String userName) {
     return new UserName(userName).validate();
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (obj == this) {
-      return true;
-    } else if (!(obj instanceof DBUser)) {
-      return false;
-    }
-
-    final DBUser other = (DBUser) obj;
-    return Objects.equals(m_email, other.m_email)
-        && Objects.equals(m_name, other.m_name)
-        && (userRole == other.userRole);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(m_email, m_name, userRole);
-  }
-
-  @Override
-  public String toString() {
-    return "name: " + m_name
-        + ", email: " + m_email
-        + ", role: " + userRole;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.util.Util;
 
+// TODO: move this class to lobby.common upon next incompatible release; it is shared between client and server
+
 /*
  * Note, the DBUser data type is passed between lobby and client.
  * TODO: annotate this class and others to identify them. Longer term drop the reflection.

--- a/game-core/src/test/java/games/strategy/engine/lobby/common/DbUserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/common/DbUserTest.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.lobby.server.userDB;
+package games.strategy.engine.lobby.common;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -10,7 +10,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.engine.lobby.common.LobbyConstants;
+import games.strategy.engine.lobby.server.userDB.DBUser;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class DbUserTest {


### PR DESCRIPTION
## Overview

The `DBUser` class is used by both lobby client and server code and should be located in the `g.s.engine.lobby.common` package, but it cannot be moved at this time due to network compatibility. I added a TODO to indicate it should be moved upon the next incompatible release. However, I did move the unit tests to clearly signal this intent.

## Functional Changes

None.

## Refactoring Changes

* Added missing Javadocs.
* Use Lombok to generate the `equals()`, `hashCode()`, and `toString()` methods.

## Manual Testing Performed

None.