### PR TITLE
Error Prone: Fix immutable enum checker violations in ClientSettingJavaFxUiBinding

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -32,154 +32,154 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
   AI_PAUSE_DURATION_BINDING(SettingType.AI) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000).get();
+      return intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000);
     }
   },
 
   ARROW_KEY_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500).get();
+      return intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500);
     }
   },
 
   BATTLE_CALC_SIMULATION_COUNT_DICE_BINDING(SettingType.BATTLE_SIMULATOR) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000).get();
+      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000);
     }
   },
 
   BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK_BINDING(SettingType.BATTLE_SIMULATOR) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000).get();
+      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000);
     }
   },
 
   CONFIRM_DEFENSIVE_ROLLS_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.CONFIRM_DEFENSIVE_ROLLS).get();
+      return toggleButton(ClientSetting.CONFIRM_DEFENSIVE_ROLLS);
     }
   },
 
   CONFIRM_ENEMY_CASUALTIES_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.CONFIRM_ENEMY_CASUALTIES).get();
+      return toggleButton(ClientSetting.CONFIRM_ENEMY_CASUALTIES);
     }
   },
 
   SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES).get();
+      return toggleButton(ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES);
     }
   },
 
   MAP_EDGE_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300).get();
+      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300);
     }
   },
 
   MAP_EDGE_SCROLL_ZONE_SIZE_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300).get();
+      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300);
     }
   },
 
   SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500).get();
+      return intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500);
     }
   },
 
   SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500).get();
+      return intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500);
     }
   },
 
   SHOW_BATTLES_WHEN_OBSERVING_BINDING(SettingType.GAME) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SHOW_BATTLES_WHEN_OBSERVING).get();
+      return toggleButton(ClientSetting.SHOW_BATTLES_WHEN_OBSERVING);
     }
   },
 
   SHOW_BETA_FEATURES_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SHOW_BETA_FEATURES).get();
+      return toggleButton(ClientSetting.SHOW_BETA_FEATURES);
     }
   },
 
   MAP_LIST_OVERRIDE_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return filePath(ClientSetting.MAP_LIST_OVERRIDE).get();
+      return filePath(ClientSetting.MAP_LIST_OVERRIDE);
     }
   },
 
   TEST_LOBBY_HOST_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return textField(ClientSetting.TEST_LOBBY_HOST).get();
+      return textField(ClientSetting.TEST_LOBBY_HOST);
     }
   },
 
   TEST_LOBBY_PORT_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true).get();
+      return intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true);
     }
   },
 
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(SettingType.GAME) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY).get();
+      return toggleButton(ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY);
     }
   },
 
   SAVE_GAMES_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH).get();
+      return folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH);
     }
   },
 
   USER_MAPS_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.USER_MAPS_FOLDER_PATH).get();
+      return folderPath(ClientSetting.USER_MAPS_FOLDER_PATH);
     }
   },
 
   WHEEL_SCROLL_AMOUNT_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300).get();
+      return intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300);
     }
   },
 
   PROXY_CHOICE(SettingType.NETWORK_PROXY) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return JavaFxSelectionComponentFactory.proxySettings().get();
+      return JavaFxSelectionComponentFactory.proxySettings();
     }
   },
 
   USE_EXPERIMENTAL_JAVAFX_UI(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI).get();
+      return toggleButton(ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
     }
   };
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -1,12 +1,18 @@
 package org.triplea.game.client.ui.javafx.util;
 
-import java.util.function.Supplier;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.filePath;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.folderPath;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.intValueRange;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.textField;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.toggleButton;
 
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSettingUiBinding;
 import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SettingType;
 import javafx.scene.layout.Region;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * Binds a {@link ClientSetting} to a JavaFX UI component. This is done by adding an enum element. As part of that the
@@ -21,121 +27,167 @@ import javafx.scene.layout.Region;
  * 1:1, and not all {@link ClientSetting}s will be available in the UI.
  * </p>
  */
+@AllArgsConstructor
 public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region> {
-  AI_PAUSE_DURATION_BINDING(
-      SettingType.AI,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000)),
+  AI_PAUSE_DURATION_BINDING(SettingType.AI) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000).get();
+    }
+  },
 
-  ARROW_KEY_SCROLL_SPEED_BINDING(
-      SettingType.MAP_SCROLLING,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500)),
+  ARROW_KEY_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500).get();
+    }
+  },
 
-  BATTLE_CALC_SIMULATION_COUNT_DICE_BINDING(
-      SettingType.BATTLE_SIMULATOR,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000)),
+  BATTLE_CALC_SIMULATION_COUNT_DICE_BINDING(SettingType.BATTLE_SIMULATOR) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000).get();
+    }
+  },
 
