### PR TITLE
Error Prone: Fix immutable enum checker violations in ClientSetting (Option 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',
+            '-Xep:ImmutableEnumChecker:ERROR',
             '-Xep:InconsistentCapitalization:ERROR',
             '-Xep:JdkObsolete:ERROR',
             '-Xep:MissingOverride:ERROR',

--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -50,13 +50,13 @@ public final class Console {
   public Console() {
     setLogLevel(getDefaultLogLevel());
 
-    ClientSetting.SHOW_CONSOLE.addSaveListener(newValue -> {
+    ClientSetting.showConsole.addSaveListener(newValue -> {
       if (newValue.equals(String.valueOf(true))) {
         SwingUtilities.invokeLater(() -> setVisible(true));
       }
     });
 
-    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.SHOW_CONSOLE.saveAndFlush(false));
+    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.saveAndFlush(false));
     LookAndFeelSwingFrameListener.register(frame);
     frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     frame.getContentPane().setLayout(new BorderLayout());
@@ -80,17 +80,17 @@ public final class Console {
     actions.add(newLogLevelButton());
     SwingUtilities.invokeLater(frame::pack);
 
-    if (ClientSetting.SHOW_CONSOLE.booleanValue()) {
+    if (ClientSetting.showConsole.booleanValue()) {
       SwingUtilities.invokeLater(() -> setVisible(true));
     }
   }
 
   private static Level getDefaultLogLevel() {
-    final String logLevelName = ClientSetting.LOGGING_VERBOSITY.value();
+    final String logLevelName = ClientSetting.loggingVerbosity.value();
     try {
       return Level.parse(logLevelName);
     } catch (final IllegalArgumentException e) {
-      log.warning("Client setting " + ClientSetting.LOGGING_VERBOSITY + " contains malformed log level ("
+      log.warning("Client setting " + ClientSetting.loggingVerbosity + " contains malformed log level ("
           + logLevelName + "); defaulting to WARNING");
       return Level.WARNING;
     }
@@ -144,7 +144,7 @@ public final class Console {
   }
 
   private static void setDefaultLogLevel(final Level level) {
-    ClientSetting.LOGGING_VERBOSITY.saveAndFlush(level.getName());
+    ClientSetting.loggingVerbosity.saveAndFlush(level.getName());
   }
 
   public void setVisible(final boolean visible) {

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -74,7 +74,7 @@ public enum ErrorMessage {
                 .toolTip("Shows the error console window with full error details.")
                 .actionListener(() -> {
                   hide();
-                  ClientSetting.SHOW_CONSOLE.saveAndFlush("true");
+                  ClientSetting.showConsole.saveAndFlush("true");
                 })
                 .build())
             .addHorizontalGlue()

--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -66,7 +66,7 @@ public final class ClientContext {
 
   public static List<DownloadFileDescription> getMapDownloadList() {
     final String mapDownloadListUrl =
-        (ClientSetting.MAP_LIST_OVERRIDE.isSet()) ? ClientSetting.MAP_LIST_OVERRIDE.value()
+        (ClientSetting.mapListOverride.isSet()) ? ClientSetting.mapListOverride.value()
             : UrlConstants.MAP_DOWNLOAD_LIST.toString();
 
     return new DownloadRunnable(mapDownloadListUrl).getDownloads();

--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -109,7 +109,7 @@ public final class ClientFileSystemHelper {
    *         retained between engine installations. Users can override this location in settings.
    */
   public static File getUserMapsFolder() {
-    final String path = getUserMapsFolderPath(ClientSetting.USER_MAPS_FOLDER_PATH, ClientSetting.MAP_FOLDER_OVERRIDE);
+    final String path = getUserMapsFolderPath(ClientSetting.userMapsFolderPath, ClientSetting.mapFolderOverride);
     final File mapsFolder = new File(path);
     if (!mapsFolder.exists()) {
       mapsFolder.mkdirs();

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -43,8 +43,8 @@ final class EngineVersionCheck {
   private static boolean isEngineUpdateCheckRequired() {
     return isEngineUpdateCheckRequired(
         LocalDate.now(),
-        ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY,
-        ClientSetting.TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE,
+        ClientSetting.firstTimeThisVersion,
+        ClientSetting.lastCheckForEngineUpdate,
         ClientSetting::flush);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -15,7 +15,7 @@ final class UpdatedMapsCheck {
   static boolean isMapUpdateCheckRequired() {
     return isMapUpdateCheckRequired(
         LocalDate.now(),
-        ClientSetting.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES,
+        ClientSetting.lastCheckForMapUpdates,
         ClientSetting::flush);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
@@ -46,8 +46,8 @@ public final class LobbyServerPropertiesFetcher {
    * configuration that we would pass back in case github is not available.
    *
    * <p>
-   * The lobby server properties may be overridden by setting values for {@link ClientSetting#TEST_LOBBY_HOST} and
-   * {@link ClientSetting#TEST_LOBBY_PORT} simultaneously. Setting only one or the other will cause them to be ignored.
+   * The lobby server properties may be overridden by setting values for {@link ClientSetting#testLobbyHost} and
+   * {@link ClientSetting#testLobbyPort} simultaneously. Setting only one or the other will cause them to be ignored.
    * </p>
    *
    * @return LobbyServerProperties as fetched and parsed from github hosted remote URL.
@@ -58,7 +58,7 @@ public final class LobbyServerPropertiesFetcher {
   }
 
   private static Optional<LobbyServerProperties> getTestOverrideProperties() {
-    return getTestOverrideProperties(ClientSetting.TEST_LOBBY_HOST, ClientSetting.TEST_LOBBY_PORT);
+    return getTestOverrideProperties(ClientSetting.testLobbyHost, ClientSetting.testLobbyPort);
   }
 
   @VisibleForTesting
@@ -80,13 +80,13 @@ public final class LobbyServerPropertiesFetcher {
     try {
       final LobbyServerProperties downloadedProps = downloadAndParseRemoteFile(lobbyPropsUrl, currentVersion,
           LobbyPropertyFileParser::parse);
-      ClientSetting.LOBBY_LAST_USED_HOST.save(downloadedProps.host);
-      ClientSetting.LOBBY_LAST_USED_PORT.save(downloadedProps.port);
+      ClientSetting.lobbyLastUsedHost.save(downloadedProps.host);
+      ClientSetting.lobbyLastUsedPort.save(downloadedProps.port);
       ClientSetting.flush();
       return downloadedProps;
     } catch (final IOException e) {
 
-      if (!ClientSetting.LOBBY_LAST_USED_HOST.isSet()) {
+      if (!ClientSetting.lobbyLastUsedHost.isSet()) {
         log.log(Level.SEVERE,
             String.format("Failed to download lobby server property file from %s; "
                 + "Please verify your internet connection and try again.",
@@ -100,8 +100,8 @@ public final class LobbyServerPropertiesFetcher {
 
       // graceful recovery case, use the last lobby address we knew about
       return new LobbyServerProperties(
-          ClientSetting.LOBBY_LAST_USED_HOST.value(),
-          ClientSetting.LOBBY_LAST_USED_PORT.intValue());
+          ClientSetting.lobbyLastUsedHost.value(),
+          ClientSetting.lobbyLastUsedPort.intValue());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -18,7 +18,7 @@ public final class ArgParser {
    * Move command line arguments to system properties or client settings.
    */
   public static void handleCommandLineArgs(final String... args) {
-    ClientSetting.MAP_FOLDER_OVERRIDE.save(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue);
+    ClientSetting.mapFolderOverride.save(ClientSetting.mapFolderOverride.defaultValue);
 
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {
       handleMapDownloadArg(args[0]);
@@ -42,7 +42,7 @@ public final class ArgParser {
 
   private static void setSystemPropertyOrClientSetting(final String key, final String value) {
     if (CliProperties.MAP_FOLDER.equals(key)) {
-      ClientSetting.MAP_FOLDER_OVERRIDE.saveAndFlush(value);
+      ClientSetting.mapFolderOverride.saveAndFlush(value);
     } else {
       System.setProperty(key, value);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -113,7 +113,7 @@ public final class GameRunner {
     Thread.setDefaultUncaughtExceptionHandler((t, e) -> log.log(Level.SEVERE, e.getLocalizedMessage(), e));
     ClientSetting.initialize();
 
-    if (!ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
+    if (!ClientSetting.useExperimentalJavaFxUi.booleanValue()) {
       Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
         LookAndFeel.initialize();
         final Console console = new Console();
@@ -147,7 +147,7 @@ public final class GameRunner {
       HttpProxy.updateSystemProxy();
     }
 
-    if (ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI.booleanValue()) {
+    if (ClientSetting.useExperimentalJavaFxUi.booleanValue()) {
       Services.loadAny(JavaFxClientRunner.class).start(args);
     } else {
       SwingUtilities.invokeLater(() -> {

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -211,7 +211,7 @@ public class ServerGame extends AbstractGame {
         }
       }, "Waiting on observer to finish joining: " + newNode.getName()).start();
       try {
-        if (!waitOnObserver.await(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME.intValue(), TimeUnit.SECONDS)) {
+        if (!waitOnObserver.await(ClientSetting.serverObserverJoinWaitTime.intValue(), TimeUnit.SECONDS)) {
           nonBlockingObserver.cannotJoinGame("Taking too long to join.");
         }
       } catch (final InterruptedException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -591,7 +591,7 @@ public class HeadlessGameServer {
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
 
-    final File mapFolder = new File(ClientSetting.MAP_FOLDER_OVERRIDE.value());
+    final File mapFolder = new File(ClientSetting.mapFolderOverride.value());
     if (!mapFolder.isDirectory()) {
       log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: '" + mapFolder + "'");
       printUsage = true;

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -39,7 +39,7 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void initialize() {
-    ClientSetting.LOOK_AND_FEEL_PREF.addSaveListener(newValue -> {
+    ClientSetting.lookAndFeel.addSaveListener(newValue -> {
       setupLookAndFeel(newValue);
       SettingsWindow.updateLookAndFeel();
       JOptionPane.showMessageDialog(
@@ -49,7 +49,7 @@ public final class LookAndFeel {
           "Close TripleA and Restart",
           JOptionPane.WARNING_MESSAGE);
     });
-    setupLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
+    setupLookAndFeel(ClientSetting.lookAndFeel.value());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
@@ -30,9 +30,9 @@ public final class LookAndFeelSwingFrameListener implements Consumer<String> {
    */
   public static void register(final JFrame component) {
     final Consumer<String> listener = new LookAndFeelSwingFrameListener(component);
-    ClientSetting.LOOK_AND_FEEL_PREF.addSaveListener(listener);
+    ClientSetting.lookAndFeel.addSaveListener(listener);
     SwingComponents.addWindowClosingListener(component,
-        () -> ClientSetting.LOOK_AND_FEEL_PREF.removeSaveListener(listener));
+        () -> ClientSetting.lookAndFeel.removeSaveListener(listener));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -133,13 +133,13 @@ public class MapDownloadController {
     return new TutorialMapPreferences() {
       @Override
       public void preventPromptToDownload() {
-        ClientSetting.TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP.save(false);
+        ClientSetting.promptToDownloadTutorialMap.save(false);
         ClientSetting.flush();
       }
 
       @Override
       public boolean canPromptToDownload() {
-        return ClientSetting.TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP.booleanValue();
+        return ClientSetting.promptToDownloadTutorialMap.booleanValue();
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -154,7 +154,7 @@ public class ServerLauncher extends AbstractLauncher {
       if (abortLaunch) {
         serverReady.countDownAll();
       }
-      if (!serverReady.await(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME.intValue(), TimeUnit.SECONDS)) {
+      if (!serverReady.await(ClientSetting.serverStartGameSyncWaitTime.intValue(), TimeUnit.SECONDS)) {
         log.warning("Aborting launch - waiting for clients to be ready timed out!");
         abortLaunch = true;
       }
@@ -184,7 +184,7 @@ public class ServerLauncher extends AbstractLauncher {
           // wait for the connection handler to notice, and shut us down
           Interruptibles.await(() -> {
             if (!abortLaunch
-                && !errorLatch.await(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME.intValue(), TimeUnit.SECONDS)) {
+                && !errorLatch.await(ClientSetting.serverObserverJoinWaitTime.intValue(), TimeUnit.SECONDS)) {
               log.warning("Waiting on error latch timed out!");
             }
           });

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -173,7 +173,7 @@ public class ClientModel implements IMessengerErrorListener {
       return props;
     }
     // load in the saved name!
-    final String playername = ClientSetting.PLAYER_NAME.value();
+    final String playername = ClientSetting.playerName.value();
     final Interruptibles.Result<ClientProps> result = Interruptibles.awaitResult(() -> SwingAction
         .invokeAndWaitResult(() -> {
           final ClientOptions options = new ClientOptions(ui, playername, GameRunner.PORT, "127.0.0.1");
@@ -208,7 +208,7 @@ public class ClientModel implements IMessengerErrorListener {
     }
     final String name = props.getName();
     log.fine("Client playing as:" + name);
-    ClientSetting.PLAYER_NAME.save(name);
+    ClientSetting.playerName.save(name);
     ClientSetting.flush();
     final int port = props.getPort();
     if (port >= 65536 || port <= 0) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -56,9 +56,9 @@ public class GameSelectorModel extends Observable {
     fileName = entry.getLocation();
     setGameData(entry.getGameData());
     if (entry.getGameData() != null) {
-      ClientSetting.DEFAULT_GAME_NAME_PREF.save(entry.getGameData().getGameName());
+      ClientSetting.defaultGameName.save(entry.getGameData().getGameName());
     }
-    ClientSetting.DEFAULT_GAME_URI_PREF.save(entry.getUri().toString());
+    ClientSetting.defaultGameUri.save(entry.getUri().toString());
     ClientSetting.flush();
   }
 
@@ -209,7 +209,7 @@ public class GameSelectorModel extends Observable {
    * on startup.
    */
   public void loadDefaultGameSameThread() {
-    final String userPreferredDefaultGameUri = ClientSetting.DEFAULT_GAME_URI_PREF.value();
+    final String userPreferredDefaultGameUri = ClientSetting.defaultGameUri.value();
 
     // we don't want to load a game file by default that is not within the map folders we can load. (ie: if a previous
     // version of triplea
@@ -249,12 +249,12 @@ public class GameSelectorModel extends Observable {
   }
 
   private static void resetToFactoryDefault() {
-    ClientSetting.DEFAULT_GAME_URI_PREF.save(ClientSetting.DEFAULT_GAME_URI_PREF.defaultValue);
+    ClientSetting.defaultGameUri.save(ClientSetting.defaultGameUri.defaultValue);
     ClientSetting.flush();
   }
 
   private static GameChooserEntry selectByName() {
-    final String userPreferredDefaultGameName = ClientSetting.DEFAULT_GAME_NAME_PREF.value();
+    final String userPreferredDefaultGameName = ClientSetting.defaultGameName.value();
 
     final GameChooserModel model = new GameChooserModel();
     GameChooserEntry selectedGame = model.findByName(userPreferredDefaultGameName)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -182,7 +182,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           .password(System.getProperty(SERVER_PASSWORD))
           .build());
     }
-    final String playername = ClientSetting.PLAYER_NAME.value();
+    final String playername = ClientSetting.playerName.value();
     final Interruptibles.Result<ServerOptions> optionsResult = Interruptibles
         .awaitResult(() -> SwingAction.invokeAndWaitResult(() -> {
           final ServerOptions options = new ServerOptions(ui, playername, GameRunner.PORT, false);
@@ -194,7 +194,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           }
           final String name = options.getName();
           log.fine("Server playing as:" + name);
-          ClientSetting.PLAYER_NAME.save(name);
+          ClientSetting.playerName.save(name);
           ClientSetting.flush();
           final int port = options.getPort();
           if (port >= 65536 || port == 0) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -24,7 +24,7 @@ public final class GameFileSelector {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = GameRunner.newFileDialog();
       fileDialog.setMode(FileDialog.LOAD);
-      fileDialog.setDirectory(new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value()).getPath());
+      fileDialog.setDirectory(new File(ClientSetting.saveGamesFolderPath.value()).getPath());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -34,7 +34,7 @@ public class HttpProxy {
   public static final String PROXY_CHOICE = "proxy.choice";
 
   public static boolean isUsingSystemProxy() {
-    return ClientSetting.PROXY_CHOICE.value().equals(ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+    return ClientSetting.proxyChoice.value().equals(ProxyChoice.USE_SYSTEM_SETTINGS.toString());
   }
 
   /**
@@ -54,8 +54,8 @@ public class HttpProxy {
       port = host.isEmpty() ? "" : String.valueOf(address.get().getPort());
     }
 
-    ClientSetting.PROXY_HOST.save(host);
-    ClientSetting.PROXY_PORT.save(port);
+    ClientSetting.proxyHost.save(host);
+    ClientSetting.proxyPort.save(port);
     ClientSetting.flush();
   }
 
@@ -87,8 +87,8 @@ public class HttpProxy {
    * Attaches proxy host and port values, if any, to the http request parameter.
    */
   public static void addProxy(final HttpRequestBase request) {
-    final String host = ClientSetting.PROXY_HOST.value();
-    final String port = ClientSetting.PROXY_PORT.value();
+    final String host = ClientSetting.proxyHost.value();
+    final String port = ClientSetting.proxyPort.value();
 
     if (Strings.emptyToNull(host) != null && Strings.emptyToNull(port) != null) {
       request.setConfig(RequestConfig

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -65,7 +65,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   @VisibleForTesting
   static File getAutoSaveFile(final String fileName) {
-    return Paths.get(ClientSetting.SAVE_GAMES_FOLDER_PATH.value(), "autoSave", fileName).toFile();
+    return Paths.get(ClientSetting.saveGamesFolderPath.value(), "autoSave", fileName).toFile();
   }
 
   private static File getAutoSaveFile(final String baseFileName, final boolean headless) {
@@ -123,7 +123,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   private SaveGameFileChooser() {
     setFileFilter(createGameDataFileFilter());
-    final File saveGamesFolder = new File(ClientSetting.SAVE_GAMES_FOLDER_PATH.value());
+    final File saveGamesFolder = new File(ClientSetting.saveGamesFolderPath.value());
     ensureDirectoryExists(saveGamesFolder);
     setCurrentDirectory(saveGamesFolder);
   }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -635,7 +635,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
       return;
     }
     // we dont want to confirm enemy casualties
-    if (!ClientSetting.CONFIRM_ENEMY_CASUALTIES.booleanValue()) {
+    if (!ClientSetting.confirmEnemyCasualties.booleanValue()) {
       return;
     }
     ui.getBattlePanel().confirmCasualties(battleId, message);

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -630,6 +630,6 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
    * Pause the game to allow the human player to see what is going on.
    */
   protected static void pause() {
-    Interruptibles.sleep(ClientSetting.AI_PAUSE_DURATION.intValue());
+    Interruptibles.sleep(ClientSetting.aiPauseDuration.intValue());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -259,6 +259,6 @@ public class ProUtils {
    * Pause the game to allow the human player to see what is going on.
    */
   public static void pause() {
-    Interruptibles.sleep(ClientSetting.AI_PAUSE_DURATION.intValue());
+    Interruptibles.sleep(ClientSetting.aiPauseDuration.intValue());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -152,8 +152,8 @@ class OddsCalculatorPanel extends JPanel {
     numRuns.setMax(20000);
 
     final int simulationCount = Properties.getLowLuck(data)
-        ? ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK.intValue()
-        : ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE.intValue();
+        ? ClientSetting.battleCalcSimulationCountLowLuck.intValue()
+        : ClientSetting.battleCalcSimulationCountDice.intValue();
     numRuns.setValue(simulationCount);
     retreatAfterXRounds.setColumns(4);
     retreatAfterXRounds.setMin(-1);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -36,128 +36,103 @@ import lombok.extern.java.Log;
  *
  * <code><pre>
  * // loading a value
- * String value = ClientSetting.AI_PAUSE_DURATION.value();
+ * String value = ClientSetting.aiPauseDuration.value();
  *
  * // saving value
- * ClientSetting.AI_PAUSE_DURATION.save(500);
+ * ClientSetting.aiPauseDuration.save(500);
  * ClientSetting.flush();
  * </pre></code>
  */
 @Log
-public enum ClientSetting implements GameSetting {
-  AI_PAUSE_DURATION(400),
-
-  ARROW_KEY_SCROLL_SPEED(70),
-
-  BATTLE_CALC_SIMULATION_COUNT_DICE(200),
-
-  BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK(500),
-
-  CONFIRM_DEFENSIVE_ROLLS(false),
-
-  CONFIRM_ENEMY_CASUALTIES(false),
-
-  DEFAULT_GAME_NAME_PREF("Big World : 1942"),
-
-  DEFAULT_GAME_URI_PREF,
-
-  FASTER_ARROW_KEY_SCROLL_MULTIPLIER(2),
-
-  SPACE_BAR_CONFIRMS_CASUALTIES(true),
-
-  LOBBY_LAST_USED_HOST,
-
-  LOBBY_LAST_USED_PORT,
-
-  LOOK_AND_FEEL_PREF(LookAndFeel.getDefaultLookAndFeelClassName()),
-
-  MAP_EDGE_SCROLL_SPEED(30),
-
-  MAP_EDGE_SCROLL_ZONE_SIZE(30),
-
-  MAP_FOLDER_OVERRIDE,
-
-  MAP_LIST_OVERRIDE,
-
-  PROXY_CHOICE,
-
-  PROXY_HOST,
-
-  PROXY_PORT,
-
-  SAVE_GAMES_FOLDER_PATH(new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames")),
-
-  SERVER_OBSERVER_JOIN_WAIT_TIME(180),
-
-  SERVER_START_GAME_SYNC_WAIT_TIME(180),
-
-  SHOW_BATTLES_WHEN_OBSERVING(true),
-
-  SHOW_BETA_FEATURES(false),
-
-  SHOW_CONSOLE(false),
-
-  TEST_LOBBY_HOST,
-
-  TEST_LOBBY_PORT,
-
-  TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY(true),
-
-  TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE,
-
-  TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES,
-
-  TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP(true),
-
-  TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
-
-  TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME,
-
-  USER_MAPS_FOLDER_PATH(new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps")),
-
-  WHEEL_SCROLL_AMOUNT(60),
-
-  PLAYER_NAME(SystemProperties.getUserName()),
-
-  USE_EXPERIMENTAL_JAVAFX_UI(false),
-
+public final class ClientSetting implements GameSetting {
+  public static final ClientSetting aiPauseDuration = new ClientSetting("AI_PAUSE_DURATION", 400);
+  public static final ClientSetting arrowKeyScrollSpeed = new ClientSetting("ARROW_KEY_SCROLL_SPEED", 70);
+  public static final ClientSetting battleCalcSimulationCountDice =
+      new ClientSetting("BATTLE_CALC_SIMULATION_COUNT_DICE", 200);
+  public static final ClientSetting battleCalcSimulationCountLowLuck =
+      new ClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
+  public static final ClientSetting confirmDefensiveRolls = new ClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
+  public static final ClientSetting confirmEnemyCasualties = new ClientSetting("CONFIRM_ENEMY_CASUALTIES", false);
+  public static final ClientSetting defaultGameName = new ClientSetting("DEFAULT_GAME_NAME_PREF", "Big World : 1942");
+  public static final ClientSetting defaultGameUri = new ClientSetting("DEFAULT_GAME_URI_PREF");
+  public static final ClientSetting fasterArrowKeyScrollMultiplier =
+      new ClientSetting("FASTER_ARROW_KEY_SCROLL_MULTIPLIER", 2);
+  public static final ClientSetting spaceBarConfirmsCasualties =
+      new ClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
+  public static final ClientSetting lobbyLastUsedHost = new ClientSetting("LOBBY_LAST_USED_HOST");
+  public static final ClientSetting lobbyLastUsedPort = new ClientSetting("LOBBY_LAST_USED_PORT");
+  public static final ClientSetting lookAndFeel =
+      new ClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
+  public static final ClientSetting mapEdgeScrollSpeed = new ClientSetting("MAP_EDGE_SCROLL_SPEED", 30);
+  public static final ClientSetting mapEdgeScrollZoneSize = new ClientSetting("MAP_EDGE_SCROLL_ZONE_SIZE", 30);
+  public static final ClientSetting mapFolderOverride = new ClientSetting("MAP_FOLDER_OVERRIDE");
+  public static final ClientSetting mapListOverride = new ClientSetting("MAP_LIST_OVERRIDE");
+  public static final ClientSetting proxyChoice = new ClientSetting("PROXY_CHOICE");
+  public static final ClientSetting proxyHost = new ClientSetting("PROXY_HOST");
+  public static final ClientSetting proxyPort = new ClientSetting("PROXY_PORT");
+  public static final ClientSetting saveGamesFolderPath =
+      new ClientSetting("SAVE_GAMES_FOLDER_PATH", new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames"));
+  public static final ClientSetting serverObserverJoinWaitTime =
+      new ClientSetting("SERVER_OBSERVER_JOIN_WAIT_TIME", 180);
+  public static final ClientSetting serverStartGameSyncWaitTime =
+      new ClientSetting("SERVER_START_GAME_SYNC_WAIT_TIME", 180);
+  public static final ClientSetting showBattlesWhenObserving =
+      new ClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
+  public static final ClientSetting showBetaFeatures = new ClientSetting("SHOW_BETA_FEATURES", false);
+  public static final ClientSetting showConsole = new ClientSetting("SHOW_CONSOLE", false);
+  public static final ClientSetting testLobbyHost = new ClientSetting("TEST_LOBBY_HOST");
+  public static final ClientSetting testLobbyPort = new ClientSetting("TEST_LOBBY_PORT");
+  public static final ClientSetting firstTimeThisVersion =
+      new ClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
+  public static final ClientSetting lastCheckForEngineUpdate =
+      new ClientSetting("TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE");
+  public static final ClientSetting lastCheckForMapUpdates = new ClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES");
+  public static final ClientSetting promptToDownloadTutorialMap =
+      new ClientSetting("TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP", true);
+  public static final ClientSetting tripleaServerObserverJointWaitTime =
+      new ClientSetting("TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME");
+  public static final ClientSetting tripleaServerStartGameSyncWaitTime =
+      new ClientSetting("TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME");
+  public static final ClientSetting userMapsFolderPath = new ClientSetting(
+      "USER_MAPS_FOLDER_PATH",
+      new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps"));
+  public static final ClientSetting wheelScrollAmount = new ClientSetting("WHEEL_SCROLL_AMOUNT", 60);
+  public static final ClientSetting playerName = new ClientSetting("PLAYER_NAME", SystemProperties.getUserName());
+  public static final ClientSetting useExperimentalJavaFxUi = new ClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
   /* for testing purposes, to be used in unit tests only */
   @VisibleForTesting
-  TEST_SETTING,
-
-  SELECTED_GAME_LOCATION,
-
-  DICE_SERVER_FOR_FORUM_GAMES,
-
-  FORUM_COMBO_BOX_SELECTION,
-
-  DICE_SERVER_FOR_PBEM_GAMES,
-
-  LOGGING_VERBOSITY(Level.WARNING.getName());
+  public static final ClientSetting test = new ClientSetting("TEST_SETTING");
+  public static final ClientSetting selectedGameLocation = new ClientSetting("SELECTED_GAME_LOCATION");
+  public static final ClientSetting diceServerForForumGames = new ClientSetting("DICE_SERVER_FOR_FORUM_GAMES");
+  public static final ClientSetting forumComboBoxSelection = new ClientSetting("FORUM_COMBO_BOX_SELECTION");
+  public static final ClientSetting diceServerForPbemGames = new ClientSetting("DICE_SERVER_FOR_PBEM_GAMES");
+  public static final ClientSetting loggingVerbosity = new ClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
 
   private static final AtomicReference<Preferences> preferencesRef = new AtomicReference<>();
 
+  private final String name;
   public final String defaultValue;
   private final Collection<Consumer<String>> onSaveActions = new CopyOnWriteArrayList<>();
 
-  ClientSetting(final String defaultValue) {
+  ClientSetting(final String name, final String defaultValue) {
+    this.name = name;
     this.defaultValue = defaultValue;
   }
 
-  ClientSetting() {
-    this("");
+  ClientSetting(final String name) {
+    this(name, "");
   }
 
-  ClientSetting(final File file) {
-    this(file.getAbsolutePath());
+  ClientSetting(final String name, final File file) {
+    this(name, file.getAbsolutePath());
   }
 
-  ClientSetting(final int defaultValue) {
-    this(String.valueOf(defaultValue));
+  ClientSetting(final String name, final int defaultValue) {
+    this(name, String.valueOf(defaultValue));
   }
 
-  ClientSetting(final boolean defaultValue) {
-    this(String.valueOf(defaultValue));
+  ClientSetting(final String name, final boolean defaultValue) {
+    this(name, String.valueOf(defaultValue));
   }
 
   /**
@@ -233,9 +208,9 @@ public enum ClientSetting implements GameSetting {
     onSaveActions.forEach(saveAction -> saveAction.accept(Strings.nullToEmpty(newValue)));
 
     if (newValue == null) {
-      getPreferences().remove(name());
+      getPreferences().remove(name);
     } else {
-      getPreferences().put(name(), newValue);
+      getPreferences().put(name, newValue);
     }
   }
 
@@ -264,11 +239,33 @@ public enum ClientSetting implements GameSetting {
   @Override
   @Nonnull
   public String value() {
-    return Strings.nullToEmpty(getPreferences().get(name(), defaultValue));
+    return Strings.nullToEmpty(getPreferences().get(name, defaultValue));
   }
 
   @Override
   public void resetAndFlush() {
     saveAndFlush(defaultValue);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (!(obj instanceof ClientSetting)) {
+      return false;
+    }
+
+    final ClientSetting other = (ClientSetting) obj;
+    return name.equals(other.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return name;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -35,7 +35,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Time (in milliseconds) between AI moves") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000);
+      return intValueRange(ClientSetting.aiPauseDuration, 0, 3000);
     }
   },
 
@@ -45,7 +45,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "How fast the map is scrolled (in pixels) when using the arrow keys") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500);
+      return intValueRange(ClientSetting.arrowKeyScrollSpeed, 0, 500);
     }
   },
 
@@ -55,7 +55,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Default battle simulation count in dice games") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000);
+      return intValueRange(ClientSetting.battleCalcSimulationCountDice, 10, 100000);
     }
   },
 
@@ -65,7 +65,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Default battle simulation count in low luck games") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000);
+      return intValueRange(ClientSetting.battleCalcSimulationCountLowLuck, 10, 100000);
     }
   },
 
@@ -75,7 +75,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Whether battle should proceed until you confirm the dice you roll while on defense") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.CONFIRM_DEFENSIVE_ROLLS);
+      return booleanRadioButtons(ClientSetting.confirmDefensiveRolls);
     }
   },
 
@@ -85,7 +85,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Whether battles should proceed only once every player has confirmed the casualties selected") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.CONFIRM_ENEMY_CASUALTIES);
+      return booleanRadioButtons(ClientSetting.confirmEnemyCasualties);
     }
   },
 
@@ -96,7 +96,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "When set to false, the confirm casualty button has to always be clicked.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES);
+      return booleanRadioButtons(ClientSetting.spaceBarConfirmsCasualties);
     }
   },
 
@@ -108,9 +108,9 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
       return selectionBox(
-          ClientSetting.LOOK_AND_FEEL_PREF,
+          ClientSetting.lookAndFeel,
           LookAndFeel.getLookAndFeelAvailableList(),
-          ClientSetting.LOOK_AND_FEEL_PREF.value(),
+          ClientSetting.lookAndFeel.value(),
           s -> s.replaceFirst(".*\\.", "").replaceFirst("LookAndFeel$", ""));
     }
   },
@@ -121,7 +121,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "How fast the map scrolls (in pixels) when the mouse is moved close to the map edge") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300);
+      return intValueRange(ClientSetting.mapEdgeScrollSpeed, 0, 300);
     }
   },
 
@@ -131,7 +131,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "How close to the edge of the map (in pixels) the mouse needs to be for the map to start scrolling") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300);
+      return intValueRange(ClientSetting.mapEdgeScrollZoneSize, 0, 300);
     }
   },
 
@@ -141,7 +141,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Maximum time (in seconds) to wait for all clients to sync data on game start") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500);
+      return intValueRange(ClientSetting.serverStartGameSyncWaitTime, 120, 1500);
     }
   },
 
@@ -151,7 +151,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Maximum time (in seconds) for host to wait for clients and observers") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500);
+      return intValueRange(ClientSetting.serverObserverJoinWaitTime, 60, 1500);
     }
   },
 
@@ -161,7 +161,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Whether to show a battle if you are only observing.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.SHOW_BATTLES_WHEN_OBSERVING);
+      return booleanRadioButtons(ClientSetting.showBattlesWhenObserving);
     }
   },
 
@@ -173,7 +173,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "Restart to fully activate") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.SHOW_BETA_FEATURES);
+      return booleanRadioButtons(ClientSetting.showBetaFeatures);
     }
   },
 
@@ -183,7 +183,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Shows the TripleA console, closing the window will turn this setting off") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.SHOW_CONSOLE);
+      return booleanRadioButtons(ClientSetting.showConsole);
     }
   },
 
@@ -194,7 +194,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "update it, and put the path to that file here.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return filePath(ClientSetting.MAP_LIST_OVERRIDE);
+      return filePath(ClientSetting.mapListOverride);
     }
   },
 
@@ -204,7 +204,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Overrides the IP address or hostname used to connect to the lobby. Useful for connecting to a test lobby.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return textField(ClientSetting.TEST_LOBBY_HOST);
+      return textField(ClientSetting.testLobbyHost);
     }
   },
 
@@ -215,7 +215,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "Set to 0 for no override") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true);
+      return intValueRange(ClientSetting.testLobbyPort, 1, 65535, true);
     }
   },
 
@@ -225,7 +225,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Setting to true will trigger for any first time prompts to be shown") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY);
+      return booleanRadioButtons(ClientSetting.firstTimeThisVersion);
     }
   },
 
@@ -235,7 +235,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "The folder where saved game files will be stored by default") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH);
+      return folderPath(ClientSetting.saveGamesFolderPath);
     }
   },
 
@@ -245,7 +245,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "The folder where game engine will download and find map files.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return folderPath(ClientSetting.USER_MAPS_FOLDER_PATH);
+      return folderPath(ClientSetting.userMapsFolderPath);
     }
   },
 
@@ -255,7 +255,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "How fast the map will scroll (in pixels) when using the mouse wheel") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300);
+      return intValueRange(ClientSetting.wheelScrollAmount, 10, 300);
     }
   },
 
@@ -277,7 +277,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "Just a proof-of-concept. Requires a restart.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return booleanRadioButtons(ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
+      return booleanRadioButtons(ClientSetting.useExperimentalJavaFxUi);
     }
   };
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -50,8 +50,8 @@ final class SelectionComponentFactory {
 
       final JRadioButton userButton =
           new JRadioButton("Use These Settings:", proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
-      final JTextField hostText = new JTextField(ClientSetting.PROXY_HOST.value(), 20);
-      final JTextField portText = new JTextField(ClientSetting.PROXY_PORT.value(), 6);
+      final JTextField hostText = new JTextField(ClientSetting.proxyHost.value(), 20);
+      final JTextField portText = new JTextField(ClientSetting.proxyPort.value(), 6);
       final JPanel radioPanel = JPanelBuilder.builder()
           .verticalBoxLayout()
           .add(noneButton)
@@ -119,14 +119,14 @@ final class SelectionComponentFactory {
       public Map<GameSetting, String> readValues() {
         final Map<GameSetting, String> values = new HashMap<>();
         if (noneButton.isSelected()) {
-          values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.NONE.toString());
+          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.NONE.toString());
         } else if (systemButton.isSelected()) {
-          values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
           HttpProxy.updateSystemProxy();
         } else {
-          values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
-          values.put(ClientSetting.PROXY_HOST, hostText.getText().trim());
-          values.put(ClientSetting.PROXY_PORT, portText.getText().trim());
+          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
+          values.put(ClientSetting.proxyHost, hostText.getText().trim());
+          values.put(ClientSetting.proxyPort, portText.getText().trim());
         }
         return values;
       }
@@ -150,17 +150,17 @@ final class SelectionComponentFactory {
       @Override
       public void resetToDefault() {
         ClientSetting.flush();
-        hostText.setText(ClientSetting.PROXY_HOST.defaultValue);
-        portText.setText(ClientSetting.PROXY_PORT.defaultValue);
-        noneButton.setSelected(Boolean.valueOf(ClientSetting.PROXY_CHOICE.defaultValue));
+        hostText.setText(ClientSetting.proxyHost.defaultValue);
+        portText.setText(ClientSetting.proxyPort.defaultValue);
+        noneButton.setSelected(Boolean.valueOf(ClientSetting.proxyChoice.defaultValue));
       }
 
       @Override
       public void reset() {
         ClientSetting.flush();
-        hostText.setText(ClientSetting.PROXY_HOST.value());
-        portText.setText(ClientSetting.PROXY_PORT.value());
-        noneButton.setSelected(ClientSetting.PROXY_CHOICE.booleanValue());
+        hostText.setText(ClientSetting.proxyHost.value());
+        portText.setText(ClientSetting.proxyPort.value());
+        noneButton.setSelected(ClientSetting.proxyChoice.booleanValue());
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -261,7 +261,7 @@ public class BattleDisplay extends JPanel {
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.
-    if (!ClientSetting.CONFIRM_DEFENSIVE_ROLLS.booleanValue()) {
+    if (!ClientSetting.confirmDefensiveRolls.booleanValue()) {
       final int maxWaitTime = 1500;
       final Timer t = new Timer();
       t.schedule(new TimerTask() {
@@ -480,7 +480,7 @@ public class BattleDisplay extends JPanel {
                 Math.min(availHeight, size.height)));
           }
           final String[] options = {"Ok", "Cancel"};
-          final String focus = ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES.booleanValue() ? options[0] : null;
+          final String focus = ClientSetting.spaceBarConfirmsCasualties.booleanValue() ? options[0] : null;
           final int option = JOptionPane.showOptionDialog(BattleDisplay.this, chooserScrollPane,
               hit.getName() + " select casualties", JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, null, options,
               focus);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -233,7 +233,7 @@ public class BattlePanel extends ActionPanel {
             break;
           }
         }
-        if (ClientSetting.SHOW_BATTLES_WHEN_OBSERVING.booleanValue() || foundHumanInBattle) {
+        if (ClientSetting.showBattlesWhenObserving.booleanValue() || foundHumanInBattle) {
           battleFrame.setVisible(true);
           battleFrame.validate();
           battleFrame.invalidate();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1757,8 +1757,8 @@ public final class TripleAFrame extends JFrame {
 
   private int computeScrollSpeed() {
     return isCtrlPressed
-        ? ClientSetting.ARROW_KEY_SCROLL_SPEED.intValue() * ClientSetting.FASTER_ARROW_KEY_SCROLL_MULTIPLIER.intValue()
-        : ClientSetting.ARROW_KEY_SCROLL_SPEED.intValue();
+        ? ClientSetting.arrowKeyScrollSpeed.intValue() * ClientSetting.fasterArrowKeyScrollMultiplier.intValue()
+        : ClientSetting.arrowKeyScrollSpeed.intValue();
   }
 
   private void showEditMode() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -26,7 +26,7 @@ final class DebugMenu extends JMenu {
       add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
     }
 
-    add(SwingAction.of("Show Console", e -> ClientSetting.SHOW_CONSOLE.saveAndFlush("true")))
+    add(SwingAction.of("Show Console", e -> ClientSetting.showConsole.saveAndFlush("true")))
         .setMnemonic(KeyEvent.VK_C);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -70,7 +70,7 @@ public final class TripleAMenuBar extends JMenuBar {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = new FileDialog(frame);
       fileDialog.setMode(FileDialog.SAVE);
-      fileDialog.setDirectory(ClientSetting.SAVE_GAMES_FOLDER_PATH.value());
+      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.value());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
 

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -100,9 +100,9 @@ public class ImageScrollerLargeView extends JComponent {
         int dx = 0;
         int dy = 0;
         if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) == InputEvent.SHIFT_DOWN_MASK) {
-          dx = e.getWheelRotation() * ClientSetting.WHEEL_SCROLL_AMOUNT.intValue();
+          dx = e.getWheelRotation() * ClientSetting.wheelScrollAmount.intValue();
         } else {
-          dy = e.getWheelRotation() * ClientSetting.WHEEL_SCROLL_AMOUNT.intValue();
+          dy = e.getWheelRotation() * ClientSetting.wheelScrollAmount.intValue();
         }
         // Update the model, which will handle its own clamping or wrapping depending on the map.
         this.model.set(this.model.getX() + dx, this.model.getY() + dy);
@@ -266,15 +266,15 @@ public class ImageScrollerLargeView extends JComponent {
   private void scroll() {
     int dy = 0;
     if ((edge & TOP) != 0) {
-      dy = -ClientSetting.MAP_EDGE_SCROLL_SPEED.intValue();
+      dy = -ClientSetting.mapEdgeScrollSpeed.intValue();
     } else if ((edge & BOTTOM) != 0) {
-      dy = ClientSetting.MAP_EDGE_SCROLL_SPEED.intValue();
+      dy = ClientSetting.mapEdgeScrollSpeed.intValue();
     }
     int dx = 0;
     if ((edge & LEFT) != 0) {
-      dx = -ClientSetting.MAP_EDGE_SCROLL_SPEED.intValue();
+      dx = -ClientSetting.mapEdgeScrollSpeed.intValue();
     } else if ((edge & RIGHT) != 0) {
-      dx = ClientSetting.MAP_EDGE_SCROLL_SPEED.intValue();
+      dx = ClientSetting.mapEdgeScrollSpeed.intValue();
     }
 
     dx = (int) (dx / scale);
@@ -290,14 +290,14 @@ public class ImageScrollerLargeView extends JComponent {
 
   private static int getNewEdge(final int x, final int y, final int width, final int height) {
     int newEdge = NONE;
-    if (x < ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE.intValue()) {
+    if (x < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
       newEdge += LEFT;
-    } else if (width - x < ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE.intValue()) {
+    } else if (width - x < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
       newEdge += RIGHT;
     }
-    if (y < ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE.intValue()) {
+    if (y < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
       newEdge += TOP;
-    } else if (height - y < ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE.intValue()) {
+    } else if (height - y < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
       newEdge += BOTTOM;
     }
     return newEdge;

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -70,21 +70,21 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void mapFolderOverrideClientSettingIsSetWhenSpecified() {
-    ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
+    ClientSetting.mapFolderOverride.save("some value");
     final String mapFolderPath = "/path/to/maps";
 
     ArgParser.handleCommandLineArgs("-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolderPath);
 
-    assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(mapFolderPath));
+    assertThat(ClientSetting.mapFolderOverride.value(), is(mapFolderPath));
   }
 
   @Test
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
-    ClientSetting.MAP_FOLDER_OVERRIDE.save("some value");
+    ClientSetting.mapFolderOverride.save("some value");
 
     ArgParser.handleCommandLineArgs();
 
-    assertThat(ClientSetting.MAP_FOLDER_OVERRIDE.value(), is(ClientSetting.MAP_FOLDER_OVERRIDE.defaultValue));
+    assertThat(ClientSetting.mapFolderOverride.value(), is(ClientSetting.mapFolderOverride.defaultValue));
   }
 
   private interface TestData {

--- a/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
@@ -24,7 +24,7 @@ final class SaveGameFileChooserTest extends AbstractClientSettingTestCase {
   final class GetAutoSaveFileTest {
     @Test
     void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.SAVE_GAMES_FOLDER_PATH.save(Paths.get("path", "to", "saves").toString());
+      ClientSetting.saveGamesFolderPath.save(Paths.get("path", "to", "saves").toString());
 
       final String fileName = "savegame.tsvg";
       assertThat(getAutoSaveFile(fileName), is(Paths.get("path", "to", "saves", "autoSave", fileName).toFile()));

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -2,38 +2,54 @@ package games.strategy.triplea.settings;
 
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-public class ClientSettingTest extends AbstractClientSettingTestCase {
+import nl.jqno.equalsverifier.EqualsVerifier;
 
-  private static final String TEST_VALUE = "value";
-
-  @Mock
-  private Consumer<String> mockSaveListener;
-
-  @Test
-  public void saveActionListenerIsCalled() {
-    ClientSetting.TEST_SETTING.addSaveListener(mockSaveListener);
-
-    ClientSetting.TEST_SETTING.save(TEST_VALUE);
-
-    Mockito.verify(mockSaveListener, Mockito.times(1))
-        .accept(TEST_VALUE);
+final class ClientSettingTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(ClientSetting.class)
+          .withNonnullFields("name")
+          .withOnlyTheseFields("name")
+          .verify();
+    }
   }
 
-  @Test
-  public void verifyRemovedSavedListenersAreNotCalled() {
-    ClientSetting.TEST_SETTING.addSaveListener(mockSaveListener);
-    ClientSetting.TEST_SETTING.removeSaveListener(mockSaveListener);
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class SaveActionTest extends AbstractClientSettingTestCase {
+    private static final String TEST_VALUE = "value";
 
-    ClientSetting.TEST_SETTING.save(TEST_VALUE);
+    @Mock
+    private Consumer<String> mockSaveListener;
 
-    Mockito.verify(mockSaveListener, Mockito.never())
-        .accept(TEST_VALUE);
+    @Test
+    void saveActionListenerIsCalled() {
+      ClientSetting.test.addSaveListener(mockSaveListener);
+
+      ClientSetting.test.save(TEST_VALUE);
+
+      Mockito.verify(mockSaveListener, Mockito.times(1))
+          .accept(TEST_VALUE);
+    }
+
+    @Test
+    void verifyRemovedSavedListenersAreNotCalled() {
+      ClientSetting.test.addSaveListener(mockSaveListener);
+      ClientSetting.test.removeSaveListener(mockSaveListener);
+
+      ClientSetting.test.save(TEST_VALUE);
+
+      Mockito.verify(mockSaveListener, Mockito.never())
+          .accept(TEST_VALUE);
+    }
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -32,140 +32,140 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
   AI_PAUSE_DURATION_BINDING(SettingType.AI) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000);
+      return intValueRange(ClientSetting.aiPauseDuration, 0, 3000);
     }
   },
 
   ARROW_KEY_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500);
+      return intValueRange(ClientSetting.arrowKeyScrollSpeed, 0, 500);
     }
   },
 
   BATTLE_CALC_SIMULATION_COUNT_DICE_BINDING(SettingType.BATTLE_SIMULATOR) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000);
+      return intValueRange(ClientSetting.battleCalcSimulationCountDice, 10, 100000);
     }
   },
 
   BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK_BINDING(SettingType.BATTLE_SIMULATOR) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000);
+      return intValueRange(ClientSetting.battleCalcSimulationCountLowLuck, 10, 100000);
     }
   },
 
   CONFIRM_DEFENSIVE_ROLLS_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.CONFIRM_DEFENSIVE_ROLLS);
+      return toggleButton(ClientSetting.confirmDefensiveRolls);
     }
   },
 
   CONFIRM_ENEMY_CASUALTIES_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.CONFIRM_ENEMY_CASUALTIES);
+      return toggleButton(ClientSetting.confirmEnemyCasualties);
     }
   },
 
   SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(SettingType.COMBAT) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES);
+      return toggleButton(ClientSetting.spaceBarConfirmsCasualties);
     }
   },
 
   MAP_EDGE_SCROLL_SPEED_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300);
+      return intValueRange(ClientSetting.mapEdgeScrollSpeed, 0, 300);
     }
   },
 
   MAP_EDGE_SCROLL_ZONE_SIZE_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300);
+      return intValueRange(ClientSetting.mapEdgeScrollZoneSize, 0, 300);
     }
   },
 
   SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500);
+      return intValueRange(ClientSetting.serverStartGameSyncWaitTime, 120, 1500);
     }
   },
 
   SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500);
+      return intValueRange(ClientSetting.serverObserverJoinWaitTime, 60, 1500);
     }
   },
 
   SHOW_BATTLES_WHEN_OBSERVING_BINDING(SettingType.GAME) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SHOW_BATTLES_WHEN_OBSERVING);
+      return toggleButton(ClientSetting.showBattlesWhenObserving);
     }
   },
 
   SHOW_BETA_FEATURES_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.SHOW_BETA_FEATURES);
+      return toggleButton(ClientSetting.showBetaFeatures);
     }
   },
 
   MAP_LIST_OVERRIDE_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return filePath(ClientSetting.MAP_LIST_OVERRIDE);
+      return filePath(ClientSetting.mapListOverride);
     }
   },
 
   TEST_LOBBY_HOST_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return textField(ClientSetting.TEST_LOBBY_HOST);
+      return textField(ClientSetting.testLobbyHost);
     }
   },
 
   TEST_LOBBY_PORT_BINDING(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 65535, true);
+      return intValueRange(ClientSetting.testLobbyPort, 1, 65535, true);
     }
   },
 
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(SettingType.GAME) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY);
+      return toggleButton(ClientSetting.firstTimeThisVersion);
     }
   },
 
   SAVE_GAMES_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH);
+      return folderPath(ClientSetting.saveGamesFolderPath);
     }
   },
 
   USER_MAPS_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.USER_MAPS_FOLDER_PATH);
+      return folderPath(ClientSetting.userMapsFolderPath);
     }
   },
 
   WHEEL_SCROLL_AMOUNT_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300);
+      return intValueRange(ClientSetting.wheelScrollAmount, 10, 300);
     }
   },
 
@@ -179,7 +179,7 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
   USE_EXPERIMENTAL_JAVAFX_UI(SettingType.TESTING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return toggleButton(ClientSetting.USE_EXPERIMENTAL_JAVAFX_UI);
+      return toggleButton(ClientSetting.useExperimentalJavaFxUi);
     }
   };
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -376,8 +376,8 @@ final class JavaFxSelectionComponentFactory {
 
       userButton = new RadioButton("Use These Settings:");
       userButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
-      hostText = new TextField(ClientSetting.PROXY_HOST.value());
-      portText = new TextField(ClientSetting.PROXY_PORT.value());
+      hostText = new TextField(ClientSetting.proxyHost.value());
+      portText = new TextField(ClientSetting.proxyPort.value());
       final VBox radioPanel = new VBox();
       radioPanel.getChildren().addAll(
           noneButton,
@@ -401,14 +401,14 @@ final class JavaFxSelectionComponentFactory {
     public Map<GameSetting, String> readValues() {
       final Map<GameSetting, String> values = new HashMap<>();
       if (noneButton.isSelected()) {
-        values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.NONE.toString());
+        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.NONE.toString());
       } else if (systemButton.isSelected()) {
-        values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
         HttpProxy.updateSystemProxy();
       } else {
-        values.put(ClientSetting.PROXY_CHOICE, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
-        values.put(ClientSetting.PROXY_HOST, hostText.getText().trim());
-        values.put(ClientSetting.PROXY_PORT, portText.getText().trim());
+        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
+        values.put(ClientSetting.proxyHost, hostText.getText().trim());
+        values.put(ClientSetting.proxyPort, portText.getText().trim());
       }
       return values;
     }
@@ -416,17 +416,17 @@ final class JavaFxSelectionComponentFactory {
     @Override
     public void resetToDefault() {
       ClientSetting.flush();
-      hostText.setText(ClientSetting.PROXY_HOST.defaultValue);
-      portText.setText(ClientSetting.PROXY_PORT.defaultValue);
-      noneButton.setSelected(Boolean.valueOf(ClientSetting.PROXY_CHOICE.defaultValue));
+      hostText.setText(ClientSetting.proxyHost.defaultValue);
+      portText.setText(ClientSetting.proxyPort.defaultValue);
+      noneButton.setSelected(Boolean.valueOf(ClientSetting.proxyChoice.defaultValue));
     }
 
     @Override
     public void reset() {
       ClientSetting.flush();
-      hostText.setText(ClientSetting.PROXY_HOST.value());
-      portText.setText(ClientSetting.PROXY_PORT.value());
-      noneButton.setSelected(ClientSetting.PROXY_CHOICE.booleanValue());
+      hostText.setText(ClientSetting.proxyHost.value());
+      portText.setText(ClientSetting.proxyPort.value());
+      noneButton.setSelected(ClientSetting.proxyChoice.booleanValue());
     }
 
     @Override


### PR DESCRIPTION
## Overview

This is the second of three proposals for resolving the last remaining Error Prone ImmutableEnumChecker violation in the `ClientSetting` class.

This proposal converts the enum to a class.  The enum constants are replaced with class fields.

#### Pros

* Mutability of `ClientSetting` is now communicated through the fact that the field names are not in UPPER_SNAKE_CASE.
* I was originally going to list this as a con, but the setting name is now independent of the field name.  This will make refactoring easier, while maintaining compatibility, at the cost of having to specify an additional constructor parameter.

#### Cons

* Additional verbosity in `ClientSetting`.
* Lots of changes outside `ClientSetting` to accommodate new field names.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the Settings window including those settings that react to update notifications (e.g. L&F, Show Console).

## Additional Review Notes

Please vote all proposed solutions up (:+1:) or down (:-1:).  If voting up, please state your preference among all proposals you voted up.