### PR TITLE
Error Prone: Promote some warnings to errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,22 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.compilerArgs += [
+            '-Xep:ByteBufferBackingArray:ERROR',
+            '-Xep:CatchAndPrintStackTrace:ERROR',
+            '-Xep:ClassCanBeStatic:ERROR',
+            '-Xep:DefaultCharset:ERROR',
+            '-Xep:FutureReturnValueIgnored:ERROR',
+            '-Xep:InconsistentCapitalization:ERROR',
+            '-Xep:JdkObsolete:ERROR',
+            '-Xep:MissingOverride:ERROR',
+            '-Xep:MutableConstantField:ERROR',
+            '-Xep:NonAtomicVolatileUpdate:ERROR',
+            '-Xep:OperatorPrecedence:ERROR',
             '-Xep:ParameterName:OFF', // workaround for https://github.com/google/error-prone/issues/780
+            '-Xep:ReferenceEquality:ERROR',
+            '-Xep:StringSplitter:ERROR',
+            '-Xep:UnsynchronizedOverridesSynchronized:ERROR',
+            '-Xep:WaitNotInLoop:ERROR',
             '-Xlint:all,-processing',
             '-Xmaxwarns', '1000'
         ]


### PR DESCRIPTION
## Overview

We've fixed legitimate violations (or suppressed verified false positives) of several Error Prone rules during the past year.  There are now zero violations of these rules in the codebase.  (There are still three ImmutableEnumChecker violations, pending the resolution of #3972.)

This PR promotes violations of those rules from warnings to errors in an effort to prevent them from accidentally being re-introduced.  All of these rules have clear resolutions, so it shouldn't require much thought to fix them (or suppress them if they are obviously false positives) during the PR process.

## Functional Changes

None.

## Manual Testing Performed

None.