### PR TITLE
Error Prone: Fix reference equality violations in TriggerAttachment

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -52,6 +52,7 @@ import games.strategy.triplea.ui.NotificationMessages;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
+import games.strategy.util.ObjectUtils;
 import games.strategy.util.Tuple;
 import lombok.extern.java.Log;
 
@@ -305,7 +306,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (trigger == null) {
       throw new GameParseException("No TriggerAttachment named: " + s[0] + thisErrorMsg());
     }
-    if (trigger == this) {
+    if (ObjectUtils.referenceEquals(trigger, this)) {
       throw new GameParseException("Cannot have a trigger activate itself!" + thisErrorMsg());
     }
     String options = value;


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `TriggerAttachment` class.

An analysis of this code indicates that using value equality on the affected line _may not_ be equivalent.  If you look a few lines above, you'll see that the `trigger` local variable is initialized by finding a `TriggerAttachment` with a specific name.  However, the implementation of `TriggerAttachment#equals()` (in `DefaultAttachment`) is based on more than just the name.  Therefore, it may produce an unexpected inequality if this check were converted from reference equality to value equality.

Thus, I left reference equality in place but converted the expression to use `ObjectUtils#referenceEquals()` to document this decision and suppress the Error Prone warning.

## Functional Changes

None.

## Manual Testing Performed

None.