### PR TITLE
Prefer JDK over Guava for string joining

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -47,7 +47,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
     final INode node = (INode) value;
     final List<Icon> icons = iconMap.get(node.toString());
     if (icons != null) {
-      super.getListCellRendererComponent(list, getNodeLabel(node), index, isSelected, cellHasFocus);
+      super.getListCellRendererComponent(list, node.getName(), index, isSelected, cellHasFocus);
       setHorizontalTextPosition(SwingConstants.LEFT);
       setIcon(new CompositeIcon(icons));
     } else {
@@ -56,13 +56,9 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
     return this;
   }
 
-  private static String getNodeLabel(final INode node) {
-    return node.getName();
-  }
-
   private String getNodeLabelWithPlayers(final INode node) {
     final Set<String> playerNames = playerMap.getOrDefault(node.toString(), Collections.emptySet());
-    return getNodeLabel(node)
+    return node.getName()
         + (playerNames.isEmpty() ? "" : playerNames.stream().collect(Collectors.joining(", ", " (", ")")));
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.chat;
 
 import java.awt.Component;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,20 +44,27 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
   @Override
   public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
       final boolean isSelected, final boolean cellHasFocus) {
-    final List<Icon> icons = iconMap.get(value.toString());
+    final INode node = (INode) value;
+    final List<Icon> icons = iconMap.get(node.toString());
     if (icons != null) {
-      super.getListCellRendererComponent(list, ((INode) value).getName(), index, isSelected, cellHasFocus);
+      super.getListCellRendererComponent(list, getNodeLabel(node, false), index, isSelected, cellHasFocus);
       setHorizontalTextPosition(SwingConstants.LEFT);
       setIcon(new CompositeIcon(icons));
     } else {
-      final StringBuilder sb = new StringBuilder(((INode) value).getName());
-      final Set<String> players = playerMap.get(value.toString());
-      if (players != null && !players.isEmpty()) {
-        sb.append(players.stream().collect(Collectors.joining(", ", " (", ")")));
-      }
-      super.getListCellRendererComponent(list, sb.toString(), index, isSelected, cellHasFocus);
+      super.getListCellRendererComponent(list, getNodeLabel(node, true), index, isSelected, cellHasFocus);
     }
     return this;
+  }
+
+  private String getNodeLabel(final INode node, final boolean includePlayers) {
+    final StringBuilder sb = new StringBuilder(node.getName());
+    if (includePlayers) {
+      final Set<String> playerNames = playerMap.getOrDefault(node.toString(), Collections.emptySet());
+      if (!playerNames.isEmpty()) {
+        sb.append(playerNames.stream().collect(Collectors.joining(", ", " (", ")")));
+      }
+    }
+    return sb.toString();
   }
 
   private void setIconMap() {

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -47,24 +47,23 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
     final INode node = (INode) value;
     final List<Icon> icons = iconMap.get(node.toString());
     if (icons != null) {
-      super.getListCellRendererComponent(list, getNodeLabel(node, false), index, isSelected, cellHasFocus);
+      super.getListCellRendererComponent(list, getNodeLabel(node), index, isSelected, cellHasFocus);
       setHorizontalTextPosition(SwingConstants.LEFT);
       setIcon(new CompositeIcon(icons));
     } else {
-      super.getListCellRendererComponent(list, getNodeLabel(node, true), index, isSelected, cellHasFocus);
+      super.getListCellRendererComponent(list, getNodeLabelWithPlayers(node), index, isSelected, cellHasFocus);
     }
     return this;
   }
 
