### PR TITLE
Checkstyle: Fix missing Javadoc violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/history/Event.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Event.java
@@ -1,5 +1,9 @@
 package games.strategy.engine.history;
 
+/**
+ * A history node that represents an event that occurred during the execution of a game step
+ * (e.g. "Russia buys 8 Infantry").
+ */
 public class Event extends IndexedHistoryNode implements Renderable {
   private static final long serialVersionUID = -8382102990360177484L;
   private final String m_description;

--- a/game-core/src/main/java/games/strategy/engine/history/EventChild.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventChild.java
@@ -1,5 +1,9 @@
 package games.strategy.engine.history;
 
+/**
+ * A history node that contains the details of an {@link Event} (e.g. for a battle event, the dice rolled during each
+ * stage of the battle, the units lost during the battle, etc.).
+ */
 public class EventChild extends HistoryNode implements Renderable {
   private static final long serialVersionUID = 2436212909638449323L;
   public final String m_text;

--- a/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -103,6 +103,9 @@ public class History extends DefaultTreeModel {
     return (lastChange >= firstChange) ? compositeChange : compositeChange.invert();
   }
 
+  /**
+   * Changes the game state to reflect the historical state at {@code node}.
+   */
   public synchronized void gotoNode(final HistoryNode node) {
     assertCorrectThread();
     getGameData().acquireWriteLock();
@@ -120,6 +123,10 @@ public class History extends DefaultTreeModel {
     }
   }
 
+  /**
+   * Changes the game state to reflect the historical state at {@code removeAfterNode}, and then removes all changes
+   * that occurred after this node.
+   */
   public synchronized void removeAllHistoryAfterNode(final HistoryNode removeAfterNode) {
     gotoNode(removeAfterNode);
     assertCorrectThread();

--- a/game-core/src/main/java/games/strategy/engine/history/HistoryNode.java
+++ b/game-core/src/main/java/games/strategy/engine/history/HistoryNode.java
@@ -2,6 +2,9 @@ package games.strategy.engine.history;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 
+/**
+ * Superclass for all nodes in the History tree view.
+ */
 public abstract class HistoryNode extends DefaultMutableTreeNode {
   private static final long serialVersionUID = 628623470654123887L;
 

--- a/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
@@ -53,6 +53,10 @@ public class HistoryWriter implements Serializable {
     addToAndSetCurrent(currentStep);
   }
 
+  /**
+   * Prepares to write a new round. Any current event, step, or round will be automatically closed before beginning the
+   * new round.
+   */
   public void startNextRound(final int round) {
     assertCorrectThread();
     if (isCurrentEvent()) {
@@ -156,6 +160,9 @@ public class HistoryWriter implements Serializable {
     m_history.changeAdded(change);
   }
 
+  /**
+   * Sets the rendering data for the current event.
+   */
   public void setRenderingData(final Object details) {
     assertCorrectThread();
     if (!isCurrentEvent()) {

--- a/game-core/src/main/java/games/strategy/engine/history/IndexedHistoryNode.java
+++ b/game-core/src/main/java/games/strategy/engine/history/IndexedHistoryNode.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.history;
 
+/**
+ * Superclass for history nodes whose child nodes represent a range of {@code Change} objects.
+ */
 public abstract class IndexedHistoryNode extends HistoryNode {
   private static final long serialVersionUID = 607716179473453685L;
   // points to the first change we are responsible for

--- a/game-core/src/main/java/games/strategy/engine/history/Renderable.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Renderable.java
@@ -1,5 +1,9 @@
 package games.strategy.engine.history;
 
+/**
+ * An adapter that converts an object that can not be directly rendered in the UI to another representation that can be
+ * rendered.
+ */
 public interface Renderable {
   Object getRenderingData();
 }

--- a/game-core/src/main/java/games/strategy/engine/history/Round.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Round.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.history;
 
+/**
+ * A history node that represents an entire game round.
+ */
 public class Round extends IndexedHistoryNode {
   private static final long serialVersionUID = 7645058269791039043L;
   private final int roundNo;

--- a/game-core/src/main/java/games/strategy/engine/history/SerializationWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/SerializationWriter.java
@@ -2,6 +2,9 @@ package games.strategy.engine.history;
 
 import java.io.Serializable;
 
+/**
+ * An object that is able to write a history node to a {@link HistoryWriter} for persistent storage.
+ */
 public interface SerializationWriter extends Serializable {
   void write(HistoryWriter writer);
 }

--- a/game-core/src/main/java/games/strategy/engine/history/Step.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Step.java
@@ -2,6 +2,9 @@ package games.strategy.engine.history;
 
 import games.strategy.engine.data.PlayerID;
 
+/**
+ * A history node that represents one step of game play (e.g. "Britain Combat Move").
+ */
 public class Step extends IndexedHistoryNode {
   private static final long serialVersionUID = 1015799886178275645L;
   private final PlayerID player;

--- a/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -25,6 +25,9 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
 
+/**
+ * Provides methods to export a screenshot for a game at a particular point in time.
+ */
 public final class ScreenshotExporter {
   private final TripleAFrame frame;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -25,6 +25,18 @@ import games.strategy.triplea.ui.SimpleUnitPanel;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 
+/**
+ * A UI component that displays details about the currently-selected history node.
+ *
+ * <p>
+ * The history node details include:
+ * </p>
+ * <ul>
+ * <li>The textual description of the node.</li>
+ * <li>A custom UI component provided by the node that provides graphical details. For example, a purchase event may
+ * display the icons (and counts) for each unit purchased.</li>
+ * </ul>
+ */
 public class HistoryDetailsPanel extends JPanel {
   private static final long serialVersionUID = 5092004144144006960L;
   private final GameData data;

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -44,6 +44,10 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.IntegerMap;
 import lombok.extern.java.Log;
 
+/**
+ * A window used to display a textual summary of a particular history node, including all of its descendants, if
+ * applicable.
+ */
 @Log
 public class HistoryLog extends JFrame {
   private static final long serialVersionUID = 4880602702815333376L;
@@ -82,6 +86,10 @@ public class HistoryLog extends JFrame {
     textArea.setText("");
   }
 
+  /**
+   * Adds details about the current turn for each player in {@code playersAllowed} to the log. Information about
+   * each step and event that occurred during the turn are included.
+   */
   public void printFullTurn(final GameData data, final boolean verbose, final Collection<PlayerID> playersAllowed) {
     HistoryNode curNode = data.getHistory().getLastNode();
     final Collection<PlayerID> players = new HashSet<>();
@@ -155,6 +163,10 @@ public class HistoryLog extends JFrame {
     return curPlayer;
   }
 
+  /**
+   * Adds details about {@code printNode} and all its sibling and child nodes that are part of the current turn for each
+   * player in {@code playersAllowed} to the log.
+   */
   public void printRemainingTurn(final HistoryNode printNode, final boolean verbose, final int diceSides,
       final Collection<PlayerID> playersAllowed) {
     final PrintWriter logWriter = printWriter;
@@ -390,6 +402,10 @@ public class HistoryLog extends JFrame {
     textArea.setText(stringWriter.toString());
   }
 
+  /**
+   * Adds a territory summary for the player associated with {@code printNode} to the log. The summary includes each
+   * unit present in the territory.
+   */
   public void printTerritorySummary(final HistoryNode printNode, final GameData data) {
     final Collection<Territory> territories;
     final PlayerID player = getPlayerId(printNode);
@@ -419,6 +435,10 @@ public class HistoryLog extends JFrame {
     printTerritorySummary(players, territories);
   }
 
+  /**
+   * Adds a territory summary for each player in {@code allowedPlayers} to the log. The summary includes each unit
+   * present in the territory.
+   */
   public void printTerritorySummary(final GameData data, final Collection<PlayerID> allowedPlayers) {
     if (allowedPlayers == null || allowedPlayers.isEmpty()) {
       printTerritorySummary(data);
@@ -479,6 +499,9 @@ public class HistoryLog extends JFrame {
     textArea.setText(stringWriter.toString());
   }
 
+  /**
+   * Adds a production summary for each player in the game to the log.
+   */
   public void printProductionSummary(final GameData data) {
     final PrintWriter logWriter = printWriter;
     final Collection<PlayerID> players;

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -350,6 +350,9 @@ public class HistoryPanel extends JPanel {
     }
   }
 
+  /**
+   * Selects the most recent history node, expanding the tree if necessary.
+   */
   public void goToEnd() {
     final HistoryNode last;
     try {


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocMethod and JavadocType rules by adding missing Javadocs.  Changes to the proposed Javadocs are welcome.

## Functional Changes

None.  **This PR only contains Javadoc changes; there are no code changes.**

## Manual Testing Performed

None.