### PR TITLE
Simplify install4j installation directory initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ before_deploy:
 ## Update engine property file in-place, append build number. eg: "engine_version = 1.9.0.0" -> "engine_version = 1.9.0.0.1234"
 - ENGINE_VERSION="1.9.0.0.${TRAVIS_BUILD_NUMBER}"
 - sed -i "s/^\(engine_version\s*=\).*/\1 ${ENGINE_VERSION}/" game-core/game_engine.properties
-- ./.travis/install_install4j
-- ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- INSTALL4J_HOME=~/install4j
+- ./.travis/install_install4j "$INSTALL4J_HOME"
+- ./gradlew -PengineVersion="$ENGINE_VERSION" -Pinstall4jHomeDir="$INSTALL4J_HOME" release
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 ## push tag triggers 'deploy' to occur, files listed in 'deploy.files' are uploaded to github releases.

--- a/.travis/install_install4j
+++ b/.travis/install_install4j
@@ -9,23 +9,10 @@ if [ -z "$INSTALL4J_7_LICENSE" ]; then
  exit -1
 fi
 
-echo "Downloading and installing install4j"
+readonly INSTALL4J_HOME=$1
+
+echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
 wget --no-verbose -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_7_0_1.sh
 chmod +x install4j_unix.sh
-./install4j_unix.sh -q -dir ~/install4j
-
-## Next, append install4jHomeDir property to ~/.gradle/gradle.properties, 
-## iff the property is not already present in the file
-## Detailed explanation of the commands:
-## The grep simply does the check if the property is there, the echo then 
-## does the append, the CD subshell gets us the absolute path to the home folder,
-## and last this is appended to the gradle properties file
-mkdir -p ~/.gradle
-grep -q "install4jHomeDir" ~/.gradle/gradle.properties 2> /dev/null \
-    || echo "install4jHomeDir=$(cd ~ && pwd)/install4j" >> ~/.gradle/gradle.properties
-
-echo "Now Running Install4j to build OS specific installers"
-~/install4j/bin/install4jc -L $INSTALL4J_7_LICENSE
-
-echo "Environment Now ready to execute 'gradle release'"
-echo ""
+./install4j_unix.sh -q -dir "$INSTALL4J_HOME"
+"$INSTALL4J_HOME/bin/install4jc" -L $INSTALL4J_7_LICENSE

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -19,11 +19,7 @@ dependencies {
 }
 
 install4j {
-    gradle.taskGraph.whenReady {
-        if (gradle.taskGraph.hasTask(generateInstallers)) {
-            installDir = file(install4jHomeDir)
-        }
-    }
+    installDir = file(install4jHomeDir)
 }
 
 jar {

--- a/game-headed/gradle.properties
+++ b/game-headed/gradle.properties
@@ -1,0 +1,5 @@
+# DO NOT MODIFY THIS PROPERTY!  If you wish to build the installers, you
+# must install install4j and define this property on the command line
+# (e.g. -Pinstall4jHomeDir=...) or in your personal Gradle properties
+# (e.g. ~/.gradle/gradle.properties).
+install4jHomeDir=.


### PR DESCRIPTION
## Overview

Per https://github.com/triplea-game/triplea/pull/4002#discussion_r216151435.

Simplifies how the install4j installation directory is initialized during a Gradle build:

* Defines a dummy (but valid) default property value and documents how one would go about customizing it.
    * This then precludes the need to check whether the property exists in _build.gradle_.
* During a Travis build, pulls knowledge of the install4j installation directory up to _.travis.yml_ and passes it to _.travis/install_install4j_ as an argument so it's not buried within the secondary script.
    * This then allows us to pass this directory to Gradle on the command line to avoid all the hooeyness of writing a custom _~/.gradle/gradle.properties_ during the build.

## Functional Changes

None.

## Manual Testing Performed

Created a branch in my fork to build the full release and verified all install4j artifacts were produced as expected.