### PR TITLE
Error Prone: Suppress false positive future return value ignored violations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -69,6 +69,15 @@ public class ChatController implements IChatController {
     chatChannel = getChatChannelName(name);
     this.remoteMessenger.registerRemote(this, getChatControlerRemoteName(name));
     ((IServerMessenger) this.messenger).addConnectionChangeListener(connectionChangeListener);
+    startPinger();
+  }
+
+  public ChatController(final String name, final Messengers messenger, final Predicate<INode> isModerator) {
+    this(name, messenger.getMessenger(), messenger.getRemoteMessenger(), messenger.getChannelMessenger(), isModerator);
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored") // false positive; see https://github.com/google/error-prone/issues/883
+  private void startPinger() {
     pingThread.scheduleAtFixedRate(() -> {
       try {
         getChatBroadcaster().ping();
@@ -76,10 +85,6 @@ public class ChatController implements IChatController {
         log.log(Level.SEVERE, "Error pinging", e);
       }
     }, 180, 60, TimeUnit.SECONDS);
-  }
-
-  public ChatController(final String name, final Messengers messenger, final Predicate<INode> isModerator) {
-    this(name, messenger.getMessenger(), messenger.getRemoteMessenger(), messenger.getChannelMessenger(), isModerator);
   }
 
   // clean up

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -104,6 +104,13 @@ public class HeadlessGameServer {
       waitForUsersHeadless();
     }, "Initialize Headless Server Setup Model").start();
 
+    startLobbyWatcher();
+
+    log.info("Game Server initialized");
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored") // false positive; see https://github.com/google/error-prone/issues/883
+  private void startLobbyWatcher() {
     int reconnect;
     try {
       final String reconnectionSeconds = System.getProperty(LOBBY_GAME_RECONNECTION,
@@ -119,7 +126,6 @@ public class HeadlessGameServer {
         log.log(Level.WARNING, "Failed to restart Lobby watcher", e);
       }
     }, reconnect, reconnect, TimeUnit.SECONDS);
-    log.info("Game Server initialized");
   }
 
   public static synchronized HeadlessGameServer getInstance() {


### PR DESCRIPTION
## Overview

Suppresses false positive violations of the Error Prone FutureReturnValueIgnored rule.

@RoiEXLab originally reported the issue [here](https://github.com/google/error-prone/issues/883), and it seems to have been confirmed as a false positive by two Error Prone contributors [here](https://github.com/google/error-prone/pull/970).  If the PR is ever merged or closed as invalid, we can remove the suppressions at that time (and deal with the issue in an as-yet-to-be-determined way in the latter case).

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

I extracted the relevant code to new private methods in order to keep the scope of the `@SuppressWarnings` annotation as narrow as possible.