### PR TITLE
Error Prone: Fix reference equality violations in PickTerritoryAndUnitsPanel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.Territory;
 
 class DefaultMapSelectionListener implements MapSelectionListener {
@@ -10,5 +12,5 @@ class DefaultMapSelectionListener implements MapSelectionListener {
   public void mouseEntered(final Territory territory) {}
 
   @Override
-  public void mouseMoved(final Territory territory, final MouseDetails me) {}
+  public void mouseMoved(final @Nullable Territory territory, final MouseDetails me) {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -791,7 +792,7 @@ class EditPanel extends ActionPanel {
     }
 
     @Override
-    public void mouseMoved(final Territory territory, final MouseDetails md) {
+    public void mouseMoved(final @Nullable Territory territory, final MouseDetails md) {
       if (!getActive()) {
         return;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.Territory;
 
 interface MapSelectionListener {
@@ -11,5 +13,5 @@ interface MapSelectionListener {
    */
   void mouseEntered(Territory territory);
 
-  void mouseMoved(Territory territory, MouseDetails md);
+  void mouseMoved(@Nullable Territory territory, MouseDetails md);
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 
 import games.strategy.engine.data.GameData;
@@ -1244,7 +1245,7 @@ public class MovePanel extends AbstractMovePanel {
     public void territorySelected(final Territory territory, final MouseDetails me) {}
 
     @Override
-    public void mouseMoved(final Territory territory, final MouseDetails me) {
+    public void mouseMoved(final @Nullable Territory territory, final MouseDetails me) {
       if (!getListening()) {
         return;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 
+import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
@@ -42,7 +42,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
   private List<Unit> unitChoices = null;
   private int unitsPerPick = 1;
   private Action currentAction = null;
-  private Territory currentHighlightedTerritory = null;
+  private @Nullable Territory currentHighlightedTerritory;
 
   public PickTerritoryAndUnitsPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
@@ -226,20 +226,21 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           setWidgetActivation();
         });
       } else {
-        log.log(Level.SEVERE, "Should not be able to select a territory outside of the selectTerritoryAction.");
+        log.severe("Should not be able to select a territory outside of the selectTerritoryAction.");
       }
     }
 
     @Override
-    public void mouseMoved(final Territory territory, final MouseDetails md) {
+    public void mouseMoved(final @Nullable Territory territory, final MouseDetails md) {
       if (!getActive()) {
-        log.log(Level.SEVERE, "Should not be able to select a territory when inactive: " + territory);
+        log.severe("Should not be able to select a territory when inactive: " + territory);
         return;
       }
+
       if (territory != null) {
         // highlight territory
         if (currentAction == selectTerritoryAction) {
-          if (currentHighlightedTerritory != territory) {
+          if (!territory.equals(currentHighlightedTerritory)) {
             if (currentHighlightedTerritory != null) {
               getMap().clearTerritoryOverlay(currentHighlightedTerritory);
             }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `PickTerritoryAndUnitsPanel` class.

An analysis of the code shows that value equality is appropriate in this case. Because one of the instances in the equality relationship is guaranteed to be non-`null`, a direct call to `Object#equals()` was used to replace the reference equality check.

## Functional Changes

None.

## Refactoring Changes

* Added `@Nullable` annotations where appropriate to document the nullity of the variables involved in the affected equality check.  Because one of the operands came from an interface method, I subsequently updated the interface and all implementors with the nullity information.
* Unrelated to this PR: replaced `Logger#log()` with `Logger#severe()`, where possible, in `PickTerritoryAndUnitsPanel`.

## Manual Testing Performed

None.