### PR TITLE
Use primitive when boxed variable is never null

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -710,8 +710,8 @@ public class DiceRoll implements Externalizable {
 
   public static void sortByStrength(final List<Unit> units, final boolean defending) {
     final Comparator<Unit> comp = (u1, u2) -> {
-      final Integer v1;
-      final Integer v2;
+      final int v1;
+      final int v2;
       if (defending) {
         v1 = UnitAttachment.get(u1.getType()).getDefense(u1.getOwner());
         v2 = UnitAttachment.get(u2.getType()).getDefense(u2.getOwner());
@@ -719,7 +719,7 @@ public class DiceRoll implements Externalizable {
         v1 = UnitAttachment.get(u1.getType()).getAttack(u1.getOwner());
         v2 = UnitAttachment.get(u2.getType()).getAttack(u2.getOwner());
       }
-      return v1.compareTo(v2);
+      return Integer.compare(v1, v2);
     };
     units.sort(comp);
   }
@@ -741,33 +741,33 @@ public class DiceRoll implements Externalizable {
         // favor rolls over strength
         if (u1.getRoll() || u2.getRoll()) {
           final int u1Bonus = u1.getRoll() && u1CanBonus ? u1.getBonus() : 0;
-          final Integer u2Bonus = u2.getRoll() && u2CanBonus ? u2.getBonus() : 0;
-          compareTo = u2Bonus.compareTo(u1Bonus);
+          final int u2Bonus = u2.getRoll() && u2CanBonus ? u2.getBonus() : 0;
+          compareTo = Integer.compare(u2Bonus, u1Bonus);
           if (compareTo != 0) {
             return compareTo;
           }
         }
         if (u1.getStrength() || u2.getStrength()) {
           final int u1Bonus = u1.getStrength() && u1CanBonus ? u1.getBonus() : 0;
-          final Integer u2Bonus = u2.getStrength() && u2CanBonus ? u2.getBonus() : 0;
-          compareTo = u2Bonus.compareTo(u1Bonus);
+          final int u2Bonus = u2.getStrength() && u2CanBonus ? u2.getBonus() : 0;
+          compareTo = Integer.compare(u2Bonus, u1Bonus);
           if (compareTo != 0) {
             return compareTo;
           }
         }
       } else {
         if (u1.getRoll() || u2.getRoll()) {
-          final Integer u1Bonus = u1.getRoll() && u1CanBonus ? u1.getBonus() : 0;
+          final int u1Bonus = u1.getRoll() && u1CanBonus ? u1.getBonus() : 0;
           final int u2Bonus = u2.getRoll() && u2CanBonus ? u2.getBonus() : 0;
-          compareTo = u1Bonus.compareTo(u2Bonus);
+          compareTo = Integer.compare(u1Bonus, u2Bonus);
           if (compareTo != 0) {
             return compareTo;
           }
         }
         if (u1.getStrength() || u2.getStrength()) {
-          final Integer u1Bonus = u1.getStrength() && u1CanBonus ? u1.getBonus() : 0;
+          final int u1Bonus = u1.getStrength() && u1CanBonus ? u1.getBonus() : 0;
           final int u2Bonus = u2.getStrength() && u2CanBonus ? u2.getBonus() : 0;
-          compareTo = u1Bonus.compareTo(u2Bonus);
+          compareTo = Integer.compare(u1Bonus, u2Bonus);
           if (compareTo != 0) {
             return compareTo;
           }
@@ -790,9 +790,9 @@ public class DiceRoll implements Externalizable {
       // come first, unless we would have support wasted otherwise. This ends up being a pretty tricky math puzzle.
       final Set<UnitType> types1 = u1.getUnitType();
       final Set<UnitType> types2 = u2.getUnitType();
-      final Integer s1 = types1 == null ? 0 : types1.size();
+      final int s1 = types1 == null ? 0 : types1.size();
       final int s2 = types2 == null ? 0 : types2.size();
-      compareTo = s1.compareTo(s2);
+      compareTo = Integer.compare(s1, s2);
       if (compareTo != 0) {
         return compareTo;
       }
@@ -804,7 +804,7 @@ public class DiceRoll implements Externalizable {
       final UnitAttachment ua1 = UnitAttachment.get(unitType1);
       final UnitAttachment ua2 = UnitAttachment.get(unitType2);
       final int unitPower1;
-      final Integer unitPower2;
+      final int unitPower2;
       if (u1.getDefence()) {
         unitPower1 = ua1.getDefenseRolls(PlayerID.NULL_PLAYERID) * ua1.getDefense(PlayerID.NULL_PLAYERID);
         unitPower2 = ua2.getDefenseRolls(PlayerID.NULL_PLAYERID) * ua2.getDefense(PlayerID.NULL_PLAYERID);
@@ -812,7 +812,7 @@ public class DiceRoll implements Externalizable {
         unitPower1 = ua1.getAttackRolls(PlayerID.NULL_PLAYERID) * ua1.getAttack(PlayerID.NULL_PLAYERID);
         unitPower2 = ua2.getAttackRolls(PlayerID.NULL_PLAYERID) * ua2.getAttack(PlayerID.NULL_PLAYERID);
       }
-      return unitPower2.compareTo(unitPower1);
+      return Integer.compare(unitPower2, unitPower1);
     };
     for (final List<UnitSupportAttachment> attachments : support) {
       attachments.sort(compList);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -25,7 +25,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.CollectionUtils;
 
@@ -151,20 +150,6 @@ public class DiceRollTest {
     final DiceRoll roll = DiceRoll.rollDice(units, true, russians, bridge, battle, "",
         TerritoryEffectHelper.getEffects(westRussia), null);
     assertThat(roll.getHits(), is(1));
-  }
-
-  @Test
-  public void testSerialize() {
-    for (int i = 0; i < 254; i++) {
-      for (int j = 0; j < 254; j++) {
-        final Die hit = new Die(i, j, DieType.MISS);
-        assertThat(hit, is(Die.getFromWriteValue(hit.getCompressedValue())));
-        final Die notHit = new Die(i, j, DieType.HIT);
-        assertThat(notHit, is(Die.getFromWriteValue(notHit.getCompressedValue())));
-        final Die ignored = new Die(i, j, DieType.IGNORED);
-        assertThat(ignored, is(Die.getFromWriteValue(ignored.getCompressedValue())));
-      }
-    }
   }
 
   @Test
@@ -454,7 +439,4 @@ public class DiceRollTest {
     assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(2));
     assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(2));
   }
-
-
-
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DieTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DieTest.java
@@ -1,0 +1,26 @@
+package games.strategy.triplea.delegate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class DieTest {
+  @Nested
+  final class CompressionTest {
+    @Test
+    void shouldBeAbleToRoundTripCompressedValue() {
+      for (int i = 0; i < 254; i++) {
+        for (int j = 0; j < 254; j++) {
+          final Die hit = new Die(i, j, Die.DieType.MISS);
+          assertThat(hit, is(Die.getFromWriteValue(hit.getCompressedValue())));
+          final Die notHit = new Die(i, j, Die.DieType.HIT);
+          assertThat(notHit, is(Die.getFromWriteValue(notHit.getCompressedValue())));
+          final Die ignored = new Die(i, j, Die.DieType.IGNORED);
+          assertThat(ignored, is(Die.getFromWriteValue(ignored.getCompressedValue())));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Replaces variables of boxed type with the corresponding primitive type when the variable is guaranteed to never be `null`, as identified by LGTM.

## Functional Changes

None.

## Refactoring Changes

I was originally going to add some characterization tests for the affected methods before making any changes, and so had started out refactoring `DiceRollTest`.  I gave up on the characterization tests due to the complexity of setting up the test fixture required by the affected methods (think attachments calling into other attachments calling into... you get the idea).  However, I kept one refactoring: pulling out an unrelated test for the `Die` class into its own fixture so as not to incur the ~1 second cost of loading and parsing a `GameData` instance it never uses.

## Manual Testing Performed

None.

## Additional Review Notes

Most of the changes are simply replacing expressions of the form `x.compareTo(y)` with `Integer.compare(x, y)`.  Per the Javadocs for `Integer#compare()`:

> The value returned is identical to what would be returned by:
>
> `Integer.valueOf(x).compareTo(Integer.valueOf(y))`