-  BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK_BINDING(
-      SettingType.BATTLE_SIMULATOR,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000)),
+  BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK_BINDING(SettingType.BATTLE_SIMULATOR) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000).get();
+    }
+  },
 
-  CONFIRM_DEFENSIVE_ROLLS_BINDING(
-      SettingType.COMBAT,
-      ClientSetting.CONFIRM_DEFENSIVE_ROLLS),
+  CONFIRM_DEFENSIVE_ROLLS_BINDING(SettingType.COMBAT) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.CONFIRM_DEFENSIVE_ROLLS).get();
+    }
+  },
 
-  CONFIRM_ENEMY_CASUALTIES_BINDING(
-      SettingType.COMBAT,
-      ClientSetting.CONFIRM_ENEMY_CASUALTIES),
+  CONFIRM_ENEMY_CASUALTIES_BINDING(SettingType.COMBAT) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.CONFIRM_ENEMY_CASUALTIES).get();
+    }
+  },
 
-  SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(
-      SettingType.COMBAT,
-      ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES),
+  SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(SettingType.COMBAT) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES).get();
+    }
+  },
 
-  MAP_EDGE_SCROLL_SPEED_BINDING(
-      SettingType.MAP_SCROLLING,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300)),
+  MAP_EDGE_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300).get();
+    }
+  },
 
-  MAP_EDGE_SCROLL_ZONE_SIZE_BINDING(
-      SettingType.MAP_SCROLLING,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300)),
+  MAP_EDGE_SCROLL_ZONE_SIZE_BINDING(SettingType.MAP_SCROLLING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300).get();
+    }
+  },
 
-  SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(
-      SettingType.NETWORK_TIMEOUTS,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500)),
+  SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500).get();
+    }
+  },
 
-  SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(
-      SettingType.NETWORK_TIMEOUTS,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500)),
+  SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500).get();
+    }
+  },
 
-  SHOW_BATTLES_WHEN_OBSERVING_BINDING(
-      SettingType.GAME,
-      ClientSetting.SHOW_BATTLES_WHEN_OBSERVING),
+  SHOW_BATTLES_WHEN_OBSERVING_BINDING(SettingType.GAME) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.SHOW_BATTLES_WHEN_OBSERVING).get();
+    }
+  },
 
-  SHOW_BETA_FEATURES_BINDING(
-      SettingType.TESTING,
-      ClientSetting.SHOW_BETA_FEATURES),
+  SHOW_BETA_FEATURES_BINDING(SettingType.TESTING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.SHOW_BETA_FEATURES).get();
+    }
+  },
 
-  MAP_LIST_OVERRIDE_BINDING(
-      SettingType.TESTING,
-      JavaFxSelectionComponentFactory.filePath(ClientSetting.MAP_LIST_OVERRIDE)),
+  MAP_LIST_OVERRIDE_BINDING(SettingType.TESTING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return filePath(ClientSetting.MAP_LIST_OVERRIDE).get();
+    }
+  },
 
-  TEST_LOBBY_HOST_BINDING(
-      SettingType.TESTING,
-      JavaFxSelectionComponentFactory.textField(ClientSetting.TEST_LOBBY_HOST)),
+  TEST_LOBBY_HOST_BINDING(SettingType.TESTING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return textField(ClientSetting.TEST_LOBBY_HOST).get();
+    }
+  },
 
-  TEST_LOBBY_PORT_BINDING(
-      SettingType.TESTING,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true)),
+  TEST_LOBBY_PORT_BINDING(SettingType.TESTING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true).get();
+    }
+  },
 
-  TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
-      SettingType.GAME,
-      ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY),
+  TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(SettingType.GAME) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY).get();
+    }
+  },
 
-  SAVE_GAMES_FOLDER_PATH_BINDING(
-      SettingType.FOLDER_LOCATIONS,
-      JavaFxSelectionComponentFactory.folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH)),
+  SAVE_GAMES_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH).get();
+    }
+  },
 
-  USER_MAPS_FOLDER_PATH_BINDING(
-      SettingType.FOLDER_LOCATIONS,
-      JavaFxSelectionComponentFactory.folderPath(ClientSetting.USER_MAPS_FOLDER_PATH)),
+  USER_MAPS_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return folderPath(ClientSetting.USER_MAPS_FOLDER_PATH).get();
+    }
+  },
 
-  WHEEL_SCROLL_AMOUNT_BINDING(
-      SettingType.MAP_SCROLLING,
-      JavaFxSelectionComponentFactory.intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300)),
+  WHEEL_SCROLL_AMOUNT_BINDING(SettingType.MAP_SCROLLING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300).get();
+    }
+  },
 
