### PR TITLE
Checkstyle: Suppress false positive member name violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -9,9 +9,11 @@ public class MouseDetails {
   private final MouseEvent mouseEvent;
   // the x position of the event on the map
   // this is in absolute pixels of the unscaled map
+  @SuppressWarnings("checkstyle:MemberName")
   private final double x;
-  // the x position of the event on the map
+  // the y position of the event on the map
   // this is in absolute pixels of the unscaled map
+  @SuppressWarnings("checkstyle:MemberName")
   private final double y;
 
   MouseDetails(final MouseEvent mouseEvent, final double x, final double y) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -16,7 +16,9 @@ import games.strategy.triplea.ui.screen.TileManager;
  */
 public abstract class MapTileDrawable implements IDrawable {
   protected boolean noImage = false;
+  @SuppressWarnings("checkstyle:MemberName")
   protected final int x;
+  @SuppressWarnings("checkstyle:MemberName")
   protected final int y;
   protected final UiContext uiContext;
   protected boolean unscaled;

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollModel.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollModel.java
@@ -11,7 +11,9 @@ import java.util.Observable;
  * </p>
  */
 public class ImageScrollModel extends Observable {
+  @SuppressWarnings("checkstyle:MemberName")
   private int x;
+  @SuppressWarnings("checkstyle:MemberName")
   private int y;
   private int boxWidth = 5;
   private int boxHeight = 5;


### PR DESCRIPTION
## Overview

Suppresses false positive violations of the Checkstyle MemberName rule.  The affected fields represent Cartesian coordinates, and `x` and `y` are traditional names for such variables.

## Functional Changes

None.

## Manual Testing Performed

None.