### PR TITLE
Do not display unit tooltips when mouse is outside of map panel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapUnitTooltipManager.java
@@ -152,11 +152,19 @@ public final class MapUnitTooltipManager implements ActionListener {
   public void actionPerformed(final ActionEvent e) {
     if (text.length() > 0) {
       final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
-      final PopupFactory popupFactory = PopupFactory.getSharedInstance();
-      final JToolTip info = new JToolTip();
-      info.setTipText("<html>" + text + "</html>");
-      popup = popupFactory.getPopup(parent, info, currentPoint.x + 20, currentPoint.y - 20);
-      popup.show();
+      if (isPointWithinParentBounds(currentPoint)) {
+        final PopupFactory popupFactory = PopupFactory.getSharedInstance();
+        final JToolTip info = new JToolTip();
+        info.setTipText("<html>" + text + "</html>");
+        popup = popupFactory.getPopup(parent, info, currentPoint.x + 20, currentPoint.y - 20);
+        popup.show();
+      }
     }
+  }
+
+  private boolean isPointWithinParentBounds(final Point pointInScreenCoordinates) {
+    final Point pointInParentCoordinates = new Point(pointInScreenCoordinates);
+    SwingUtilities.convertPointFromScreen(pointInParentCoordinates, parent);
+    return parent.getBounds().contains(pointInParentCoordinates);
   }
 }


### PR DESCRIPTION
## Overview

Addresses the issue in #3994 when scrolling the small map until the cursor is over a unit, and releasing the left mouse button, results in a unit tooltip appearing after two seconds.  I'm not sure if this also addresses the other scenarios described in #3994.

The root cause of the issue addressed in this PR is that mouse events are received for the `Window` ancestor of the `parent` parameter passed to `MapUnitTooltipManager` (which is `MapPanel`).  This `Window` includes the small map panel (among other components).  So, to be sure the unit tooltips are only displayed when the mouse cursor is within `MapPanel`, we have to test that the cursor location is within these bounds.

## Functional Changes

* Do not display unit tooltip if the mouse cursor is outside the bounds of the `MapPanel` when a tooltip event is received.

## Manual Testing Performed

* Verified scrolling the small map until the cursor is over a unit, and releasing the left mouse button, does not result in a unit tooltip appearing after two seconds.
* Verified hovering over a unit in the map panel for two seconds results in the unit tooltip being displayed.  Including when the map panel coordinate system != the screen coordinate system (e.g. when the window is not maximized and its top-left corner is positioned somewhere away from the top-left corner of the screen).

## Additional Review Notes

Please review with whitespace changes ignored.