### PR TITLE
Error Prone: Fix reference equality violations in RouteDescription

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -30,10 +30,10 @@ public class RouteDescription {
   public boolean equals(final Object o) {
     if (o == this) {
       return true;
-    }
-    if (o == null) {
+    } else if (!(o instanceof RouteDescription)) {
       return false;
     }
+
     final RouteDescription other = (RouteDescription) o;
     if ((start == null && other.start != null) || (other.start == null && start != null)
         || (start != other.start && !start.equals(other.start))) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -5,7 +5,11 @@ import java.awt.Point;
 import java.util.Objects;
 
 import games.strategy.engine.data.Route;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@AllArgsConstructor
+@Getter
 class RouteDescription {
   private final Route route;
   // this point is in map co-ordinates, un scaled
@@ -13,13 +17,6 @@ class RouteDescription {
   // this point is in map co-ordinates, un scaled
   private final Point end;
   private final Image cursorImage;
-
-  RouteDescription(final Route route, final Point start, final Point end, final Image cursorImage) {
-    this.route = route;
-    this.start = start;
-    this.end = end;
-    this.cursorImage = cursorImage;
-  }
 
   @Override
   public int hashCode() {
@@ -60,21 +57,5 @@ class RouteDescription {
     diffY *= diffY;
     final int endDiff = (int) Math.sqrt(diffX + diffY);
     return endDiff < 6;
-  }
-
-  public Route getRoute() {
-    return route;
-  }
-
-  public Point getStart() {
-    return start;
-  }
-
-  public Point getEnd() {
-    return end;
-  }
-
-  public Image getCursorImage() {
-    return cursorImage;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 import games.strategy.engine.data.Route;
 
-public class RouteDescription {
+class RouteDescription {
   private final Route route;
   // this point is in map co-ordinates, un scaled
   private final Point start;

--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -32,12 +32,10 @@ class RouteDescription {
     }
 
     final RouteDescription other = (RouteDescription) o;
-    if ((start == null && other.start != null) || (other.start == null && start != null)
-        || (start != other.start && !start.equals(other.start))) {
+    if (!Objects.equals(start, other.start)) {
       return false;
     }
-    if ((route == null && other.route != null) || (other.route == null && route != null)
-        || (route != other.route && !route.equals(other.route))) {
+    if (!Objects.equals(route, other.route)) {
       return false;
     }
     if ((end == null && other.end != null) || (other.end == null && end != null)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -4,6 +4,8 @@ import java.awt.Image;
 import java.awt.Point;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.Route;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,12 +13,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 class RouteDescription {
-  private final Route route;
+  private final @Nullable Route route;
   // this point is in map co-ordinates, un scaled
-  private final Point start;
+  private final @Nullable Point start;
   // this point is in map co-ordinates, un scaled
-  private final Point end;
-  private final Image cursorImage;
+  private final @Nullable Point end;
+  private final @Nullable Image cursorImage;
 
   @Override
   public int hashCode() {

--- a/game-core/src/test/java/games/strategy/triplea/ui/RouteDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/RouteDescriptionTest.java
@@ -2,28 +2,85 @@ package games.strategy.triplea.ui;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 import java.awt.Image;
 import java.awt.Point;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
 
 final class RouteDescriptionTest {
+  @ExtendWith(MockitoExtension.class)
   @Nested
   final class EqualsTest {
-    private final RouteDescription reference = new RouteDescription(
-        new Route(),
-        new Point(),
-        new Point(),
-        mock(Image.class));
+    private final Route route = new Route();
+    private final Point start = new Point();
+    private final Point end = new Point();
+    @Mock
+    private Image image;
 
     @Test
     void shouldReturnFalseWhenOtherIsNotInstanceOfRouteDescription() {
+      final RouteDescription reference = new RouteDescription(route, start, end, image);
+
       assertThat(reference.equals(new Object()), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceRouteIsNullAndOtherRouteIsNotNull() {
+      final RouteDescription reference = new RouteDescription(null, start, end, image);
+      final RouteDescription other = new RouteDescription(route, start, end, image);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceRouteIsNotNullAndOtherRouteIsNull() {
+      final RouteDescription reference = new RouteDescription(route, start, end, image);
+      final RouteDescription other = new RouteDescription(null, start, end, image);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceRouteIsNotEqualToOtherRoute() {
+      final RouteDescription reference = new RouteDescription(route, start, end, image);
+      final Route otherRoute = new Route(new Territory("territoryName", new GameData()));
+      final RouteDescription other = new RouteDescription(otherRoute, start, end, image);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceStartIsNullAndOtherStartIsNotNull() {
+      final RouteDescription reference = new RouteDescription(route, null, end, image);
+      final RouteDescription other = new RouteDescription(route, start, end, image);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceStartIsNotNullAndOtherStartIsNull() {
+      final RouteDescription reference = new RouteDescription(route, start, end, image);
+      final RouteDescription other = new RouteDescription(route, null, end, image);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenReferenceStartIsNotEqualToOtherStart() {
+      final RouteDescription reference = new RouteDescription(route, start, end, image);
+      final Point otherStart = new Point(start.x + 1, start.y);
+      final RouteDescription other = new RouteDescription(route, otherStart, end, image);
+
+      assertThat(reference.equals(other), is(false));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/RouteDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/RouteDescriptionTest.java
@@ -1,0 +1,29 @@
+package games.strategy.triplea.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import java.awt.Image;
+import java.awt.Point;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.Route;
+
+final class RouteDescriptionTest {
+  @Nested
+  final class EqualsTest {
+    private final RouteDescription reference = new RouteDescription(
+        new Route(),
+        new Point(),
+        new Point(),
+        mock(Image.class));
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNotInstanceOfRouteDescription() {
+      assertThat(reference.equals(new Object()), is(false));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `RouteDescription` class.

## Functional Changes

One bug fix in `RouteDescription` beyond the Error Prone fixes that affects runtime behavior:

* Fixed a potential `ClassCastException` in `equals()`.

## Refactoring Changes

A few refactorings in `RouteDescription` beyond the Error Prone fixes:

* Decreased class accessibility to package-private.
* Use Lombok `@AllArgsConstructor` and `@Getter`.
* Annotated all fields as `@Nullable`.

## Manual Testing Performed

None.