### PR TITLE
Remove no-op method from IServerMessenger

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -329,12 +329,10 @@ public class HeadlessGameServer {
         try {
           for (final INode node : nodes) {
             final String realName = IServerMessenger.getRealName(node.getName());
-            final String ip = node.getAddress().getHostAddress();
             final String mac = messenger.getPlayerMac(node.getName());
             if (realName.equals(playerName)) {
               log.info("Remote Mute of Player: " + playerName);
               messenger.notifyUsernameMutingOfPlayer(realName, expire);
-              messenger.notifyIpMutingOfPlayer(ip, expire);
               messenger.notifyMacMutingOfPlayer(mac, expire);
               return;
             }

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/MutePlayerAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/MutePlayerAction.java
@@ -49,10 +49,8 @@ public class MutePlayerAction extends AbstractAction {
     for (final INode node : messenger.getNodes()) {
       if (node.getName().equals(name)) {
         final String realName = IServerMessenger.getRealName(node.getName());
-        final String ip = node.getAddress().getHostAddress();
         final String mac = messenger.getPlayerMac(node.getName());
         messenger.notifyUsernameMutingOfPlayer(realName, null);
-        messenger.notifyIpMutingOfPlayer(ip, null);
         messenger.notifyMacMutingOfPlayer(mac, null);
         return;
       }

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -172,11 +172,6 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     }
   }
 
-  @Override
-  public void notifyIpMutingOfPlayer(final String ip, final Instant muteExpires) {
-    // TODO: remove if no backwards compat issues
-  }
-
   private final List<String> liveMutedMacAddresses = new ArrayList<>();
 
   private boolean isMacMutedInCache(final String mac) {

--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -114,9 +114,6 @@ public class HeadlessServerMessenger implements IServerMessenger {
   public void notifyUsernameMutingOfPlayer(final String username, final Instant muteExpires) {}
 
   @Override
-  public void notifyIpMutingOfPlayer(final String ip, final Instant muteExpires) {}
-
-  @Override
   public void notifyMacMutingOfPlayer(final String mac, final Instant muteExpires) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -53,8 +53,6 @@ public interface IServerMessenger extends IMessenger {
 
   void notifyUsernameMutingOfPlayer(String username, Instant muteExpires);
 
-  void notifyIpMutingOfPlayer(String ip, Instant muteExpires);
-
   void notifyMacMutingOfPlayer(String mac, Instant muteExpires);
 
   boolean isUsernameMiniBanned(String username);


### PR DESCRIPTION
## Overview

Removes the `IServerMessenger#notifyIpMutingOfPlayer()` method.  The only implementation of this method was turned into a no-op in fe55b9888.

`IServerMessenger` is not an RMI interface.  Thus, there should be no issues with removing a method from this interface.

## Functional Changes

None.

## Manual Testing Performed

Verified this change didn't break compatibility in the following scenarios:

* Mute a player in a bot from the lobby.
    * Configuration: lobby server (10663), moderator lobby client (9687), game client (9687), headless game server (this branch).
* Mute a player in a network game from the host.
    * Configuration: game server (this branch), game client (9687).