### PR TITLE
Error Prone: Fix reference equality violations in RouteFinder

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -65,7 +64,7 @@ class RouteFinder {
   private Route getRoute(final Territory start, final Territory destination) {
     final List<Territory> route = new ArrayList<>();
     Territory current = destination;
-    while (!Objects.equals(current, start)) {
+    while (!start.equals(current)) {
       if (current == null) {
         return null;
       }

--- a/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -64,7 +65,7 @@ class RouteFinder {
   private Route getRoute(final Territory start, final Territory destination) {
     final List<Territory> route = new ArrayList<>();
     Territory current = destination;
-    while (current != start) {
+    while (!Objects.equals(current, start)) {
       if (current == null) {
         return null;
       }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `RouteFinder` class.

An analysis of the code shows that value equality should be equivalent to reference equality here.  Because at least one of the arguments is `null`, I used `Objects#equals()` instead of calling `Object#equals()` directly.

## Functional Changes

None.

## Manual Testing Performed

Tested various combat moves to verify the expected route was found correctly.