### PR TITLE
Add subproject for headless game server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects {
     apply plugin: 'net.ltgt.errorprone'
 
     apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
+    apply from: "${rootProject.projectDir}/gradle/scripts/version.gradle"
 
     repositories {
         jcenter()

--- a/eclipse/launchers/HeadlessGameRunner.launch
+++ b/eclipse/launchers/HeadlessGameRunner.launch
@@ -2,14 +2,15 @@
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
 <stringAttribute key="bad_container_name" value="/triplea/eclipse/lau"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java"/>
+<listEntry value="/game-headless/src/main/java/org/triplea/game/headless/runner/HeadlessGameRunner.java"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.triplea.game.headless.runner.HeadlessGameRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Ptriplea.game=&#13;&#10;-Ptriplea.server=true&#13;&#10;-Ptriplea.port=3300&#13;&#10;-Ptriplea.lobby.host=127.0.0.1&#13;&#10;-Ptriplea.lobby.port=3304&#13;&#10;-Ptriplea.name=Bot1_TestServer &#13;&#10;-Ptriplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;-Ptriplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;-Ptriplea.lobby.game.comments=automated_host&#13;&#10;-Ptriplea.map.folder=${system_property:user.home}/triplea/downloadedMaps"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-core"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-headless"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:game-core}"/>
 </launchConfiguration>

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -7,29 +7,13 @@ plugins {
 
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = 'games.strategy.engine.framework.GameRunner'
+version = getEngineVersion()
 
 ext {
     releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
     rootFilesDir = file("$buildDir/rootFiles")
     shadowLibsDir = file("$buildDir/shadowLibs")
-
-    gameEnginePropertiesFile = file('game_engine.properties')
-}
-
-def getEngineVersion() {
-    if (project.hasProperty('engineVersion')) {
-        return project.engineVersion
-    }
-
-    def props = new Properties()
-    gameEnginePropertiesFile.withInputStream { props.load(it) }
-    def devEngineVersion = props.getProperty('engine_version')
-    if (!devEngineVersion) {
-        throw new GradleException("unable to determine engine version: "
-                + "you must define either the project property 'engineVersion' or the game engine property 'engine_version'")
-    }
-    return "${devEngineVersion}"
 }
 
 def remoteFile(url) {
@@ -41,8 +25,6 @@ def remoteFile(url) {
     }
     files(file)
 }
-
-version = getEngineVersion()
 
 jar {
     manifest {
@@ -134,7 +116,7 @@ task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
             into(folder)
         }
     }
-    from(gameEnginePropertiesFile)
+    from(file('game_engine.properties'))
     from(shadowJar.outputs) {
         into('bin')
     }

--- a/game-headless/README.md
+++ b/game-headless/README.md
@@ -1,0 +1,3 @@
+# Headless Game Server
+
+A headless game server for TripleA, also known as a _bot_.

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -1,0 +1,35 @@
+plugins {
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '2.0.4'
+}
+
+archivesBaseName = "$group-$name"
+description = 'TripleA Headless Game Server'
+mainClassName = 'org.triplea.game.headless.runner.HeadlessGameRunner'
+version = getEngineVersion()
+
+dependencies {
+    compile project(':game-core')
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+}
+
+task headlessGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
+    from project(':game-core').file('game_engine.properties')
+    from(project(':game-core').file('assets')) {
+        into 'assets'
+    }
+    from(shadowJar.outputs) {
+        into 'bin'
+    }
+}
+
+task release(group: 'release', dependsOn: headlessGameArchive) {
+    doLast {
+        publishArtifacts(headlessGameArchive.outputs.files)
+    }
+}

--- a/game-headless/src/main/java/org/triplea/game/headless/runner/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/headless/runner/HeadlessGameRunner.java
@@ -1,0 +1,18 @@
+package org.triplea.game.headless.runner;
+
+import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
+
+/**
+ * Runs a headless game server.
+ */
+public final class HeadlessGameRunner {
+  private HeadlessGameRunner() {}
+
+  /**
+   * Entry point for running a new headless game server. The headless game server runs until the process is killed or
+   * the headless game server is shut down via administrative command.
+   */
+  public static void main(final String[] args) {
+    HeadlessGameServer.main(args);
+  }
+}

--- a/gradle/scripts/version.gradle
+++ b/gradle/scripts/version.gradle
@@ -1,0 +1,16 @@
+ext.getEngineVersion = {
+    if (project.hasProperty('engineVersion')) {
+        return project.engineVersion
+    }
+
+    def props = new Properties()
+    def gameEnginePropertiesFile = project(':game-core').file('game_engine.properties')
+    gameEnginePropertiesFile.withInputStream { props.load(it) }
+    def devEngineVersion = props.getProperty('engine_version')
+    if (!devEngineVersion) {
+        throw new GradleException('unable to determine engine version: '
+                + 'you must define either the project property "engineVersion" '
+                + 'or the game engine property "engine_version"')
+    }
+    return devEngineVersion
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name='triplea'
 include 'game-core'
+include 'game-headless'
 include 'lobby'
 include 'lobby-db'
 include 'test-common'


### PR DESCRIPTION
## Overview

This PR begins the process of migrating the headless code into its own subproject: `game-headless`.  (Presumably, in the future, there will be a `game-headed` subproject that contains only the headed code, while all common code remains in `game-core`.)

I marked this PR **&lt;PREVIEW>** because, if we go forward with this split, there is one big consequence that everyone needs to understand and agree upon before it is merged:

:warning: **Users will no longer be able to run a bot from the standard installers.** :warning:

That is, if a user wants to run a bot, they will have to download an additional artifact.  The install4j installers and the portable build will _eventually_ no longer contain the code required to run a bot.

(@prastle, your opinion here would be appreciated since you have the most experience with users running their own bots.)

#### Migration plan

* Once this PR is merged, update the infrastructure scripts to use the new build artifact instead of the portable build  (_*-all_platforms.zip_).
* Once the new infrastructure scripts have been merged, we'll be clear to start migrating code to the `game-headless` project.

#### Other considerations

* We'll have an extra artifact in each release that is pretty much the same size as the  portable build (currently ~24 MiB).  Obviously, that size will decrease over time as headed code is moved out of `game-core` into its own subproject.  Likewise, the headed artifacts will decrease in size as code is moved to `game-headless`.
* We currently have to pull some files from `game-core` into the build artifact (_game_engine.properties_ and the _assets_ folder).  We'll eventually need to think of a proper way to share things like this that need to land in both the headed and headless build artifacts (hopefully we can figure out a way to decouple the headless code from the _assets_ folder).  Not sure what that will be, but for now there are a few smells in the `game-headless` buildscript that reference `project(:game-core)` directly.

## Functional Changes

None.

## Manual Testing Performed

* Verified I could run a bot from my IDE using the Eclipse launch configuration.  Tested lobby connection and starting a new game.
* Verified I could run a bot using the new build artifact.  Tested lobby connection and starting a new game.
* Created a release branch in my fork to run the complete build and verified the new artifact is built as expected:
    ![game-headless-release](https://user-images.githubusercontent.com/4826349/44951372-910cd280-ae30-11e8-89e7-4ad25c0fa4df.png)
