### PR TITLE
Remove HeadlessGameServer entry point

### DIFF
--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -14,7 +14,7 @@ loosely maps to an app.
 ### User-Facing TripleA Apps
 - [Lobby](https://github.com/triplea-game/triplea/tree/master/lobby)
 - Dice Roller (aka: marti)
-- [Bot (game hosting) servers](https://github.com/triplea-game/triplea/blob/master/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java)
+- [Bot (game hosting) servers](https://github.com/triplea-game/triplea/tree/master/game-headless)
 - [NodeBB Forums](https://forums.triplea-game.org) (nodeBB)
 
 ### Support Apps

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -527,9 +527,14 @@ public class HeadlessGameServer {
   }
 
   /**
-   * Launches a bot server. Most properties are passed via command line-like arguments.
+   * Starts a new headless game server. This method will return before the headless game server exits. The headless game
+   * server runs until the process is killed or the headless game server is shut down via administrative command.
+   *
+   * <p>
+   * Most properties are passed via command line-like arguments.
+   * </p>
    */
-  public static void main(final String[] args) {
+  public static void start(final String[] args) {
     final ArgValidationResult validation = HeadlessGameServerCliParam.validateArgs(args);
     if (!validation.isValid()) {
       log.log(Level.SEVERE,

--- a/game-headless/src/main/java/org/triplea/game/headless/runner/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/headless/runner/HeadlessGameRunner.java
@@ -13,6 +13,6 @@ public final class HeadlessGameRunner {
    * the headless game server is shut down via administrative command.
    */
   public static void main(final String[] args) {
-    HeadlessGameServer.main(args);
+    HeadlessGameServer.start(args);
   }
 }


### PR DESCRIPTION
## Overview

Removes the `HeadlessGameServer#main()` entry point.  After triplea-game/infrastructure#133, there are no longer any references to this entry point.

## Functional Changes

None.

## Manual Testing Performed

Verified I could start a bot from the IDE, from the Gradle `:game-headless:run` task, and using the zip archive artifact produced by the `game-headless` project.