### PR TITLE
Decouple SaveGameFileChooser from HeadlessGameServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -26,6 +26,7 @@ import games.strategy.engine.delegate.DelegateExecutionManager;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.delegate.IPersistentDelegate;
+import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.IObserverWaitingToJoin;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
@@ -442,8 +443,8 @@ public class ServerGame extends AbstractGame {
     if (gameData.getSequence().next()) {
       gameData.getHistory().getHistoryWriter().startNextRound(gameData.getSequence().getRound());
       autoSave(gameData.getSequence().getRound() % 2 == 0
-          ? SaveGameFileChooser.getAutoSaveEvenFileName()
-          : SaveGameFileChooser.getAutoSaveOddFileName());
+          ? SaveGameFileChooser.getEvenRoundAutoSaveFileName(HeadlessGameServer.headless())
+          : SaveGameFileChooser.getOddRoundAutoSaveFileName(HeadlessGameServer.headless()));
     }
     if (autoSaveThisDelegate && !currentStep.getName().endsWith("Move")) {
       autoSave(getAutoSaveAfterFileNameForDelegate(currentDelegate));

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -267,7 +267,7 @@ public class HeadlessGameServer {
           try {
             serverGame.saveGame(new File(
                 ClientSetting.SAVE_GAMES_FOLDER_PATH.value(),
-                SaveGameFileChooser.getAutoSaveFileName()));
+                SaveGameFileChooser.getHeadlessAutoSaveFileName()));
           } catch (final Exception e) {
             log.log(Level.SEVERE, "Failed to save game", e);
           }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -212,7 +212,7 @@ public class ServerLauncher extends AbstractLauncher {
             serverModel.setAllPlayersToNullNodes();
             final File f1 = new File(
                 ClientSetting.SAVE_GAMES_FOLDER_PATH.value(),
-                SaveGameFileChooser.getAutoSaveFileName());
+                SaveGameFileChooser.getHeadlessAutoSaveFileName());
             if (f1.exists()) {
               gameSelectorModel.load(f1);
             } else {
@@ -316,7 +316,7 @@ public class ServerLauncher extends AbstractLauncher {
   private void saveAndEndGame(final INode node) {
     // a hack, if headless save to the autosave to avoid polluting our savegames folder with a million saves
     final File f = headless
-        ? new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), SaveGameFileChooser.getAutoSaveFileName())
+        ? new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), SaveGameFileChooser.getHeadlessAutoSaveFileName())
         : new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), getConnectionLostFileName());
     try {
       serverGame.saveGame(f);

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -8,25 +8,41 @@ import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.engine.framework.GameDataFileUtils;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.triplea.settings.ClientSetting;
 
-public class SaveGameFileChooser extends JFileChooser {
+/**
+ * A file chooser for save games. Defaults to the user's configured save game folder.
+ *
+ * <p>
+ * Also provides several methods for getting the names of auto-save files periodically generated during a game.
+ * </p>
+ */
+public final class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
-  private static final String AUTOSAVE_FILE_NAME = GameDataFileUtils.addExtension("autosave");
-  private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_odd");
-  private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_even");
+
+  @VisibleForTesting
+  static final String HEADLESS_AUTOSAVE_FILE_NAME = GameDataFileUtils.addExtension("autosave");
+  @VisibleForTesting
+  static final String ODD_ROUND_AUTOSAVE_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_odd");
+  @VisibleForTesting
+  static final String EVEN_ROUND_AUTOSAVE_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_even");
+
   private static SaveGameFileChooser instance;
 
+  /**
+   * The available auto-saves that can be loaded by a headless game server.
+   */
   public enum AUTOSAVE_TYPE {
-    AUTOSAVE(getAutoSaveFileName()),
+    AUTOSAVE(getHeadlessAutoSaveFileName()),
 
     AUTOSAVE2(""),
 
-    AUTOSAVE_ODD(getAutoSaveOddFileName()),
+    AUTOSAVE_ODD(getOddRoundAutoSaveFileName(true)),
 
-    AUTOSAVE_EVEN(getAutoSaveEvenFileName());
+    AUTOSAVE_EVEN(getEvenRoundAutoSaveFileName(true));
 
     private final String fileName;
 
@@ -39,37 +55,26 @@ public class SaveGameFileChooser extends JFileChooser {
     }
   }
 
-  public static String getAutoSaveFileName() {
-    if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(TRIPLEA_NAME,
-          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
-      if (saveSuffix.length() > 0) {
-        return saveSuffix + "_" + AUTOSAVE_FILE_NAME;
-      }
-    }
-    return AUTOSAVE_FILE_NAME;
+  public static String getHeadlessAutoSaveFileName() {
+    return getAutoSaveFileName(HEADLESS_AUTOSAVE_FILE_NAME, true);
   }
 
-  public static String getAutoSaveOddFileName() {
-    if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(TRIPLEA_NAME,
-          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
-      if (saveSuffix.length() > 0) {
-        return saveSuffix + "_" + AUTOSAVE_ODD_ROUND_FILE_NAME;
+  private static String getAutoSaveFileName(final String baseFileName, final boolean headless) {
+    if (headless) {
+      final String prefix = System.getProperty(TRIPLEA_NAME, System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
+      if (!prefix.isEmpty()) {
+        return prefix + "_" + baseFileName;
       }
     }
-    return AUTOSAVE_ODD_ROUND_FILE_NAME;
+    return baseFileName;
   }
 
-  public static String getAutoSaveEvenFileName() {
-    if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(TRIPLEA_NAME,
-          System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
-      if (saveSuffix.length() > 0) {
-        return saveSuffix + "_" + AUTOSAVE_EVEN_ROUND_FILE_NAME;
-      }
-    }
-    return AUTOSAVE_EVEN_ROUND_FILE_NAME;
+  public static String getOddRoundAutoSaveFileName(final boolean headless) {
+    return getAutoSaveFileName(ODD_ROUND_AUTOSAVE_FILE_NAME, headless);
+  }
+
+  public static String getEvenRoundAutoSaveFileName(final boolean headless) {
+    return getAutoSaveFileName(EVEN_ROUND_AUTOSAVE_FILE_NAME, headless);
   }
 
   public static SaveGameFileChooser getInstance() {

--- a/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
@@ -1,0 +1,136 @@
+package games.strategy.engine.framework.ui;
+
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.EVEN_ROUND_AUTOSAVE_FILE_NAME;
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.HEADLESS_AUTOSAVE_FILE_NAME;
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.ODD_ROUND_AUTOSAVE_FILE_NAME;
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.getEvenRoundAutoSaveFileName;
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.getHeadlessAutoSaveFileName;
+import static games.strategy.engine.framework.ui.SaveGameFileChooser.getOddRoundAutoSaveFileName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.framework.CliProperties;
+
+final class SaveGameFileChooserTest {
+  abstract class AbstractAutoSaveFileNameTestCase {
+    static final String HOST_NAME = "hostName";
+    static final String PLAYER_NAME = "playerName";
+
+    void givenHostName(final String hostName) {
+      System.setProperty(CliProperties.LOBBY_GAME_HOSTED_BY, hostName);
+    }
+
+    void givenHostNameNotDefined() {
+      System.clearProperty(CliProperties.LOBBY_GAME_HOSTED_BY);
+    }
+
+    void givenPlayerName(final String playerName) {
+      System.setProperty(CliProperties.TRIPLEA_NAME, playerName);
+    }
+
+    void givenPlayerNameNotDefined() {
+      System.clearProperty(CliProperties.TRIPLEA_NAME);
+    }
+
+    @AfterEach
+    void clearSystemProperties() {
+      givenHostNameNotDefined();
+      givenPlayerNameNotDefined();
+    }
+  }
+
+  @Nested
+  final class GetHeadlessAutoSaveFileNameTest extends AbstractAutoSaveFileNameTestCase {
+    @Test
+    void shouldPrefixFileNameWithPlayerName() {
+      givenPlayerName(PLAYER_NAME);
+      givenHostName(HOST_NAME);
+
+      assertThat(getHeadlessAutoSaveFileName(), is(PLAYER_NAME + "_" + HEADLESS_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldPrefixFileNameWithHostNameWhenPlayerNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostName(HOST_NAME);
+
+      assertThat(getHeadlessAutoSaveFileName(), is(HOST_NAME + "_" + HEADLESS_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldNotPrefixFileNameWhenPlayerNameNotDefinedAndHostNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostNameNotDefined();
+
+      assertThat(getHeadlessAutoSaveFileName(), is(HEADLESS_AUTOSAVE_FILE_NAME));
+    }
+  }
+
+  @Nested
+  final class GetEvenRoundAutoSaveFileNameTest extends AbstractAutoSaveFileNameTestCase {
+    @Test
+    void shouldNotPrefixFileNameWhenHeaded() {
+      assertThat(getEvenRoundAutoSaveFileName(false), is(EVEN_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldPrefixFileNameWithPlayerNameWhenHeadless() {
+      givenPlayerName(PLAYER_NAME);
+      givenHostName(HOST_NAME);
+
+      assertThat(getEvenRoundAutoSaveFileName(true), is(PLAYER_NAME + "_" + EVEN_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldPrefixFileNameWithHostNameWhenHeadlessAndPlayerNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostName(HOST_NAME);
+
+      assertThat(getEvenRoundAutoSaveFileName(true), is(HOST_NAME + "_" + EVEN_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldNotPrefixFileNameWhenHeadlessAndPlayerNameNotDefinedAndHostNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostNameNotDefined();
+
+      assertThat(getEvenRoundAutoSaveFileName(true), is(EVEN_ROUND_AUTOSAVE_FILE_NAME));
+    }
+  }
+
+  @Nested
+  final class GetOddRoundAutoSaveFileNameTest extends AbstractAutoSaveFileNameTestCase {
+    @Test
+    void shouldNotPrefixFileNameWhenHeaded() {
+      assertThat(getOddRoundAutoSaveFileName(false), is(ODD_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldPrefixFileNameWithPlayerNameWhenHeadless() {
+      givenPlayerName(PLAYER_NAME);
+      givenHostName(HOST_NAME);
+
+      assertThat(getOddRoundAutoSaveFileName(true), is(PLAYER_NAME + "_" + ODD_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldPrefixFileNameWithHostNameWhenHeadlessAndPlayerNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostName(HOST_NAME);
+
+      assertThat(getOddRoundAutoSaveFileName(true), is(HOST_NAME + "_" + ODD_ROUND_AUTOSAVE_FILE_NAME));
+    }
+
+    @Test
+    void shouldNotPrefixFileNameWhenHeadlessAndPlayerNameNotDefinedAndHostNameNotDefined() {
+      givenPlayerNameNotDefined();
+      givenHostNameNotDefined();
+
+      assertThat(getOddRoundAutoSaveFileName(true), is(ODD_ROUND_AUTOSAVE_FILE_NAME));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Decouples the static methods in the `SaveGameFileChooser` class from `HeadlessGameServer`.

The `getAutoSaveFileName()` method was only ever called in a headless context, so I renamed it appropriately to make this clear.  Also note that `AUTOSAVE_TYPE#getFileName()` is only ever called in a headless context.

The remaining methods could be called in either a headed or headless context, so I added a new Boolean parameter for the caller to specify this.  My philosophy in these decoupling PRs is to keep pushing the responsibility for determining if the context is headless up the stack until they converge in hopefully one or two places where it will be easier to inject this state from `HeadlessGameServer` or `GameRunner`.

## Functional Changes

None.

## Refactoring Changes

* Renamed the `SaveGameFileChooser` methods and constants to place the adjective before the noun.
* Merged the implementations of the `getXXXAutoSaveFileName()` methods into a single method after first adding characterization tests.

## Manual Testing Performed

* **Headless game server:** Verified headless/even/odd auto-saves were created at the appropriate points in a game.
* **Headed game server:** Verified the even/odd auto-saves were created at the appropriate points in a game.