### PR TITLE
Use Lombok Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'net.ltgt.errorprone' version '0.0.15' apply false
+    id 'io.franzbecker.gradle-lombok' version '1.14' apply false
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
@@ -32,6 +33,7 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java'
     apply plugin: 'net.ltgt.errorprone'
+    apply plugin: 'io.franzbecker.gradle-lombok'
 
     apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
     apply from: "${rootProject.projectDir}/gradle/scripts/remote-lib.gradle"
@@ -45,7 +47,6 @@ subprojects {
     ext {
         hamcrestVersion = '2.0.0.0'
         junitJupiterVersion = '5.3.1'
-        lombokVersion = '1.18.0'
         mockitoVersion = '2.22.0'
         postgresqlVersion = '42.2.2'
         sonatypeGoodiesPrefsVersion = '2.2.5'
@@ -61,8 +62,6 @@ subprojects {
     dependencies {
         compile 'com.google.guava:guava:24.1-jre'
 
-        compileOnly "org.projectlombok:lombok:$lombokVersion"
-
         errorprone 'com.google.errorprone:error_prone_core:2.3.1'
 
         testCompile 'nl.jqno.equalsverifier:equalsverifier:2.5.2'
@@ -70,8 +69,6 @@ subprojects {
         testCompile 'org.junit-pioneer:junit-pioneer:0.1.2'
         testCompile "org.mockito:mockito-core:$mockitoVersion"
         testCompile "org.mockito:mockito-junit-jupiter:$mockitoVersion"
-
-        testCompileOnly "org.projectlombok:lombok:$lombokVersion"
 
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 
@@ -126,6 +123,11 @@ subprojects {
             xml.enabled = true
             html.enabled = true
         }
+    }
+
+    lombok {
+        version = '1.18.2'
+        sha256 = 'f13db210efa2092a58bb7befce58ffa502e5fefc5e1099f45007074008756bc0'
     }
 
     test {


### PR DESCRIPTION
## Overview

I've been playing around with transitioning our JDK9 build to JDK10.  As usual, the problems seem to center on the interaction between Lombok and Error Prone. :disappointed: 

Anyway, as part of an incremental movement towards a JDK10+ build, this PR changes the build to use the Lombok Gradle plugin rather than configuring Lombok manually.  Apparently, there are a few other configurations to which Lombok should be applied that we were missing.  It seems better to let the plugin handle those details.

It also upgrades Lombok to the latest version (1.18.0 -> 1.18.2).

## Functional Changes

None.

## Manual Testing Performed

Smoke tested a client run from the Gradle `:game-headed:run` task, as well as the portable build produced by the `:game-headed:headedGameArchive` task.