### PR TITLE
 Add subproject for headed game client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
 
 apply from: 'gradle/scripts/yaml.gradle'
 
+description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
+
 ext {
     schemasDir = file('config/triplea/schemas')
 }

--- a/eclipse/launchers/HeadedGameRunner.launch
+++ b/eclipse/launchers/HeadedGameRunner.launch
@@ -2,14 +2,15 @@
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
 <stringAttribute key="bad_container_name" value="/triplea/eclipse/lauc"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java"/>
+<listEntry value="/game-headed/src/main/java/org/triplea/game/headed/runner/HeadedGameRunner.java"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.GameRunner"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-core"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.triplea.game.headed.runner.HeadedGameRunner"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="game-headed"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:game-core}"/>
 </launchConfiguration>

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -1,19 +1,11 @@
 plugins {
-    id 'application'
-    id 'com.github.johnrengelman.shadow' version '2.0.4'
-    id 'com.install4j.gradle' version '7.0.1'
     id 'de.undercouch.download' version '3.4.3'
 }
 
-description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
-mainClassName = 'games.strategy.engine.framework.GameRunner'
-version = getEngineVersion()
+description = 'TripleA core library containing code shared between headed and headless versions'
 
 ext {
-    releasesDir = file("$buildDir/releases")
     remoteLibsDir = file('.remote-libs')
-    rootFilesDir = file("$buildDir/rootFiles")
-    shadowLibsDir = file("$buildDir/shadowLibs")
 }
 
 def remoteFile(url) {
@@ -24,12 +16,6 @@ def remoteFile(url) {
         overwrite false
     }
     files(file)
-}
-
-jar {
-    manifest {
-        attributes 'Main-Class': mainClassName, 'TripleA-Version': version
-    }
 }
 
 dependencies {
@@ -60,98 +46,17 @@ dependencies {
     }
 }
 
-task cleanRemoteLibs(type: Delete, group: LifecycleBasePlugin.BUILD_GROUP, description: 'Deletes the remote libraries directory.') {
-    delete remoteLibsDir
-}
-
-shadowJar {
-    destinationDir = shadowLibsDir
-    baseName = 'triplea'
-    classifier = 'all'
-    version = version
-}
-
-task downloadAssets(group: 'release') {
-    doLast {
-        [
-            'icons/triplea_icon_16_16.png',
-            'icons/triplea_icon_32_32.png',
-            'icons/triplea_icon_48_48.png',
-            'icons/triplea_icon_64_64.png',
-            'icons/triplea_icon_128_128.png',
-            'icons/triplea_icon_256_256.png',
-            'install4j/macosx-amd64-1.8.0_144.tar.gz',
-            'install4j/windows-amd64-1.8.0_144.tar.gz',
-            'install4j/windows-x86-1.8.0_144.tar.gz'
-        ].each { path ->
-            download {
-                src "https://raw.githubusercontent.com/triplea-game/assets/master/$path"
-                dest "$buildDir/assets/$path"
-                overwrite false
-            }
-        }
-    }
-}
-
-import com.install4j.gradle.Install4jTask
-task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
-    projectFile = file('build.install4j')
-    release project.version
-    doFirst {
-        logger.lifecycle("building installer release of version '${project.version}'")
-    }
-}
-
-task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]) {
-    doLast {
-        ant.chmod(dir: releasesDir, perm: '+x', includes: '*.sh')
-    }
-}
-
-task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
-    baseName = 'triplea'
-    classifier = 'all_platforms'
-    ['assets', 'dice_servers'].each { folder ->
-        from(folder) {
-            into(folder)
-        }
-    }
-    from(file('game_engine.properties'))
-    from(shadowJar.outputs) {
-        into('bin')
-    }
-}
-
-task release(group: 'release', dependsOn: [generateZipReleases, generateInstallerReleases]) {
-    doLast {
-        publishArtifacts([
-            file("$distsDir/triplea-${version}-all_platforms.zip"),
-            file("$releasesDir/TripleA_${version}_macos.dmg"),
-            file("$releasesDir/TripleA_${version}_unix.sh"),
-            file("$releasesDir/TripleA_${version}_windows-32bit.exe"),
-            file("$releasesDir/TripleA_${version}_windows-64bit.exe")
-        ])
-    }
-}
-
-gradle.taskGraph.whenReady { graph ->
-    graph.getAllTasks().any({
-        if (it.name == "generateInstallers") {
-            if (!project.hasProperty('install4jHomeDir')) {
-                File propertiesFile = file("${System.getProperty('user.home')}/.gradle/gradle.properties")
-                throw new RuntimeException("Specify install4jHomeDir in $propertiesFile")
-            }
-            def p = file(project.install4jHomeDir)
-            logger.lifecycle('using install4j home directory ' + p.getAbsolutePath())
-            it.project.install4j.installDir = file(project.install4jHomeDir)
-        }
-    })
-}
-
 checkstyleMain {
     maxWarnings = checkstyleMainMaxWarnings.toInteger()
 }
 
 checkstyleTest {
     maxWarnings = checkstyleTestMaxWarnings.toInteger()
+}
+
+task cleanRemoteLibs(
+        type: Delete,
+        group: LifecycleBasePlugin.BUILD_GROUP,
+        description: 'Deletes the remote libraries directory.') {
+    delete remoteLibsDir
 }

