### PR TITLE
Error Prone: Fix reference equality violations with PlayerID

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/history/Step.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Step.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.history;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.PlayerID;
 
 /**
@@ -7,12 +9,11 @@ import games.strategy.engine.data.PlayerID;
  */
 public class Step extends IndexedHistoryNode {
   private static final long serialVersionUID = 1015799886178275645L;
-  private final PlayerID player;
+  private final @Nullable PlayerID player;
   private final String stepName;
   private final String delegateName;
 
-  /** Creates a new instance of Step. */
-  Step(final String stepName, final String delegateName, final PlayerID player, final int changeStartIndex,
+  Step(final String stepName, final String delegateName, final @Nullable PlayerID player, final int changeStartIndex,
       final String displayName) {
     super(displayName, changeStartIndex);
     this.stepName = stepName;
@@ -20,7 +21,7 @@ public class Step extends IndexedHistoryNode {
     this.player = player;
   }
 
-  public PlayerID getPlayerId() {
+  public @Nullable PlayerID getPlayerId() {
     return player;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -8,9 +8,12 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -85,6 +88,7 @@ final class ProTechAi {
       final PlayerID player) {
     final boolean transportsFirst = false;
 
+    @Nullable
     PlayerID enemyPlayer = null;
     final List<PlayerID> enemyPlayers = getEnemyPlayers(data, player);
     final HashMap<PlayerID, Float> enemyPlayerAttackMap = new HashMap<>();
@@ -268,7 +272,7 @@ final class ProTechAi {
       }
     }
     for (final PlayerID enemyPlayerCandidate : enemyPlayers) {
-      if (enemyPlayer != enemyPlayerCandidate) {
+      if (!Objects.equals(enemyPlayer, enemyPlayerCandidate)) {
         // give 40% of other players...this is will affect a lot of decisions by AI
         maxStrength += enemyPlayerAttackMap.get(enemyPlayerCandidate) * 0.40F;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -159,7 +161,7 @@ public class ProSimulateTurnUtils {
   private static boolean checkIfCapturedTerritoryIsAlliedCapital(final Territory t, final GameData data,
       final PlayerID player, final IDelegateBridge delegateBridge) {
 
-    final PlayerID terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(t);
+    final @Nullable PlayerID terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(t);
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta != null && ta.getCapital() != null && terrOrigOwner != null
@@ -172,7 +174,7 @@ public class ProSimulateTurnUtils {
           CollectionUtils.getMatches(originallyOwned, Matches.isTerritoryAllied(terrOrigOwner, data));
       friendlyTerritories.add(t);
       for (final Territory item : friendlyTerritories) {
-        if (item.getOwner() == terrOrigOwner) {
+        if (item.getOwner().equals(terrOrigOwner)) {
           continue;
         }
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -65,7 +65,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       }
 
       for (final PlayerID otherPlayer : playersToSearch) {
-        if (otherPlayer == player) {
+        if (otherPlayer.equals(player)) {
           continue;
         }
         paa = (PoliticalActionAttachment) otherPlayer.getAttachment(nameOfAttachment);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -109,7 +109,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         }
       } else {
         for (final PlayerID otherPlayer : playersToSearch) {
-          if (otherPlayer == player) {
+          if (otherPlayer.equals(player)) {
             continue;
           }
           ra = (RulesAttachment) otherPlayer.getAttachment(nameOfAttachment);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -120,7 +120,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
 
       for (final PlayerID otherPlayer : playersToSearch) {
-        if (otherPlayer == player) {
+        if (otherPlayer.equals(player)) {
           continue;
         }
         ta = (TriggerAttachment) otherPlayer.getAttachment(nameOfAttachment);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -15,6 +15,8 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.data.Change;
@@ -618,7 +620,7 @@ public class BattleTracker implements Serializable {
       }
     }
     // is this an allied territory, revert to original owner if it is, unless they dont own there captital
-    final PlayerID terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(territory);
+    final @Nullable PlayerID terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(territory);
     PlayerID newOwner = id;
     // if the original owner is the current owner, and the current owner is our enemy or canTakeOver,
     // then we do not worry about this.
@@ -702,7 +704,7 @@ public class BattleTracker implements Serializable {
           CollectionUtils.getMatches(originallyOwned, Matches.isTerritoryAllied(terrOrigOwner, data));
       // give back the factories as well.
       for (final Territory item : friendlyTerritories) {
-        if (item.getOwner() == terrOrigOwner) {
+        if (item.getOwner().equals(terrOrigOwner)) {
           continue;
         }
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.PlayerID;
@@ -801,11 +803,11 @@ public final class Matches {
       if (ta == null) {
         return false;
       }
-      final PlayerID origOwner = OriginalOwnerTracker.getOriginalOwner(t);
+      final @Nullable PlayerID origOwner = OriginalOwnerTracker.getOriginalOwner(t);
       if (t.isWater()) {
         // if it's water, it is a Convoy Center
         // Can't get PUs for capturing a CC, only original owner can get them. (Except capturing null player CCs)
-        if (!(origOwner == null || origOwner.equals(PlayerID.NULL_PLAYERID) || origOwner == player)) {
+        if (!(origOwner == null || origOwner.equals(PlayerID.NULL_PLAYERID) || origOwner.equals(player))) {
           return false;
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
@@ -46,7 +48,7 @@ public class OriginalOwnerTracker implements Serializable {
     return TripleAUnit.get(unit).getOriginalOwner();
   }
 
-  public static PlayerID getOriginalOwner(final Territory t) {
+  public static @Nullable PlayerID getOriginalOwner(final Territory t) {
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta == null) {
       return null;

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -433,7 +433,7 @@ class OddsCalculatorPanel extends JPanel {
         } else {
           // we need to find out the defender for sea zones
           for (final PlayerID player : location.getUnits().getPlayersWithUnits()) {
-            if (player != getAttacker() && !data.getRelationshipTracker().isAllied(player, getAttacker())) {
+            if (!player.equals(getAttacker()) && !data.getRelationshipTracker().isAllied(player, getAttacker())) {
               defenderCombo.setSelectedItem(player);
               break;
             }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -92,10 +93,11 @@ class TerritoryDetailPanel extends AbstractStatPanel {
     panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
     final List<UnitCategory> units = UnitSeperator.getSortedUnitCategories(territory, uiContext.getMapData());
+    @Nullable
     PlayerID currentPlayer = null;
     for (final UnitCategory item : units) {
       // seperate players with a seperator
-      if (item.getOwner() != currentPlayer) {
+      if (!item.getOwner().equals(currentPlayer)) {
         currentPlayer = item.getOwner();
         panel.add(Box.createVerticalStrut(15));
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -527,7 +527,6 @@ public class HistoryLog extends JFrame {
     textArea.setText(stringWriter.toString());
   }
 
-  // copied from StatPanel
   private static int getProduction(final PlayerID player, final GameData data) {
     int production = 0;
     for (final Territory place : data.getMap().getTerritories()) {
@@ -537,7 +536,7 @@ public class HistoryLog extends JFrame {
           || (place.isWater()
               && ta != null
               && !PlayerID.NULL_PLAYERID.equals(OriginalOwnerTracker.getOriginalOwner(place))
-              && OriginalOwnerTracker.getOriginalOwner(place) == player
+              && player.equals(OriginalOwnerTracker.getOriginalOwner(place))
               && place.getOwner().equals(player))) {
         isConvoyOrLand = true;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -14,9 +14,11 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
 import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
@@ -291,6 +293,7 @@ final class ExportMenu extends JMenu {
       clone.getHistory().gotoNode(clone.getHistory().getLastNode());
       @SuppressWarnings("unchecked")
       final Enumeration<TreeNode> nodes = ((DefaultMutableTreeNode) clone.getHistory().getRoot()).preorderEnumeration();
+      @Nullable
       PlayerID currentPlayer = null;
       int round = 0;
       while (nodes.hasMoreElements()) {
@@ -308,7 +311,7 @@ final class ExportMenu extends JMenu {
         }
         // this is to stop from having multiple entries for each players turn.
         if (!showPhaseStats) {
-          if (step.getPlayerId() == currentPlayer) {
+          if (Objects.equals(step.getPlayerId(), currentPlayer)) {
             continue;
           }
         }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule involving instances of `PlayerID`.

After analyzing existing code, I couldn't find any cases where reference equality between `PlayerID` instances would be appropriate.  Therefore, converting all such occurrences to value equality seems to be the right thing to do.

However, there are many cases where a `PlayerID` instance may be `null`.  In order to decide if a direct call to `Object#equals()` is appropriate, or if an indirect comparison via `Objects#equals()` is required, I performed some additional nullity analysis.  To aid myself (and the reviewer), I added `@Nullable` annotations where appropriate.  If I was 100% certain using `Object#equals()` would not result in an NPE, I used it; otherwise I used `Objects#equals()`.

## Functional Changes

None.

## Manual Testing Performed

None.