### PR TITLE
Add intercept airbase logic

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -146,6 +146,7 @@ public class UnitAttachment extends DefaultAttachment {
   private int m_bombingMaxDieSides = -1;
   private int m_bombingBonus = 0;
   private boolean m_canIntercept = false;
+  private boolean m_requiresAirBaseToIntercept = false;
   private boolean m_canEscort = false;
   private boolean m_canAirBattle = false;
   private int m_airDefense = 0;
@@ -201,6 +202,8 @@ public class UnitAttachment extends DefaultAttachment {
   private int m_maxScrambleDistance = -1;
   // -1 for infinite
   private int m_maxScrambleCount = -1;
+  // -1 for infinite
+  private int m_maxInterceptCount = -1;
   // special abilities
   private int m_blockade = 0;
   // a colon delimited list of the units this unit can repair.
@@ -248,6 +251,22 @@ public class UnitAttachment extends DefaultAttachment {
 
   private void resetCanIntercept() {
     m_canIntercept = false;
+  }
+
+  public void setRequiresAirBaseToIntercept(final String value) {
+    m_requiresAirBaseToIntercept = getBool(value);
+  }
+
+  public void setRequiresAirBaseToIntercept(final Boolean value) {
+    m_requiresAirBaseToIntercept = value;
+  }
+
+  public boolean getRequiresAirBaseToIntercept() {
+    return m_requiresAirBaseToIntercept;
+  }
+
+  public void resetRequiresAirBaseToIntercept() {
+    m_requiresAirBaseToIntercept = false;
   }
 
   private void setCanEscort(final String value) {
@@ -1476,6 +1495,22 @@ public class UnitAttachment extends DefaultAttachment {
     m_maxScrambleDistance = -1;
   }
 
+  public void setMaxInterceptCount(final String s) {
+    m_maxInterceptCount = getInt(s);
+  }
+
+  public void setMaxInterceptCount(final Integer s) {
+    m_maxInterceptCount = s;
+  }
+
+  public int getMaxInterceptCount() {
+    return m_maxInterceptCount;
+  }
+
+  public void resetMaxInterceptCount() {
+    m_maxInterceptCount = -1;
+  }
+
   private void setMaxOperationalDamage(final String s) {
     m_maxOperationalDamage = getInt(s);
   }
@@ -2698,8 +2733,11 @@ public class UnitAttachment extends DefaultAttachment {
         + (m_givesMovement != null ? (m_givesMovement.size() == 0 ? "empty" : m_givesMovement.toString()) : "null")
         + "  repairsUnits:"
         + (m_repairsUnits != null ? (m_repairsUnits.isEmpty() ? "empty" : m_repairsUnits.toString()) : "null")
-        + "  canScramble:" + m_canScramble + "  maxScrambleDistance:" + m_maxScrambleDistance + "  isAirBase:"
-        + m_isAirBase + "  maxScrambleCount:" + m_maxScrambleCount
+        + "  canScramble:" + m_canScramble
+        + "  maxScrambleDistance:" + m_maxScrambleDistance
+        + "  isAirBase:" + m_isAirBase
+        + "  maxScrambleCount:" + m_maxScrambleCount
+        + "  maxInterceptCount:" + m_maxInterceptCount
         + "  whenCapturedChangesInto:"
         + (m_whenCapturedChangesInto != null
             ? (m_whenCapturedChangesInto.size() == 0 ? "empty" : m_whenCapturedChangesInto.toString())
@@ -2713,9 +2751,13 @@ public class UnitAttachment extends DefaultAttachment {
         + (m_whenHitPointsRepairedChangesInto != null
             ? (m_whenHitPointsRepairedChangesInto.size() == 0 ? "empty" : m_whenHitPointsRepairedChangesInto.toString())
             : "null")
-        + "  canIntercept:" + m_canIntercept + "  canEscort:" + m_canEscort + "  canAirBattle:" + m_canAirBattle
-        + "  airDefense:" + m_airDefense + "  airAttack:" + m_airAttack + "  canNotMoveDuringCombatMove:"
-        + m_canNotMoveDuringCombatMove + "  movementLimit:"
+        + "  canIntercept:" + m_canIntercept
+        + "  requiresAirBaseToIntercept:" + m_requiresAirBaseToIntercept
+        + "  canEscort:" + m_canEscort
+        + "  canAirBattle:" + m_canAirBattle
+        + "  airDefense:" + m_airDefense
+        + "  airAttack:" + m_airAttack
+        + "  canNotMoveDuringCombatMove:" + m_canNotMoveDuringCombatMove + "  movementLimit:"
         + (m_movementLimit != null ? m_movementLimit.toString() : "null") + "  attackingLimit:"
         + (m_attackingLimit != null ? m_attackingLimit.toString() : "null") + "  placementLimit:"
         + (m_placementLimit != null ? m_placementLimit.toString() : "null")
@@ -3487,6 +3529,12 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setCanIntercept,
                 this::getCanIntercept,
                 this::resetCanIntercept))
+        .put("requiresAirbaseToIntercept",
+            MutableProperty.of(
+                this::setRequiresAirBaseToIntercept,
+                this::setRequiresAirBaseToIntercept,
+                this::getRequiresAirBaseToIntercept,
+                this::resetRequiresAirBaseToIntercept))
         .put("canEscort",
             MutableProperty.of(
                 this::setCanEscort,
@@ -3660,6 +3708,12 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setMaxScrambleCount,
                 this::getMaxScrambleCount,
                 this::resetMaxScrambleCount))
+        .put("maxInterceptCount",
+            MutableProperty.of(
+                this::setMaxInterceptCount,
+                this::setMaxInterceptCount,
+                this::getMaxInterceptCount,
+                this::resetMaxInterceptCount))
         .put("blockade",
             MutableProperty.of(
                 this::setBlockade,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1916,6 +1916,9 @@ public class UnitAttachment extends DefaultAttachment {
     m_bombingTargets = null;
   }
 
+  /**
+   * Finds potential unit types which all passed in bombers and rockets can target.
+   */
   public static Set<UnitType> getAllowedBombingTargetsIntersection(final Collection<Unit> bombersOrRockets,
       final GameData data) {
     if (bombersOrRockets.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -253,11 +253,11 @@ public class UnitAttachment extends DefaultAttachment {
     m_canIntercept = false;
   }
 
-  public void setRequiresAirBaseToIntercept(final String value) {
+  private void setRequiresAirBaseToIntercept(final String value) {
     m_requiresAirBaseToIntercept = getBool(value);
   }
 
-  public void setRequiresAirBaseToIntercept(final Boolean value) {
+  private void setRequiresAirBaseToIntercept(final Boolean value) {
     m_requiresAirBaseToIntercept = value;
   }
 
@@ -265,7 +265,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_requiresAirBaseToIntercept;
   }
 
-  public void resetRequiresAirBaseToIntercept() {
+  private void resetRequiresAirBaseToIntercept() {
     m_requiresAirBaseToIntercept = false;
   }
 
@@ -1495,11 +1495,11 @@ public class UnitAttachment extends DefaultAttachment {
     m_maxScrambleDistance = -1;
   }
 
-  public void setMaxInterceptCount(final String s) {
+  private void setMaxInterceptCount(final String s) {
     m_maxInterceptCount = getInt(s);
   }
 
-  public void setMaxInterceptCount(final Integer s) {
+  private void setMaxInterceptCount(final Integer s) {
     m_maxInterceptCount = s;
   }
 
@@ -1507,7 +1507,7 @@ public class UnitAttachment extends DefaultAttachment {
     return m_maxInterceptCount;
   }
 
-  public void resetMaxInterceptCount() {
+  private void resetMaxInterceptCount() {
     m_maxInterceptCount = -1;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -688,13 +688,9 @@ public class AirBattle extends AbstractBattle {
         .and(Matches.unitIsAirBase())
         .and(Matches.unitIsNotDisabled())
         .and(Matches.unitIsBeingTransported().negate());
-    return u -> {
-      boolean result = canIntercept.test(u);
-      if (Matches.unitRequiresAirBaseToIntercept().test(u)) {
-        result = result && Matches.territoryHasUnitsThatMatch(airbasesCanIntercept).test(territory);
-      }
-      return result;
-    };
+    return u -> canIntercept.test(u)
+        && (!Matches.unitRequiresAirBaseToIntercept().test(u)
+            || Matches.territoryHasUnitsThatMatch(airbasesCanIntercept).test(territory));
   }
 
   static boolean territoryCouldPossiblyHaveAirBattleDefenders(final Territory territory, final PlayerID attacker,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -37,6 +37,9 @@ import games.strategy.util.Interruptibles;
 import games.strategy.util.PredicateBuilder;
 import lombok.extern.java.Log;
 
+/**
+ * Battle class used for air battles and interception before a standard battle.
+ */
 @Log
 public class AirBattle extends AbstractBattle {
   private static final long serialVersionUID = 4686241714027216395L;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2083,6 +2083,10 @@ public final class Matches {
     return u -> UnitAttachment.get(u.getType()).getCanIntercept();
   }
 
+  public static Predicate<Unit> unitRequiresAirBaseToIntercept() {
+    return u -> UnitAttachment.get(u.getType()).getRequiresAirBaseToIntercept();
+  }
+
   static Predicate<Unit> unitCanEscort() {
     return u -> UnitAttachment.get(u.getType()).getCanEscort();
   }

--- a/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -47,7 +47,7 @@ public class DiceImageFactory {
   private Map<Integer, Image> generateDice(final Color color) {
     final ImageFactory imageFactory = new ImageFactory();
     imageFactory.setResourceLoader(resourceLoader);
-    return IntStream.rangeClosed(1, diceSides)
+    return IntStream.rangeClosed(0, diceSides)
         .parallel()
         .boxed()
         .collect(Collectors.toMap(Function.identity(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -132,6 +132,7 @@ import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
+import games.strategy.triplea.delegate.AirBattle;
 import games.strategy.triplea.delegate.AirThatCantLandUtil;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.BattleDelegate;
@@ -1434,7 +1435,7 @@ public final class TripleAFrame extends JFrame {
       whereFrom.setFont(new Font("Arial", Font.BOLD, 12));
       panelChooser.add(whereFrom);
       panelChooser.add(new JLabel(" "));
-      final int maxAllowed = possible.size();
+      final int maxAllowed = Math.min(AirBattle.getMaxInterceptionCount(current, possible), possible.size());
       final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
       chooser.setMaxAndShowMaxButton(maxAllowed);
       panelChooser.add(chooser);


### PR DESCRIPTION
## Overview
Addresses: https://forums.triplea-game.org/topic/491/require-airbase-to-intercept

## Functional Changes
- Add 2 new XML unit fields: requiresAirbaseToIntercept and maxInterceptCount
- This allows interception to work like scrambling does requiring airbase and having a max number per airbase
- Fixed a dice image regression caused by https://github.com/triplea-game/triplea/pull/3388

## Manual Testing Performed
- Tested existing TWW functionality that it was unchanged
- Edited TWW XML with:
Added to Airfield: `<option name="maxInterceptCount" value="1"/>`
Added to Fighter: `<option name="requiresAirbaseToIntercept" value="true"/>`
- Verified that when bombing it limits the number of fighter based on number of airfields and if no airfields then no fighters can intercept
