### PR TITLE
Error Prone: Work around false positive reference equality violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -38,6 +38,7 @@ import games.strategy.triplea.util.BonusIncomeUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Interruptibles;
+import games.strategy.util.ObjectUtils;
 import games.strategy.util.Tuple;
 
 /**
@@ -516,7 +517,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   private static Comparator<Territory> getSingleNeighborBlockadesThenHighestToLowestProduction(
       final Collection<Territory> blockadeZones, final GameMap map) {
     return (t1, t2) -> {
-      if (t1 == t2 || (t1 == null && t2 == null)) {
+      if (ObjectUtils.referenceEquals(t1, t2)) {
         return 0;
       }
       if (t1 == null) {
@@ -550,7 +551,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   private static Comparator<Territory> getSingleBlockadeThenHighestToLowestBlockadeDamage(
       final HashMap<Territory, Tuple<Integer, List<Territory>>> damagePerBlockadeZone) {
     return (t1, t2) -> {
-      if (t1 == t2 || (t1 == null && t2 == null)) {
+      if (ObjectUtils.referenceEquals(t1, t2)) {
         return 0;
       }
       if (t1 == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import games.strategy.engine.data.Change;
@@ -38,7 +39,6 @@ import games.strategy.triplea.util.BonusIncomeUtils;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Interruptibles;
-import games.strategy.util.ObjectUtils;
 import games.strategy.util.Tuple;
 
 /**
@@ -517,7 +517,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   private static Comparator<Territory> getSingleNeighborBlockadesThenHighestToLowestProduction(
       final Collection<Territory> blockadeZones, final GameMap map) {
     return (t1, t2) -> {
-      if (ObjectUtils.referenceEquals(t1, t2)) {
+      if (Objects.equals(t1, t2)) {
         return 0;
       }
       if (t1 == null) {
@@ -525,9 +525,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       }
       if (t2 == null) {
         return -1;
-      }
-      if (t1.equals(t2)) {
-        return 0;
       }
       // if a territory is only touching 1 blockadeZone, we must take it first
       final Collection<Territory> neighborBlockades1 = new ArrayList<>(map.getNeighbors(t1));
@@ -551,7 +548,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   private static Comparator<Territory> getSingleBlockadeThenHighestToLowestBlockadeDamage(
       final HashMap<Territory, Tuple<Integer, List<Territory>>> damagePerBlockadeZone) {
     return (t1, t2) -> {
-      if (ObjectUtils.referenceEquals(t1, t2)) {
+      if (Objects.equals(t1, t2)) {
         return 0;
       }
       if (t1 == null) {
@@ -559,9 +556,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       }
       if (t2 == null) {
         return -1;
-      }
-      if (t1.equals(t2)) {
-        return 0;
       }
       final Tuple<Integer, List<Territory>> tuple1 = damagePerBlockadeZone.get(t1);
       final Tuple<Integer, List<Territory>> tuple2 = damagePerBlockadeZone.get(t2);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -7,8 +7,11 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -514,18 +517,14 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     return IAbstractForumPosterDelegate.class;
   }
 
-  private static Comparator<Territory> getSingleNeighborBlockadesThenHighestToLowestProduction(
+  @VisibleForTesting
+  static Comparator<Territory> getSingleNeighborBlockadesThenHighestToLowestProduction(
       final Collection<Territory> blockadeZones, final GameMap map) {
-    return (t1, t2) -> {
+    return Comparator.nullsLast((t1, t2) -> {
       if (Objects.equals(t1, t2)) {
         return 0;
       }
-      if (t1 == null) {
-        return 1;
-      }
-      if (t2 == null) {
-        return -1;
-      }
+
       // if a territory is only touching 1 blockadeZone, we must take it first
       final Collection<Territory> neighborBlockades1 = new ArrayList<>(map.getNeighbors(t1));
       neighborBlockades1.retainAll(blockadeZones);
@@ -542,21 +541,17 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       return Comparator.comparing(TerritoryAttachment::get,
           Comparator.nullsFirst(Comparator.comparingInt(TerritoryAttachment::getProduction)))
           .compare(t1, t2);
-    };
+    });
   }
 
-  private static Comparator<Territory> getSingleBlockadeThenHighestToLowestBlockadeDamage(
-      final HashMap<Territory, Tuple<Integer, List<Territory>>> damagePerBlockadeZone) {
-    return (t1, t2) -> {
+  @VisibleForTesting
+  static Comparator<Territory> getSingleBlockadeThenHighestToLowestBlockadeDamage(
+      final Map<Territory, Tuple<Integer, List<Territory>>> damagePerBlockadeZone) {
+    return Comparator.nullsLast((t1, t2) -> {
       if (Objects.equals(t1, t2)) {
         return 0;
       }
-      if (t1 == null) {
-        return 1;
-      }
-      if (t2 == null) {
-        return -1;
-      }
+
       final Tuple<Integer, List<Territory>> tuple1 = damagePerBlockadeZone.get(t1);
       final Tuple<Integer, List<Territory>> tuple2 = damagePerBlockadeZone.get(t2);
       final int num1 = tuple1.getSecond().size();
@@ -570,6 +565,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       final int d1 = tuple1.getFirst();
       final int d2 = tuple2.getFirst();
       return Integer.compare(d2, d1);
-    };
+    });
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -64,6 +64,7 @@ import games.strategy.ui.ImageScrollerLargeView;
 import games.strategy.ui.Util;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.Interruptibles;
+import games.strategy.util.ObjectUtils;
 import games.strategy.util.Tuple;
 
 /**
@@ -415,7 +416,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   private boolean unitsChanged(final Tuple<Territory, List<Unit>> newUnits) {
-    return newUnits != currentUnits
+    return !ObjectUtils.referenceEquals(newUnits, currentUnits)
         && (newUnits == null
             || currentUnits == null
             || !newUnits.getFirst().equals(currentUnits.getFirst())

--- a/game-core/src/main/java/games/strategy/util/ObjectUtils.java
+++ b/game-core/src/main/java/games/strategy/util/ObjectUtils.java
@@ -1,0 +1,24 @@
+package games.strategy.util;
+
+import javax.annotation.Nullable;
+
+/**
+ * A collection of useful methods for working with instances of {@link Object}.
+ */
+public final class ObjectUtils {
+  private ObjectUtils() {}
+
+  /**
+   * Returns {@code true} if both {@code a} and {@code b} refer to the same object or are both {@code null}; otherwise
+   * returns {@code false}.
+   *
+   * <p>
+   * Use this method only when you really need to compare object references for equality. In almost all cases you should
+   * be using {@link Object#equals(Object)}. <strong>Using this method documents your intention that a reference
+   * equality check is required.</strong>
+   * </p>
+   */
+  public static boolean referenceEquals(final @Nullable Object a, final @Nullable Object b) {
+    return a == b;
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
@@ -1,25 +1,101 @@
 package games.strategy.triplea.delegate;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 
-public class AbstractEndTurnDelegateTest extends DelegateTest {
-
-  @Test
-  public void testFindEstimatedIncome() throws Exception {
-    final GameData global40Data = TestMapGameData.GLOBAL1940.getGameData();
-    final PlayerID germans = GameDataTestUtil.germans(global40Data);
-    final IntegerMap<Resource> results = AbstractEndTurnDelegate.findEstimatedIncome(germans, global40Data);
-    final int pus = results.getInt(new Resource(Constants.PUS, global40Data));
-    assertEquals(40, pus);
+final class AbstractEndTurnDelegateTest {
+  @Nested
+  final class FindEstimatedIncomeTest extends DelegateTest {
+    @Test
+    void testFindEstimatedIncome() throws Exception {
+      final GameData global40Data = TestMapGameData.GLOBAL1940.getGameData();
+      final PlayerID germans = GameDataTestUtil.germans(global40Data);
+      final IntegerMap<Resource> results = AbstractEndTurnDelegate.findEstimatedIncome(germans, global40Data);
+      final int pus = results.getInt(new Resource(Constants.PUS, global40Data));
+      assertEquals(40, pus);
+    }
   }
 
+  @Nested
+  final class GetSingleNeighborBlockadesThenHighestToLowestProductionTest {
+    private final GameData gameData = new GameData();
+    private final Comparator<Territory> comparator = AbstractEndTurnDelegate
+        .getSingleNeighborBlockadesThenHighestToLowestProduction(Collections.emptyList(), gameData.getMap());
+    private final Territory territory = new Territory("territoryName", gameData);
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreNull() {
+      assertThat(comparator.compare(null, null), is(0));
+    }
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreSame() {
+      assertThat(comparator.compare(territory, territory), is(0));
+    }
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreEqual() {
+      assertThat(comparator.compare(territory, new Territory(territory.getName(), gameData)), is(0));
+    }
+
+    @Test
+    void shouldReturnLessThanZeroWhenFirstTerritoryIsNonNullAndSecondTerritoryIsNull() {
+      assertThat(comparator.compare(territory, null), is(lessThan(0)));
+    }
+
+    @Test
+    void shouldReturnGreaterThanZeroWhenFirstTerritoryIsNullAndSecondTerritoryIsNonNull() {
+      assertThat(comparator.compare(null, territory), is(greaterThan(0)));
+    }
+  }
+
+  @Nested
+  final class GetSingleBlockadeThenHighestToLowestBlockadeDamageTest {
+    private final GameData gameData = new GameData();
+    private final Comparator<Territory> comparator = AbstractEndTurnDelegate
+        .getSingleBlockadeThenHighestToLowestBlockadeDamage(Collections.emptyMap());
+    private final Territory territory = new Territory("territoryName", gameData);
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreNull() {
+      assertThat(comparator.compare(null, null), is(0));
+    }
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreSame() {
+      assertThat(comparator.compare(territory, territory), is(0));
+    }
+
+    @Test
+    void shouldReturnZeroWhenBothTerritoriesAreEqual() {
+      assertThat(comparator.compare(territory, new Territory(territory.getName(), gameData)), is(0));
+    }
+
+    @Test
+    void shouldReturnLessThanZeroWhenFirstTerritoryIsNonNullAndSecondTerritoryIsNull() {
+      assertThat(comparator.compare(territory, null), is(lessThan(0)));
+    }
+
+    @Test
+    void shouldReturnGreaterThanZeroWhenFirstTerritoryIsNullAndSecondTerritoryIsNonNull() {
+      assertThat(comparator.compare(null, territory), is(greaterThan(0)));
+    }
+  }
 }

--- a/game-core/src/test/java/games/strategy/util/ObjectUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/ObjectUtilsTest.java
@@ -1,0 +1,30 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class ObjectUtilsTest {
+  @Nested
+  final class ReferenceEqualsTest {
+    @Test
+    void shouldReturnTrueWhenReferencesAreSame() {
+      final Object a = new Object();
+
+      assertThat(ObjectUtils.referenceEquals(null, null), is(true));
+      assertThat(ObjectUtils.referenceEquals(a, a), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferencesAreNotSame() {
+      final Object a = new Object();
+      final Object b = new Object();
+
+      assertThat(ObjectUtils.referenceEquals(a, null), is(false));
+      assertThat(ObjectUtils.referenceEquals(null, a), is(false));
+      assertThat(ObjectUtils.referenceEquals(a, b), is(false));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

I found three violations of the Error Prone ReferenceEquality rule where a reference equality check is actually correct.  Each case is effectively a variation of an `equals()` implementation, where it is acceptable (even according to the [Error Prone docs](http://errorprone.info/bugpattern/ReferenceEquality)) to use reference equality as a short-circuiting optimization.

Instead of simply suppressing the warnings, I extracted a new utility method (`referenceEquals()`) that communicates to a code reader, "Yes, I really want to use reference equality here--it's not a mistake."

## Functional Changes

None.

## Manual Testing Performed

None.