### PR TITLE
Target Java 8 in Java 9 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle
 .idea
 .project
+.remote-libs/
 .settings
 .checkstyle
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,15 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
 }
 
 subprojects {
+    apply plugin: 'checkstyle'
+    apply plugin: 'jacoco'
+    apply plugin: 'java'
+    apply plugin: 'net.ltgt.errorprone'
+
+    apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
+    apply from: "${rootProject.projectDir}/gradle/scripts/remote-lib.gradle"
+    apply from: "${rootProject.projectDir}/gradle/scripts/version.gradle"
+
     group = 'triplea'
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -40,14 +49,6 @@ subprojects {
         postgresqlVersion = '42.2.2'
         sonatypeGoodiesPrefsVersion = '2.2.4'
     }
-
-    apply plugin: 'checkstyle'
-    apply plugin: 'jacoco'
-    apply plugin: 'java'
-    apply plugin: 'net.ltgt.errorprone'
-
-    apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
-    apply from: "${rootProject.projectDir}/gradle/scripts/version.gradle"
 
     repositories {
         jcenter()
@@ -87,6 +88,11 @@ subprojects {
         ]
         options.encoding = 'UTF-8'
         options.incremental = true
+
+        // workaround for https://github.com/gradle/gradle/issues/2510
+        if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+            options.compilerArgs += ['--release', '8']
+        }
     }
 
     check {

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -11,6 +11,7 @@ mainClassName = 'org.triplea.game.headed.runner.HeadedGameRunner'
 version = getEngineVersion()
 
 ext {
+    javaFxRuntimeUrl = 'https://github.com/triplea-game/assets/raw/master/javafx/jfxrt-1.8.0_181.jar'
     releasesDir = file("$buildDir/releases")
     testFxVersion = '4.0.13-alpha'
 }
@@ -18,10 +19,18 @@ ext {
 dependencies {
     compile project(':game-core')
 
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+        compileOnly remoteLib(javaFxRuntimeUrl)
+    }
+
     testCompile project(':test-common')
     testCompile "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
     testCompile "org.testfx:testfx-core:$testFxVersion"
     testCompile "org.testfx:testfx-junit5:$testFxVersion"
+
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+        testCompileOnly remoteLib(javaFxRuntimeUrl)
+    }
 
     if (JavaVersion.current() == JavaVersion.VERSION_1_9) {
         testRuntimeOnly 'org.testfx:openjfx-monocle:jdk-9+181'

--- a/gradle/scripts/remote-lib.gradle
+++ b/gradle/scripts/remote-lib.gradle
@@ -1,0 +1,32 @@
+import java.nio.file.Paths
+
+import de.undercouch.gradle.tasks.download.DownloadAction
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath group: 'de.undercouch', name: 'gradle-download-task', version: '3.4.3'
+    }
+}
+
+def remoteLibsDir = file('.remote-libs')
+
+ext.remoteLib = { url ->
+    def file = file("$remoteLibsDir/${Paths.get(new URI(url).path).fileName}")
+    def download = new DownloadAction(project)
+    download.src url
+    download.dest file
+    download.overwrite false
+    download.execute()
+    files(file)
+}
+
+task cleanRemoteLibs(
+        type: Delete,
+        group: LifecycleBasePlugin.BUILD_GROUP,
+        description: 'Deletes the remote libraries directory.') {
+    delete remoteLibsDir
+}


### PR DESCRIPTION
## Overview

Fixes #2803.

## Functional Changes

* Pass `--release 8` to the compiler in the Java 9 build to ensure it links against the Java 8 runtime.
* Because the `--release` flag only uses the public JDK, it does not include any extensions that may be installed, and JavaFX is considered an extension to Java 8.  Therefore, we have to bring the JavaFX 8 runtime in as a dependency.  This dependency is not available publicly, so the version from the latest JDK 8 was added to our `assets` repo (triplea-game/assets#21).

## Manual Testing Performed

Ran a local build using Java 9 to produce the `game-headed` artifacts.  Ran the portable build artifact under Java 8 and verified I could connect to the lobby (the original problem reported in #2801).  Also verified the JavaFX client ran correctly from both Java 8 and Java 9.