### PR TITLE
Initialize JavaFX text field selection component

### DIFF
--- a/game-core/src/main/java/org/triplea/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-core/src/main/java/org/triplea/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -162,7 +162,13 @@ class JavaFxSelectionComponentFactory {
 
   static Supplier<SelectionComponent<Region>> textField(final ClientSetting clientSetting) {
     return () -> new SelectionComponent<Region>() {
-      final TextField textField = new TextField();
+      final TextField textField = newTextField();
+
+      private TextField newTextField() {
+        final TextField textField = new TextField();
+        textField.setText(clientSetting.value());
+        return textField;
+      }
 
       @Override
       public Region getUiComponent() {


### PR DESCRIPTION
## Overview

The `JavaFxSelectionComponentFactory#textField()` method does not initialize the underlying `TextField` with the current value of the `ClientSetting`.  This PR corrects that.

## Functional Changes

* Initialize the `TextField` value using the current value of the associated `ClientSetting`.

## Manual Testing Performed

* Verified the lobby host override setting is initialized correctly in the JFX client settings window.
* Verified changing the lobby host override setting in the JFX client settings window and saving the settings pushes the new value to the preference store.