### PR TITLE
Remove unused @Builder support

### DIFF
--- a/game-core/src/main/java/swinglib/JPanelBuilder.java
+++ b/game-core/src/main/java/swinglib/JPanelBuilder.java
@@ -34,9 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import games.strategy.triplea.ResourceLoader;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.extern.java.Log;
 import swinglib.GridBagHelper.Anchor;
 import swinglib.GridBagHelper.ColumnSpan;
@@ -479,8 +477,6 @@ public class JPanelBuilder {
   /**
    * Struct-like class for the various properties and styles that can be applied to a panel.
    */
-  @Builder
-  @AllArgsConstructor(access = AccessLevel.PRIVATE)
   private static final class PanelProperties {
     BorderLayoutPosition borderLayoutPosition = BorderLayoutPosition.DEFAULT;
     GridBagHelper.ColumnSpan columnSpan = GridBagHelper.ColumnSpan.of(1);


### PR DESCRIPTION
## Overview

Lombok was issuing the following warning on each field of the `JPanelBuilder$PanelProperties` class:

> `@Builder` will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add `@Builder.Default`. If it is not supposed to be settable during building, make the field final.

It turns out the generated builder for this class isn't even used, so I simply removed the Lombok annotations completely.

## Functional Changes

None.

## Manual Testing Performed

None.