### PR TITLE
Fix race condition between creating and referencing main frame

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -148,9 +148,9 @@ public class GameRunner {
       SwingUtilities.invokeLater(() -> {
         mainFrame = newMainFrame();
         setupPanelModel.showSelectType();
+        new Thread(GameRunner::showMainFrame).start();
       });
 
-      showMainFrame();
       LocalSystemChecker.launch();
       UpdateChecks.launch();
     }


### PR DESCRIPTION
## Overview

Fixes #4003.

The root cause of the NPE in `SetupPanelModel#showServer()` is due to a race condition between the creation of the main frame window in `GameRunner#main()` and referencing it in `GameRunner#showMainFrame()`.

## Functional Changes

* Ensure `GameRunner#showMainFrame()` is not called until `GameRunner#mainFrame` has been initialized.

## Manual Testing Performed

Reproduced the scenario described in #4003 and verified no exceptions were raised.