### PR TITLE
Write intermediate save game to file instead of memory

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -1,21 +1,38 @@
 package games.strategy.engine.framework;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
+import java.io.OutputStream;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.io.IoUtils;
-import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
-public class GameDataManagerTest extends AbstractClientSettingTestCase {
-  @Test
-  public void testLoadStoreKeepsGameUuid() throws IOException {
-    final GameData data = new GameData();
-    final byte[] bytes = IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
-    final GameData loaded = IoUtils.readFromMemory(bytes, GameDataManager::loadGame);
-    assertEquals(loaded.getProperties().get(GameData.GAME_UUID), data.getProperties().get(GameData.GAME_UUID));
+final class GameDataManagerTest {
+  @Nested
+  final class RoundTripTest {
+    @Test
+    void shouldPreserveGameUuid() throws Exception {
+      final GameData data = new GameData();
+      final byte[] bytes = IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
+      final GameData loaded = IoUtils.readFromMemory(bytes, GameDataManager::loadGame);
+      assertEquals(loaded.getProperties().get(GameData.GAME_UUID), data.getProperties().get(GameData.GAME_UUID));
+    }
+  }
+
+  @Nested
+  final class SaveGameTest {
+    @Test
+    void shouldCloseOutputStream() throws Exception {
+      final OutputStream os = mock(OutputStream.class);
+
+      GameDataManager.saveGame(os, new GameData());
+
+      verify(os).close();
+    }
   }
 }


### PR DESCRIPTION
## Overview

I was cleaning up some old branches and came across this one from about six months ago.  It seems like a pretty straightforward optimization, but feel free to close it if it's not worth it.

In a nutshell, the `GameDataManager#saveGame()` method would write a save game to memory first just in case an error occurred so that the user's existing save game wouldn't be overwritten with a partial save game.  This PR instead writes the save game to a temporary file first.  If the save is successful, it then copies the temporary file to the file selected by the user.

## Functional Changes

None.

## Manual Testing Performed

Loaded a save game with about 20 rounds from `master`, and then re-saved it using this branch.  Confirmed loading the new save game worked as expected.