### PR TITLE
Error Prone: Fix string splitter violations in GameParser

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/data/GameParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameParserTest.java
@@ -1,20 +1,24 @@
 package games.strategy.engine.data;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.util.Tuple;
 
-public final class GameParserTest {
+final class GameParserTest {
   @Nested
-  public final class DecapitalizeTest {
+  final class DecapitalizeTest {
     @Test
-    public void shouldReturnValueWithFirstCharacterDecapitalized() {
+    void shouldReturnValueWithFirstCharacterDecapitalized() {
       Arrays.asList(
           Tuple.of("", ""),
           Tuple.of("N", "n"),
@@ -29,6 +33,43 @@ public final class GameParserTest {
                 GameParser.decapitalize(value),
                 is(decapitalizedValue));
           });
+    }
+  }
+
+  @Nested
+  final class ParsePlayersFromIsDisplayedForTest {
+    private final GameData gameData = new GameData();
+    private final GameParser gameParser = new GameParser(gameData, "mapName");
+
+    private String joinPlayerNames(final PlayerID... playerIds) {
+      return Arrays.stream(playerIds)
+          .map(PlayerID::getName)
+          .collect(Collectors.joining(":"));
+    }
+
+    @Test
+    void shouldReturnPlayersWhenAllPlayersExist() throws Exception {
+      final PlayerID player1 = new PlayerID("player1Name", gameData);
+      gameData.getPlayerList().addPlayerId(player1);
+      final PlayerID player2 = new PlayerID("player2Name", gameData);
+      gameData.getPlayerList().addPlayerId(player2);
+
+      assertThat(
+          gameParser.parsePlayersFromIsDisplayedFor(joinPlayerNames(player1)),
+          contains(player1));
+      assertThat(
+          gameParser.parsePlayersFromIsDisplayedFor(joinPlayerNames(player1, player2)),
+          contains(player1, player2));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAnyPlayerDoesNotExist() {
+      final PlayerID player = new PlayerID("unknownPlayerName", gameData);
+
+      final Exception e = assertThrows(
+          GameParseException.class,
+          () -> gameParser.parsePlayersFromIsDisplayedFor(joinPlayerNames(player)));
+      assertThat(e.getMessage(), containsString("Parse resources could not find player: " + player.getName()));
     }
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `GameParser` class.

## Functional Changes

None.

## Manual Testing Performed

Verified I could start a POS2 game, which uses the `isDisplayedFor` attribute.