### PR TITLE
Find Territory: Animate border of selected territory

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
@@ -2,9 +2,14 @@ package games.strategy.triplea.ui;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 import javax.swing.AbstractAction;
+import javax.swing.Timer;
+
+import games.strategy.engine.data.Territory;
 
 /**
  * A UI action that prompts the user to select a territory by name and then centers the map on the selected territory.
@@ -27,6 +32,44 @@ public final class FindTerritoryAction extends AbstractAction {
         frame,
         "Find Territory",
         frame.getGame().getData().getMap().getTerritories());
-    dialog.open().ifPresent(frame.getMapPanel()::centerOn);
+    dialog.open().ifPresent(this::showTerritory);
+  }
+
+  private void showTerritory(final Territory territory) {
+    final MapPanel mapPanel = frame.getMapPanel();
+    mapPanel.centerOn(territory);
+    TerritoryBorderAnimator.run(mapPanel, territory);
+  }
+
+  private static final class TerritoryBorderAnimator implements ActionListener {
+    private static final int FRAME_DELAY_IN_MS = 500;
+    private static final int TOTAL_FRAMES = 10;
+
+    private int frame;
+    private final MapPanel mapPanel;
+    private final Territory territory;
+
+    private TerritoryBorderAnimator(final MapPanel mapPanel, final Territory territory) {
+      this.mapPanel = mapPanel;
+      this.territory = territory;
+    }
+
+    static void run(final MapPanel mapPanel, final Territory territory) {
+      new Timer(FRAME_DELAY_IN_MS, new TerritoryBorderAnimator(mapPanel, territory)).start();
+    }
+
+    @Override
+    public void actionPerformed(final ActionEvent e) {
+      if ((frame % 2) == 0) {
+        mapPanel.setTerritoryOverlayForBorder(territory, Color.WHITE);
+      } else {
+        mapPanel.clearTerritoryOverlay(territory);
+      }
+      mapPanel.paintImmediately(mapPanel.getBounds());
+
+      if (++frame >= TOTAL_FRAMES) {
+        ((Timer) e.getSource()).stop();
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

Animates the border of the territory selected via the Find Territory dialog.

## Functional Changes

Runs an animation that alternates between a white overlay border and no overlay border on the selected territory.  The animation runs for 10 frames so that the border will appear to be highlighted a total of five times.  Each frame of the animation runs for 500 ms.

## Manual Testing Performed

Basic visual testing to ensure the animation appears as expected.

## Screen Shots

[find-territory-animate-border.zip](https://github.com/triplea-game/triplea/files/2436082/find-territory-animate-border.zip)

