### PR TITLE
Set initial focus in game server password dialog

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -63,11 +63,19 @@ public class ClientLogin implements IConnectionLogin {
     return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(() -> {
       final JPasswordField passwordField = new JPasswordField();
       passwordField.setColumns(15);
-      JOptionPane.showMessageDialog(
-          JOptionPane.getFrameForComponent(parentComponent),
+      final JOptionPane optionPane = new JOptionPane(
           passwordField,
-          "Enter a password to join the game",
-          JOptionPane.QUESTION_MESSAGE);
+          JOptionPane.QUESTION_MESSAGE,
+          JOptionPane.DEFAULT_OPTION) {
+        private static final long serialVersionUID = -6461902648509091914L;
+
+        @Override
+        public void selectInitialValue() {
+          super.selectInitialValue();
+          passwordField.requestFocusInWindow();
+        }
+      };
+      optionPane.createDialog(parentComponent, "Enter a password to join the game").setVisible(true);
       return new String(passwordField.getPassword());
     })).result.orElse("");
   }


### PR DESCRIPTION
## Overview

When a user is prompted to enter a game server password, the dialog that is displayed has the initial focus set to the **OK** button instead of the password field.  This results in a needless step on the part of the user to change the focus to the password field.  This PR changes the dialog so that the password field receives the initial focus.

## Functional Changes

* Set initial focus in game server password dialog to the password field.

## Manual Testing Performed

Connected to a password-protected server game and, when prompted to enter the game password, verified the initial focus was on the password field.

## Before & After Screen Shots

### Before

![password-dialog-before](https://user-images.githubusercontent.com/4826349/45593358-fc879180-b952-11e8-8c05-603d88b0be22.png)

### After

![password-dialog-after](https://user-images.githubusercontent.com/4826349/45593359-00b3af00-b953-11e8-9eeb-7ebb33ab8521.png)