### PR TITLE
Remove option to select autosave2 when connected to bot

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -369,7 +369,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
 
     @Override
     public void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE autoSaveType) {
-      if (HeadlessGameServer.getInstance() == null || autoSaveType == SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE2) {
+      if (HeadlessGameServer.getInstance() == null) {
         return;
       }
       final File save = new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), autoSaveType.getFileName());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -252,7 +252,6 @@ public class ClientSetupPanel extends SetupPanel {
     actions.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
     actions.add(clientModel.getHostBotChangeGameToSaveGameClientAction());
     actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE2));
     actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_ODD));
     actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_EVEN));
     actions.add(clientModel.getHostBotGetGameSaveClientAction(this));

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -131,8 +131,6 @@ public class GameSelectorPanel extends JPanel implements Observer {
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
               SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE2));
-          menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
               SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_ODD));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
               SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN));

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -38,7 +38,15 @@ public final class SaveGameFileChooser extends JFileChooser {
   public enum AUTOSAVE_TYPE {
     AUTOSAVE(getHeadlessAutoSaveFileName()),
 
-    AUTOSAVE2(""),
+    /**
+     * A second auto-save that a headless game server will alternate between (the other being {@link #AUTOSAVE}).
+     *
+     * @deprecated No longer supported. If an old client happens to request this auto-save, it now forwards to the
+     *             same file as {@link #AUTOSAVE} instead of simply doing nothing. Remove upon next stable release (i.e.
+     *             once no stable client will ever request this auto-save).
+     */
+    @Deprecated
+    AUTOSAVE2(getHeadlessAutoSaveFileName()),
 
     AUTOSAVE_ODD(getOddRoundAutoSaveFileName(true)),
 


### PR DESCRIPTION
## Overview

Support for autosave2 was removed in #1672 (May 2017).  However, the UI still allows the user to select it.  If selected, the bot simply does nothing.  This PR removes the autosave2 options from the UI.

## Functional Changes

* Removed autosave2 from the **Open Saved Game** and **Network...** menus on the client options screen.
* If an old client (that still has the autosave2 option available) happens to request autosave2 from a bot at this branch or later, the bot will now load the original autosave instead of doing nothing.

## Manual Testing Performed

* Connected a 9687 client to a bot from this branch.  Verified that, if autosave2 is selected, autosave is loaded instead of doing nothing.

## Before & After Screen Shots

### Before

![connect-1-before](https://user-images.githubusercontent.com/4826349/45134802-58d7fd80-b16a-11e8-88f4-c71b9d638c10.png)

![connect-2-before](https://user-images.githubusercontent.com/4826349/45134887-b409f000-b16a-11e8-83e8-60f28451eaa3.png)

### After

![connect-1-after](https://user-images.githubusercontent.com/4826349/45134805-5e354800-b16a-11e8-9a61-fd040c722fa5.png)

![connect-2-after](https://user-images.githubusercontent.com/4826349/45134890-b9673a80-b16a-11e8-8e85-41aea6886ba6.png)