--- a/game-headed/README.md
+++ b/game-headed/README.md
@@ -1,0 +1,3 @@
+# Headed Game Client
+
+A headed game client (and server) for TripleA. A full-featured Swing client and an experimental JavaFX client are provided.

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -1,0 +1,108 @@
+import com.install4j.gradle.Install4jTask
+
+plugins {
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '2.0.4'
+    id 'com.install4j.gradle' version '7.0.1'
+    id 'de.undercouch.download' version '3.4.3'
+}
+
+archivesBaseName = "$group-$name"
+description = 'TripleA Headed Game Client'
+mainClassName = 'org.triplea.game.headed.runner.HeadedGameRunner'
+version = getEngineVersion()
+
+ext {
+    releasesDir = file("$buildDir/releases")
+}
+
+dependencies {
+    compile project(':game-core')
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+}
+
+run {
+    workingDir = project(':game-core').projectDir
+}
+
+task downloadAssets(group: 'release') {
+    doLast {
+        [
+            'icons/triplea_icon_16_16.png',
+            'icons/triplea_icon_32_32.png',
+            'icons/triplea_icon_48_48.png',
+            'icons/triplea_icon_64_64.png',
+            'icons/triplea_icon_128_128.png',
+            'icons/triplea_icon_256_256.png',
+            'install4j/macosx-amd64-1.8.0_144.tar.gz',
+            'install4j/windows-amd64-1.8.0_144.tar.gz',
+            'install4j/windows-x86-1.8.0_144.tar.gz'
+        ].each { path ->
+            download {
+                src "https://raw.githubusercontent.com/triplea-game/assets/master/$path"
+                dest "$buildDir/assets/$path"
+                overwrite false
+            }
+        }
+    }
+}
+
+task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
+    projectFile = file('build.install4j')
+    release project.version
+    doFirst {
+        logger.lifecycle("building installer release of version '${project.version}'")
+    }
+}
+
+task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]) {
+    doLast {
+        ant.chmod(dir: releasesDir, perm: '+x', includes: '*.sh')
+    }
+}
+
+task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
+    baseName = 'triplea'
+    classifier = 'all_platforms'
+    from project(':game-core').file('game_engine.properties')
+    from(project(':game-core').file('assets')) {
+        into 'assets'
+    }
+    from(project(':game-core').file('dice_servers')) {
+        into 'dice_servers'
+    }
+    from(shadowJar.outputs) {
+        into 'bin'
+    }
+}
+
+task release(group: 'release', dependsOn: [generateZipReleases, generateInstallerReleases]) {
+    doLast {
+        publishArtifacts([
+            file("$distsDir/triplea-${version}-all_platforms.zip"),
+            file("$releasesDir/TripleA_${version}_macos.dmg"),
+            file("$releasesDir/TripleA_${version}_unix.sh"),
+            file("$releasesDir/TripleA_${version}_windows-32bit.exe"),
+            file("$releasesDir/TripleA_${version}_windows-64bit.exe")
+        ])
+    }
+}
+
+gradle.taskGraph.whenReady { graph ->
+    graph.getAllTasks().any({
+        if (it.name == "generateInstallers") {
+            if (!project.hasProperty('install4jHomeDir')) {
+                File propertiesFile = file("${System.getProperty('user.home')}/.gradle/gradle.properties")
+                throw new RuntimeException("Specify install4jHomeDir in $propertiesFile")
+            }
+            def p = file(project.install4jHomeDir)
+            logger.lifecycle('using install4j home directory ' + p.getAbsolutePath())
+            it.project.install4j.installDir = file(project.install4jHomeDir)
+        }
+    })
+}

