### PR TITLE
Upgrade EqualsVerifier to 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
 
         implementation 'com.google.guava:guava:24.1-jre'
 
-        testImplementation 'nl.jqno.equalsverifier:equalsverifier:2.5.2'
+        testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.0'
         testImplementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
         testImplementation 'org.junit-pioneer:junit-pioneer:0.1.2'


### PR DESCRIPTION
## Overview

Upgrades the EqualsVerifier test dependency to the latest version.  This fixes the illegal access violations that occur when running `GuidTest` on Java 9+, as reported in #2796.

## Functional Changes

None.

## Manual Testing Performed

Verified that running `GuidTest` on Java 9.0.4 with `--illegal-access=warn` reports no illegal access warnings.