-  PROXY_CHOICE(
-      SettingType.NETWORK_PROXY,
-      JavaFxSelectionComponentFactory.proxySettings()),
+  PROXY_CHOICE(SettingType.NETWORK_PROXY) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return JavaFxSelectionComponentFactory.proxySettings().get();
+    }
+  },
 
-  USE_EXPERIMENTAL_JAVAFX_UI(
-      SettingType.TESTING,
-      ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
+  USE_EXPERIMENTAL_JAVAFX_UI(SettingType.TESTING) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return toggleButton(ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI).get();
+    }
+  };
 
+  @Getter(onMethod_ = {@Override})
   private final SettingType type;
-  private final Supplier<SelectionComponent<Region>> selectionComponentFactory;
-
-  ClientSettingJavaFxUiBinding(
-      final SettingType type,
-      final Supplier<SelectionComponent<Region>> selectionComponentFactory) {
-    this.type = type;
-    this.selectionComponentFactory = selectionComponentFactory;
-  }
-
-  ClientSettingJavaFxUiBinding(final SettingType type, final ClientSetting setting) {
-    this(type, JavaFxSelectionComponentFactory.toggleButton(setting));
-  }
-
-  @Override
-  public SelectionComponent<Region> newSelectionComponent() {
-    return selectionComponentFactory.get();
-  }
 
   @Override
   public String getTitle() {
     return "";
-  }
-
-  @Override
-  public SettingType getType() {
-    return type;
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
 import java.util.prefs.Preferences;
 
 import com.google.common.base.Strings;
@@ -29,23 +28,23 @@ import javafx.scene.layout.VBox;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 
-class JavaFxSelectionComponentFactory {
+final class JavaFxSelectionComponentFactory {
 
   private JavaFxSelectionComponentFactory() {}
 
-  static Supplier<SelectionComponent<Region>> intValueRange(
+  static SelectionComponent<Region> intValueRange(
       final ClientSetting clientSetting,
       final int minValue,
       final int maxValue) {
     return intValueRange(clientSetting, minValue, maxValue, false);
   }
 
-  static Supplier<SelectionComponent<Region>> intValueRange(
+  static SelectionComponent<Region> intValueRange(
       final ClientSetting clientSetting,
       final int minValue,
       final int maxValue,
       final boolean allowUnset) {
-    return () -> new SelectionComponent<Region>() {
+    return new SelectionComponent<Region>() {
 
       final Spinner<Integer> spinner = createSpinner();
 
@@ -112,8 +111,8 @@ class JavaFxSelectionComponentFactory {
     };
   }
 
-  static Supplier<SelectionComponent<Region>> toggleButton(final ClientSetting clientSetting) {
-    return () -> new SelectionComponent<Region>() {
+  static SelectionComponent<Region> toggleButton(final ClientSetting clientSetting) {
+    return new SelectionComponent<Region>() {
       final CheckBox checkBox = getCheckBox();
 
       private CheckBox getCheckBox() {
@@ -160,8 +159,8 @@ class JavaFxSelectionComponentFactory {
     };
   }
 
-  static Supplier<SelectionComponent<Region>> textField(final ClientSetting clientSetting) {
-    return () -> new SelectionComponent<Region>() {
+  static SelectionComponent<Region> textField(final ClientSetting clientSetting) {
+    return new SelectionComponent<Region>() {
       final TextField textField = newTextField();
 
       private TextField newTextField() {
@@ -208,20 +207,17 @@ class JavaFxSelectionComponentFactory {
     };
   }
 
-
-  static Supplier<SelectionComponent<Region>> folderPath(final ClientSetting clientSetting) {
-    return () -> new FolderSelector(clientSetting);
+  static SelectionComponent<Region> folderPath(final ClientSetting clientSetting) {
+    return new FolderSelector(clientSetting);
   }
 
-  static Supplier<SelectionComponent<Region>> filePath(final ClientSetting clientSetting) {
-    return () -> new FileSelector(clientSetting);
+  static SelectionComponent<Region> filePath(final ClientSetting clientSetting) {
+    return new FileSelector(clientSetting);
   }
 
-
-  static Supplier<SelectionComponent<Region>> proxySettings() {
-    return ProxySetting::new;
+  static SelectionComponent<Region> proxySettings() {
+    return new ProxySetting();
   }
-
 
   private static final class FolderSelector extends Region implements SelectionComponent<Region> {
     private final ClientSetting clientSetting;


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ImmutableEnumChecker rule in the `ClientSettingJavaFxUiBinding` enum.  The fix recommended in the [Error Prone docs](http://errorprone.info/bugpattern/ImmutableEnumChecker) is to replace functional interface fields with abstract methods.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the client settings in the JavaFX UI.