### PR TITLE
Error Prone: Fix reference equality violations in GameMap

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -251,7 +253,10 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param cond condition that covered territories of the route must match
    */
   public Route getRoute(final Territory t1, final Territory t2, final Predicate<Territory> cond) {
-    if (t1 == t2) {
+    checkNotNull(t1);
+    checkNotNull(t2);
+
+    if (t1.equals(t2)) {
       return new Route(t1);
     }
     if (getNeighbors(t1, cond).contains(t2)) {
@@ -297,12 +302,15 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *
    * @param start start territory of the route
    * @param end end territory of the route
-   * @param matches HashMap of territory matches for covered territories
+   * @param matches Map of territory matches for covered territories
    * @return a composite route between two territories
    */
   public Route getCompositeRoute(final Territory start, final Territory end,
       final Map<Predicate<Territory>, Integer> matches) {
-    if (start == end) {
+    checkNotNull(start);
+    checkNotNull(end);
+
+    if (start.equals(end)) {
       return new Route(start);
     }
     final Predicate<Territory> allCond = t -> matches.keySet().stream().anyMatch(p -> p.test(t));

--- a/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameMapTest.java
@@ -1,0 +1,36 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class GameMapTest {
+  private final GameData gameData = new GameData();
+  private final GameMap gameMap = new GameMap(gameData);
+
+  @Nested
+  final class GetCompositeRouteTest {
+    @Test
+    void shouldReturnRouteToSelfWhenStartEqualsEnd() {
+      final Territory start = new Territory("territory", gameData);
+      final Territory end = new Territory("territory", gameData);
+
+      assertThat(gameMap.getCompositeRoute(start, end, Collections.emptyMap()), is(new Route(start)));
+    }
+  }
+
+  @Nested
+  final class GetRouteTest {
+    @Test
+    void shouldReturnRouteToSelfWhenStartEqualsEnd() {
+      final Territory start = new Territory("territory", gameData);
+      final Territory end = new Territory("territory", gameData);
+
+      assertThat(gameMap.getRoute(start, end), is(new Route(start)));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `GameMap` class.

An examination of the code in question would seem to indicate value equality is indeed the right choice.  In addition, all other equality checks between `Territory`s in this class are performed using value equality instead of reference equality.

## Functional Changes

None.

## Refactoring Changes

Added `null` checks on the `Territory` arguments for the affected methods.  The various `Route` constructors require non-`null` `Territory`s, so this can be seen as an attempt to fail fast.  The addition of these preconditions weren't absolutely necessary, but it helps to document the decision why I didn't use `Objects#equals()` instead of calling `Object#equals()` directly.

## Manual Testing Performed

None.