### PR TITLE
Fix NPE when deserializing graph with circular references on Java 9+

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
@@ -40,5 +42,11 @@ public class DefaultNamed extends GameDataComponent implements Named {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(getClass()).add("name", m_name).toString();
+  }
+
+  // Workaround for JDK-8199664
+  @SuppressWarnings("static-method")
+  private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
   }
 }


### PR DESCRIPTION
## Overview

This is a possible fix for #3274.

It implements the workaround described in JDK-8199664.  Based on all the error reports we've had related to this problem, I think providing a `readObject()` method in `DefaultNamed` _may_ be sufficient, as opposed to my original suggestion that it would have to be added to all `Serializable` classes that are part of a `GameData` graph.  I suspect we'll just have to wait to see if there are any other scenarios where a similar problem manifests.

## Functional Changes

None.

## Manual Testing Performed

I was able to use the reproduction steps in #3997 to reliably reproduce the NPE when run under JDK-9.0.4.  I verified that no NPE occurs in the same scenario with this fix.