### PR TITLE
Disable JDK linter annotation processing warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ subprojects {
     tasks.withType(JavaCompile).configureEach {
         options.compilerArgs += [
             '-Xep:ParameterName:OFF', // workaround for https://github.com/google/error-prone/issues/780
-            '-Xlint:all',
+            '-Xlint:all,-processing',
             '-Xmaxwarns', '1000'
         ]
         options.encoding = 'UTF-8'


### PR DESCRIPTION
## Overview

Disables the `processing` class of JDK linter warnings.  For example:

> warning: No processor claimed any of these annotations: org.junit.jupiter.api.Test,org.mockito.InjectMocks,org.junit.jupiter.api.BeforeEach,org.triplea.test.common.Integration,org.junit.jupiter.api.extension.ExtendWith,org.mockito.Mock,org.junit.jupiter.api.Nested,javax.annotation.Nullable

This class of warnings only seems useful if we were writing our own annotation processors in order to detect mistakes that prevent those processors from being applied to the desired annotations.  Since we have no annotation processors in the TripleA code, the warnings we get about third-party annotations not being processed is simply noise.

It would be ideal if the JDK provided the ability to suppress this warning for individual annotations that are known to not require an annotation processor.  Unfortunately, it doesn't.

See the [javac docs](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javac.html#BHCJCABJ) for more information about the `-Xlint:processing` warning.

## Functional Changes

None.

## Manual Testing Performed

None.