### PR TITLE
Replace GameRunner$Context with services

### DIFF
--- a/game-core/src/main/java/org/triplea/game/client/ui/javafx/JavaFxClientRunner.java
+++ b/game-core/src/main/java/org/triplea/game/client/ui/javafx/JavaFxClientRunner.java
@@ -1,0 +1,11 @@
+package org.triplea.game.client.ui.javafx;
+
+/**
+ * A service for running the JavaFX client.
+ */
+public interface JavaFxClientRunner {
+  /**
+   * Starts the JavaFX client with the specified command-line arguments.
+   */
+  void start(String[] args);
+}

--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -1,9 +1,6 @@
 package org.triplea.game.client;
 
-import org.triplea.game.client.ui.javafx.TripleA;
-
 import games.strategy.engine.framework.GameRunner;
-import javafx.application.Application;
 
 /**
  * Runs a headed game client.
@@ -15,13 +12,6 @@ public final class HeadedGameRunner {
    * Entry point for running a new headed game client.
    */
   public static void main(final String[] args) {
-    GameRunner.start(GameRunner.Context.builder()
-        .args(args)
-        .startJavaFxClient(HeadedGameRunner::startJavaFxClient)
-        .build());
-  }
-
-  private static void startJavaFxClient(final String[] args) {
-    Application.launch(TripleA.class, args);
+    GameRunner.start(args);
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -17,7 +17,6 @@ public final class HeadedGameRunner {
   public static void main(final String[] args) {
     GameRunner.start(GameRunner.Context.builder()
         .args(args)
-        .mainClass(HeadedGameRunner.class)
         .startJavaFxClient(HeadedGameRunner::startJavaFxClient)
         .build());
   }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/DefaultJavaFxClientRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/DefaultJavaFxClientRunner.java
@@ -1,0 +1,13 @@
+package org.triplea.game.client.ui.javafx;
+
+import javafx.application.Application;
+
+/**
+ * Default implementation of the {@link JavaFxClientRunner} service.
+ */
+public final class DefaultJavaFxClientRunner implements JavaFxClientRunner {
+  @Override
+  public void start(final String[] args) {
+    Application.launch(TripleA.class, args);
+  }
+}

--- a/game-headed/src/main/resources/META-INF/services/org.triplea.game.client.ui.javafx.JavaFxClientRunner
+++ b/game-headed/src/main/resources/META-INF/services/org.triplea.game.client.ui.javafx.JavaFxClientRunner
@@ -1,0 +1,1 @@
+org.triplea.game.client.ui.javafx.DefaultJavaFxClientRunner


### PR DESCRIPTION
## Overview

#4055 introduced the `ApplicationContext` service, and it seems that using `ServiceLoader` is a cleaner way to break dependencies between subprojects than, for example, the recently-added `GameRunner$Context` type.  (`ServiceLoader` doesn't so much break the dependency completely as it introduces a layer of indirection per the _Dependency inversion principle_.)  On one hand, it will make it much easier to move code from `game-core` to either `game-headed` or `game-headless`.  On the other hand, it won't force us to redesign poor dependency injection as we move the code between subprojects because downstream code can still magically obtain a reference to the dependency via `ServiceLoader`, whereas before it might have obtained it from a global variable (e.g. `HeadlessGameServer#getInstance()`).

As more code gets moved to `game-headed` and `game-headless`, I would expect to see new service interfaces come and go.  As dependencies are moved out of `game-core`, new services will be added.  As the dependents themselves are moved out of `game-core`, the previously-added services will technically no longer be necessary and can be removed, if desired.

## Functional Changes

None.

## Refactoring Changes

The dependencies previously offered by `GameRunner$Context` are now obtained using the `ApplicationContext` service (for the entry point class) and the `JavaFxClientRunner` service (for starting a new JavaFX client).

## Manual Testing Performed

* Verified I could both join and host a game in the lobby (this validates the correct entry point class is available).
* Verified I could start a JavaFX client.