### PR TITLE
Update MoveValidator to try using land transports for land canals

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1434,10 +1434,10 @@ public final class Matches {
     return u -> TechTracker.hasImprovedArtillerySupport(u.getOwner());
   }
 
+  // TODO: Eventually remove as only used by AI and doesn't handle canals very well
   public static Predicate<Territory> territoryHasNonAllowedCanal(final PlayerID player,
-      final Collection<Unit> unitsMoving,
-      final GameData data) {
-    return t -> MoveValidator.validateCanal(t, null, unitsMoving, player, data).isPresent();
+      final Collection<Unit> unitsMoving, final GameData data) {
+    return t -> MoveValidator.validateCanal(new Route(t), unitsMoving, player, data) != null;
   }
 
   public static Predicate<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -569,9 +569,11 @@ public class MoveValidator {
       // Check that units have enough movement considering land transports
       final Collection<Unit> unitsWithoutDependents = findNonDependentUnits(units, route, newDependents);
       final Set<Unit> unitsWithEnoughMovement = unitsWithoutDependents.stream()
-          .filter(unit -> Matches.unitHasEnoughMovementForRoute(route).test(unit)).collect(Collectors.toSet());
+          .filter(unit -> Matches.unitHasEnoughMovementForRoute(route).test(unit))
+          .collect(Collectors.toSet());
       final Set<Unit> unitsWithoutEnoughMovement = unitsWithoutDependents.stream()
-          .filter(unit -> !Matches.unitHasEnoughMovementForRoute(route).test(unit)).collect(Collectors.toSet());
+          .filter(unit -> !Matches.unitHasEnoughMovementForRoute(route).test(unit))
+          .collect(Collectors.toSet());
       checkLandTransports(data, route, player, unitsWithEnoughMovement, unitsWithoutEnoughMovement)
           .forEach(unit -> result.addDisallowedUnit("Not all units have enough movement", unit));
 


### PR DESCRIPTION
## Overview
Addresses: https://forums.triplea-game.org/topic/984/add-support-for-land-transports-moving-through-canals

## Functional Changes
- Added checks to canal validation to try to land transport units if they can't move through themselves

## Manual Testing Performed
- Tested latest Red Sun Over China and Total World War which both use land transports extensively

## Additional Review Notes
- Recommend reviewing without whitespace changes: ?w=1
- Move validation and particularly canal validation code is pretty rough. I did some significant refactoring while making this change to avoid code duplication but I'm sure there is far more that can still be done. But given the complexity and that this is primarily a feature PR, I tried to minimize risk of adverse effects.