### PR TITLE
Remove useless comparison test

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -227,17 +227,12 @@ public final class LobbyLoginValidator implements ILoginValidator {
     final StringBuilder sb = new StringBuilder(64);
     sb.append("Ban time left: ");
     if (days > 0) {
-      sb.append(days);
-      sb.append(" Days ");
+      sb.append(days).append(" Days ");
     }
     if (hours > 0) {
-      sb.append(hours);
-      sb.append(" Hours ");
+      sb.append(hours).append(" Hours ");
     }
-    if (minutes > 0) {
-      sb.append(minutes);
-      sb.append(" Minutes ");
-    }
+    sb.append(minutes).append(" Minutes");
     return sb.toString();
   }
 


### PR DESCRIPTION
## Overview

Removes a useless comparison test, as identified by LGTM.  `minutes` is always greater than zero because it is initialized from the expression `Math.max(1, <something>)`, which will always be greater than or equal to 1.

## Functional Changes

None.

## Refactoring Changes

Merged a few lines so that some `StringBuilder` calls read more naturally.

## Manual Testing Performed

Banned a user for one minute and attempted to login as that user when less than one minute was left on the ban.  Verified the error message indicated the ban time remaining was "1 Minutes".