### PR TITLE
Use modern Gradle dependency configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,23 +60,20 @@ subprojects {
     }
 
     dependencies {
-        compile 'com.google.guava:guava:24.1-jre'
-
         errorprone 'com.google.errorprone:error_prone_core:2.3.1'
 
-        testCompile 'nl.jqno.equalsverifier:equalsverifier:2.5.2'
-        testCompile "org.hamcrest:java-hamcrest:$hamcrestVersion"
-        testCompile 'org.junit-pioneer:junit-pioneer:0.1.2'
-        testCompile "org.mockito:mockito-core:$mockitoVersion"
-        testCompile "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+        implementation 'com.google.guava:guava:24.1-jre'
 
+        testImplementation 'nl.jqno.equalsverifier:equalsverifier:2.5.2'
+        testImplementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
-
-        testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
-        testRuntime 'org.junit.platform:junit-platform-launcher:1.3.1'
-        testRuntime 'org.slf4j:slf4j-nop:1.7.25'
+        testImplementation 'org.junit-pioneer:junit-pioneer:0.1.2'
+        testImplementation "org.mockito:mockito-core:$mockitoVersion"
+        testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
 
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.3.1'
+        testRuntimeOnly 'org.slf4j:slf4j-nop:1.7.25'
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -7,20 +7,20 @@ ext {
 }
 
 dependencies {
-    compile 'com.github.openjson:openjson:1.0.10'
-    compile 'com.googlecode.soundlibs:jlayer:1.0.1.4'
-    compile 'com.sun.mail:javax.mail:1.6.1'
-    compile 'com.yuvimasory:orange-extensions:1.3.0'
-    compile 'commons-cli:commons-cli:1.4'
-    compile 'commons-codec:commons-codec:1.11'
-    compile 'commons-io:commons-io:2.6'
-    compile 'org.apache.commons:commons-math3:3.6.1'
-    compile "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
-    compile "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
-    compile 'org.yaml:snakeyaml:1.19'
+    implementation 'com.github.openjson:openjson:1.0.10'
+    implementation 'com.googlecode.soundlibs:jlayer:1.0.1.4'
+    implementation 'com.sun.mail:javax.mail:1.6.1'
+    implementation 'com.yuvimasory:orange-extensions:1.3.0'
+    implementation 'commons-cli:commons-cli:1.4'
+    implementation 'commons-codec:commons-codec:1.11'
+    implementation 'commons-io:commons-io:2.6'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
+    implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
+    implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
+    implementation 'org.yaml:snakeyaml:1.19'
 
-    testCompile project(':test-common')
-    testCompile "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
+    testImplementation project(':test-common')
+    testImplementation "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
 }
 
 checkstyleMain {

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -16,23 +16,23 @@ ext {
 }
 
 dependencies {
-    compile project(':game-core')
-
     if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
         compileOnly remoteLib(javaFxRuntimeUrl)
     }
 
-    runtime 'com.github.kirill-grouchnikov:substance:5d33cea' // v8.0.02 + Jitpack build fix
-    runtime 'com.github.kirill-grouchnikov:trident:v1.5.00'
+    implementation project(':game-core')
 
-    testCompile project(':test-common')
-    testCompile "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
-    testCompile "org.testfx:testfx-core:$testFxVersion"
-    testCompile "org.testfx:testfx-junit5:$testFxVersion"
+    runtimeOnly 'com.github.kirill-grouchnikov:substance:5d33cea' // v8.0.02 + Jitpack build fix
+    runtimeOnly 'com.github.kirill-grouchnikov:trident:v1.5.00'
 
     if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
         testCompileOnly remoteLib(javaFxRuntimeUrl)
     }
+
+    testImplementation project(':test-common')
+    testImplementation "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
+    testImplementation "org.testfx:testfx-core:$testFxVersion"
+    testImplementation "org.testfx:testfx-junit5:$testFxVersion"
 
     if (JavaVersion.current() == JavaVersion.VERSION_1_9) {
         testRuntimeOnly 'org.testfx:openjfx-monocle:jdk-9+181'

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -11,7 +11,7 @@ description = 'TripleA Headless Game Server'
 mainClassName = 'org.triplea.game.server.HeadlessGameRunner'
 
 dependencies {
-    compile project(':game-core')
+    implementation project(':game-core')
 }
 
 jar {

--- a/http-client/build.gradle
+++ b/http-client/build.gradle
@@ -1,10 +1,11 @@
 description = 'Http client library for http-server, provides an API for client-server interactions'
 
 dependencies {
-  compile project(':http-data')
-  compile 'com.netflix.feign:feign-core:8.18.0'
-  compile 'com.netflix.feign:feign-gson:8.18.0'
-  testCompile project(':test-common')
-  testCompile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
-  testCompile 'com.github.tomakehurst:wiremock:2.18.0'
+    implementation project(':http-data')
+    implementation 'com.netflix.feign:feign-core:8.18.0'
+    implementation 'com.netflix.feign:feign-gson:8.18.0'
+
+    testImplementation project(':test-common')
+    testImplementation 'com.github.tomakehurst:wiremock:2.18.0'
+    testImplementation 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
 }

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -7,8 +7,9 @@ description = 'TripleA Http Server'
 mainClassName = 'org.triplea.server.http.spark.SparkServerMain'
 
 dependencies {
-    compile 'com.sparkjava:spark-core:2.3'
-    testCompile project(':test-common')
+    implementation 'com.sparkjava:spark-core:2.3'
+
+    testImplementation project(':test-common')
 }
 
 jar {
@@ -19,7 +20,7 @@ jar {
 
 task httpServerArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     from(shadowJar.outputs) {
-        into('bin')
+        into 'bin'
     }
 }
 

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -8,12 +8,12 @@ description = 'TripleA Lobby'
 mainClassName = 'org.triplea.lobby.server.LobbyRunner'
 
 dependencies {
-    compile project(':game-core')
-    compile 'org.mindrot:jbcrypt:0.4'
+    implementation project(':game-core')
+    implementation 'org.mindrot:jbcrypt:0.4'
 
-    runtime "org.postgresql:postgresql:$postgresqlVersion"
+    runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
 
-    testCompile project(':test-common')
+    testImplementation project(':test-common')
 }
 
 jar {

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -1,6 +1,6 @@
 description = 'Test utility library, generic test utilities useful for TripleA projects'
 
 dependencies {
-    compile "org.hamcrest:java-hamcrest:$hamcrestVersion"
-    compile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+    implementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
+    implementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 }


### PR DESCRIPTION
## Overview

Several Gradle dependency configurations have been deprecated.  This PR replaces them with their modern equivalents, as shown below:

Old | New
:-- | :--
compile | implementation
runtime | runtimeOnly
testCompile | testImplementation
testRuntime | testRuntimeOnly

## Functional Changes

None.

## Manual Testing Performed

Built the archive artifacts for the lobby, headless game server, and headed game client, and made sure they all ran as expected.