### PR TITLE
Checkstyle: Fix member name violations in InternalDiceServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -17,11 +17,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
   private static final long serialVersionUID = -8369097763085658445L;
   private static final char DICE_SEPARATOR = ',';
 
-  private final transient IRandomSource randomSource;
-
-  public InternalDiceServer() {
-    randomSource = new PlainRandomSource();
-  }
+  private final transient IRandomSource randomSource = new PlainRandomSource();
 
   @Override
   public EditorPanel getEditor() {

--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -17,10 +17,10 @@ public class InternalDiceServer implements IRemoteDiceServer {
   private static final long serialVersionUID = -8369097763085658445L;
   private static final char DICE_SEPARATOR = ',';
 
-  private final transient IRandomSource _randomSource;
+  private final transient IRandomSource randomSource;
 
   public InternalDiceServer() {
-    _randomSource = new PlainRandomSource();
+    randomSource = new PlainRandomSource();
   }
 
   @Override
@@ -32,7 +32,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
   public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
       final String gameUuid) {
     // the interface is rather stupid, you have to return a string here, which is then passed back in getDice()
-    final int[] ints = _randomSource.getRandom(max, numDice, "Internal Dice Server");
+    final int[] ints = randomSource.getRandom(max, numDice, "Internal Dice Server");
     final StringBuilder sb = new StringBuilder();
     for (final int i : ints) {
       sb.append(i).append(DICE_SEPARATOR);


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in the `InternalDiceServer` class.  The affected field is `transient` and renaming it shouldn't cause compatibility issues.

## Functional Changes

None.

## Refactoring Changes

* Inlined the initialization of the `randomSource` field.

## Manual Testing Performed

* Loaded an old PBEM game using `InternalDiceServer` into this branch and played through combat.
* Saved a PBEM game using `InternalDiceServer` from this branch and loaded it into 9687 and played through combat.