### PR TITLE
Error Prone: Fix string splitter violations in ClipPlayer

### DIFF
--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -24,6 +24,8 @@ import java.util.prefs.Preferences;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import com.google.common.base.Splitter;
+
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.io.FileUtils;
@@ -346,7 +348,7 @@ public class ClipPlayer {
       sounds.put(pathName, availableSounds);
       return availableSounds;
     }
-    for (final String path : resourcePath.split(";")) {
+    for (final String path : Splitter.on(';').split(resourcePath)) {
       availableSounds.addAll(findClipFiles(ASSETS_SOUNDS_FOLDER + "/" + path));
     }
     if (availableSounds.isEmpty()) {


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `ClipPlayer` class.  The replacement code was suggested by Error Prone.

## Functional Changes

None.

## Manual Testing Performed

Verified game start sound still played as expected in WW2 Classic.  (I couldn't find any maps that have a custom _sound.properties_ file to try to test a string that actually contains semi-colons.)