### PR TITLE
Fix raw type usage

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -121,7 +121,7 @@ public enum SettingsWindow {
     int row = 0;
     for (final ClientSettingSwingUiBinding setting : settings) {
       final SelectionComponent<JComponent> selectionComponent =
-          selectionComponentsBySetting.computeIfAbsent(setting, GameSettingUiBinding::newSelectionComponent);
+          selectionComponentsBySetting.computeIfAbsent(setting, ClientSettingSwingUiBinding::newSelectionComponent);
       final int topInset = (row == 0) ? 0 : 10;
       panel.add(
           JLabelBuilder.builder()


### PR DESCRIPTION
## Overview

Fixes the following `rawtypes` warning emitted by the compiler:

```
.../game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java:124: warning: [rawtypes] found raw type: GameSettingUiBinding
          selectionComponentsBySetting.computeIfAbsent(setting, GameSettingUiBinding::newSelectionComponent);
                                                                ^
  missing type arguments for generic class GameSettingUiBinding<T>
  where T is a type-variable:
    T extends Object declared in interface GameSettingUiBinding
```

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the Swing settings window.