### PR TITLE
Store all auto-saves in the same folder

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -263,9 +263,7 @@ public class HeadlessGameServer {
         new Thread(() -> {
           log.info("Remote Stop Game Initiated.");
           try {
-            serverGame.saveGame(new File(
-                ClientSetting.SAVE_GAMES_FOLDER_PATH.value(),
-                SaveGameFileChooser.getHeadlessAutoSaveFileName()));
+            serverGame.saveGame(SaveGameFileChooser.getHeadlessAutoSaveFile());
           } catch (final Exception e) {
             log.log(Level.SEVERE, "Failed to save game", e);
           }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -7,7 +7,6 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
 import java.awt.Component;
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -369,14 +368,10 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
 
     @Override
     public void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE autoSaveType) {
-      if (HeadlessGameServer.getInstance() == null) {
-        return;
+      final @Nullable HeadlessGameServer headlessGameServer = HeadlessGameServer.getInstance();
+      if (headlessGameServer != null) {
+        headlessGameServer.loadGameSave(autoSaveType.getFile());
       }
-      final File save = new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), autoSaveType.getFileName());
-      if (!save.exists()) {
-        return;
-      }
-      HeadlessGameServer.getInstance().loadGameSave(save);
     }
 
     @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -18,6 +18,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.triplea.settings.ClientSetting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * A file chooser for save games. Defaults to the user's configured save game folder.
@@ -34,6 +36,8 @@ public final class SaveGameFileChooser extends JFileChooser {
   /**
    * The available auto-saves that can be loaded by a headless game server.
    */
+  @AllArgsConstructor
+  @Getter
   public enum AUTOSAVE_TYPE {
     AUTOSAVE(getHeadlessAutoSaveFile()),
 
@@ -51,15 +55,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
     AUTOSAVE_EVEN(getEvenRoundAutoSaveFile(true));
 
-    private final String fileName;
-
-    AUTOSAVE_TYPE(final File file) {
-      this.fileName = file.getName();
-    }
-
-    public File getFile() {
-      return getAutoSaveFile(fileName);
-    }
+    private final File file;
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/util/StringUtils.java
+++ b/game-core/src/main/java/games/strategy/util/StringUtils.java
@@ -1,0 +1,19 @@
+package games.strategy.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A collection of useful methods for working with instances of {@link String}.
+ */
+public final class StringUtils {
+  private StringUtils() {}
+
+  /**
+   * Returns {@code value} with the first character capitalized. An empty string is returned unchanged.
+   */
+  public static String capitalize(final String value) {
+    checkNotNull(value);
+
+    return value.isEmpty() ? value : (value.substring(0, 1).toUpperCase() + value.substring(1));
+  }
+}

--- a/game-core/src/test/java/games/strategy/util/StringUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package games.strategy.util;
+
+import static games.strategy.util.StringUtils.capitalize;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class StringUtilsTest {
+  @Nested
+  final class CapitalizeTest {
+    @Test
+    void shouldCapitalizeFirstCharacterAndLeaveOtherCharactersUnchanged() {
+      assertThat(capitalize(""), is(""));
+      assertThat(capitalize("a"), is("A"));
+      assertThat(capitalize("A"), is("A"));
+      assertThat(capitalize("abcd"), is("Abcd"));
+      assertThat(capitalize("aBCD"), is("ABCD"));
+      assertThat(capitalize("ABCD"), is("ABCD"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes #3977.

## Functional Changes

* All auto-saves are now stored in _&lt;userSaveGameFolder>/autoSave_.  Previously, some were stored in this folder and some were stored in _&lt;userSaveGameFolder>_.

## Refactoring Changes

* Moved all methods that generate auto-save file names to `SaveGameFileChooser` so they are co-located.
* Modified `ServerGame#saveGame()` to create the save game folder if it does not exist.  Previously, this functionality was spread across multiple methods.
* Extracted `StringUtils#capitalize()` for use by the auto-save file name generators.  Even though this method is only used by `SaveGameFileChooser`, I hung it on a top-level class because there are a couple of other locations in the code that duplicate this logic.  I plan on replacing them in a follow-up PR.

## Manual Testing Performed

* Verified a bot can now load the _autosave_round_even.tsvg_ and _autosave_round_odd.tsvg_ auto-saves.
* Tested all code paths that generate an auto-save (_autosave.tsvg_, _autosave_round_even.tsvg_, _autosave_round_odd.tsvg_, _connection_lost_on\_*.tsvg_, _autosaveBefore*.tsvg_, and _autosaveAfter*.tsvg_) both in headed and headless games.
* Verified the _autoSave_ folder is automatically created on the above code paths.