### PR TITLE
Error Prone: Fix string splitter violations in HistoryLog

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -405,7 +405,7 @@ public class HistoryLog extends JFrame {
 
   @VisibleForTesting
   static String parsePlayerNameFromDiceRollMessage(final String message) {
-    return message.split(" roll ")[0];
+    return message.substring(0, message.indexOf(" roll "));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -22,6 +22,8 @@ import javax.swing.JTextArea;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
@@ -233,9 +235,8 @@ public class HistoryLog extends JFrame {
               logWriter.println(indent + moreIndent + title);
             } else {
               // dice roll
-              // Japanese roll dice for 1 armour in Russia, round 1
               logWriter.print(indent + moreIndent + diceMsg1);
-              final String player = diceMsg1.split(" roll ")[0];
+              final String player = parsePlayerNameFromDiceRollMessage(diceMsg1);
               final DiceRoll diceRoll = (DiceRoll) details;
               final int hits = diceRoll.getHits();
               int rolls = 0;
@@ -400,6 +401,11 @@ public class HistoryLog extends JFrame {
     }
     logWriter.println();
     textArea.setText(stringWriter.toString());
+  }
+
+  @VisibleForTesting
+  static String parsePlayerNameFromDiceRollMessage(final String message) {
+    return message.split(" roll ")[0];
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
@@ -1,0 +1,20 @@
+package games.strategy.triplea.ui.history;
+
+import static games.strategy.triplea.ui.history.HistoryLog.parsePlayerNameFromDiceRollMessage;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class HistoryLogTest {
+  @Nested
+  final class ParsePlayerNameFromDiceRollMessageTest {
+    @Test
+    void shouldParsePlayerName() {
+      assertThat(
+          parsePlayerNameFromDiceRollMessage("Japanese roll dice for 1 battleship in Australia, round 2 :"),
+          is("Japanese"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `HistoryLog` class.

## Functional Changes

None.

## Manual Testing Performed

Verified the **Show Detailed Log** command from the History View context menu produces the same results before and after this change.