### PR TITLE
Add auto-completion support to SelectTerritoryDialog

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -26,7 +26,7 @@ final class SelectTerritoryDialog extends JDialog {
   SelectTerritoryDialog(final Frame owner, final String title, final Collection<Territory> territories) {
     super(owner, title, true);
 
-    territoryComboBox = new JComboBox<>(territories.toArray(new Territory[0]));
+    territoryComboBox = new JComboBox<>(territories.stream().sorted().toArray(Territory[]::new));
     AutoCompletion.enable(territoryComboBox);
     final JButton okButton = JButtonBuilder.builder()
         .okTitle()

--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -4,6 +4,7 @@ import java.awt.Frame;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -12,9 +13,9 @@ import javax.swing.JDialog;
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.data.Territory;
-import games.strategy.ui.AutoCompletion;
 import games.strategy.ui.SwingComponents;
 import swinglib.JButtonBuilder;
+import swinglib.JComboBoxBuilder;
 import swinglib.JPanelBuilder;
 
 final class SelectTerritoryDialog extends JDialog {
@@ -26,8 +27,10 @@ final class SelectTerritoryDialog extends JDialog {
   SelectTerritoryDialog(final Frame owner, final String title, final Collection<Territory> territories) {
     super(owner, title, true);
 
-    territoryComboBox = new JComboBox<>(territories.stream().sorted().toArray(Territory[]::new));
-    AutoCompletion.enable(territoryComboBox);
+    territoryComboBox = JComboBoxBuilder.builder(Territory.class)
+        .items(territories.stream().sorted().collect(Collectors.toList()))
+        .enableAutoComplete()
+        .build();
     final JButton okButton = JButtonBuilder.builder()
         .okTitle()
         .actionListener(() -> close(Result.OK))

--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -12,6 +12,7 @@ import javax.swing.JDialog;
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.data.Territory;
+import games.strategy.ui.AutoCompletion;
 import games.strategy.ui.SwingComponents;
 import swinglib.JButtonBuilder;
 import swinglib.JPanelBuilder;
@@ -26,6 +27,7 @@ final class SelectTerritoryDialog extends JDialog {
     super(owner, title, true);
 
     territoryComboBox = new JComboBox<>(territories.toArray(new Territory[0]));
+    AutoCompletion.enable(territoryComboBox);
     final JButton okButton = JButtonBuilder.builder()
         .okTitle()
         .actionListener(() -> close(Result.OK))

--- a/game-core/src/main/java/games/strategy/ui/AutoCompletion.java
+++ b/game-core/src/main/java/games/strategy/ui/AutoCompletion.java
@@ -1,0 +1,232 @@
+package games.strategy.ui;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import javax.swing.ComboBoxEditor;
+import javax.swing.ComboBoxModel;
+import javax.swing.JComboBox;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.PlainDocument;
+
+/**
+ * From http://www.orbital-computer.de/JComboBox. Originally released into the Public Domain
+ * (http://creativecommons.org/licenses/publicdomain/).
+ *
+ * @param <E> The type of the combo box elements.
+ */
+public final class AutoCompletion<E> extends PlainDocument {
+  private static final long serialVersionUID = 3467837392266952714L;
+
+  private final JComboBox<E> comboBox;
+  private ComboBoxModel<E> model;
+  private JTextComponent editor;
+  // flag to indicate if setSelectedItem has been called
+  // subsequent calls to remove/insertString should be ignored
+  private boolean selecting = false;
+  private final boolean hidePopupOnFocusLoss;
+  private boolean hitBackspace = false;
+  private boolean hitBackspaceOnSelection;
+  private final KeyListener editorKeyListener;
+  private final FocusListener editorFocusListener;
+
+  private AutoCompletion(final JComboBox<E> comboBox) {
+    this.comboBox = comboBox;
+    model = comboBox.getModel();
+    comboBox.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(final ActionEvent e) {
+        if (!selecting) {
+          highlightCompletedText(0);
+        }
+      }
+    });
+    comboBox.addPropertyChangeListener(new PropertyChangeListener() {
+      @Override
+      @SuppressWarnings("unchecked")
+      public void propertyChange(final PropertyChangeEvent e) {
+        if (e.getPropertyName().equals("editor")) {
+          configureEditor((ComboBoxEditor) e.getNewValue());
+        }
+        if (e.getPropertyName().equals("model")) {
+          model = (ComboBoxModel<E>) e.getNewValue();
+        }
+      }
+    });
+    editorKeyListener = new KeyAdapter() {
+      @Override
+      public void keyPressed(final KeyEvent e) {
+        if ((e.getKeyCode() != KeyEvent.VK_ENTER)
+            && (e.getKeyCode() != KeyEvent.VK_ESCAPE)
+            && comboBox.isDisplayable()) {
+          comboBox.setPopupVisible(true);
+        }
+        hitBackspace = false;
+        switch (e.getKeyCode()) {
+          // determine if the pressed key is backspace (needed by the remove method)
+          case KeyEvent.VK_BACK_SPACE:
+            hitBackspace = true;
+            hitBackspaceOnSelection = editor.getSelectionStart() != editor.getSelectionEnd();
+            break;
+          // ignore delete key
+          case KeyEvent.VK_DELETE:
+            e.consume();
+            comboBox.getToolkit().beep();
+            break;
+          default:
+            break;
+        }
+      }
+    };
+    // Bug 5100422 on Java 1.5: Editable JComboBox won't hide popup when tabbing out
+    hidePopupOnFocusLoss = System.getProperty("java.version").startsWith("1.5");
+    // Highlight whole text when gaining focus
+    editorFocusListener = new FocusAdapter() {
+      @Override
+      public void focusGained(final FocusEvent e) {
+        highlightCompletedText(0);
+      }
+
+      @Override
+      public void focusLost(final FocusEvent e) {
+        // Workaround for Bug 5100422 - Hide Popup on focus loss
+        if (hidePopupOnFocusLoss) {
+          comboBox.setPopupVisible(false);
+        }
+      }
+    };
+    configureEditor(comboBox.getEditor());
+    // Handle initially selected object
+    final Object selected = comboBox.getSelectedItem();
+    if (selected != null) {
+      setText(selected.toString());
+    }
+    highlightCompletedText(0);
+  }
+
+  public static <E> void enable(final JComboBox<E> comboBox) {
+    // has to be editable
+    comboBox.setEditable(true);
+    // change the editor's document
+    @SuppressWarnings("unused")
+    final AutoCompletion<E> autoCompletion = new AutoCompletion<>(comboBox);
+  }
+
+  void configureEditor(final ComboBoxEditor newEditor) {
+    if (editor != null) {
+      editor.removeKeyListener(editorKeyListener);
+      editor.removeFocusListener(editorFocusListener);
+    }
+
+    if (newEditor != null) {
+      editor = (JTextComponent) newEditor.getEditorComponent();
+      editor.addKeyListener(editorKeyListener);
+      editor.addFocusListener(editorFocusListener);
+      editor.setDocument(this);
+    }
+  }
+
+  @Override
+  public void remove(final int initialOffs, final int len) throws BadLocationException {
+    int offs = initialOffs;
+    // return immediately when selecting an item
+    if (selecting) {
+      return;
+    }
+    if (hitBackspace) {
+      // user hit backspace => move the selection backwards
+      // old item keeps being selected
+      if (offs > 0) {
+        if (hitBackspaceOnSelection) {
+          offs--;
+        }
+      } else {
+        // User hit backspace with the cursor positioned on the start => beep
+        comboBox.getToolkit().beep(); // when available use: UIManager.getLookAndFeel().provideErrorFeedback(comboBox);
+      }
+      highlightCompletedText(offs);
+    } else {
+      super.remove(offs, len);
+    }
+  }
+
+  @Override
+  public void insertString(final int initialOffs, final String str, final AttributeSet a) throws BadLocationException {
+    int offs = initialOffs;
+    // return immediately when selecting an item
+    if (selecting) {
+      return;
+    }
+    // insert the string into the document
+    super.insertString(offs, str, a);
+    // lookup and select a matching item
+    Object item = lookupItem(getText(0, getLength()));
+    if (item != null) {
+      setSelectedItem(item);
+    } else {
+      // keep old item selected if there is no match
+      item = comboBox.getSelectedItem();
+      // imitate no insert (later on offs will be incremented by str.length(): selection won't move forward)
+      offs = offs - str.length();
+      // provide feedback to the user that his input has been received but can not be accepted
+      comboBox.getToolkit().beep(); // when available use: UIManager.getLookAndFeel().provideErrorFeedback(comboBox);
+    }
+    setText(item.toString());
+    // select the completed part
+    highlightCompletedText(offs + str.length());
+  }
+
+  private void setText(final String text) {
+    try {
+      // remove all text and insert the completed string
+      super.remove(0, getLength());
+      super.insertString(0, text, null);
+    } catch (final BadLocationException e) {
+      throw new RuntimeException(e.toString());
+    }
+  }
+
+  private void highlightCompletedText(final int start) {
+    editor.setCaretPosition(getLength());
+    editor.moveCaretPosition(start);
+  }
+
+  private void setSelectedItem(final Object item) {
+    selecting = true;
+    model.setSelectedItem(item);
+    selecting = false;
+  }
+
+  private Object lookupItem(final String pattern) {
+    final Object selectedItem = model.getSelectedItem();
+    // only search for a different item if the currently selected does not match
+    if (selectedItem != null && startsWithIgnoreCase(selectedItem.toString(), pattern)) {
+      return selectedItem;
+    }
+    // iterate over all items
+    for (int i = 0, n = model.getSize(); i < n; i++) {
+      final Object currentItem = model.getElementAt(i);
+      // current item starts with the pattern?
+      if (currentItem != null && startsWithIgnoreCase(currentItem.toString(), pattern)) {
+        return currentItem;
+      }
+    }
+    // no item starts with the pattern => return null
+    return null;
+  }
+
+  // checks if str1 starts with str2 - ignores case
+  private static boolean startsWithIgnoreCase(final String str1, final String str2) {
+    return str1.toUpperCase().startsWith(str2.toUpperCase());
+  }
+}

--- a/game-core/src/main/java/swinglib/AutoCompletion.java
+++ b/game-core/src/main/java/swinglib/AutoCompletion.java
@@ -1,4 +1,4 @@
-package games.strategy.ui;
+package swinglib;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -25,7 +25,7 @@ import javax.swing.text.PlainDocument;
  *
  * @param <E> The type of the combo box elements.
  */
-public final class AutoCompletion<E> extends PlainDocument {
+final class AutoCompletion<E> extends PlainDocument {
   private static final long serialVersionUID = 3467837392266952714L;
 
   private final JComboBox<E> comboBox;
@@ -114,7 +114,7 @@ public final class AutoCompletion<E> extends PlainDocument {
     highlightCompletedText(0);
   }
 
-  public static <E> void enable(final JComboBox<E> comboBox) {
+  static <E> void enable(final JComboBox<E> comboBox) {
     // has to be editable
     comboBox.setEditable(true);
     // change the editor's document

--- a/game-core/src/main/java/swinglib/JComboBoxBuilder.java
+++ b/game-core/src/main/java/swinglib/JComboBoxBuilder.java
@@ -1,125 +1,96 @@
 package swinglib;
 
 import java.awt.event.ItemEvent;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javax.annotation.Nullable;
 import javax.swing.JComboBox;
 
 import com.google.common.base.Preconditions;
 
-import games.strategy.triplea.settings.ClientSetting;
-
 /**
  * Builds a swing JComboBox that supports String values only. This is a pull down
- * box with menu options that can be selected.
+ * box with items that can be selected.
  * <br />
  * Example usage:
  *
  * <pre>
  * <code>
- *   JComboBox combBox = JComboBoxBuilder.builder()
- *       .menuOptions("option 1", "option 2")
- *       .itemListener(selection -> selection.equals("option 1") ? fooBar())
- *       .build();
+ * JComboBox&lt;String> comboBox = JComboBoxBuilder.builder(String.class)
+ *     .items("option 1", "option 2")
+ *     .itemSelectedAction(selection -> selection.equals("option 1") ? foo() : bar())
+ *     .build();
  * </code>
  * </pre>
+ *
+ * @param <E> The type of the combo box items.
  */
-public final class JComboBoxBuilder {
+public final class JComboBoxBuilder<E> {
+  private final Class<E> itemType;
+  private final List<E> items = new ArrayList<>();
+  private @Nullable Consumer<E> itemSelectedAction;
+  private @Nullable String toolTip;
+  private boolean autoCompleteEnabled;
 
-  private final List<String> options = new ArrayList<>();
-
-  private Consumer<String> selectionAction;
-
-  private String settingKeyName;
-
-  private ClientSetting clientSetting;
-
-  private String toolTip;
-
-  private JComboBoxBuilder() {
-
+  private JComboBoxBuilder(final Class<E> itemType) {
+    this.itemType = itemType;
   }
 
   /**
    * Builds the swing component.
    */
-  public JComboBox<String> build() {
-    Preconditions.checkState(options.size() > 0);
-    final Consumer<String> myAction = selectionAction;
+  public JComboBox<E> build() {
+    Preconditions.checkState(items.size() > 0);
 
-    final JComboBox<String> comboBox = new JComboBox<>(options.toArray(new String[0]));
+    @SuppressWarnings("unchecked")
+    final E[] array = (E[]) Array.newInstance(itemType, items.size());
+    final JComboBox<E> comboBox = new JComboBox<>(items.toArray(array));
 
-    if (clientSetting != null) {
-      final String lastValue = clientSetting.value();
-
-      if (options.contains(lastValue)) {
-        comboBox.setSelectedItem(lastValue);
-      } else {
-        clientSetting.resetAndFlush();
-      }
-    }
-
-    if (settingKeyName != null) {
-      final String lastValue = ClientSetting.load(settingKeyName);
-
-      if (options.contains(lastValue)) {
-        // note: this will fire any item action listeners
-        comboBox.setSelectedItem(lastValue);
-      }
-    }
-
-    if (selectionAction != null) {
+    final @Nullable Consumer<E> myAction = this.itemSelectedAction;
+    if (myAction != null) {
       comboBox.addItemListener(e -> {
-
         // combo box will fire two events when you change selection, first a 'ItemEvent.DESELECTED' event and then
         // a 'ItemEvent.SELECTED' event. We keep it simple for now and ignore the deselected event
         if (e.getStateChange() == ItemEvent.SELECTED) {
-          final String selectionValue = (e.getItem() == null) ? null : e.getItem().toString();
-
-          Preconditions.checkState(!(clientSetting != null && settingKeyName != null),
-              "Only one of ClientSetting or settingKey should be set at a type, they are"
-                  + "are redundant to each other. One is a type safe enum, the other is a free form String value."
-                  + " Client setting == null ? " + (clientSetting == null)
-                  + ", settingKeyName == null ? " + (settingKeyName == null));
-
-          if (clientSetting != null) {
-            clientSetting.saveAndFlush(selectionValue);
-          } else if (settingKeyName != null) {
-            ClientSetting.save(settingKeyName, selectionValue);
-            ClientSetting.flush();
-          }
-
+          final @Nullable E selectionValue = itemType.cast(e.getItem());
           myAction.accept(selectionValue);
         }
       });
     }
 
     comboBox.setToolTipText(toolTip);
+
+    if (autoCompleteEnabled) {
+      AutoCompletion.enable(comboBox);
+    }
+
     return comboBox;
   }
 
-  public static JComboBoxBuilder builder() {
-    return new JComboBoxBuilder();
+  public static <E> JComboBoxBuilder<E> builder(final Class<E> itemType) {
+    Preconditions.checkNotNull(itemType);
+    return new JComboBoxBuilder<>(itemType);
   }
 
   /**
-   * Adds a set of options to be displayed in the combo box.
+   * Adds a set of items to be displayed in the combo box.
    */
-  public JComboBoxBuilder menuOptions(final Collection<String> options) {
-    Preconditions.checkArgument(!options.isEmpty());
-    this.options.addAll(options);
+  public JComboBoxBuilder<E> items(final Collection<E> items) {
+    Preconditions.checkArgument(!items.isEmpty());
+    this.items.addAll(items);
     return this;
   }
 
   /**
-   * Adds a single option to be displayed in the combo box (additive with any existing).
+   * Adds a single item to be displayed in the combo box (additive with any existing).
    */
-  public JComboBoxBuilder menuOption(final String option) {
-    Preconditions.checkArgument(!option.isEmpty());
-    this.options.add(option);
+  public JComboBoxBuilder<E> item(final E item) {
+    Preconditions.checkNotNull(item);
+    items.add(item);
     return this;
   }
 
@@ -127,45 +98,19 @@ public final class JComboBoxBuilder {
    * Adds a listener that is fired when an item is selected. The input value
    * to the passed in consumer is the value selected.
    */
-  public JComboBoxBuilder itemListener(final Consumer<String> selectionAction) {
-    Preconditions.checkNotNull(selectionAction);
-    this.selectionAction = selectionAction;
+  public JComboBoxBuilder<E> itemSelectedAction(final Consumer<E> itemSelectedAction) {
+    Preconditions.checkNotNull(itemSelectedAction);
+    this.itemSelectedAction = itemSelectedAction;
     return this;
   }
 
-  /**
-   * Toggles a behavior where the last selected value will be remembered as a default.
-   * This uses ClientSettings, so it would use the windows registry to store these values.
-   *
-   * @param settingKeyName A key name to be used for storage. Unique names will overwrite each other.
-   */
-  public JComboBoxBuilder useLastSelectionAsFutureDefault(final String settingKeyName) {
-    this.settingKeyName = settingKeyName;
-    if (selectionAction == null) {
-      selectionAction = value -> {
-      };
-    }
-    return this;
-  }
-
-  /**
-   * Toggles a behavior where last selected value is remembered. The ClientSetting passed in
-   * as a parameter is used to 'back' this behavior. The value of the ClientSetting will
-   * be read for a default value and will be saved back when the combo box selection has
-   * been updated.
-   */
-  public JComboBoxBuilder useLastSelectionAsFutureDefault(final ClientSetting clientSetting) {
-    this.clientSetting = clientSetting;
-    if (selectionAction == null) {
-      selectionAction = value -> {
-      };
-    }
-    return this;
-  }
-
-
-  public JComboBoxBuilder toolTip(final String toolTip) {
+  public JComboBoxBuilder<E> toolTip(final String toolTip) {
     this.toolTip = toolTip;
+    return this;
+  }
+
+  public JComboBoxBuilder<E> enableAutoComplete() {
+    autoCompleteEnabled = true;
     return this;
   }
 }


### PR DESCRIPTION
## Overview

Addresses https://forums.triplea-game.org/topic/1026/find-province-command.

Adds auto-completion support to the combo box in the `SelectTerritoryDialog` so the user may type the start of the territory name to auto-select the correct entry instead of picking it from the drop-down list.

(**NB:** The vanilla Swing non-editable combo-box does support limited auto-completion, but it's highly time-dependent, and doesn't work when spaces are present in the name [the space triggers the drop-down list to appear].  It also can't be customized to handle accented characters, as has been discussed on the forum.)

## Functional Changes

* The territory combo-box in the `SelectTerritoryDialog` is now editable.
* The user can type in any valid territory name (and only a valid territory name).
* The combo-box will auto-complete the closest match to what the user has typed so far.
* The territory list is now sorted lexicographically for real.  I mistakenly assumed in #4115 this was the case.

## Other Changes

The auto-complete support comes from the new `AutoCompletion` class.  This class was taken verbatim from [here](http://www.orbital-computer.de/JComboBox/).  It was modified only in the following respects:

* To conform to our formatter guidelines and Checkstyle rules.
* One functional change was made in the key listener to not display the drop-down list when the user presses <kbd>Enter</kbd> or <kbd>Esc</kbd> when the combo-box has focus.  This prevents the drop-down list from interfering with how these keypresses are processed by the dialog itself (i.e. to close it).

This code has been released into the public domain, so there are no licensing issues bringing it into a GPL-3.0-or-later project.

## Manual Testing Performed

* Same tests as were performed for #4115.
* In addition, ensured the auto-complete functionality behaved as expected.

## Before & After Screen Shots

### Before

![select-territory-dialog-before](https://user-images.githubusercontent.com/4826349/46267312-308db580-c502-11e8-8dda-7fe36ac9aeb5.png)

### After

![select-territory-dialog-after](https://user-images.githubusercontent.com/4826349/46267317-35eb0000-c502-11e8-9610-5dd2853e9937.png)

## Additional Review Notes

When searching for libraries to support auto-completion functionality, the `AutoCompletion` class, seemed to have the simplest and most robust implementation (based on my testing).  I would have preferred a binary dependency, but I couldn't find a suitable one.  At 232 lines, it doesn't seem like a huge maintenance burden to bring into our codebase.  However, if anyone wants to recommend a different library, I'd be happy to give it a shot.

Also, one big plus I see with `AutoCompletion` is that it is decorator-based rather than inheritance-based.  As seen from the diff, the changes to existing code was one line.

Note that `AutoCompletion` implements auto-completion in a very opinionated way, and makes heavy use of selecting text in the text field component of the combo box (as can be seen from the above screenshot).  Reviewers may want to check out this branch and play around with the auto-selection behavior to see if they're comfortable with it.  It surprised me at first, but I quickly got used to it.  The original author gives a lot of justification for this design at the above link.