### PR TITLE
Fix potential NPE in GameSequence

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Level;
 
 import lombok.extern.java.Log;
 
@@ -44,8 +43,8 @@ public class GameSequence extends GameDataComponent implements Iterable<GameStep
     }
     if (!found) {
       m_currentIndex = 0;
-      log.log(Level.SEVERE, "Step Not Found (" + stepDisplayName + ":" + player.getName() + "), will instead use: "
-          + m_steps.get(m_currentIndex));
+      log.severe(() -> String.format("Step Not Found (%s:%s), will instead use: %s",
+          stepDisplayName, (player != null) ? player.getName() : "null", m_steps.get(m_currentIndex)));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/data/GameSequenceTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameSequenceTest.java
@@ -1,0 +1,80 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Properties;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.delegate.IDelegate;
+import games.strategy.engine.xml.TestDelegate;
+
+final class GameSequenceTest {
+  @Nested
+  final class SetRoundAndStepTest {
+    private static final String GAME_STEP_NAME = "gameStep";
+    private static final String OTHER_GAME_STEP_NAME = "otherGameStep";
+
+    private final GameData gameData = new GameData();
+    private final PlayerID player = new PlayerID("player", gameData);
+    private final GameSequence gameSequence = new GameSequence(gameData);
+
+    private GameStep newGameStep(final String displayName, final @Nullable PlayerID player) {
+      final IDelegate delegate = new TestDelegate();
+      delegate.initialize("delegateName", "delegateDisplayName");
+      return new GameStep("stepName", displayName, player, delegate, gameData, new Properties());
+    }
+
+    @Test
+    void shouldSetRound() {
+      gameSequence.addStep(newGameStep(GAME_STEP_NAME, player));
+
+      final int round = 42;
+      gameSequence.setRoundAndStep(round, null, null);
+
+      assertThat(gameSequence.getRound(), is(round));
+    }
+
+    @Test
+    void shouldSetStepIndexWhenPlayerIsNullAndStepExists() {
+      gameSequence.addStep(newGameStep(GAME_STEP_NAME, null));
+      gameSequence.addStep(newGameStep(OTHER_GAME_STEP_NAME, null));
+
+      gameSequence.setRoundAndStep(1, OTHER_GAME_STEP_NAME, null);
+
+      assertThat(gameSequence.getStepIndex(), is(1));
+    }
+
+    @Test
+    void shouldSetStepIndexToZeroWhenPlayerIsNullAndStepNotExists() {
+      gameSequence.addStep(newGameStep(GAME_STEP_NAME, null));
+
+      gameSequence.setRoundAndStep(1, OTHER_GAME_STEP_NAME, null);
+
+      assertThat(gameSequence.getStepIndex(), is(0));
+    }
+
+    @Test
+    void shouldSetStepIndexWhenPlayerIsNotNullAndStepExists() {
+      gameSequence.addStep(newGameStep(GAME_STEP_NAME, player));
+      gameSequence.addStep(newGameStep(OTHER_GAME_STEP_NAME, player));
+
+      gameSequence.setRoundAndStep(1, OTHER_GAME_STEP_NAME, player);
+
+      assertThat(gameSequence.getStepIndex(), is(1));
+    }
+
+    @Test
+    void shouldSetStepIndexToZeroWhenPlayerIsNotNullAndStepNotExists() {
+      gameSequence.addStep(newGameStep(GAME_STEP_NAME, player));
+
+      gameSequence.setRoundAndStep(1, GAME_STEP_NAME, player);
+
+      assertThat(gameSequence.getStepIndex(), is(0));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes a potential NPE in `GameSequence#setRoundAndStep()`, as identified by static analysis.

## Functional Changes

None.

## Manual Testing Performed

None.  Added unit tests that error with an NPE when the `player` argument is `null` and verified they passed after applying the fix.