### PR TITLE
Run code formatter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -229,7 +229,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       final Collection<Unit> units, final PlayerID player) {
     return getNeighbors(territory, player == null
         ? neighborFilter
-        : neighborFilter.and(t ->  MoveValidator.canAnyUnitsPassCanal(territory, t, units, player, getData())));
+        : neighborFilter.and(t -> MoveValidator.canAnyUnitsPassCanal(territory, t, units, player, getData())));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -223,7 +223,7 @@ public class GameDataExporter {
   private void printConstantProperties(final Map<String, Object> conProperties) {
     for (final String propName : conProperties.keySet()) {
       switch (propName) {
-        case "notes":  // TODO: unchecked reflection
+        case "notes": // TODO: unchecked reflection
           // Special handling of notes property
           printNotes((String) conProperties.get(propName));
           break;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -25,7 +25,7 @@ public class HeadlessServerSetupPanelModel extends SetupPanelModel {
 
   @Override
   protected void setGameTypePanel(final ISetupPanel panel) {
-    if (panel == null || panel instanceof  HeadlessServerSetup) {
+    if (panel == null || panel instanceof HeadlessServerSetup) {
       super.setGameTypePanel(panel);
     } else {
       throw new IllegalArgumentException("Invalid panel of type " + panel.getClass());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -313,7 +313,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         setTerritoryCount(String.valueOf(allTerrs.size()));
         return allTerrs;
       }
-      default:  // The list just contained 1 territory
+      default: // The list just contained 1 territory
         final Territory t = data.getMap().getTerritory(name);
         if (t == null) {
           throw new IllegalStateException("No territory called:" + name + thisErrorMsg());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -979,7 +979,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       // get all the units in the territory
       final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());
       switch (exclType) {
-        case "allied":  // any allied units in the territory. (does not include owned units)
+        case "allied": // any allied units in the territory. (does not include owned units)
           allUnits.removeAll(CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players)));
           allUnits
               .retainAll(CollectionUtils.getMatches(allUnits, Matches.alliedUnitOfAnyOfThesePlayers(players, data)));
@@ -988,10 +988,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           allUnits.removeAll(
               CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).negate()));
           break;
-        case "enemy":  // any enemy units in the territory
+        case "enemy": // any enemy units in the territory
           allUnits.retainAll(CollectionUtils.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)));
           break;
-        case "enemy_surface":  // any enemy units (not trn/sub) in the territory
+        case "enemy_surface": // any enemy units (not trn/sub) in the territory
           allUnits.retainAll(
               CollectionUtils.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)
                   .and(Matches.unitIsNotSub())

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -114,7 +114,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
       if (!optionalTrigger.isPresent()) {
         continue;
       }
-      final TriggerAttachment toFire  = optionalTrigger.get();
+      final TriggerAttachment toFire = optionalTrigger.get();
       final HashSet<TriggerAttachment> toFireSet = new HashSet<>();
       toFireSet.add(toFire);
       final String[] options = splitOnColon(tuple.getSecond());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -554,7 +554,7 @@ public class AirMovementValidator {
     return (route != null)
         && (route.numberOfSteps() <= movementLeft)
         && (!areNeutralsPassableByAir
-          || getNeutralCharge(data, route) <= player.getResources().getQuantity(Constants.PUS));
+            || getNeutralCharge(data, route) <= player.getResources().getQuantity(Constants.PUS));
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
@@ -29,13 +29,16 @@ public class RouteFinderTest {
   /**
    * This is an adjacency matrix.
    * It's representing this graph:
-   * <pre><code>
+   *
+   * <pre>
+   * <code>
    * (7)---(5)---(4)
    *  |     |     |
    * (8)---(6)---(3)---(0)
    *              |     |
    *             (2)---(1)
-   * </code></pre>
+   * </code>
+   * </pre>
    */
   private final int[][] graph = {
       {0, 1, 0, 1, 0, 0, 0, 0, 0},

--- a/http-client/src/test/java/org/triplea/http/client/WireMockSystemTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/WireMockSystemTest.java
@@ -102,11 +102,11 @@ class WireMockSystemTest {
         ErrorReportingHttpClient.newClient(hostUri, timeoutMillis, timeoutMillis),
         ErrorReport::new,
         Collections.emptyList())
-        .sendErrorReport(ErrorReportDetails.builder()
-            .messageFromUser(MESSAGE_FROM_USER)
-            .gameVersion(GAME_VERSION)
-            .logRecord(logRecord)
-            .build());
+            .sendErrorReport(ErrorReportDetails.builder()
+                .messageFromUser(MESSAGE_FROM_USER)
+                .gameVersion(GAME_VERSION)
+                .logRecord(logRecord)
+                .build());
   }
 
   @Test


### PR DESCRIPTION
## Overview

Runs the code formatter on all projects.  I'm doing this to prepare for any code formatter configuration changes that may be made based on the discussion in #4123.  This will hopefully remove any noise in order to evaluate configuration changes to ensure they don't introduce unwanted behavior.

Note that there appears to be a bug in the Eclipse Photon code formatter related to nested enums that have a Javadoc applied.  In those cases, the formatter wants to under- or over-indent the enum elements.  I have manually reverted those changes before submitting this PR, and will submit an Eclipse bug report if one hasn't already been created.

## Functional Changes

None.

## Manual Testing Performed

None.