### PR TITLE
Use Project#findProperty() in Gradle scripts where possible

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -42,7 +42,9 @@ dependencies {
 }
 
 install4j {
-    installDir = file(install4jHomeDir)
+    // If you wish to build the installers, you must install install4j and define the "install4jHomeDir" property on the
+    // command line (e.g. -Pinstall4jHomeDir=...) or in your personal Gradle properties (e.g. ~/.gradle/gradle.properties).
+    installDir = file(project.findProperty('install4jHomeDir') ?: '.')
 }
 
 jar {

--- a/game-headed/gradle.properties
+++ b/game-headed/gradle.properties
@@ -1,5 +1,0 @@
-# DO NOT MODIFY THIS PROPERTY!  If you wish to build the installers, you
-# must install install4j and define this property on the command line
-# (e.g. -Pinstall4jHomeDir=...) or in your personal Gradle properties
-# (e.g. ~/.gradle/gradle.properties).
-install4jHomeDir=.

--- a/gradle/scripts/version.gradle
+++ b/gradle/scripts/version.gradle
@@ -1,5 +1,5 @@
 ext.getBuildId = {
-    return (project.hasProperty('buildId') && !project.buildId.isEmpty()) ? project.buildId : 'dev'
+    return project.findProperty('buildId') ?: 'dev'
 }
 
 ext.getProductVersion = {


### PR DESCRIPTION
## Overview

Uses the Gradle `Project#findProperty()` method to shorten or inline code where possible.

## Functional Changes

None.

## Manual Testing Performed

Ran a full release build in my fork to ensure all artifacts were produced as expected.