### PR TITLE
Error Prone: Fix reference equality violations in UndoablePlacement

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -57,7 +57,7 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   @Override
   public final String getMoveLabel() {
-    if (m_producerTerritory != m_placeTerritory) {
+    if (!m_producerTerritory.equals(m_placeTerritory)) {
       return m_producerTerritory.getName() + " -> " + m_placeTerritory.getName();
     }
     return m_placeTerritory.getName();
@@ -75,7 +75,7 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   @Override
   public String toString() {
-    if (m_producerTerritory != m_placeTerritory) {
+    if (!m_producerTerritory.equals(m_placeTerritory)) {
       return m_producerTerritory.getName() + " produces in " + m_placeTerritory.getName() + ": "
           + MyFormatter.unitsToTextNoOwner(m_units);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -57,10 +57,13 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   @Override
   public final String getMoveLabel() {
-    if (!m_producerTerritory.equals(m_placeTerritory)) {
-      return m_producerTerritory.getName() + " -> " + m_placeTerritory.getName();
-    }
-    return m_placeTerritory.getName();
+    return getMoveLabel(" -> ");
+  }
+
+  private String getMoveLabel(final String separator) {
+    return m_producerTerritory.equals(m_placeTerritory)
+        ? m_placeTerritory.getName()
+        : m_producerTerritory.getName() + separator + m_placeTerritory.getName();
   }
 
   @Override
@@ -75,10 +78,6 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   @Override
   public String toString() {
-    if (!m_producerTerritory.equals(m_placeTerritory)) {
-      return m_producerTerritory.getName() + " produces in " + m_placeTerritory.getName() + ": "
-          + MyFormatter.unitsToTextNoOwner(m_units);
-    }
-    return m_placeTerritory.getName() + ": " + MyFormatter.unitsToTextNoOwner(m_units);
+    return getMoveLabel(" produces in ") + ": " + MyFormatter.unitsToTextNoOwner(m_units);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
@@ -1,0 +1,70 @@
+package games.strategy.triplea.delegate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.CompositeChange;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+
+final class UndoablePlacementTest {
+  private static final String UNIT_TYPE_NAME = "infantry";
+
+  private final GameData gameData = new GameData();
+  private final Territory placeTerritory = new Territory("placeTerritory", gameData);
+
+  private UndoablePlacement newUndoablePlacement(final Territory producerTerritory, final Territory placeTerritory) {
+    return new UndoablePlacement(
+        new CompositeChange(),
+        producerTerritory,
+        placeTerritory,
+        Collections.singletonList(new Unit(new UnitType(UNIT_TYPE_NAME, gameData), null, gameData)));
+  }
+
+  @Nested
+  final class GetMoveLabelTest {
+    @Test
+    void shouldUsePlaceTerritoryWhenPlaceTerritoryEqualsProducerTerritory() {
+      final Territory producerTerritory = placeTerritory;
+      final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
+
+      assertThat(undoablePlacement.getMoveLabel(), is(placeTerritory.getName()));
+    }
+
+    @Test
+    void shouldUsePlaceTerritoryAndProducerTerritoryWhenPlaceTerritoryNotEqualsProducerTerritory() {
+      final Territory producerTerritory = new Territory("producerTerritory", gameData);
+      final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
+
+      assertThat(undoablePlacement.getMoveLabel(), is(producerTerritory.getName() + " -> " + placeTerritory.getName()));
+    }
+  }
+
+  @Nested
+  final class ToStringTest {
+    @Test
+    void shouldUsePlaceTerritoryWhenPlaceTerritoryEqualsProducerTerritory() {
+      final Territory producerTerritory = placeTerritory;
+      final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
+
+      assertThat(undoablePlacement.toString(), is(placeTerritory.getName() + ": 1 " + UNIT_TYPE_NAME));
+    }
+
+    @Test
+    void shouldUsePlaceTerritoryAndProducerTerritoryWhenPlaceTerritoryNotEqualsProducerTerritory() {
+      final Territory producerTerritory = new Territory("producerTerritory", gameData);
+      final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
+
+      assertThat(
+          undoablePlacement.toString(),
+          is(producerTerritory.getName() + " produces in " + placeTerritory.getName() + ": 1 " + UNIT_TYPE_NAME));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
@@ -32,7 +32,7 @@ final class UndoablePlacementTest {
   final class GetMoveLabelTest {
     @Test
     void shouldUsePlaceTerritoryWhenPlaceTerritoryEqualsProducerTerritory() {
-      final Territory producerTerritory = placeTerritory;
+      final Territory producerTerritory = new Territory(placeTerritory.getName(), gameData);
       final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
 
       assertThat(undoablePlacement.getMoveLabel(), is(placeTerritory.getName()));
@@ -51,7 +51,7 @@ final class UndoablePlacementTest {
   final class ToStringTest {
     @Test
     void shouldUsePlaceTerritoryWhenPlaceTerritoryEqualsProducerTerritory() {
-      final Territory producerTerritory = placeTerritory;
+      final Territory producerTerritory = new Territory(placeTerritory.getName(), gameData);
       final UndoablePlacement undoablePlacement = newUndoablePlacement(producerTerritory, placeTerritory);
 
       assertThat(undoablePlacement.toString(), is(placeTerritory.getName() + ": 1 " + UNIT_TYPE_NAME));


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `UndoablePlacement` class.

An analysis of the code indicates value equality between `Territory` instances is appropriate within this class.  Characterization tests were added before converting reference equality checks to value equality checks.

## Functional Changes

None.

## Refactoring Changes

Extracted a method to avoid duplication in formatting logic between `getMoveLabel()` and `toString()`.

## Manual Testing Performed

None.