### PR TITLE
Error Prone: Suppress class can be static violations in RelationshipTracker

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -109,6 +109,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
   /**
    * RelatedPlayers is a class of 2 players that are related, used in relationships.
    */
+  @SuppressWarnings("ClassCanBeStatic") // TODO: make class static upon next incompatible release
   public class RelatedPlayers implements Serializable {
     private static final long serialVersionUID = 2124258606502106751L;
 


### PR DESCRIPTION
## Overview

Suppresses one violation of the Error Prone ClassCanBeStatic rule in the `RelationshipTracker$RelatedPlayers` class.  `RelationshipTracker$RelatedPlayers` cannot be made static (and thus remove its back-reference to `RelationshipTracker`) until the next incompatible release due to compatibility requirements with older clients.

## Functional Changes

None.

## Manual Testing Performed

None.