### PR TITLE
Error Prone: Fix string splitter violations in InternalDiceServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -2,6 +2,8 @@ package games.strategy.engine.random;
 
 import java.util.Objects;
 
+import com.google.common.base.Splitter;
+
 import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 
@@ -13,6 +15,8 @@ import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
  */
 public class InternalDiceServer implements IRemoteDiceServer {
   private static final long serialVersionUID = -8369097763085658445L;
+  private static final char DICE_SEPARATOR = ',';
+
   private final transient IRandomSource _randomSource;
 
   public InternalDiceServer() {
@@ -31,19 +35,16 @@ public class InternalDiceServer implements IRemoteDiceServer {
     final int[] ints = _randomSource.getRandom(max, numDice, "Internal Dice Server");
     final StringBuilder sb = new StringBuilder();
     for (final int i : ints) {
-      sb.append(i).append(",");
+      sb.append(i).append(DICE_SEPARATOR);
     }
     return sb.substring(0, sb.length() - 1);
   }
 
   @Override
   public int[] getDice(final String string, final int count) {
-    final String[] strArray = string.split(",");
-    final int[] intArray = new int[strArray.length];
-    for (int i = 0; i < strArray.length; i++) {
-      intArray[i] = Integer.parseInt(strArray[i]);
-    }
-    return intArray;
+    return Splitter.on(DICE_SEPARATOR).splitToList(string).stream()
+        .mapToInt(Integer::parseInt)
+        .toArray();
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
@@ -31,7 +31,7 @@ final class InternalDiceServerTest {
     void shouldThrowExceptionWhenStringIsMalformed() {
       assertThrows(NumberFormatException.class, () -> getDice(""));
       assertThrows(NumberFormatException.class, () -> getDice("A"));
-      // assertThrows(NumberFormatException.class, () -> getDice("1,"));
+      assertThrows(NumberFormatException.class, () -> getDice("1,"));
       assertThrows(NumberFormatException.class, () -> getDice(",2"));
       assertThrows(NumberFormatException.class, () -> getDice("1,,3"));
       assertThrows(NumberFormatException.class, () -> getDice("1,A,3"));

--- a/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
@@ -1,0 +1,40 @@
+package games.strategy.engine.random;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class InternalDiceServerTest {
+  private final InternalDiceServer internalDiceServer = new InternalDiceServer();
+
+  @Nested
+  final class GetDiceTest {
+    private Integer[] getDice(final String string) {
+      final int ignoredCount = -1;
+      return Arrays.stream(internalDiceServer.getDice(string, ignoredCount)).boxed().toArray(Integer[]::new);
+    }
+
+    @Test
+    void shouldReturnDiceWhenStringIsWellFormed() {
+      assertThat(getDice("1"), is(arrayContaining(1)));
+      assertThat(getDice("1,2"), is(arrayContaining(1, 2)));
+      assertThat(getDice("1,2,3"), is(arrayContaining(1, 2, 3)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStringIsMalformed() {
+      assertThrows(NumberFormatException.class, () -> getDice(""));
+      assertThrows(NumberFormatException.class, () -> getDice("A"));
+      // assertThrows(NumberFormatException.class, () -> getDice("1,"));
+      assertThrows(NumberFormatException.class, () -> getDice(",2"));
+      assertThrows(NumberFormatException.class, () -> getDice("1,,3"));
+      assertThrows(NumberFormatException.class, () -> getDice("1,A,3"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `InternalDiceServer` class.

## Functional Changes

None.

## Manual Testing Performed

Played through the combat phase of a PBEM game using the Internal Dice Server in which `InternalDiceServer#getDice()` was called repeatedly.