### PR TITLE
Add a naming conventions document page

### DIFF
--- a/docs/dev/conventions/naming_conventions.md
+++ b/docs/dev/conventions/naming_conventions.md
@@ -1,0 +1,12 @@
+Casing Types:
+- [Kebab_case](https://en.wikipedia.org/wiki/Kebab_case)
+
+
+## java
+
+- Use [google java naming guide](https://google.github.io/styleguide/javaguide.html#s5-naming)
+
+
+## urls
+
+- kebab_case

--- a/docs/dev/conventions/naming_conventions.md
+++ b/docs/dev/conventions/naming_conventions.md
@@ -1,5 +1,5 @@
 Casing Types:
-- [Kebab_case](https://en.wikipedia.org/wiki/Kebab_case)
+- [Kebab-case](https://en.wikipedia.org/wiki/Kebab_case)
 
 
 ## java
@@ -9,4 +9,4 @@ Casing Types:
 
 ## urls
 
-- kebab_case
+- kebab-case


### PR DESCRIPTION
## Overview
To start, so far we have agreed to follow google java naming convention by default and recently decided a url convention in: https://github.com/triplea-game/triplea/issues/3954

## Functional Changes
- none, new documentation only

## Additional Review Notes
- documenting the decision reached in: https://github.com/triplea-game/triplea/issues/3954
