### PR TITLE
Rename game-headed archive artifact

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -83,8 +83,6 @@ task headedGameInstallers(
 }
 
 task headedGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
-    baseName = 'triplea'
-    classifier = 'all_platforms'
     from project(':game-core').file('.triplea-root')
     from(project(':game-core').file('assets')) {
         into 'assets'


### PR DESCRIPTION
## Overview

Renames the `game-headed` project's archive artifact (i.e. the portable build) to follow the standard naming convention of _&lt;group>-&lt;artifact>-&lt;version>.zip_.  This convention is already being used by the `game-headless` project.

For example, _triplea-1.9.0.0.12345-all_platforms.zip_ will now be named _triplea-game-headed-1.9.0.0.12345.zip_.

I grepped the code on `infrastructure:master` to verify it no longer contains a reference to this artifact with the old name (this was changed in triplea-game/infrastructure#133).

## Functional Changes

None.

## Manual Testing Performed

Built a full release in my fork to ensure the newly-named artifact is published.