### PR TITLE
PBEM: Require login credentials for Gmail and Hotmail

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -45,6 +45,8 @@ public class EmailSenderEditor extends EditorPanel {
   private final JLabel toLabel = new JLabel("To:");
   private final JLabel hostLabel = new JLabel("Host:");
   private final JLabel portLabel = new JLabel("Port:");
+  private final JLabel loginLabel = new JLabel("Login:");
+  private final JLabel passwordLabel = new JLabel("Password:");
   private final JButton testEmail = new JButton("Test Email");
   private final JCheckBox alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
   private final JCheckBox credentialsSaved = new JCheckBox("Remember me");
@@ -80,13 +82,11 @@ public class EmailSenderEditor extends EditorPanel {
     add(toAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
         GridBagConstraints.HORIZONTAL, new Insets(0, 0, bottomSpace, 0), 0, 0));
     row++;
-    final JLabel loginLabel = new JLabel("Login:");
     add(loginLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
     add(login, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
     row++;
-    final JLabel passwordLabel = new JLabel("Password:");
     add(passwordLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
     add(password, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
@@ -190,10 +190,11 @@ public class EmailSenderEditor extends EditorPanel {
   public boolean isBeanValid() {
     final boolean hostValid = validateTextFieldNotEmpty(host, hostLabel);
     final boolean portValid = validateTextField(port, portLabel, new IntegerRangeValidator(0, 65635));
-    // boolean loginValid = validateTextFieldNotEmpty(login, loginLabel);
-    // boolean passwordValid = validateTextFieldNotEmpty(password, passwordLabel);
+    final boolean authenticationRequired = genericEmailSender.isAuthenticationRequired();
+    final boolean loginValid = !authenticationRequired || validateTextFieldNotEmpty(login, loginLabel);
+    final boolean passwordValid = !authenticationRequired || validateTextFieldNotEmpty(password, passwordLabel);
     final boolean addressValid = validateTextField(toAddress, toLabel, new EmailValidator(false));
-    final boolean allValid = hostValid && portValid && /* loginValid && passwordValid && */addressValid;
+    final boolean allValid = hostValid && portValid && loginValid && passwordValid && addressValid;
     testEmail.setEnabled(allValid);
     return allValid;
   }

--- a/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -197,6 +197,18 @@ public class GenericEmailSender implements IEmailSender {
     }
   }
 
+  /**
+   * Returns {@code true} if the email provider requires authentication; otherwise returns {@code false}.
+   *
+   * <p>
+   * Subclasses may override and are not required to call the superclass implementation. This implementation always
+   * returns {@code false}.
+   * </p>
+   */
+  public boolean isAuthenticationRequired() {
+    return false;
+  }
+
   @Override
   public String getUserName() {
     return USE_TRANSIENT_CREDENTIAL.equals(m_userName) ? transientUserName : m_userName;

--- a/game-core/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
@@ -42,6 +42,11 @@ public class GmailEmailSender extends GenericEmailSender {
   }
 
   @Override
+  public boolean isAuthenticationRequired() {
+    return true;
+  }
+
+  @Override
   public String getHelpText() {
     return HelpSupport.loadHelp("gmailEmailSender.html");
   }

--- a/game-core/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
@@ -42,6 +42,11 @@ public class HotmailEmailSender extends GenericEmailSender {
   }
 
   @Override
+  public boolean isAuthenticationRequired() {
+    return true;
+  }
+
+  @Override
   public String getHelpText() {
     return HelpSupport.loadHelp("hotmailEmailSender.html");
   }


### PR DESCRIPTION
## Overview

In response to https://forums.triplea-game.org/topic/974/dice-roller-error.

To avoid similar confusion in the future, this PR now requires the **Login** and **Password** fields to be non-empty for the Gmail and Hotmail providers.  In the past, these fields used to be required for all email providers.  However, this was disabled in 9a4ea25a7, presumably to support generic SMTP servers that do not require authentication (that's just a guess).

## Functional Changes

The PBEM **Login** and **Password** fields must be non-empty for the Gmail and Hotmail providers.  The UI will disable the **Play** and **Test Email** buttons as long as they are empty.

The Generic SMTP provider still allows empty **Login** and **Password** fields.

## Manual Testing Performed

Verified the **Login** and **Password** field labels are colored red, and the **Play** and **Test Email** buttons are disabled, when the corresponding text fields are empty for the Gmail and Hotmail providers.

Verified the **Login** and **Password** field labels are NOT colored red, and the **Play** and **Test Email** buttons are NOT disabled, when the corresponding text fields are empty for the Generic SMTP provider.