### PR TITLE
Error Prone: Fix string splitter violations in Matches

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1883,7 +1883,7 @@ public final class Matches {
       final String filterForUnitType) {
     return u -> {
       for (final String receives : UnitAttachment.get(u.getType()).getReceivesAbilityWhenWith()) {
-        final String[] s = receives.split(":");
+        final String[] s = receives.split(":", 2);
         if (s[0].equals(filterForAbility) && s[1].equals(filterForUnitType)) {
           return true;
         }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone StringSplitter rule in the `Matches` class.

An analysis of the `UnitAttachment#m_receivesAbilityWhenWith` field shows that its elements will only ever have two tokens, and this is enforced during game parsing.  Therefore, adding a value of `2` for the `limit` parameter of `String#split()` should be sufficient.

## Functional Changes

None.

## Manual Testing Performed

None.