### PR TITLE
Rename lobby archive artifact

### DIFF
--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -24,8 +24,6 @@ jar {
 }
 
 task lobbyArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
-    baseName = 'triplea'
-    classifier = 'server'
     from('config') {
         into 'config'
     }


### PR DESCRIPTION
## Overview

Renames the `lobby` project's archive artifact to follow the standard naming convention of _&lt;group>-&lt;artifact>-&lt;version>.zip_.  This convention is already being used by the `game-headed` and `game-headless` projects.

For example, _triplea-1.9.0.0.12345-server.zip_ will now be named _triplea-lobby-1.9.0.0.12345.zip_.

**This PR should be merged simultaneously with triplea-game/infrastructure#134 to minimize potential failures when the infrastructure attempts to deploy the new lobby to PreRelease.**

## Functional Changes

None.

## Manual Testing Performed

Built a full release in my fork to ensure the newly-named artifact is published.