### PR TITLE
Remove need for test-specific client setting

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -95,9 +95,6 @@ public final class ClientSetting implements GameSetting {
   public static final ClientSetting wheelScrollAmount = new ClientSetting("WHEEL_SCROLL_AMOUNT", 60);
   public static final ClientSetting playerName = new ClientSetting("PLAYER_NAME", SystemProperties.getUserName());
   public static final ClientSetting useExperimentalJavaFxUi = new ClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
-  /* for testing purposes, to be used in unit tests only */
-  @VisibleForTesting
-  public static final ClientSetting test = new ClientSetting("TEST_SETTING");
   public static final ClientSetting loggingVerbosity = new ClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
 
   private static final AtomicReference<Preferences> preferencesRef = new AtomicReference<>();
@@ -106,24 +103,25 @@ public final class ClientSetting implements GameSetting {
   public final String defaultValue;
   private final Collection<Consumer<String>> onSaveActions = new CopyOnWriteArrayList<>();
 
-  ClientSetting(final String name, final String defaultValue) {
+  private ClientSetting(final String name, final String defaultValue) {
     this.name = name;
     this.defaultValue = defaultValue;
   }
 
+  @VisibleForTesting
   ClientSetting(final String name) {
     this(name, "");
   }
 
-  ClientSetting(final String name, final File file) {
+  private ClientSetting(final String name, final File file) {
     this(name, file.getAbsolutePath());
   }
 
-  ClientSetting(final String name, final int defaultValue) {
+  private ClientSetting(final String name, final int defaultValue) {
     this(name, String.valueOf(defaultValue));
   }
 
-  ClientSetting(final String name, final boolean defaultValue) {
+  private ClientSetting(final String name, final boolean defaultValue) {
     this(name, String.valueOf(defaultValue));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -30,12 +30,13 @@ final class ClientSettingTest {
 
     @Mock
     private Consumer<String> mockSaveListener;
+    private final ClientSetting clientSetting = new ClientSetting("TEST_SETTING");
 
     @Test
     void saveActionListenerIsCalled() {
-      ClientSetting.test.addSaveListener(mockSaveListener);
+      clientSetting.addSaveListener(mockSaveListener);
 
-      ClientSetting.test.save(TEST_VALUE);
+      clientSetting.save(TEST_VALUE);
 
       Mockito.verify(mockSaveListener, Mockito.times(1))
           .accept(TEST_VALUE);
@@ -43,10 +44,10 @@ final class ClientSettingTest {
 
     @Test
     void verifyRemovedSavedListenersAreNotCalled() {
-      ClientSetting.test.addSaveListener(mockSaveListener);
-      ClientSetting.test.removeSaveListener(mockSaveListener);
+      clientSetting.addSaveListener(mockSaveListener);
+      clientSetting.removeSaveListener(mockSaveListener);
 
-      ClientSetting.test.save(TEST_VALUE);
+      clientSetting.save(TEST_VALUE);
 
       Mockito.verify(mockSaveListener, Mockito.never())
           .accept(TEST_VALUE);


### PR DESCRIPTION
## Overview

Removes the need for a test-specific client setting that is part of the public API of `ClientSetting`.  Tests that require such a setting can now simply create their own instance.

## Refactoring Changes

Made all but one constructor private.  This should have been done as part of #4119.