### PR TITLE
Error Prone: Fix string splitter violations in BattleTracker

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.Attachable;
@@ -25,6 +26,10 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.formatter.MyFormatter;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @MapSupport
 public class TerritoryAttachment extends DefaultAttachment {
@@ -455,7 +460,8 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_captureUnitOnEnteringBy = new ArrayList<>();
   }
 
-  private void setWhenCapturedByGoesTo(final String value) throws GameParseException {
+  @VisibleForTesting
+  void setWhenCapturedByGoesTo(final String value) throws GameParseException {
     final String[] s = splitOnColon(value);
     if (s.length != 2) {
       throw new GameParseException(
@@ -474,12 +480,27 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_whenCapturedByGoesTo = value;
   }
 
-  public ArrayList<String> getWhenCapturedByGoesTo() {
+  private ArrayList<String> getWhenCapturedByGoesTo() {
     return m_whenCapturedByGoesTo;
   }
 
   private void resetWhenCapturedByGoesTo() {
     m_whenCapturedByGoesTo = new ArrayList<>();
+  }
+
+  public List<CaptureOwnershipChange> getCaptureOwnershipChanges() {
+    return m_whenCapturedByGoesTo.stream()
+        .map(this::parseCaptureOwnershipChange)
+        .collect(Collectors.toList());
+  }
+
+  private CaptureOwnershipChange parseCaptureOwnershipChange(final String encodedCaptureOwnershipChange) {
+    final String[] tokens = splitOnColon(encodedCaptureOwnershipChange);
+    assert tokens.length == 2;
+    final GameData gameData = getData();
+    return new CaptureOwnershipChange(
+        gameData.getPlayerList().getPlayerId(tokens[0]),
+        gameData.getPlayerList().getPlayerId(tokens[1]));
   }
 
   private void setTerritoryEffect(final String value) throws GameParseException {
@@ -847,5 +868,16 @@ public class TerritoryAttachment extends DefaultAttachment {
                 this::getResources,
                 this::resetResources))
         .build();
+  }
+
+  /**
+   * Specifies the player that will take ownership of a territory when it is captured by another player.
+   */
+  @AllArgsConstructor(access = AccessLevel.PACKAGE)
+  @EqualsAndHashCode
+  @ToString
+  public static final class CaptureOwnershipChange {
+    public final PlayerID capturingPlayer;
+    public final PlayerID receivingPlayer;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -644,16 +644,15 @@ public class BattleTracker implements Serializable {
     }
     // if we have specially set this territory to have whenCapturedByGoesTo,
     // then we set that here (except we don't set it if we are liberating allied owned territory)
-    if (isTerritoryOwnerAnEnemy && newOwner.equals(id) && Matches.territoryHasWhenCapturedByGoesTo().test(territory)) {
-      for (final String value : ta.getWhenCapturedByGoesTo()) {
-        final String[] s = value.split(":");
-        final PlayerID capturingPlayer = data.getPlayerList().getPlayerId(s[0]);
-        final PlayerID goesToPlayer = data.getPlayerList().getPlayerId(s[1]);
-        if (capturingPlayer.equals(goesToPlayer)) {
+    if (isTerritoryOwnerAnEnemy
+        && newOwner.equals(id)
+        && Matches.territoryHasCaptureOwnershipChanges().test(territory)) {
+      for (final TerritoryAttachment.CaptureOwnershipChange captureOwnershipChange : ta.getCaptureOwnershipChanges()) {
+        if (captureOwnershipChange.capturingPlayer.equals(captureOwnershipChange.receivingPlayer)) {
           continue;
         }
-        if (capturingPlayer.equals(id)) {
-          newOwner = goesToPlayer;
+        if (captureOwnershipChange.capturingPlayer.equals(id)) {
+          newOwner = captureOwnershipChange.receivingPlayer;
           break;
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -794,7 +796,7 @@ public class BattleTracker implements Serializable {
             UnitAttachment.get(u.getType()).getWhenCapturedChangesInto();
         final PlayerID currentOwner = u.getOwner();
         for (final String value : map.keySet()) {
-          final String[] s = value.split(":");
+          final String[] s = Iterables.toArray(Splitter.on(':').split(value), String.class);
           if (!(s[0].equals("any") || data.getPlayerList().getPlayerId(s[0]).equals(currentOwner))) {
             continue;
           }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1920,10 +1920,10 @@ public final class Matches {
     };
   }
 
-  static Predicate<Territory> territoryHasWhenCapturedByGoesTo() {
+  static Predicate<Territory> territoryHasCaptureOwnershipChanges() {
     return t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      return ta != null && !ta.getWhenCapturedByGoesTo().isEmpty();
+      return (ta != null) && !ta.getCaptureOwnershipChanges().isEmpty();
     };
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TerritoryAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TerritoryAttachmentTest.java
@@ -1,0 +1,76 @@
+package games.strategy.triplea.attachments;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class TerritoryAttachmentTest {
+  @Nested
+  final class GetCaptureOwnershipChangesTest {
+    private final GameData gameData = new GameData();
+    private final PlayerID player1 = new PlayerID("player1", gameData);
+    private final PlayerID player2 = new PlayerID("player2", gameData);
+    private final PlayerID player3 = new PlayerID("player3", gameData);
+    private final TerritoryAttachment territoryAttachment =
+        new TerritoryAttachment("territoryAttachment", null, gameData);
+
+    private String join(final String... values) {
+      return String.join(":", values);
+    }
+
+    @BeforeEach
+    void setUpGameData() {
+      gameData.getPlayerList().addPlayerId(player1);
+      gameData.getPlayerList().addPlayerId(player2);
+      gameData.getPlayerList().addPlayerId(player3);
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenZeroCaptureOwnershipChangesExist() {
+      assertThat(territoryAttachment.getCaptureOwnershipChanges(), hasSize(0));
+    }
+
+    @Test
+    void shouldReturnListOfSizeOneWhenOneCaptureOwnershipChangeExists() throws Exception {
+      territoryAttachment.setWhenCapturedByGoesTo(join(player1.getName(), player2.getName()));
+
+      assertThat(
+          territoryAttachment.getCaptureOwnershipChanges(),
+          contains(new TerritoryAttachment.CaptureOwnershipChange(player1, player2)));
+    }
+
+    @Test
+    void shouldReturnListOfSizeTwoWhenTwoCaptureOwnershipChangesExists() throws Exception {
+      territoryAttachment.setWhenCapturedByGoesTo(join(player1.getName(), player3.getName()));
+      territoryAttachment.setWhenCapturedByGoesTo(join(player2.getName(), player3.getName()));
+
+      assertThat(
+          territoryAttachment.getCaptureOwnershipChanges(),
+          contains(
+              new TerritoryAttachment.CaptureOwnershipChange(player1, player3),
+              new TerritoryAttachment.CaptureOwnershipChange(player2, player3)));
+    }
+  }
+
+  @Nested
+  final class CaptureOwnershipChangeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      final GameData gameData = new GameData();
+      EqualsVerifier.forClass(TerritoryAttachment.CaptureOwnershipChange.class)
+          .withPrefabValues(
+              PlayerID.class,
+              new PlayerID("redPlayerId", gameData),
+              new PlayerID("blackPlayerId", gameData))
+          .verify();
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `BattleTracker` class.

The first commit extracts a new class to represent the parsed value so the caller isn't responsible for looking up player names.  The caller was relatively simple, and there was a 1:1 correspondence between existing variables and the new class fields.  Not sure if the name I chose for the new class (`CaptureOwnershipChange`) is acceptable; that seemed better than `WhenCapturedByGoesTo` and a corresponding getter named `getWhenCapturedByGoesTos()`.  But I can change it back if consistency is more important.

The second commit is a bit of a punt.  I could have done the same thing as in the first commit, but, in this case, the caller is more complex, and there's no test coverage.  I erred on the side of caution and simply replaced the call to `String#split()` with the equivalent Guava code.

## Functional Changes

None.

## Manual Testing Performed

None.