### PR TITLE
Add dont_draw_units Property

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -1,8 +1,7 @@
 package games.strategy.triplea.ui;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -19,7 +18,6 @@ import javax.swing.border.EmptyBorder;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.odds.calculator.OddsCalculatorDialog;
 import games.strategy.triplea.util.UnitCategory;
@@ -80,26 +78,20 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br></html>";
     }
     add(new JLabel(labelText));
-    gameData.acquireReadLock();
-    final Collection<Unit> unitsInTerritory;
-    try {
-      unitsInTerritory = territory.getUnits().getUnits();
-    } finally {
-      gameData.releaseReadLock();
-    }
-    add(new JLabel("Units: " + unitsInTerritory.size()));
-    final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, uiContext));
+    add(new JLabel("Units: " + territory.getUnits().getUnits().stream()
+        .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName())).count()));
+    final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(territory, uiContext));
     scroll.setBorder(BorderFactory.createEmptyBorder());
     scroll.getVerticalScrollBar().setUnitIncrement(20);
     add(scroll);
     refresh();
   }
 
-  private static JPanel unitsInTerritoryPanel(final Collection<Unit> unitsInTerritory, final UiContext uiContext) {
+  private static JPanel unitsInTerritoryPanel(final Territory territory, final UiContext uiContext) {
     final JPanel panel = new JPanel();
     panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-    final Set<UnitCategory> units = UnitSeperator.categorize(unitsInTerritory);
+    final List<UnitCategory> units = UnitSeperator.getSortedUnitCategories(territory, uiContext.getMapData());
     PlayerID currentPlayer = null;
     for (final UnitCategory item : units) {
       // seperate players with a seperator

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -77,6 +77,7 @@ public class MapData implements Closeable {
   public static final String PROPERTY_MAP_SHOWSEAZONENAMES = "map.showSeaZoneNames";
   public static final String PROPERTY_MAP_DRAWNAMESFROMTOPLEFT = "map.drawNamesFromTopLeft";
   public static final String PROPERTY_MAP_USENATION_CONVOYFLAGS = "map.useNation_convoyFlags";
+  public static final String PROPERTY_DONT_DRAW_UNITS = "dont_draw_units";
   public static final String PROPERTY_DONT_DRAW_TERRITORY_NAMES = "dont_draw_territory_names";
   public static final String PROPERTY_MAP_MAPBLENDS = "map.mapBlends";
   public static final String PROPERTY_MAP_MAPBLENDMODE = "map.mapBlendMode";
@@ -118,6 +119,7 @@ public class MapData implements Closeable {
   private final Map<String, List<String>> contains = new HashMap<>();
   private final Properties mapProperties = new Properties();
   private final Map<String, List<Point>> territoryEffects = new HashMap<>();
+  private Set<String> undrawnUnits;
   private Set<String> undrawnTerritoriesNames;
   private final Map<Image, List<Point>> decorations = new HashMap<>();
   private final Map<String, Image> territoryNameImages = new HashMap<>();
@@ -352,6 +354,14 @@ public class MapData implements Closeable {
     // zero = normal behavior
     final String stack = mapProperties.getProperty(PROPERTY_UNITS_STACK_SIZE, "0");
     return Math.max(0, Integer.parseInt(stack));
+  }
+
+  public boolean shouldDrawUnit(final String unitName) {
+    if (undrawnUnits == null) {
+      final String property = mapProperties.getProperty(PROPERTY_DONT_DRAW_UNITS, "");
+      undrawnUnits = new HashSet<>(Arrays.asList(property.split(",")));
+    }
+    return !undrawnUnits.contains(unitName);
   }
 
   public boolean shouldDrawTerritoryName(final String territoryName) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -152,11 +152,14 @@ public final class HelpMenu extends JMenu {
         hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
             .append("><td>Unit</td><td>Name</td><td>Cost</td><td>Tool Tip</td></tr>");
         for (final UnitType ut : entry.getValue()) {
-          i++;
-          hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
-              .append(">").append("<td>").append(getUnitImageUrl(ut, player, uiContext)).append("</td>").append("<td>")
-              .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHtml())
-              .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
+          if (uiContext.getMapData().shouldDrawUnit(ut.getName())) {
+            i++;
+            hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
+                .append(">").append("<td>").append(getUnitImageUrl(ut, player, uiContext)).append("</td>")
+                .append("<td>")
+                .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHtml())
+                .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
+          }
         }
         i++;
         hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -23,16 +23,12 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -346,7 +342,7 @@ public class TileManager {
     }
 
     Point lastPlace = null;
-    for (final UnitCategory category : getSortedUnitCategories(territory, data)) {
+    for (final UnitCategory category : UnitSeperator.getSortedUnitCategories(territory, mapData)) {
       final boolean overflow;
       if (placementPoints.hasNext()) {
         lastPlace = new Point(placementPoints.next());
@@ -372,25 +368,6 @@ public class TileManager {
         drawnOn.add(tile);
       }
     }
-  }
-
-  @VisibleForTesting
-  static List<UnitCategory> getSortedUnitCategories(final Territory t, final GameData data) {
-    final List<UnitCategory> categories = new ArrayList<>(UnitSeperator.categorize(t.getUnits().getUnits()));
-    final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
-    categories.sort(Comparator
-        .comparing(UnitCategory::getOwner, Comparator
-            .comparing((final PlayerID p) -> !p.equals(t.getOwner()))
-            .thenComparing(p -> Matches.isAtWar(p, data).test(t.getOwner()))
-            .thenComparing(data.getPlayerList().getPlayers()::indexOf))
-        .thenComparing(uc -> Matches.unitTypeCanMove(uc.getOwner()).test(uc.getType()))
-        .thenComparing(UnitCategory::getType, Comparator
-            .comparing((final UnitType ut) -> !Matches.unitTypeCanNotMoveDuringCombatMove().test(ut))
-            .thenComparing(ut -> !Matches.unitTypeIsSea().test(ut))
-            .thenComparing(ut -> !(t.isWater() && Matches.unitTypeIsAir().test(ut)))
-            .thenComparing(ut -> !Matches.unitTypeIsLand().test(ut))
-            .thenComparing(xmlUnitTypes::indexOf)));
-    return categories;
   }
 
   public Image createTerritoryImage(final Territory t, final GameData data, final MapData mapData) {

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitSeperatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitSeperatorTest.java
@@ -1,12 +1,17 @@
-package games.strategy.triplea.ui.screen;
+package games.strategy.triplea.util;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -14,10 +19,14 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.GameDataTestUtil;
-import games.strategy.triplea.util.UnitCategory;
+import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class TileManagerTest {
+@ExtendWith(MockitoExtension.class)
+public class UnitSeperatorTest {
+
+  @Mock
+  private MapData mockMapData;
 
   @Test
   public void testGetSortedUnitCategories() throws Exception {
@@ -38,7 +47,8 @@ public class TileManagerTest {
     units.addAll(GameDataTestUtil.germanFactory(data).create(1, germans));
     units.addAll(GameDataTestUtil.truck(data).create(1, germans));
     GameDataTestUtil.addTo(northernGermany, units);
-    final List<UnitCategory> categories = TileManager.getSortedUnitCategories(northernGermany, data);
+    when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(true);
+    final List<UnitCategory> categories = UnitSeperator.getSortedUnitCategories(northernGermany, mockMapData);
     final List<UnitCategory> expected = new ArrayList<>();
     expected.add(createUnitCategory("germanFactory", germans, data));
     expected.add(createUnitCategory("Truck", germans, data));
@@ -49,6 +59,21 @@ public class TileManagerTest {
     expected.add(createUnitCategory("britishFactory", british, data));
     expected.add(createUnitCategory("Truck", british, data));
     expected.add(createUnitCategory("britishInfantry", british, data));
+    assertEquals(expected, categories);
+  }
+
+  @Test
+  public void testGetSortedUnitCategoriesDontDrawUnit() throws Exception {
+    final GameData data = TestMapGameData.TWW.getGameData();
+    final Territory northernGermany = territory("Northern Germany", data);
+    northernGermany.getUnits().clear();
+    final List<Unit> units = new ArrayList<>();
+    final PlayerID italians = GameDataTestUtil.italy(data);
+    units.addAll(GameDataTestUtil.italianInfantry(data).create(1, italians));
+    GameDataTestUtil.addTo(northernGermany, units);
+    when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(false);
+    final List<UnitCategory> categories = UnitSeperator.getSortedUnitCategories(northernGermany, mockMapData);
+    final List<UnitCategory> expected = new ArrayList<>();
     assertEquals(expected, categories);
   }
 


### PR DESCRIPTION
## Overview
Addresses: https://forums.triplea-game.org/topic/977/invisible-units

## Functional Changes
- Add new map.properties property: `dont_draw_units` which the engine uses to determine if certain units shouldn't be displayed on map tiles, territory panel, and unit help
- Example line added to Red Sun Over China:
`dont_draw_units=ruralproduction,station`

## Manual Testing Performed
- Tested on Red Sun Over China with above line added to map.properties
- Launched a few other maps to ensure no unintended side effects

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![image](https://user-images.githubusercontent.com/1427689/44819964-7fb79200-abb4-11e8-93e9-288e0398293c.png)


### After
![image](https://user-images.githubusercontent.com/1427689/44819908-4ed75d00-abb4-11e8-8b6b-0987285894e6.png)
