### PR TITLE
Rename DelegateTest

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.xml.TestMapGameData;
  * players, territories, and unit types.
  * </p>
  */
-public class DelegateTestCase {
+public abstract class AbstractDelegateTestCase {
   protected GameData gameData;
   protected PlayerID british;
   protected PlayerID japanese;
@@ -85,7 +85,7 @@ public class DelegateTestCase {
   protected UnitType carrier;
   protected Resource pus;
 
-  protected DelegateTestCase() {}
+  protected AbstractDelegateTestCase() {}
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
@@ -22,7 +22,7 @@ import games.strategy.util.IntegerMap;
 
 final class AbstractEndTurnDelegateTest {
   @Nested
-  final class FindEstimatedIncomeTest extends DelegateTestCase {
+  final class FindEstimatedIncomeTest extends AbstractDelegateTestCase {
     @Test
     void testFindEstimatedIncome() throws Exception {
       final GameData global40Data = TestMapGameData.GLOBAL1940.getGameData();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
@@ -22,7 +22,7 @@ import games.strategy.util.IntegerMap;
 
 final class AbstractEndTurnDelegateTest {
   @Nested
-  final class FindEstimatedIncomeTest extends DelegateTest {
+  final class FindEstimatedIncomeTest extends DelegateTestCase {
     @Test
     void testFindEstimatedIncome() throws Exception {
       final GameData global40Data = TestMapGameData.GLOBAL1940.getGameData();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
@@ -15,7 +15,15 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class DelegateTest {
+/**
+ * Superclass for fixtures that test delegates.
+ *
+ * <p>
+ * Pre-loads the {@link TestMapGameData#DELEGATE_TEST} save game and provides fields for the most-commonly-accessed
+ * players, territories, and unit types.
+ * </p>
+ */
+public class DelegateTestCase {
   protected GameData gameData;
   protected PlayerID british;
   protected PlayerID japanese;
@@ -77,6 +85,8 @@ public class DelegateTest {
   protected UnitType bomber;
   protected UnitType carrier;
   protected Resource pus;
+
+  protected DelegateTestCase() {}
 
   @BeforeEach
   public void setUp() throws Exception {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
@@ -162,11 +162,11 @@ public class DelegateTestCase {
         new TechAttachment(Constants.TECH_ATTACHMENT_NAME, player, gameData));
   }
 
-  public void assertValid(final String string) {
+  protected static void assertValid(final String string) {
     assertNull(string, string);
   }
 
-  public void assertError(final String string) {
+  protected static void assertError(final String string) {
     assertNotNull(string, string);
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DelegateTestCase.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -172,11 +171,5 @@ public class DelegateTestCase {
 
   protected ITestDelegateBridge getDelegateBridge(final PlayerID player) {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
-  }
-
-  @Test
-  public void testTest() {
-    assertValid(null);
-    assertError("Cannot do this");
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -26,7 +26,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
-public class MoveDelegateTest extends DelegateTestCase {
+public class MoveDelegateTest extends AbstractDelegateTestCase {
   MoveDelegate delegate;
   ITestDelegateBridge bridge;
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -26,7 +26,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
-public class MoveDelegateTest extends DelegateTest {
+public class MoveDelegateTest extends DelegateTestCase {
   MoveDelegate delegate;
   ITestDelegateBridge bridge;
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class MoveValidatorTest extends DelegateTestCase {
+public class MoveValidatorTest extends AbstractDelegateTestCase {
 
   @Test
   public void testEnemyUnitsInPath() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class MoveValidatorTest extends DelegateTest {
+public class MoveValidatorTest extends DelegateTestCase {
 
   @Test
   public void testEnemyUnitsInPath() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -15,7 +15,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.test.ScriptedRandomSource;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class MustFightBattleTest extends DelegateTest {
+public class MustFightBattleTest extends DelegateTestCase {
   @Test
   public void testFightWithIsSuicideOnHit() throws Exception {
     final GameData twwGameData = TestMapGameData.TWW.getGameData();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -15,7 +15,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.test.ScriptedRandomSource;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class MustFightBattleTest extends DelegateTestCase {
+public class MustFightBattleTest extends AbstractDelegateTestCase {
   @Test
   public void testFightWithIsSuicideOnHit() throws Exception {
     final GameData twwGameData = TestMapGameData.TWW.getGameData();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -20,7 +20,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 
-public class PacificTest extends DelegateTest {
+public class PacificTest extends DelegateTestCase {
   UnitType armor;
   UnitType artillery;
   UnitType marine;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -20,7 +20,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 
-public class PacificTest extends DelegateTestCase {
+public class PacificTest extends AbstractDelegateTestCase {
   UnitType armor;
   UnitType artillery;
   UnitType marine;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -19,7 +19,7 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.util.IntegerMap;
 
-public class PlaceDelegateTest extends DelegateTest {
+public class PlaceDelegateTest extends DelegateTestCase {
   protected PlaceDelegate delegate;
   protected ITestDelegateBridge bridge;
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -19,7 +19,7 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.util.IntegerMap;
 
-public class PlaceDelegateTest extends DelegateTestCase {
+public class PlaceDelegateTest extends AbstractDelegateTestCase {
   protected PlaceDelegate delegate;
   protected ITestDelegateBridge bridge;
 


### PR DESCRIPTION
## Overview

Renames `DelegateTest` to `AbstractDelegateTestCase` and marks it `abstract` to make it clear that this class is a test fixture base class and not a test fixture itself.

## Functional Changes

None.

## Refactoring Changes

* Changed the `assertValid()` and `assertError()` methods to be `protected` and `static`.
* Removed `testTest()`.  It is an essentially-useless test, and it adds about a second to the runtime of each test subclass.

## Manual Testing Performed

None.