### PR TITLE
Find Territory: Ignore combining marks in territory name

### DIFF
--- a/game-core/src/main/java/swinglib/AutoCompletion.java
+++ b/game-core/src/main/java/swinglib/AutoCompletion.java
@@ -10,6 +10,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.text.Normalizer;
 
 import javax.swing.ComboBoxEditor;
 import javax.swing.ComboBoxModel;
@@ -18,6 +19,8 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.PlainDocument;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * From http://www.orbital-computer.de/JComboBox. Originally released into the Public Domain
@@ -210,14 +213,14 @@ final class AutoCompletion<E> extends PlainDocument {
   private Object lookupItem(final String pattern) {
     final Object selectedItem = model.getSelectedItem();
     // only search for a different item if the currently selected does not match
-    if (selectedItem != null && startsWithIgnoreCase(selectedItem.toString(), pattern)) {
+    if (selectedItem != null && startsWith(selectedItem.toString(), pattern)) {
       return selectedItem;
     }
     // iterate over all items
     for (int i = 0, n = model.getSize(); i < n; i++) {
       final Object currentItem = model.getElementAt(i);
       // current item starts with the pattern?
-      if (currentItem != null && startsWithIgnoreCase(currentItem.toString(), pattern)) {
+      if (currentItem != null && startsWith(currentItem.toString(), pattern)) {
         return currentItem;
       }
     }
@@ -225,8 +228,14 @@ final class AutoCompletion<E> extends PlainDocument {
     return null;
   }
 
-  // checks if str1 starts with str2 - ignores case
-  private static boolean startsWithIgnoreCase(final String str1, final String str2) {
-    return str1.toUpperCase().startsWith(str2.toUpperCase());
+  @VisibleForTesting
+  static boolean startsWith(final String str1, final String str2) {
+    return normalize(str1).startsWith(normalize(str2));
+  }
+
+  private static String normalize(final String str) {
+    return Normalizer.normalize(str, Normalizer.Form.NFD)
+        .replaceAll("\\p{M}", "")
+        .toUpperCase();
   }
 }

--- a/game-core/src/test/java/swinglib/AutoCompletionTest.java
+++ b/game-core/src/test/java/swinglib/AutoCompletionTest.java
@@ -1,0 +1,42 @@
+package swinglib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static swinglib.AutoCompletion.startsWith;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class AutoCompletionTest {
+  @Nested
+  final class StartsWithTest {
+    @Test
+    void shouldReturnTrueWhenFirstStartsWithSecond() {
+      assertThat(startsWith("Mongolia", "M"), is(true));
+      assertThat(startsWith("Mongolia", "Mong"), is(true));
+      assertThat(startsWith("Mongolia", "Mongolia"), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFirstStartsWithSecondIgnoringCase() {
+      assertThat(startsWith("Mongolia", "m"), is(true));
+      assertThat(startsWith("Mongolia", "mong"), is(true));
+      assertThat(startsWith("Mongolia", "monGOLia"), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFirstStartsWithSecondIgnoringCombiningMarks() {
+      assertThat(startsWith("Lhûn", "Lhûn"), is(true));
+      assertThat(startsWith("Lhûn", "Lhu"), is(true));
+      assertThat(startsWith("Lhûn", "Lhun"), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenFirstDoesNotStartWithSecond() {
+      assertThat(startsWith("Mongolia", "N"), is(false));
+      assertThat(startsWith("Mongolia", "Mont"), is(false));
+      assertThat(startsWith("Mongolia", "mont"), is(false));
+      assertThat(startsWith("Mongolia", "Mongoliaa"), is(false));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Modifies the Find Territory dialog to ignore combining marks (e.g. accents) in the territory name.  For example, this allows a user to type `Lhu` and it will match `Lhûn`.

## Functional Changes

The `AutoCompletion#startsWith()` method now removes Unicode combining marks from both strings before checking if the first string starts with the second.

## Manual Testing Performed

Verified I could select territories with accents on the Battle for Arda map by only typing the unaccented characters.

From a usability perspective, performance didn't seem to be affected by the additional normalization.