### PR TITLE
Error Prone: Fix immutable enum checker violations in ClientSetting (Option 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',
+            '-Xep:ImmutableEnumChecker:ERROR',
             '-Xep:InconsistentCapitalization:ERROR',
             '-Xep:JdkObsolete:ERROR',
             '-Xep:MissingOverride:ERROR',


### PR DESCRIPTION
## Overview

This is the first of three proposals for resolving the last remaining Error Prone ImmutableEnumChecker violation in the `ClientSetting` class.

This proposal moves the mutability out of each `ClientSetting` instance and into a class-level variable.  There is already precedent for mutability at the class level via the `preferencesRef` field.

#### Pros

* Relatively simple change.

#### Cons

* A bit of a smell.  It would smell slightly less if the update notification mechanism were moved to a separate _Mediator_-like type, but I'm not sure that's justified at this time.
* Slight increase in lock contention because all instances attempt to acquire the same lock when manipulating save actions (a relatively rare operation).

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the Settings window including those settings that react to update notifications (e.g. L&F, Show Console).

## Additional Review Notes

Please vote all proposed solutions up (:+1:) or down (:-1:).  If voting up, please state your preference among all proposals you voted up.