### PR TITLE
Performance improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -258,12 +258,6 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     checkNotNull(t1);
     checkNotNull(t2);
 
-    if (t1.equals(t2)) {
-      return new Route(t1);
-    }
-    if (getNeighbors(t1, cond).contains(t2)) {
-      return new Route(t1, t2);
-    }
     return new RouteFinder(this, cond).findRoute(t1, t2).orElse(null);
   }
 
@@ -276,9 +270,6 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       final Predicate<Territory> cond, final Collection<Unit> units, final PlayerID player) {
     checkNotNull(t1);
     checkNotNull(t2);
-    if (t1.equals(t2)) {
-      return new Route(t1);
-    }
     return new RouteFinder(this, Matches.territoryIs(t2).or(cond), units, player).findRoute(t1, t2).orElse(null);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -145,7 +145,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (neighborFilter == null) {
       return getNeighbors(territory);
     }
-    return m_connections.getOrDefault(territory, Collections.emptySet()).stream()
+    return m_connections.getOrDefault(territory, Collections.emptySet())
+        .parallelStream()
         .filter(neighborFilter)
         .collect(Collectors.toSet());
   }
@@ -226,13 +227,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
 
   Set<Territory> getNeighborsValidatingCanals(final Territory territory, final Predicate<Territory> neighborFilter,
       final Collection<Unit> units, final PlayerID player) {
-    final Set<Territory> neighbors = getNeighbors(territory, neighborFilter);
-    if (player != null) {
-      return neighbors.parallelStream()
-          .filter(t -> MoveValidator.canAnyUnitsPassCanal(territory, t, units, player, getData()))
-          .collect(Collectors.toSet());
-    }
-    return neighbors;
+    return getNeighbors(territory, player == null
+        ? neighborFilter
+        : neighborFilter.and(t ->  MoveValidator.canAnyUnitsPassCanal(territory, t, units, player, getData())));
   }
 
   /**


### PR DESCRIPTION
## Overview
Follow-up to #4068

## Functional Changes
None. Perhaps a little "fix" I'll point out in the diff.

## Manual Testing Performed
Route is drawn faster than before.

## Benchmarks
### Disclaimer
The values are not really consistent. I added a print statement to print the ms and went with the mouse in circles over the map while holding a unit.
So there's a little bit of randomness involved.
Also before "direct routes" were calculated outside of the RouteFinder, now they are calculated within this class, so this shifts the performance a little bit in favour of this PR as well.

Average route calculation time before #4068 : 9.402ms
Average route calculation time after this PR: 4.93545ms