### PR TITLE
Fix network proxy client setting UI

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -31,8 +31,6 @@ public class HttpProxy {
     NONE, USE_SYSTEM_SETTINGS, USE_USER_PREFERENCES
   }
 
-  public static final String PROXY_CHOICE = "proxy.choice";
-
   public static boolean isUsingSystemProxy() {
     return ClientSetting.proxyChoice.value().equals(ProxyChoice.USE_SYSTEM_SETTINGS.toString());
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -18,6 +18,7 @@ import com.google.common.base.Strings;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
+import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.SystemProperties;
 import lombok.extern.java.Log;
 
@@ -67,7 +68,8 @@ public final class ClientSetting implements GameSetting {
   public static final ClientSetting mapEdgeScrollZoneSize = new ClientSetting("MAP_EDGE_SCROLL_ZONE_SIZE", 30);
   public static final ClientSetting mapFolderOverride = new ClientSetting("MAP_FOLDER_OVERRIDE");
   public static final ClientSetting mapListOverride = new ClientSetting("MAP_LIST_OVERRIDE");
-  public static final ClientSetting proxyChoice = new ClientSetting("PROXY_CHOICE");
+  public static final ClientSetting proxyChoice =
+      new ClientSetting("PROXY_CHOICE", HttpProxy.ProxyChoice.NONE.toString());
   public static final ClientSetting proxyHost = new ClientSetting("PROXY_HOST");
   public static final ClientSetting proxyPort = new ClientSetting("PROXY_PORT");
   public static final ClientSetting saveGamesFolderPath =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -4,6 +4,7 @@ import static games.strategy.triplea.settings.SelectionComponentFactory.booleanR
 import static games.strategy.triplea.settings.SelectionComponentFactory.filePath;
 import static games.strategy.triplea.settings.SelectionComponentFactory.folderPath;
 import static games.strategy.triplea.settings.SelectionComponentFactory.intValueRange;
+import static games.strategy.triplea.settings.SelectionComponentFactory.proxySettings;
 import static games.strategy.triplea.settings.SelectionComponentFactory.selectionBox;
 import static games.strategy.triplea.settings.SelectionComponentFactory.textField;
 
@@ -266,7 +267,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "This only effects Play-By-Forum games, dice servers, and map downloads.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return SelectionComponentFactory.proxySettings();
+      return proxySettings(ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
     }
   },
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -24,16 +24,6 @@ public interface SelectionComponent<T> {
    */
   Map<GameSetting, String> readValues();
 
-  /**
-   * UI component should update to show an error, eg: background turn red.
-   */
-  void indicateError();
-
-  /**
-   * UI component should revert back to a normal state, clearing any changes from {@code indicateError}.
-   */
-  void clearError();
-
   void resetToDefault();
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionListener;
 import java.util.Collections;
@@ -131,22 +130,6 @@ final class SelectionComponentFactory {
       }
 
       @Override
-      public void indicateError() {
-        if (!isHostTextValid()) {
-          hostText.setBackground(Color.RED);
-        }
-        if (!isPortTextValid()) {
-          portText.setBackground(Color.RED);
-        }
-      }
-
-      @Override
-      public void clearError() {
-        hostText.setBackground(Color.WHITE);
-        portText.setBackground(Color.WHITE);
-      }
-
-      @Override
       public void resetToDefault() {
         ClientSetting.flush();
         hostText.setText(proxyHostClientSetting.defaultValue);
@@ -202,12 +185,6 @@ final class SelectionComponentFactory {
       public String validValueDescription() {
         return "";
       }
-
-      @Override
-      public void indicateError() {}
-
-      @Override
-      public void clearError() {}
 
       @Override
       public Map<GameSetting, String> readValues() {
@@ -313,13 +290,11 @@ final class SelectionComponentFactory {
       @Override
       public void resetToDefault() {
         field.setText(clientSetting.defaultValue);
-        clearError();
       }
 
       @Override
       public void reset() {
         field.setText(clientSetting.value());
-        clearError();
       }
     };
   }
@@ -375,13 +350,11 @@ final class SelectionComponentFactory {
       @Override
       public void resetToDefault() {
         comboBox.setSelectedItem(clientSetting.defaultValue);
-        clearError();
       }
 
       @Override
       public void reset() {
         comboBox.setSelectedItem(clientSetting.value());
-        clearError();
       }
     };
   }
@@ -405,28 +378,16 @@ final class SelectionComponentFactory {
       @Override
       public void reset() {
         textField.setText(clientSetting.value());
-        clearError();
       }
 
       @Override
       public void resetToDefault() {
         textField.setText(clientSetting.defaultValue);
-        clearError();
       }
     };
   }
 
   private abstract static class AlwaysValidInputSelectionComponent implements SelectionComponent<JComponent> {
-    @Override
-    public void indicateError() {
-      // no-op, component only allows valid selections
-    }
-
-    @Override
-    public void clearError() {
-      // also a no-op
-    }
-
     @Override
     public boolean isValid() {
       return true;

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -38,7 +38,10 @@ import swinglib.JPanelBuilder;
 final class SelectionComponentFactory {
   private SelectionComponentFactory() {}
 
-  static SelectionComponent<JComponent> proxySettings() {
+  static SelectionComponent<JComponent> proxySettings(
+      final ClientSetting proxyChoiceClientSetting,
+      final ClientSetting proxyHostClientSetting,
+      final ClientSetting proxyPortClientSetting) {
     return new SelectionComponent<JComponent>() {
       final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
       final HttpProxy.ProxyChoice proxyChoice =
@@ -50,8 +53,8 @@ final class SelectionComponentFactory {
 
       final JRadioButton userButton =
           new JRadioButton("Use These Settings:", proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
-      final JTextField hostText = new JTextField(ClientSetting.proxyHost.value(), 20);
-      final JTextField portText = new JTextField(ClientSetting.proxyPort.value(), 6);
+      final JTextField hostText = new JTextField(proxyHostClientSetting.value(), 20);
+      final JTextField portText = new JTextField(proxyPortClientSetting.value(), 6);
       final JPanel radioPanel = JPanelBuilder.builder()
           .verticalBoxLayout()
           .add(noneButton)
@@ -119,14 +122,14 @@ final class SelectionComponentFactory {
       public Map<GameSetting, String> readValues() {
         final Map<GameSetting, String> values = new HashMap<>();
         if (noneButton.isSelected()) {
-          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.NONE.toString());
+          values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.NONE.toString());
         } else if (systemButton.isSelected()) {
-          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+          values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
           HttpProxy.updateSystemProxy();
         } else {
-          values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
-          values.put(ClientSetting.proxyHost, hostText.getText().trim());
-          values.put(ClientSetting.proxyPort, portText.getText().trim());
+          values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
+          values.put(proxyHostClientSetting, hostText.getText().trim());
+          values.put(proxyPortClientSetting, portText.getText().trim());
         }
         return values;
       }
@@ -150,17 +153,17 @@ final class SelectionComponentFactory {
       @Override
       public void resetToDefault() {
         ClientSetting.flush();
-        hostText.setText(ClientSetting.proxyHost.defaultValue);
-        portText.setText(ClientSetting.proxyPort.defaultValue);
-        noneButton.setSelected(Boolean.valueOf(ClientSetting.proxyChoice.defaultValue));
+        hostText.setText(proxyHostClientSetting.defaultValue);
+        portText.setText(proxyPortClientSetting.defaultValue);
+        noneButton.setSelected(Boolean.valueOf(proxyChoiceClientSetting.defaultValue));
       }
 
       @Override
       public void reset() {
         ClientSetting.flush();
-        hostText.setText(ClientSetting.proxyHost.value());
-        portText.setText(ClientSetting.proxyPort.value());
-        noneButton.setSelected(ClientSetting.proxyChoice.booleanValue());
+        hostText.setText(proxyHostClientSetting.value());
+        portText.setText(proxyPortClientSetting.value());
+        noneButton.setSelected(proxyChoiceClientSetting.booleanValue());
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.prefs.Preferences;
+import java.util.logging.Level;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
@@ -23,9 +23,9 @@ import javax.swing.SpinnerNumberModel;
 
 import com.google.common.base.Strings;
 
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.ui.SwingComponents;
+import lombok.extern.java.Log;
 import swinglib.JButtonBuilder;
 import swinglib.JPanelBuilder;
 
@@ -34,6 +34,7 @@ import swinglib.JPanelBuilder;
  * For example, if we have a setting that needs a number, we could create an integer text field with this
  * class. This class takes care of the UI code to ensure we render the proper swing component with validation.
  */
+@Log
 final class SelectionComponentFactory {
   private SelectionComponentFactory() {}
 
@@ -42,14 +43,10 @@ final class SelectionComponentFactory {
       final ClientSetting proxyHostClientSetting,
       final ClientSetting proxyPortClientSetting) {
     return new SelectionComponent<JComponent>() {
-      final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
-      final HttpProxy.ProxyChoice proxyChoice =
-          HttpProxy.ProxyChoice.valueOf(pref.get(HttpProxy.PROXY_CHOICE, HttpProxy.ProxyChoice.NONE.toString()));
+      final HttpProxy.ProxyChoice proxyChoice = parseProxyChoice(proxyChoiceClientSetting.value());
       final JRadioButton noneButton = new JRadioButton("None", proxyChoice == HttpProxy.ProxyChoice.NONE);
       final JRadioButton systemButton =
           new JRadioButton("Use System Settings", proxyChoice == HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS);
-
-
       final JRadioButton userButton =
           new JRadioButton("Use These Settings:", proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
       final JTextField hostText = new JTextField(proxyHostClientSetting.value(), 20);
@@ -64,7 +61,6 @@ final class SelectionComponentFactory {
           .add(new JLabel("Proxy Port: "))
           .add(portText)
           .build();
-
       final ActionListener enableUserSettings = e -> {
         if (userButton.isSelected()) {
           hostText.setEnabled(true);
@@ -74,6 +70,15 @@ final class SelectionComponentFactory {
           portText.setEnabled(false);
         }
       };
+
+      private HttpProxy.ProxyChoice parseProxyChoice(final String encodedProxyChoice) {
+        try {
+          return HttpProxy.ProxyChoice.valueOf(encodedProxyChoice);
+        } catch (final IllegalArgumentException e) {
+          log.log(Level.WARNING, "Illegal proxy choice: '" + encodedProxyChoice + "'", e);
+          return HttpProxy.ProxyChoice.NONE;
+        }
+      }
 
       @Override
       public JComponent getUiComponent() {
@@ -134,7 +139,15 @@ final class SelectionComponentFactory {
         ClientSetting.flush();
         hostText.setText(proxyHostClientSetting.defaultValue);
         portText.setText(proxyPortClientSetting.defaultValue);
-        noneButton.setSelected(Boolean.valueOf(proxyChoiceClientSetting.defaultValue));
+        setProxyChoice(proxyChoiceClientSetting.defaultValue);
+      }
+
+      private void setProxyChoice(final String encodedProxyChoice) {
+        final HttpProxy.ProxyChoice proxyChoice = parseProxyChoice(encodedProxyChoice);
+        noneButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.NONE);
+        systemButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS);
+        userButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
+        enableUserSettings.actionPerformed(null);
       }
 
       @Override
@@ -142,7 +155,7 @@ final class SelectionComponentFactory {
         ClientSetting.flush();
         hostText.setText(proxyHostClientSetting.value());
         portText.setText(proxyPortClientSetting.value());
-        noneButton.setSelected(proxyChoiceClientSetting.booleanValue());
+        setProxyChoice(proxyChoiceClientSetting.value());
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -69,14 +69,10 @@ final class SelectionComponentFactory {
       final ActionListener enableUserSettings = e -> {
         if (userButton.isSelected()) {
           hostText.setEnabled(true);
-          hostText.setBackground(Color.WHITE);
           portText.setEnabled(true);
-          portText.setBackground(Color.WHITE);
         } else {
           hostText.setEnabled(false);
-          hostText.setBackground(Color.DARK_GRAY);
           portText.setEnabled(false);
-          portText.setBackground(Color.DARK_GRAY);
         }
       };
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -3,6 +3,7 @@ package org.triplea.game.client.ui.javafx.util;
 import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.filePath;
 import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.folderPath;
 import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.intValueRange;
+import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.proxySettings;
 import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.textField;
 import static org.triplea.game.client.ui.javafx.util.JavaFxSelectionComponentFactory.toggleButton;
 
@@ -172,7 +173,7 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
   PROXY_CHOICE(SettingType.NETWORK_PROXY) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return JavaFxSelectionComponentFactory.proxySettings();
+      return proxySettings(ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
     }
   },
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -85,20 +85,6 @@ final class JavaFxSelectionComponentFactory {
         return Collections.singletonMap(clientSetting, stringValue);
       }
 
-      /**
-       * Does nothing.
-       * Using a Spinner should ensure no invalid values can be entered.
-       */
-      @Override
-      public void indicateError() {}
-
-      /**
-       * Does nothing.
-       * Using a Spinner should ensure no invalid values can be entered.
-       */
-      @Override
-      public void clearError() {}
-
       @Override
       public void resetToDefault() {
         spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.defaultValue));
@@ -142,12 +128,6 @@ final class JavaFxSelectionComponentFactory {
       }
 
       @Override
-      public void indicateError() {}
-
-      @Override
-      public void clearError() {}
-
-      @Override
       public void resetToDefault() {
         checkBox.selectedProperty().set(Boolean.parseBoolean(clientSetting.defaultValue));
       }
@@ -188,12 +168,6 @@ final class JavaFxSelectionComponentFactory {
       public Map<GameSetting, String> readValues() {
         return Collections.singletonMap(clientSetting, textField.getText());
       }
-
-      @Override
-      public void indicateError() {}
-
-      @Override
-      public void clearError() {}
 
       @Override
       public void resetToDefault() {
@@ -283,12 +257,6 @@ final class JavaFxSelectionComponentFactory {
     public String validValueDescription() {
       return "";
     }
-
-    @Override
-    public void indicateError() {}
-
-    @Override
-    public void clearError() {}
   }
 
   private static final class FileSelector extends Region implements SelectionComponent<Region> {
@@ -353,12 +321,6 @@ final class JavaFxSelectionComponentFactory {
     public String validValueDescription() {
       return "";
     }
-
-    @Override
-    public void indicateError() {}
-
-    @Override
-    public void clearError() {}
   }
 
   private static final class ProxySetting extends Region implements SelectionComponent<Region> {
@@ -441,16 +403,6 @@ final class JavaFxSelectionComponentFactory {
       noneButton.setSelected(proxyChoiceClientSetting.booleanValue());
     }
 
-    @Override
-    public void indicateError() {
-      if (!isHostTextValid()) {
-        hostText.setStyle("-fx-background-color: #FF0000;");
-      }
-      if (!isPortTextValid()) {
-        portText.setStyle("-fx-background-color: #FF0000;");
-      }
-    }
-
     private boolean isHostTextValid() {
       return !Strings.nullToEmpty(hostText.getText()).trim().isEmpty();
     }
@@ -471,12 +423,6 @@ final class JavaFxSelectionComponentFactory {
     @Override
     public boolean isValid() {
       return !userButton.isSelected() || (isHostTextValid() && isPortTextValid());
-    }
-
-    @Override
-    public void clearError() {
-      hostText.setStyle("-fx-background-color: #FFFFFF;");
-      portText.setStyle("-fx-background-color: #FFFFFF;");
     }
 
     @Override

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -215,8 +215,11 @@ final class JavaFxSelectionComponentFactory {
     return new FileSelector(clientSetting);
   }
 
-  static SelectionComponent<Region> proxySettings() {
-    return new ProxySetting();
+  static SelectionComponent<Region> proxySettings(
+      final ClientSetting proxyChoiceClientSetting,
+      final ClientSetting proxyHostClientSetting,
+      final ClientSetting proxyPortClientSetting) {
+    return new ProxySetting(proxyChoiceClientSetting, proxyHostClientSetting, proxyPortClientSetting);
   }
 
   private static final class FolderSelector extends Region implements SelectionComponent<Region> {
@@ -359,13 +362,22 @@ final class JavaFxSelectionComponentFactory {
   }
 
   private static final class ProxySetting extends Region implements SelectionComponent<Region> {
+    private final ClientSetting proxyChoiceClientSetting;
+    private final ClientSetting proxyHostClientSetting;
+    private final ClientSetting proxyPortClientSetting;
     private final RadioButton noneButton;
     private final RadioButton systemButton;
     private final RadioButton userButton;
     private final TextField hostText;
     private final TextField portText;
 
-    ProxySetting() {
+    ProxySetting(
+        final ClientSetting proxyChoiceClientSetting,
+        final ClientSetting proxyHostClientSetting,
+        final ClientSetting proxyPortClientSetting) {
+      this.proxyChoiceClientSetting = proxyChoiceClientSetting;
+      this.proxyHostClientSetting = proxyHostClientSetting;
+      this.proxyPortClientSetting = proxyPortClientSetting;
       final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
       final HttpProxy.ProxyChoice proxyChoice =
           HttpProxy.ProxyChoice.valueOf(pref.get(HttpProxy.PROXY_CHOICE, HttpProxy.ProxyChoice.NONE.toString()));
@@ -376,8 +388,8 @@ final class JavaFxSelectionComponentFactory {
 
       userButton = new RadioButton("Use These Settings:");
       userButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
-      hostText = new TextField(ClientSetting.proxyHost.value());
-      portText = new TextField(ClientSetting.proxyPort.value());
+      hostText = new TextField(proxyHostClientSetting.value());
+      portText = new TextField(proxyPortClientSetting.value());
       final VBox radioPanel = new VBox();
       radioPanel.getChildren().addAll(
           noneButton,
@@ -401,14 +413,14 @@ final class JavaFxSelectionComponentFactory {
     public Map<GameSetting, String> readValues() {
       final Map<GameSetting, String> values = new HashMap<>();
       if (noneButton.isSelected()) {
-        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.NONE.toString());
+        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.NONE.toString());
       } else if (systemButton.isSelected()) {
-        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS.toString());
         HttpProxy.updateSystemProxy();
       } else {
-        values.put(ClientSetting.proxyChoice, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
-        values.put(ClientSetting.proxyHost, hostText.getText().trim());
-        values.put(ClientSetting.proxyPort, portText.getText().trim());
+        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_USER_PREFERENCES.toString());
+        values.put(proxyHostClientSetting, hostText.getText().trim());
+        values.put(proxyPortClientSetting, portText.getText().trim());
       }
       return values;
     }
@@ -416,17 +428,17 @@ final class JavaFxSelectionComponentFactory {
     @Override
     public void resetToDefault() {
       ClientSetting.flush();
-      hostText.setText(ClientSetting.proxyHost.defaultValue);
-      portText.setText(ClientSetting.proxyPort.defaultValue);
-      noneButton.setSelected(Boolean.valueOf(ClientSetting.proxyChoice.defaultValue));
+      hostText.setText(proxyHostClientSetting.defaultValue);
+      portText.setText(proxyPortClientSetting.defaultValue);
+      noneButton.setSelected(Boolean.valueOf(proxyChoiceClientSetting.defaultValue));
     }
 
     @Override
     public void reset() {
       ClientSetting.flush();
-      hostText.setText(ClientSetting.proxyHost.value());
-      portText.setText(ClientSetting.proxyPort.value());
-      noneButton.setSelected(ClientSetting.proxyChoice.booleanValue());
+      hostText.setText(proxyHostClientSetting.value());
+      portText.setText(proxyPortClientSetting.value());
+      noneButton.setSelected(proxyChoiceClientSetting.booleanValue());
     }
 
     @Override


### PR DESCRIPTION
## Overview

This PR originally started out as a simple refactoring that moves knowledge of the specific proxy client settings out of `*SelectionComponentFactory` to `ClientSetting*UiBinding` where this knowledge already exists for every other client setting UI binding.

However, during testing, I found several problems with the proxy client setting UIs.  I went ahead and fixed those issues along with the original refactoring, so that this PR now becomes primarily a bug fix.

## Functional Changes

* Read the proxy choice from `ClientSetting#proxyChoice` instead of the legacy `proxy.choice` preference.
* Removed custom background colors for the proxy host/port controls.  Just let the L&F manage the control colors.

## Refactoring Changes

* Inject the three proxy client settings into the associated UI selection component instead of hard-coding references back to them.  This is consistent with how every other UI selection component behaves.
* Removed the unused `SelectionComponent#indicateError()` and `clearError()` methods.

## Manual Testing Performed

Tested the Network Proxy tab in the settings window using both the Swing and JFX clients.  Verified changing the settings and resetting them work as expected.