### PR TITLE
Make backup copies of lobby system properties for lobby watcher

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -1,0 +1,83 @@
+package games.strategy.engine.framework.startup.ui;
+
+import static games.strategy.engine.framework.startup.ui.InGameLobbyWatcher.getLobbySystemProperty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class InGameLobbyWatcherTest {
+  @Nested
+  final class GetLobbySystemPropertyTest {
+    private static final String KEY = "__GetLobbySystemPropertyTest__key";
+    private static final String BACKUP_KEY = KEY + ".backup";
+    private static final String VALUE = "primaryValue";
+    private static final String BACKUP_VALUE = "backupValue";
+
+    @AfterEach
+    void clearSystemProperties() {
+      givenPrimaryValueNotSet();
+      givenBackupValueNotSet();
+    }
+
+    private void givenPrimaryValueSet() {
+      System.setProperty(KEY, VALUE);
+    }
+
+    private void givenPrimaryValueNotSet() {
+      System.clearProperty(KEY);
+    }
+
+    private void givenBackupValueSet() {
+      System.setProperty(BACKUP_KEY, BACKUP_VALUE);
+    }
+
+    private void givenBackupValueNotSet() {
+      System.clearProperty(BACKUP_KEY);
+    }
+
+    @Test
+    void shouldReturnPrimaryValueWhenPrimaryValueSet() {
+      givenPrimaryValueSet();
+
+      assertThat(getLobbySystemProperty(KEY), is(VALUE));
+    }
+
+    @Test
+    void shouldClearPrimaryValueWhenPrimaryValueSet() {
+      givenPrimaryValueSet();
+
+      getLobbySystemProperty(KEY);
+
+      assertThat(System.getProperty(KEY), is(nullValue()));
+    }
+
+    @Test
+    void shouldCopyPrimaryValueToBackupValueWhenPrimaryValueSet() {
+      givenPrimaryValueSet();
+
+      getLobbySystemProperty(KEY);
+
+      assertThat(System.getProperty(BACKUP_KEY), is(VALUE));
+    }
+
+    @Test
+    void shouldReturnBackupValueWhenPrimaryValueNotSet() {
+      givenPrimaryValueNotSet();
+      givenBackupValueSet();
+
+      assertThat(getLobbySystemProperty(KEY), is(BACKUP_VALUE));
+    }
+
+    @Test
+    void shouldReturnNullWhenPrimaryValueNotSetAndBackupValueNotSet() {
+      givenPrimaryValueNotSet();
+      givenBackupValueNotSet();
+
+      assertThat(getLobbySystemProperty(KEY), is(nullValue()));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes #4102.

The original lobby system properties need to be cleared (I'm not sure where this requirement comes from, but it's been in the code for some time).  However, the original values need to be backed up to secondary system properties so they can be read at a later time.  For example, when the lobby watcher is restarted.

This is effectively a revert of #3676, but cleans up the original code a bit to encapsulate the knowledge of backing up and clearing the lobby system properties.

## Functional Changes

Upon the creation of the first lobby watcher instance, the following lobby system properties:

* `triplea.lobby.host`
* `triplea.lobby.port`
* `triplea.lobby.game.hostedBy`

are each backed up to a corresponding system property with the same name but a `.backup` suffix. The original system property is then cleared (per above, I don't know where this requirement comes from).

Upon creation of the second and subsequent lobby watcher instances, the values from the backup system properties will be used, thus ensuring the lobby watcher can connect to the original lobby specified on the command-line.

This is a slightly different approach taken to the code that existed prior to #3676.  In that version, the backup system properties were copied to the original system properties just long enough for the lobby watcher creation code to read the values, then the original system properties are cleared once again.

The approach proposed in this PR is slightly cleaner because it doesn't keep copying the system properties back-and-forth between the original and backup versions.  But there's still a big smell related to having to clear the original properties in the first place.

## Manual Testing Performed

Verified a bot connected to a lobby periodically shuts down its lobby watcher and then re-creates it.  I visually confirmed the bot entry in the lobby disappears for a few seconds and then reappears during this process.