### PR TITLE
Do not prompt for game password when null or empty

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -6,7 +6,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
@@ -38,16 +41,16 @@ public final class ClientLoginValidator implements ILoginValidator {
   }
 
   private final IServerMessenger serverMessenger;
-  private String password;
+  private @Nullable String password;
 
   public ClientLoginValidator(final IServerMessenger serverMessenger) {
     this.serverMessenger = serverMessenger;
   }
 
   /**
-   * Set the password required for the game, or to null if no password is required.
+   * Set the password required for the game. If {@code null} or empty, no password is required.
    */
-  public void setGamePassword(final String password) {
+  public void setGamePassword(final @Nullable String password) {
     // TODO do not store the plain password, but the hash instead in the next incompatible release
     this.password = password;
   }
@@ -58,7 +61,7 @@ public final class ClientLoginValidator implements ILoginValidator {
 
     challenge.put("Sever Version", ClientContext.engineVersion().toString());
 
-    if (password != null) {
+    if (!Strings.isNullOrEmpty(password)) {
       challenge.put(PASSWORD_REQUIRED_PROPERTY, Boolean.TRUE.toString());
       challenge.putAll(Md5CryptAuthenticator.newChallenge());
       challenge.putAll(HmacSha512Authenticator.newChallenge());


### PR DESCRIPTION
## Overview

Follow-up to #4046.

If no game password is specified when running a bot (e.g. not providing `-Ptriplea.server.password` on the command line), the client is not prompted to enter a password.  However, if an empty game password is specified when running a bot (e.g. providing `-Ptriplea.server.password=` on the command line), the client is still prompted to enter a password.  This PR changes the server so that the behavior when the password is `null` or empty is consistent.

## Functional Changes

* If the game server password is `null` or empty, the client is not prompted for a password.  Otherwise, the client is prompted for a password.

## Manual Testing Performed

* Ran a bot without `-Ptriplea.server.password` and verified the client is not prompted for a password.
* Ran a bot with `-Ptriplea.server.password=` and verified the client is not prompted for a password.
* Ran a bot with `-Ptriplea.server.password=1234` and verified the client is prompted for a password.