### PR TITLE
Error Prone: Fix reference equality violations in GameDataExporter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -7,8 +7,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.logging.Level;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
@@ -45,6 +46,8 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Tuple;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.extern.java.Log;
 
 /**
@@ -641,28 +644,12 @@ public class GameDataExporter {
     xmlfile.append("    </map>\n");
   }
 
-  private static final class Connection {
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  @VisibleForTesting
+  static final class Connection {
     private final Territory territory1;
     private final Territory territory2;
-
-    private Connection(final Territory t1, final Territory t2) {
-      territory1 = t1;
-      territory2 = t2;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(territory1) + Objects.hashCode(territory2);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (o == null) {
-        return false;
-      }
-      final Connection con = (Connection) o;
-      return (territory1 == con.territory1 && territory2 == con.territory2);
-    }
   }
 
   private void connections(final GameData data) {

--- a/game-core/src/test/java/games/strategy/engine/data/export/GameDataExporterTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/export/GameDataExporterTest.java
@@ -1,0 +1,27 @@
+package games.strategy.engine.data.export;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class GameDataExporterTest {
+  @Nested
+  final class ConnectionTest {
+    @Nested
+    final class EqualsAndHashCodeTest {
+      @Test
+      void shouldBeEquatableAndHashable() {
+        final GameData gameData = new GameData();
+        EqualsVerifier.forClass(GameDataExporter.Connection.class)
+            .withPrefabValues(
+                Territory.class,
+                new Territory("redTerritory", gameData),
+                new Territory("blackTerritory", gameData))
+            .verify();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `GameDataExporter$Connection` class.  The reference equality checks here were part of an `equals()` implementation and should have been using value equality to begin with.

## Functional Changes

None.

## Manual Testing Performed

Exported a map before and after this change and verified the results were identical.