### PR TITLE
Checkstyle: Fix member name violations in history UI

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/history/Event.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Event.java
@@ -6,30 +6,30 @@ package games.strategy.engine.history;
  */
 public class Event extends IndexedHistoryNode implements Renderable {
   private static final long serialVersionUID = -8382102990360177484L;
-  private final String m_description;
+  private final String description;
   // additional data used for rendering this event
-  private Object m_renderingData;
+  private Object renderingData;
 
   public String getDescription() {
-    return m_description;
+    return description;
   }
 
   Event(final String description, final int changeStartIndex) {
     super(description, changeStartIndex);
-    m_description = description;
+    this.description = description;
   }
 
   @Override
   public Object getRenderingData() {
-    return m_renderingData;
+    return renderingData;
   }
 
-  public void setRenderingData(final Object data) {
-    m_renderingData = data;
+  public void setRenderingData(final Object renderingData) {
+    this.renderingData = renderingData;
   }
 
   @Override
   public SerializationWriter getWriter() {
-    return new EventHistorySerializer(m_description, m_renderingData);
+    return new EventHistorySerializer(description, renderingData);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/EventChild.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventChild.java
@@ -6,27 +6,27 @@ package games.strategy.engine.history;
  */
 public class EventChild extends HistoryNode implements Renderable {
   private static final long serialVersionUID = 2436212909638449323L;
-  public final String m_text;
-  public final Object m_renderingData;
+  private final String text;
+  private final Object renderingData;
 
   public EventChild(final String text, final Object renderingData) {
     super(text);
-    m_text = text;
-    m_renderingData = renderingData;
+    this.text = text;
+    this.renderingData = renderingData;
   }
 
   @Override
   public Object getRenderingData() {
-    return m_renderingData;
+    return renderingData;
   }
 
   @Override
   public String toString() {
-    return m_text;
+    return text;
   }
 
   @Override
   public SerializationWriter getWriter() {
-    return new EventChildWriter(m_text, m_renderingData);
+    return new EventChildWriter(text, renderingData);
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in a few history UI classes.  The `Event` and `EventChild` classes ultimately inherit from `DefaultMutableTreeNode`, and thus are UI-specific and should not be stored in a save game.  To verify this, I grepped some old save games and did not find these class names stored within (although the associated `EventHistorySerializer` and `EventChildWriter` classes _are_ present in a save game).

## Functional Changes

None.

## Manual Testing Performed

None.