### PR TITLE
Fix RMI regression in IRemoteHostUtils

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -109,7 +109,7 @@ public class InGameLobbyWatcher {
       final UnifiedMessenger um = new UnifiedMessenger(messenger);
       final RemoteMessenger rm = new RemoteMessenger(um);
       final RemoteHostUtils rhu = new RemoteHostUtils(messenger.getServerNode(), gameMessenger);
-      rm.registerRemote(rhu, IRemoteHostUtils.newRemoteNameForNode(um.getLocalNode()));
+      rm.registerRemote(rhu, IRemoteHostUtils.Companion.newRemoteNameForNode(um.getLocalNode()));
       return new InGameLobbyWatcher(messenger, rm, gameMessenger, parent, oldWatcher);
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Failed to create in-game lobby watcher", e);

--- a/game-core/src/main/java/games/strategy/engine/lobby/common/IRemoteHostUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/common/IRemoteHostUtils.java
@@ -27,11 +27,23 @@ public interface IRemoteHostUtils extends IRemote {
 
   String getSalt();
 
-  static RemoteName newRemoteNameForNode(final INode node) {
-    checkNotNull(node);
+  /**
+   * Companion object for {@link IRemoteHostUtils} that provides various utility methods.
+   *
+   * <p>
+   * <strong>NOTE:</strong> These methods cannot be members of {@link IRemoteHostUtils} directly (even if they are
+   * static) because their presence may affect the RMI method ordinal calculation.
+   * </p>
+   */
+  final class Companion {
+    private Companion() {}
 
-    return new RemoteName(
-        "games.strategy.engine.lobby.server.RemoteHostUtils:" + node.toString(),
-        IRemoteHostUtils.class);
+    public static RemoteName newRemoteNameForNode(final INode node) {
+      checkNotNull(node);
+
+      return new RemoteName(
+          "games.strategy.engine.lobby.server.RemoteHostUtils:" + node.toString(),
+          IRemoteHostUtils.class);
+    }
   }
 }

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -208,7 +208,7 @@ final class ModeratorController implements IModeratorController {
         "Getting salt for Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     return remoteHostUtils.getSalt();
@@ -222,7 +222,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.getChatLogHeadlessHostBot(hashedPassword, salt);
@@ -244,7 +244,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response =
@@ -267,7 +267,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.bootPlayerHeadlessHostBot(playerNameToBeBooted, hashedPassword, salt);
@@ -288,7 +288,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hours, hashedPassword, salt);
@@ -309,7 +309,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.stopGameHeadlessHostBot(hashedPassword, salt);
@@ -333,7 +333,7 @@ final class ModeratorController implements IModeratorController {
         "Started Remote Shutdown of Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.shutDownHeadlessHostBot(hashedPassword, salt);
@@ -395,7 +395,7 @@ final class ModeratorController implements IModeratorController {
     if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
-    final RemoteName remoteName = IRemoteHostUtils.newRemoteNameForNode(node);
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
     return remoteHostUtils.getConnections();

--- a/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -208,10 +208,13 @@ final class ModeratorController implements IModeratorController {
         "Getting salt for Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     return remoteHostUtils.getSalt();
+  }
+
+  private IRemoteHostUtils getRemoteHostUtilsForNode(final INode node) {
+    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
+    return (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
   }
 
   @Override
@@ -222,9 +225,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response = remoteHostUtils.getChatLogHeadlessHostBot(hashedPassword, salt);
     log.info(String.format(
         ((response == null || response.equals("Invalid password!")) ? "Failed" : "Successful")
@@ -244,9 +245,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response =
         remoteHostUtils.mutePlayerHeadlessHostBot(playerNameToBeMuted, minutes, hashedPassword, salt);
     log.info(String.format(
@@ -267,9 +266,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response = remoteHostUtils.bootPlayerHeadlessHostBot(playerNameToBeBooted, hashedPassword, salt);
     log.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Boot of " + playerNameToBeBooted
@@ -288,9 +285,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hours, hashedPassword, salt);
     log.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Ban of " + playerNameToBeBanned
@@ -309,9 +304,7 @@ final class ModeratorController implements IModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response = remoteHostUtils.stopGameHeadlessHostBot(hashedPassword, salt);
     log.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
@@ -333,9 +326,7 @@ final class ModeratorController implements IModeratorController {
         "Started Remote Shutdown of Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     final String response = remoteHostUtils.shutDownHeadlessHostBot(hashedPassword, salt);
     log.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
@@ -395,9 +386,7 @@ final class ModeratorController implements IModeratorController {
     if (serverMessenger.getServerNode().equals(node)) {
       throw new IllegalStateException("Cannot do this for server node");
     }
-    final RemoteName remoteName = IRemoteHostUtils.Companion.newRemoteNameForNode(node);
-    final IRemoteHostUtils remoteHostUtils =
-        (IRemoteHostUtils) allMessengers.getRemoteMessenger().getRemote(remoteName);
+    final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
     return remoteHostUtils.getConnections();
   }
 


### PR DESCRIPTION
## Overview

Fixes a regression caused by #3850.

The addition of the static `newRemoteNameForNode()` method altered the RMI method ordinal calculation for the `IRemoteHostUtils` interface, thus causing compatibility issues when a post-3850 bot was connected to a pre-3850 lobby (only the `shutDownHeadlessHostBot()` and `stopGameHeadlessHostBot()` would fail).

This PR moves the static method to a "companion" class on the interface whose sole responsibility is to host static methods for this interface.  If this smells, alternative proposals are welcome.  (My goal here was to keep the `RemoteName` factory method co-located with the interface rather than splitting off another utility class in this package.)

## Functional Changes

None.

## Refactoring Changes

* Extracted the helper method `ModeratorController#getRemoteHostUtilsForNode()` to encapsulate two lines repeated throughout the enclosing class.

## Manual Testing Performed

Verified shutting down a bot from the lobby succeeds (prior to this PR, it raised an exception on the bot and caused the lobby client to freeze).