### PR TITLE
Don't replace same image name multiple times

### DIFF
--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -1,6 +1,8 @@
 package games.strategy.util;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,6 +50,7 @@ public class LocalizeHtml {
     final Pattern patternLink = Pattern.compile(PATTERN_HTML_IMG_SRC_TAG);
     final Matcher matcherTag = patternTag.matcher(htmlText);
     Matcher matcherLink;
+    final List<String> alreadyReplaced = new ArrayList<>();
     while (matcherTag.find()) {
       // img tag
       final String href = matcherTag.group(1);
@@ -64,6 +67,9 @@ public class LocalizeHtml {
           }
           // remove quotes
           final String link = fullLink.substring(1, fullLink.length() - 1);
+          if (alreadyReplaced.contains(link)) {
+            break;
+          }
 
           // remove full parent path
           final String imageFileName = link.substring(Math.max((link.lastIndexOf("/") + 1), 0));
@@ -80,6 +86,7 @@ public class LocalizeHtml {
           }
 
           localizedHtmlText = localizedHtmlText.replaceAll(link, replacementUrl.toString());
+          alreadyReplaced.add(link);
         }
       }
     }

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -1,8 +1,8 @@
 package games.strategy.util;
 
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -50,7 +50,7 @@ public class LocalizeHtml {
     final Pattern patternLink = Pattern.compile(PATTERN_HTML_IMG_SRC_TAG);
     final Matcher matcherTag = patternTag.matcher(htmlText);
     Matcher matcherLink;
-    final List<String> alreadyReplaced = new ArrayList<>();
+    final Set<String> alreadyReplaced = new HashSet<>();
     while (matcherTag.find()) {
       // img tag
       final String href = matcherTag.group(1);
@@ -67,12 +67,13 @@ public class LocalizeHtml {
           }
           // remove quotes
           final String link = fullLink.substring(1, fullLink.length() - 1);
-          if (alreadyReplaced.contains(link)) {
+          if (!alreadyReplaced.add(link)) {
             break;
           }
 
           // remove full parent path
           final String imageFileName = link.substring(Math.max((link.lastIndexOf("/") + 1), 0));
+
           // replace when testing with: "REPLACEMENTPATH/" + imageFileName;
           URL replacementUrl = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
 
@@ -84,9 +85,7 @@ public class LocalizeHtml {
             log.log(Level.SEVERE, "Could not find: " + ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
             continue;
           }
-
           localizedHtmlText = localizedHtmlText.replaceAll(link, replacementUrl.toString());
-          alreadyReplaced.add(link);
         }
       }
     }


### PR DESCRIPTION
Currently, an image can only be referenced 1 time in the game notes as otherwise it'll not display properly due to it being replaced multiple times.

See this PR for a map that now has it: https://github.com/triplea-maps/red_sun_over_china/pull/7