### PR TITLE
Error Prone: Fix reference equality violations in UnitBattleComparator

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -51,7 +51,7 @@ public class UnitBattleComparator implements Comparator<Unit> {
     final boolean transporting2 = TransportTracker.isTransporting(u2);
     final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
     final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
-    if (ua1 == ua2 && u1.getOwner().equals(u2.getOwner())) {
+    if (ua1.equals(ua2) && u1.getOwner().equals(u2.getOwner())) {
       if (transporting1 && !transporting2) {
         return 1;
       }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `UnitBattleComparator` class.

An analysis of the code indicates testing for value equality between instances of `UnitAttachment` should be okay.  `DefaultAttachment` implements a reasonable `equals()` method.  This implementation tests for reference equality first, so it is at least a superset of the existing reference equality check.

`UnitAttachment#get()` is guaranteed to return a non-`null` value, so I replaced the reference equality check with a direct call to `Object#equals()`.

## Functional Changes

None.

## Manual Testing Performed

I tested naval combat involving transports, both with and without cargo.  I verified that the transports without cargo are sorted before those with cargo in the casualty selection dialog.