### PR TITLE
Add missing serialVersionUID

### DIFF
--- a/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitException.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/rate/RateLimitException.java
@@ -7,4 +7,5 @@ import org.triplea.http.client.throttle.MessageNotSentException;
  * are blocked client-side from being sent.
  */
 public class RateLimitException extends MessageNotSentException {
+  private static final long serialVersionUID = -6955742287574721284L;
 }


### PR DESCRIPTION
## Overview

Adds the missing `serialVersionUID` field to the `RateLimitException` class, as identified by static analysis.

## Functional Changes

None.

## Manual Testing Performed

None.