### PR TITLE
 Extract ServerMessenger subclasses for game host and lobby 

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/AdministrativeChatMessages.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/AdministrativeChatMessages.java
@@ -1,0 +1,27 @@
+package games.strategy.engine.chat;
+
+/**
+ * A collection of chat messages sent by the server in response to an administrative event.
+ *
+ * <p>
+ * Various types in the chat subsystem test these messages for equality. If one matches, a corresponding human-readable
+ * message is displayed to the user appearing to be authored by the "chat administrator" rather than the user at the
+ * node that sent the message. Therefore, these messages should be thought more of as opaque identifiers rather than
+ * actual messages displayed to a user.
+ * </p>
+ * <p>
+ * Each message contains a leading special character to make it more difficult for the user at the server/host to forge
+ * an administrative chat message.
+ * </p>
+ */
+public final class AdministrativeChatMessages {
+  // FIXME: It appears the leading special character in each message was lost at some time in the past due to a dev
+  // using a non-Unicode encoding, which resulted in their replacement with question marks. The question marks should
+  // probably be changed back to a "difficult to type" Unicode character.
+
+  public static final String YOU_HAVE_BEEN_MUTED_GAME = "?YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST";
+  public static final String YOU_HAVE_BEEN_MUTED_LOBBY =
+      "?YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER";
+
+  private AdministrativeChatMessages() {}
+}

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -30,7 +30,6 @@ import javax.swing.text.StyleConstants;
 import com.google.common.base.Ascii;
 
 import games.strategy.net.INode;
-import games.strategy.net.ServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
 import games.strategy.ui.SwingAction;
@@ -103,11 +102,11 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
           text.setText("");
           for (final ChatMessage message : chat.getChatHistory()) {
             if (message.getFrom().equals(chat.getServerNode().getName())) {
-              if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
+              if (message.getMessage().equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_LOBBY)) {
                 addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
                     "ADMIN_CHAT_CONTROL", false);
                 continue;
-              } else if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
+              } else if (message.getMessage().equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_GAME)) {
                 addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
                 continue;
               }
@@ -240,11 +239,11 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
         return;
       }
       if (from.equals(chat.getServerNode().getName())) {
-        if (message.equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
+        if (message.equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_LOBBY)) {
           addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
               "ADMIN_CHAT_CONTROL", false);
           return;
-        } else if (message.equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
+        } else if (message.equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_GAME)) {
           addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
           return;
         }

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -12,7 +12,6 @@ import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
-import games.strategy.net.ServerMessenger;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
 import games.strategy.util.TimeManager;
@@ -77,11 +76,11 @@ public class HeadlessChat implements IChatListener, IChatPanel {
         allText = new StringBuilder();
         for (final ChatMessage message : this.chat.getChatHistory()) {
           if (message.getFrom().equals(this.chat.getServerNode().getName())) {
-            if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
+            if (message.getMessage().equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_LOBBY)) {
               addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
                   "ADMIN_CHAT_CONTROL", false);
               continue;
-            } else if (message.getMessage().equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
+            } else if (message.getMessage().equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_GAME)) {
               addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
               continue;
             }
