### PR TITLE
Move UnitType#getTooltip() to TooltipProperties

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -15,11 +15,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import games.strategy.triplea.TripleAUnit;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.image.UnitImageFactory;
-import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
-import games.strategy.util.LocalizeHtml;
 import lombok.extern.java.Log;
 
 /**
@@ -72,23 +69,6 @@ public class UnitType extends NamedAttachable {
   @Override
   public int hashCode() {
     return Objects.hashCode(getName());
-  }
-
-  /**
-   * Get unit type tooltip checking for custom tooltip content.
-   */
-  public String getTooltip(final PlayerID playerId) {
-    final String customTip = TooltipProperties.getInstance().getToolTip(this, playerId);
-    if (!customTip.isEmpty()) {
-      return LocalizeHtml.localizeImgLinksInHtml(customTip);
-    }
-    final String generated = UnitAttachment.get(this)
-        .toStringShortAndOnlyImportantDifferences((playerId == null ? PlayerID.NULL_PLAYERID : playerId));
-    final String appendedTip = TooltipProperties.getInstance().getAppendedToolTip(this, playerId);
-    if (!appendedTip.isEmpty()) {
-      return generated + LocalizeHtml.localizeImgLinksInHtml(appendedTip);
-    }
-    return generated;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -30,6 +30,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.util.CollectionUtils;
@@ -273,7 +274,7 @@ public class OrderOfLossesInputPanel extends JPanel {
         final String unitName =
             OOL_ALL + OOL_AMOUNT_DESCRIPTOR + category.getType().getName();
         final String toolTipText = "<html>" + category.getType().getName() + ":  "
-            + category.getType().getTooltip(category.getOwner()) + "</html>";
+            + TooltipProperties.getInstance().getTooltip(category.getType(), category.getOwner()) + "</html>";
         final Optional<Image> img =
             uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(),
                 category.hasDamageOrBombingUnitDamage(), category.getDisabled());

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -17,6 +17,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.ui.ScrollableTextField;
@@ -38,7 +39,8 @@ public class UnitPanel extends JPanel {
     textField.addChangeListener(field -> notifyListeners());
 
     final String toolTipText = "<html>" + category.getType().getName() + ":  " + costs.getInt(category.getType())
-        + " cost, <br /> &nbsp;&nbsp;&nbsp;&nbsp; " + category.getType().getTooltip(category.getOwner())
+        + " cost, <br /> &nbsp;&nbsp;&nbsp;&nbsp; "
+        + TooltipProperties.getInstance().getTooltip(category.getType(), category.getOwner())
         + "</html>";
     setCount(category.getUnits().size());
     setLayout(new GridBagLayout());

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -246,7 +246,7 @@ public class ProductionPanel extends JPanel {
           final int movement = attach.getMovement(id);
           final int defense = attach.getDefense(id);
           info.setText(attack + " | " + defense + " | " + movement);
-          tooltip.append(type.getName()).append(": ").append(type.getTooltip(id));
+          tooltip.append(type.getName()).append(": ").append(TooltipProperties.getInstance().getTooltip(type, id));
           name.setText(type.getName());
           if (attach.getConsumesUnits() != null && attach.getConsumesUnits().totalValues() == 1) {
             name.setForeground(Color.CYAN);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -109,8 +109,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         final Icon flaggedUnitIcon =
             new OverlayIcon(unitIcon.get(), flagIcon, unitIcon.get().getIconWidth() - (flagIcon.getIconWidth() / 2), 0);
         final JLabel label = new JLabel("x" + item.getUnits().size(), flaggedUnitIcon, SwingConstants.LEFT);
-        final String toolTipText =
-            "<html>" + item.getType().getName() + ": " + item.getType().getTooltip(currentPlayer) + "</html>";
+        final String toolTipText = "<html>" + item.getType().getName() + ": "
+            + TooltipProperties.getInstance().getTooltip(item.getType(), currentPlayer) + "</html>";
         label.setToolTipText(toolTipText);
         panel.add(label);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -38,6 +38,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
+import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.ui.SwingAction;
@@ -158,7 +159,8 @@ public final class HelpMenu extends JMenu {
                 .append(">").append("<td>").append(getUnitImageUrl(ut, player, uiContext)).append("</td>")
                 .append("<td>")
                 .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHtml())
-                .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
+                .append("</td>").append("<td>").append(TooltipProperties.getInstance().getTooltip(ut, player))
+                .append("</td></tr>");
           }
         }
         i++;


### PR DESCRIPTION
## Overview

Tooltip functionality is a UI layer concern and should not be in the domain layer.

## Functional Changes

None.

## Refactoring Changes

A few small changes in `TooltipProperties`:

* Made class `final`.
* Made constructor `private`.
* Inlined methods no longer called externally.
* Added missing Javadoc.

## Manual Testing Performed

Opened the unit help menu for WW2 Classic to ensure unit tooltips were rendered correctly.