### PR TITLE
Checkstyle: Fix missing Javadoc violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -7,6 +7,9 @@ import java.util.logging.Level;
 
 import lombok.extern.java.Log;
 
+/**
+ * A contiguous sequence of {@link GameStep}s within a single game round.
+ */
 @Log
 public class GameSequence extends GameDataComponent implements Iterable<GameStep> {
   private static final long serialVersionUID = 6354618406598578287L;

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -29,6 +29,9 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.system.HttpProxy;
 import lombok.extern.java.Log;
 
+/**
+ * Provides methods to download files via HTTP.
+ */
 @Log
 public final class DownloadUtils {
   @VisibleForTesting
@@ -127,7 +130,9 @@ public final class DownloadUtils {
     }
   }
 
-
+  /**
+   * The result of a file download request.
+   */
   public static class FileDownloadResult {
     public final boolean wasSuccess;
     public final File downloadedFile;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
@@ -4,6 +4,10 @@ import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.lobby.server.GameDescription.GameStatus;
 
+/**
+ * A proxy for an {@link InGameLobbyWatcher} to accommodate dynamically changing the underlying lobby watcher as games
+ * are started and stopped on the host.
+ */
 public class InGameLobbyWatcherWrapper {
   private volatile InGameLobbyWatcher lobbyWatcher = null;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -17,6 +17,9 @@ import com.google.common.base.Strings;
 import games.strategy.triplea.settings.ClientSetting;
 import lombok.extern.java.Log;
 
+/**
+ * Provides methods to configure the proxy to use for HTTP requests.
+ */
 @Log
 public class HttpProxy {
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -6,6 +6,9 @@ import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.Messengers;
 
+/**
+ * Provides information about a client connection to a lobby server.
+ */
 public class LobbyClient {
   private final Messengers messengers;
   private final boolean isAnonymousLogin;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -21,6 +21,15 @@ import games.strategy.net.MacFinder;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.util.Md5Crypt;
 
+/**
+ * The client side of the lobby authentication protocol.
+ *
+ * <p>
+ * The client is responsible for sending the initial authentication request to the server containing the user's name.
+ * The server will send back an authentication challenge. The client then sends a response to the challenge to prove the
+ * user knows the correct password.
+ * </p>
+ */
 public class LobbyLogin {
   private final Window parentWindow;
   private final LobbyServerProperties lobbyServerProperties;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -37,6 +37,9 @@ import games.strategy.triplea.ui.menubar.LobbyMenu;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.EventThreadJOptionPane;
 
+/**
+ * The top-level frame window for the lobby client UI.
+ */
 public class LobbyFrame extends JFrame {
   private static final long serialVersionUID = -388371674076362572L;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/EditGameCommentAction.java
@@ -8,6 +8,9 @@ import javax.swing.JOptionPane;
 
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 
+/**
+ * A UI action that prompts the user to change the comment displayed in the lobby game list for the selected game host.
+ */
 public class EditGameCommentAction extends AbstractAction {
   private static final long serialVersionUID = 1723950003185387843L;
   private final InGameLobbyWatcherWrapper lobbyWatcher;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/RemoveGameFromLobbyAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/RemoveGameFromLobbyAction.java
@@ -6,6 +6,9 @@ import javax.swing.AbstractAction;
 
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 
+/**
+ * A UI action that removes the selected game host from the lobby. There is no prompt to confirm the action.
+ */
 public class RemoveGameFromLobbyAction extends AbstractAction {
   private static final long serialVersionUID = 8802420945692279375L;
   private final InGameLobbyWatcherWrapper lobbyWatcher;

--- a/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -186,6 +186,11 @@ public class PBEMMessagePoster implements Serializable {
     return m_emailSender != null && m_emailSender.getAlsoPostAfterCombatMove();
   }
 
+  /**
+   * Posts a game turn summary (and optionally the associated save game) to the specified email service (if provided)
+   * and forum (if provided). The user is first prompted to confirm they wish to perform the action before the turn is
+   * posted.
+   */
   public static void postTurn(final String title, final HistoryLog historyLog, final boolean includeSaveGame,
       final PBEMMessagePoster posterPbem, final IAbstractForumPosterDelegate postingDelegate,
       final MainGameFrame mainGameFrame, final JComponent postButton) {

--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -171,6 +171,12 @@ public class ClipPlayer {
     setBeSilentInPreferencesWithoutAffectingCurrent(beSilent);
   }
 
+  /**
+   * Sets the {@code SOUND_PREFERENCE_GLOBAL_SWITCH} preference in the backing store without changing the current value
+   * in memory.
+   *
+   * @see #setBeSilent(boolean)
+   */
   public static void setBeSilentInPreferencesWithoutAffectingCurrent(final boolean silentBool) {
     final Preferences prefs = Preferences.userNodeForPackage(ClipPlayer.class);
     final boolean current = prefs.getBoolean(SOUND_PREFERENCE_GLOBAL_SWITCH, DEFAULT_SOUND_SILENCED_SWITCH_SETTING);

--- a/game-core/src/main/java/games/strategy/sound/HeadlessSoundChannel.java
+++ b/game-core/src/main/java/games/strategy/sound/HeadlessSoundChannel.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 
 import games.strategy.engine.data.PlayerID;
 
+/**
+ * Implementation of {@link ISound} that does nothing (i.e. no sounds will be played).
+ */
 public class HeadlessSoundChannel implements ISound {
 
   @Override

--- a/game-core/src/main/java/games/strategy/thread/LockUtil.java
+++ b/game-core/src/main/java/games/strategy/thread/LockUtil.java
@@ -46,6 +46,15 @@ public enum LockUtil {
 
   private final AtomicReference<ErrorReporter> errorReporterRef = new AtomicReference<>(new DefaultErrorReporter());
 
+  /**
+   * Acquires {@code lock}.
+   *
+   * <p>
+   * If {@code lock} is not currently held by the current thread, verifies that all other locks acquired prior to
+   * {@code lock} by the thread that most-recently held {@code lock} are held by the current thread. If not, a message
+   * will be written to the associated error reporter.
+   * </p>
+   */
   public void acquireLock(final Lock lock) {
     // we already have the lock, increase the count
     if (isLockHeld(lock)) {

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -11,6 +11,10 @@ import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.AbstractUiContext;
 import lombok.extern.java.Log;
 
+/**
+ * Provides methods that convert relative links within a game description into absolute links that will work on the
+ * local system.
+ */
 @Log
 public class LocalizeHtml {
   public static final String ASSET_IMAGE_FOLDER = "doc/images/";
@@ -39,6 +43,10 @@ public class LocalizeHtml {
     return localizeImgLinksInHtml(htmlText, AbstractUiContext.getResourceLoader(), null);
   }
 
+  /**
+   * Replaces relative image links within the HTML document {@code htmlText} with absolute links that point to the
+   * correct location on the local file system.
+   */
   public static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader resourceLoader,
       final String mapNameDir) {
     if (htmlText == null || (resourceLoader == null && (mapNameDir == null || mapNameDir.trim().length() == 0))) {

--- a/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-core/src/main/java/tools/image/CenterPicker.java
@@ -46,6 +46,15 @@ import games.strategy.util.PointFileReaderWriter;
 import lombok.extern.java.Log;
 import tools.util.ToolArguments;
 
+/**
+ * The center picker map-making tool.
+ *
+ * <p>
+ * This tool will allow you to manually specify center locations for each territory on a given map. Center locations
+ * tell the game where to put things like flags, text, unit placements, etc. It will generate a {@code centers.txt} file
+ * containing the territory center locations.
+ * </p>
+ */
 @Log
 public final class CenterPicker {
   private File mapFolderLocation;


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocMethod and JavadocType rules by adding missing Javadocs.  Changes to the proposed Javadocs are welcome.

## Functional Changes

None.  **This PR only contains Javadoc changes; there are no code changes.**

## Manual Testing Performed

None.