### PR TITLE
Update lobby_server.yaml

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -6,8 +6,8 @@
     No talking politics in the lobby! Take your political comments to a private game!
     Lobby Rules: https://forums.triplea-game.org/topic/4
     
-    All bots have been updated to use the latest stable Engine Version: 1.9.0.0.9687. Its strongly recommended that 
-    ALL players update their TripleA install by downloading the latest release here: http://triplea-game.org/download/
+    All automated hosts have been updated to use the latest stable engine. It's recommended that 
+    all players download and install the latest release here: http://triplea-game.org/download/
     
     Please sign up for the upcoming tournaments:
     - Global 1940 2nd: https://forums.triplea-game.org/topic/855/global-1940-2nd-edition-tournament


### PR DESCRIPTION
If it is still true that all bots are updated and you still want to have that warning in the lobby chatlog and because the current release is 1.9.0.0.11996 and I belive it is not advisable having multiple references that need to be all updated each time.
Otherwise, please delete that line totally or update it consistently.