### PR TITLE
Simplify game-headed Gradle tasks

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -65,7 +65,7 @@ task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]
     }
 }
 
-task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
+task headedGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     baseName = 'triplea'
     classifier = 'all_platforms'
     from project(':game-core').file('game_engine.properties')
@@ -80,9 +80,9 @@ task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
     }
 }
 
-task release(group: 'release', dependsOn: [generateZipReleases, generateInstallerReleases]) {
+task release(group: 'release', dependsOn: [headedGameArchive, generateInstallerReleases]) {
     doLast {
-        publishArtifacts(generateZipReleases.outputs.files + [
+        publishArtifacts(headedGameArchive.outputs.files + [
             file("$releasesDir/TripleA_${version}_macos.dmg"),
             file("$releasesDir/TripleA_${version}_unix.sh"),
             file("$releasesDir/TripleA_${version}_windows-32bit.exe"),

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -32,7 +32,7 @@ run {
     workingDir = project(':game-core').projectDir
 }
 
-task downloadAssets(group: 'release') {
+task downloadInstallerAssets(group: 'release') {
     doLast {
         [
             'icons/triplea_icon_16_16.png',
@@ -54,12 +54,13 @@ task downloadAssets(group: 'release') {
     }
 }
 
-task generateInstallers(type: com.install4j.gradle.Install4jTask, dependsOn: [shadowJar, downloadAssets], group: 'release') {
+task headedGameInstallers(
+        type: com.install4j.gradle.Install4jTask,
+        group: 'release',
+        dependsOn: [shadowJar, downloadInstallerAssets]) {
     projectFile = file('build.install4j')
     release = version
-}
 
-task generateInstallerReleases(group: 'release', dependsOn: [generateInstallers]) {
     doLast {
         ant.chmod(dir: releasesDir, perm: '+x', includes: '*.sh')
     }
@@ -80,7 +81,7 @@ task headedGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     }
 }
 
-task release(group: 'release', dependsOn: [headedGameArchive, generateInstallerReleases]) {
+task release(group: 'release', dependsOn: [headedGameArchive, headedGameInstallers]) {
     doLast {
         publishArtifacts(headedGameArchive.outputs.files + [
             file("$releasesDir/TripleA_${version}_macos.dmg"),

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -82,8 +82,7 @@ task generateZipReleases(type: Zip, group: 'release', dependsOn: shadowJar) {
 
 task release(group: 'release', dependsOn: [generateZipReleases, generateInstallerReleases]) {
     doLast {
-        publishArtifacts([
-            file("$distsDir/triplea-${version}-all_platforms.zip"),
+        publishArtifacts(generateZipReleases.outputs.files + [
             file("$releasesDir/TripleA_${version}_macos.dmg"),
             file("$releasesDir/TripleA_${version}_unix.sh"),
             file("$releasesDir/TripleA_${version}_windows-32bit.exe"),


### PR DESCRIPTION
## Overview

A few minor simplifications of the Gradle tasks in the `game-headed` project.  Some were done simply for consistency with the other Gradle buildscripts that produce artifacts.  Please see the commit list for context.

## Functional Changes

None.

## Manual Testing Performed

* Created a branch in my fork to build the full release and verified all `game-headed` artifacts were produced as expected.
* Verified the Unix installer has the executable bit set during a local run of the `:game-headed:release` task.