### PR TITLE
Error Prone: Fix reference equality violations in EditValidator

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -29,7 +29,7 @@ class EditValidator {
     // territory cannot be in an UndoableMove route
     final List<UndoableMove> moves = DelegateFinder.moveDelegate(data).getMovesMade();
     for (final UndoableMove move : moves) {
-      if (move.getRoute().getStart() == territory || move.getRoute().getEnd() == territory) {
+      if (move.getRoute().getStart().equals(territory) || move.getRoute().getEnd().equals(territory)) {
         return "Territory is start or end of a pending move";
       }
     }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `EditValidator` class.

An analysis of the affected code indicates value equality is appropriate in both cases.  Further analysis of the `Route` class shows that the start and end territories should never be `null`.  Thus, `Object#equals()` was used to replace the reference equality checks.

## Functional Changes

None.

## Manual Testing Performed

Performed the following test that covers all branches of the affected line:

1. Perform a combat move.
1. Enter edit mode.
1. Attempt to change the owner of the start territory of the combat move.
1. Verify expected error message is displayed.
1. Attempt to change the owner of the end territory of the combat move.
1. Verify expected error message is displayed.
1. Attempt to change the owner of a territory not at the start or end of the combat move.
1. Verify no error message is displayed.