### PR TITLE
Improve line separator handling in ErrorMessage

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -95,7 +95,7 @@ public enum ErrorMessage {
   public static void show(final String msg) {
     if (INSTANCE.enableErrorPopup && INSTANCE.isVisible.compareAndSet(false, true)) {
       SwingUtilities.invokeLater(() -> {
-        INSTANCE.errorMessage.setText(msg);
+        INSTANCE.errorMessage.setText(TextUtils.textToHtml(msg));
         INSTANCE.windowReference.pack();
         INSTANCE.windowReference.setLocationRelativeTo(null);
         INSTANCE.windowReference.setVisible(true);

--- a/game-core/src/main/java/games/strategy/debug/TextUtils.java
+++ b/game-core/src/main/java/games/strategy/debug/TextUtils.java
@@ -1,0 +1,14 @@
+package games.strategy.debug;
+
+import com.google.common.html.HtmlEscapers;
+
+final class TextUtils {
+  private TextUtils() {}
+
+  static String textToHtml(final String text) {
+    return "<html>"
+        + HtmlEscapers.htmlEscaper().escape(text)
+            .replaceAll(System.lineSeparator(), "<br/>")
+        + "</html>";
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/auto/health/check/LocalSystemChecker.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/health/check/LocalSystemChecker.java
@@ -30,11 +30,10 @@ public final class LocalSystemChecker {
     final Collection<Exception> exceptions = localSystemChecker.getExceptions();
     if (!exceptions.isEmpty()) {
       log.warning(String.format(
-          "Warning!! %d system checks failed. Some game features may not be available or may not work correctly.%n%s",
+          "%d system check(s) failed. Some game features may not be available or may not work correctly.%n%s",
           exceptions.size(), localSystemChecker.getStatusMessage()));
     }
   }
-
 
   private final Set<SystemCheck> systemChecks;
 
@@ -84,6 +83,6 @@ public final class LocalSystemChecker {
   private String getStatusMessage() {
     return systemChecks.stream()
         .map(SystemCheck::getResultMessage)
-        .collect(Collectors.joining("\n"));
+        .collect(Collectors.joining(System.lineSeparator()));
   }
 }

--- a/game-core/src/test/java/games/strategy/debug/TextUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/debug/TextUtilsTest.java
@@ -1,0 +1,30 @@
+package games.strategy.debug;
+
+import static games.strategy.debug.TextUtils.textToHtml;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class TextUtilsTest {
+  @Nested
+  final class TextToHtmlTest {
+    @Test
+    void shouldEmbedTextInHtmlElement() {
+      assertThat(textToHtml("test"), is("<html>test</html>"));
+    }
+
+    @Test
+    void shouldEscapeHtmlMetacharacters() {
+      assertThat(textToHtml("abc<>&\"'123"), is("<html>abc&lt;&gt;&amp;&quot;&#39;123</html>"));
+    }
+
+    @Test
+    void shouldReplaceLineSeparatorsWithBreakElement() {
+      assertThat(
+          textToHtml("a" + System.lineSeparator() + "b" + System.lineSeparator() + "c"),
+          is("<html>a<br/>b<br/>c</html>"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

`ErrorMessage` uses a vanilla `JLabel` to display the error message.  In some cases (e.g. the system check facility), these error messages contain line separators for the purpose of formating the content.  `JLabel` does not process line separators, so a multi-line error message will be displayed as one very long line.

## Functional Changes

* Modified `ErrorMessage` to correctly display line separators.  This is done by converting the message to HTML before display.  Please advise if I missed any considerations when converting text to HTML.
* Also removed the now-redundant `Warning!!` text from the front of the system check failure message.

## Manual Testing Performed

Manually triggered a system check failure to verify the multi-line message is now displayed as expected (see below).

## Before & After Screen Shots

### Before

![error-message-before](https://user-images.githubusercontent.com/4826349/44829249-b8be2980-abe9-11e8-805b-bba285ac3525.png)

### After

![error-message-after](https://user-images.githubusercontent.com/4826349/44829256-bd82dd80-abe9-11e8-92ed-9934b823f2ea.png)