### PR TITLE
Error Prone: Fix reference equality violations in TripleAUnit

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -117,8 +117,8 @@ public class TripleAUnit extends Unit {
     // rather we look at the transported by property of units
     for (final Territory t : getData().getMap()) {
       // find the territory this transport is in
-      if (t.getUnits().getUnits().contains(this)) {
-        return t.getUnits().getMatches(o -> TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this);
+      if (t.getUnits().contains(this)) {
+        return getTransporting(t.getUnits());
       }
     }
     return Collections.emptyList();
@@ -127,8 +127,7 @@ public class TripleAUnit extends Unit {
   public List<Unit> getTransporting(final Collection<Unit> transportedUnitsPossible) {
     // we don't store the units we are transporting
     // rather we look at the transported by property of units
-    return CollectionUtils.getMatches(transportedUnitsPossible,
-        o -> TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this);
+    return CollectionUtils.getMatches(transportedUnitsPossible, o -> equals(get(o).getTransportedBy()));
   }
 
   public List<Unit> getUnloaded() {


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `TripleAUnit` class.

An analysis of the code indicates value equality is appropriate here.  Each `Unit` (and thus `TripleAUnit`) is uniquely identified by a `GUID`, and that is the sole field used for comparison in the `Unit#equals()` method.  Therefore, value equality is basically the same as reference equality (except if there is the possibility of the same `Unit` instance being deserialized multiple times).  In fact, value equality is already used in the affected method on line 120 where the unit collection is tested for the presence of `this`.

I replaced the reference equality check with a call to `Object#equals()` since `this` was one of the objects used in the equality comparison and is guaranteed to be non-`null`.

## Functional Changes

None.

## Refactoring Changes

* Got rid of the call to `UnitCollection#getUnits()` on line 120.  `UnitCollection` implements `Collection<Unit>` so that `Collection#contains()` can be called directly without creating an intermediate copy.
* Replaced the call to `UnitCollection#getMatches()` on line 121 with a call to `TripleAUnit#getTransporting(Collection<Unit>)` since it is basically duplicated logic.

## Manual Testing Performed

None.  However, existing unit tests cover both branches in the equality check.