### PR TITLE
Error Prone: Fix string splitter violations in UnitIconProperties

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -17,6 +17,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.swing.SwingUtilities;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
 import games.strategy.engine.data.events.GameDataChangeListener;
@@ -289,7 +290,8 @@ public class GameData implements Serializable {
     return gameVersion;
   }
 
-  void setGameName(final String gameName) {
+  @VisibleForTesting
+  public void setGameName(final String gameName) {
     this.gameName = gameName;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
@@ -48,6 +48,12 @@ public class OrderedProperties extends Properties {
   }
 
   @Override
+  public synchronized void putAll(final Map<?, ?> m) {
+    keys.addAll(m.keySet());
+    super.putAll(m);
+  }
+
+  @Override
   public synchronized Object remove(final Object key) {
     keys.remove(key);
     return super.remove(key);

--- a/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/OrderedProperties.java
@@ -1,10 +1,13 @@
 package games.strategy.triplea.ui;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -19,6 +22,13 @@ public class OrderedProperties extends Properties {
   @Override
   public Enumeration<?> propertyNames() {
     return Collections.enumeration(keys);
+  }
+
+  @Override
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    return keys.stream()
+        .map(key -> new AbstractMap.SimpleEntry<>(key, get(key)))
+        .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -46,6 +47,14 @@ public abstract class PropertyFile {
 
   protected PropertyFile(final String fileName) {
     this(fileName, AbstractUiContext.getResourceLoader());
+  }
+
+  @VisibleForTesting
+  protected PropertyFile(final Properties properties) {
+    // need to implement OrderedProperties#entrySet() in order to use Properties#putAll()
+    for (final Object key : properties.keySet()) {
+      this.properties.put(key, properties.get(key));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PropertyFile.java
@@ -51,10 +51,7 @@ public abstract class PropertyFile {
 
   @VisibleForTesting
   protected PropertyFile(final Properties properties) {
-    // need to implement OrderedProperties#entrySet() in order to use Properties#putAll()
-    for (final Object key : properties.keySet()) {
-      this.properties.put(key, properties.get(key));
-    }
+    this.properties.putAll(properties);
   }
 
   @SuppressWarnings("unchecked")

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
@@ -102,16 +103,16 @@ public final class UnitIconProperties extends PropertyFile {
    */
   @VisibleForTesting
   static UnitIconDescriptor parseUnitIconDescriptor(final String encodedIconId, final String iconPath) {
-    final String[] iconIdTokens = encodedIconId.split(";");
-    final String encodedUnitTypeId = iconIdTokens[0];
-    final Optional<String> conditionName = (iconIdTokens.length == 2)
-        ? Optional.ofNullable(iconIdTokens[1])
+    final List<String> iconIdTokens = Splitter.on(';').splitToList(encodedIconId);
+    final String encodedUnitTypeId = iconIdTokens.get(0);
+    final Optional<String> conditionName = (iconIdTokens.size() == 2)
+        ? Optional.ofNullable(iconIdTokens.get(1))
         : Optional.empty();
 
-    final String[] unitTypeIdTokens = encodedUnitTypeId.split("\\.", 3);
-    final String gameName = unitTypeIdTokens[0];
-    final String playerName = unitTypeIdTokens[1];
-    final String unitTypeName = unitTypeIdTokens[2];
+    final List<String> unitTypeIdTokens = Splitter.on('.').limit(3).splitToList(encodedUnitTypeId);
+    final String gameName = unitTypeIdTokens.get(0);
+    final String playerName = unitTypeIdTokens.get(1);
+    final String unitTypeName = unitTypeIdTokens.get(2);
 
     return new UnitIconDescriptor(gameName, playerName, unitTypeName, conditionName, iconPath);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -152,9 +152,6 @@ public final class UnitIconProperties extends PropertyFile {
     final String gameName = normalizeGameName(gameData);
     // TODO: convert to stream
     for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
-      // TODO: to test the other branch, modify test to add a satisfied condition for a different game
-      // just add additional properties for entries that have different game name, different player name, and
-      // different unit type name
       // TODO: eventually extract a matches(gameName, playerName, unitTypeName) method
       if (gameName.equals(unitIconDescriptor.gameName)
           && playerName.equals(unitIconDescriptor.playerName)

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -52,17 +52,16 @@ public final class UnitIconProperties extends PropertyFile {
   }
 
   private ImmutableList<UnitIconDescriptor> parseUnitIconDescriptors() {
-    final ImmutableList.Builder<UnitIconDescriptor> unitIconDescriptorsBuilder = ImmutableList.builder();
-    // need to implement OrderedProperties#entrySet() to ensure it preserves order; fallback to keySet() for now
-    for (final Object key : properties.keySet()) {
+    final ImmutableList.Builder<UnitIconDescriptor> builder = ImmutableList.builder();
+    for (final Map.Entry<Object, Object> property : properties.entrySet()) {
       try {
-        unitIconDescriptorsBuilder.add(parseUnitIconDescriptor(key.toString(), properties.getProperty(key.toString())));
+        builder.add(parseUnitIconDescriptor(property.getKey().toString(), property.getValue().toString()));
       } catch (final MalformedUnitIconDescriptorException e) {
         log.log(Level.WARNING, e, () -> "Expected " + PROPERTY_FILE + " property key to be of the form "
             + "<game_name>.<player>.<unit_type>;attachmentName OR if always true <game_name>.<player>.<unit_type>");
       }
     }
-    return unitIconDescriptorsBuilder.build();
+    return builder.build();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 
 import javax.annotation.Nullable;
@@ -124,8 +123,7 @@ public final class UnitIconProperties extends PropertyFile {
         playerName,
         unitTypeName,
         gameData,
-        AbstractPlayerRulesAttachment::getCondition,
-        conditionsStatus::get);
+        AbstractPlayerRulesAttachment::getCondition);
   }
 
   @VisibleForTesting
@@ -133,8 +131,7 @@ public final class UnitIconProperties extends PropertyFile {
       final String playerName,
       final String unitTypeName,
       final GameData gameData,
-      final ConditionSupplier conditionSupplier,
-      final Predicate<ICondition> isConditionEnabled) {
+      final ConditionSupplier conditionSupplier) {
     final List<String> imagePaths = new ArrayList<>();
     final String gameName =
         FileNameUtils.replaceIllegalCharacters(gameData.getGameName(), '_').replaceAll(" ", "_");
@@ -146,7 +143,7 @@ public final class UnitIconProperties extends PropertyFile {
         if (startOfKey.equals(keyParts[0])) {
           if (keyParts.length == 2) {
             final @Nullable ICondition condition = conditionSupplier.getCondition(playerName, keyParts[1], gameData);
-            if (isConditionEnabled.test(condition)) {
+            if (conditionsStatus.get(condition)) {
               imagePaths.add(properties.get(key).toString());
             }
           } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -112,8 +112,7 @@ public final class UnitIconProperties extends PropertyFile {
   private void initializeConditionsStatus(final GameData gameData, final ConditionSupplier conditionSupplier) {
     final String gameName = normalizeGameName(gameData);
     for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
-      // TODO: eventually extract a matches(gameName) method
-      if (gameName.equals(unitIconDescriptor.gameName)) {
+      if (unitIconDescriptor.matches(gameName)) {
         unitIconDescriptor.conditionName.ifPresent(conditionName -> {
           final @Nullable ICondition condition =
               conditionSupplier.getCondition(unitIconDescriptor.playerName, conditionName, gameData);
@@ -150,12 +149,8 @@ public final class UnitIconProperties extends PropertyFile {
       final ConditionSupplier conditionSupplier) {
     final List<String> imagePaths = new ArrayList<>();
     final String gameName = normalizeGameName(gameData);
-    // TODO: convert to stream
     for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
-      // TODO: eventually extract a matches(gameName, playerName, unitTypeName) method
-      if (gameName.equals(unitIconDescriptor.gameName)
-          && playerName.equals(unitIconDescriptor.playerName)
-          && unitTypeName.equals(unitIconDescriptor.unitTypeName)) {
+      if (unitIconDescriptor.matches(gameName, playerName, unitTypeName)) {
         OptionalUtils.ifPresentOrElse(
             unitIconDescriptor.conditionName,
             conditionName -> {
@@ -201,6 +196,16 @@ public final class UnitIconProperties extends PropertyFile {
     final String unitTypeName;
     final Optional<String> conditionName;
     final String unitIconPath;
+
+    boolean matches(final String gameName) {
+      return this.gameName.equals(gameName);
+    }
+
+    boolean matches(final String gameName, final String playerName, final String unitTypeName) {
+      return this.gameName.equals(gameName)
+          && this.playerName.equals(playerName)
+          && this.unitTypeName.equals(unitTypeName);
+    }
   }
 
   @VisibleForTesting

--- a/game-core/src/test/java/games/strategy/triplea/ui/OrderedPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/OrderedPropertiesTest.java
@@ -4,17 +4,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class OrderedPropertiesTest {
+  private final OrderedProperties properties = new OrderedProperties();
+
   @Nested
   final class EntrySetTest {
     @SuppressWarnings("unchecked")
     @Test
     void shouldReturnEntriesInInsertionOrder() {
-      final OrderedProperties properties = new OrderedProperties();
       properties.put("key1", "value1");
       properties.put("key2", "value2");
       properties.put("key3", "value3");
@@ -29,6 +32,21 @@ final class OrderedPropertiesTest {
               new AbstractMap.SimpleEntry<>("key3", "value3"),
               new AbstractMap.SimpleEntry<>("key4", "value4"),
               new AbstractMap.SimpleEntry<>("key5", "value5")));
+    }
+  }
+
+  @Nested
+  final class PutAllTest {
+    @Test
+    void shouldTrackPropertyKeysInInsertionOrder() {
+      final Map<Object, Object> map = new LinkedHashMap<>();
+      map.put("key1", "value1");
+      map.put("key2", "value2");
+      map.put("key3", "value3");
+
+      properties.putAll(map);
+
+      assertThat(properties.keySet(), contains("key1", "key2", "key3"));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/OrderedPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/OrderedPropertiesTest.java
@@ -1,0 +1,34 @@
+package games.strategy.triplea.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.AbstractMap;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class OrderedPropertiesTest {
+  @Nested
+  final class EntrySetTest {
+    @SuppressWarnings("unchecked")
+    @Test
+    void shouldReturnEntriesInInsertionOrder() {
+      final OrderedProperties properties = new OrderedProperties();
+      properties.put("key1", "value1");
+      properties.put("key2", "value2");
+      properties.put("key3", "value3");
+      properties.put("key4", "value4");
+      properties.put("key5", "value5");
+
+      assertThat(
+          properties.entrySet(),
+          contains(
+              new AbstractMap.SimpleEntry<>("key1", "value1"),
+              new AbstractMap.SimpleEntry<>("key2", "value2"),
+              new AbstractMap.SimpleEntry<>("key3", "value3"),
+              new AbstractMap.SimpleEntry<>("key4", "value4"),
+              new AbstractMap.SimpleEntry<>("key5", "value5")));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -110,6 +111,23 @@ final class UnitIconPropertiesTest {
     @Test
     void shouldParseUnitIconDescriptorWithoutCondition() {
       assertThat(parseUnitIconDescriptorWithCondition(null), is(newUnitIconDescriptorWithCondition(null)));
+    }
+
+    @Test
+    void shouldReturnNullObjectWhenIconIdTokenCountNotEqualToOneOrTwo() {
+      assertThrows(
+          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("", ICON_1_PATH));
+      assertThrows(
+          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2.a3;b1;c1", ICON_1_PATH));
+    }
+
+    @Test
+    void shouldReturnNullObjectWhenUnitTypeIdTokenCountNotEqualToThree() {
+      assertThrows(
+          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2;b1", ICON_1_PATH));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -1,0 +1,68 @@
+package games.strategy.triplea.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Joiner;
+
+import games.strategy.triplea.ui.UnitIconProperties.UnitIconDescriptor;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class UnitIconPropertiesTest {
+  @Nested
+  final class ParseUnitIconDescriptorTest {
+    private static final String GAME_NAME = "gameName";
+    private static final String ICON_PATH = "path/to/icon.png";
+    private static final String PLAYER_NAME = "playerName";
+    private static final String UNIT_TYPE_NAME = "unitTypeName";
+
+    private UnitIconDescriptor newUnitIconDescriptorWithCondition(final @Nullable String conditionName) {
+      return new UnitIconDescriptor(
+          GAME_NAME,
+          PLAYER_NAME,
+          UNIT_TYPE_NAME,
+          Optional.ofNullable(conditionName),
+          ICON_PATH);
+    }
+
+    private UnitIconDescriptor parseUnitIconDescriptorWithCondition(final @Nullable String conditionName) {
+      final String encodedUnitTypeId = Joiner.on('.').join(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME);
+      final String encodedIconId = (conditionName != null)
+          ? Joiner.on(';').join(encodedUnitTypeId, conditionName)
+          : encodedUnitTypeId;
+      return UnitIconProperties.parseUnitIconDescriptor(encodedIconId, ICON_PATH);
+    }
+
+    @Test
+    void shouldParseUnitIconDescriptorWithCondition() {
+      final String conditionName = "conditionName";
+
+      assertThat(
+          parseUnitIconDescriptorWithCondition(conditionName),
+          is(newUnitIconDescriptorWithCondition(conditionName)));
+    }
+
+    @Test
+    void shouldParseUnitIconDescriptorWithoutCondition() {
+      assertThat(parseUnitIconDescriptorWithCondition(null), is(newUnitIconDescriptorWithCondition(null)));
+    }
+  }
+
+  @Nested
+  final class UnitIconDescriptorTest {
+    @Nested
+    final class EqualsAndHashCodeTest {
+      @Test
+      void shouldBeEquatableAndHashable() {
+        EqualsVerifier.forClass(UnitIconDescriptor.class).verify();
+      }
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -139,7 +139,7 @@ final class UnitIconPropertiesTest {
     }
 
     @Test
-    void shouldReturnNullObjectWhenIconIdTokenCountNotEqualToOneOrTwo() {
+    void shouldThrowExceptionWhenIconIdTokenCountNotEqualToOneOrTwo() {
       assertThrows(
           MalformedUnitIconDescriptorException.class,
           () -> UnitIconProperties.parseUnitIconDescriptor("", ICON_1_PATH));
@@ -149,7 +149,7 @@ final class UnitIconPropertiesTest {
     }
 
     @Test
-    void shouldReturnNullObjectWhenUnitTypeIdTokenCountNotEqualToThree() {
+    void shouldThrowExceptionWhenUnitTypeIdTokenCountNotEqualToThree() {
       assertThrows(
           MalformedUnitIconDescriptorException.class,
           () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2;b1", ICON_1_PATH));

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -1,9 +1,14 @@
 package games.strategy.triplea.ui;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
@@ -12,41 +17,93 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Joiner;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.ui.UnitIconProperties.UnitIconDescriptor;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 final class UnitIconPropertiesTest {
+  private static final String CONDITION_1_NAME = "condition1Name";
+  private static final String CONDITION_2_NAME = "condition2Name";
+  private static final String GAME_NAME = "gameName";
+  private static final String ICON_1_PATH = "path/to/icon_1.png";
+  private static final String ICON_2_PATH = "path/to/icon_2.png";
+  private static final String ICON_3_PATH = "path/to/icon_3.png";
+  private static final String PLAYER_NAME = "playerName";
+  private static final String UNIT_TYPE_NAME = "unitTypeName";
+
+  private static String formatIconId(final @Nullable String conditionName) {
+    final String encodedUnitTypeId = Joiner.on('.').join(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME);
+    return (conditionName != null)
+        ? Joiner.on(';').join(encodedUnitTypeId, conditionName)
+        : encodedUnitTypeId;
+  }
+
+  @Nested
+  final class GetImagePathsTest {
+    private GameData givenGameData() {
+      final GameData gameData = new GameData();
+      gameData.setGameName(GAME_NAME);
+      return gameData;
+    }
+
+    private ICondition givenCondition(final String name) {
+      final ICondition condition = mock(ICondition.class);
+      when(condition.getName()).thenReturn(name);
+      return condition;
+    }
+
+    private UnitIconProperties.ConditionSupplier givenConditionSupplier(final GameData gameData) {
+      final UnitIconProperties.ConditionSupplier conditionSupplier = mock(UnitIconProperties.ConditionSupplier.class);
+      final ICondition condition1 = givenCondition(CONDITION_1_NAME);
+      when(conditionSupplier.getCondition(PLAYER_NAME, CONDITION_1_NAME, gameData)).thenReturn(condition1);
+      final ICondition condition2 = givenCondition(CONDITION_2_NAME);
+      when(conditionSupplier.getCondition(PLAYER_NAME, CONDITION_2_NAME, gameData)).thenReturn(condition2);
+      return conditionSupplier;
+    }
+
+    @Test
+    void shouldReturnImagePathsForIconsWithEnabledConditionOrNoCondition() {
+      final GameData gameData = givenGameData();
+      final UnitIconProperties.ConditionSupplier conditionSupplier = givenConditionSupplier(gameData);
+      final Properties properties = new OrderedProperties();
+      properties.put(formatIconId(CONDITION_1_NAME), ICON_1_PATH);
+      properties.put(formatIconId(CONDITION_2_NAME), ICON_2_PATH);
+      properties.put(formatIconId(null), ICON_3_PATH);
+      final UnitIconProperties unitIconProperties = new UnitIconProperties(properties, gameData, conditionSupplier);
+      final Predicate<ICondition> isConditionEnabled = condition -> CONDITION_1_NAME.equals(condition.getName());
+
+      assertThat(
+          unitIconProperties.getImagePaths(
+              PLAYER_NAME,
+              UNIT_TYPE_NAME,
+              gameData,
+              conditionSupplier,
+              isConditionEnabled),
+          contains(ICON_1_PATH, ICON_3_PATH));
+    }
+  }
+
   @Nested
   final class ParseUnitIconDescriptorTest {
-    private static final String GAME_NAME = "gameName";
-    private static final String ICON_PATH = "path/to/icon.png";
-    private static final String PLAYER_NAME = "playerName";
-    private static final String UNIT_TYPE_NAME = "unitTypeName";
-
     private UnitIconDescriptor newUnitIconDescriptorWithCondition(final @Nullable String conditionName) {
       return new UnitIconDescriptor(
           GAME_NAME,
           PLAYER_NAME,
           UNIT_TYPE_NAME,
           Optional.ofNullable(conditionName),
-          ICON_PATH);
+          ICON_1_PATH);
     }
 
     private UnitIconDescriptor parseUnitIconDescriptorWithCondition(final @Nullable String conditionName) {
-      final String encodedUnitTypeId = Joiner.on('.').join(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME);
-      final String encodedIconId = (conditionName != null)
-          ? Joiner.on(';').join(encodedUnitTypeId, conditionName)
-          : encodedUnitTypeId;
-      return UnitIconProperties.parseUnitIconDescriptor(encodedIconId, ICON_PATH);
+      return UnitIconProperties.parseUnitIconDescriptor(formatIconId(conditionName), ICON_1_PATH);
     }
 
     @Test
     void shouldParseUnitIconDescriptorWithCondition() {
-      final String conditionName = "conditionName";
-
       assertThat(
-          parseUnitIconDescriptorWithCondition(conditionName),
-          is(newUnitIconDescriptorWithCondition(conditionName)));
+          parseUnitIconDescriptorWithCondition(CONDITION_1_NAME),
+          is(newUnitIconDescriptorWithCondition(CONDITION_1_NAME)));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ui;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -35,7 +36,15 @@ final class UnitIconPropertiesTest {
   private static final String UNIT_TYPE_NAME = "unitTypeName";
 
   private static String formatIconId(final @Nullable String conditionName) {
-    final String encodedUnitTypeId = Joiner.on('.').join(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME);
+    return formatIconId(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, conditionName);
+  }
+
+  private static String formatIconId(
+      final String gameName,
+      final String playerName,
+      final String unitTypeName,
+      final @Nullable String conditionName) {
+    final String encodedUnitTypeId = Joiner.on('.').join(gameName, playerName, unitTypeName);
     return (conditionName != null)
         ? Joiner.on(';').join(encodedUnitTypeId, conditionName)
         : encodedUnitTypeId;
@@ -83,6 +92,21 @@ final class UnitIconPropertiesTest {
       assertThat(
           unitIconProperties.getImagePaths(PLAYER_NAME, UNIT_TYPE_NAME, gameData, conditionSupplier),
           contains(ICON_1_PATH, ICON_3_PATH));
+    }
+
+    @Test
+    void shouldIgnoreIconsThatHaveDifferentUnitTypeId() {
+      final GameData gameData = givenGameData();
+      final UnitIconProperties.ConditionSupplier conditionSupplier = givenConditionSupplier(gameData);
+      final Properties properties = new OrderedProperties();
+      properties.put(formatIconId("otherGameName", PLAYER_NAME, UNIT_TYPE_NAME, null), ICON_1_PATH);
+      properties.put(formatIconId(GAME_NAME, "otherPlayerName", UNIT_TYPE_NAME, null), ICON_2_PATH);
+      properties.put(formatIconId(GAME_NAME, PLAYER_NAME, "otherUnitTypeName", null), ICON_3_PATH);
+      final UnitIconProperties unitIconProperties = new UnitIconProperties(properties, gameData, conditionSupplier);
+
+      assertThat(
+          unitIconProperties.getImagePaths(PLAYER_NAME, UNIT_TYPE_NAME, gameData, conditionSupplier),
+          is(empty()));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -22,6 +22,7 @@ import com.google.common.base.Joiner;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.attachments.ICondition;
+import games.strategy.triplea.ui.UnitIconProperties.MalformedUnitIconDescriptorException;
 import games.strategy.triplea.ui.UnitIconProperties.UnitIconDescriptor;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -140,17 +141,17 @@ final class UnitIconPropertiesTest {
     @Test
     void shouldReturnNullObjectWhenIconIdTokenCountNotEqualToOneOrTwo() {
       assertThrows(
-          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          MalformedUnitIconDescriptorException.class,
           () -> UnitIconProperties.parseUnitIconDescriptor("", ICON_1_PATH));
       assertThrows(
-          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          MalformedUnitIconDescriptorException.class,
           () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2.a3;b1;c1", ICON_1_PATH));
     }
 
     @Test
     void shouldReturnNullObjectWhenUnitTypeIdTokenCountNotEqualToThree() {
       assertThrows(
-          UnitIconProperties.MalformedUnitIconDescriptorException.class,
+          MalformedUnitIconDescriptorException.class,
           () -> UnitIconProperties.parseUnitIconDescriptor("a1.a2;b1", ICON_1_PATH));
     }
   }
@@ -162,6 +163,40 @@ final class UnitIconPropertiesTest {
       @Test
       void shouldBeEquatableAndHashable() {
         EqualsVerifier.forClass(UnitIconDescriptor.class).verify();
+      }
+    }
+
+    @Nested
+    final class MatchesGameNameTest {
+      private final UnitIconDescriptor unitIconDescriptor =
+          new UnitIconDescriptor(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, Optional.empty(), ICON_1_PATH);
+
+      @Test
+      void shouldReturnTrueWhenGameNameMatches() {
+        assertThat(unitIconDescriptor.matches(GAME_NAME), is(true));
+      }
+
+      @Test
+      void shouldReturnFalseWhenGameNameDoesNotMatch() {
+        assertThat(unitIconDescriptor.matches("otherGameName"), is(false));
+      }
+    }
+
+    @Nested
+    final class MatchesGameNameAndPlayerNameAndUnitTypeNameTest {
+      private final UnitIconDescriptor unitIconDescriptor =
+          new UnitIconDescriptor(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME, Optional.empty(), ICON_1_PATH);
+
+      @Test
+      void shouldReturnTrueWhenGameNameAndPlayerNameAndUnitTypeNameMatches() {
+        assertThat(unitIconDescriptor.matches(GAME_NAME, PLAYER_NAME, UNIT_TYPE_NAME), is(true));
+      }
+
+      @Test
+      void shouldReturnFalseWhenGameNameOrPlayerNameOrUnitTypeNameDoesNotMatch() {
+        assertThat(unitIconDescriptor.matches("otherGameName", PLAYER_NAME, UNIT_TYPE_NAME), is(false));
+        assertThat(unitIconDescriptor.matches(GAME_NAME, "otherPlayerName", UNIT_TYPE_NAME), is(false));
+        assertThat(unitIconDescriptor.matches(GAME_NAME, PLAYER_NAME, "otherUnitTypeName"), is(false));
       }
     }
   }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `UnitIconProperties` class.

Once again, this PR grew way beyond what I originally intended.  The majority of changes were required to get the affected code under test.

## Functional Changes

* Implemented `OrderedProperties#entrySet()` to be consistent with the intent of that class (i.e. to return entries in the same order they were inserted).
* Fixed a Java 9 bug in `OrderedProperties`.  In Java 8, `Properties#putAll()` repeatedly invokes `put()`.  However, in Java 9, it no longer does so.  Thus, `OrderedProperties#put()` is no longer called, and the `OrderedProperties#keys` collection is no longer updated.  Fixed by overriding `putAll()` to first update the `keys` collection before delegating to the superclass implementation.
* Changed log level of a malformed _unit_icons.properties_ line from `SEVERE` to `WARNING` since the error is recoverable, and the user can continue to play the game in a slightly degraded state (no unit icon overlays).

## Refactoring Changes

* Changed `UnitIconProperties#conditionsStatus` from a static field to an instance field.  `UnitIconProperties` is effectively a singleton, so there should only ever be one copy of this field anyway.  ("Effectively" means we guarantee there is only ever one instance active at a time, but new instances may be created on-demand no more than once every 10 seconds.)
* Modified `UnitIconProperties` to parse _unit_icons.properties_ once when the instance is created rather than once when it is created and once again every time `getImagePaths()` is called.
* Fixed some implicit control-flow-by-exception in the _unit_icons.properties_ parsing code.  Now throw an explicit exception if a line from this file is malformed instead of just letting an `IndexOutOfBoundsException` be raised.

## Manual Testing Performed

Verified _unit_icons.properties_ in TWW 1941 Beta (the only map that apparently has this file) is parsed correctly.  To accomplish this, I used edit mode to give Germany all technologies and verified the map was redrawn with the appropriate unit overlays.