### PR TITLE
Simplify install4j home directory handling in Gradle buildscript

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -1,5 +1,3 @@
-import com.install4j.gradle.Install4jTask
-
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
@@ -18,6 +16,14 @@ ext {
 
 dependencies {
     compile project(':game-core')
+}
+
+install4j {
+    gradle.taskGraph.whenReady {
+        if (gradle.taskGraph.hasTask(generateInstallers)) {
+            installDir = file(install4jHomeDir)
+        }
+    }
 }
 
 jar {
@@ -52,12 +58,9 @@ task downloadAssets(group: 'release') {
     }
 }
 
-task generateInstallers(type: Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
+task generateInstallers(type: com.install4j.gradle.Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
     projectFile = file('build.install4j')
-    release project.version
-    doFirst {
-        logger.lifecycle("building installer release of version '${project.version}'")
-    }
+    release = version
 }
 
 task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]) {
@@ -91,18 +94,4 @@ task release(group: 'release', dependsOn: [generateZipReleases, generateInstalle
             file("$releasesDir/TripleA_${version}_windows-64bit.exe")
         ])
     }
-}
-
-gradle.taskGraph.whenReady { graph ->
-    graph.getAllTasks().any({
-        if (it.name == "generateInstallers") {
-            if (!project.hasProperty('install4jHomeDir')) {
-                File propertiesFile = file("${System.getProperty('user.home')}/.gradle/gradle.properties")
-                throw new RuntimeException("Specify install4jHomeDir in $propertiesFile")
-            }
-            def p = file(project.install4jHomeDir)
-            logger.lifecycle('using install4j home directory ' + p.getAbsolutePath())
-            it.project.install4j.installDir = file(project.install4jHomeDir)
-        }
-    })
 }


### PR DESCRIPTION
## Overview

Simplifies how the install4j home directory is handled within the `game-headed` Gradle buildscript.

I removed the code that explicitly checked to see if the `install4jHomeDir` project property was defined.  If it was not defined, the code would throw an exception containing a message instructing the user to add it to _~/.gradle/gradle.properties_.

It would seem that the default error message displayed when this property isn't defined is sufficient:

```
* What went wrong:
A problem occurred evaluating project ':game-headed'.
> Could not get unknown property 'install4jHomeDir' for object of type com.install4j.gradle.Install4jExtension.
```

A Gradle user should understand how to specify a project property, which, in addition to using _~/.gradle/gradle.properties_, could also be specified via the command line using `-P`.  Please feel free to disagree.

## Functional Changes

None.

## Manual Testing Performed

* Verified the `:game-headed:release` task runs as expected both locally and on Travis.
* Verified the `install4jHomeDir` project property does not have to be defined _unless_ the `:game-headed:generateInstallers` task is scheduled for execution.  That means, for example, you can run `:game-headed:check` without having to define `install4jHomeDir`.  This preserves existing behavior.