### PR TITLE
Replace printStackTrace() with appropriate substitute

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -78,8 +78,7 @@ public class RemoteRandom implements IRemoteRandom {
     try {
       remoteNumbers = CryptoRandomSource.bytesToInts(vault.get(remoteVaultId));
     } catch (final NotUnlockedException e1) {
-      e1.printStackTrace();
-      throw new IllegalStateException("Could not unlock numbers, cheating suspected");
+      throw new IllegalStateException("Could not unlock numbers, cheating suspected", e1);
     }
     final int[] verifiedNumbers = CryptoRandomSource.mix(remoteNumbers, localNumbers, max);
     addVerifiedRandomNumber(new VerifiedRandomNumbers(annotation, verifiedNumbers));

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -257,8 +257,7 @@ public class Vault {
       try {
         decrypted = cipher.doFinal(encrypted);
       } catch (final Exception e1) {
-        e1.printStackTrace();
-        throw new IllegalStateException(e1.getMessage());
+        throw new IllegalStateException("Failed to decrypt vault values", e1);
       }
       if (decrypted.length < KNOWN_VAL.length) {
         throw new IllegalStateException("decrypted is not long enough to have known value, cheating is suspected");

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -181,7 +181,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> im
       final IEditDelegate editDelegate = (IEditDelegate) getPlayerBridge().getRemotePersistentDelegate("edit");
       editDelegate.setEditMode(editMode);
     } catch (final Exception exception) {
-      exception.printStackTrace();
+      log.log(Level.SEVERE, "Failed to set edit mode to " + editMode, exception);
       // toggle back to previous state since setEditMode failed
       ui.getEditModeButtonModel().setSelected(!ui.getEditModeButtonModel().isSelected());
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -48,11 +48,13 @@ import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.Interruptibles;
+import lombok.extern.java.Log;
 import swinglib.JPanelBuilder;
 
 /**
  * UI for fighting battles.
  */
+@Log
 public class BattlePanel extends ActionPanel {
   private static final long serialVersionUID = 5304208569738042592L;
   private final JLabel actionLabel = new JLabel();
@@ -181,10 +183,7 @@ public class BattlePanel extends ActionPanel {
       Interruptibles.sleep(count);
       // something is wrong, we shouldnt have to wait this long
       if (count > 200) {
-
-        new IllegalStateException(
-            "battle not displayed, looking for:" + battleId + " showing:" + currentBattleDisplayed)
-                .printStackTrace();
+        log.severe("battle not displayed, looking for:" + battleId + " showing:" + currentBattleDisplayed);
         return false;
       }
       displayed = currentBattleDisplayed;

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -91,7 +91,7 @@ class BattleStepsPanel extends JPanel implements Active {
       }
       // we cant find it, something is wrong
       if (!targetStep.equals(LAST_STEP) && listModel.lastIndexOf(targetStep) == -1) {
-        new IllegalStateException("Step not found:" + targetStep + " in:" + listModel).printStackTrace();
+        log.severe("Step not found:" + targetStep + " in:" + listModel);
         clearTargetStep();
         return true;
       }


### PR DESCRIPTION
## Overview

Replaces calls to `Throwable#printStackTrace()` with an appropriate substitute based on the context (e.g. logging the exception, including it as the cause of another exception, etc.).

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

I didn't replace the following call to `printStackTrace(PrintWriter)` because it seems legitimate (it includes the stack trace in the message displayed to the user when an error occurs communicating with a dice server):

https://github.com/triplea-game/triplea/blob/0ddbc20a735db16656786b849fb5649cb0f8be1d/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java#L255-L258