### PR TITLE
Error Prone: Fix reference equality violations in BattleTracker

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -400,7 +400,7 @@ public class BattleTracker implements Serializable {
     if (canConquerMiddleSteps) {
       conquered.addAll(route.getMatches(conquerable));
       // in case we begin in enemy territory, and blitz out of it, check the first territory
-      if (route.getStart() != route.getEnd() && conquerable.test(route.getStart())) {
+      if (!route.getStart().equals(route.getEnd()) && conquerable.test(route.getStart())) {
         conquered.add(route.getStart());
       }
     }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ReferenceEquality rule in the `BattleTracker` class.

An analysis of the code reveals that value equality is appropriate here.  Because the`Route#getStart()` and `Route#getEnd()` methods guarantee to return non-`null` values, I replaced the reference equality check with a direct call to `Object#equals()`.

## Functional Changes

None.

## Manual Testing Performed

None.