### PR TITLE
Add Find Territory command

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
@@ -1,0 +1,32 @@
+package games.strategy.triplea.ui;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.AbstractAction;
+
+/**
+ * A UI action that prompts the user to select a territory by name and then centers the map on the selected territory.
+ * If no territory is selected, this action does nothing.
+ */
+public final class FindTerritoryAction extends AbstractAction {
+  private static final long serialVersionUID = 5122180892200519366L;
+
+  private final TripleAFrame frame;
+
+  public FindTerritoryAction(final TripleAFrame frame) {
+    super("Find Territory...");
+
+    this.frame = checkNotNull(frame);
+  }
+
+  @Override
+  public void actionPerformed(final ActionEvent e) {
+    final SelectTerritoryDialog dialog = new SelectTerritoryDialog(
+        frame,
+        "Find Territory",
+        frame.getGame().getData().getMap().getTerritories());
+    dialog.open().ifPresent(frame.getMapPanel()::centerOn);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -1,0 +1,76 @@
+package games.strategy.triplea.ui;
+
+import java.awt.Frame;
+import java.util.Collection;
+import java.util.Optional;
+
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.ui.SwingComponents;
+import swinglib.JButtonBuilder;
+import swinglib.JPanelBuilder;
+
+final class SelectTerritoryDialog extends JDialog {
+  private static final long serialVersionUID = -1601616824595826610L;
+
+  private Result result = Result.CANCEL;
+  private final JComboBox<Territory> territoryComboBox;
+
+  SelectTerritoryDialog(final Frame owner, final String title, final Collection<Territory> territories) {
+    super(owner, title, true);
+
+    territoryComboBox = new JComboBox<>(territories.toArray(new Territory[0]));
+    final JButton okButton = JButtonBuilder.builder()
+        .okTitle()
+        .actionListener(() -> close(Result.OK))
+        .build();
+    getRootPane().setDefaultButton(okButton);
+
+    add(JPanelBuilder.builder()
+        .borderEmpty(10)
+        .verticalBoxLayout()
+        .add(territoryComboBox)
+        .addVerticalStrut(20)
+        .add(JPanelBuilder.builder()
+            .horizontalBoxLayout()
+            .addHorizontalGlue()
+            .add(okButton)
+            .addHorizontalStrut(5)
+            .add(JButtonBuilder.builder()
+                .cancelTitle()
+                .actionListener(() -> close(Result.CANCEL))
+                .build())
+            .build())
+        .build());
+    pack();
+    setLocationRelativeTo(owner);
+
+    SwingComponents.addEscapeKeyListener(this, () -> close(Result.CANCEL));
+  }
+
+  Optional<Territory> open() {
+    setVisible(true);
+
+    switch (result) {
+      case OK:
+        return Optional.of((Territory) territoryComboBox.getSelectedItem());
+      case CANCEL:
+        return Optional.empty();
+      default:
+        throw new AssertionError("unknown result: " + result);
+    }
+  }
+
+  private void close(final Result result) {
+    setVisible(false);
+    dispose();
+    this.result = result;
+  }
+
+  private enum Result {
+    OK, CANCEL
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -3,10 +3,13 @@ package games.strategy.triplea.ui;
 import java.awt.Frame;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.data.Territory;
 import games.strategy.ui.SwingComponents;
@@ -53,10 +56,14 @@ final class SelectTerritoryDialog extends JDialog {
 
   Optional<Territory> open() {
     setVisible(true);
+    return getSelectedTerritory(result, territoryComboBox::getSelectedItem);
+  }
 
+  @VisibleForTesting
+  static Optional<Territory> getSelectedTerritory(final Result result, final Supplier<Object> selectedItemSupplier) {
     switch (result) {
       case OK:
-        return Optional.of((Territory) territoryComboBox.getSelectedItem());
+        return Optional.of((Territory) selectedItemSupplier.get());
       case CANCEL:
         return Optional.empty();
       default:
@@ -70,7 +77,8 @@ final class SelectTerritoryDialog extends JDialog {
     this.result = result;
   }
 
-  private enum Result {
+  @VisibleForTesting
+  enum Result {
     OK, CANCEL
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -31,6 +31,7 @@ import games.strategy.engine.random.RandomStatsDetails;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.odds.calculator.OddsCalculatorDialog;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.ui.FindTerritoryAction;
 import games.strategy.triplea.ui.PoliticalStateOverview;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
@@ -74,13 +75,17 @@ final class GameMenu extends JMenu {
     addRollDice();
     addMenuItemWithHotkey(SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null)),
         KeyEvent.VK_B);
+    addSeparator();
+    addMenuItemWithHotkey(new FindTerritoryAction(frame), KeyEvent.VK_F)
+        .setMnemonic(KeyEvent.VK_F);
   }
 
-  private void addMenuItemWithHotkey(final Action action, final int keyCode) {
+  private JMenuItem addMenuItemWithHotkey(final Action action, final int keyCode) {
     final JMenuItem gameMenuItem = add(action);
     gameMenuItem.setMnemonic(keyCode);
     gameMenuItem.setAccelerator(
         KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+    return gameMenuItem;
   }
 
   private void addEditMode() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -31,7 +31,6 @@ import games.strategy.engine.random.RandomStatsDetails;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.odds.calculator.OddsCalculatorDialog;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.ui.FindTerritoryAction;
 import games.strategy.triplea.ui.PoliticalStateOverview;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
@@ -75,17 +74,13 @@ final class GameMenu extends JMenu {
     addRollDice();
     addMenuItemWithHotkey(SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null)),
         KeyEvent.VK_B);
-    addSeparator();
-    addMenuItemWithHotkey(new FindTerritoryAction(frame), KeyEvent.VK_F)
-        .setMnemonic(KeyEvent.VK_F);
   }
 
-  private JMenuItem addMenuItemWithHotkey(final Action action, final int keyCode) {
+  private void addMenuItemWithHotkey(final Action action, final int keyCode) {
     final JMenuItem gameMenuItem = add(action);
     gameMenuItem.setMnemonic(keyCode);
     gameMenuItem.setAccelerator(
         KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-    return gameMenuItem;
   }
 
   private void addEditMode() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -33,6 +34,7 @@ import javax.swing.JRadioButton;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
@@ -45,6 +47,7 @@ import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.ui.AbstractUiContext;
+import games.strategy.triplea.ui.FindTerritoryAction;
 import games.strategy.triplea.ui.PurchasePanel;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
@@ -90,6 +93,8 @@ final class ViewMenu extends JMenu {
     addShowCommentLog();
     addTabbedProduction();
     addShowGameUuid();
+    addSeparator();
+    addFindTerritory();
 
     showMapDetails.setEnabled(uiContext.getMapData().getHasRelief());
   }
@@ -523,5 +528,12 @@ final class ViewMenu extends JMenu {
     chatTimeBox.setSelected(false);
     add(chatTimeBox);
     chatTimeBox.setEnabled(frame.hasChat());
+  }
+
+  private void addFindTerritory() {
+    final JMenuItem menuItem = add(new FindTerritoryAction(frame));
+    menuItem
+        .setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+    menuItem.setMnemonic(KeyEvent.VK_F);
   }
 }

--- a/game-core/src/main/java/swinglib/JButtonBuilder.java
+++ b/game-core/src/main/java/swinglib/JButtonBuilder.java
@@ -78,6 +78,13 @@ public class JButtonBuilder {
   }
 
   /**
+   * Sets the button title to the system's Cancel button text.
+   */
+  public JButtonBuilder cancelTitle() {
+    return title(UIManager.getString("OptionPane.cancelButtonText"));
+  }
+
+  /**
    * Toggles the button as 'selected', which gives keyboard focus to the button. By default button is not selected.
    */
   public JButtonBuilder selected(final boolean value) {

--- a/game-core/src/test/java/games/strategy/triplea/ui/SelectTerritoryDialogTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/SelectTerritoryDialogTest.java
@@ -1,0 +1,31 @@
+package games.strategy.triplea.ui;
+
+import static games.strategy.triplea.ui.SelectTerritoryDialog.getSelectedTerritory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ui.SelectTerritoryDialog.Result;
+
+final class SelectTerritoryDialogTest {
+  @Nested
+  final class GetSelectedTerritoryTest {
+    private final Territory territory = new Territory("territory", new GameData());
+
+    @Test
+    void shouldReturnTerritoryWhenResultIsOk() {
+      assertThat(getSelectedTerritory(Result.OK, () -> territory), is(Optional.of(territory)));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenResultIsCancel() {
+      assertThat(getSelectedTerritory(Result.CANCEL, () -> territory), is(Optional.empty()));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Addresses https://forums.triplea-game.org/topic/1026/find-province-command.

This is the first of two or more PRs that will fully implement this feature.  This PR implements the basic functionality of prompting the user to choose from a list of territories, and then center the map on the selected territory.  Follow-up PRs will explore optimizing the territory selection process via free-form text entry.

## Functional Changes

* Added the new **View > Find Territory...** command to the menu bar.
    * This command is also available via the mnemonic <kbd>Alt</kbd>+<kbd>V</kbd>, <kbd>F</kbd>.
    * This command is also available via the hotkey <kbd>Ctrl</kbd>+<kbd>F</kbd>.
    * Selecting this command displays a dialog with a combo box that contains all map territories in lexicographical order.
    * The initial focus is on the combo box.
    * In addition to the mouse, the user can use the following keys to navigate the combo box:
        * Up/down arrow
        * Page up/down
        * Alpha keys to change the selection to the first item matching the pressed letter.
    * Closing the dialog by pressing <kbd>Enter</kbd> or clicking the **OK** button will center the map on the selected territory.
    * Closing the dialog by pressing <kbd>Esc</kbd>, clicking the **Cancel** button, or clicking the system close menu will do nothing.

## Manual Testing Performed

* Verified the map view is centered on the selected territory.
* Verified the map view is not changed if no territory is selected.
* Verified all "OK" close actions work as expected.
* Verified all "Cancel" close actions work as expected.

## Screen Shots

![find-territory-menu-new](https://user-images.githubusercontent.com/4826349/46265736-77c27900-c4f7-11e8-9575-20488bf1771b.png)

![find-territory-dialog](https://user-images.githubusercontent.com/4826349/46248771-bff47500-c3eb-11e8-809e-5ce10dd4c438.png)

## Additional Reviewer Notes

* ~I dithered between adding the **Find Territory...** command to the **View** and **Game** menus.  Please advise if **View** would have been a better choice.~ **EDIT:** Moved to **View** menu based on forum feedback.
* I added the **Find Territory...** command to the end of the **View** menu.  Please advise if it would be better positioned at the beginning of, or some other location within, this menu.