### PR TITLE
Fix NPE when showing ErrorMessage

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -12,6 +12,7 @@ import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import games.strategy.triplea.settings.ClientSetting;
 import swinglib.JButtonBuilder;
@@ -96,7 +97,7 @@ public enum ErrorMessage {
   public static void show(final LogRecord record) {
     if (INSTANCE.enableErrorPopup && INSTANCE.isVisible.compareAndSet(false, true)) {
       SwingUtilities.invokeLater(() -> {
-        INSTANCE.errorMessage.setText(TextUtils.textToHtml(record.getMessage()));
+        INSTANCE.errorMessage.setText(TextUtils.textToHtml(Strings.nullToEmpty(record.getMessage())));
         INSTANCE.windowReference.pack();
         INSTANCE.windowReference.setLocationRelativeTo(null);
         INSTANCE.windowReference.setVisible(true);


### PR DESCRIPTION
## Overview

Fixes the second exception (not the root cause) reported in #4003.

## Functional Changes

Convert a `null` error message to an empty string before displaying it.

## Manual Testing Performed

Reproducing the scenario described in #4003, I verified the second exception is no longer raised.