### PR TITLE
Reduce accessibility where possible

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/IGameStepAdvancer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameStepAdvancer.java
@@ -3,7 +3,7 @@ package games.strategy.engine.framework;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.message.IRemote;
 
-public interface IGameStepAdvancer extends IRemote {
+interface IGameStepAdvancer extends IRemote {
   /**
    * A server calls this methods on client game when a player
    * starts a certain step.

--- a/game-core/src/main/java/games/strategy/engine/framework/IServerRemote.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IServerRemote.java
@@ -2,6 +2,6 @@ package games.strategy.engine.framework;
 
 import games.strategy.engine.message.IRemote;
 
-public interface IServerRemote extends IRemote {
+interface IServerRemote extends IRemote {
   byte[] getSavedGame();
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -18,7 +18,7 @@ import lombok.extern.java.Log;
  * To hold various static utility methods for running a java program.
  */
 @Log
-public class ProcessRunnerUtil {
+class ProcessRunnerUtil {
 
   static void populateBasicJavaArgs(final List<String> commands) {
     final String javaCommand = SystemProperties.getJavaHome() + File.separator + "bin" + File.separator + "java";
@@ -41,7 +41,7 @@ public class ProcessRunnerUtil {
     }
   }
 
-  public static void exec(final List<String> commands) {
+  static void exec(final List<String> commands) {
     final ProcessBuilder builder = new ProcessBuilder(commands);
     // merge the streams, so we only have to start one reader thread
     builder.redirectErrorStream(true);

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/AggregateEstimate.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/AggregateEstimate.java
@@ -12,7 +12,7 @@ import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Tuple;
 
-public class AggregateEstimate extends AggregateResults {
+class AggregateEstimate extends AggregateResults {
   private final int battleRoundsFought;
   private final double winPercentage;
   private final List<Unit> remainingAttackingUnits;

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
@@ -14,7 +14,7 @@ import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
 import games.strategy.triplea.odds.calculator.AggregateResults;
 import games.strategy.triplea.odds.calculator.IOddsCalculator;
 
-public class FastOddsEstimator implements IOddsCalculator {
+class FastOddsEstimator implements IOddsCalculator {
 
   private Territory location = null;
   private Collection<Unit> attackingUnits = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyGameModifiedChannel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyGameModifiedChannel.java
@@ -4,7 +4,7 @@ import games.strategy.engine.data.Change;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.IGameModifiedChannel;
 
-public class ProDummyGameModifiedChannel implements IGameModifiedChannel {
+class ProDummyGameModifiedChannel implements IGameModifiedChannel {
   @Override
   public void addChildToEvent(final String text, final Object renderingData) {}
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -55,7 +55,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     return get(player, nameOfAttachment, null);
   }
 
-  public static PoliticalActionAttachment get(final PlayerID player, final String nameOfAttachment,
+  static PoliticalActionAttachment get(final PlayerID player, final String nameOfAttachment,
       final Collection<PlayerID> playersToSearch) {
     PoliticalActionAttachment paa = (PoliticalActionAttachment) player.getAttachment(nameOfAttachment);
     if (paa == null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -98,7 +98,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     return get(player, nameOfAttachment, null, false);
   }
 
-  public static RulesAttachment get(final PlayerID player, final String nameOfAttachment,
+  static RulesAttachment get(final PlayerID player, final String nameOfAttachment,
       final Collection<PlayerID> playersToSearch, final boolean allowNull) {
     RulesAttachment ra = (RulesAttachment) player.getAttachment(nameOfAttachment);
     if (ra == null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -110,7 +110,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return get(player, nameOfAttachment, null);
   }
 
-  public static TriggerAttachment get(final PlayerID player, final String nameOfAttachment,
+  static TriggerAttachment get(final PlayerID player, final String nameOfAttachment,
       final Collection<PlayerID> playersToSearch) {
     TriggerAttachment ta = (TriggerAttachment) player.getAttachment(nameOfAttachment);
     if (ta == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -60,7 +60,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     ALL, SUBS, NONE
   }
 
-  public enum RetreatType {
+  private enum RetreatType {
     DEFAULT, SUBS, PLANES, PARTIAL_AMPHIB
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
@@ -13,7 +13,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import lombok.extern.java.Log;
 
 @Log
-public class InitialSetup {
+class InitialSetup {
   private final Map<UnitType, UnitAttachment> unitInfoMap = new HashMap<>();
 
   InitialSetup() {}

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 import games.strategy.engine.data.GameData;
 
-public class PrintGenerationData {
+class PrintGenerationData {
   private File outDir;
   private GameData gameData;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
@@ -13,7 +13,7 @@ import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 
-public abstract class AbstractForumPosterPanel extends ActionPanel {
+abstract class AbstractForumPosterPanel extends ActionPanel {
   private static final long serialVersionUID = -5084680807785728744L;
   private final JLabel actionLabel;
   protected IPlayerBridge playerBridge;

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -25,7 +25,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import swinglib.JButtonBuilder;
 
-public abstract class AbstractMovePanel extends ActionPanel {
+abstract class AbstractMovePanel extends ActionPanel {
   private static final long serialVersionUID = -4153574987414031433L;
   private static final int entryPadding = 15;
   private final TripleAFrame frame;

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -35,7 +35,7 @@ import games.strategy.triplea.delegate.AbstractUndoableMove;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 
-public abstract class AbstractUndoableMovesPanel extends JPanel {
+abstract class AbstractUndoableMovesPanel extends JPanel {
   private static final long serialVersionUID = 1910945925958952416L;
   protected List<AbstractUndoableMove> moves;
 
@@ -50,7 +50,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     moves = Collections.emptyList();
   }
 
-  public void setMoves(final List<AbstractUndoableMove> undoableMoves) {
+  void setMoves(final List<AbstractUndoableMove> undoableMoves) {
     moves = undoableMoves;
     SwingUtilities.invokeLater(this::initLayout);
   }
@@ -158,7 +158,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     return containerBox;
   }
 
-  public int getCountOfMovesMade() {
+  int getCountOfMovesMade() {
     return moves.size();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/Active.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/Active.java
@@ -1,5 +1,5 @@
 package games.strategy.triplea.ui;
 
-public interface Active {
+interface Active {
   void deactivate();
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -42,7 +42,7 @@ import games.strategy.ui.SwingAction;
 import lombok.extern.java.Log;
 
 @Log
-public class CommentPanel extends JPanel {
+class CommentPanel extends JPanel {
   private static final long serialVersionUID = -9122162393288045888L;
   private JTextPane text;
   private JScrollPane scrollPane;
@@ -202,7 +202,7 @@ public class CommentPanel extends JPanel {
   }
 
   /** thread safe. */
-  public void addMessage(final String message) {
+  void addMessage(final String message) {
     SwingAction.invokeNowOrLater(() -> {
       try {
         final Document doc = text.getDocument();

--- a/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.Territory;
 
-public class DefaultMapSelectionListener implements MapSelectionListener {
+class DefaultMapSelectionListener implements MapSelectionListener {
   @Override
   public void territorySelected(final Territory territory, final MouseDetails me) {}
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -25,13 +25,13 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
 import games.strategy.util.IntegerMap;
 
-public class EconomyPanel extends AbstractStatPanel {
+class EconomyPanel extends AbstractStatPanel {
   private static final long serialVersionUID = -7713792841831042952L;
   private final List<ResourceStat> resourceStats = new ArrayList<>();
   private ResourceTableModel resourceModel;
   private final UiContext uiContext;
 
-  public EconomyPanel(final GameData data, final UiContext uiContext) {
+  EconomyPanel(final GameData data, final UiContext uiContext) {
     super(data);
     this.uiContext = uiContext;
     initLayout();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -20,15 +20,14 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.util.IntegerMap;
 
-public class EditProductionPanel extends ProductionPanel {
+class EditProductionPanel extends ProductionPanel {
   private static final long serialVersionUID = 5826523459539469173L;
 
-  public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
+  static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
       final UiContext uiContext) {
     return new EditProductionPanel(uiContext).show(id, parent, data, false, new IntegerMap<>());
   }
 
-  /** Creates new EditProductionPanel. */
   private EditProductionPanel(final UiContext uiContext) {
     super(uiContext);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -9,7 +9,7 @@ import games.strategy.engine.pbem.ForumPosterComponent;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.ui.SwingAction;
 
-public class EndTurnPanel extends AbstractForumPosterPanel {
+class EndTurnPanel extends AbstractForumPosterPanel {
   private static final long serialVersionUID = -6282316384529504341L;
   protected final Action doneAction = SwingAction.of("Done", e -> {
     if (forumPosterComponent.getHasPostedTurnSummary()

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanelSmallView.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanelSmallView.java
@@ -6,10 +6,10 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.ImageScrollerSmallView;
 
-public class MapPanelSmallView extends ImageScrollerSmallView {
+class MapPanelSmallView extends ImageScrollerSmallView {
   private static final long serialVersionUID = 8706930659664327612L;
 
-  public MapPanelSmallView(final Image img, final ImageScrollModel model, final MapData mapData) {
+  MapPanelSmallView(final Image img, final ImageScrollModel model, final MapData mapData) {
     super(img, model, mapData);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.Territory;
 
-public interface MapSelectionListener {
+interface MapSelectionListener {
   void territorySelected(Territory territory, MouseDetails md);
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -5,7 +5,7 @@ import java.awt.event.MouseEvent;
 
 import javax.swing.SwingUtilities;
 
-public class MouseDetails {
+class MouseDetails {
   private final MouseEvent mouseEvent;
   // the x position of the event on the map
   // this is in absolute pixels of the unscaled map

--- a/game-core/src/main/java/games/strategy/triplea/ui/MouseOverUnitListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MouseOverUnitListener.java
@@ -5,7 +5,7 @@ import java.util.List;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
-public interface MouseOverUnitListener {
+interface MouseOverUnitListener {
   /**
    * units will be empty if the mouse is not over any unit.
    */

--- a/game-core/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
@@ -8,7 +8,7 @@ import games.strategy.engine.pbem.ForumPosterComponent;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.ui.SwingAction;
 
-public class MoveForumPosterPanel extends AbstractForumPosterPanel {
+class MoveForumPosterPanel extends AbstractForumPosterPanel {
   private static final long serialVersionUID = -533962696697230277L;
 
   MoveForumPosterPanel(final GameData data, final MapPanel map) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
@@ -7,7 +7,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
-public class NotesPanel extends JPanel {
+class NotesPanel extends JPanel {
   private static final long serialVersionUID = 2746643868463714526L;
   protected final JEditorPane gameNotesPane;
 
@@ -17,7 +17,7 @@ public class NotesPanel extends JPanel {
   // so instead we keep the main copy in the TripleAMenuBar, and then give it to the notes tab. this prevents out of
   // memory errors for
   // maps with large images in their games notes.
-  public NotesPanel(final JEditorPane gameNotesPane) {
+  NotesPanel(final JEditorPane gameNotesPane) {
     this.gameNotesPane = gameNotesPane;
     initLayout();
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -28,15 +28,14 @@ import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.util.CollectionUtils;
 
-public class PlacePanel extends AbstractMovePanel {
+class PlacePanel extends AbstractMovePanel {
   private static final long serialVersionUID = -4411301492537704785L;
   private final JLabel actionLabel = new JLabel();
   private final JLabel leftToPlaceLabel = new JLabel();
   private PlaceData placeData;
   private final SimpleUnitPanel unitsToPlace;
 
-  /** Creates new PlacePanel. */
-  public PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
+  PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map, frame);
     undoableMovesPanel = new UndoablePlacementsPanel(this);
     unitsToPlace = new SimpleUnitPanel(map.getUiContext());

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -18,7 +18,7 @@ import games.strategy.engine.data.PlayerList;
 import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
 
-public class PlayerChooser extends JOptionPane {
+class PlayerChooser extends JOptionPane {
   private static final long serialVersionUID = -7272867474891641839L;
   private JList<PlayerID> list;
   private final PlayerList players;
@@ -26,14 +26,11 @@ public class PlayerChooser extends JOptionPane {
   private final UiContext uiContext;
   private final boolean allowNeutral;
 
-  // private JOptionPane m_pane;
-  /** Creates new PlayerChooser. */
-  public PlayerChooser(final PlayerList players, final UiContext uiContext, final boolean allowNeutral) {
+  PlayerChooser(final PlayerList players, final UiContext uiContext, final boolean allowNeutral) {
     this(players, null, uiContext, allowNeutral);
   }
 
-  /** Creates new PlayerChooser. */
-  public PlayerChooser(final PlayerList players, final PlayerID defaultPlayer, final UiContext uiContext,
+  PlayerChooser(final PlayerList players, final PlayerID defaultPlayer, final UiContext uiContext,
       final boolean allowNeutral) {
     setMessageType(JOptionPane.PLAIN_MESSAGE);
     setOptionType(JOptionPane.OK_CANCEL_OPTION);
@@ -78,7 +75,7 @@ public class PlayerChooser extends JOptionPane {
    *
    * @return the player or null
    */
-  public PlayerID getSelected() {
+  PlayerID getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
       return list.getSelectedValue();
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -43,7 +43,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.util.IntegerMap;
 import swinglib.JDialogBuilder;
 
-public class ProductionPanel extends JPanel {
+class ProductionPanel extends JPanel {
   private static final long serialVersionUID = -1539053979479586609L;
 
   protected final UiContext uiContext;
@@ -57,8 +57,7 @@ public class ProductionPanel extends JPanel {
   private JDialog dialog;
   private boolean bid;
 
-
-  public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
+  static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
       final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext uiContext) {
     return new ProductionPanel(uiContext).show(id, parent, data, bid, initialPurchase);
   }
@@ -78,11 +77,10 @@ public class ProductionPanel extends JPanel {
     this.uiContext = uiContext;
   }
 
-
   /**
    * Shows the production panel, and returns a map of selected rules.
    */
-  public IntegerMap<ProductionRule> show(final PlayerID id, final JFrame parent, final GameData data, final boolean bid,
+  IntegerMap<ProductionRule> show(final PlayerID id, final JFrame parent, final GameData data, final boolean bid,
       final IntegerMap<ProductionRule> initialPurchase) {
     final JDialogBuilder dialogBuilder = JDialogBuilder.builder()
         .contents(this)

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -41,7 +41,7 @@ import games.strategy.ui.SwingComponents;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
-public class ProductionRepairPanel extends JPanel {
+class ProductionRepairPanel extends JPanel {
   private static final long serialVersionUID = -6344711064699083729L;
   private final JFrame owner = null;
   private JDialog dialog;
@@ -54,7 +54,7 @@ public class ProductionRepairPanel extends JPanel {
   private Collection<PlayerID> allowedPlayersToRepair;
   private GameData data;
 
-  public static HashMap<Unit, IntegerMap<RepairRule>> getProduction(final PlayerID id,
+  static HashMap<Unit, IntegerMap<RepairRule>> getProduction(final PlayerID id,
       final Collection<PlayerID> allowedPlayersToRepair, final JFrame parent, final GameData data, final boolean bid,
       final HashMap<Unit, IntegerMap<RepairRule>> initialPurchase, final UiContext uiContext) {
     return new ProductionRepairPanel(uiContext).show(id, allowedPlayersToRepair, parent, data, bid, initialPurchase);
@@ -77,7 +77,7 @@ public class ProductionRepairPanel extends JPanel {
   /**
    * Shows the production panel, and returns a map of selected rules.
    */
-  public HashMap<Unit, IntegerMap<RepairRule>> show(final PlayerID id,
+  HashMap<Unit, IntegerMap<RepairRule>> show(final PlayerID id,
       final Collection<PlayerID> allowedPlayersToRepair, final JFrame parent, final GameData data, final boolean bid,
       final HashMap<Unit, IntegerMap<RepairRule>> initialPurchase) {
     if (!(parent == owner)) {
@@ -100,7 +100,7 @@ public class ProductionRepairPanel extends JPanel {
     return getProduction();
   }
 
-  public List<Rule> getRules() {
+  List<Rule> getRules() {
     return this.rules;
   }
 
@@ -110,9 +110,7 @@ public class ProductionRepairPanel extends JPanel {
     SwingComponents.addEscapeKeyListener(dialog, () -> dialog.setVisible(false));
   }
 
-  /** Creates new ProductionRepairPanel. */
-  // the constructor can be accessed by subclasses
-  public ProductionRepairPanel(final UiContext uiContext) {
+  ProductionRepairPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
   }
 
@@ -222,7 +220,7 @@ public class ProductionRepairPanel extends JPanel {
     return id.getResources();
   }
 
-  public class Rule extends JPanel {
+  private class Rule extends JPanel {
     private static final long serialVersionUID = -6781214135310064908L;
     private final ScrollableTextField text = new ScrollableTextField(0, Integer.MAX_VALUE);
     private final IntegerMap<Resource> cost;
@@ -272,7 +270,7 @@ public class ProductionRepairPanel extends JPanel {
       return cost;
     }
 
-    public int getQuantity() {
+    int getQuantity() {
       return text.getValue();
     }
 
@@ -288,7 +286,7 @@ public class ProductionRepairPanel extends JPanel {
       text.setMax((int) (Math.ceil(((double) Math.min(max, maxRepairAmount) / (double) repairResults))));
     }
 
-    public Unit getUnit() {
+    Unit getUnit() {
       return unit;
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -18,7 +18,7 @@ import games.strategy.util.UrlStreams;
 import lombok.extern.java.Log;
 
 @Log
-public class ProductionTabsProperties {
+class ProductionTabsProperties {
   // Filename
   private static final String PROPERTY_FILE = "production_tabs";
   // Properties
@@ -64,7 +64,7 @@ public class ProductionTabsProperties {
     }
   }
 
-  public static ProductionTabsProperties getInstance(final PlayerID playerId, final List<Rule> rules) {
+  static ProductionTabsProperties getInstance(final PlayerID playerId, final List<Rule> rules) {
     return new ProductionTabsProperties(playerId, rules);
   }
 
@@ -92,15 +92,15 @@ public class ProductionTabsProperties {
     return Integer.valueOf(properties.getProperty(NUMBER_OF_TABS, "0"));
   }
 
-  public boolean useDefaultTabs() {
+  boolean useDefaultTabs() {
     return Boolean.valueOf(properties.getProperty(USE_DEFAULT_TABS, "true"));
   }
 
-  public int getRows() {
+  int getRows() {
     return Integer.valueOf(properties.getProperty(NUMBER_OF_ROWS, "0"));
   }
 
-  public int getColumns() {
+  int getColumns() {
     return Integer.valueOf(properties.getProperty(NUMBER_OF_COLUMNS, "0"));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.IntegerMap;
 
-public class RepairPanel extends ActionPanel {
+class RepairPanel extends ActionPanel {
   private static final long serialVersionUID = 3045997038627313714L;
   private static final String CHANGE = "Change...";
   private static final String BUY = "Repair...";
@@ -34,8 +34,7 @@ public class RepairPanel extends ActionPanel {
   private final JLabel repairdSoFar = new JLabel();
   private final JButton buyButton;
 
-  /** Creates new RepairPanel. */
-  public RepairPanel(final GameData data, final MapPanel map) {
+  RepairPanel(final GameData data, final MapPanel map) {
     super(data, map);
     unitsPanel = new SimpleUnitPanel(map.getUiContext());
     buyButton = new JButton(BUY);

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -42,7 +42,7 @@ import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.util.IntegerMap;
 
-public class StatPanel extends AbstractStatPanel {
+class StatPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 4340684166664492498L;
   private final StatTableModel dataModel;
   private final TechTableModel techModel;
@@ -50,8 +50,7 @@ public class StatPanel extends AbstractStatPanel {
   protected final Map<PlayerID, ImageIcon> mapPlayerImage = new HashMap<>();
   protected final UiContext uiContext;
 
-  /** Creates a new instance of StatPanel. */
-  public StatPanel(final GameData data, final UiContext uiContext) {
+  StatPanel(final GameData data, final UiContext uiContext) {
     super(data);
     this.uiContext = uiContext;
     dataModel = new StatTableModel();
@@ -150,12 +149,12 @@ public class StatPanel extends AbstractStatPanel {
     /* Underlying data for the table */
     private String[][] collectedData;
 
-    public StatTableModel() {
+    StatTableModel() {
       setStatCollums();
       gameData.addDataChangeListener(this);
     }
 
-    public void setStatCollums() {
+    void setStatCollums() {
       stats = new IStat[] {new PuStat(), new ProductionStat(), new UnitsStat(), new TuvStat()};
       if (gameData.getMap().getTerritories().stream().anyMatch(Matches.territoryIsVictoryCity())) {
         final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
@@ -248,7 +247,7 @@ public class StatPanel extends AbstractStatPanel {
       }
     }
 
-    public synchronized void setGameData(final GameData data) {
+    synchronized void setGameData(final GameData data) {
       synchronized (this) {
         gameData.removeDataChangeListener(this);
         gameData = data;
@@ -273,7 +272,7 @@ public class StatPanel extends AbstractStatPanel {
     /* Convenience mapping of technology names -> row */
     private final Map<String, Integer> rowMap = new HashMap<>();
 
-    public TechTableModel() {
+    TechTableModel() {
       gameData.addDataChangeListener(this);
       initColList();
       /* Load the country -> col mapping */
@@ -330,7 +329,7 @@ public class StatPanel extends AbstractStatPanel {
       Arrays.sort(colList, 0, players.size());
     }
 
-    public void update() {
+    void update() {
       clearAdvances();
       // copy so aquire/release read lock are on the same object!
       final GameData gameData = StatPanel.this.gameData;
@@ -402,7 +401,7 @@ public class StatPanel extends AbstractStatPanel {
       SwingUtilities.invokeLater(StatPanel.this::repaint);
     }
 
-    public void setGameData(final GameData data) {
+    void setGameData(final GameData data) {
       gameData.removeDataChangeListener(this);
       gameData = data;
       gameData.addDataChangeListener(this);
@@ -431,7 +430,7 @@ public class StatPanel extends AbstractStatPanel {
   }
 
   class PuStat extends ResourceStat {
-    public PuStat() {
+    PuStat() {
       super(getResourcePUs(gameData));
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -27,7 +27,7 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Tuple;
 import swinglib.JPanelBuilder;
 
-public class TabbedProductionPanel extends ProductionPanel {
+class TabbedProductionPanel extends ProductionPanel {
   private static final long serialVersionUID = 3481282212500641144L;
   private int rows;
   private int columns;
@@ -36,7 +36,7 @@ public class TabbedProductionPanel extends ProductionPanel {
     super(uiContext);
   }
 
-  public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
+  static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data,
       final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext uiContext) {
     return new TabbedProductionPanel(uiContext).show(id, parent, data, bid, initialPurchase);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -37,7 +37,7 @@ import games.strategy.ui.SwingComponents;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
-public class TechPanel extends ActionPanel {
+class TechPanel extends ActionPanel {
   private static final long serialVersionUID = -6477919141575138007L;
   private final JLabel actionLabel = new JLabel();
   private TechRoll techRoll;
@@ -45,8 +45,7 @@ public class TechPanel extends ActionPanel {
   private int quantity;
   private IntegerMap<PlayerID> whoPaysHowMuch = null;
 
-  /** Creates new TechPanel. */
-  public TechPanel(final GameData data, final MapPanel map) {
+  TechPanel(final GameData data, final MapPanel map) {
     super(data, map);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -17,7 +17,7 @@ import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.dataObjects.TechResults;
 import games.strategy.ui.SwingComponents;
 
-public class TechResultsDisplay extends JPanel {
+class TechResultsDisplay extends JPanel {
   private static final long serialVersionUID = -8303376983862918107L;
 
   TechResultsDisplay(final TechResults msg, final UiContext uiContext, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.ui.OverlayIcon;
 import games.strategy.ui.SwingComponents;
 
-public class TerritoryDetailPanel extends AbstractStatPanel {
+class TerritoryDetailPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 1377022163587438988L;
   private final UiContext uiContext;
   private final JButton showOdds = new JButton("Battle Calculator (Ctrl-B)");

--- a/game-core/src/main/java/games/strategy/triplea/ui/UndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UndoableMovesPanel.java
@@ -3,10 +3,10 @@ package games.strategy.triplea.ui;
 import games.strategy.triplea.delegate.AbstractUndoableMove;
 import games.strategy.triplea.delegate.UndoableMove;
 
-public class UndoableMovesPanel extends AbstractUndoableMovesPanel {
+class UndoableMovesPanel extends AbstractUndoableMovesPanel {
   private static final long serialVersionUID = -3864287736715943608L;
 
-  public UndoableMovesPanel(final AbstractMovePanel movePanel) {
+  UndoableMovesPanel(final AbstractMovePanel movePanel) {
     super(movePanel);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UndoablePlacementsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UndoablePlacementsPanel.java
@@ -2,10 +2,10 @@ package games.strategy.triplea.ui;
 
 import games.strategy.triplea.delegate.AbstractUndoableMove;
 
-public class UndoablePlacementsPanel extends AbstractUndoableMovesPanel {
+class UndoablePlacementsPanel extends AbstractUndoableMovesPanel {
   private static final long serialVersionUID = -8905646288832196354L;
 
-  public UndoablePlacementsPanel(final AbstractMovePanel movePanel) {
+  UndoablePlacementsPanel(final AbstractMovePanel movePanel) {
     super(movePanel);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitSelectionListener.java
@@ -5,7 +5,7 @@ import java.util.List;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
-public interface UnitSelectionListener {
+interface UnitSelectionListener {
   /**
    * Note, if the mouse is clicked where there are no units, units will be empty but territory will still be correct.
    */


### PR DESCRIPTION
## Overview

Reduces the accessibility of types and methods from public to package-private or private, where possible.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested a network game to ensure reducing the accessibility of `IRemote` interfaces didn't break RMI somehow.