--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="7.0.1" transformSequenceNumber="7">
-  <directoryPresets config="./game_engine.properties" />
+  <directoryPresets config="../game-core/game_engine.properties" />
   <application name="TripleA" distributionSourceDir="" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" excludeSignedFromPacking="true" commonExternalFiles="false" createMd5Sums="false" shrinkRuntime="true" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="http://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" backupOnSave="false" autoSave="true" convertDotsToUnderscores="false" macSignature="????" macVolumeId="af9346379363d40e" javaMinVersion="1.8" javaMaxVersion="1.8" allowBetaVM="true" jdkMode="jdk" jdkName="">
     <languages skipLanguageSelection="false" languageSelectionInPrincipalLanguage="false">
       <principalLanguage id="en" customLocalizationFile="" />
@@ -25,16 +25,16 @@
       <mountPoint id="22" root="" location="" mode="755" />
     </mountPoints>
     <entries>
-      <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="28" file="../game-core/assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <dirEntry mountPoint="23" file="build/shadowLibs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="23" file="build/libs" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="27" file="../game-core/dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
-      <fileEntry mountPoint="22" file="game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <fileEntry mountPoint="22" file="../game-core/game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
     </entries>
     <components />
   </files>
@@ -49,7 +49,7 @@
           <versionLine x="144" y="22" text="version ${compiler:sys.version}" fontSize="8" fontColor="0,0,0" bold="false" />
         </text>
       </splashScreen>
-      <java mainClass="games.strategy.engine.framework.GameRunner" mainMode="1" vmParameters="" arguments="" allowVMPassthroughParameters="true" preferredVM="" bundleRuntime="true">
+      <java mainClass="org.triplea.game.headed.runner.HeadedGameRunner" mainMode="1" vmParameters="" arguments="" allowVMPassthroughParameters="true" preferredVM="" bundleRuntime="true">
         <classPath>
           <scanDirectory location="bin" failOnError="false" />
         </classPath>

--- a/game-headed/src/main/java/org/triplea/game/headed/runner/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/headed/runner/HeadedGameRunner.java
@@ -1,0 +1,17 @@
+package org.triplea.game.headed.runner;
+
+import games.strategy.engine.framework.GameRunner;
+
+/**
+ * Runs a headed game client.
+ */
+public final class HeadedGameRunner {
+  private HeadedGameRunner() {}
+
+  /**
+   * Entry point for running a new headed game client.
+   */
+  public static void main(final String[] args) {
+    GameRunner.main(args);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name='triplea'
 include 'game-core'
+include 'game-headed'
 include 'game-headless'
 include 'http-client'
 include 'http-data'


### PR DESCRIPTION
## Overview

This PR begins the process of migrating the headed code into its own subproject: `game-headed`.  It pretty much follows the same pattern used for `game-headless` in #3951.

## Functional Changes

None.

## Manual Testing Performed

* Verified I could run the headed client from my IDE using the Eclipse launch configuration.
* Verified I could run the headed client from Gradle using the `:game-headed:run` task.
* Created a release branch in my fork to run the complete build and verified the existing artifacts are built as expected.
* Smoke tested the following release artifacts:
    * Portable build (Linux, Windows x86_64)
    * Unix installer
    * Windows x86_64 installer