### PR TITLE
Enable full exception logging in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,12 @@ subprojects {
         }
     }
 
+    tasks.withType(Test).configureEach {
+        testLogging {
+            exceptionFormat = 'full'
+        }
+    }
+
     check {
         dependsOn 'integTest'
     }


### PR DESCRIPTION
## Overview

Debugging aid for #4083.  Turns on full stack traces for test failure exceptions instead of just logging the type and message.  (We had previously added this capability in 81c598672, but, for some reason, it was removed in 5432fd516.)

## Functional Changes

None.

## Manual Testing Performed

None.