-  private String getNodeLabel(final INode node, final boolean includePlayers) {
-    final StringBuilder sb = new StringBuilder(node.getName());
-    if (includePlayers) {
-      final Set<String> playerNames = playerMap.getOrDefault(node.toString(), Collections.emptySet());
-      if (!playerNames.isEmpty()) {
-        sb.append(playerNames.stream().collect(Collectors.joining(", ", " (", ")")));
-      }
-    }
-    return sb.toString();
+  private static String getNodeLabel(final INode node) {
+    return node.getName();
+  }
+
+  private String getNodeLabelWithPlayers(final INode node) {
+    final Set<String> playerNames = playerMap.getOrDefault(node.toString(), Collections.emptySet());
+    return getNodeLabel(node)
+        + (playerNames.isEmpty() ? "" : playerNames.stream().collect(Collectors.joining(", ", " (", ")")));
   }
 
   private void setIconMap() {

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -13,8 +13,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JList;
 import javax.swing.SwingConstants;
 
-import com.google.common.base.Joiner;
-
 import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.PlayerManager;
 import games.strategy.engine.framework.IGame;
@@ -54,9 +52,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
       final StringBuilder sb = new StringBuilder(((INode) value).getName());
       final Set<String> players = playerMap.get(value.toString());
       if (players != null && !players.isEmpty()) {
-        sb.append(" (");
-        sb.append(Joiner.on(", ").join(players));
-        sb.append(")");
+        sb.append(players.stream().collect(Collectors.joining(", ", " (", ")")));
       }
       super.getListCellRendererComponent(list, sb.toString(), index, isSelected, cellHasFocus);
     }

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -10,8 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 
-import com.google.common.base.Joiner;
-
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
@@ -194,7 +192,7 @@ public class GameDataExporter {
         // TODO: unchecked reflection
         listField = ComboProperty.class.getDeclaredField(ComboProperty.POSSIBLE_VALUES_FIELD_NAME);
         listField.setAccessible(true);
-        typeString = "            <list>" + Joiner.on(',').join((List<String>) listField.get(prop)) + "</list>\n";
+        typeString = "            <list>" + String.join(",", (List<String>) listField.get(prop)) + "</list>\n";
       } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
         log.log(Level.SEVERE, "An Error occured whilst trying to print the Property \"" + value + "\"", e);
       }

--- a/game-core/src/main/java/games/strategy/util/Version.java
+++ b/game-core/src/main/java/games/strategy/util/Version.java
@@ -11,8 +11,6 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
-import com.google.common.base.Joiner;
-
 /**
  * Represents a version string.
  * versions are of the form major.minor.point.micro
@@ -187,7 +185,12 @@ public final class Version implements Serializable, Comparable<Version> {
    * Creates a complete version string with '.' as separator, even if some version numbers are 0.
    */
   public String toStringFull() {
-    return Joiner.on('.').join(m_major, m_minor, m_point, m_micro == Integer.MAX_VALUE ? "dev" : m_micro);
+    return String.join(
+        ".",
+        String.valueOf(m_major),
+        String.valueOf(m_minor),
+        String.valueOf(m_point),
+        (m_micro == Integer.MAX_VALUE) ? "dev" : String.valueOf(m_micro));
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/PoliticalActionAttachmentTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Joiner;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
@@ -28,7 +26,7 @@ final class PoliticalActionAttachmentTest {
         new PoliticalActionAttachment("politicalActionAttachment", null, gameData);
 
     private String join(final String... values) {
-      return Joiner.on(':').join(values);
+      return String.join(":", values);
     }
 
     @BeforeEach

--- a/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/UnitAttachmentTest.java
@@ -9,9 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.security.SecureRandom;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -135,6 +133,6 @@ public class UnitAttachmentTest {
   }
 
   private static String concatWithColon(final String... args) {
-    return Arrays.stream(args).collect(Collectors.joining(":"));
+    return String.join(":", args);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -18,8 +18,6 @@ import javax.annotation.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Joiner;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.ui.UnitIconProperties.MalformedUnitIconDescriptorException;
@@ -45,9 +43,9 @@ final class UnitIconPropertiesTest {
       final String playerName,
       final String unitTypeName,
       final @Nullable String conditionName) {
-    final String encodedUnitTypeId = Joiner.on('.').join(gameName, playerName, unitTypeName);
+    final String encodedUnitTypeId = String.join(".", gameName, playerName, unitTypeName);
     return (conditionName != null)
-        ? Joiner.on(';').join(encodedUnitTypeId, conditionName)
+        ? String.join(";", encodedUnitTypeId, conditionName)
         : encodedUnitTypeId;
   }
 


### PR DESCRIPTION
## Overview

Prefer the JDK's built-in `String` joining capability rather than using an external library (Guava in this case).

## Functional Changes

None.

## Manual Testing Performed

None, but I did verify that `String#join()` produces the same results as `Joiner#join()` for several scenarios, including an empty list of strings to join.