### PR TITLE
Error Prone: Fix reference equality violations with NULL_PLAYERID

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -805,7 +805,7 @@ public final class Matches {
       if (t.isWater()) {
         // if it's water, it is a Convoy Center
         // Can't get PUs for capturing a CC, only original owner can get them. (Except capturing null player CCs)
-        if (!(origOwner == null || origOwner == PlayerID.NULL_PLAYERID || origOwner == player)) {
+        if (!(origOwner == null || origOwner.equals(PlayerID.NULL_PLAYERID) || origOwner == player)) {
           return false;
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -536,7 +536,7 @@ public class HistoryLog extends JFrame {
       if (!place.isWater()
           || (place.isWater()
               && ta != null
-              && OriginalOwnerTracker.getOriginalOwner(place) != PlayerID.NULL_PLAYERID
+              && !PlayerID.NULL_PLAYERID.equals(OriginalOwnerTracker.getOriginalOwner(place))
               && OriginalOwnerTracker.getOriginalOwner(place) == player
               && place.getOwner().equals(player))) {
         isConvoyOrLand = true;


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in usages of `PlayerID#NULL_PLAYERID`.

Every other equality comparison with `NULL_PLAYERID` in the code compares values; only the two occurrences changed in this PR compared references.  Therefore, these two were probably just oversights and changing them to value comparisons should be safe.

Also, there is no other place in the code that creates an instance of `PlayerID` with the name `"Neutral"` (`Constants#PLAYER_NAME_NEUTRAL`), so there should never be a false positive of some other `PlayerID` instance being equal to `NULL_PLAYERID` other than `NULL_PLAYERID` itself (or a deserialized copy of `NULL_PLAYERID`).

## Functional Changes

None.

## Manual Testing Performed

None.