### PR TITLE
Avoid potential overflow during multiplication

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
+++ b/game-core/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
@@ -68,7 +68,7 @@ public class RandomStatsDetails implements Serializable {
       double sumOfSquaredMeanDeviations = 0;
       // TODO: does this need to be updated to take data.getDiceSides() ?
       for (int i = 1; i <= diceSides; i++) {
-        sumOfSquaredMeanDeviations += (stats.getInt(i) - (localTotal / diceSides))
+        sumOfSquaredMeanDeviations += (double) (stats.getInt(i) - (localTotal / diceSides))
             * (stats.getInt(i) - (localTotal / diceSides));
       }
       variance = sumOfSquaredMeanDeviations / (localTotal - 1);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -226,10 +226,10 @@ class ProCombatMoveAi {
       if (isFfa == 1 && tuvSwing > 0) {
         tuvSwing *= 0.5;
       }
-      final double territoryValue = (1 + isLand + isCanHold * (1 + 2 * isFfa * isLand)) * (1 + isEmptyLand)
+      final double territoryValue = (1 + isLand + isCanHold * (1 + 2.0 * isFfa * isLand)) * (1 + isEmptyLand)
           * (1 + isFactory) * (1 - 0.5 * isAmphib) * production;
-      double attackValue = (tuvSwing + territoryValue) * (1 + 4 * isEnemyCapital)
-          * (1 + 2 * isNotNeutralAdjacentToMyCapital) * (1 - 0.9 * isNeutral);
+      double attackValue = (tuvSwing + territoryValue) * (1 + 4.0 * isEnemyCapital)
+          * (1 + 2.0 * isNotNeutralAdjacentToMyCapital) * (1 - 0.9 * isNeutral);
 
       // Check if a negative value neutral territory should be attacked
       if (attackValue <= 0 && !patd.isNeedAmphibUnits() && ProUtils.isNeutralLand(t)) {
@@ -413,7 +413,7 @@ class ProCombatMoveAi {
         totalValue += territoryValueMap.get(ProData.unitTerritoryMap.get(u));
       }
       final double averageValue = totalValue / nonAirAttackers.size() * 0.75;
-      final double territoryValue = territoryValueMap.get(t) * (1 + 4 * isFactory);
+      final double territoryValue = territoryValueMap.get(t) * (1 + 4.0 * isFactory);
       if (!t.isWater() && territoryValue < averageValue) {
         attackMap.get(t).setCanHold(false);
         ProLogger.debug(
@@ -668,7 +668,7 @@ class ProCombatMoveAi {
             isEnemyCapital = 1;
           }
         }
-        final double attackValue = result.getTuvSwing() + production * (1 + 3 * isEnemyCapital);
+        final double attackValue = result.getTuvSwing() + production * (1 + 3.0 * isEnemyCapital);
         if (!patd.isStrafing() && (0.75 * enemyTuvSwing) > attackValue) {
           ProLogger.debug("Removing amphib territory: " + patd.getTerritory() + ", enemyTUVSwing="
               + enemyTuvSwing + ", attackValue=" + attackValue);
@@ -923,7 +923,7 @@ class ProCombatMoveAi {
           capitalValue = ProUtils.getPlayerProduction(t.getOwner(), data);
         }
         final double territoryValue =
-            (1 + isLand - isCantHoldAmphib + isFactory + isCanHold * (1 + 2 * isFfa + 2 * isFactory)) * production
+            (1 + isLand - isCantHoldAmphib + isFactory + isCanHold * (1 + 2.0 * isFfa + 2.0 * isFactory)) * production
                 + capitalValue;
         double tuvSwing = result.getTuvSwing();
         if (isFfa == 1 && tuvSwing > 0) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -395,7 +395,7 @@ class ProNonCombatMoveAi {
       final List<Unit> extraUnits = new ArrayList<>(defendingUnitsAndNotAa);
       extraUnits.removeAll(minDefendingUnitsAndNotAa);
       final double extraUnitValue = TuvUtils.getTuv(extraUnits, ProData.unitValueMap);
-      final double holdValue = extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2 * isMyCapital);
+      final double holdValue = extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2.0 * isMyCapital);
       if (minDefendingUnitsAndNotAa.size() != defendingUnitsAndNotAa.size()
           && (result.getTuvSwing() - holdValue) < minResult.getTuvSwing()) {
         ProLogger
@@ -477,8 +477,8 @@ class ProNonCombatMoveAi {
 
       // Calculate defense value for prioritization
       final double territoryValue =
-          unitOwnerMultiplier * (2 * production + 10 * isFactory + 0.5 * cantMoveUnitValue + 0.5 * neighborValue)
-              * (1 + 10 * isMyCapital) * (1 + 4 * isEnemyOrAlliedCapital);
+          unitOwnerMultiplier * (2.0 * production + 10.0 * isFactory + 0.5 * cantMoveUnitValue + 0.5 * neighborValue)
+              * (1 + 10.0 * isMyCapital) * (1 + 4.0 * isEnemyOrAlliedCapital);
       moveMap.get(t).setValue(territoryValue);
     }
 
@@ -904,7 +904,7 @@ class ProNonCombatMoveAi {
         }
         final int unsafeTransportValue = TuvUtils.getTuv(unsafeTransports, ProData.unitValueMap);
         final double holdValue =
-            extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2 * isMyCapital) - unsafeTransportValue;
+            extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2.0 * isMyCapital) - unsafeTransportValue;
 
         // Find strategic value
         boolean hasHigherStrategicValue = true;
@@ -1422,7 +1422,7 @@ class ProNonCombatMoveAi {
               final int transports = CollectionUtils.countMatches(moveMap.get(t).getAllDefenders(),
                   ProMatches.unitIsOwnedTransport(player));
               final double value = (1 + transports) * moveMap.get(t).getSeaValue()
-                  + (1 + transports * 100) * moveMap.get(t).getValue() / 10000;
+                  + (1 + transports * 100.0) * moveMap.get(t).getValue() / 10000;
               ProLogger.trace(t + ", value=" + value + ", seaValue=" + moveMap.get(t).getSeaValue() + ", tValue="
                   + moveMap.get(t).getValue() + ", transports=" + transports);
               if (value > maxValue) {
@@ -1787,9 +1787,9 @@ class ProNonCombatMoveAi {
         final int isntFactory = ProMatches.territoryHasInfraFactoryAndIsLand().test(t) ? 0 : 1;
         final int hasOwnedCarrier =
             moveMap.get(t).getAllDefenders().stream().anyMatch(ProMatches.unitIsOwnedCarrier(player)) ? 1 : 0;
-        final double airValue = (200.0 * numSeaAttackTerritories + 100 * numLandAttackTerritories
-            + 10 * numEnemyAttackTerritories + numNearbyEnemyTerritories) / (1 + cantHoldWithoutAllies)
-            / (1 + cantHoldWithoutAllies * isntFactory) * (1 + hasOwnedCarrier);
+        final double airValue = (200.0 * numSeaAttackTerritories + 100.0 * numLandAttackTerritories
+            + 10.0 * numEnemyAttackTerritories + numNearbyEnemyTerritories) / (1 + cantHoldWithoutAllies)
+            / (1 + (double) cantHoldWithoutAllies * isntFactory) * (1 + hasOwnedCarrier);
         if (airValue > maxAirValue) {
           maxAirValue = airValue;
           maxTerritory = t;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -515,7 +515,7 @@ class ProPurchaseAi {
 
       // Calculate defense value for prioritization
       final double territoryValue =
-          (2.0 * production + 4 * isFactory + 0.5 * defendingUnitValue) * (1 + isFactory) * (1 + 10.0 * isMyCapital);
+          (2.0 * production + 4.0 * isFactory + 0.5 * defendingUnitValue) * (1 + isFactory) * (1 + 10.0 * isMyCapital);
       placeTerritory.setDefenseValue(territoryValue);
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -515,7 +515,7 @@ class ProPurchaseAi {
 
       // Calculate defense value for prioritization
       final double territoryValue =
-          (2 * production + 4 * isFactory + 0.5 * defendingUnitValue) * (1 + isFactory) * (1 + 10 * isMyCapital);
+          (2.0 * production + 4 * isFactory + 0.5 * defendingUnitValue) * (1 + isFactory) * (1 + 10.0 * isMyCapital);
       placeTerritory.setDefenseValue(territoryValue);
     }
 
@@ -1087,8 +1087,8 @@ class ProPurchaseAi {
       }
 
       // Calculate sea value for prioritization
-      final double territoryValue =
-          placeTerritory.getStrategicValue() * (1 + numMyTransports + 0.1 * numSeaDefenders) / (1 + 3 * needDefenders);
+      final double territoryValue = placeTerritory.getStrategicValue()
+          * (1 + numMyTransports + 0.1 * numSeaDefenders) / (1 + 3.0 * needDefenders);
       ProLogger.debug(t + ", value=" + territoryValue + ", strategicValue=" + placeTerritory.getStrategicValue()
           + ", numMyTransports=" + numMyTransports + ", numSeaDefenders=" + numSeaDefenders + ", needDefenders="
           + needDefenders);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -86,7 +86,7 @@ class ProRetreatAi {
     // Calculate current attack value
     double territoryValue = 0;
     if (result.isHasLandUnitRemaining() || attackers.stream().noneMatch(Matches.unitIsAir())) {
-      territoryValue = result.getWinPercentage() / 100 * (2 * production * (1 + isFactory) * (1 + isCapital));
+      territoryValue = result.getWinPercentage() / 100 * (2.0 * production * (1 + isFactory) * (1 + isCapital));
     }
     double battleValue = result.getTuvSwing() + territoryValue;
     if (!isAttacker) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -306,9 +306,9 @@ final class ProTechAi {
           // played with this value a good bit
           strength += 1.00F;
           if (attacking) {
-            strength += unitAttack * unitAttachment.getHitPoints();
+            strength += (float) unitAttack * unitAttachment.getHitPoints();
           } else {
-            strength += unitAttachment.getDefense(u.getOwner()) * unitAttachment.getHitPoints();
+            strength += (float) unitAttachment.getDefense(u.getOwner()) * unitAttachment.getHitPoints();
           }
           if (attacking && unitAttack == 0) {
             strength -= 0.50F;
@@ -320,7 +320,7 @@ final class ProTechAi {
         } else if (unitAttachment.getIsAir() == sea) {
           strength += 1.00F;
           if (attacking) {
-            strength += unitAttachment.getAttack(u.getOwner()) * unitAttachment.getAttackRolls(u.getOwner());
+            strength += (float) unitAttachment.getAttack(u.getOwner()) * unitAttachment.getAttackRolls(u.getOwner());
           } else {
             strength += unitAttachment.getDefense(u.getOwner());
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -89,7 +89,7 @@ public class ProBattleUtils {
     }
     final int myHitPoints = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);
-    return (2 * myHitPoints) + myPower;
+    return (2.0 * myHitPoints) + myPower;
   }
 
   private static double estimatePower(final Territory t, final List<Unit> myUnits, final List<Unit> enemyUnits,

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -29,7 +29,7 @@ public class ProTerritoryValueUtils {
   public static double findTerritoryAttackValue(final PlayerID player, final Territory t) {
     final GameData data = ProData.getData();
     final int isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).test(t) ? 1 : 0;
-    double value = 3 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
+    double value = 3.0 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
           ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnits().getUnits()), new ArrayList<>(), false);
@@ -191,7 +191,7 @@ public class ProTerritoryValueUtils {
       final int isNeutral = ProUtils.isNeutralLand(t) ? 1 : 0;
       final int landMassSize = 1 + data.getMap()
           .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)).size();
-      final double value = Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3 * isNeutral)
+      final double value = Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3.0 * isNeutral)
           * landMassSize / maxLandMassSize;
       enemyCapitalsAndFactoriesMap.put(t, value);
     }

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/PuChart.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/PuChart.java
@@ -69,7 +69,7 @@ class PuChart {
 
   private void drawEllipseAndString(final int x, final int y, final String string) {
     g2d.setFont(chartFont);
-    g2d.draw(new Ellipse2D.Double(5 + 87 * x, 5 + 87 * y, 72, 72));
+    g2d.draw(new Ellipse2D.Double(5 + 87.0 * x, 5 + 87.0 * y, 72, 72));
     final FontMetrics metrics = g2d.getFontMetrics();
     final int h = metrics.stringWidth(string) / 2;
     final int k = metrics.getHeight() / 2;

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -651,8 +651,8 @@ public class MapPanel extends ImageScrollerLargeView {
     // that way when we scroll slowly we wont notice a glitch
     if (undrawnTiles.isEmpty()) {
       final Rectangle2D extendedBounds = new Rectangle2D.Double(Math.max(model.getX() - preDrawMargin, 0),
-          Math.max(model.getY() - preDrawMargin, 0), getScaledWidth() + (2 * preDrawMargin),
-          getScaledHeight() + (2 * preDrawMargin));
+          Math.max(model.getY() - preDrawMargin, 0), getScaledWidth() + (2.0 * preDrawMargin),
+          getScaledHeight() + (2.0 * preDrawMargin));
       final List<Tile> tileList = tileManager.getTiles(extendedBounds);
       for (final Tile tile : tileList) {
         if (tile.isDirty()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -423,7 +423,7 @@ class StatPanel extends AbstractStatPanel {
       /*
        * Match will Check if terr is a Land Convoy Route and check ownership of neighboring Sea Zone, or if contested
        */
-      return production * Properties.getPuMultiplier(data);
+      return (double) production * Properties.getPuMultiplier(data);
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes potential overflows in multiplicative expressions, as identified by LGTM.

Based on the actual range of the operands involved in these expressions, I don't think any of them would actually overflow.  Nonetheless, these changes ensure the wider type is used consistently throughout the expression.

I believe in all cases there should be no loss in precision.  However, please point out any expression where you think this assertion may not hold.

## Functional Changes

None.

## Manual Testing Performed

None.