### PR TITLE
Error Prone: Fix string splitter violations in auto update checks

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -1,37 +1,31 @@
 package games.strategy.engine.auto.update;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoField;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.logging.Level;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+
 import games.strategy.engine.ClientContext;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.GameSetting;
 import games.strategy.util.EventThreadJOptionPane;
 import lombok.extern.java.Log;
 
 @Log
-class EngineVersionCheck {
+final class EngineVersionCheck {
+  private EngineVersionCheck() {}
+
   static void checkForLatestEngineVersionOut() {
     try {
-      final boolean firstTimeThisVersion = ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY.booleanValue();
-      // check at most once per 2 days (but still allow a 'first run message' for a new version of triplea)
-      final LocalDateTime localDateTime = LocalDateTime.now();
-      final int year = localDateTime.get(ChronoField.YEAR);
-      final int day = localDateTime.get(ChronoField.DAY_OF_YEAR);
-      // format year:day
-      final String lastCheckTime = ClientSetting.TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE.value();
-      if (!firstTimeThisVersion && lastCheckTime.trim().length() > 0) {
-        final String[] yearDay = lastCheckTime.split(":");
-        if (Integer.parseInt(yearDay[0]) >= year && Integer.parseInt(yearDay[1]) + 1 >= day) {
-          return;
-        }
+      if (!isEngineUpdateCheckRequired()) {
+        return;
       }
-
-      ClientSetting.TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE.save(year + ":" + day);
-      ClientSetting.flush();
 
       final EngineVersionProperties latestEngineOut = EngineVersionProperties.contactServerForEngineVersionProperties();
       if (latestEngineOut == null) {
@@ -45,5 +39,46 @@ class EngineVersionCheck {
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Error while checking for engine updates", e);
     }
+  }
+
+  private static boolean isEngineUpdateCheckRequired() {
+    return isEngineUpdateCheckRequired(
+        LocalDate.now(),
+        ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY,
+        ClientSetting.TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE,
+        ClientSetting::flush);
+  }
+
+  @VisibleForTesting
+  static boolean isEngineUpdateCheckRequired(
+      final LocalDate now,
+      final GameSetting firstRunSetting,
+      final GameSetting updateCheckDateSetting,
+      final Runnable flushSetting) {
+    // check at most once per 2 days (but still allow a 'first run message' for a new version of TripleA)
+    final boolean firstRun = firstRunSetting.booleanValue();
+    final String encodedUpdateCheckDate = updateCheckDateSetting.value();
+    if (!firstRun && !encodedUpdateCheckDate.trim().isEmpty()) {
+      final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
+      if (updateCheckDate.until(now, ChronoUnit.DAYS) < 2) {
+        return false;
+      }
+    }
+
+    updateCheckDateSetting.save(formatUpdateCheckDate(now));
+    flushSetting.run();
+
+    return true;
+  }
+
+  @VisibleForTesting
+  static LocalDate parseUpdateCheckDate(final String encodedUpdateCheckDate) {
+    final List<String> tokens = Splitter.on(':').splitToList(encodedUpdateCheckDate);
+    return LocalDate.ofYearDay(Integer.parseInt(tokens.get(0)), Integer.parseInt(tokens.get(1)));
+  }
+
+  @VisibleForTesting
+  static String formatUpdateCheckDate(final LocalDate updateCheckDate) {
+    return updateCheckDate.getYear() + ":" + updateCheckDate.getDayOfYear();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.auto.update;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -60,7 +59,7 @@ final class EngineVersionCheck {
     final String encodedUpdateCheckDate = updateCheckDateSetting.value();
     if (!firstRun && !encodedUpdateCheckDate.trim().isEmpty()) {
       final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
-      if (updateCheckDate.until(now, ChronoUnit.DAYS) < 2) {
+      if (updateCheckDate.isAfter(now.minusDays(2))) {
         return false;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -25,7 +25,7 @@ public class UpdateChecks {
     TutorialMapCheck.checkForTutorialMap();
     EngineVersionCheck.checkForLatestEngineVersionOut();
 
-    if (UpdatedMapsCheck.shouldRunMapUpdateCheck()) {
+    if (UpdatedMapsCheck.isMapUpdateCheckRequired()) {
       MapDownloadController.checkDownloadedMapsAreLatest();
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.auto.update;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -29,7 +28,7 @@ final class UpdatedMapsCheck {
     final String encodedUpdateCheckDate = updateCheckDateSetting.value();
     if (!encodedUpdateCheckDate.trim().isEmpty()) {
       final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
-      if (updateCheckDate.until(now, ChronoUnit.MONTHS) < 1) {
+      if (updateCheckDate.isAfter(now.minusMonths(1))) {
         return false;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -1,30 +1,53 @@
 package games.strategy.engine.auto.update;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoField;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 
-import com.google.common.base.Strings;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.GameSetting;
 
-class UpdatedMapsCheck {
+final class UpdatedMapsCheck {
+  private UpdatedMapsCheck() {}
 
-  static boolean shouldRunMapUpdateCheck() {
+  static boolean isMapUpdateCheckRequired() {
+    return isMapUpdateCheckRequired(
+        LocalDate.now(),
+        ClientSetting.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES,
+        ClientSetting::flush);
+  }
+
+  @VisibleForTesting
+  static boolean isMapUpdateCheckRequired(
+      final LocalDate now,
+      final GameSetting updateCheckDateSetting,
+      final Runnable flushSetting) {
     // check at most once per month
-    final LocalDateTime locaDateTime = LocalDateTime.now();
-    final int year = locaDateTime.get(ChronoField.YEAR);
-    final int month = locaDateTime.get(ChronoField.MONTH_OF_YEAR);
-    // format year:month
-    final String lastCheckTime = ClientSetting.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES.value();
-
-    if (!Strings.nullToEmpty(lastCheckTime).trim().isEmpty()) {
-      final String[] yearMonth = lastCheckTime.split(":");
-      if (Integer.parseInt(yearMonth[0]) >= year && Integer.parseInt(yearMonth[1]) >= month) {
+    final String encodedUpdateCheckDate = updateCheckDateSetting.value();
+    if (!encodedUpdateCheckDate.trim().isEmpty()) {
+      final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
+      if (updateCheckDate.until(now, ChronoUnit.MONTHS) < 1) {
         return false;
       }
     }
-    ClientSetting.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES.save(year + ":" + month);
-    ClientSetting.flush();
+
+    updateCheckDateSetting.save(formatUpdateCheckDate(now));
+    flushSetting.run();
+
     return true;
+  }
+
+  @VisibleForTesting
+  static LocalDate parseUpdateCheckDate(final String encodedUpdateCheckDate) {
+    final List<String> tokens = Splitter.on(':').splitToList(encodedUpdateCheckDate);
+    return LocalDate.of(Integer.parseInt(tokens.get(0)), Integer.parseInt(tokens.get(1)), 1);
+  }
+
+  @VisibleForTesting
+  static String formatUpdateCheckDate(final LocalDate updateCheckDate) {
+    return updateCheckDate.getYear() + ":" + updateCheckDate.getMonthValue();
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
@@ -1,0 +1,148 @@
+package games.strategy.engine.auto.update;
+
+import static games.strategy.engine.auto.update.EngineVersionCheck.formatUpdateCheckDate;
+import static games.strategy.engine.auto.update.EngineVersionCheck.parseUpdateCheckDate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import games.strategy.triplea.settings.GameSetting;
+
+final class EngineVersionCheckTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class IsEngineUpdateCheckRequiredTest {
+    private final LocalDate now = LocalDate.of(2008, 6, 1);
+    @Mock
+    private GameSetting firstRunSetting;
+    @Mock
+    private GameSetting updateCheckDateSetting;
+    @Mock
+    private Runnable flushSetting;
+
+    private void givenFirstRun() {
+      when(firstRunSetting.booleanValue()).thenReturn(true);
+    }
+
+    private void givenNotFirstRun() {
+      when(firstRunSetting.booleanValue()).thenReturn(false);
+    }
+
+    private void givenEngineUpdateCheckNeverRun() {
+      when(updateCheckDateSetting.value()).thenReturn("");
+    }
+
+    private void givenEngineUpdateCheckLastRunRelativeToNow(final long amountToAdd, final TemporalUnit unit) {
+      when(updateCheckDateSetting.value()).thenReturn(formatUpdateCheckDate(now.plus(amountToAdd, unit)));
+    }
+
+    private boolean whenIsEngineUpdateCheckRequired() {
+      return EngineVersionCheck.isEngineUpdateCheckRequired(now, firstRunSetting, updateCheckDateSetting, flushSetting);
+    }
+
+    @Test
+    void shouldReturnTrueWhenFirstRun() {
+      givenFirstRun();
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckLastRunOneYearAgo() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.YEARS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckLastRunTwoDaysAgo() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(-2, ChronoUnit.DAYS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckNeverRun() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckNeverRun();
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldSaveAndFlushLastUpdateCheckDateSettingWhenReturnsTrue() {
+      givenFirstRun();
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
+      verify(updateCheckDateSetting).save(formatUpdateCheckDate(now));
+      verify(flushSetting).run();
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunOneDayAgo() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.DAYS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunToday() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(0, ChronoUnit.DAYS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunOneDayHence() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(1, ChronoUnit.DAYS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
+    }
+
+    @Test
+    void shouldNotSaveAndFlushLastUpdateCheckDateSettingWhenReturnsFalse() {
+      givenNotFirstRun();
+      givenEngineUpdateCheckLastRunRelativeToNow(0, ChronoUnit.DAYS);
+
+      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
+      verify(updateCheckDateSetting, never()).save(anyString());
+      verify(flushSetting, never()).run();
+    }
+  }
+
+  @Nested
+  final class ParseUpdateCheckDateTest {
+    @Test
+    void shouldParseStringAsDate() {
+      assertThat(parseUpdateCheckDate("2018:1"), is(LocalDate.ofYearDay(2018, 1)));
+      assertThat(parseUpdateCheckDate("1941:365"), is(LocalDate.ofYearDay(1941, 365)));
+    }
+  }
+
+  @Nested
+  final class FormatUpdateCheckDateTest {
+    @Test
+    void shouldFormatDateAsString() {
+      assertThat(formatUpdateCheckDate(LocalDate.ofYearDay(2018, 1)), is("2018:1"));
+      assertThat(formatUpdateCheckDate(LocalDate.ofYearDay(1941, 365)), is("1941:365"));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -1,0 +1,117 @@
+package games.strategy.engine.auto.update;
+
+import static games.strategy.engine.auto.update.UpdatedMapsCheck.formatUpdateCheckDate;
+import static games.strategy.engine.auto.update.UpdatedMapsCheck.parseUpdateCheckDate;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import games.strategy.triplea.settings.GameSetting;
+
+final class UpdatedMapsCheckTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class IsMapUpdateCheckRequiredTest {
+    private final LocalDate now = LocalDate.of(2008, 6, 1);
+    @Mock
+    private GameSetting updateCheckDateSetting;
+    @Mock
+    private Runnable flushSetting;
+
+    private void givenMapUpdateCheckNeverRun() {
+      when(updateCheckDateSetting.value()).thenReturn("");
+    }
+
+    private void givenMapUpdateCheckLastRunRelativeToNow(final long amountToAdd, final TemporalUnit unit) {
+      when(updateCheckDateSetting.value()).thenReturn(formatUpdateCheckDate(now.plus(amountToAdd, unit)));
+    }
+
+    private boolean whenIsMapUpdateCheckRequired() {
+      return UpdatedMapsCheck.isMapUpdateCheckRequired(now, updateCheckDateSetting, flushSetting);
+    }
+
+    @Test
+    void shouldReturnTrueWhenMapUpdateCheckLastRunOneYearAgo() {
+      givenMapUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.YEARS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenMapUpdateCheckLastRunOneMonthAgo() {
+      givenMapUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.MONTHS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenMapUpdateCheckNeverRun() {
+      givenMapUpdateCheckNeverRun();
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(true));
+    }
+
+    @Test
+    void shouldSaveAndFlushLastUpdateCheckDateSettingWhenReturnsTrue() {
+      givenMapUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.YEARS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(true));
+      verify(updateCheckDateSetting).save(formatUpdateCheckDate(now));
+      verify(flushSetting).run();
+    }
+
+    @Test
+    void shouldReturnFalseWhenMapUpdateCheckLastRunThisMonth() {
+      givenMapUpdateCheckLastRunRelativeToNow(0, ChronoUnit.MONTHS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenMapUpdateCheckLastRunOneMonthHence() {
+      givenMapUpdateCheckLastRunRelativeToNow(1, ChronoUnit.MONTHS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(false));
+    }
+
+    @Test
+    void shouldNotSaveAndFlushLastUpdateCheckDateSettingWhenReturnsFalse() {
+      givenMapUpdateCheckLastRunRelativeToNow(0, ChronoUnit.MONTHS);
+
+      assertThat(whenIsMapUpdateCheckRequired(), is(false));
+      verify(updateCheckDateSetting, never()).save(anyString());
+      verify(flushSetting, never()).run();
+    }
+  }
+
+  @Nested
+  final class ParseUpdateCheckDateTest {
+    @Test
+    void shouldParseStringAsDate() {
+      assertThat(parseUpdateCheckDate("2018:1"), is(LocalDate.of(2018, 1, 1)));
+      assertThat(parseUpdateCheckDate("1941:12"), is(LocalDate.of(1941, 12, 1)));
+    }
+  }
+
+  @Nested
+  final class FormatUpdateCheckDateTest {
+    @Test
+    void shouldFormatDateAsString() {
+      assertThat(formatUpdateCheckDate(LocalDate.of(2018, 1, 1)), is("2018:1"));
+      assertThat(formatUpdateCheckDate(LocalDate.of(1941, 12, 1)), is("1941:12"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the auto update check classes `EngineVersionCheck` and `UpdatedMapsCheck`.

The size of this PR is a bit bigger than I'd like simply because I had to do some refactoring to be able to write unit tests to cover the changes.  However, 2/3 of the total PR is in the unit tests.

All changes were made after first covering the existing code with characterization tests.

## Functional Changes

None.

## Refactoring Changes

* Renamed `UpdatedMapsCheck#shouldRunMapUpdateCheck()` to `isMapUpdateCheckRequired()`.
* Use `LocalDate` instead of `LocalDateTime` to internally track when the last update check occurred.  We only track the update check date, never time.

## Manual Testing Performed

Verified the engine update check ran in the following scenarios:

* first run: true, last update check: today (**see below**)
* first run: false, last update check: two days in past

Verified the engine update check DID NOT run in the following scenarios:

* first run: false, last update check: today
* first run: false, last update check: tomorrow

Verified the map update check ran in the following scenarios:

* last update check: last month

Verified the map update check DID NOT run in the following scenarios:

* last update check: this month

## Additional Review Notes

I believe there is a bug in the engine update check related to the first run setting.  This setting is never reset to `false`, and since the default value is `true` for a fresh engine install, that means the engine update check runs _every time_ the client runs (unless the user goes into the engine settings and explicitly sets **Game > Show First Time Prompts** to false).  This appears to have broke about two years ago.  I will create a separate issue to discuss how best to resolve it.