### PR TITLE
Use Jitpack for Substance dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .gradle
 .idea
 .project
-.remote-libs/
 .settings
 .checkstyle
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ subprojects {
 
     repositories {
         jcenter()
+        maven {
+            url 'https://jitpack.io'
+        }
     }
 
     dependencies {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -1,24 +1,7 @@
-plugins {
-    id 'de.undercouch.download' version '3.4.3'
-}
-
 description = 'TripleA core library containing code shared between headed and headless versions'
 
-ext {
-    remoteLibsDir = file('.remote-libs')
-}
-
-def remoteFile(url) {
-    def file = file("$remoteLibsDir/${java.nio.file.Paths.get(new URI(url).path).fileName}")
-    download {
-        src url
-        dest file
-        overwrite false
-    }
-    files(file)
-}
-
 dependencies {
+    compile 'com.github.kirill-grouchnikov:substance:master-v8.0.02-g5d33cea-2'
     compile 'com.github.openjson:openjson:1.0.10'
     compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
     compile 'com.sun.mail:javax.mail:1.6.1'
@@ -30,9 +13,8 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.19'
     compile 'com.yuvimasory:orange-extensions:1.3.0'
     compile 'commons-cli:commons-cli:1.4'
-    compile remoteFile('https://github.com/kirill-grouchnikov/substance/raw/f894ef784a2ac20acf13e6ed2c7c26123399787b/drop/8.0.02/substance-8.0.02.jar')
 
-    runtime remoteFile('https://github.com/kirill-grouchnikov/substance/raw/f894ef784a2ac20acf13e6ed2c7c26123399787b/drop/8.0.02/trident-1.5.00.jar')
+    runtime 'com.github.kirill-grouchnikov:trident:v1.5.00'
 
     testCompile project(':test-common')
     testCompile 'org.sonatype.goodies:goodies-prefs:2.2.4'
@@ -52,11 +34,4 @@ checkstyleMain {
 
 checkstyleTest {
     maxWarnings = checkstyleTestMaxWarnings.toInteger()
-}
-
-task cleanRemoteLibs(
-        type: Delete,
-        group: LifecycleBasePlugin.BUILD_GROUP,
-        description: 'Deletes the remote libraries directory.') {
-    delete remoteLibsDir
 }


### PR DESCRIPTION
## Overview

Replaces direct download of Substance dependencies with Jitpack.

Note that according to the kirill-grouchnikov/radiance project, official Maven artifacts for Substance are expected sometime this month or in October, so this will be a short-lived improvement, but it's an improvement nonetheless.

(h/t @RoiEXLab for encouraging kirill-grouchnikov to update his build to be Jitpack-compatible.)

## Functional Changes

None.

## Manual Testing Performed

Verified running the client with a Substance UI worked without issue when run from the following:

* Eclipse launch configuration
* Gradle `:game-headed:run` task
* Portable build