### PR TITLE
Decouple GameDescription from HeadlessGameServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.startup.ui;
 
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_SUPPORT_EMAIL;
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
@@ -166,18 +167,21 @@ public class InGameLobbyWatcher {
         (oldWatcher == null || oldWatcher.gameDescription == null || oldWatcher.gameDescription.getRound() == null)
             ? "-"
             : oldWatcher.gameDescription.getRound();
-    gameDescription = new GameDescription(
-        messenger.getLocalNode(),
-        serverMessenger.getLocalNode().getPort(),
-        startDateTime,
-        "???",
-        playerCount,
-        gameStatus,
-        gameRound,
-        serverMessenger.getLocalNode().getName(),
-        System.getProperty(LOBBY_GAME_COMMENTS),
-        passworded,
-        ClientContext.engineVersion().toString(), "0");
+    gameDescription = GameDescription.builder()
+        .hostedBy(messenger.getLocalNode())
+        .port(serverMessenger.getLocalNode().getPort())
+        .startDateTime(startDateTime)
+        .gameName("???")
+        .playerCount(playerCount)
+        .status(gameStatus)
+        .round(gameRound)
+        .hostName(serverMessenger.getLocalNode().getName())
+        .comment(System.getProperty(LOBBY_GAME_COMMENTS))
+        .passworded(passworded)
+        .engineVersion(ClientContext.engineVersion().toString())
+        .gameVersion("0")
+        .botSupportEmail(HeadlessGameServer.headless() ? System.getProperty(LOBBY_GAME_SUPPORT_EMAIL, "") : "")
+        .build();
     final ILobbyGameController controller =
         (ILobbyGameController) this.remoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME);
     synchronized (mutex) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -7,13 +7,11 @@ import java.io.ObjectOutput;
 import java.time.Instant;
 import java.util.Optional;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
-import games.strategy.engine.framework.CliProperties;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.net.INode;
 import games.strategy.net.Node;
+import lombok.Builder;
 
 // TODO: move this class to lobby.common upon next incompatible release; it is shared between client and server
 
@@ -69,7 +67,7 @@ public class GameDescription implements Externalizable, Cloneable {
   private boolean passworded;
   /**
    * Engine version, used to be useful when multiple engine versions were in same lobby,
-   * now that lobby has homogonous versions and should going forward, this column is no
+   * now that lobby has homogeneous versions and should going forward, this column is no
    * longer useful.
    *
    * @deprecated No longer used, waiting for non-compatible change opportunity to remove.
@@ -77,16 +75,26 @@ public class GameDescription implements Externalizable, Cloneable {
   @Deprecated
   private String engineVersion;
   private String gameVersion;
-  private String botSupportEmail = (HeadlessGameServer.getInstance() != null)
-      ? System.getProperty(CliProperties.LOBBY_GAME_SUPPORT_EMAIL, "")
-      : "";
+  private String botSupportEmail = "";
 
   // if you add a field, add it to write/read object as well for Externalizable
   public GameDescription() {}
 
-  public GameDescription(final INode hostedBy, final int port, final Instant startDateTime, final String gameName,
-      final int playerCount, final GameStatus status, final String round, final String hostName, final String comment,
-      final boolean passworded, final String engineVersion, final String gameVersion) {
+  @Builder
+  private GameDescription(
+      final INode hostedBy,
+      final int port,
+      final Instant startDateTime,
+      final String gameName,
+      final int playerCount,
+      final GameStatus status,
+      final String round,
+      final String hostName,
+      final String comment,
+      final boolean passworded,
+      final String engineVersion,
+      final String gameVersion,
+      final String botSupportEmail) {
     this.hostName = hostName;
     this.hostedBy = hostedBy;
     this.port = port;
@@ -99,6 +107,7 @@ public class GameDescription implements Externalizable, Cloneable {
     this.passworded = passworded;
     this.engineVersion = engineVersion;
     this.gameVersion = gameVersion;
+    this.botSupportEmail = Strings.nullToEmpty(botSupportEmail);
   }
 
   @Override
@@ -182,11 +191,6 @@ public class GameDescription implements Externalizable, Cloneable {
 
   public Optional<String> getBotSupportEmail() {
     return Optional.ofNullable(Strings.emptyToNull(botSupportEmail));
-  }
-
-  @VisibleForTesting
-  public void setBotSupportEmail(final String botSupportEmail) {
-    this.botSupportEmail = botSupportEmail;
   }
 
   public boolean isBot() {

--- a/game-core/src/test/java/games/strategy/engine/lobby/common/GameDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/common/GameDescriptionTest.java
@@ -10,41 +10,37 @@ import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.lobby.server.GameDescription;
 
-public final class GameDescriptionTest {
+final class GameDescriptionTest {
   @Nested
-  public final class GetBotSupportEmailTest {
-    private final GameDescription gameDescription = new GameDescription();
-
+  final class GetBotSupportEmailTest {
     @Test
-    public void shouldReturnBotSupportEmailWhenBotSupportEmailIsNotEmpty() {
+    void shouldReturnBotSupportEmailWhenBotSupportEmailIsNotEmpty() {
       final String botSupportEmail = "bot@me.com";
-      gameDescription.setBotSupportEmail(botSupportEmail);
+      final GameDescription gameDescription = GameDescription.builder().botSupportEmail(botSupportEmail).build();
 
       assertThat(gameDescription.getBotSupportEmail(), is(Optional.of(botSupportEmail)));
     }
 
     @Test
-    public void shouldReturnEmptyWhenBotSupportEmailIsEmpty() {
-      gameDescription.setBotSupportEmail("");
+    void shouldReturnEmptyWhenBotSupportEmailIsEmpty() {
+      final GameDescription gameDescription = GameDescription.builder().botSupportEmail("").build();
 
       assertThat(gameDescription.getBotSupportEmail(), is(Optional.empty()));
     }
   }
 
   @Nested
-  public final class IsBotTest {
-    private final GameDescription gameDescription = new GameDescription();
-
+  final class IsBotTest {
     @Test
-    public void shouldReturnTrueWhenBotSupportEmailIsNotEmpty() {
-      gameDescription.setBotSupportEmail("bot@me.com");
+    void shouldReturnTrueWhenBotSupportEmailIsNotEmpty() {
+      final GameDescription gameDescription = GameDescription.builder().botSupportEmail("bot@me.com").build();
 
       assertThat(gameDescription.isBot(), is(true));
     }
 
     @Test
-    public void shouldReturnFalseWhenBotSupportEmailIsEmpty() {
-      gameDescription.setBotSupportEmail("");
+    void shouldReturnFalseWhenBotSupportEmailIsEmpty() {
+      final GameDescription gameDescription = GameDescription.builder().botSupportEmail("").build();
 
       assertThat(gameDescription.isBot(), is(false));
     }


### PR DESCRIPTION
## Overview

Decouples the `GameDescription` class from `HeadlessGameServer`.  I pushed the dependency up one level to `InGameLobbyWatcher`, which already has multiple dependencies on `HeadlessGameServer`.  So one more isn't going to make much of a difference when we tackle breaking the same dependency there in the future.

## Functional Changes

None.

## Refactoring Changes

* Added builder support to `GameDescription` to get a handle on the 10+ parameter constructor.

## Manual Testing Performed

* Connected a bot to the lobby and verified its entry in the game list was italicized, indicating it's a bot.
* Hosted a headed game through the lobby and verified its entry in the game list was NOT italicized, indicating it's NOT a bot.