### PR TITLE
Don't spawn unnecessary process for piping output

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -42,29 +42,10 @@ class ProcessRunnerUtil {
   }
 
   static void exec(final List<String> commands) {
-    final ProcessBuilder builder = new ProcessBuilder(commands);
-    // merge the streams, so we only have to start one reader thread
-    builder.redirectErrorStream(true);
     try {
-      final Process p = builder.start();
-      final InputStream s = p.getInputStream();
-      // we need to read the input stream to prevent possible
-      // deadlocks
-      startDaemonThread(() -> {
-        try (Scanner scanner = new Scanner(s, Charset.defaultCharset().name())) {
-          while (scanner.hasNextLine()) {
-            System.out.println(scanner.nextLine());
-          }
-        }
-      }, "Process output gobbler");
+      new ProcessBuilder(commands).inheritIO().start();
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Failed to start new process", e);
     }
-  }
-
-  private static void startDaemonThread(final Runnable runnable, final String name) {
-    final Thread thread = new Thread(runnable, name);
-    thread.setDaemon(true);
-    thread.start();
   }
 }


### PR DESCRIPTION
## Overview
Just saw that this could be done easier.

## Functional Changes
None. Less overhead though

## Manual Testing Performed
Joined a bot and verified the output of the newly spawned jvm is still being printed to the console.