### PR TITLE
Do not cache SelectionComponent in game setting UI binding enums

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.Map;
 import java.util.function.Supplier;
 
 import javax.swing.JComponent;
@@ -184,18 +183,16 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
   private final SettingType type;
   private final String title;
   final String description;
-  private final Supplier<SelectionComponent<JComponent>> selectionComponentBuilder;
-
-  private SelectionComponent<JComponent> selectionComponent;
+  private final Supplier<SelectionComponent<JComponent>> selectionComponentFactory;
 
   ClientSettingSwingUiBinding(
       final String title,
       final SettingType type,
-      final Supplier<SelectionComponent<JComponent>> selectionComponentBuilder,
+      final Supplier<SelectionComponent<JComponent>> selectionComponentFactory,
       final String description) {
     this.title = Preconditions.checkNotNull(Strings.emptyToNull(title));
     this.type = Preconditions.checkNotNull(type);
-    this.selectionComponentBuilder = Preconditions.checkNotNull(selectionComponentBuilder);
+    this.selectionComponentFactory = Preconditions.checkNotNull(selectionComponentFactory);
     this.description = Preconditions.checkNotNull(Strings.emptyToNull(description));
   }
 
@@ -208,44 +205,8 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
   }
 
   @Override
-  public JComponent buildSelectionComponent() {
-    return current().getUiComponent();
-  }
-
-  private SelectionComponent<JComponent> current() {
-    if (selectionComponent == null) {
-      selectionComponent = selectionComponentBuilder.get();
-    }
-    return selectionComponent;
-  }
-
-  public void dispose() {
-    selectionComponent = null;
-  }
-
-  @Override
-  public boolean isValid() {
-    return current().isValid();
-  }
-
-  @Override
-  public Map<GameSetting, String> readValues() {
-    return current().readValues();
-  }
-
-  @Override
-  public String validValueDescription() {
-    return current().validValueDescription();
-  }
-
-  @Override
-  public void reset() {
-    current().reset();
-  }
-
-  @Override
-  public void resetToDefault() {
-    current().resetToDefault();
+  public SelectionComponent<JComponent> newSelectionComponent() {
+    return selectionComponentFactory.get();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSettingUiBinding.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.Map;
-
 /**
  * Interface for UI components used to update ClientSetting values. Since the components can get their
  * initial value from the ClientSetting they represent, the only 'write' operation is 'resetToDefault'.
@@ -11,29 +9,9 @@ import java.util.Map;
  */
 public interface GameSettingUiBinding<T> {
   /**
-   * Builds or rebuilds the underlying UI component from current settings.
+   * Returns a new selection component for the setting.
    */
-  T buildSelectionComponent();
-
-  /**
-   * Reads the value set in the UI and return true if it is valid, false otherwise.
-   */
-  boolean isValid();
-
-  /**
-   * Reads values from UI components, returns them in a map of Setting -> value.
-   */
-  Map<GameSetting, String> readValues();
-
-  /**
-   * Returns helpful description message of what values are valid.
-   */
-  String validValueDescription();
-
-  /**
-   * Reset any settings that are bound, and reset the UI.
-   */
-  void reset();
+  SelectionComponent<T> newSelectionComponent();
 
   /**
    * The title describing the setting that can be updated in 2 or 3 words. The space for this value is very
@@ -48,6 +26,4 @@ public interface GameSettingUiBinding<T> {
    * Returns the setting type used to group related settings in the UI.
    */
   SettingType getType();
-
-  void resetToDefault();
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -19,16 +19,16 @@ interface SaveFunction {
    * Returns a result message after persisting settings.
    */
   static SaveResult saveSettings(
-      final Iterable<? extends GameSettingUiBinding<JComponent>> settings,
+      final Iterable<? extends SelectionComponent<JComponent>> selectionComponents,
       final Runnable settingsFlushToDisk) {
     final StringBuilder successMsg = new StringBuilder();
     final StringBuilder failMsg = new StringBuilder();
 
     // save all the values, save stuff that is valid and that was updated
-    settings.forEach(setting -> {
-      if (setting.isValid()) {
+    selectionComponents.forEach(selectionComponent -> {
+      if (selectionComponent.isValid()) {
         // read and save all settings
-        setting.readValues()
+        selectionComponent.readValues()
             .entrySet()
             .stream()
             .filter(entry -> !entry.getKey().value().equals(entry.getValue()))
@@ -37,9 +37,9 @@ interface SaveFunction {
               successMsg.append(String.format("%s was updated to: %s\n", entry.getKey(), entry.getValue()));
             });
       } else {
-        final Map<GameSetting, String> values = setting.readValues();
-        values.forEach((entry, value) -> failMsg.append(String.format("Could not set %s to %s, %s\n",
-            setting.getTitle(), value, setting.validValueDescription())));
+        final Map<GameSetting, String> values = selectionComponent.readValues();
+        values.forEach((key, value) -> failMsg.append(String.format("Could not set %s to %s, %s\n",
+            key, value, selectionComponent.validValueDescription())));
       }
     });
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -11,6 +11,9 @@ import java.util.Map;
 public interface SelectionComponent<T> {
   T getUiComponent();
 
+  /**
+   * Reads the value set in the UI and return true if it is valid, false otherwise.
+   */
   boolean isValid();
 
   String validValueDescription();
@@ -33,5 +36,8 @@ public interface SelectionComponent<T> {
 
   void resetToDefault();
 
+  /**
+   * Reset any settings that are bound, and reset the UI.
+   */
   void reset();
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -24,7 +24,6 @@ import javax.swing.UIManager;
 import javax.swing.border.Border;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.ui.SwingComponents;
@@ -45,8 +44,6 @@ import swinglib.JTextAreaBuilder;
 @SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
 public enum SettingsWindow {
   INSTANCE;
-
-  private static final ImmutableList<SettingType> SETTING_TYPES = ImmutableList.copyOf(SettingType.values());
 
   private @Nullable JDialog dialog;
   private @Nullable JTabbedPane tabbedPane;
@@ -92,7 +89,7 @@ public enum SettingsWindow {
 
   private JComponent createContents() {
     tabbedPane = SwingComponents.newJTabbedPane(1000, 400);
-    SETTING_TYPES
+    Arrays.stream(SettingType.values())
         .forEach(settingType -> tabbedPane.add(settingType.tabTitle, buildTabPanel(getSettingsByType(settingType))));
 
     return JPanelBuilder.builder()
@@ -206,7 +203,7 @@ public enum SettingsWindow {
 
     final int selectedTabIndex = tabbedPane.getSelectedIndex();
     assert selectedTabIndex != -1 : "you called this method before adding any tabs";
-    return getSettingsByType(SETTING_TYPES.get(selectedTabIndex)).stream()
+    return getSettingsByType(SettingType.values()[selectedTabIndex]).stream()
         .map(selectionComponentsBySetting::get)
         .collect(Collectors.toList());
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -5,6 +5,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -187,32 +188,26 @@ public enum SettingsWindow {
   }
 
   private void saveSettings() {
-    getSelectedSelectionComponents().ifPresent(selectionComponents -> {
-      final SaveFunction.SaveResult saveResult = SaveFunction.saveSettings(selectionComponents, ClientSetting::flush);
-      JOptionPane.showMessageDialog(dialog, saveResult.message, "Results", saveResult.dialogType);
-    });
+    final SaveFunction.SaveResult saveResult =
+        SaveFunction.saveSettings(getSelectedSelectionComponents(), ClientSetting::flush);
+    JOptionPane.showMessageDialog(dialog, saveResult.message, "Results", saveResult.dialogType);
   }
 
   private void resetSettings() {
-    getSelectedSelectionComponents()
-        .ifPresent(selectionComponents -> selectionComponents.forEach(SelectionComponent::reset));
+    getSelectedSelectionComponents().forEach(SelectionComponent::reset);
   }
 
   private void resetSettingsToDefault() {
-    getSelectedSelectionComponents()
-        .ifPresent(selectionComponents -> selectionComponents.forEach(SelectionComponent::resetToDefault));
+    getSelectedSelectionComponents().forEach(SelectionComponent::resetToDefault);
   }
 
-  private Optional<List<SelectionComponent<JComponent>>> getSelectedSelectionComponents() {
+  private Collection<SelectionComponent<JComponent>> getSelectedSelectionComponents() {
     assert tabbedPane != null;
 
     final int selectedTabIndex = tabbedPane.getSelectedIndex();
-    if (selectedTabIndex == -1) {
-      return Optional.empty();
-    }
-
-    return Optional.of(getSettingsByType(SETTING_TYPES.get(selectedTabIndex)).stream()
+    assert selectedTabIndex != -1 : "you called this method before adding any tabs";
+    return getSettingsByType(SETTING_TYPES.get(selectedTabIndex)).stream()
         .map(selectionComponentsBySetting::get)
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList());
   }
 }

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.triplea.client.ui.javafx.util.ClientSettingJavaFxUiBinding;
@@ -35,7 +36,7 @@ class SettingsPane extends StackPane {
   private final TripleA triplea;
   private final Map<ClientSettingJavaFxUiBinding, SelectionComponent<Region>> selectionComponentsBySetting =
       Arrays.stream(ClientSettingJavaFxUiBinding.values()).collect(Collectors.toMap(
-          setting -> setting,
+          Function.identity(),
           setting -> setting.newSelectionComponent(),
           (oldValue, newValue) -> {
             throw new AssertionError("impossible condition: enum contains duplicate values");

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/SettingsPane.java
@@ -37,7 +37,7 @@ class SettingsPane extends StackPane {
   private final Map<ClientSettingJavaFxUiBinding, SelectionComponent<Region>> selectionComponentsBySetting =
       Arrays.stream(ClientSettingJavaFxUiBinding.values()).collect(Collectors.toMap(
           Function.identity(),
-          setting -> setting.newSelectionComponent(),
+          ClientSettingJavaFxUiBinding::newSelectionComponent,
           (oldValue, newValue) -> {
             throw new AssertionError("impossible condition: enum contains duplicate values");
           },

--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -1,12 +1,8 @@
 package org.triplea.client.ui.javafx.util;
 
-import java.util.Map;
 import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
-
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.GameSettingUiBinding;
 import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SettingType;
@@ -115,11 +111,13 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
       ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
 
   private final SettingType type;
-  private final Supplier<SelectionComponent<Region>> nodeSupplier;
+  private final Supplier<SelectionComponent<Region>> selectionComponentFactory;
 
-  ClientSettingJavaFxUiBinding(final SettingType type, final Supplier<SelectionComponent<Region>> nodeSupplier) {
+  ClientSettingJavaFxUiBinding(
+      final SettingType type,
+      final Supplier<SelectionComponent<Region>> selectionComponentFactory) {
     this.type = type;
-    this.nodeSupplier = Suppliers.memoize(nodeSupplier::get);
+    this.selectionComponentFactory = selectionComponentFactory;
   }
 
   ClientSettingJavaFxUiBinding(final SettingType type, final ClientSetting setting) {
@@ -127,38 +125,13 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
   }
 
   @Override
-  public Region buildSelectionComponent() {
-    return nodeSupplier.get().getUiComponent();
-  }
-
-  @Override
-  public boolean isValid() {
-    return nodeSupplier.get().isValid();
-  }
-
-  @Override
-  public Map<GameSetting, String> readValues() {
-    return nodeSupplier.get().readValues();
-  }
-
-  @Override
-  public String validValueDescription() {
-    return nodeSupplier.get().validValueDescription();
-  }
-
-  @Override
-  public void reset() {
-    nodeSupplier.get().reset();
+  public SelectionComponent<Region> newSelectionComponent() {
+    return selectionComponentFactory.get();
   }
 
   @Override
   public String getTitle() {
     return "";
-  }
-
-  @Override
-  public void resetToDefault() {
-    nodeSupplier.get().resetToDefault();
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -22,10 +22,10 @@ import com.google.common.collect.ImmutableMap;
 public class SaveFunctionTest {
 
   @Mock
-  private GameSettingUiBinding<JComponent> mockBinding;
+  private SelectionComponent<JComponent> mockSelectionComponent;
 
   @Mock
-  private GameSettingUiBinding<JComponent> mockBinding2;
+  private SelectionComponent<JComponent> mockSelectionComponent2;
 
   @Mock
   private GameSetting mockSetting;
@@ -34,7 +34,7 @@ public class SaveFunctionTest {
   public void messageOnValidIsInformation() {
     givenValidationResults(true, true);
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockBinding, mockBinding2), () -> {
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
         });
 
     MatcherAssert.assertThat("There will always be a message back to the user",
@@ -44,13 +44,13 @@ public class SaveFunctionTest {
   }
 
   private void givenValidationResults(final boolean first, final boolean second) {
-    Mockito.when(mockBinding.isValid()).thenReturn(first);
-    Mockito.when(mockBinding.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
+    Mockito.when(mockSelectionComponent.isValid()).thenReturn(first);
+    Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
     if (first) {
       Mockito.when(mockSetting.value()).thenReturn("");
     }
-    Mockito.when(mockBinding2.isValid()).thenReturn(second);
-    Mockito.when(mockBinding2.readValues()).thenReturn(ImmutableMap.of(mockSetting, "abc"));
+    Mockito.when(mockSelectionComponent2.isValid()).thenReturn(second);
+    Mockito.when(mockSelectionComponent2.readValues()).thenReturn(ImmutableMap.of(mockSetting, "abc"));
   }
 
   @Test
@@ -58,7 +58,7 @@ public class SaveFunctionTest {
     givenValidationResults(false, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockBinding, mockBinding2), () -> {
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
         });
 
     MatcherAssert.assertThat(result.message.isEmpty(), is(false));
@@ -70,7 +70,7 @@ public class SaveFunctionTest {
     givenValidationResults(true, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockBinding, mockBinding2), () -> {
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
         });
 
     MatcherAssert.assertThat(result.message.isEmpty(), is(false));
@@ -82,13 +82,15 @@ public class SaveFunctionTest {
   public void valueSavedWhenValid() {
     final AtomicInteger callCount = new AtomicInteger(0);
 
-    Mockito.when(mockBinding.isValid()).thenReturn(true);
-    Mockito.when(mockBinding.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
+    Mockito.when(mockSelectionComponent.isValid()).thenReturn(true);
+    Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
     Mockito.when(mockSetting.value()).thenReturn("");
 
-    Mockito.when(mockBinding2.isValid()).thenReturn(false);
+    Mockito.when(mockSelectionComponent2.isValid()).thenReturn(false);
 
-    SaveFunction.saveSettings(Arrays.asList(mockBinding, mockBinding2), callCount::incrementAndGet);
+    SaveFunction.saveSettings(
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2),
+        callCount::incrementAndGet);
 
     MatcherAssert.assertThat("Make sure we flushed! A call count of '1' means our runnable was called,"
         + "which should only happen when settings were successfully saved.",
@@ -101,9 +103,9 @@ public class SaveFunctionTest {
   public void noSettingsSavedIfAllInvalid() {
     final AtomicInteger callCount = new AtomicInteger(0);
 
-    Mockito.when(mockBinding.isValid()).thenReturn(false);
+    Mockito.when(mockSelectionComponent.isValid()).thenReturn(false);
 
-    SaveFunction.saveSettings(Collections.singletonList(mockBinding), callCount::incrementAndGet);
+    SaveFunction.saveSettings(Collections.singletonList(mockSelectionComponent), callCount::incrementAndGet);
 
     MatcherAssert.assertThat("The one setting value was not valid, nothing should be saved, our "
         + "increment value runnable should not have been called, callCount should still be at zero.",


### PR DESCRIPTION
## Overview

The `ClientSettingSwingUiBinding` and `ClientSettingJavaFxUiBinding` enums cache the `SelectionComponent` instances they create per setting.  (`SelectionComponent`s are basically wrappers around the underlying UI component managed by the window system.)  In addition to being a violation of the Error Prone ImmutableEnumChecker rule, this can lead to hard-to-reason-about code due to potential sharing of the cached value, which may be unexpected by clients.

This PR offloads management of a game setting's `SelectionComponent` to the UI component that will ultimately display it (currently `SettingsWindow` in Swing, and `SettingsPanel` in JavaFX).  This avoids the need to cache `SelectionComponent`s within the various game setting UI binding enums.

## Functional Changes

* `SelectionComponent`s are now managed by the various setting windows rather than `ClientSettingSwingUiBinding` and `ClientSettingJavaFxUiBinding`.

## Manual Testing Performed

Smoke tested the setting windows in both the Swing and JavaFX clients, including reset, reset to default, and save functions.