### PR TITLE
Error Prone: Fix future return value ignored violations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -31,6 +31,8 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.tree.TreeNode;
 
+import org.triplea.common.util.concurrent.CompletableFutureUtils;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.history.Event;
@@ -96,8 +98,10 @@ class CommentPanel extends JPanel {
     save.setMargin(inset);
     save.setFocusable(false);
     for (final PlayerID playerId : data.getPlayerList().getPlayers()) {
-      CompletableFuture.supplyAsync(() -> frame.getUiContext().getFlagImageFactory().getSmallFlag(playerId))
+      final CompletableFuture<?> future = CompletableFuture
+          .supplyAsync(() -> frame.getUiContext().getFlagImageFactory().getSmallFlag(playerId))
           .thenAccept(image -> SwingUtilities.invokeLater(() -> iconMap.put(playerId, new ImageIcon(image))));
+      CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to load small flag icon for " + playerId);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -79,6 +79,8 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.tree.DefaultMutableTreeNode;
 
+import org.triplea.common.util.concurrent.CompletableFutureUtils;
+
 import com.google.common.base.Preconditions;
 
 import games.strategy.engine.chat.Chat;
@@ -1576,9 +1578,11 @@ public final class TripleAFrame extends JFrame {
       }
     });
     if (player != null && !player.isNull()) {
-      CompletableFuture.supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
+      final CompletableFuture<?> future = CompletableFuture
+          .supplyAsync(() -> uiContext.getFlagImageFactory().getFlag(player))
           .thenApplyAsync(ImageIcon::new)
           .thenAccept(icon -> SwingUtilities.invokeLater(() -> this.round.setIcon(icon)));
+      CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to set round icon for " + player);
       lastStepPlayer = currentStepPlayer;
       currentStepPlayer = player;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -10,10 +10,13 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import javax.imageio.ImageIO;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+
+import org.triplea.common.util.concurrent.CompletableFutureUtils;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.history.HistoryNode;
@@ -57,7 +60,7 @@ public final class ScreenshotExporter {
   }
 
   private void runSave(final GameData gameData, final HistoryNode node, final File file) {
-    SwingComponents.runWithProgressBar(frame, "Saving map snapshot...", () -> {
+    final CompletableFuture<?> future = SwingComponents.runWithProgressBar(frame, "Saving map snapshot...", () -> {
       save(gameData, node, file);
       return null;
     }).whenComplete((ignore, e) -> SwingUtilities.invokeLater(() -> {
@@ -68,6 +71,7 @@ public final class ScreenshotExporter {
         JOptionPane.showMessageDialog(frame, e.getMessage(), "Error Saving Map Snapshot", JOptionPane.ERROR_MESSAGE);
       }
     }));
+    CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to save map snapshot");
   }
 
   private void save(final GameData gameData, final HistoryNode node, final File file) throws IOException {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -28,6 +28,8 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
+import org.triplea.common.util.concurrent.CompletableFutureUtils;
+
 import com.apple.eawt.Application;
 
 import games.strategy.engine.ClientContext;
@@ -246,8 +248,10 @@ public final class HelpMenu extends JMenu {
     // displays whatever is in the notes field in html
     final String trimmedNotes = gameData.getProperties().get("notes", "").trim();
     if (!trimmedNotes.isEmpty()) {
-      CompletableFuture.supplyAsync(() -> LocalizeHtml.localizeImgLinksInHtml(trimmedNotes))
+      final CompletableFuture<?> future = CompletableFuture
+          .supplyAsync(() -> LocalizeHtml.localizeImgLinksInHtml(trimmedNotes))
           .thenAccept(notes -> SwingUtilities.invokeLater(() -> gameNotesPane.setText(notes)));
+      CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to set game notes text");
       gameNotesPane.setEditable(false);
       gameNotesPane.setContentType("text/html");
       gameNotesPane.setForeground(Color.BLACK);

--- a/game-core/src/main/java/org/triplea/common/util/concurrent/CompletableFutureUtils.java
+++ b/game-core/src/main/java/org/triplea/common/util/concurrent/CompletableFutureUtils.java
@@ -1,0 +1,40 @@
+package org.triplea.common.util.concurrent;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.extern.java.Log;
+
+/**
+ * A collection of useful methods for working with instances of {@link CompletableFuture}.
+ */
+@Log
+public final class CompletableFutureUtils {
+  private CompletableFutureUtils() {}
+
+  /**
+   * Logs any exception thrown by {@code future} when it is complete. If {@code future} completes normally, no action is
+   * taken.
+   */
+  public static void logExceptionWhenComplete(final CompletableFuture<?> future, final String message) {
+    checkNotNull(future);
+    checkNotNull(message);
+
+    logExceptionWhenComplete(future, message, log);
+  }
+
+  @SuppressWarnings("FutureReturnValueIgnored")
+  @VisibleForTesting
+  static void logExceptionWhenComplete(final CompletableFuture<?> future, final String message, final Logger logger) {
+    future.whenComplete((result, ex) -> {
+      if (ex != null) {
+        logger.log(Level.SEVERE, message, ex);
+      }
+    });
+  }
+}

--- a/game-core/src/test/java/org/triplea/common/util/concurrent/CompletableFutureUtilsTest.java
+++ b/game-core/src/test/java/org/triplea/common/util/concurrent/CompletableFutureUtilsTest.java
@@ -1,0 +1,47 @@
+package org.triplea.common.util.concurrent;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.triplea.common.util.concurrent.CompletableFutureUtils.logExceptionWhenComplete;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+final class CompletableFutureUtilsTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class LogExceptionWhenCompleteTest {
+    private static final String ERROR_MESSAGE = "error message";
+
+    @Mock
+    private Logger logger;
+
+    @Test
+    void shouldNotWriteLogWhenFutureCompletesNormally() {
+      final CompletableFuture<Object> future = new CompletableFuture<>();
+      logExceptionWhenComplete(future, ERROR_MESSAGE, logger);
+      future.complete(new Object());
+
+      verify(logger, never()).log(any(Level.class), anyString(), any(Throwable.class));
+    }
+
+    @Test
+    void shouldWriteLogWhenFutureCompletesExceptionally() {
+      final CompletableFuture<Object> future = new CompletableFuture<>();
+      logExceptionWhenComplete(future, ERROR_MESSAGE, logger);
+      final Exception ex = new Exception();
+      future.completeExceptionally(ex);
+
+      verify(logger).log(Level.SEVERE, ERROR_MESSAGE, ex);
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone FutureReturnValueIgnored rule.

The fix was to attach a completion handler to all `CompletableFuture` instances that logs any exception thrown during the operation.  A helper method was extracted to implement the handler.  Because that helper method also ignores the returned `CompletableFuture`, Error Prone raises another FutureReturnValueIgnored violation on this method.  By inspection, one can observe we are correctly handling the exception, and so I suppressed the violation on the helper method.

## Functional Changes

None.

## Manual Testing Performed

None.