### PR TITLE
Checkstyle: Fix member naming violations in TestAttachment

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -26,6 +26,8 @@
         <property name="file" value="${samedir}/suppressions.xml"/>
     </module>
 
+    <module name="SuppressWarningsFilter"/>
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
         <module name="FileTabCharacter">
@@ -33,6 +35,7 @@
         </module>
 
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/game-core/src/main/java/games/strategy/engine/xml/TestAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/xml/TestAttachment.java
@@ -21,9 +21,8 @@ import games.strategy.engine.data.annotations.InternalDoNotExport;
 public class TestAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 4886924951201479496L;
 
-  private String m_value;
+  private String value;
 
-  /** Creates new TestAttachment. */
   public TestAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
@@ -47,15 +46,15 @@ public class TestAttachment extends DefaultAttachment {
   public void setName(final String name) {}
 
   public void setValue(final String value) {
-    m_value = value;
+    this.value = value;
   }
 
   public String getValue() {
-    return m_value;
+    return value;
   }
 
   public void resetValue() {
-    m_value = null;
+    value = null;
   }
 
   @Override

--- a/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
+++ b/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
@@ -19,10 +19,10 @@ public final class MapPropertyWrapperTest {
   public final class GetPropertyFieldTest {
     @Test
     public void shouldReturnFieldWhenFieldWithEmUnderscorePrefixExistsInTargetClass() {
-      final Field field = MapPropertyWrapper.getPropertyField("value", TestAttachment.class);
+      final Field field = MapPropertyWrapper.getPropertyField("intValue", ExampleEmUnderscoreAttachment.class);
 
-      assertThat(field.getName(), is("m_value"));
-      assertThat(field.getDeclaringClass(), is(TestAttachment.class));
+      assertThat(field.getName(), is("m_intValue"));
+      assertThat(field.getDeclaringClass(), is(ExampleEmUnderscoreAttachment.class));
     }
 
     @Test
@@ -52,6 +52,17 @@ public final class MapPropertyWrapperTest {
     @Test
     public void shouldThrowExceptionWhenFieldDoesNotExist() {
       assertThrows(IllegalStateException.class, () -> MapPropertyWrapper.getPropertyField("xxx", TestAttachment.class));
+    }
+  }
+
+  static class ExampleEmUnderscoreAttachment extends TestAttachment {
+    private static final long serialVersionUID = 4140595034027616571L;
+
+    @SuppressWarnings("checkstyle:MemberName") // "m_" prefix required for test
+    int m_intValue;
+
+    ExampleEmUnderscoreAttachment(final String name, final Attachable attachable, final GameData gameData) {
+      super(name, attachable, gameData);
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes a violation of the Checkstyle MemberName rule in the `TestAttachment` class.

Although this attachment could technically be serialized with a save game, in practice, it appears this is not the case.  I searched all `triplea-maps` repos for use of this attachment and got zero hits.  I also grepped an older save game for this class and no instances were found.

## Functional Changes

None.

## Manual Testing Performed

None.