### PR TITLE
Fix broken :game-headless:run task

### DIFF
--- a/game-headless/README.md
+++ b/game-headless/README.md
@@ -1,3 +1,22 @@
 # Headless Game Server
 
 A headless game server for TripleA, also known as a _bot_.
+
+## Run
+
+Example command to run a new headless game server from Gradle:
+
+```
+$ ./gradlew :game-headless:run --args=' \
+    -Ptriplea.game= \
+    -Ptriplea.lobby.game.comments=automated_host \
+    -Ptriplea.lobby.game.hostedBy=Bot1_TestServer \
+    -Ptriplea.lobby.game.supportEmail=developer@gmail.com \
+    -Ptriplea.lobby.host=127.0.0.1 \
+    -Ptriplea.lobby.port=3304 \
+    -Ptriplea.map.folder=/home/me/triplea/downloadedMaps \
+    -Ptriplea.name=Bot1_TestServer \
+    -Ptriplea.port=3300 \
+    -Ptriplea.server=true \
+    '
+```

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -18,6 +18,10 @@ jar {
     }
 }
 
+run {
+    workingDir = project(':game-core').projectDir
+}
+
 task headlessGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     from project(':game-core').file('game_engine.properties')
     from(project(':game-core').file('assets')) {


### PR DESCRIPTION
## Overview

For the time being, the `game-headless` project needs to run from the `game-core` project directory in order to correctly locate external files (e.g. _game_engine.properties_).

## Functional Changes

None.

## Manual Testing Performed

Verified I could run the `:game-headless:run` task (with the appropriate command-line arguments).