### PR TITLE
Introduce http-client + http-data

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -5,6 +5,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.LogRecord;
 
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -92,10 +93,10 @@ public enum ErrorMessage {
     INSTANCE.enableErrorPopup = true;
   }
 
-  public static void show(final String msg) {
+  public static void show(final LogRecord record) {
     if (INSTANCE.enableErrorPopup && INSTANCE.isVisible.compareAndSet(false, true)) {
       SwingUtilities.invokeLater(() -> {
-        INSTANCE.errorMessage.setText(TextUtils.textToHtml(msg));
+        INSTANCE.errorMessage.setText(TextUtils.textToHtml(record.getMessage()));
         INSTANCE.windowReference.pack();
         INSTANCE.windowReference.setLocationRelativeTo(null);
         INSTANCE.windowReference.setVisible(true);

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -116,7 +116,7 @@ public class GameRunner {
         LogManager.getLogManager().getLogger("").addHandler(new ConsoleHandler(
             logMsg -> {
               if (logMsg.getLevel().intValue() > Level.INFO.intValue()) {
-                ErrorMessage.show(logMsg.getMessage());
+                ErrorMessage.show(logMsg);
               }
               console.append(formatter.format(logMsg));
             }));

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,0 +1,4 @@
+## Overview
+
+Provides an API for communicating with an http-server. Needs a host URI
+to be initialized.

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -1,0 +1,10 @@
+description = 'Http client library for http-server, provides an API for client-server interactions'
+
+dependencies {
+  compile project(':http-data')
+  compile 'com.netflix.feign:feign-core:8.18.0'
+  compile 'com.netflix.feign:feign-gson:8.18.0'
+  testCompile project(':test-common')
+  testCompile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
+  testCompile 'com.github.tomakehurst:wiremock:2.18.0'
+}

--- a/http-client/src/main/java/org/triplea/http/client/ErrorReportingClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/ErrorReportingClient.java
@@ -1,0 +1,66 @@
+package org.triplea.http.client;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.triplea.http.client.throttle.rate.RateLimitingThrottle;
+import org.triplea.http.client.throttle.size.MessageSizeThrottle;
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportDetails;
+import org.triplea.http.data.error.report.ErrorReportResponse;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * Provides high level communication between a TripleA client game and the remote http-server application.
+ */
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorReportingClient {
+
+  private final ErrorReportingHttpClient errorReportingHttpClient;
+
+  private final Function<ErrorReportDetails, ErrorReport> errorReportFunction;
+
+  private final List<Consumer<ErrorReport>> throttleRules;
+
+  /**
+   * Factory method for creating a new http error reporting client, can be used to upload
+   * a JSON error report to the server.
+   */
+  public static ErrorReportingClient withHostUri(final URI hostUri) {
+    checkNotNull(hostUri);
+
+    return new ErrorReportingClient(
+        ErrorReportingHttpClient.newClient(hostUri),
+        ErrorReport::new,
+        Arrays.asList(
+            new MessageSizeThrottle(),
+            new RateLimitingThrottle()));
+  }
+
+  /**
+   * Sends error report details via http to remote server.
+   * 
+   * @param reportData The data to be sent.
+   */
+  public ServiceCallResult<ErrorReportResponse> sendErrorReport(final ErrorReportDetails reportData) {
+    final ErrorReport errorReport = errorReportFunction.apply(reportData);
+    try {
+      throttleRules.forEach(rule -> rule.accept(errorReport));
+      final ErrorReportResponse response = errorReportingHttpClient.sendErrorReport(errorReport);
+      return ServiceCallResult.<ErrorReportResponse>builder()
+          .payload(response)
+          .build();
+    } catch (final RuntimeException e) {
+      return ServiceCallResult.<ErrorReportResponse>builder()
+          .thrown(e)
+          .build();
+    }
+  }
+}

--- a/http-client/src/main/java/org/triplea/http/client/ErrorReportingHttpClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/ErrorReportingHttpClient.java
@@ -1,0 +1,57 @@
+package org.triplea.http.client;
+
+import java.net.URI;
+
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import feign.Feign;
+import feign.Headers;
+import feign.Logger;
+import feign.Request;
+import feign.RequestLine;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+
+@SuppressWarnings("InterfaceNeverImplemented")
+interface ErrorReportingHttpClient {
+
+  @VisibleForTesting
+  String ERROR_REPORT_PATH = "/error-report";
+  /**
+   * How long we can take to start receiving a message.
+   */
+  int DEFAULT_CONNECT_TIMEOUT = 5 * 1000;
+  /**
+   * How long we can spend receiving a message.
+   */
+  int DEFAULT_READ_TIME_OUT = 20 * 1000;
+
+  @RequestLine("POST " + ERROR_REPORT_PATH)
+  @Headers({
+      "Content-Type: application/json",
+      "Accept: application/json"
+  })
+  ErrorReportResponse sendErrorReport(ErrorReport errorReport);
+
+  static ErrorReportingHttpClient newClient(final URI hostUri) {
+    return newClient(hostUri, DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIME_OUT);
+  }
+
+  @VisibleForTesting
+  static ErrorReportingHttpClient newClient(
+      final URI hostUri,
+      int connectTimeoutMillis,
+      int readTimeoutMillis) {
+    return Feign.builder()
+        .encoder(new GsonEncoder())
+        .decoder(new GsonDecoder())
+        .logger(new Logger.JavaLogger())
+        .logLevel(Logger.Level.FULL)
+        .options(new Request.Options(connectTimeoutMillis, readTimeoutMillis))
+        .target(ErrorReportingHttpClient.class, hostUri.toString());
+  }
+
+}

--- a/http-client/src/main/java/org/triplea/http/client/ServiceCallResult.java
+++ b/http-client/src/main/java/org/triplea/http/client/ServiceCallResult.java
@@ -1,0 +1,60 @@
+package org.triplea.http.client;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+/**
+ * Class that represents the result of an http service call. The 'payload' is the body portion of
+ * the response, typically will be a POJO and the type of this generic class would be the corresponding java type.
+ * 
+ * @param <T> If response is JSON then the generic type will be the corresponding Java class, otherwise if
+ *        the response from server is plain text the generic type would be String.
+ */
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ServiceCallResult<T> {
+  /**
+   * Response payload from server, null if we never sent a message or did not receive a response.
+   */
+  @Nullable
+  private final T payload;
+
+  /**
+   * Any exceptions we caught while sending/receiving.
+   */
+  @Nullable
+  private final Throwable thrown;
+
+  /**
+   * Convenience method to get the error message frome exception message (if present).
+   * 
+   * @return An empty string if no exception is present, otherwise the exception message is returned.
+   */
+  public String getErrorDetails() {
+    return Optional.ofNullable(thrown)
+        .map(Throwable::getMessage)
+        .orElse("");
+  }
+
+  /**
+   * Any exceptions sending or receiving the service call result will be returned, if no errors then
+   * will return empty.
+   */
+  public Optional<Throwable> getThrown() {
+    return Optional.ofNullable(thrown);
+  }
+
+  /**
+   * Returns the payload object if the service call was successful, otherwise an empty object if there was
+   * a problem in the service call send or receive.
+   */
+  Optional<T> getPayload() {
+    return Optional.ofNullable(payload);
+  }
+
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/MessageNotSentException.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/MessageNotSentException.java
@@ -1,0 +1,17 @@
+package org.triplea.http.client.throttle;
+
+import lombok.NoArgsConstructor;
+
+/**
+ * Raised when message is throttled (not sent and dropped) due to client side restrictions.
+ * Such client side throttles are a safety check to guard against bugs that could
+ * accidently send bad messages.
+ */
+@NoArgsConstructor
+public class MessageNotSentException extends RuntimeException {
+  private static final long serialVersionUID = 3303214733527625189L;
+
+  public MessageNotSentException(final String message) {
+    super(message);
+  }
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitException.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitException.java
@@ -1,0 +1,10 @@
+package org.triplea.http.client.throttle.rate;
+
+import org.triplea.http.client.throttle.MessageNotSentException;
+
+/**
+ * This exceptions represents a client-side throttle when messages are sent too frequently and
+ * are blocked client-side from being sent.
+ */
+public class RateLimitException extends MessageNotSentException {
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitingThrottle.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitingThrottle.java
@@ -1,0 +1,43 @@
+package org.triplea.http.client.throttle.rate;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Consumer;
+
+import org.triplea.http.data.error.report.ErrorReport;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A simple rate limit throttle that remembers the time of last request
+ * and rejects new requests if not enough time has elapsed since
+ * the previous request.
+ */
+public class RateLimitingThrottle implements Consumer<ErrorReport> {
+
+  private static final int MIN_MILLIS_BETWEEN_REQUESTS = 15_000;
+  private final int minMillisBetweenRequests;
+  private volatile Instant lastInstant = Instant.ofEpochMilli(0);
+
+  public RateLimitingThrottle() {
+    this(MIN_MILLIS_BETWEEN_REQUESTS);
+  }
+
+  @VisibleForTesting
+  RateLimitingThrottle(final int minMillisBetweenRequests) {
+    this.minMillisBetweenRequests = minMillisBetweenRequests;
+  }
+
+  @Override
+  public void accept(final ErrorReport errorReport) {
+    final Instant nextInstant = Instant.now();
+
+    final long millisSinceLast;
+    millisSinceLast = lastInstant.until(nextInstant, ChronoUnit.MILLIS);
+    lastInstant = nextInstant;
+
+    if (millisSinceLast < minMillisBetweenRequests) {
+      throw new RateLimitException();
+    }
+  }
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageExceedsMaxSizeException.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageExceedsMaxSizeException.java
@@ -1,0 +1,17 @@
+package org.triplea.http.client.throttle.size;
+
+import org.triplea.http.client.throttle.MessageNotSentException;
+import org.triplea.http.data.error.report.ErrorReport;
+
+/**
+ * An exception that indicates there were too many characters in the outgoing payload message.
+ */
+public class MessageExceedsMaxSizeException extends MessageNotSentException {
+
+  private static final long serialVersionUID = -7983918555284517976L;
+
+  MessageExceedsMaxSizeException(final ErrorReport errorReport) {
+    super(String.format("Could not send error report message, message is too long (%s characters)",
+        errorReport.toString().length()));
+  }
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageSizeThrottle.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageSizeThrottle.java
@@ -1,0 +1,38 @@
+package org.triplea.http.client.throttle.size;
+
+import java.util.function.Consumer;
+
+import org.triplea.http.data.error.report.ErrorReport;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+/**
+ * Checks size of a single message and if too large throws an exception.
+ */
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageSizeThrottle implements Consumer<ErrorReport> {
+
+  /**
+   * An upper bound where we will no longer send a message if it is too long.
+   * The unit is character count, which is not quite the send sizse, but good enough for our
+   * purpose of bounding message size. The upper bound is meant to be generous and really prevent
+   * a programming error from sending a really large payload.
+   */
+  private static final int DEFAULT_CHARACTER_LIMIT = 32_000;
+
+  private final int characterLimit;
+
+
+  public MessageSizeThrottle() {
+    this(DEFAULT_CHARACTER_LIMIT);
+  }
+
+  @Override
+  public void accept(final ErrorReport errorReport) {
+    if (errorReport.toString().length() > characterLimit) {
+      throw new MessageExceedsMaxSizeException(errorReport);
+    }
+  }
+}
+

--- a/http-client/src/test/java/org/triplea/http/client/ErrorReportingClientTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/ErrorReportingClientTest.java
@@ -1,0 +1,59 @@
+package org.triplea.http.client;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportDetails;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorReportingClientTest {
+
+  private static final ErrorReportDetails ERROR_DATA = ErrorReportDetails.builder()
+      .gameVersion("sample version")
+      .build();
+
+  @Mock
+  private ErrorReport errorReport;
+
+  @Mock
+  private ErrorReportingHttpClient errorReportingHttpClient;
+  @Mock
+  private Function<ErrorReportDetails, ErrorReport> errorReportFunction;
+  @Mock
+  private Consumer<ErrorReport> consumer;
+
+  private ErrorReportingClient errorReportingClient;
+
+  @BeforeEach
+  void setup() {
+    errorReportingClient = new ErrorReportingClient(
+        errorReportingHttpClient,
+        errorReportFunction,
+        singletonList(consumer));
+  }
+
+  @Test
+  void sendErrorReport() {
+    when(errorReportFunction.apply(ERROR_DATA))
+        .thenReturn(errorReport);
+
+    errorReportingClient.sendErrorReport(ERROR_DATA);
+
+    verify(errorReportingHttpClient, times(1))
+        .sendErrorReport(errorReport);
+    verify(consumer, times(1))
+        .accept(errorReport);
+  }
+}

--- a/http-client/src/test/java/org/triplea/http/client/ServiceCallResultTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/ServiceCallResultTest.java
@@ -1,0 +1,46 @@
+package org.triplea.http.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceCallResultTest {
+  private static final String SAMPLE_MESSGE = "message from exception";
+
+  @Test
+  void getPayload() {
+    assertThat(
+        "We do not set a payload on the service call result, then getting it returns an empty optional",
+        ServiceCallResult.<String>builder()
+            .build()
+            .getPayload()
+            .isPresent(),
+        is(false));
+
+    assertThat(
+        "When we set the payload value, getting the payload returns a non-empty optional",
+        ServiceCallResult.<String>builder()
+            .payload(SAMPLE_MESSGE)
+            .build()
+            .getPayload()
+            .orElseThrow(() -> new IllegalStateException("expecting value to be present")),
+        is(SAMPLE_MESSGE));
+  }
+
+  @Test
+  void getErrorDetails() {
+    assertThat(
+        ServiceCallResult.<String>builder()
+            .build()
+            .getErrorDetails(),
+        is(""));
+
+    assertThat(
+        ServiceCallResult.<String>builder()
+            .thrown(new IllegalStateException(SAMPLE_MESSGE))
+            .build()
+            .getErrorDetails(),
+        is(SAMPLE_MESSGE));
+  }
+}

--- a/http-client/src/test/java/org/triplea/http/client/WireMockSystemTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/WireMockSystemTest.java
@@ -1,0 +1,184 @@
+package org.triplea.http.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportDetails;
+import org.triplea.http.data.error.report.ErrorReportResponse;
+import org.triplea.test.common.Integration;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.Fault;
+
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+/**
+ * A test that checks the http client works, we use wiremock to simulate a server so we are not coupled
+ * to any one server implementation. Server sub-projects should include the http-client as a test dependency
+ * to then create an integration test to be sure that everything would work. Meanwhile we can test here
+ * against a generic/stubbed server to be sure the client contract works as expected.
+ */
+@ExtendWith({
+    WiremockResolver.class,
+    WiremockUriResolver.class
+})
+@Integration
+class WireMockSystemTest {
+  private static final String CONTENT_TYPE_JSON = "application/json";
+  private static final String MESSAGE_FROM_USER = "msg";
+  private static final String GAME_VERSION = "version";
+  private static final LogRecord logRecord = new LogRecord(Level.SEVERE, "record");
+  private static final int timeoutMillis = 20;
+
+  @Test
+  void sendErrorReportSuccessCase(
+      @WiremockResolver.Wiremock final WireMockServer server,
+      @WiremockUriResolver.WiremockUri final String uri) {
+
+    givenHttpServerSuccessResponse(server);
+
+    final ServiceCallResult<ErrorReportResponse> response = doServiceCall(server);
+
+    verify(postRequestedFor(urlMatching(ErrorReportingHttpClient.ERROR_REPORT_PATH))
+        .withRequestBody(containing(MESSAGE_FROM_USER))
+        .withRequestBody(containing(GAME_VERSION))
+        .withRequestBody(containing(logRecord.getMessage()))
+        .withRequestBody(containing(logRecord.getLevel().toString()))
+        .withHeader(HttpHeaders.CONTENT_TYPE, matching(CONTENT_TYPE_JSON)));
+
+    assertThat(response.getThrown().isPresent(), is(false));
+    assertThat(response.getPayload().isPresent(), is(true));
+  }
+
+  private static void givenHttpServerSuccessResponse(final WireMockServer wireMockServer) {
+    wireMockServer.stubFor(post(urlEqualTo(ErrorReportingHttpClient.ERROR_REPORT_PATH))
+        .withHeader(HttpHeaders.ACCEPT, equalTo(CONTENT_TYPE_JSON))
+        .willReturn(aResponse()
+            .withStatus(HttpStatus.SC_OK)
+            .withHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .withBody(String.format("{ \"result\":\"%s\" }", ErrorReportResponse.SUCCESS))));
+
+  }
+
+  private ServiceCallResult<ErrorReportResponse> doServiceCall(final WireMockServer wireMockServer) {
+    return createClient(wireMockServer)
+        .sendErrorReport(ErrorReportDetails.builder()
+            .messageFromUser(MESSAGE_FROM_USER)
+            .gameVersion(GAME_VERSION)
+            .logRecord(logRecord)
+            .build());
+  }
+
+  private ErrorReportingClient createClient(final WireMockServer wireMockServer) {
+    WireMock.configureFor("localhost", wireMockServer.port());
+    final URI hostUri = URI.create(wireMockServer.url(""));
+    return new ErrorReportingClient(
+        ErrorReportingHttpClient.newClient(hostUri, timeoutMillis, timeoutMillis),
+        ErrorReport::new,
+        Collections.emptyList());
+  }
+
+  @Test
+  void communicationFaultCases(
+      @WiremockResolver.Wiremock final WireMockServer wireMockServer,
+      @WiremockUriResolver.WiremockUri final String uri) {
+
+    Arrays.asList(
+        // caution, one of the wiremock faults is known to cause a hang in windows, so to aviod that
+        // problem do not use the full available list of of wiremock faults
+        Fault.EMPTY_RESPONSE,
+        Fault.RANDOM_DATA_THEN_CLOSE)
+        .forEach(fault -> testFaultHandling(wireMockServer, fault));
+  }
+
+  private void testFaultHandling(final WireMockServer wireMockServer, final Fault fault) {
+    givenFaultyConnection(wireMockServer, fault);
+
+    final ServiceCallResult<ErrorReportResponse> response = doServiceCall(wireMockServer);
+
+    assertThat(response.getPayload().isPresent(), is(false));
+    assertThat(response.getThrown().isPresent(), is(true));
+    assertThat(response.getErrorDetails(), not(emptyOrNullString()));
+  }
+
+  private static void givenFaultyConnection(final WireMockServer wireMockServer, final Fault fault) {
+    wireMockServer.stubFor(post(urlEqualTo(ErrorReportingHttpClient.ERROR_REPORT_PATH))
+        .withHeader(HttpHeaders.ACCEPT, equalTo(CONTENT_TYPE_JSON))
+        .willReturn(aResponse()
+            .withFault(fault)
+            .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .withHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .withBody("a simulated error occurred")));
+  }
+
+  @Test
+  void server500(
+      @WiremockResolver.Wiremock final WireMockServer wireMockServer,
+      @WiremockUriResolver.WiremockUri final String uri) {
+    givenServer500(wireMockServer);
+
+    final ServiceCallResult<ErrorReportResponse> response = doServiceCall(wireMockServer);
+
+    assertThat(response.getPayload().isPresent(), is(false));
+    assertThat(response.getThrown().isPresent(), is(true));
+    assertThat(response.getErrorDetails(), not(emptyOrNullString()));
+  }
+
+  private static void givenServer500(final WireMockServer wireMockServer) {
+    wireMockServer.stubFor(post(urlEqualTo(ErrorReportingHttpClient.ERROR_REPORT_PATH))
+        .withHeader(HttpHeaders.ACCEPT, equalTo(CONTENT_TYPE_JSON))
+        .willReturn(aResponse()
+            .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+            .withHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .withBody("{ \"result\":\"FAILURE\" }")));
+  }
+
+  @Test
+  void timeoutCase(
+      @WiremockResolver.Wiremock final WireMockServer wireMockServer,
+      @WiremockUriResolver.WiremockUri final String uri) {
+    WireMock.configureFor("localhost", wireMockServer.port());
+
+    final int delayGreaterThanTheTimeout = timeoutMillis + 5;
+
+    wireMockServer.stubFor(post(urlEqualTo(ErrorReportingHttpClient.ERROR_REPORT_PATH))
+        .withHeader(HttpHeaders.ACCEPT, equalTo(CONTENT_TYPE_JSON))
+        .willReturn(aResponse()
+            .withFixedDelay(delayGreaterThanTheTimeout)
+            .withStatus(HttpStatus.SC_OK)
+            .withHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE_JSON)
+            .withBody("{ \"result\":\"SUCCESS\" }")));
+
+    final ServiceCallResult<ErrorReportResponse> response = doServiceCall(wireMockServer);
+
+    assertThat(response.getPayload().isPresent(), is(false));
+    assertThat(response.getThrown().isPresent(), is(true));
+  }
+}

--- a/http-client/src/test/java/org/triplea/http/client/throttle/rate/RateLimitingThrottleTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/throttle/rate/RateLimitingThrottleTest.java
@@ -1,0 +1,45 @@
+package org.triplea.http.client.throttle.rate;
+
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportDetails;
+
+class RateLimitingThrottleTest {
+
+  private static final ErrorReport ERROR_REPORT = new ErrorReport(ErrorReportDetails.builder()
+      .logRecord(new LogRecord(Level.SEVERE, "message"))
+      .gameVersion("engine version")
+      .build());
+
+  private static final int MIN_MILLIS_BETWEEN_REQUSETS = 5;
+
+
+  @Test
+  void throttleNumberOfRequestPer() throws Exception {
+    final Consumer<ErrorReport> throttle =
+        new RateLimitingThrottle(MIN_MILLIS_BETWEEN_REQUSETS);
+
+    // no throttle expected on the first call
+    throttle.accept(ERROR_REPORT);
+
+    Thread.sleep(MIN_MILLIS_BETWEEN_REQUSETS + 1);
+
+    // no thottle expected given we had the wait period
+    throttle.accept(ERROR_REPORT);
+
+    Thread.sleep(MIN_MILLIS_BETWEEN_REQUSETS + 1);
+
+    // ensure the n+1 works if we wait longer than the min time
+    throttle.accept(ERROR_REPORT);
+
+    // now trigger the throttle by sending another request without any delay
+    Assertions.assertThrows(RateLimitException.class,
+        () -> throttle.accept(ERROR_REPORT));
+  }
+}

--- a/http-client/src/test/java/org/triplea/http/client/throttle/size/MessageSizeThrottleTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/throttle/size/MessageSizeThrottleTest.java
@@ -1,0 +1,33 @@
+package org.triplea.http.client.throttle.size;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.triplea.http.data.error.report.ErrorReport;
+import org.triplea.http.data.error.report.ErrorReportDetails;
+
+class MessageSizeThrottleTest {
+
+  private static final ErrorReport ERROR_REPORT = new ErrorReport(ErrorReportDetails.builder()
+      .gameVersion("version info")
+      .build());
+
+  @Test
+  void messageSizeOverLimitIsNotAllowed() {
+    final int characterLimit = ERROR_REPORT.toString().length() - 1;
+
+    Assertions.assertThrows(MessageExceedsMaxSizeException.class,
+        () -> new MessageSizeThrottle(characterLimit)
+            .accept(ERROR_REPORT));
+  }
+
+  @SuppressWarnings("JUnitTestMethodWithNoAssertions")
+  @Test
+  void messageSizeUnderLimitIsAllowed() {
+    final int characterLimit = ERROR_REPORT.toString().length() + 1;
+
+    new MessageSizeThrottle(characterLimit)
+        .accept(ERROR_REPORT);
+    // no exceptions expected
+  }
+}

--- a/http-data/README.md
+++ b/http-data/README.md
@@ -1,0 +1,7 @@
+## Overview
+
+http-data contains common data models that are converted to and 
+from JSON formatted Strings. These data models should
+be kept in sync between http-client and http-server with
+backward compatibility considerations kept in mind when
+updating files in this project.

--- a/http-data/build.gradle
+++ b/http-data/build.gradle
@@ -1,0 +1,5 @@
+description = 'Contains common data models exchanged between client/server'
+
+dependencies {
+
+}

--- a/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReport.java
+++ b/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReport.java
@@ -1,0 +1,61 @@
+package org.triplea.http.data.error.report;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Represents data that would be uploaded to a server.
+ */
+@Getter
+@ToString
+public class ErrorReport {
+
+  private final String messageFromUser;
+  private final String gameVersion;
+  private final String operatingSystem;
+  private final String javaVersion;
+
+  private final String logLevel;
+  private final String errorMessageToUser;
+  private final String exceptionMessage;
+  private final String stackTrace;
+  private final String className;
+  private final String methodName;
+
+  public ErrorReport(final ErrorReportDetails details) {
+    final String messageFromUser = details.getMessageFromUser();
+    final String gameVersion = details.getGameVersion();
+
+    this.messageFromUser = messageFromUser;
+    this.gameVersion = gameVersion;
+    operatingSystem = System.getProperty("os.name");
+    javaVersion = System.getProperty("java.version");
+    logLevel = details.getLogRecord()
+        .map(LogRecord::getLevel)
+        .map(Level::toString)
+        .orElse("");
+    errorMessageToUser = details.getLogRecord()
+        .map(LogRecord::getMessage)
+        .orElse("");
+    exceptionMessage = details.getLogRecord()
+        .map(LogRecord::getThrown)
+        .map(Throwable::getMessage)
+        .orElse("");
+    stackTrace = details.getLogRecord()
+        .map(LogRecord::getThrown)
+        .map(Throwable::getStackTrace)
+        .map(Arrays::toString)
+        .orElse("");
+    className = details.getLogRecord()
+        .map(LogRecord::getSourceClassName)
+        .orElse("");
+    methodName = details.getLogRecord()
+        .map(LogRecord::getSourceMethodName)
+        .orElse("");
+  }
+
+}

--- a/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReportDetails.java
+++ b/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReportDetails.java
@@ -1,0 +1,35 @@
+package org.triplea.http.data.error.report;
+
+import java.util.Optional;
+import java.util.logging.LogRecord;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Strings;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Data object for parameters used to construct an {@code ErrorReport}.
+ */
+@Builder
+@Getter(AccessLevel.PACKAGE)
+public final class ErrorReportDetails {
+  @Nonnull
+  private final String gameVersion;
+  @Nullable
+  private final String messageFromUser;
+  @Nullable
+  private final LogRecord logRecord;
+
+  String getMessageFromUser() {
+    return Strings.nullToEmpty(messageFromUser);
+  }
+
+  Optional<LogRecord> getLogRecord() {
+    return Optional.ofNullable(logRecord);
+  }
+}

--- a/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReportResponse.java
+++ b/http-data/src/main/java/org/triplea/http/data/error/report/ErrorReportResponse.java
@@ -1,0 +1,49 @@
+package org.triplea.http.data.error.report;
+
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Data object that corresponds to the JSON response from http-server for error reporting.
+ */
+@Builder
+@Getter
+public class ErrorReportResponse {
+  @VisibleForTesting
+  public static final String SUCCESS = "SUCCESS";
+  public static final ErrorReportResponse SUCCESS_RESPONSE = ErrorReportResponse.builder()
+      .result(SUCCESS)
+      .build();
+
+  /**
+   * A status message String, expected to be 'SUCCESS' or 'FAILURE', with 'FAILURE' meaning
+   * the error report was not saved on the server.
+   */
+  private final String result;
+
+  /**
+   * A public identifier reported back to the user to link the report back to what we saved
+   * on the server.
+   */
+  private final String savedReportId;
+
+
+  /**
+   * True if the error report was sent and saved by the server.
+   */
+  public boolean isSuccess() {
+    return SUCCESS.equals(result);
+  }
+
+  /**
+   * Returns the saved report identifier if the server successfully saved the error report request.
+   */
+  public Optional<String> getSavedReportId() {
+    return Optional.ofNullable(Strings.emptyToNull(savedReportId));
+  }
+}

--- a/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportDetailsTest.java
+++ b/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportDetailsTest.java
@@ -1,0 +1,48 @@
+package org.triplea.http.data.error.report;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ErrorReportDetailsTest {
+
+
+  private ErrorReportDetails.ErrorReportDetailsBuilder minMessage;
+
+  @BeforeEach
+  void setup() {
+    minMessage = ErrorReportDetails.builder()
+        .gameVersion("game version");
+  }
+
+  @Test
+  void messageFromUserIsNeverNull() {
+    assertThat(
+        minMessage.build()
+            .getMessageFromUser(),
+        emptyString());
+  }
+
+  @Test
+  void logRecordNullableConvertedToAnOptional() {
+    assertThat(
+        minMessage.build()
+            .getLogRecord()
+            .isPresent(),
+        is(false));
+
+    assertThat(
+        minMessage
+            .logRecord(new LogRecord(Level.SEVERE, "msg"))
+            .build()
+            .getLogRecord()
+            .isPresent(),
+        is(true));
+  }
+}

--- a/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportResponseTest.java
+++ b/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportResponseTest.java
@@ -1,0 +1,37 @@
+package org.triplea.http.data.error.report;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+class ErrorReportResponseTest {
+
+  @Test
+  public void successFlag() {
+    assertThat(ErrorReportResponse.SUCCESS_RESPONSE.isSuccess(), is(true));
+    assertThat(ErrorReportResponse.builder().build().isSuccess(), is(false));
+  }
+
+
+  @Test
+  public void verifyErrorReportIdBehavior() {
+    assertThat(ErrorReportResponse.builder().build().getSavedReportId().isPresent(), is(false));
+    assertThat(
+        ErrorReportResponse.builder()
+            .savedReportId("")
+            .build()
+            .getSavedReportId()
+            .isPresent(),
+        is(false));
+
+    final String exampleValue = "non empty";
+    assertThat(
+        ErrorReportResponse.builder()
+            .savedReportId(exampleValue)
+            .build()
+            .getSavedReportId()
+            .orElseThrow(() -> new IllegalStateException("expected a value to be present")),
+        is(exampleValue));
+  }
+}

--- a/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportTest.java
+++ b/http-data/src/test/java/org/triplea/http/data/error/report/ErrorReportTest.java
@@ -1,0 +1,64 @@
+package org.triplea.http.data.error.report;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Test;
+
+class ErrorReportTest {
+  private static final String MESSAGE_TO_USER = "msg";
+  private static final String EXCEPTION_MESSAGE = "exception msg";
+  private static final String CLASS = "class";
+  private static final String METHOD = "class";
+
+  private static final Level LEVEL = Level.SEVERE;
+
+  private static final String GAME_VERSION = "version";
+  private static final String MESSAGE_FROM_USER = "message from user";
+
+  private static final Exception exception = new Exception(EXCEPTION_MESSAGE);
+
+  @Test
+  void errorDetailsCopiedOver() {
+    final LogRecord record = new LogRecord(LEVEL, MESSAGE_TO_USER);
+    record.setThrown(exception);
+    record.setSourceClassName(CLASS);
+    record.setSourceMethodName(METHOD);
+
+    final ErrorReport errorReport = new ErrorReport(ErrorReportDetails.builder()
+        .logRecord(record)
+        .gameVersion(GAME_VERSION)
+        .messageFromUser(MESSAGE_FROM_USER)
+        .build());
+
+    assertThat(errorReport.getOperatingSystem(), notNullValue());
+    assertThat(errorReport.getGameVersion(), is(GAME_VERSION));
+    assertThat(errorReport.getMessageFromUser(), is(MESSAGE_FROM_USER));
+    assertThat(errorReport.getLogLevel(), is(LEVEL.toString()));
+    assertThat(errorReport.getErrorMessageToUser(), is(MESSAGE_TO_USER));
+    assertThat(errorReport.getExceptionMessage(), is(EXCEPTION_MESSAGE));
+    assertThat(errorReport.getStackTrace(), containsString(ErrorReportTest.class.getName()));
+    assertThat(errorReport.getClassName(), is(CLASS));
+    assertThat(errorReport.getMethodName(), is(METHOD));
+  }
+
+  @Test
+  void errorDetailsWhenExceptionNotPresent() {
+    final LogRecord record = new LogRecord(LEVEL, EXCEPTION_MESSAGE);
+
+    final ErrorReport errorReport = new ErrorReport(ErrorReportDetails.builder()
+        .logRecord(record)
+        .gameVersion(GAME_VERSION)
+        .messageFromUser(MESSAGE_FROM_USER)
+        .build());
+
+    assertThat(errorReport.getExceptionMessage(), emptyString());
+    assertThat(errorReport.getStackTrace(), emptyString());
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name='triplea'
 include 'game-core'
 include 'game-headless'
+include 'http-client'
+include 'http-data'
 include 'http-server'
 include 'lobby'
 include 'lobby-db'


### PR DESCRIPTION
## Overview

This update continues development of the error-reporting feature and adds a middle-ware piece that provides an API the game-engine client can use to communicate to the http-server. The http client-server interchange format for communication is JSON formatted String which can then be automatically converted to Java objects pretty easily.

The API is developed to a nearly production ready detail, the feature for error-reporting is expanded to support user input to describe the problem to us, which opens up the feature for ad-hoc error-reporting even without a stack trace (so more than just an automated stack trace upload).

Http-client would ideally provide as much validation and safety checks as we can, the entry points are minimal and that helps then guarantee the integrity of the rest of the system. To this extent, the client has a built in throttle to drop messages that wind up being too large (a large arbitrary number was chosen to start to give us an upper bound), and a simplistic rate throttle so only one error report can be sent every few seconds.

The http-client is tested with '[WireMock](http://wiremock.org/)' which is a stand-alone http server simulator (so this update is independent of http-server). Using that we can test failure scenarios very closely.

To avoid re-inventing the wheel http client, [Feign](https://www.baeldung.com/intro-to-feign) is picked up to create an http client implementation that is bound to an API that we define as an interface with annotations. This reduces the need for unit testing to a pretty reasonable minimum as largely we just define an interface and then use a client builder to create the concrete implementation. The burden is then largely for system/integration testing to verify that things would work provided we use the API presented by http-client sub-project.

Next steps:
 - game engine client code update to use the new http-client and have the error reporting feature behind a feature flag.
 - server side updates to comply with the API now defined by the client.
 - infrastructure updates to stand-up the http server



## Functional Changes
- none, two new libraries added: http-client + http-data, but neither are used by prod code yet.
- when triplea game-core does include http-client as a dependnecy, the new Feign libraries for http client will add 100KB to the DL size
- there is a refactoring change in the main game code to receive a LogRecord instead of 'String'. This is done so that when we tie into the http-client we will have access to the exception in the LogRecord and could then send it.

## Manual Testing Performed
- none

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After
![screenshot from 2018-09-03 15-37-57](https://user-images.githubusercontent.com/12397753/45002784-65542e80-af8f-11e8-9d22-67b5998ded89.png)
