### PR TITLE
Add SettingType accessor to GameSettingUiBinding

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -182,7 +182,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "Just a proof-of-concept. Requires a restart.");
 
   private final SettingType type;
-  final String title;
+  private final String title;
   final String description;
   private final Supplier<SelectionComponent<JComponent>> selectionComponentBuilder;
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -181,8 +181,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Enable the experimental JavaFX UI. Not recommended. Isn't working yet.\n"
           + "Just a proof-of-concept. Requires a restart.");
 
-
-  final SettingType type;
+  private final SettingType type;
   final String title;
   final String description;
   private final Supplier<SelectionComponent<JComponent>> selectionComponentBuilder;
@@ -252,5 +251,10 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
   @Override
   public String getTitle() {
     return title;
+  }
+
+  @Override
+  public SettingType getType() {
+    return type;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
@@ -44,5 +44,10 @@ public interface GameSettingUiBinding<T> {
    */
   String getTitle();
 
+  /**
+   * Returns the setting type used to group related settings in the UI.
+   */
+  SettingType getType();
+
   void resetToDefault();
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -34,8 +34,4 @@ public interface SelectionComponent<T> {
   void resetToDefault();
 
   void reset();
-
-  default String getTitle() {
-    return "";
-  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingType.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingType.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.settings;
 
 
 /**
- * Groups settings together. Each setting in {@code ClientSettingUiBinding} will map to one {@code SettingType}.
+ * Groups settings together. Each {@link GameSettingUiBinding} will map to one {@code SettingType}.
  * Each {@code SettingType} will have its own tab in the SettingsWindow, every ui binding with that type will
  * be shown on that tab.
  */

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -121,7 +121,7 @@ public enum SettingsWindow {
       final int topInset = (row == 0) ? 0 : 10;
       panel.add(
           JLabelBuilder.builder()
-              .text(setting.title)
+              .text(setting.getTitle())
               .build(),
           new GridBagConstraints(0, row, 1, 1, 0.0, 0.0,
               GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(topInset, 0, 0, 0), 0, 0));

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -100,7 +100,7 @@ public enum SettingsWindow {
 
   private static List<ClientSettingSwingUiBinding> getSettingsByType(final SettingType type) {
     return Arrays.stream(ClientSettingSwingUiBinding.values())
-        .filter(setting -> setting.type == type)
+        .filter(setting -> setting.getType().equals(type))
         .collect(Collectors.toList());
   }
 

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
@@ -56,7 +56,7 @@ class SettingsPane extends StackPane {
       tab.setContent(new ScrollPane(pane));
       pane.prefWidthProperty().bind(tabPane.widthProperty());
       Arrays.stream(ClientSettingJavaFxUiBinding.values())
-          .filter(b -> b.getCategory() == type)
+          .filter(b -> b.getType().equals(type))
           .forEach(b -> {
             final Tooltip tooltip = new Tooltip(bundle.getString("settings.tooltip." + b.name().toLowerCase()));
             final Region element = b.buildSelectionComponent();

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -153,7 +153,7 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
 
   @Override
   public String getTitle() {
-    return nodeSupplier.get().getTitle();
+    return "";
   }
 
   @Override

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -114,17 +114,16 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
       SettingType.TESTING,
       ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
 
-  private final SettingType category;
+  private final SettingType type;
   private final Supplier<SelectionComponent<Region>> nodeSupplier;
 
-  ClientSettingJavaFxUiBinding(final SettingType category,
-      final Supplier<SelectionComponent<Region>> nodeSupplier) {
-    this.category = category;
+  ClientSettingJavaFxUiBinding(final SettingType type, final Supplier<SelectionComponent<Region>> nodeSupplier) {
+    this.type = type;
     this.nodeSupplier = Suppliers.memoize(nodeSupplier::get);
   }
 
-  ClientSettingJavaFxUiBinding(final SettingType category, final ClientSetting setting) {
-    this(category, JavaFxSelectionComponentFactory.toggleButton(setting));
+  ClientSettingJavaFxUiBinding(final SettingType type, final ClientSetting setting) {
+    this(type, JavaFxSelectionComponentFactory.toggleButton(setting));
   }
 
   @Override
@@ -162,7 +161,8 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
     nodeSupplier.get().resetToDefault();
   }
 
-  public SettingType getCategory() {
-    return category;
+  @Override
+  public SettingType getType() {
+    return type;
   }
 }

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -109,11 +109,6 @@ class JavaFxSelectionComponentFactory {
       public void reset() {
         spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.value()));
       }
-
-      @Override
-      public String getTitle() {
-        return "";
-      }
     };
   }
 


### PR DESCRIPTION
## Overview

Both implementations of `GameSettingUiBinding` provide a `SettingType` accessor, so it seems logical that it should be defined on the common interface rather than as a class method.

The second commit is somewhat unrelated.  It simply removes the `SelectionComponent#getTitle()` method.  The return value of this method doesn't appear to be used for anything.  `ClientSettingSwingUiBinding` maintains the title itself and does not query the `SelectionComponent`.  `ClientSettingJavaFxUiBinding` loads the title on-demand from the resource system and never actually uses the value returned from the `SelectionComponent`.

The third commit is tangentially-related to the second.  Since the `GameSettingUiBinding` interface already defines a `getTitle()` method, it simply forces `ClientSettingSwingUiBinding` clients to use that getter instead of accessing the field directly.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the engine settings UI in both the Swing and JFX clients.