### PR TITLE
Use consistent version for all artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,9 @@ after_success:
 before_deploy:
 ## Update engine property file in-place, append build number. eg: "engine_version = 1.9.0.0" -> "engine_version = 1.9.0.0.1234"
 - ENGINE_VERSION="1.9.0.0.${TRAVIS_BUILD_NUMBER}"
-- LOBBY_VERSION="$ENGINE_VERSION"
 - sed -i "s/^\(engine_version\s*=\).*/\1 ${ENGINE_VERSION}/" game-core/game_engine.properties
 - ./.travis/install_install4j
-- ./gradlew -PengineVersion="$ENGINE_VERSION" -PlobbyVersion="$LOBBY_VERSION" release
+- ./gradlew -PengineVersion="$ENGINE_VERSION" release
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 ## push tag triggers 'deploy' to occur, files listed in 'deploy.files' are uploaded to github releases.

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -3,15 +3,10 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 
+archivesBaseName = "$group-$name"
 description = 'TripleA Lobby'
 mainClassName = 'games.strategy.engine.lobby.server.LobbyRunner'
-version = project.hasProperty('lobbyVersion') ? project.lobbyVersion : 'dev'
-
-jar {
-    manifest {
-        attributes 'Main-Class': mainClassName, 'TripleA-Version': version
-    }
-}
+version = getEngineVersion()
 
 dependencies {
     compile project(':game-core')
@@ -22,27 +17,25 @@ dependencies {
     testCompile project(':test-common')
 }
 
-shadowJar {
-    destinationDir = libsDir
-    baseName = 'triplea-lobby'
-    classifier = 'all'
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
 }
 
-task lobbyServer(type: Zip, group: 'release', dependsOn: shadowJar) {
+task lobbyArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     baseName = 'triplea'
     classifier = 'server'
     from('config') {
-        into('config')
+        into 'config'
     }
     from(shadowJar.outputs) {
-        into('bin')
+        into 'bin'
     }
 }
 
-task release(group: 'release', dependsOn: lobbyServer) {
+task release(group: 'release', dependsOn: lobbyArchive) {
     doLast {
-        publishArtifacts([
-            file("$distsDir/triplea-$version-server.zip")
-        ])
+        publishArtifacts(lobbyArchive.outputs.files)
     }
 }


### PR DESCRIPTION
## Overview

As discussed in https://github.com/triplea-game/triplea/pull/3951#discussion_r214546739.

Modifies the `lobby` project buildscript to use the `getEngineVersion()` function instead of using the custom `lobbyVersion` project property.  Also made some small improvements to the `lobby` buildscript similar to what has been done in the `game-headed` and `game-headless` projects:

* Remove `TripleA-Version` property from manifest (I plan on revisiting this as discussed in https://github.com/triplea-game/triplea/pull/3990#discussion_r216130378).
* Use defaults where possible.
* Simplify syntax where possible.

## Functional Changes

None.

## Manual Testing Performed

* Verified a local Gradle build without the `engineVersion` project property defined produces a lobby artifact with the verison `1.9.0.0.dev` instead of just `dev`.
* Created a branch in my fork to generate a complete release and verified the resulting lobby artifact has the correct version and starts as expected.