### PR TITLE
Upgrade TestFX

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -12,7 +12,7 @@ mainClassName = 'org.triplea.game.client.HeadedGameRunner'
 ext {
     javaFxRuntimeUrl = 'https://github.com/triplea-game/assets/raw/master/javafx/jfxrt-1.8.0_181.jar'
     releasesDir = file("$buildDir/releases")
-    testFxVersion = '4.0.13-alpha'
+    testFxVersion = '4.0.14-alpha'
 }
 
 dependencies {


### PR DESCRIPTION
## Overview

Upgrades the TestFX dependency to the latest available version.

This should have been part of #4057, but I didn't want to mess with upgrading Monocle at the time.  It turns out there's no new versions of Monocle for Java 8/9/10, so no Monocle upgrade is necessary.

## Functional Changes

None.

## Manual Testing Performed

None.