### PR TITLE
Improve Gradle upgrade process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ check {
     dependsOn 'validateYamls'
 }
 
+wrapper {
+    distributionType = Wrapper.DistributionType.ALL
+}
+
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {
     doLast {
         def lobbyServerYamlFile = file('lobby_server.yaml')

--- a/docs/dev/gradle.md
+++ b/docs/dev/gradle.md
@@ -1,5 +1,6 @@
-## How to upgrade gradle
+## How to upgrade Gradle
 
-- Execute: `./gradlew wrapper --gradle-version=<version> --distribution-type=ALL`, where `<version>` is replaced with the desired Gradle version (e.g. `4.8.1`, `4.9`, etc.)
-- Commit everything
-- Do some smoke testing and submit a PR
+- Execute: `./gradlew wrapper --gradle-version=<version>`, where `<version>` is replaced with the desired Gradle version (e.g. `4.8.1`, `4.9`, etc.).
+- Verify _gradle/wrapper/gradle-wrapper.jar_ has been modified. If not, re-run the previous command.
+- Commit everything.
+- Do some smoke testing and submit a PR.


### PR DESCRIPTION
## Overview

Two improvements to the Gradle upgrade process:

* Configure the build to always use the `ALL` distribution so the upgrader doesn't have to specify it on the command line.
* Document that the `wrapper` task may have to be run twice to ensure _gradle-wrapper.jar_ is properly updated.  (I believe the root cause of this issue has something to do with what version of Gradle is running the `wrapper` task.  On the first run, version X is running, and does not update the jar file to version Y.  On the second run, version Y is running, and that does update the jar file to version Y.  Not sure if this is by design or a bug.)

## Functional Changes

None.

## Manual Testing Performed

Verified running the Gradle `wrapper` task works as expected.