### PR TITLE
Remove IHistoryDetailsPanel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.ui.SimpleUnitPanel;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 
-public class HistoryDetailsPanel extends JPanel implements IHistoryDetailsPanel {
+public class HistoryDetailsPanel extends JPanel {
   private static final long serialVersionUID = 5092004144144006960L;
   private final GameData data;
   private final JTextArea title = new JTextArea();
@@ -44,9 +44,8 @@ public class HistoryDetailsPanel extends JPanel implements IHistoryDetailsPanel 
     this.mapPanel = mapPanel;
   }
 
-  @Override
   @SuppressWarnings("unchecked")
-  public void render(final HistoryNode node) {
+  void render(final HistoryNode node) {
     removeAll();
     mapPanel.setRoute(null);
     final Insets insets = new Insets(5, 0, 0, 0);

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -42,12 +42,11 @@ public class HistoryPanel extends JPanel {
   private static final long serialVersionUID = -8353246449552215276L;
   private final GameData data;
   private final JTree tree;
-  private final IHistoryDetailsPanel details;
+  private final HistoryDetailsPanel details;
   private HistoryNode currentPopupNode;
   private final JPopupMenu popup;
 
-  // private boolean m_lockBefore;
-  public HistoryPanel(final GameData data, final IHistoryDetailsPanel details, final JPopupMenu popup,
+  public HistoryPanel(final GameData data, final HistoryDetailsPanel details, final JPopupMenu popup,
       final UiContext uiContext) {
     mouseOverPanel = false;
     mouseWasOverPanel = false;

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/IHistoryDetailsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/IHistoryDetailsPanel.java
@@ -1,7 +1,0 @@
-package games.strategy.triplea.ui.history;
-
-import games.strategy.engine.history.HistoryNode;
-
-public interface IHistoryDetailsPanel {
-  void render(final HistoryNode node);
-}


### PR DESCRIPTION
## Overview

Noticed this while I was adding some missing Javadocs.  `IHistoryDetailsPanel` is an unnecessary abstraction because `TripleAFrame` (the owner of `HistoryPanel`)  uses the concrete `HistoryDetailsPanel` class directly.

## Functional Changes

None.

## Manual Testing Performed

Verified the history and history details panels are displayed correctly.