### PR TITLE
Preserve map order when making copy

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -81,7 +82,13 @@ public class PlayerListing implements Serializable {
             .orElse(Collections.emptyMap())
             .entrySet()
             .stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> Sets.newHashSet(e.getValue())));
+            .collect(Collectors.toMap(
+                Entry::getKey,
+                e -> Sets.newHashSet(e.getValue()),
+                (u, v) -> {
+                  throw new IllegalStateException(String.format("Duplicate key %s", u));
+                },
+                LinkedHashMap::new));
 
     // make sure none of the collection values are null.
     // m_playerToNodeListing is an exception, it can have null values meaning no user has chosen a given nation.


### PR DESCRIPTION
## Overview

Fixes #4065.

h/t @ron-murhammer for finding the root cause.  The fix is to specify the type of map to be created when making the copy.

## Functional Changes

Order is preserved when copying the `playerNamesAndAlliancesInTurnOrder` map.

## Manual Testing Performed

Verified the player order for Classic was correct in a bot game.