### PR TITLE
Error Prone: Fix string splitter violations in attachments

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.attachments;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -11,7 +13,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -30,6 +34,7 @@ import games.strategy.triplea.formatter.MyFormatter;
  */
 public abstract class AbstractConditionsAttachment extends DefaultAttachment implements ICondition {
   private static final long serialVersionUID = -9008441256118867078L;
+  private static final Splitter HYPHEN_SPLITTER = Splitter.on('-');
   protected static final String AND = "AND";
   protected static final String OR = "OR";
   protected static final String DEFAULT_CHANCE = "1:1";
@@ -96,7 +101,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   void setConditionType(final String value) throws GameParseException {
     final String uppercaseValue = value.toUpperCase();
     if (uppercaseValue.matches("AND|X?OR|\\d+(?:-\\d+)?")) {
-      final String[] split = uppercaseValue.split("-");
+      final String[] split = splitOnHyphen(uppercaseValue);
       if (split.length != 2 || Integer.parseInt(split[1]) > Integer.parseInt(split[0])) {
         m_conditionType = uppercaseValue;
         return;
@@ -104,6 +109,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     }
     throw new GameParseException("conditionType must be equal to 'AND' or 'OR' or 'XOR' or 'y' or 'y-z' where Y "
         + "and Z are valid positive integers and Z is greater than Y" + thisErrorMsg());
+  }
+
+  protected static String[] splitOnHyphen(final String value) {
+    checkNotNull(value);
+
+    return Iterables.toArray(HYPHEN_SPLITTER.split(value), String.class);
   }
 
   private String getConditionType() {
@@ -206,7 +217,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
         }
       }
     } else {
-      final String[] nums = conditionType.split("-");
+      final String[] nums = splitOnHyphen(conditionType);
       if (nums.length == 1) {
         final int start = Integer.parseInt(nums[0]);
         int count = 0;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -214,7 +214,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         start = getInt(subString);
         end = start;
       } catch (final Exception e) {
-        final String[] s2 = subString.split("-");
+        final String[] s2 = splitOnHyphen(subString);
         if (s2.length != 2) {
           throw new GameParseException("Invalid syntax for turn range, must be 'int-int'" + thisErrorMsg());
         }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -198,8 +198,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     }
     if (!s[3].equalsIgnoreCase("currentRound")) {
       try {
-        getInt(s[3].split("-")[0]);
-        getInt(s[3].split("-")[1]);
+        getInt(splitOnHyphen(s[3])[0]);
+        getInt(splitOnHyphen(s[3])[1]);
       } catch (final Exception e) {
         throw new GameParseException("round must either be currentRound or two numbers like: 2-4" + thisErrorMsg());
       }
@@ -792,7 +792,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         int end = round;
         final boolean currentRound = roundType.equalsIgnoreCase("currentRound");
         if (!currentRound) {
-          final String[] rounds = roundType.split("-");
+          final String[] rounds = splitOnHyphen(roundType);
           start = getInt(rounds[0]);
           end = getInt(rounds[1]);
         }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in attachment classes.  This was done by extracting a method to the superclass `AbstractConditionsAttachment` to be used by all condition attachments for splitting a string on a hyphen, and then updating all applicable call sites to use this new method.  Finally, I converted the method implementation from `String#split()` to use Guava's `Splitter`.

To minimize the chance of regressions, I preserved the result of the split operation as a `String[]` rather than use a `List<String>`, as typically returned by `Splitter`.

## Functional Changes

None.

## Manual Testing Performed

Verified no issues starting a TWW game.  (TWW has some `conditionType` attributes whose values follow the `#-#` format.)