### PR TITLE
Seperate inherited methods from each other

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -445,20 +445,10 @@ public class HeadlessGameServer {
       final SetupPanelModel setupPanelModel, final ServerGame serverGame) {
     try {
       final ISetupPanel setup = setupPanelModel.getPanel();
-      if (setup == null) {
+      if (setup == null || serverGame != null || setup.canGameStart()) {
         return;
       }
-      if (serverGame != null) {
-        return;
-      }
-      if (setup.canGameStart()) {
-        return;
-      }
-      if (setup instanceof ServerSetupPanel) {
-        ((ServerSetupPanel) setup).repostLobbyWatcher(serverGame);
-      } else if (setup instanceof HeadlessServerSetup) {
-        ((HeadlessServerSetup) setup).repostLobbyWatcher(serverGame);
-      }
+      setup.repostLobbyWatcher();
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Failed to restart lobby watcher", e);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -117,11 +117,9 @@ public class HeadlessGameServer {
     }
     lobbyWatcherResetupThread.scheduleAtFixedRate(() -> {
       try {
-        restartLobbyWatcher(setupPanelModel, game);
+        restartLobbyWatcher();
       } catch (final Exception e) {
-        Interruptibles.sleep(10 * 60 * 1000);
-        // try again, but don't catch it this time
-        restartLobbyWatcher(setupPanelModel, game);
+        log.log(Level.WARNING, "Failed to restart Lobby watcher", e);
       }
     }, reconnect, reconnect, TimeUnit.SECONDS);
     log.info("Game Server initialized");
@@ -437,11 +435,10 @@ public class HeadlessGameServer {
     return game;
   }
 
-  private static synchronized void restartLobbyWatcher(
-      final SetupPanelModel setupPanelModel, final ServerGame serverGame) {
+  private synchronized void restartLobbyWatcher() {
     try {
-      final ISetupPanel setup = setupPanelModel.getPanel();
-      if (setup == null || serverGame != null || setup.canGameStart()) {
+      final HeadlessServerSetup setup = (HeadlessServerSetup) setupPanelModel.getPanel();
+      if (setup == null || game != null || setup.canGameStart()) {
         return;
       }
       setup.repostLobbyWatcher();

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -69,7 +69,7 @@ public class HeadlessGameServer {
   private final ScheduledExecutorService lobbyWatcherResetupThread = Executors.newScheduledThreadPool(1);
   private final String startDate = TimeManager.getFullUtcString(Instant.now());
   private static HeadlessGameServer instance = null;
-  private final SetupPanelModel setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
+  private final HeadlessServerSetupPanelModel setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
   private ServerGame game = null;
   private boolean shutDown = false;
 
@@ -437,7 +437,7 @@ public class HeadlessGameServer {
 
   private synchronized void restartLobbyWatcher() {
     try {
-      final HeadlessServerSetup setup = (HeadlessServerSetup) setupPanelModel.getPanel();
+      final HeadlessServerSetup setup = setupPanelModel.getPanel();
       if (setup == null || game != null || setup.canGameStart()) {
         return;
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -45,9 +45,6 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   }
 
   synchronized void repostLobbyWatcher() {
-    if (canGameStart()) {
-      return;
-    }
     lobbyWatcher.shutDown();
     Interruptibles.sleep(3000);
     createLobbyWatcher();

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -44,8 +44,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);
   }
 
-  @Override
-  public synchronized void repostLobbyWatcher() {
+  synchronized void repostLobbyWatcher() {
     if (canGameStart()) {
       return;
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -38,7 +38,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     internalPlayerListChanged();
   }
 
-  void createLobbyWatcher() {
+  private void createLobbyWatcher() {
     lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(model.getMessenger(), null,
         lobbyWatcher.getInGameLobbyWatcher()));
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -11,7 +11,6 @@ import javax.swing.JComponent;
 
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.IRemoteModelListener;
@@ -45,20 +44,14 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);
   }
 
-  synchronized void repostLobbyWatcher(final IGame game) {
-    if (game != null) {
-      return;
-    }
+  @Override
+  public synchronized void repostLobbyWatcher() {
     if (canGameStart()) {
       return;
     }
-    shutDownLobbyWatcher();
+    lobbyWatcher.shutDown();
     Interruptibles.sleep(3000);
     createLobbyWatcher();
-  }
-
-  void shutDownLobbyWatcher() {
-    lobbyWatcher.shutDown();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -20,8 +20,7 @@ public class HeadlessServerSetupPanelModel extends SetupPanelModel {
       model.cancel();
       return;
     }
-    final HeadlessServerSetup serverSetup = new HeadlessServerSetup(model, gameSelectorModel);
-    setGameTypePanel(serverSetup);
+    setGameTypePanel(new HeadlessServerSetup(model, gameSelectorModel));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.headlessGameServer;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
+import games.strategy.engine.framework.startup.ui.ISetupPanel;
 
 /**
  * Setup panel model for headless server.
@@ -21,5 +22,19 @@ public class HeadlessServerSetupPanelModel extends SetupPanelModel {
     }
     final HeadlessServerSetup serverSetup = new HeadlessServerSetup(model, gameSelectorModel);
     setGameTypePanel(serverSetup);
+  }
+
+  @Override
+  protected void setGameTypePanel(final ISetupPanel panel) {
+    if (panel == null || panel instanceof  HeadlessServerSetup) {
+      super.setGameTypePanel(panel);
+    } else {
+      throw new IllegalArgumentException("Invalid panel of type " + panel.getClass());
+    }
+  }
+
+  @Override
+  public HeadlessServerSetup getPanel() {
+    return (HeadlessServerSetup) super.getPanel();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -45,4 +45,8 @@ public interface ISetupPanel {
   Optional<ILauncher> getLauncher();
 
   List<Action> getUserActions();
+
+  default void repostLobbyWatcher() {
+    throw new UnsupportedOperationException(getClass() + " is not a lobby related class");
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -45,8 +45,4 @@ public interface ISetupPanel {
   Optional<ILauncher> getLauncher();
 
   List<Action> getUserActions();
-
-  default void repostLobbyWatcher() {
-    throw new UnsupportedOperationException(getClass() + " is not a lobby related class");
-  }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -73,16 +73,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);
   }
 
-  @Override
-  public synchronized void repostLobbyWatcher() {
-    if (canGameStart()) {
-      return;
-    }
-    lobbyWatcher.shutDown();
-    Interruptibles.sleep(1000);
-    createLobbyWatcher();
-  }
-
   private void createComponents() {
     final IServerMessenger messenger = model.getMessenger();
     final Color backGround = new JTextField().getBackground();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -67,7 +67,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     internalPlayerListChanged();
   }
 
-  void createLobbyWatcher() {
+  private void createLobbyWatcher() {
     lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(model.getMessenger(), this,
         lobbyWatcher.getInGameLobbyWatcher()));
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -42,7 +42,6 @@ import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
 import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.net.IServerMessenger;
-import games.strategy.util.Interruptibles;
 
 /** Setup panel displayed for hosting a non-lobby network game (using host option from main panel). */
 public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -29,7 +29,6 @@ import javax.swing.SwingUtilities;
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
-import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.network.ui.BanPlayerAction;
 import games.strategy.engine.framework.network.ui.BootPlayerAction;
 import games.strategy.engine.framework.network.ui.MutePlayerAction;
@@ -74,20 +73,14 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     lobbyWatcher.setGameSelectorModel(gameSelectorModel);
   }
 
-  public synchronized void repostLobbyWatcher(final IGame game) {
-    if (game != null) {
-      return;
-    }
+  @Override
+  public synchronized void repostLobbyWatcher() {
     if (canGameStart()) {
       return;
     }
-    shutDownLobbyWatcher();
+    lobbyWatcher.shutDown();
     Interruptibles.sleep(1000);
     createLobbyWatcher();
-  }
-
-  void shutDownLobbyWatcher() {
-    lobbyWatcher.shutDown();
   }
 
   private void createComponents() {


### PR DESCRIPTION
## Overview
Static analysis notified me that the Game argument in repostLobbyWatcher is always null, I inspected the usages and it turns out there is an instanceof statement that's never being triggered.
One thing lead to the next and here we are.

## Functional Changes
Almost none. The only functional difference is that when we now fail recreating a lobby watcher then the error is being logged, and proceeded normally, as opposed to trying again and "crashing".

## Manual Testing Performed
I verified I could start a bot and it would connect to the lobby.