### PR TITLE
Error Prone: Fix reference equality violations in AI code

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -192,7 +192,7 @@ final class ProTechAi {
             }
             if (!t4.equals(waterCheck)) {
               final Route seaRoute = getMaxSeaRoute(data, t4, waterCheck, enemyPlayer, maxTransportDistance);
-              if (seaRoute == null || seaRoute.getEnd() == null || seaRoute.getEnd() != waterCheck) {
+              if (seaRoute == null || seaRoute.getEnd() == null || !seaRoute.getEnd().equals(waterCheck)) {
                 continue;
               }
             }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.Streams;
 
 import games.strategy.engine.data.GameData;
@@ -776,7 +778,7 @@ public class WeakAi extends AbstractAi {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int totalPu = player.getResources().getQuantity(pus);
     int leftToSpend = totalPu;
-    final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+    final @Nullable Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
     final List<RepairRule> repairRules;
@@ -808,7 +810,7 @@ public class WeakAi extends AbstractAi {
         if (Matches.unitHasTakenSomeBombingUnitDamage().test(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
         }
-        if (fixTerr == capitol) {
+        if (fixTerr.equals(capitol)) {
           capProduction =
               TripleAUnit.getHowMuchCanUnitProduce(possibleFactoryNeedingRepair, fixTerr, player, data, true, true);
           capUnit = possibleFactoryNeedingRepair;
@@ -990,13 +992,13 @@ public class WeakAi extends AbstractAi {
     if (player.getUnits().size() == 0) {
       return;
     }
-    final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+    final @Nullable Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     // place in capitol first
     placeAllWeCanOn(data, capitol, placeDelegate, player);
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {
-      if (t != capitol && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
+      if (!t.equals(capitol) && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 
@@ -54,7 +56,9 @@ public class TerritoryAttachment extends DefaultAttachment {
    * own.
    * If a capital has no neighbor connections, it will be sent last.
    */
-  public static Territory getFirstOwnedCapitalOrFirstUnownedCapital(final PlayerID player, final GameData data) {
+  public static @Nullable Territory getFirstOwnedCapitalOrFirstUnownedCapital(
+      final PlayerID player,
+      final GameData data) {
     final List<Territory> capitals = new ArrayList<>();
     final List<Territory> noNeighborCapitals = new ArrayList<>();
     for (final Territory current : data.getMap().getTerritories()) {


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in AI code.

An analysis of the code revealed that value equality should be appropriate in the instances where reference equality was being used.  In all cases, I was able to identify one object in the equality relation that was guaranteed to be non-`null`, and so I used `Object#equals()` as the replacement expression.

## Functional Changes

None.

## Refactoring Changes

* I added `@Nullable` in a few places to help identify values that can be `null`.

## Manual Testing Performed

None.