@@ -107,11 +106,11 @@ public class HeadlessChat implements IChatListener, IChatPanel {
     // TODO: I don't really think we need a new thread for this...
     new Thread(() -> {
       if (from.equals(chat.getServerNode().getName())) {
-        if (message.equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_LOBBY)) {
+        if (message.equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_LOBBY)) {
           addChatMessage("YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER",
               "ADMIN_CHAT_CONTROL", false);
           return;
-        } else if (message.equals(ServerMessenger.YOU_HAVE_BEEN_MUTED_GAME)) {
+        } else if (message.equals(AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_GAME)) {
           addChatMessage("YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST", "HOST_CHAT_CONTROL", false);
           return;
         }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameServerMessenger.java
@@ -1,0 +1,24 @@
+package games.strategy.engine.framework.startup.mc;
+
+import java.io.IOException;
+
+import games.strategy.engine.chat.AdministrativeChatMessages;
+import games.strategy.net.AbstractServerMessenger;
+import games.strategy.net.IObjectStreamFactory;
+
+final class GameServerMessenger extends AbstractServerMessenger {
+  GameServerMessenger(final String name, final int port, final IObjectStreamFactory objectStreamFactory)
+      throws IOException {
+    super(name, port, objectStreamFactory);
+  }
+
+  @Override
+  protected String getAdministrativeMuteChatMessage() {
+    return AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_GAME;
+  }
+
+  @Override
+  protected String getChatChannelName() {
+    return ServerModel.CHAT_NAME;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -63,7 +63,6 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
-import games.strategy.net.ServerMessenger;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
@@ -251,7 +250,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     this.ui = (ui == null) ? null : JOptionPane.getFrameForComponent(ui);
 
     try {
-      serverMessenger = ServerMessenger.newInstanceForGameHost(props.getName(), props.getPort(), objectStreamFactory);
+      serverMessenger = new GameServerMessenger(props.getName(), props.getPort(), objectStreamFactory);
       final ClientLoginValidator clientLoginValidator = new ClientLoginValidator(serverMessenger);
       clientLoginValidator.setGamePassword(props.getPassword());
       serverMessenger.setLoginValidator(clientLoginValidator);

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -22,17 +22,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
 import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.IChatChannel;
-import games.strategy.engine.config.lobby.LobbyPropertyReader;
-import games.strategy.engine.lobby.server.db.Database;
-import games.strategy.engine.lobby.server.db.MutedMacController;
-import games.strategy.engine.lobby.server.db.MutedUsernameController;
 import games.strategy.engine.message.HubInvoke;
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteName;
@@ -47,7 +43,7 @@ import lombok.extern.java.Log;
  * A Messenger that can have many clients connected to it.
  */
 @Log
-public class ServerMessenger implements IServerMessenger, NioSocketListener {
+public abstract class AbstractServerMessenger implements IServerMessenger, NioSocketListener {
   private final Selector acceptorSelector;
   private final ServerSocketChannel socketChannel;
   private final Node node;
@@ -61,54 +57,18 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   private final Map<INode, SocketChannel> nodeToChannel = new ConcurrentHashMap<>();
   private final Map<SocketChannel, INode> channelToNode = new ConcurrentHashMap<>();
 
-  /**
-   * The lobby database if this instance is for use by a lobby; otherwise {@code null}.
-   */
-  private final @Nullable Database database;
-
   // A hack, till I think of something better
-  private ServerMessenger(
-      final String name,
-      final int requestedPortNumber,
-      final IObjectStreamFactory streamFactory,
-      final @Nullable Database database)
+  protected AbstractServerMessenger(final String name, final int port, final IObjectStreamFactory objectStreamFactory)
       throws IOException {
-    this.database = database;
     socketChannel = ServerSocketChannel.open();
     socketChannel.configureBlocking(false);
     socketChannel.socket().setReuseAddress(true);
-    socketChannel.socket().bind(new InetSocketAddress(requestedPortNumber), 10);
-    final int boundPortNumber = socketChannel.socket().getLocalPort();
-    nioSocket = new NioSocket(streamFactory, this, "Server");
+    socketChannel.socket().bind(new InetSocketAddress(port), 10);
+    final int boundPort = socketChannel.socket().getLocalPort();
+    nioSocket = new NioSocket(objectStreamFactory, this, "Server");
     acceptorSelector = Selector.open();
-    node = new Node(name, IpFinder.findInetAddress(), boundPortNumber);
+    node = new Node(name, IpFinder.findInetAddress(), boundPort);
     new Thread(new ConnectionHandler(), "Server Messenger Connection Handler").start();
-  }
-
-  public static ServerMessenger newInstanceForGameHost(
-      final String name,
-      final int requestedPortNumber)
-      throws IOException {
-    return newInstanceForGameHost(name, requestedPortNumber, new DefaultObjectStreamFactory());
-  }
-
-  public static ServerMessenger newInstanceForGameHost(
-      final String name,
-      final int requestedPortNumber,
-      final IObjectStreamFactory streamFactory)
-      throws IOException {
-    return new ServerMessenger(name, requestedPortNumber, streamFactory, null);
-  }
-
-  public static ServerMessenger newInstanceForLobby(
-      final String name,
-      final LobbyPropertyReader lobbyPropertyReader)
-      throws IOException {
-    return new ServerMessenger(
-        name,
-        lobbyPropertyReader.getPort(),
-        new DefaultObjectStreamFactory(),
-        new Database(lobbyPropertyReader));
   }
 
   @Override
@@ -179,14 +139,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     forwardBroadcast(header);
   }
 
-  private boolean isLobby() {
-    return database != null;
-  }
-
-  private boolean isGame() {
-    return !isLobby();
-  }
-
   private final Object cachedListLock = new Object();
   private final Map<String, String> cachedMacAddresses = new HashMap<>();
 
@@ -203,7 +155,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   // which can be very slow
   private final List<String> liveMutedUsernames = new ArrayList<>();
 
-  private boolean isUsernameMuted(final String username) {
+  private boolean isUsernameMutedInCache(final String username) {
     synchronized (cachedListLock) {
       return liveMutedUsernames.contains(username);
     }
@@ -228,7 +180,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   private final List<String> liveMutedMacAddresses = new ArrayList<>();
 
-  private boolean isMacMuted(final String mac) {
+  private boolean isMacMutedInCache(final String mac) {
     synchronized (cachedListLock) {
       return liveMutedMacAddresses.contains(mac);
     }
@@ -260,30 +212,58 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   public void notifyPlayerLogin(final String uniquePlayerName, final String mac) {
     synchronized (cachedListLock) {
       cachedMacAddresses.put(uniquePlayerName, mac);
-      if (isLobby()) {
-        final String realName = IServerMessenger.getRealName(uniquePlayerName);
-        if (!liveMutedUsernames.contains(realName)) {
-          final Optional<Instant> muteTill = new MutedUsernameController(database).getUsernameUnmuteTime(realName);
-          muteTill.ifPresent(instant -> {
-            if (instant.isAfter(Instant.now())) {
-              // Signal the player as muted
-              liveMutedUsernames.add(realName);
-              scheduleUsernameUnmuteAt(realName, instant);
-            }
-          });
-        }
-        if (!liveMutedMacAddresses.contains(mac)) {
-          final Optional<Instant> muteTill = new MutedMacController(database).getMacUnmuteTime(mac);
-          muteTill.ifPresent(instant -> {
-            if (instant.isAfter(Instant.now())) {
-              // Signal the player as muted
-              liveMutedMacAddresses.add(mac);
-              scheduleMacUnmuteAt(mac, instant);
-            }
-          });
-        }
+      final String realName = IServerMessenger.getRealName(uniquePlayerName);
+      if (!liveMutedUsernames.contains(realName)) {
+        final Optional<Instant> muteTill = getUsernameUnmuteTime(realName);
+        muteTill.ifPresent(instant -> {
+          if (instant.isAfter(Instant.now())) {
+            // Signal the player as muted
+            liveMutedUsernames.add(realName);
+            scheduleUsernameUnmuteAt(realName, instant);
+          }
+        });
+      }
+      if (!liveMutedMacAddresses.contains(mac)) {
+        final Optional<Instant> muteTill = getMacUnmuteTime(mac);
+        muteTill.ifPresent(instant -> {
+          if (instant.isAfter(Instant.now())) {
+            // Signal the player as muted
+            liveMutedMacAddresses.add(mac);
+            scheduleMacUnmuteAt(mac, instant);
+          }
+        });
       }
     }
+  }
+
+  /**
+   * Returns the instant at which the user associated with the specified username is to be unmuted or empty if the user
+   * is not currently muted.
+   *
+   * <p>
+   * Subclasses may override and are not required to call the superclass implementation. This implementation returns an
+   * empty instant indicating the user is not currently muted.
+   * </p>
+   *
+   * @param username The username of the user.
+   */
+  protected Optional<Instant> getUsernameUnmuteTime(final String username) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the instant at which the user associated with the specified MAC is to be unmuted or empty if the user is
+   * not currently muted.
+   *
+   * <p>
+   * Subclasses may override and are not required to call the superclass implementation. This implementation returns an
+   * empty instant indicating the user is not currently muted.
+   * </p>
+   *
+   * @param mac The MAC of the user.
+   */
+  protected Optional<Instant> getMacUnmuteTime(final String mac) {
+    return Optional.empty();
   }
 
   private final HashMap<String, String> playersThatLeftMacsLast10 = new HashMap<>();
@@ -298,13 +278,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
   }
 
-  // Special character to stop spoofing by server
-  public static final String YOU_HAVE_BEEN_MUTED_LOBBY =
-      "?YOUR LOBBY CHATTING HAS BEEN TEMPORARILY 'MUTED' BY THE ADMINS, TRY AGAIN LATER";
-
-  // Special character to stop spoofing by host
-  public static final String YOU_HAVE_BEEN_MUTED_GAME = "?YOUR CHATTING IN THIS GAME HAS BEEN 'MUTED' BY THE HOST";
-
   @Override
   public void messageReceived(final MessageHeader msg, final SocketChannel channel) {
     final INode expectedReceive = channelToNode.get(channel);
@@ -312,21 +285,10 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
       throw new IllegalStateException("Expected: " + expectedReceive + " not: " + msg.getFrom());
     }
     if (msg.getMessage() instanceof HubInvoke) { // Chat messages are always HubInvoke's
-      if (isLobby() && ((HubInvoke) msg.getMessage()).call.getRemoteName().equals("_ChatCtrl_LOBBY_CHAT")) {
+      if (((HubInvoke) msg.getMessage()).call.getRemoteName().equals(getChatControlChannelName())) {
         final String realName = IServerMessenger.getRealName(msg.getFrom().getName());
-        if (isUsernameMuted(realName) || isMacMuted(getPlayerMac(msg.getFrom().getName()))) {
-          bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_LOBBY, msg.getFrom());
-          return;
-        }
-      } else if (isGame() && ((HubInvoke) msg.getMessage()).call.getRemoteName()
-          .equals("_ChatCtrlgames.strategy.engine.framework.ui.ServerStartup.CHAT_NAME")) {
-        final String realName = IServerMessenger.getRealName(msg.getFrom().getName());
-        if (isUsernameMuted(realName)) {
-          bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_GAME, msg.getFrom());
-          return;
-        }
-        if (isMacMuted(getPlayerMac(msg.getFrom().getName()))) {
-          bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_GAME, msg.getFrom());
+        if (isUsernameMutedInCache(realName) || isMacMutedInCache(getPlayerMac(msg.getFrom().getName()))) {
+          bareBonesSendChatMessage(getAdministrativeMuteChatMessage(), msg.getFrom());
           return;
         }
       }
@@ -341,11 +303,24 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     }
   }
 
+  private String getChatControlChannelName() {
+    return ChatController.getChatChannelName(getChatChannelName());
+  }
+
+  /**
+   * Returns the name of the chat channel.
+   */
+  protected abstract String getChatChannelName();
+
+  /**
+   * Returns the administrative chat message to send a user who has been muted.
+   *
+   * @see games.strategy.engine.chat.AdministrativeChatMessages
+   */
+  protected abstract String getAdministrativeMuteChatMessage();
+
   private void bareBonesSendChatMessage(final String message, final INode to) {
-    final RemoteName rn = new RemoteName(isLobby()
-        ? ChatController.getChatChannelName("_LOBBY_CHAT")
-        : ChatController.getChatChannelName("games.strategy.engine.framework.ui.ServerStartup.CHAT_NAME"),
-        IChatChannel.class);
+    final RemoteName rn = new RemoteName(getChatControlChannelName(), IChatChannel.class);
     final RemoteMethodCall call = new RemoteMethodCall(
         rn.getName(),
         "chatOccured",
@@ -601,8 +576,11 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
               }
               continue;
             }
-            final ServerQuarantineConversation conversation =
-                new ServerQuarantineConversation(loginValidator, socketChannel, nioSocket, ServerMessenger.this);
+            final ServerQuarantineConversation conversation = new ServerQuarantineConversation(
+                loginValidator,
+                socketChannel,
+                nioSocket,
+                AbstractServerMessenger.this);
             nioSocket.add(socketChannel, conversation);
           } else if (!key.isValid()) {
             key.cancel();
@@ -614,17 +592,32 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   private TimerTask getUsernameUnmuteTask(final String username) {
     return createUnmuteTimerTask(
-        () -> (isLobby() && !new MutedUsernameController(database).isUsernameMuted(username)) || isGame(),
+        () -> isUsernameMutedInBackingStore(username),
         () -> liveMutedUsernames.remove(username));
   }
 
-  private TimerTask createUnmuteTimerTask(final Supplier<Boolean> runCondition, final Runnable action) {
+  /**
+   * Returns {@code true} if the user associated with the specified username is muted according to the backing store
+   * (e.g. a database); otherwise {@code false}.
+   *
+   * <p>
+   * Subclasses may override and are not required to call the superclass implementation. This implementation returns
+   * {@code false} indicating the user is not currently muted.
+   * </p>
+   *
+   * @param username The username of the user.
+   */
+  protected boolean isUsernameMutedInBackingStore(final String username) {
+    return false;
+  }
+
+  private TimerTask createUnmuteTimerTask(final BooleanSupplier isUserMuted, final Runnable unmuteUser) {
     return new TimerTask() {
       @Override
       public void run() {
-        if (runCondition.get()) {
+        if (!isUserMuted.getAsBoolean()) {
           synchronized (cachedListLock) {
-            action.run();
+            unmuteUser.run();
           }
         }
       }
@@ -633,8 +626,23 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   private TimerTask getMacUnmuteTask(final String mac) {
     return createUnmuteTimerTask(
-        () -> (isLobby() && !new MutedMacController(database).isMacMuted(mac)) || isGame(),
+        () -> isMacMutedInBackingStore(mac),
         () -> liveMutedMacAddresses.remove(mac));
+  }
+
+  /**
+   * Returns {@code true} if the user associated with the specified MAC is muted according to the backing store (e.g. a
+   * database); otherwise {@code false}.
+   *
+   * <p>
+   * Subclasses may override and are not required to call the superclass implementation. This implementation returns
+   * {@code false} indicating the user is not currently muted.
+   * </p>
+   *
+   * @param mac The MAC of the user.
+   */
+  protected boolean isMacMutedInBackingStore(final String mac) {
+    return false;
   }
 
   @Override
@@ -698,6 +706,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   @Override
   public String toString() {
-    return "ServerMessenger LocalNode:" + node + " ClientNodes:" + nodeToChannel.keySet();
+    return getClass().getSimpleName() + " LocalNode:" + node + " ClientNodes:" + nodeToChannel.keySet();
   }
 }

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -6,10 +6,10 @@ import java.nio.channels.SocketChannel;
 import java.util.Map;
 import java.util.logging.Level;
 
+import games.strategy.net.AbstractServerMessenger;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
-import games.strategy.net.ServerMessenger;
 import lombok.extern.java.Log;
 
 /**
@@ -39,10 +39,10 @@ public class ServerQuarantineConversation extends QuarantineConversation {
   private String remoteName;
   private String remoteMac;
   private Map<String, String> challenge;
-  private final ServerMessenger serverMessenger;
+  private final AbstractServerMessenger serverMessenger;
 
   public ServerQuarantineConversation(final ILoginValidator validator, final SocketChannel channel,
-      final NioSocket socket, final ServerMessenger serverMessenger) {
+      final NioSocket socket, final AbstractServerMessenger serverMessenger) {
     this.validator = validator;
     this.socket = socket;
     this.channel = channel;

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -24,7 +24,7 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
-import games.strategy.net.ServerMessenger;
+import games.strategy.net.TestServerMessenger;
 import games.strategy.sound.SoundPath;
 
 @Integration
@@ -48,7 +48,7 @@ public final class ChatIntegrationTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    serverMessenger = ServerMessenger.newInstanceForGameHost("Server", 0);
+    serverMessenger = new TestServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
     final int serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -18,7 +18,7 @@ import games.strategy.net.IConnectionLogin;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
-import games.strategy.net.ServerMessenger;
+import games.strategy.net.TestServerMessenger;
 
 @Integration
 public final class ClientLoginIntegrationTest {
@@ -35,7 +35,7 @@ public final class ClientLoginIntegrationTest {
   }
 
   private static IServerMessenger newServerMessenger() throws Exception {
-    final ServerMessenger serverMessenger = ServerMessenger.newInstanceForGameHost("server", 0);
+    final IServerMessenger serverMessenger = new TestServerMessenger("server", 0);
     serverMessenger.setAcceptNewConnections(true);
     serverMessenger.setLoginValidator(newLoginValidator(serverMessenger));
     return serverMessenger;

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -18,7 +18,7 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.MessengerTestUtils;
-import games.strategy.net.ServerMessenger;
+import games.strategy.net.TestServerMessenger;
 import games.strategy.util.Interruptibles;
 
 public class ChannelMessengerTest {
@@ -31,7 +31,7 @@ public class ChannelMessengerTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverMessenger = ServerMessenger.newInstanceForGameHost("Server", 0);
+    serverMessenger = new TestServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
     serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -33,7 +33,7 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.Node;
-import games.strategy.net.ServerMessenger;
+import games.strategy.net.TestServerMessenger;
 import games.strategy.util.Interruptibles;
 
 public class RemoteMessengerTest {
@@ -128,10 +128,10 @@ public class RemoteMessengerTest {
   @Test
   public void testRemoteCall() throws Exception {
     final RemoteName test = new RemoteName("test", ITestRemote.class);
-    ServerMessenger server = null;
+    IServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = ServerMessenger.newInstanceForGameHost("server", 0);
+      server = new TestServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
       final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
@@ -160,7 +160,7 @@ public class RemoteMessengerTest {
     }
   }
 
-  private static void shutdownServerAndClient(final ServerMessenger server, final ClientMessenger client) {
+  private static void shutdownServerAndClient(final IServerMessenger server, final ClientMessenger client) {
     if (server != null) {
       server.shutDown();
     }
@@ -172,10 +172,10 @@ public class RemoteMessengerTest {
   @Test
   public void testRemoteCall2() throws Exception {
     final RemoteName test = new RemoteName("test", ITestRemote.class);
-    ServerMessenger server = null;
+    IServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = ServerMessenger.newInstanceForGameHost("server", 0);
+      server = new TestServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
       final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
@@ -200,10 +200,10 @@ public class RemoteMessengerTest {
     // when the client shutdown, remotes created
     // on the client should not be visible on server
     final RemoteName test = new RemoteName("test", ITestRemote.class);
-    ServerMessenger server = null;
+    IServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = ServerMessenger.newInstanceForGameHost("server", 0);
+      server = new TestServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
       final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();
@@ -226,10 +226,10 @@ public class RemoteMessengerTest {
     // when the client shutdown, remotes created
     // on the client should not be visible on server
     final RemoteName test = new RemoteName("test", IFoo.class);
-    ServerMessenger server = null;
+    IServerMessenger server = null;
     ClientMessenger client = null;
     try {
-      server = ServerMessenger.newInstanceForGameHost("server", 0);
+      server = new TestServerMessenger("server", 0);
       server.setAcceptNewConnections(true);
       final int serverPort = server.getLocalNode().getSocketAddress().getPort();
       final String mac = MacFinder.getHashedMacAddress();

--- a/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -21,7 +21,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.MessengerTestUtils;
 import games.strategy.net.Node;
-import games.strategy.net.ServerMessenger;
+import games.strategy.net.TestServerMessenger;
 
 /**
  * Comment(KG): This test is broken, If you run each test individually they all work, but when running all test in the
@@ -37,7 +37,7 @@ public class VaultTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverMessenger = ServerMessenger.newInstanceForGameHost("Server", 0);
+    serverMessenger = new TestServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
     final int serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();
     final String mac = MacFinder.getHashedMacAddress();

--- a/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -32,7 +32,7 @@ public class MessengerIntegrationTest {
 
   @BeforeEach
   public void setUp() throws IOException {
-    serverMessenger = ServerMessenger.newInstanceForGameHost("Server", 0);
+    serverMessenger = new TestServerMessenger("Server", 0);
     serverMessenger.setAcceptNewConnections(true);
     serverMessenger.addMessageListener(serverMessageListener);
     serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();

--- a/game-core/src/test/java/games/strategy/net/TestServerMessenger.java
+++ b/game-core/src/test/java/games/strategy/net/TestServerMessenger.java
@@ -1,0 +1,22 @@
+package games.strategy.net;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link IServerMessenger} suitable for testing.
+ */
+public final class TestServerMessenger extends AbstractServerMessenger {
+  public TestServerMessenger(final String name, final int port) throws IOException {
+    super(name, port, new DefaultObjectStreamFactory());
+  }
+
+  @Override
+  protected String getAdministrativeMuteChatMessage() {
+    return "You have been muted";
+  }
+
+  @Override
+  protected String getChatChannelName() {
+    return "_TEST_CHAT";
+  }
+}

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -10,7 +10,6 @@ import games.strategy.engine.lobby.common.LobbyConstants;
 import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
-import games.strategy.net.ServerMessenger;
 import games.strategy.sound.ClipPlayer;
 
 /**
@@ -38,8 +37,7 @@ public final class LobbyServer {
   static void start(final LobbyPropertyReader lobbyPropertyReader) throws IOException {
     ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
 
-    final IServerMessenger server =
-        ServerMessenger.newInstanceForLobby(LobbyConstants.ADMIN_USERNAME, lobbyPropertyReader);
+    final IServerMessenger server = new LobbyServerMessenger(LobbyConstants.ADMIN_USERNAME, lobbyPropertyReader);
     final Messengers messengers = new Messengers(server);
     server.setLoginValidator(new LobbyLoginValidator(lobbyPropertyReader));
     // setup common objects

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServerMessenger.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/LobbyServerMessenger.java
@@ -1,0 +1,57 @@
+package games.strategy.engine.lobby.server;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import games.strategy.engine.chat.AdministrativeChatMessages;
+import games.strategy.engine.config.lobby.LobbyPropertyReader;
+import games.strategy.engine.lobby.common.LobbyConstants;
+import games.strategy.engine.lobby.server.db.Database;
+import games.strategy.engine.lobby.server.db.MutedMacController;
+import games.strategy.engine.lobby.server.db.MutedUsernameController;
+import games.strategy.net.AbstractServerMessenger;
+import games.strategy.net.DefaultObjectStreamFactory;
+
+final class LobbyServerMessenger extends AbstractServerMessenger {
+  private final MutedMacController mutedMacController;
+  private final MutedUsernameController mutedUsernameController;
+
+  LobbyServerMessenger(final String name, final LobbyPropertyReader lobbyPropertyReader) throws IOException {
+    super(name, lobbyPropertyReader.getPort(), new DefaultObjectStreamFactory());
+
+    final Database database = new Database(lobbyPropertyReader);
+    mutedMacController = new MutedMacController(database);
+    mutedUsernameController = new MutedUsernameController(database);
+  }
+
+  @Override
+  protected String getAdministrativeMuteChatMessage() {
+    return AdministrativeChatMessages.YOU_HAVE_BEEN_MUTED_LOBBY;
+  }
+
+  @Override
+  protected String getChatChannelName() {
+    return LobbyConstants.LOBBY_CHAT;
+  }
+
+  @Override
+  protected Optional<Instant> getMacUnmuteTime(final String mac) {
+    return mutedMacController.getMacUnmuteTime(mac);
+  }
+
+  @Override
+  protected Optional<Instant> getUsernameUnmuteTime(final String username) {
+    return mutedUsernameController.getUsernameUnmuteTime(username);
+  }
+
+  @Override
+  protected boolean isMacMutedInBackingStore(final String mac) {
+    return mutedMacController.isMacMuted(mac);
+  }
+
+  @Override
+  protected boolean isUsernameMutedInBackingStore(final String username) {
+    return mutedUsernameController.isUsernameMuted(username);
+  }
+}


### PR DESCRIPTION
## Overview

`ServerMessenger` contains logic for both a lobby server and a game server.  This unnecessarily couples what should be a pure network abstraction to the lobby code.

This PR converts `ServerMessenger` to an abstract superclass (`AbstractServerMessenger`) and extracts three new subclasses that contain the specialized logic for game servers (`GameServerMessenger`), lobby servers (`LobbyServerMessenger`), and tests (`TestServerMessenger`).

## Functional Changes

None.

## Manual Testing Performed

Tested general chat and muting a user in a headed network game for the following scenarios:

* game server (this branch), game client (this branch)
* game server (this branch), game client (9687)
* game server (9687), game client (this branch)

Tested general chat and muting a user in a headless network game for the following scenarios:

* headless game server (this branch), game client (this branch)
* headless game server (this branch), game client (9687)
* headless game server (10663), game client (this branch)

Tested general chat and muting a user (via both username nad MAC) in the lobby for the following configurations:

* lobby server (this branch), moderator lobby client (this branch), user lobby client (this branch)
* lobby server (this branch), moderator lobby client (this branch), user lobby client (9687)
* lobby server (this branch), moderator lobby client (9687), user lobby client (this branch)
* lobby server (10663), moderator lobby client (this branch), user lobby client (this branch)
* lobby server (10663), moderator lobby client (this branch), user lobby client (9687)
* lobby server (10663), moderator lobby client (9687), user lobby client (this branch)

## Additional Review Notes

Please view with whitespace changes ignored.