### PR TITLE
Nest EqualsVerifier tests to avoid static method warnings

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
@@ -1,12 +1,16 @@
 package games.strategy.engine.data;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public final class FakeAttachmentTest {
-  @Test
-  public void shouldBeEquatableAndHashable() {
-    EqualsVerifier.forClass(FakeAttachment.class).verify();
+final class FakeAttachmentTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(FakeAttachment.class).verify();
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/net/GuidTest.java
+++ b/game-core/src/test/java/games/strategy/net/GuidTest.java
@@ -1,15 +1,19 @@
 package games.strategy.net;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
-public final class GuidTest {
-  @Test
-  public void shouldBeEquatableAndHashable() {
-    EqualsVerifier.forClass(GUID.class)
-        .suppress(Warning.NONFINAL_FIELDS)
-        .verify();
+final class GuidTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(GUID.class)
+          .suppress(Warning.NONFINAL_FIELDS)
+          .verify();
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitOwnerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitOwnerTest.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.util;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.GameData;
@@ -7,19 +8,22 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.UnitType;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public final class UnitOwnerTest {
-  @Test
-  public void shouldBeEquatableAndHashable() {
-    final GameData gameData = new GameData();
-    EqualsVerifier.forClass(UnitOwner.class)
-        .withPrefabValues(
-            PlayerID.class,
-            new PlayerID("player1Name", gameData),
-            new PlayerID("player2Name", gameData))
-        .withPrefabValues(
-            UnitType.class,
-            new UnitType("unitType1Name", gameData),
-            new UnitType("unitType2Name", gameData))
-        .verify();
+final class UnitOwnerTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      final GameData gameData = new GameData();
+      EqualsVerifier.forClass(UnitOwner.class)
+          .withPrefabValues(
+              PlayerID.class,
+              new PlayerID("player1Name", gameData),
+              new PlayerID("player2Name", gameData))
+          .withPrefabValues(
+              UnitType.class,
+              new UnitType("unitType1Name", gameData),
+              new UnitType("unitType2Name", gameData))
+          .verify();
+    }
   }
 }

--- a/lobby/src/test/java/org/triplea/lobby/server/UserTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/UserTest.java
@@ -1,12 +1,16 @@
 package org.triplea.lobby.server;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public final class UserTest {
-  @Test
-  public void shouldBeEquatableAndHashable() {
-    EqualsVerifier.forClass(User.class).verify();
+final class UserTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(User.class).verify();
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR simply nests any top-level EqualsVerifier tests in an inner test fixture named `EqualsAndHashCodeTest` to avoid some annoying "this method can be declared `static`" warnings.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

Please review with whitespace changes ignored, as there are a lot of indentation changes.