### PR TITLE
Use consistent naming for lobby common interface remote name constants

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -179,7 +179,7 @@ public class InGameLobbyWatcher {
         passworded,
         ClientContext.engineVersion().toString(), "0");
     final ILobbyGameController controller =
-        (ILobbyGameController) this.remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
+        (ILobbyGameController) this.remoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME);
     synchronized (mutex) {
       controller.postGame(gameId, (GameDescription) gameDescription.clone());
     }
@@ -266,7 +266,7 @@ public class InGameLobbyWatcher {
     }
     synchronized (mutex) {
       final ILobbyGameController controller =
-          (ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
+          (ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME);
       controller.updateGame(gameId, (GameDescription) gameDescription.clone());
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.client;
 
 import games.strategy.engine.lobby.common.IModeratorController;
-import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.net.IMessenger;
@@ -20,7 +19,7 @@ public class LobbyClient {
   public boolean isAdmin() {
     if (isAdmin == null) {
       final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-          .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+          .getRemote(IModeratorController.REMOTE_NAME);
       isAdmin = controller.isAdmin();
     }
     return isAdmin;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -109,7 +109,7 @@ public class LobbyFrame extends JFrame {
       return Collections.emptyList();
     }
     final IModeratorController controller = (IModeratorController) client.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final List<Action> actions = new ArrayList<>();
     actions.add(SwingAction.of("Boot " + clickedOn.getName(), e -> {
       if (!confirm("Boot " + clickedOn.getName())) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -105,7 +105,7 @@ class LobbyGamePanel extends JPanel {
 
   boolean isAdmin() {
     return ((IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME)).isAdmin();
+        .getRemote(IModeratorController.REMOTE_NAME)).isAdmin();
   }
 
   private void setupListeners() {
@@ -258,7 +258,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     controller.boot(lobbyWatcherNode);
     JOptionPane.showMessageDialog(null, "The game you selected has been disconnected from the lobby.");
   }
@@ -270,7 +270,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final String text = controller.getInformationOn(lobbyWatcherNode);
     final String connections = controller.getHostConnections(lobbyWatcherNode);
     final JTextPane textPane = new JTextPane();
@@ -293,7 +293,7 @@ class LobbyGamePanel extends JPanel {
     // we sort the table, so get the correct index
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();
@@ -365,7 +365,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();
@@ -405,7 +405,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();
@@ -457,7 +457,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();
@@ -492,7 +492,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();
@@ -525,7 +525,7 @@ class LobbyGamePanel extends JPanel {
     }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller = (IModeratorController) messengers.getRemoteMessenger()
-        .getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+        .getRemote(IModeratorController.REMOTE_NAME);
     final JLabel label = new JLabel("Enter Host Remote Access Password, (Leave blank for no password).");
     final JPasswordField passwordField = new JPasswordField();
     final JPanel panel = new JPanel();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -54,7 +54,7 @@ class LobbyGameTableModel extends AbstractTableModel {
       final IRemoteMessenger remoteMessenger) {
     this.messenger = messenger;
     this.admin = admin;
-    channelMessenger.registerChannelSubscriber(lobbyGameBroadcaster, ILobbyGameBroadcaster.GAME_BROADCASTER_CHANNEL);
+    channelMessenger.registerChannelSubscriber(lobbyGameBroadcaster, ILobbyGameBroadcaster.REMOTE_NAME);
 
     final Map<GUID, GameDescription> games =
         ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -57,7 +57,7 @@ class LobbyGameTableModel extends AbstractTableModel {
     channelMessenger.registerChannelSubscriber(lobbyGameBroadcaster, ILobbyGameBroadcaster.REMOTE_NAME);
 
     final Map<GUID, GameDescription> games =
-        ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();
+        ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME)).listGames();
     for (final GUID id : games.keySet()) {
       updateGame(id, games.get(id));
     }

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/ILobbyGameBroadcaster.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/ILobbyGameBroadcaster.java
@@ -9,7 +9,7 @@ import games.strategy.net.GUID;
  * A service that notifies nodes of lobby game state changes (e.g. when games are added to or removed from the lobby).
  */
 public interface ILobbyGameBroadcaster extends IChannelSubscribor {
-  RemoteName GAME_BROADCASTER_CHANNEL =
+  RemoteName REMOTE_NAME =
       new RemoteName("games.strategy.engine.lobby.server.IGameBroadcaster.CHANNEL", ILobbyGameBroadcaster.class);
 
   void gameUpdated(GUID gameId, GameDescription description);

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/ILobbyGameController.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/ILobbyGameController.java
@@ -11,8 +11,9 @@ import games.strategy.net.GUID;
  * A service that provides management operations for lobby games.
  */
 public interface ILobbyGameController extends IRemote {
-  RemoteName GAME_CONTROLLER_REMOTE = new RemoteName(
-      "games.strategy.engine.lobby.server.IGameController.GAME_CONTROLLER_REMOTE", ILobbyGameController.class);
+  RemoteName REMOTE_NAME = new RemoteName(
+      "games.strategy.engine.lobby.server.IGameController.GAME_CONTROLLER_REMOTE",
+      ILobbyGameController.class);
 
   void postGame(GUID gameId, GameDescription description);
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/IModeratorController.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/IModeratorController.java
@@ -5,12 +5,16 @@ import java.util.Date;
 import javax.annotation.Nullable;
 
 import games.strategy.engine.message.IRemote;
+import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 
 /**
  * A service that provides lobby management operations whose use is restricted to lobby moderators.
  */
 public interface IModeratorController extends IRemote {
+  RemoteName REMOTE_NAME =
+      new RemoteName("games.strategy.engine.lobby.server.ModeratorController:Global", IModeratorController.class);
+
   // TODO: The methods accepting a Date parameter can be converted to Instant after the next incompatible release.
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/IUserManager.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/IUserManager.java
@@ -9,8 +9,7 @@ import games.strategy.engine.message.RemoteName;
  * {@code userName} must match the name of the calling user).
  */
 public interface IUserManager extends IRemote {
-  RemoteName USER_MANAGER =
-      new RemoteName("games.strategy.engine.lobby.server.USER_MANAGER", IUserManager.class);
+  RemoteName REMOTE_NAME = new RemoteName("games.strategy.engine.lobby.server.USER_MANAGER", IUserManager.class);
 
   /**
    * Update the user info, returning an error string if an error occurs.

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/LobbyConstants.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.lobby.common;
 
-import games.strategy.engine.message.RemoteName;
 import games.strategy.util.Version;
 
 /**
@@ -11,8 +10,6 @@ public final class LobbyConstants {
   public static final String LOBBY_CHAT = "_LOBBY_CHAT";
   public static final Version LOBBY_VERSION = new Version(1, 0, 0);
   public static final String LOBBY_WATCHER_NAME = "lobby_watcher";
-  public static final RemoteName MODERATOR_CONTROLLER_REMOTE_NAME =
-      new RemoteName("games.strategy.engine.lobby.server.ModeratorController:Global", IModeratorController.class);
 
   private LobbyConstants() {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -30,7 +30,6 @@ import games.strategy.engine.lobby.client.ui.MacLobbyWrapper;
 import games.strategy.engine.lobby.client.ui.TimespanDialog;
 import games.strategy.engine.lobby.common.IModeratorController;
 import games.strategy.engine.lobby.common.IUserManager;
-import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.lobby.common.login.RsaAuthenticator;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.INode;
@@ -100,7 +99,7 @@ public final class LobbyMenu extends JMenuBar {
     revive.setEnabled(true);
     revive.addActionListener(event -> new Thread(() -> {
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
-          .getRemoteMessenger().getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+          .getRemoteMessenger().getRemote(IModeratorController.REMOTE_NAME);
       final StringBuilder builder = new StringBuilder();
       builder.append("Online Players:\r\n\r\n");
       for (final INode player : lobbyFrame.getChatMessagePanel().getChat().getOnlinePlayers()) {
@@ -160,7 +159,7 @@ public final class LobbyMenu extends JMenuBar {
       TimespanDialog.prompt(lobbyFrame, "Select Timespan",
           "Please consult other admins before banning longer than 1 day.", date -> {
             final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
-                .getRemoteMessenger().getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+                .getRemoteMessenger().getRemote(IModeratorController.REMOTE_NAME);
             controller.banUsername(newDummyNode(name), date);
           });
     });
@@ -193,7 +192,7 @@ public final class LobbyMenu extends JMenuBar {
       TimespanDialog.prompt(lobbyFrame, "Select Timespan",
           "Please consult other admins before banning longer than 1 day.", date -> {
             final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
-                .getRemoteMessenger().getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+                .getRemoteMessenger().getRemote(IModeratorController.REMOTE_NAME);
             controller.banMac(newDummyNode("__unknown__"), mac, date);
           });
     });
@@ -215,7 +214,7 @@ public final class LobbyMenu extends JMenuBar {
         return;
       }
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
-          .getRemoteMessenger().getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+          .getRemoteMessenger().getRemote(IModeratorController.REMOTE_NAME);
       controller.banUsername(newDummyNode(name), Date.from(Instant.EPOCH));
     });
     item.setEnabled(true);
@@ -237,7 +236,7 @@ public final class LobbyMenu extends JMenuBar {
         return;
       }
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
-          .getRemoteMessenger().getRemote(LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+          .getRemoteMessenger().getRemote(IModeratorController.REMOTE_NAME);
       controller.banMac(newDummyNode("__unknown__"), mac, Date.from(Instant.EPOCH));
     });
     item.setEnabled(true);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -293,7 +293,7 @@ public final class LobbyMenu extends JMenuBar {
 
   private void updateAccountDetails() {
     final IUserManager manager =
-        (IUserManager) lobbyFrame.getLobbyClient().getRemoteMessenger().getRemote(IUserManager.USER_MANAGER);
+        (IUserManager) lobbyFrame.getLobbyClient().getRemoteMessenger().getRemote(IUserManager.REMOTE_NAME);
     final DBUser user = manager.getUserInfo(lobbyFrame.getLobbyClient().getMessenger().getLocalNode().getName());
     if (user == null) {
       JOptionPane.showMessageDialog(this, "No user info found", "Error", JOptionPane.ERROR_MESSAGE);

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -58,7 +58,7 @@ public final class LobbyGameTableModelTest {
       fakeGame = Tuple.of(new GUID(), mockGameDescription);
       fakeGameMap.put(fakeGame.getFirst(), fakeGame.getSecond());
 
-      Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE))
+      Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME))
           .thenReturn(mockLobbyController);
       Mockito.when(mockLobbyController.listGames()).thenReturn(fakeGameMap);
       testObj = new LobbyGameTableModel(true, mockMessenger, mockChannelMessenger, mockRemoteMessenger);

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -101,7 +101,7 @@ final class LobbyGameController implements ILobbyGameController {
   }
 
   void register(final IRemoteMessenger remote) {
-    remote.registerRemote(this, GAME_CONTROLLER_REMOTE);
+    remote.registerRemote(this, REMOTE_NAME);
   }
 
   @Override

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -52,7 +52,7 @@ public final class LobbyServer {
     new StatusManager(messengers).shutDown();
 
     final LobbyGameController controller = new LobbyGameController((ILobbyGameBroadcaster) messengers
-        .getChannelMessenger().getChannelBroadcastor(ILobbyGameBroadcaster.GAME_BROADCASTER_CHANNEL), server);
+        .getChannelMessenger().getChannelBroadcastor(ILobbyGameBroadcaster.REMOTE_NAME), server);
     controller.register(messengers.getRemoteMessenger());
 
     // now we are open for business

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 import games.strategy.engine.config.lobby.LobbyPropertyReader;
 import games.strategy.engine.lobby.common.IModeratorController;
 import games.strategy.engine.lobby.common.IRemoteHostUtils;
-import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.lobby.server.db.BannedMacController;
 import games.strategy.engine.lobby.server.db.BannedUsernameController;
 import games.strategy.engine.lobby.server.db.Database;
@@ -403,6 +402,6 @@ final class ModeratorController implements IModeratorController {
   }
 
   void register(final IRemoteMessenger messenger) {
-    messenger.registerRemote(this, LobbyConstants.MODERATOR_CONTROLLER_REMOTE_NAME);
+    messenger.registerRemote(this, REMOTE_NAME);
   }
 }

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/UserManager.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/UserManager.java
@@ -22,7 +22,7 @@ final class UserManager implements IUserManager {
   }
 
   void register(final IRemoteMessenger messenger) {
-    messenger.registerRemote(this, IUserManager.USER_MANAGER);
+    messenger.registerRemote(this, REMOTE_NAME);
   }
 
   @Override


### PR DESCRIPTION
## Overview

For consistency:

* Ensure all `RemoteName` constants are a member of the corresponding remote interface.
* Rename all constants to `REMOTE_NAME` as the interface name itself provides sufficient context.

## Functional Changes

None.

## Manual Testing Performed

None.