### PR TITLE
Replace resource text with resource icons for user action cost

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -94,10 +94,11 @@ public class ResourceImageFactory extends AbstractImageFactory {
       return new JButton(text);
     }
     final JPanel panel = getResourcesPanel(resources);
+    panel.setOpaque(false);
     panel.add(new JLabel(text));
     panel.setSize(panel.getPreferredSize());
     panel.doLayout();
-    final BufferedImage image = new BufferedImage(panel.getWidth(), panel.getHeight(), BufferedImage.TYPE_INT_RGB);
+    final BufferedImage image = new BufferedImage(panel.getWidth(), panel.getHeight(), BufferedImage.TYPE_INT_ARGB);
     final Graphics2D g = image.createGraphics();
     panel.paint(g);
     g.dispose();

--- a/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -85,6 +85,10 @@ public class ResourceImageFactory extends AbstractImageFactory {
     return resourcePanel;
   }
 
+  /**
+   * Returns button with resource amounts and given text. If resources is empty then returns
+   * button with just the text.
+   */
   public JButton getResourcesButton(final ResourceCollection resources, final String text) {
     if (resources.isEmpty()) {
       return new JButton(text);

--- a/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -1,10 +1,14 @@
 package games.strategy.triplea.image;
 
+import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
+import java.awt.image.BufferedImage;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
@@ -48,18 +52,18 @@ public class ResourceImageFactory extends AbstractImageFactory {
     return label;
   }
 
-  public JPanel getResourcesPanel(final ResourceCollection resources, final GameData data) {
-    return getResourcesPanel(resources, false, null, data);
+  public JPanel getResourcesPanel(final ResourceCollection resources) {
+    return getResourcesPanel(resources, false, null);
   }
 
-  public JPanel getResourcesPanel(final ResourceCollection resources, final PlayerID player, final GameData data) {
-    return getResourcesPanel(resources, true, player, data);
+  public JPanel getResourcesPanel(final ResourceCollection resources, final PlayerID player) {
+    return getResourcesPanel(resources, true, player);
   }
 
-  private JPanel getResourcesPanel(final ResourceCollection resources, final boolean showEmpty, final PlayerID player,
-      final GameData data) {
+  private JPanel getResourcesPanel(final ResourceCollection resources, final boolean showEmpty, final PlayerID player) {
     final JPanel resourcePanel = new JPanel();
     final List<Resource> resourcesInOrder;
+    final GameData data = resources.getData();
     data.acquireReadLock();
     try {
       resourcesInOrder = data.getResourceList().getResources();
@@ -79,6 +83,21 @@ public class ResourceImageFactory extends AbstractImageFactory {
               new Insets(0, 0, 0, 0), 0, 0));
     }
     return resourcePanel;
+  }
+
+  public JButton getResourcesButton(final ResourceCollection resources, final String text) {
+    if (resources.isEmpty()) {
+      return new JButton(text);
+    }
+    final JPanel panel = getResourcesPanel(resources);
+    panel.add(new JLabel(text));
+    panel.setSize(panel.getPreferredSize());
+    panel.doLayout();
+    final BufferedImage image = new BufferedImage(panel.getWidth(), panel.getHeight(), BufferedImage.TYPE_INT_RGB);
+    final Graphics2D g = image.createGraphics();
+    panel.paint(g);
+    g.dispose();
+    return new JButton(new ImageIcon(image));
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -171,7 +171,9 @@ public class PoliticsPanel extends ActionPanel {
     for (final PoliticalActionAttachment paa : validPoliticalActions) {
       politicalActionButtonPanel.add(getOtherPlayerFlags(paa), new GridBagConstraints(0, row, 1, 1, 1.0, 1.0,
           GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, insets, 0, 0));
-      final JButton button = new JButton(getActionButtonText(paa));
+      final JButton button = getMap().getUiContext().getResourceImageFactory().getResourcesButton(
+          new ResourceCollection(getData(), paa.getCostResources()),
+          UserActionText.getInstance().getButtonText(paa.getText()));
       button.addActionListener(ae -> {
         selectPoliticalActionButton.setEnabled(false);
         doneButton.setEnabled(false);
@@ -218,12 +220,6 @@ public class PoliticsPanel extends ActionPanel {
       panel.add(new JLabel(new ImageIcon(this.getMap().getUiContext().getFlagImageFactory().getFlag(p))));
     }
     return panel;
-  }
-
-  private String getActionButtonText(final PoliticalActionAttachment paa) {
-    final String costString = paa.getCostResources().isEmpty() ? ""
-        : "[" + ResourceCollection.toString(paa.getCostResources(), getData()) + "] ";
-    return costString + PoliticsText.getInstance().getButtonText(paa.getText());
   }
 
   private static JLabel getActionDescriptionLabel(final PoliticalActionAttachment paa) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -174,7 +174,7 @@ class ProductionPanel extends JPanel {
     remainingResources.removeAll();
     left.setText(String.format("%d total units purchased. Remaining resources: ", totalUnits));
     if (resourceCollection != null) {
-      remainingResources.add(uiContext.getResourceImageFactory().getResourcesPanel(resourceCollection, id, data));
+      remainingResources.add(uiContext.getResourceImageFactory().getResourcesPanel(resourceCollection, id));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1343,7 +1343,7 @@ public final class TripleAFrame extends JFrame {
             fuelCostPanel.add(label,
                 new GridBagConstraints(0, count, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
                     new Insets(0, 0, 0, 0), 0, 0));
-            fuelCostPanel.add(uiContext.getResourceImageFactory().getResourcesPanel(entry.getValue(), data),
+            fuelCostPanel.add(uiContext.getResourceImageFactory().getResourcesPanel(entry.getValue()),
                 new GridBagConstraints(1, count++, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
                     new Insets(0, 0, 0, 0), 0, 0));
             if (!entry.getKey().getResources().has(entry.getValue().getResourcesCopy())) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -160,7 +160,9 @@ public class UserActionPanel extends ActionPanel {
       userActionButtonPanel.add(getOtherPlayerFlags(uaa), new GridBagConstraints(0, row, 1, 1, 0.0, 0.0,
           GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(topInset, 0, bottomInset, 4), 0, 0));
 
-      final JButton button = new JButton(getActionButtonText(uaa));
+      final JButton button = getMap().getUiContext().getResourceImageFactory().getResourcesButton(
+          new ResourceCollection(getData(), uaa.getCostResources()),
+          UserActionText.getInstance().getButtonText(uaa.getText()));
       button.addActionListener(ae -> {
         selectUserActionButton.setEnabled(false);
         doneButton.setEnabled(false);
@@ -214,12 +216,6 @@ public class UserActionPanel extends ActionPanel {
       panel.add(new JLabel(new ImageIcon(this.getMap().getUiContext().getFlagImageFactory().getFlag(p))));
     }
     return panel;
-  }
-
-  private String getActionButtonText(final UserActionAttachment paa) {
-    final String costString = paa.getCostResources().isEmpty() ? ""
-        : "[" + ResourceCollection.toString(paa.getCostResources(), getData()) + "] ";
-    return costString + UserActionText.getInstance().getButtonText(paa.getText());
   }
 
   private static JLabel getActionDescriptionLabel(final UserActionAttachment paa) {


### PR DESCRIPTION
## Overview
Further address: https://forums.triplea-game.org/topic/418/expand-useractionattachment-politicalactionattachment-to-all-resources

## Functional Changes
- User and political action buttons will now display resource icons instead of text

## Manual Testing Performed
- Checked Iron War user actions

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![image](https://user-images.githubusercontent.com/1427689/46327165-dce4a000-c5c5-11e8-9746-61f54f00c075.png)

### After
![image](https://user-images.githubusercontent.com/1427689/46327158-d1917480-c5c5-11e8-8925-feac4ec4e1af.png)
