### PR TITLE
Remove unused method

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -51,10 +51,6 @@ public final class ClientContext {
 
   private ClientContext() {}
 
-  public static GameEnginePropertyReader gameEnginePropertyReader() {
-    return instance.gameEnginePropertyReader;
-  }
-
   public static DownloadCoordinator downloadCoordinator() {
     return instance.downloadCoordinator;
   }

--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -16,7 +16,6 @@ public class ClientContextIntegrationTest extends AbstractClientSettingTestCase 
   public void verifyClientContext() {
     assertThat(ClientContext.downloadCoordinator(), notNullValue());
     assertThat(ClientContext.engineVersion(), notNullValue());
-    assertThat(ClientContext.gameEnginePropertyReader(), notNullValue());
     assertThat(ClientContext.mapDownloadController(), notNullValue());
 
     assertThat(ClientContext.getMapDownloadList(), notNullValue());

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.io.IoUtils;
@@ -23,7 +22,6 @@ public class ChangeTripleATest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    ClientContext.gameEnginePropertyReader();
     gameData = TestMapGameData.BIG_WORLD_1942.getGameData();
     can = gameData.getMap().getTerritory("Western Canada");
     assertEquals(2, can.getUnits().getUnitCount());


### PR DESCRIPTION
## Overview

Removes the unused `ClientContext#gameEnginePropertyReader()` method.

## Functional Changes

None.

## Manual Testing Performed

None.