### PR TITLE
Add sample scripts for running a bot

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*       text=auto
+*.bat   text eol=crlf

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -1,3 +1,6 @@
+import org.apache.tools.ant.filters.FixCrLfFilter
+import org.apache.tools.ant.filters.ReplaceTokens
+
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
@@ -26,6 +29,11 @@ task headlessGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     from project(':game-core').file('.triplea-root')
     from(project(':game-core').file('assets')) {
         into 'assets'
+    }
+    from file('scripts/run_bot')
+    from(file('scripts/run_bot.bat')) {
+        filter(ReplaceTokens, tokens: [version: version])
+        filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance("crlf")) // workaround for https://github.com/gradle/gradle/issues/1151
     }
     from(shadowJar.outputs) {
         into 'bin'

--- a/game-headless/scripts/run_bot
+++ b/game-headless/scripts/run_bot
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# This is a sample script for running a TripleA bot on a Unix-like system.
+#
+# THIS SCRIPT MAY NOT RUN CORRECTLY UNLESS YOU CUSTOMIZE SOME OF THE VARIABLES
+# BELOW!  Please read each variable description carefully and modify them, if
+# appropriate.
+#
+# To run this script, change to the directory in which you unpacked the
+# headless game server archive, and type "./run_bot".
+#
+
+###############################################################################
+# VARIABLES THAT YOU MAY CUSTOMIZE BEGIN HERE
+###############################################################################
+
+#
+# The folder from which the bot will load game maps.
+#
+# The default value is the folder in which the TripleA game client stores
+# maps that it downloads.  Under normal circumstances, you will not have to
+# change this variable.  However, if you customized the settings in your
+# TripleA client to use a different maps folder, you should change this
+# variable to refer to the same location.
+#
+readonly MAPS_FOLDER="$HOME/triplea/downloadedMaps"
+
+#
+# The port on which the bot will listen for connections.  This port must be
+# reachable from the Internet, so you may have to configure your firewall
+# appropriately.
+#
+# Under normal circumstances, you will not have to change this variable.
+# However, if you choose to run multiple bots on your system, you need to
+# select a different available port for each bot.
+#
+readonly BOT_PORT=3300
+
+#
+# The name of the bot as displayed in the lobby.  Each bot must have a unique
+# name.
+#
+# The default value uses a combination of your username and the local port
+# you selected above on which the bot will run.  Under normal circumstances,
+# you will not have to change this variable.
+#
+readonly BOT_NAME="Bot_${USER}_${BOT_PORT}"
+
+#
+# The password used to secure access to games running on your bot.  Users
+# attempting to start a new game or connect to an existing game on your bot
+# will be prompted for this password.  If the password is an empty string,
+# the user will not be prompted, and any lobby user will be able to use your
+# bot.
+#
+# The default value is an empty password. You should change this to a
+# non-empty string if you do not want arbitrary users to use your bot.  For
+# example, you may wish to run a private game for you and some friends.  In
+# that case, set the password to a non-empty string and communicate it to
+# your friends in some manner (e.g. via email).
+#
+readonly BOT_PASSWORD=
+
+#
+# The hostname of the lobby to which the bot will connect.
+#
+# The default value is the hostname for the TripleA community's public lobby.
+# Under normal circumstances, you will not have to change this variable.
+#
+readonly LOBBY_HOST=lobby.triplea-game.org
+
+#
+# The port on which the lobby to which the bot will connect listens for
+# connections.
+#
+# The default value is the port for the TripleA community's public lobby.
+# Under normal circumstances, you will not have to change this variable.
+#
+readonly LOBBY_PORT=3304
+
+#
+# The email address at which you can be contacted.  Lobby moderators will
+# communicate with you using this email address if they notice problems with
+# your bot, or if they need to perform remote maintenance on your bot (e.g.
+# to shut down your bot).
+#
+# The default value is meaningless.  IT IS STRONGLY RECOMMENDED THAT YOU
+# CHANGE THIS VARIABLE TO A VALID EMAIL ADDRESS THAT YOU CONTROL.
+#
+readonly LOBBY_SUPPORT_EMAIL="${USER}@localhost.localdomain"
+
+#
+# The password used to secure remote maintenance of your bot.  A lobby
+# moderator who wishes to perform remote maintenance on your bot will be
+# required to enter this password in order to complete any maintenance
+# action.  If the password is an empty string, a lobby moderator will be able
+# to perform remote maintenance on your bot without your permission.
+#
+# The default value is an empty password. You should change this to a
+# non-empty string if you do not want lobby moderators to interfere with the
+# operation of your bot.  Note that a lobby moderator that cannot perform
+# remote maintenance of your bot may choose to boot your bot from the lobby.
+#
+readonly LOBBY_SUPPORT_PASSWORD=
+
+###############################################################################
+# VARIABLES THAT YOU MAY CUSTOMIZE END HERE
+#
+# DO NOT MODIFY ANYTHING BELOW THIS LINE!
+###############################################################################
+
+java \
+    -server \
+    -Xmx256M \
+    -Djava.awt.headless=true \
+    -jar bin/triplea-game-headless-*-all.jar \
+    -Ptriplea.game= \
+    -Ptriplea.lobby.game.comments=automated_host \
+    -Ptriplea.lobby.game.hostedBy="$BOT_NAME" \
+    -Ptriplea.lobby.game.supportEmail="$LOBBY_SUPPORT_EMAIL" \
+    -Ptriplea.lobby.game.supportPassword="$LOBBY_SUPPORT_PASSWORD" \
+    -Ptriplea.lobby.host="$LOBBY_HOST" \
+    -Ptriplea.lobby.port="$LOBBY_PORT" \
+    -Ptriplea.map.folder="$MAPS_FOLDER" \
+    -Ptriplea.name="$BOT_NAME" \
+    -Ptriplea.port="$BOT_PORT" \
+    -Ptriplea.server=true \
+    -Ptriplea.server.password="$BOT_PASSWORD"

--- a/game-headless/scripts/run_bot.bat
+++ b/game-headless/scripts/run_bot.bat
@@ -1,0 +1,128 @@
+@ECHO OFF
+REM
+REM This is a sample batch file for running a TripleA bot on a Windows system.
+REM
+REM THIS SCRIPT MAY NOT RUN CORRECTLY UNLESS YOU CUSTOMIZE SOME OF THE
+REM VARIABLES BELOW!  Please read each variable description carefully and
+REM modify them, if appropriate.
+REM
+REM To run this script, change to the directory in which you unpacked the
+REM headless game server archive, and type "run_bot.bat".
+REM
+
+REM ###########################################################################
+REM VARIABLES THAT YOU MAY CUSTOMIZE BEGIN HERE
+REM ###########################################################################
+
+REM
+REM The folder from which the bot will load game maps.
+REM
+REM The default value is the folder in which the TripleA game client stores
+REM maps that it downloads.  Under normal circumstances, you will not have to
+REM change this variable.  However, if you customized the settings in your
+REM TripleA client to use a different maps folder, you should change this
+REM variable to refer to the same location.
+REM
+SET MAPS_FOLDER=%USERPROFILE%\triplea\downloadedMaps
+
+REM
+REM The port on which the bot will listen for connections.  This port must be
+REM reachable from the Internet, so you may have to configure your firewall
+REM appropriately.
+REM
+REM Under normal circumstances, you will not have to change this variable.
+REM However, if you choose to run multiple bots on your system, you need to
+REM select a different available port for each bot.
+REM
+SET BOT_PORT=3300
+
+REM
+REM The name of the bot as displayed in the lobby.  Each bot must have a unique
+REM name.
+REM
+REM The default value uses a combination of your username and the local port
+REM you selected above on which the bot will run.  Under normal circumstances,
+REM you will not have to change this variable.
+REM
+SET BOT_NAME=Bot_%USERNAME%_%BOT_PORT%
+
+REM
+REM The password used to secure access to games running on your bot.  Users
+REM attempting to start a new game or connect to an existing game on your bot
+REM will be prompted for this password.  If the password is an empty string,
+REM the user will not be prompted, and any lobby user will be able to use your
+REM bot.
+REM
+REM The default value is an empty password. You should change this to a
+REM non-empty string if you do not want arbitrary users to use your bot.  For
+REM example, you may wish to run a private game for you and some friends.  In
+REM that case, set the password to a non-empty string and communicate it to
+REM your friends in some manner (e.g. via email).
+REM
+SET BOT_PASSWORD=
+
+REM
+REM The hostname of the lobby to which the bot will connect.
+REM
+REM The default value is the hostname for the TripleA community's public lobby.
+REM Under normal circumstances, you will not have to change this variable.
+REM
+SET LOBBY_HOST=lobby.triplea-game.org
+
+REM
+REM The port on which the lobby to which the bot will connect listens for
+REM connections.
+REM
+REM The default value is the port for the TripleA community's public lobby.
+REM Under normal circumstances, you will not have to change this variable.
+REM
+SET LOBBY_PORT=3304
+
+REM
+REM The email address at which you can be contacted.  Lobby moderators will
+REM communicate with you using this email address if they notice problems with
+REM your bot, or if they need to perform remote maintenance on your bot (e.g.
+REM to shut down your bot).
+REM
+REM The default value is meaningless.  IT IS STRONGLY RECOMMENDED THAT YOU
+REM CHANGE THIS VARIABLE TO A VALID EMAIL ADDRESS THAT YOU CONTROL.
+REM
+SET LOBBY_SUPPORT_EMAIL=%USERNAME%@localhost.localdomain
+
+REM
+REM The password used to secure remote maintenance of your bot.  A lobby
+REM moderator who wishes to perform remote maintenance on your bot will be
+REM required to enter this password in order to complete any maintenance
+REM action.  If the password is an empty string, a lobby moderator will be able
+REM to perform remote maintenance on your bot without your permission.
+REM
+REM The default value is an empty password. You should change this to a
+REM non-empty string if you do not want lobby moderators to interfere with the
+REM operation of your bot.  Note that a lobby moderator that cannot perform
+REM remote maintenance of your bot may choose to boot your bot from the lobby.
+REM
+SET LOBBY_SUPPORT_PASSWORD=
+
+REM ###########################################################################
+REM VARIABLES THAT YOU MAY CUSTOMIZE END HERE
+REM
+REM DO NOT MODIFY ANYTHING BELOW THIS LINE!
+REM ###########################################################################
+
+java^
+ -server^
+ -Xmx256M^
+ -Djava.awt.headless=true^
+ -jar bin\triplea-game-headless-@version@-all.jar^
+ -Ptriplea.game=^
+ -Ptriplea.lobby.game.comments=automated_host^
+ -Ptriplea.lobby.game.hostedBy=%BOT_NAME%^
+ -Ptriplea.lobby.game.supportEmail=%LOBBY_SUPPORT_EMAIL%^
+ -Ptriplea.lobby.game.supportPassword=%LOBBY_SUPPORT_PASSWORD%^
+ -Ptriplea.lobby.host=%LOBBY_HOST%^
+ -Ptriplea.lobby.port=%LOBBY_PORT%^
+ -Ptriplea.map.folder="%MAPS_FOLDER%"^
+ -Ptriplea.name=%BOT_NAME%^
+ -Ptriplea.port=%BOT_PORT%^
+ -Ptriplea.server=true^
+ -Ptriplea.server.password=%BOT_PASSWORD%


### PR DESCRIPTION
## Overview

Adds sample Unix and Windows scripts for running a bot to the `game-headless` archive artifact.  This should hopefully help us keep how to run a bot documented for end users who wish to do so.

## Functional Changes

* Added the new _run_bot_ (Unix) and _run_bot.bat_ (Windows) scripts to the root directory of the `game-headless` archive artifact.  These scripts are expected to be modified by the user before actual use.  The scripts contain instructions for what needs to be changed.

## Manual Testing Performed

* Created a full release in my fork and confirmed the resulting `game-headless` archive artifact contained the new scripts.
* Verified using the sample scripts from the archive (with appropriate customizations) worked as expected on both Windows and Linux.

## Additional Review Notes

Feedback and suggestions for improvement on the following are welcome:

* The general text within the scripts.  Can anything be improved to help an end-user as opposed to a dev?
* I'm not sure if _scripts_ is the best folder to store the _run_bot*_ scripts within the repo.  Any other name that would be more descriptive here?
* I'll note this below, but I had to jump through some hoops to get _run_bot.bat_ to work with the current version because, AFAIK, the Windows command prompt doesn't support wildcards when running an executable, as Bash does.  Please let me know if there's some wildcard syntax I'm not aware of.

Also note the following:

* These scripts pass an empty server password CLI arg (i.e. `-Ptriplea.server.password=`) if the user doesn't specify a password.  This has a strange side effect: even though an empty password was specified, the server will still prompt the client for a password.  Apparently, the code only checks for a `null` password to determine if it should _not_ prompt the client.  The workaround at this time is simply to leave the password field empty when prompted and click OK.  I plan on submitting a follow-up PR that will fix the server to treat a `null` and empty password identically.