### PR TITLE
Error Prone: Suppress immutable enum checker violations in ClientSetting (Option 3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',
+            '-Xep:ImmutableEnumChecker:ERROR',
             '-Xep:InconsistentCapitalization:ERROR',
             '-Xep:JdkObsolete:ERROR',
             '-Xep:MissingOverride:ERROR',

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -44,6 +44,7 @@ import lombok.extern.java.Log;
  * </pre></code>
  */
 @Log
+@SuppressWarnings("ImmutableEnumChecker") // conscious decision to violate enum immutability
 public enum ClientSetting implements GameSetting {
   AI_PAUSE_DURATION(400),
 


### PR DESCRIPTION
## Overview

This is the third of three proposals for resolving the last remaining Error Prone ImmutableEnumChecker violation in the `ClientSetting` class.

This proposal simply suppresses the violation, accepting that we are violating the Principle of Least Surprise at having a mutable enum.

#### Pros

* One line change.

#### Cons

* We're punting.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

Please vote all proposed solutions up (:+1:) or down (:-1:).  If voting up, please state your preference among all proposals you voted up.