### PR TITLE
Error Prone: Fix string splitter violations in relationship change parsing

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.ToString;
 
 /**
@@ -24,7 +26,8 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
     super(data);
   }
 
-  void addPlayerId(final PlayerID player) {
+  @VisibleForTesting
+  public void addPlayerId(final PlayerID player) {
     m_players.put(player.getName(), player);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.RelationshipTypeAttachment;
 
@@ -81,7 +83,8 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
    *
    * @return the RelationshipType just created (convenience method for the GameParser)
    */
-  protected RelationshipType addRelationshipType(final RelationshipType relationshipType) {
+  @VisibleForTesting
+  public RelationshipType addRelationshipType(final RelationshipType relationshipType) {
     m_relationshipTypes.put(relationshipType.getName(), relationshipType);
     return relationshipType;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -83,9 +83,7 @@ public class AiPoliticalUtils {
   // TODO have another look at this part.
   private static boolean goesTowardsWar(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
-    for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          nextAction.parseRelationshipChange(relationshipChangeString);
+    for (final PoliticalActionAttachment.RelationshipChange relationshipChange : nextAction.getRelationshipChanges()) {
       final PlayerID p1 = relationshipChange.player1;
       final PlayerID p2 = relationshipChange.player2;
       // only continue if p1 or p2 is the AI
@@ -103,9 +101,7 @@ public class AiPoliticalUtils {
 
   private static boolean awayFromAlly(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
-    for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          nextAction.parseRelationshipChange(relationshipChangeString);
+    for (final PoliticalActionAttachment.RelationshipChange relationshipChange : nextAction.getRelationshipChanges()) {
       final PlayerID p1 = relationshipChange.player1;
       final PlayerID p2 = relationshipChange.player2;
       // only continue if p1 or p2 is the AI

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -84,7 +84,7 @@ public class AiPoliticalUtils {
   private static boolean goesTowardsWar(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final String[] relationshipChange = relationshipChangeString.split(":");
+      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
       final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
       final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       // only continue if p1 or p2 is the AI
@@ -103,7 +103,7 @@ public class AiPoliticalUtils {
   private static boolean awayFromAlly(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final String[] relationshipChange = relationshipChangeString.split(":");
+      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
       final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
       final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       // only continue if p1 or p2 is the AI

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -84,13 +84,15 @@ public class AiPoliticalUtils {
   private static boolean goesTowardsWar(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+      final PoliticalActionAttachment.RelationshipChange relationshipChange =
+          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
+        final RelationshipType newType =
+            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
         if (currentType.getRelationshipTypeAttachment().isNeutral()
             && newType.getRelationshipTypeAttachment().isWar()) {
           return true;
@@ -103,13 +105,15 @@ public class AiPoliticalUtils {
   private static boolean awayFromAlly(final PoliticalActionAttachment nextAction, final PlayerID p0,
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
-      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+      final PoliticalActionAttachment.RelationshipChange relationshipChange =
+          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
+        final RelationshipType newType =
+            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
         if (currentType.getRelationshipTypeAttachment().isAllied()
             && (newType.getRelationshipTypeAttachment().isNeutral()
                 || newType.getRelationshipTypeAttachment().isWar())) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -85,14 +85,13 @@ public class AiPoliticalUtils {
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
       final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+          nextAction.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = relationshipChange.player1;
+      final PlayerID p2 = relationshipChange.player2;
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType =
-            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+        final RelationshipType newType = relationshipChange.relationshipType;
         if (currentType.getRelationshipTypeAttachment().isNeutral()
             && newType.getRelationshipTypeAttachment().isWar()) {
           return true;
@@ -106,14 +105,13 @@ public class AiPoliticalUtils {
       final GameData data) {
     for (final String relationshipChangeString : nextAction.getRelationshipChange()) {
       final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+          nextAction.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = relationshipChange.player1;
+      final PlayerID p2 = relationshipChange.player2;
       // only continue if p1 or p2 is the AI
       if (p0.equals(p1) || p0.equals(p2)) {
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType =
-            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+        final RelationshipType newType = relationshipChange.relationshipType;
         if (currentType.getRelationshipTypeAttachment().isAllied()
             && (newType.getRelationshipTypeAttachment().isNeutral()
                 || newType.getRelationshipTypeAttachment().isWar())) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -57,9 +57,7 @@ class ProPoliticsAi {
     final Map<PoliticalActionAttachment, List<PlayerID>> neutralMap = new HashMap<>();
     for (final PoliticalActionAttachment action : validWarActions) {
       final List<PlayerID> warPlayers = new ArrayList<>();
-      for (final String relationshipChangeString : action.getRelationshipChange()) {
-        final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            action.parseRelationshipChange(relationshipChangeString);
+      for (final PoliticalActionAttachment.RelationshipChange relationshipChange : action.getRelationshipChanges()) {
         final PlayerID player1 = relationshipChange.player1;
         final PlayerID player2 = relationshipChange.player2;
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -58,7 +58,7 @@ class ProPoliticsAi {
     for (final PoliticalActionAttachment action : validWarActions) {
       final List<PlayerID> warPlayers = new ArrayList<>();
       for (final String relationshipChange : action.getRelationshipChange()) {
-        final String[] s = relationshipChange.split(":");
+        final String[] s = PoliticalActionAttachment.parseRelationshipChange(relationshipChange);
         final PlayerID player1 = data.getPlayerList().getPlayerId(s[0]);
         final PlayerID player2 = data.getPlayerList().getPlayerId(s[1]);
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -59,12 +59,11 @@ class ProPoliticsAi {
       final List<PlayerID> warPlayers = new ArrayList<>();
       for (final String relationshipChangeString : action.getRelationshipChange()) {
         final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-        final PlayerID player1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-        final PlayerID player2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+            action.parseRelationshipChange(relationshipChangeString);
+        final PlayerID player1 = relationshipChange.player1;
+        final PlayerID player2 = relationshipChange.player2;
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
-        final RelationshipType newRelation =
-            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+        final RelationshipType newRelation = relationshipChange.relationshipType;
         if (!oldRelation.equals(newRelation) && Matches.relationshipTypeIsAtWar().test(newRelation)
             && (player1.equals(player) || player2.equals(player))) {
           PlayerID warPlayer = player2;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -57,12 +57,14 @@ class ProPoliticsAi {
     final Map<PoliticalActionAttachment, List<PlayerID>> neutralMap = new HashMap<>();
     for (final PoliticalActionAttachment action : validWarActions) {
       final List<PlayerID> warPlayers = new ArrayList<>();
-      for (final String relationshipChange : action.getRelationshipChange()) {
-        final String[] s = PoliticalActionAttachment.parseRelationshipChange(relationshipChange);
-        final PlayerID player1 = data.getPlayerList().getPlayerId(s[0]);
-        final PlayerID player2 = data.getPlayerList().getPlayerId(s[1]);
+      for (final String relationshipChangeString : action.getRelationshipChange()) {
+        final PoliticalActionAttachment.RelationshipChange relationshipChange =
+            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+        final PlayerID player1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+        final PlayerID player2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
-        final RelationshipType newRelation = data.getRelationshipTypeList().getRelationshipType(s[2]);
+        final RelationshipType newRelation =
+            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
         if (!oldRelation.equals(newRelation) && Matches.relationshipTypeIsAtWar().test(newRelation)
             && (player1.equals(player) || player2.equals(player))) {
           PlayerID warPlayer = player2;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.concurrent.Immutable;
+
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
@@ -24,6 +26,9 @@ import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 /**
  * An attachment, attached to a player that will describe which political
@@ -115,18 +120,15 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    * @param encodedRelationshipChange The encoded relationship change of the form
    *        {@code <player1Name>:<player2Name>:<relationshipTypeName>}.
    *
-   * @return An array whose first element is the first player's name, whose second element is the second player's name,
-   *         and whose third element is the relationship type name.
-   *
    * @throws IllegalArgumentException If {@code encodedRelationshipChange} does not contain exactly three tokens
    *         separated by colons.
    */
-  public static String[] parseRelationshipChange(final String encodedRelationshipChange) {
+  public static RelationshipChange parseRelationshipChange(final String encodedRelationshipChange) {
     checkNotNull(encodedRelationshipChange);
 
     final String[] tokens = splitOnColon(encodedRelationshipChange);
     checkArgument(tokens.length == 3, String.format("Expected three tokens but was '%s'", encodedRelationshipChange));
-    return tokens;
+    return new RelationshipChange(tokens[0], tokens[1], tokens[2]);
   }
 
   /**
@@ -175,5 +177,18 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
                 this::getRelationshipChange,
                 this::resetRelationshipChange))
         .build();
+  }
+
+  /**
+   * A relationship change specified in a political action attachment. Specifies the relationship type that will exist
+   * between two players after the action is successful.
+   */
+  @AllArgsConstructor(access = AccessLevel.PACKAGE)
+  @EqualsAndHashCode
+  @Immutable
+  public static final class RelationshipChange {
+    public final String player1Name;
+    public final String player2Name;
+    public final String relationshipTypeName;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.annotation.concurrent.Immutable;
-
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
@@ -21,6 +19,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.RelationshipType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.Properties;
@@ -28,7 +27,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 
 /**
  * An attachment, attached to a player that will describe which political
@@ -123,12 +121,16 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    * @throws IllegalArgumentException If {@code encodedRelationshipChange} does not contain exactly three tokens
    *         separated by colons.
    */
-  public static RelationshipChange parseRelationshipChange(final String encodedRelationshipChange) {
+  public RelationshipChange parseRelationshipChange(final String encodedRelationshipChange) {
     checkNotNull(encodedRelationshipChange);
 
     final String[] tokens = splitOnColon(encodedRelationshipChange);
     checkArgument(tokens.length == 3, String.format("Expected three tokens but was '%s'", encodedRelationshipChange));
-    return new RelationshipChange(tokens[0], tokens[1], tokens[2]);
+    final GameData gameData = getData();
+    return new RelationshipChange(
+        gameData.getPlayerList().getPlayerId(tokens[0]),
+        gameData.getPlayerList().getPlayerId(tokens[1]),
+        gameData.getRelationshipTypeList().getRelationshipType(tokens[2]));
   }
 
   /**
@@ -183,12 +185,10 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    * A relationship change specified in a political action attachment. Specifies the relationship type that will exist
    * between two players after the action is successful.
    */
-  @AllArgsConstructor(access = AccessLevel.PACKAGE)
-  @EqualsAndHashCode
-  @Immutable
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
   public static final class RelationshipChange {
-    public final String player1Name;
-    public final String player2Name;
-    public final String relationshipTypeName;
+    public final PlayerID player1;
+    public final PlayerID player2;
+    public final RelationshipType relationshipType;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -1,5 +1,8 @@
 package games.strategy.triplea.attachments;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -104,6 +107,26 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
 
   private void resetRelationshipChange() {
     m_relationshipChange = new ArrayList<>();
+  }
+
+  /**
+   * Parses the specified encoded political action attachment relationship change.
+   *
+   * @param encodedRelationshipChange The encoded relationship change of the form
+   *        {@code <player1Name>:<player2Name>:<relationshipTypeName>}.
+   *
+   * @return An array whose first element is the first player's name, whose second element is the second player's name,
+   *         and whose third element is the relationship type name.
+   *
+   * @throws IllegalArgumentException If {@code encodedRelationshipChange} does not contain exactly three tokens
+   *         separated by colons.
+   */
+  public static String[] parseRelationshipChange(final String encodedRelationshipChange) {
+    checkNotNull(encodedRelationshipChange);
+
+    final String[] tokens = splitOnColon(encodedRelationshipChange);
+    checkArgument(tokens.length == 3, String.format("Expected three tokens but was '%s'", encodedRelationshipChange));
+    return tokens;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2010,9 +2010,7 @@ public final class Matches {
       final Predicate<RelationshipType> currentRelation, final Predicate<RelationshipType> newRelation,
       final GameData data) {
     return paa -> {
-      for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            paa.parseRelationshipChange(relationshipChangeString);
+      for (final PoliticalActionAttachment.RelationshipChange relationshipChange : paa.getRelationshipChanges()) {
         final PlayerID p1 = relationshipChange.player1;
         final PlayerID p2 = relationshipChange.player2;
         if (player != null && !(p1.equals(player) || p2.equals(player))) {
@@ -2031,9 +2029,7 @@ public final class Matches {
   public static Predicate<PoliticalActionAttachment> politicalActionAffectsAtLeastOneAlivePlayer(
       final PlayerID currentPlayer, final GameData data) {
     return paa -> {
-      for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            paa.parseRelationshipChange(relationshipChangeString);
+      for (final PoliticalActionAttachment.RelationshipChange relationshipChange : paa.getRelationshipChanges()) {
         final PlayerID p1 = relationshipChange.player1;
         final PlayerID p2 = relationshipChange.player2;
         if (!currentPlayer.equals(p1)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2011,7 +2011,7 @@ public final class Matches {
       final GameData data) {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final String[] relationshipChange = relationshipChangeString.split(":");
+        final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
         final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
         final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
         if (player != null && !(p1.equals(player) || p2.equals(player))) {
@@ -2031,7 +2031,7 @@ public final class Matches {
       final PlayerID currentPlayer, final GameData data) {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final String[] relationshipChange = relationshipChangeString.split(":");
+        final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
         final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
         final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
         if (!currentPlayer.equals(p1)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2012,15 +2012,14 @@ public final class Matches {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
         final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+            paa.parseRelationshipChange(relationshipChangeString);
+        final PlayerID p1 = relationshipChange.player1;
+        final PlayerID p2 = relationshipChange.player2;
         if (player != null && !(p1.equals(player) || p2.equals(player))) {
           continue;
         }
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType =
-            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+        final RelationshipType newType = relationshipChange.relationshipType;
         if (currentRelation.test(currentType) && newRelation.test(newType)) {
           return true;
         }
@@ -2034,9 +2033,9 @@ public final class Matches {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
         final PoliticalActionAttachment.RelationshipChange relationshipChange =
-            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+            paa.parseRelationshipChange(relationshipChangeString);
+        final PlayerID p1 = relationshipChange.player1;
+        final PlayerID p2 = relationshipChange.player2;
         if (!currentPlayer.equals(p1)) {
           if (p1.amNotDeadYet(data)) {
             return true;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2011,14 +2011,16 @@ public final class Matches {
       final GameData data) {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+        final PoliticalActionAttachment.RelationshipChange relationshipChange =
+            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
         if (player != null && !(p1.equals(player) || p2.equals(player))) {
           continue;
         }
         final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-        final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
+        final RelationshipType newType =
+            data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
         if (currentRelation.test(currentType) && newRelation.test(newType)) {
           return true;
         }
@@ -2031,9 +2033,10 @@ public final class Matches {
       final PlayerID currentPlayer, final GameData data) {
     return paa -> {
       for (final String relationshipChangeString : paa.getRelationshipChange()) {
-        final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+        final PoliticalActionAttachment.RelationshipChange relationshipChange =
+            PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+        final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+        final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
         if (!currentPlayer.equals(p1)) {
           if (p1.amNotDeadYet(data)) {
             return true;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -334,12 +334,11 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
       final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID player1 = getData().getPlayerList().getPlayerId(relationshipChange.player1Name);
-      final PlayerID player2 = getData().getPlayerList().getPlayerId(relationshipChange.player2Name);
+          paa.parseRelationshipChange(relationshipChangeString);
+      final PlayerID player1 = relationshipChange.player1;
+      final PlayerID player2 = relationshipChange.player2;
       final RelationshipType oldRelation = getData().getRelationshipTracker().getRelationshipType(player1, player2);
-      final RelationshipType newRelation =
-          getData().getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+      final RelationshipType newRelation = relationshipChange.relationshipType;
       if (oldRelation.equals(newRelation)) {
         continue;
       }
@@ -408,9 +407,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
       final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+          paa.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = relationshipChange.player1;
+      final PlayerID p2 = relationshipChange.player2;
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
@@ -419,8 +418,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         continue;
       }
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-      final RelationshipType newType =
-          data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+      final RelationshipType newType = relationshipChange.relationshipType;
       if (Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().test(currentType)
           && Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().negate().test(newType)) {
         for (final PlayerID p3 : p1AlliedWith) {
@@ -452,16 +450,15 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
       final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
+          paa.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = relationshipChange.player1;
+      final PlayerID p2 = relationshipChange.player2;
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
       final PlayerID otherPlayer = (p1.equals(player) ? p2 : p1);
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-      final RelationshipType newType =
-          data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
+      final RelationshipType newType = relationshipChange.relationshipType;
       if (Matches.relationshipTypeIsAtWar().test(currentType)
           && Matches.relationshipTypeIsAtWar().negate().test(newType)) {
         final Collection<PlayerID> otherPlayersAlliedWith =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -332,12 +332,14 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     getMyselfOutOfAlliance(paa, player, bridge);
     getNeutralOutOfWarWithAllies(paa, player, bridge);
     final CompositeChange change = new CompositeChange();
-    for (final String relationshipChange : paa.getRelationshipChange()) {
-      final String[] s = PoliticalActionAttachment.parseRelationshipChange(relationshipChange);
-      final PlayerID player1 = getData().getPlayerList().getPlayerId(s[0]);
-      final PlayerID player2 = getData().getPlayerList().getPlayerId(s[1]);
+    for (final String relationshipChangeString : paa.getRelationshipChange()) {
+      final PoliticalActionAttachment.RelationshipChange relationshipChange =
+          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+      final PlayerID player1 = getData().getPlayerList().getPlayerId(relationshipChange.player1Name);
+      final PlayerID player2 = getData().getPlayerList().getPlayerId(relationshipChange.player2Name);
       final RelationshipType oldRelation = getData().getRelationshipTracker().getRelationshipType(player1, player2);
-      final RelationshipType newRelation = getData().getRelationshipTypeList().getRelationshipType(s[2]);
+      final RelationshipType newRelation =
+          getData().getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
       if (oldRelation.equals(newRelation)) {
         continue;
       }
@@ -405,9 +407,10 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     p1AlliedWith.remove(player);
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+      final PoliticalActionAttachment.RelationshipChange relationshipChange =
+          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
@@ -416,7 +419,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         continue;
       }
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-      final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
+      final RelationshipType newType =
+          data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
       if (Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().test(currentType)
           && Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().negate().test(newType)) {
         for (final PlayerID p3 : p1AlliedWith) {
@@ -447,15 +451,17 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player, data));
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
-      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
-      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
+      final PoliticalActionAttachment.RelationshipChange relationshipChange =
+          PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
+      final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange.player1Name);
+      final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange.player2Name);
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
       final PlayerID otherPlayer = (p1.equals(player) ? p2 : p1);
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
-      final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
+      final RelationshipType newType =
+          data.getRelationshipTypeList().getRelationshipType(relationshipChange.relationshipTypeName);
       if (Matches.relationshipTypeIsAtWar().test(currentType)
           && Matches.relationshipTypeIsAtWar().negate().test(newType)) {
         final Collection<PlayerID> otherPlayersAlliedWith =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -332,9 +332,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     getMyselfOutOfAlliance(paa, player, bridge);
     getNeutralOutOfWarWithAllies(paa, player, bridge);
     final CompositeChange change = new CompositeChange();
-    for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          paa.parseRelationshipChange(relationshipChangeString);
+    for (final PoliticalActionAttachment.RelationshipChange relationshipChange : paa.getRelationshipChanges()) {
       final PlayerID player1 = relationshipChange.player1;
       final PlayerID player2 = relationshipChange.player2;
       final RelationshipType oldRelation = getData().getRelationshipTracker().getRelationshipType(player1, player2);
@@ -405,9 +403,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player, data));
     p1AlliedWith.remove(player);
     final CompositeChange change = new CompositeChange();
-    for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          paa.parseRelationshipChange(relationshipChangeString);
+    for (final PoliticalActionAttachment.RelationshipChange relationshipChange : paa.getRelationshipChanges()) {
       final PlayerID p1 = relationshipChange.player1;
       final PlayerID p2 = relationshipChange.player2;
       if (!(p1.equals(player) || p2.equals(player))) {
@@ -448,9 +444,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final Collection<PlayerID> p1AlliedWith =
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player, data));
     final CompositeChange change = new CompositeChange();
-    for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final PoliticalActionAttachment.RelationshipChange relationshipChange =
-          paa.parseRelationshipChange(relationshipChangeString);
+    for (final PoliticalActionAttachment.RelationshipChange relationshipChange : paa.getRelationshipChanges()) {
       final PlayerID p1 = relationshipChange.player1;
       final PlayerID p2 = relationshipChange.player2;
       if (!(p1.equals(player) || p2.equals(player))) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -333,7 +333,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     getNeutralOutOfWarWithAllies(paa, player, bridge);
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChange : paa.getRelationshipChange()) {
-      final String[] s = relationshipChange.split(":");
+      final String[] s = PoliticalActionAttachment.parseRelationshipChange(relationshipChange);
       final PlayerID player1 = getData().getPlayerList().getPlayerId(s[0]);
       final PlayerID player2 = getData().getPlayerList().getPlayerId(s[1]);
       final RelationshipType oldRelation = getData().getRelationshipTracker().getRelationshipType(player1, player2);
@@ -405,7 +405,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     p1AlliedWith.remove(player);
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final String[] relationshipChange = relationshipChangeString.split(":");
+      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
       final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
       final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       if (!(p1.equals(player) || p2.equals(player))) {
@@ -447,7 +447,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         CollectionUtils.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(player, data));
     final CompositeChange change = new CompositeChange();
     for (final String relationshipChangeString : paa.getRelationshipChange()) {
-      final String[] relationshipChange = relationshipChangeString.split(":");
+      final String[] relationshipChange = PoliticalActionAttachment.parseRelationshipChange(relationshipChangeString);
       final PlayerID p1 = data.getPlayerList().getPlayerId(relationshipChange[0]);
       final PlayerID p2 = data.getPlayerList().getPlayerId(relationshipChange[1]);
       if (!(p1.equals(player) || p2.equals(player))) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -25,7 +25,6 @@ import javax.swing.SwingUtilities;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
-import games.strategy.engine.data.RelationshipTypeList;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
@@ -249,25 +248,16 @@ public class PoliticsPanel extends ActionPanel {
         return 0;
       }
       final PoliticalActionAttachment.RelationshipChange paa1RelationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(paa1.getRelationshipChange().iterator().next());
+          paa1.parseRelationshipChange(paa1.getRelationshipChange().iterator().next());
       final PoliticalActionAttachment.RelationshipChange paa2RelationshipChange =
-          PoliticalActionAttachment.parseRelationshipChange(paa2.getRelationshipChange().iterator().next());
-      final RelationshipTypeList relationshipTypeList;
-      gameData.acquireReadLock();
-      try {
-        relationshipTypeList = gameData.getRelationshipTypeList();
-      } finally {
-        gameData.releaseReadLock();
-      }
-      final RelationshipType paa1NewType =
-          relationshipTypeList.getRelationshipType(paa1RelationshipChange.relationshipTypeName);
-      final RelationshipType paa2NewType =
-          relationshipTypeList.getRelationshipType(paa2RelationshipChange.relationshipTypeName);
+          paa2.parseRelationshipChange(paa2.getRelationshipChange().iterator().next());
+      final RelationshipType paa1NewType = paa1RelationshipChange.relationshipType;
+      final RelationshipType paa2NewType = paa2RelationshipChange.relationshipType;
       // sort by player
-      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerId(paa1RelationshipChange.player1Name);
-      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerId(paa1RelationshipChange.player2Name);
-      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerId(paa2RelationshipChange.player1Name);
-      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerId(paa2RelationshipChange.player2Name);
+      final PlayerID paa1p1 = paa1RelationshipChange.player1;
+      final PlayerID paa1p2 = paa1RelationshipChange.player2;
+      final PlayerID paa2p1 = paa2RelationshipChange.player1;
+      final PlayerID paa2p2 = paa2RelationshipChange.player2;
       final PlayerID paa1OtherPlayer = (player.equals(paa1p1) ? paa1p2 : paa1p1);
       final PlayerID paa2OtherPlayer = (player.equals(paa2p1) ? paa2p2 : paa2p1);
       if (!paa1OtherPlayer.equals(paa2OtherPlayer)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -248,9 +248,9 @@ public class PoliticsPanel extends ActionPanel {
       if (paa1.equals(paa2)) {
         return 0;
       }
-      final String[] paa1RelationChange =
+      final PoliticalActionAttachment.RelationshipChange paa1RelationshipChange =
           PoliticalActionAttachment.parseRelationshipChange(paa1.getRelationshipChange().iterator().next());
-      final String[] paa2RelationChange =
+      final PoliticalActionAttachment.RelationshipChange paa2RelationshipChange =
           PoliticalActionAttachment.parseRelationshipChange(paa2.getRelationshipChange().iterator().next());
       final RelationshipTypeList relationshipTypeList;
       gameData.acquireReadLock();
@@ -259,13 +259,15 @@ public class PoliticsPanel extends ActionPanel {
       } finally {
         gameData.releaseReadLock();
       }
-      final RelationshipType paa1NewType = relationshipTypeList.getRelationshipType(paa1RelationChange[2]);
-      final RelationshipType paa2NewType = relationshipTypeList.getRelationshipType(paa2RelationChange[2]);
+      final RelationshipType paa1NewType =
+          relationshipTypeList.getRelationshipType(paa1RelationshipChange.relationshipTypeName);
+      final RelationshipType paa2NewType =
+          relationshipTypeList.getRelationshipType(paa2RelationshipChange.relationshipTypeName);
       // sort by player
-      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerId(paa1RelationChange[0]);
-      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerId(paa1RelationChange[1]);
-      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerId(paa2RelationChange[0]);
-      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerId(paa2RelationChange[1]);
+      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerId(paa1RelationshipChange.player1Name);
+      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerId(paa1RelationshipChange.player2Name);
+      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerId(paa2RelationshipChange.player1Name);
+      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerId(paa2RelationshipChange.player2Name);
       final PlayerID paa1OtherPlayer = (player.equals(paa1p1) ? paa1p2 : paa1p1);
       final PlayerID paa2OtherPlayer = (player.equals(paa2p1) ? paa2p2 : paa2p1);
       if (!paa1OtherPlayer.equals(paa2OtherPlayer)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -248,8 +248,10 @@ public class PoliticsPanel extends ActionPanel {
       if (paa1.equals(paa2)) {
         return 0;
       }
-      final String[] paa1RelationChange = paa1.getRelationshipChange().iterator().next().split(":");
-      final String[] paa2RelationChange = paa2.getRelationshipChange().iterator().next().split(":");
+      final String[] paa1RelationChange =
+          PoliticalActionAttachment.parseRelationshipChange(paa1.getRelationshipChange().iterator().next());
+      final String[] paa2RelationChange =
+          PoliticalActionAttachment.parseRelationshipChange(paa2.getRelationshipChange().iterator().next());
       final RelationshipTypeList relationshipTypeList;
       gameData.acquireReadLock();
       try {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -248,9 +248,9 @@ public class PoliticsPanel extends ActionPanel {
         return 0;
       }
       final PoliticalActionAttachment.RelationshipChange paa1RelationshipChange =
-          paa1.parseRelationshipChange(paa1.getRelationshipChange().iterator().next());
+          paa1.getRelationshipChanges().iterator().next();
       final PoliticalActionAttachment.RelationshipChange paa2RelationshipChange =
-          paa2.parseRelationshipChange(paa2.getRelationshipChange().iterator().next());
+          paa2.getRelationshipChanges().iterator().next();
       final RelationshipType paa1NewType = paa1RelationshipChange.relationshipType;
       final RelationshipType paa2NewType = paa2RelationshipChange.relationshipType;
       // sort by player

--- a/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
@@ -1,0 +1,42 @@
+package games.strategy.triplea.attachments;
+
+import static games.strategy.triplea.attachments.PoliticalActionAttachment.parseRelationshipChange;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+final class PoliticalActionAttachmentTest {
+  @Nested
+  final class ParseRelationshipChangeTest {
+    private static final String PLAYER_1_NAME = "player1Name";
+    private static final String PLAYER_2_NAME = "player2Name";
+    private static final String RELATIONSHIP_TYPE_NAME = "relationshipTypeName";
+
+    private String join(final String... values) {
+      return Joiner.on(':').join(values);
+    }
+
+    @Test
+    void shouldReturnPlayerNamesAndRelationshipTypeName() {
+      assertThat(
+          parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)),
+          is(arrayContaining(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTokenCountNotEqualToThree() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME)));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME, "other")));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
@@ -1,51 +1,56 @@
 package games.strategy.triplea.attachments;
 
-import static games.strategy.triplea.attachments.PoliticalActionAttachment.parseRelationshipChange;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Joiner;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.RelationshipType;
 
 final class PoliticalActionAttachmentTest {
   @Nested
   final class ParseRelationshipChangeTest {
-    private static final String PLAYER_1_NAME = "player1Name";
-    private static final String PLAYER_2_NAME = "player2Name";
-    private static final String RELATIONSHIP_TYPE_NAME = "relationshipTypeName";
+    private final GameData gameData = new GameData();
+    private final PlayerID player1 = new PlayerID("player1Name", gameData);
+    private final PlayerID player2 = new PlayerID("player2Name", gameData);
+    private final RelationshipType relationshipType = new RelationshipType("relationshipTypeName", gameData);
+    private final PoliticalActionAttachment politicalActionAttachment =
+        new PoliticalActionAttachment("politicalActionAttachmentName", null, gameData);
 
     private String join(final String... values) {
       return Joiner.on(':').join(values);
     }
 
+    @BeforeEach
+    void setUpGameData() {
+      gameData.getPlayerList().addPlayerId(player1);
+      gameData.getPlayerList().addPlayerId(player2);
+      gameData.getRelationshipTypeList().addRelationshipType(relationshipType);
+    }
+
     @Test
     void shouldParseRelationshipChangeWhenTokenCountEqualsThree() {
-      assertThat(
-          parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)),
-          is(new PoliticalActionAttachment.RelationshipChange(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)));
+      final PoliticalActionAttachment.RelationshipChange relationshipChange = politicalActionAttachment
+          .parseRelationshipChange(join(player1.getName(), player2.getName(), relationshipType.getName()));
+
+      assertThat(relationshipChange.player1, is(player1));
+      assertThat(relationshipChange.player2, is(player2));
+      assertThat(relationshipChange.relationshipType, is(relationshipType));
     }
 
     @Test
     void shouldThrowExceptionWhenTokenCountNotEqualsThree() {
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME)));
-      assertThrows(
-          IllegalArgumentException.class,
-          () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME, "other")));
-    }
-  }
-
-  @Nested
-  final class RelationshipChangeTest {
-    @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(PoliticalActionAttachment.RelationshipChange.class).verify();
+      assertThrows(IllegalArgumentException.class, () -> politicalActionAttachment.parseRelationshipChange(
+          join(player1.getName(), player2.getName())));
+      assertThrows(IllegalArgumentException.class, () -> politicalActionAttachment.parseRelationshipChange(
+          join(player1.getName(), player2.getName(), relationshipType.getName(), "other")));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.attachments;
 
 import static games.strategy.triplea.attachments.PoliticalActionAttachment.parseRelationshipChange;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -10,6 +9,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Joiner;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 final class PoliticalActionAttachmentTest {
   @Nested
@@ -23,20 +24,28 @@ final class PoliticalActionAttachmentTest {
     }
 
     @Test
-    void shouldReturnPlayerNamesAndRelationshipTypeName() {
+    void shouldParseRelationshipChangeWhenTokenCountEqualsThree() {
       assertThat(
           parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)),
-          is(arrayContaining(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)));
+          is(new PoliticalActionAttachment.RelationshipChange(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME)));
     }
 
     @Test
-    void shouldThrowExceptionWhenTokenCountNotEqualToThree() {
+    void shouldThrowExceptionWhenTokenCountNotEqualsThree() {
       assertThrows(
           IllegalArgumentException.class,
           () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME)));
       assertThrows(
           IllegalArgumentException.class,
           () -> parseRelationshipChange(join(PLAYER_1_NAME, PLAYER_2_NAME, RELATIONSHIP_TYPE_NAME, "other")));
+    }
+  }
+
+  @Nested
+  final class RelationshipChangeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(PoliticalActionAttachment.RelationshipChange.class).verify();
     }
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule when parsing relationship change strings associated with a `PoliticalActionAttachment`.

## Functional Changes

None.

## Refactoring Changes

The second commit is a refactoring that doesn't affect fixing the Error Prone violations in the first commit.  It extracts the new type `PoliticalActionAttachment$RelationshipChange` so that callers don't have to access the elements of a `String[]` by index, but rather can use named fields to access the relevant information of a relationship change.  This change can be easily reverted if it's deemed too risky due to lack of test coverage.

## Manual Testing Performed

Verified I could play through the politics phase of WW2 Global 1940, which contains several `relationshipChange` options in its various `PoliticalActionAttachment` elements.