### PR TITLE
Error Prone: Fix reference equality violations in EditPanel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.swing.AbstractAction;
@@ -619,11 +620,11 @@ class EditPanel extends ActionPanel {
         return;
       }
       final boolean rightMouse = md.isRightButton();
-      if (!selectedUnits.isEmpty() && !(selectedTerritory == t)) {
+      if (!selectedUnits.isEmpty() && !Objects.equals(selectedTerritory, t)) {
         deselectUnits(new ArrayList<>(selectedUnits), t, md);
         selectedTerritory = null;
       }
-      if (rightMouse && (selectedTerritory == t)) {
+      if (rightMouse && Objects.equals(selectedTerritory, t)) {
         deselectUnits(units, t, md);
       }
       if (!rightMouse && (currentAction == addUnitsAction)) {
@@ -640,7 +641,7 @@ class EditPanel extends ActionPanel {
     private void deselectUnits(final List<Unit> units, final Territory t, final MouseDetails md) {
       // no unit selected, deselect the most recent
       if (units.isEmpty()) {
-        if (md.isControlDown() || t != selectedTerritory || selectedUnits.isEmpty()) {
+        if (md.isControlDown() || !Objects.equals(t, selectedTerritory) || selectedUnits.isEmpty()) {
           selectedUnits.clear();
         } else {
           // remove the last element
@@ -648,7 +649,7 @@ class EditPanel extends ActionPanel {
         }
       } else { // user has clicked on a specific unit
         // deselect all if control is down
-        if (md.isControlDown() || t != selectedTerritory) {
+        if (md.isControlDown() || !Objects.equals(t, selectedTerritory)) {
           selectedUnits.removeAll(units);
         } else { // deselect one
           // remove those with the least movement first
@@ -801,7 +802,7 @@ class EditPanel extends ActionPanel {
         }
         // highlight territory
         if (currentAction == changeTerritoryOwnerAction || currentAction == addUnitsAction) {
-          if (currentTerritory != territory) {
+          if (!Objects.equals(currentTerritory, territory)) {
             if (currentTerritory != null) {
               getMap().clearTerritoryOverlay(currentTerritory);
             }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `EditPanel` class.

I reviewed the use of `Territory` assignment within this class, and there appears to be no special reason why reference equality has been used.  Therefore, value equality should be acceptable.

Due to the regular use of `null` references for the `EditPanel#currentTerritory` field and other local `Territory` variables, it wasn't always clear when a variable would be non-`null`.  Therefore, I erred on the side of caution and used `Objects#equals()` for all equality checks rather than calling `Object#equals()` directly and risking an NPE.

## Functional Changes

None.

## Manual Testing Performed

Tested various operations in edit mode.  Added traces to ensure I hit all five code paths affected by this PR.