### PR TITLE
Remove unused field

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -50,7 +50,6 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Md5Crypt;
-import games.strategy.util.TimeManager;
 import games.strategy.util.Util;
 import lombok.extern.java.Log;
 
@@ -66,7 +65,6 @@ public class HeadlessGameServer {
   private final AvailableGames availableGames = new AvailableGames();
   private final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private final ScheduledExecutorService lobbyWatcherResetupThread = Executors.newScheduledThreadPool(1);
-  private final String startDate = TimeManager.getFullUtcString(Instant.now());
   private static HeadlessGameServer instance = null;
   private final HeadlessServerSetupPanelModel setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
   private ServerGame game = null;

--- a/game-core/src/main/java/games/strategy/util/TimeManager.java
+++ b/game-core/src/main/java/games/strategy/util/TimeManager.java
@@ -1,6 +1,5 @@
 package games.strategy.util;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -10,16 +9,8 @@ import java.time.format.FormatStyle;
 /**
  * Provides methods for formatting time in various formats.
  */
-public class TimeManager {
-  /**
-   * Prints an {@link Instant} localized, with all details.
-   *
-   * @param instant The {@link Instant} being returned as String
-   * @return formatted GMT Date String
-   */
-  public static String getFullUtcString(final Instant instant) {
-    return DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL).withZone(ZoneOffset.UTC).format(instant);
-  }
+public final class TimeManager {
+  private TimeManager() {}
 
   /**
    * Returns a String representing the current {@link LocalDateTime}.


### PR DESCRIPTION
## Overview

Removes the unused `HeadlessGameServer#startDate` field.

After removing this field, `TimeManager#getFullUtcString()` is no longer used, as well.

## Functional Changes

None.

## Refactoring Changes

* As `TimeManager` only contains static methods, made it `final` and added a private constructor.

## Manual Testing Performed

None.