### PR TITLE
Checkstyle: Suppress remaining naming violations

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -35,6 +35,11 @@
         </module>
 
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE\-OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE\-ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
         <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/CompositeChange.java
@@ -8,6 +8,8 @@ import java.util.List;
  */
 public class CompositeChange extends Change {
   private static final long serialVersionUID = 8152962976769419486L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Change> m_changes;
 
   public CompositeChange(final Change... changes) {

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -29,8 +29,10 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   private static final Splitter COLON_SPLITTER = Splitter.on(':');
 
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Attachable m_attachedTo;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_name;
 
   protected DefaultAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
@@ -11,6 +11,8 @@ import com.google.common.base.MoreObjects;
  */
 public class DefaultNamed extends GameDataComponent implements Named {
   private static final long serialVersionUID = -5737716450699952621L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
 
   public DefaultNamed(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/DelegateList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DelegateList.java
@@ -16,6 +16,8 @@ import games.strategy.engine.delegate.IDelegate;
  */
 public class DelegateList extends GameDataComponent implements Iterable<IDelegate> {
   private static final long serialVersionUID = 4156921032854553312L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<String, IDelegate> m_delegates = new HashMap<>();
 
   public DelegateList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameDataComponent.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameDataComponent.java
@@ -12,7 +12,9 @@ import games.strategy.engine.data.annotations.InternalDoNotExport;
  */
 public class GameDataComponent implements Serializable {
   private static final long serialVersionUID = -2066504666509851740L;
+
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private GameData m_data;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -28,14 +28,19 @@ import games.strategy.util.IntegerMap;
  */
 public class GameMap extends GameDataComponent implements Iterable<Territory> {
   private static final long serialVersionUID = -4606700588396439283L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Territory> m_territories = new ArrayList<>();
   // note that all entries are unmodifiable
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Territory, Set<Territory>> m_connections = new HashMap<>();
   // for fast lookup based on the string name of the territory
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, Territory> m_territoryLookup = new HashMap<>();
   // nil if the map is not grid-based
   // otherwise, m_gridDimensions.length is the number of dimensions,
   // and each element is the size of a dimension
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int[] m_gridDimensions = null;
 
   GameMap(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -13,9 +13,13 @@ import lombok.extern.java.Log;
 public class GameSequence extends GameDataComponent implements Iterable<GameStep> {
   private static final long serialVersionUID = 6354618406598578287L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<GameStep> m_steps = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_currentIndex;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_round = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_roundOffset = 0;
 
   public GameSequence(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -15,12 +15,20 @@ import games.strategy.engine.delegate.IDelegate;
  */
 public class GameStep extends GameDataComponent {
   private static final long serialVersionUID = -7944468945162840931L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_displayName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final PlayerID m_player;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_delegate;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_runCount = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxRunCount = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Properties m_properties;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
+++ b/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
@@ -9,6 +9,8 @@ import java.util.Map;
  */
 public class NamedAttachable extends DefaultNamed implements Attachable {
   private static final long serialVersionUID = 8597712929519099255L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, IAttachment> m_attachments = new HashMap<>();
 
   /** Creates new NamedAttachable. */

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -19,22 +19,32 @@ import lombok.EqualsAndHashCode;
 /**
  * A game player (nation, power, etc.).
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   private static final long serialVersionUID = -2284878450555315947L;
 
   private static final String DEFAULT_TYPE_AI = "AI";
   private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_optional;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_canBeDisabled;
   private final String defaultType;
   private final boolean isHidden;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isDisabled = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final UnitCollection m_unitsHeld;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ResourceCollection m_resources;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ProductionFrontier m_productionFrontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private RepairFrontier m_repairFrontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechnologyFrontierList m_technologyFrontiers;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_whoAmI = "null:no_one";
 
   public PlayerID(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -19,7 +19,9 @@ import lombok.ToString;
 @ToString
 public class PlayerList extends GameDataComponent implements Iterable<PlayerID> {
   private static final long serialVersionUID = -3895068111754745446L;
+
   // maps String playerName -> PlayerID
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, PlayerID> m_players = new LinkedHashMap<>();
 
   public PlayerList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
@@ -12,7 +12,10 @@ import java.util.List;
  */
 public class ProductionFrontier extends DefaultNamed implements Iterable<ProductionRule> {
   private static final long serialVersionUID = -5967251608158552892L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<ProductionRule> m_rules;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<ProductionRule> m_cachedRules;
 
   public ProductionFrontier(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionFrontierList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionFrontierList.java
@@ -11,6 +11,8 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class ProductionFrontierList extends GameDataComponent {
   private static final long serialVersionUID = -7565214499087021809L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, ProductionFrontier> m_productionFrontiers = new HashMap<>();
 
   public ProductionFrontierList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -10,7 +10,10 @@ import games.strategy.util.IntegerMap;
  */
 public class ProductionRule extends DefaultNamed {
   private static final long serialVersionUID = -6598296283127741307L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<Resource> m_cost = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<NamedAttachable> m_results = new IntegerMap<>();
 
   /** Creates new ProductionRule. */

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionRuleList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionRuleList.java
@@ -11,6 +11,8 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class ProductionRuleList extends GameDataComponent {
   private static final long serialVersionUID = -5313215563006788188L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, ProductionRule> m_productionRules = new HashMap<>();
 
   public ProductionRuleList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -12,7 +12,9 @@ import games.strategy.triplea.attachments.RelationshipTypeAttachment;
  */
 public class RelationshipTracker extends RelationshipInterpreter {
   private static final long serialVersionUID = -4740671761925519069L;
+
   // map of "playername:playername" to RelationshipType that exists between those 2 players
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final HashMap<RelatedPlayers, Relationship> m_relationships = new HashMap<>();
 
   public RelationshipTracker(final GameData data) {
@@ -122,7 +124,9 @@ public class RelationshipTracker extends RelationshipInterpreter {
       return Objects.hashCode(m_p1) + Objects.hashCode(m_p2);
     }
 
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private final PlayerID m_p1;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private final PlayerID m_p2;
 
     public RelatedPlayers(final PlayerID p1, final PlayerID p2) {

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -14,6 +14,8 @@ import games.strategy.triplea.attachments.RelationshipTypeAttachment;
  */
 public class RelationshipTypeList extends GameDataComponent implements Iterable<RelationshipType> {
   private static final long serialVersionUID = 6590541694575435151L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final HashMap<String, RelationshipType> m_relationshipTypes = new HashMap<>();
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/RepairFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RepairFrontier.java
@@ -12,7 +12,10 @@ import java.util.List;
  */
 public class RepairFrontier extends DefaultNamed implements Iterable<RepairRule> {
   private static final long serialVersionUID = -5148536624986056753L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<RepairRule> m_rules;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<RepairRule> m_cachedRules;
 
   public RepairFrontier(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/RepairFrontierList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RepairFrontierList.java
@@ -9,6 +9,8 @@ import java.util.Set;
  */
 public class RepairFrontierList extends GameDataComponent {
   private static final long serialVersionUID = -5877933681560908405L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, RepairFrontier> m_repairFrontiers = new HashMap<>();
 
   public RepairFrontierList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -9,7 +9,10 @@ import games.strategy.util.IntegerMap;
  */
 public class RepairRule extends DefaultNamed {
   private static final long serialVersionUID = -45646671022993959L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Resource> m_cost;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<NamedAttachable> m_results;
 
   public RepairRule(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/RepairRuleList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RepairRuleList.java
@@ -10,6 +10,8 @@ import java.util.Map;
 // TODO: rename this class upon next incompatible release to replace "List" suffix since this collection is not ordered
 public class RepairRuleList extends GameDataComponent {
   private static final long serialVersionUID = 8153102637443800391L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, RepairRule> m_repairRules = new HashMap<>();
 
   public RepairRuleList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -8,6 +8,8 @@ import games.strategy.util.IntegerMap;
  */
 public class ResourceCollection extends GameDataComponent {
   private static final long serialVersionUID = -1247795977888113757L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Resource> m_resources = new IntegerMap<>();
 
   public ResourceCollection(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
@@ -10,6 +10,8 @@ import java.util.Map;
  */
 public class ResourceList extends GameDataComponent {
   private static final long serialVersionUID = -8812702449627698253L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, Resource> m_resourceList = new LinkedHashMap<>();
 
   public ResourceList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -39,7 +39,10 @@ import games.strategy.util.Tuple;
 public class Route implements Serializable, Iterable<Territory> {
   private static final long serialVersionUID = 8743882455488948557L;
   private static final List<Territory> EMPTY_TERRITORY_LIST = Collections.emptyList();
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Territory> m_steps = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Territory m_start;
 
   public Route() {}

--- a/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
@@ -14,8 +14,12 @@ import games.strategy.triplea.delegate.TechAdvance;
  */
 public class TechnologyFrontier extends GameDataComponent implements Iterable<TechAdvance> {
   private static final long serialVersionUID = -5245743727479551766L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<TechAdvance> m_techs = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<TechAdvance> m_cachedTechs;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
 
   public TechnologyFrontier(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
@@ -11,6 +11,8 @@ import games.strategy.triplea.delegate.TechAdvance;
  */
 public class TechnologyFrontierList extends GameDataComponent {
   private static final long serialVersionUID = 2958122401265284935L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<TechnologyFrontier> m_technologyFrontiers = new ArrayList<>();
 
   public TechnologyFrontierList(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -9,11 +9,15 @@ import javax.annotation.Nullable;
  */
 public class Territory extends NamedAttachable implements NamedUnitHolder, Comparable<Territory> {
   private static final long serialVersionUID = -6390555051736721082L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_water;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private PlayerID m_owner = PlayerID.NULL_PLAYERID;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final UnitCollection m_units;
   // In a grid-based game, stores the coordinate of the Territory
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"checkstyle:MemberName", "unused"}) // remove upon next incompatible release
   private final int[] m_coordinate;
 
   public Territory(final String name, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -22,9 +22,14 @@ import lombok.extern.java.Log;
 @Log
 public class Unit extends GameDataComponent implements DynamicallyModifiable {
   private static final long serialVersionUID = -7906193079642776282L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private PlayerID m_owner;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final GUID m_uid;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_hits = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final UnitType m_type;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -18,7 +18,10 @@ import games.strategy.util.IntegerMap;
  */
 public class UnitCollection extends GameDataComponent implements Collection<Unit> {
   private static final long serialVersionUID = -3534037864426122864L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Unit> m_units = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final NamedUnitHolder m_holder;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
@@ -10,7 +10,10 @@ import games.strategy.util.IntegerMap;
  */
 public class UnitHitsChange extends Change {
   private static final long serialVersionUID = 2862726651812142713L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Unit> m_hits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Unit> m_undoHits;
 
   private UnitHitsChange(final IntegerMap<Unit> hits, final IntegerMap<Unit> undoHits) {

--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -12,6 +12,8 @@ import java.util.Set;
  */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, UnitType> m_unitTypes = new LinkedHashMap<>();
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/UnitsList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitsList.java
@@ -14,7 +14,9 @@ import games.strategy.net.GUID;
  */
 public class UnitsList implements Serializable, Iterable<Unit> {
   private static final long serialVersionUID = -3134052492257867416L;
+
   // TODO - fix this, all units are never gcd
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<GUID, Unit> m_allUnits = new HashMap<>();
 
   UnitsList() {}

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
@@ -7,10 +7,16 @@ import games.strategy.engine.data.IAttachment;
 
 class AddAttachmentChange extends Change {
   private static final long serialVersionUID = -21015135248288454L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IAttachment m_attachment;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_originalAttachmentName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_originalAttachable;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_attachable;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
 
   public AddAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
@@ -8,8 +8,12 @@ import games.strategy.triplea.delegate.TechAdvance;
 
 class AddAvailableTech extends Change {
   private static final long serialVersionUID = 5664428883866434959L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechAdvance m_tech;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechnologyFrontier m_frontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final PlayerID m_player;
 
   public AddAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddBattleRecordsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddBattleRecordsChange.java
@@ -9,7 +9,10 @@ import games.strategy.triplea.delegate.dataObjects.BattleRecords;
 
 class AddBattleRecordsChange extends Change {
   private static final long serialVersionUID = -6927678548172402611L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final BattleRecords m_recordsToAdd;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_round;
 
   AddBattleRecordsChange(final BattleRecords battleRecords, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
@@ -7,7 +7,10 @@ import games.strategy.engine.data.ProductionRule;
 
 class AddProductionRule extends Change {
   private static final long serialVersionUID = 2583955907289570063L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ProductionRule m_rule;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ProductionFrontier m_frontier;
 
   public AddProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -14,8 +14,12 @@ import games.strategy.engine.data.UnitHolder;
  */
 class AddUnits extends Change {
   private static final long serialVersionUID = 2694342784633196289L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_units;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_type;
 
   AddUnits(final UnitCollection collection, final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
@@ -10,9 +10,14 @@ import games.strategy.engine.data.IAttachment;
  */
 class AttachmentPropertyReset extends Change {
   private static final long serialVersionUID = 9208154387325299072L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_attachedTo;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_attachmentName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_oldValue;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_property;
 
   AttachmentPropertyReset(final IAttachment attachment, final String property) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
@@ -8,9 +8,14 @@ import games.strategy.engine.data.MutableProperty;
 
 class AttachmentPropertyResetUndo extends Change {
   private static final long serialVersionUID = 5943939650116851332L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_attachedTo;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_attachmentName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_newValue;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_property;
 
   AttachmentPropertyResetUndo(final Attachable attachTo, final String attachmentName, final Object newValue,

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
@@ -11,8 +11,12 @@ import games.strategy.engine.data.ResourceCollection;
  */
 class ChangeResourceChange extends Change {
   private static final long serialVersionUID = -2304294240555842126L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_player;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_resource;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_quantity;
 
   ChangeResourceChange(final PlayerID player, final Resource resource, final int quantity) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
@@ -7,10 +7,16 @@ import games.strategy.triplea.attachments.TechAttachment;
 
 class GenericTechChange extends Change {
   private static final long serialVersionUID = -2439447526511535571L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_attachedTo;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_attachmentName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_newValue;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_oldValue;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_property;
 
   GenericTechChange(final TechAttachment attachment, final boolean newValue, final String property) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -13,9 +13,14 @@ import games.strategy.engine.data.Unit;
  */
 public class ObjectPropertyChange extends Change {
   private static final long serialVersionUID = 4218093376094170940L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Unit m_object;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_property;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_newValue;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_oldValue;
 
   ObjectPropertyChange(final Unit object, final String property, final Object newValue) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
@@ -10,11 +10,15 @@ import games.strategy.engine.data.Territory;
  */
 class OwnerChange extends Change {
   private static final long serialVersionUID = -5938125380623744929L;
+
   /**
    * Either new or old owner can be null.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_old;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_new;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_territory;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -18,9 +18,13 @@ class PlayerOwnerChange extends Change {
   /**
    * Maps unit id -> owner as String.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<GUID, String> m_old;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<GUID, String> m_new;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_location;
+
   private static final long serialVersionUID = -9154938431233632882L;
 
   PlayerOwnerChange(final Collection<Unit> units, final PlayerID newOwner, final Territory location) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
@@ -6,8 +6,12 @@ import games.strategy.engine.data.PlayerID;
 
 class PlayerWhoAmIChange extends Change {
   private static final long serialVersionUID = -1486914230174337300L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_startWhoAmI;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_endWhoAmI;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_player;
 
   PlayerWhoAmIChange(final String newWhoAmI, final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
@@ -9,9 +9,13 @@ import games.strategy.engine.data.ProductionFrontier;
  * Change a players production frontier.
  */
 class ProductionFrontierChange extends Change {
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_startFrontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_endFrontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_player;
+
   private static final long serialVersionUID = 3336145814067456701L;
 
   ProductionFrontierChange(final ProductionFrontier newFrontier, final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -13,9 +13,14 @@ import games.strategy.util.CollectionUtils;
  */
 class RelationshipChange extends Change {
   private static final long serialVersionUID = 2694339584633196289L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_player1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_player2;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_OldRelation;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_NewRelation;
 
   RelationshipChange(final PlayerID player1, final PlayerID player2, final RelationshipType oldRelation,

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
@@ -7,10 +7,16 @@ import games.strategy.engine.data.IAttachment;
 
 class RemoveAttachmentChange extends Change {
   private static final long serialVersionUID = 6365648682759047674L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IAttachment m_attachment;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_originalAttachmentName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_originalAttachable;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Attachable m_attachable;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
 
   public RemoveAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
@@ -8,8 +8,12 @@ import games.strategy.triplea.delegate.TechAdvance;
 
 class RemoveAvailableTech extends Change {
   private static final long serialVersionUID = 6131447662760022521L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechAdvance m_tech;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechnologyFrontier m_frontier;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final PlayerID m_player;
 
   public RemoveAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
@@ -9,7 +9,10 @@ import games.strategy.triplea.delegate.dataObjects.BattleRecords;
 
 class RemoveBattleRecordsChange extends Change {
   private static final long serialVersionUID = 3286634991233029854L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final BattleRecords m_recordsToRemove;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_round;
 
   RemoveBattleRecordsChange(final BattleRecords battleRecords, final int round) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
@@ -7,7 +7,10 @@ import games.strategy.engine.data.ProductionRule;
 
 class RemoveProductionRule extends Change {
   private static final long serialVersionUID = 2312599802275503095L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ProductionRule m_rule;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ProductionFrontier m_frontier;
 
   public RemoveProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
@@ -11,8 +11,12 @@ import games.strategy.engine.data.UnitHolder;
 
 class RemoveUnits extends Change {
   private static final long serialVersionUID = -6410444472951010568L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_units;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_type;
 
   RemoveUnits(final UnitCollection collection, final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/SetPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/SetPropertyChange.java
@@ -6,8 +6,12 @@ import games.strategy.engine.data.properties.GameProperties;
 
 class SetPropertyChange extends Change {
   private static final long serialVersionUID = -1377597975513821508L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_property;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_value;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_oldValue;
 
   SetPropertyChange(final String property, final Object value, final GameProperties properties) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
@@ -10,7 +10,10 @@ import javax.swing.JComponent;
  */
 public abstract class AEditableProperty implements IEditableProperty, Serializable, Comparable<AEditableProperty> {
   private static final long serialVersionUID = -5005729898242568847L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_description;
 
   public AEditableProperty(final String name, final String description) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -9,6 +9,8 @@ import javax.swing.JComponent;
 public class BooleanProperty extends AEditableProperty {
   // compatible with 0.9.0.2 saved games
   private static final long serialVersionUID = -7265501762343216435L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean mValue;
 
   public BooleanProperty(final String name, final String description, final boolean defaultValue) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -16,6 +16,8 @@ import javax.swing.JTable;
  */
 public class CollectionProperty<T> extends AEditableProperty {
   private static final long serialVersionUID = 5338055034530377261L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<T> m_values;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -15,9 +15,14 @@ import games.strategy.engine.ClientFileSystemHelper;
  */
 public class DoubleProperty extends AEditableProperty {
   private static final long serialVersionUID = 5521967819500867581L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_max;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_min;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private double m_value;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_places;
 
   public DoubleProperty(final String name, final String description, final double max, final double min,

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -27,7 +27,9 @@ public class FileProperty extends AEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final String[] defaultImageSuffixes = {"png", "jpg", "jpeg", "gif"};
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String[] m_acceptableSuffixes;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private File m_file;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -18,7 +18,10 @@ import javax.swing.JComponent;
  */
 public class MapProperty<T, U> extends AEditableProperty {
   private static final long serialVersionUID = -8021039503574228146L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<T, U> m_map;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final List<IEditableProperty> m_properties = new ArrayList<>();
 
   public MapProperty(final String name, final String description, final Map<T, U> map) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -22,6 +22,7 @@ public class NumberProperty extends AEditableProperty {
   public static final String MIN_PROPERTY_NAME = "min";
   private final int min;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_value;
 
   public NumberProperty(final String name, final String description, final int max, final int min, final int def) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -12,6 +12,8 @@ import javax.swing.JTextField;
  */
 public class StringProperty extends AEditableProperty {
   private static final long serialVersionUID = 4382624884674152208L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_value;
 
   public StringProperty(final String name, final String description, final String defaultValue) {

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.framework.headlessGameServer;
 
 import java.io.File;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.framework.headlessGameServer;
 
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.framework.headlessGameServer;
 
 import java.util.List;

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetupPanelModel.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.framework.headlessGameServer;
 
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;

--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -31,17 +31,26 @@ import games.strategy.util.Version;
 public class PlayerListing implements Serializable {
   // keep compatability with older versions
   private static final long serialVersionUID = -8913538086737733980L;
+
   /**
    * Maps String player name -> node Name
    * if node name is null then the player is available to play.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, String> m_playerToNodeListing;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, Boolean> m_playersEnabledListing;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, String> m_localPlayerTypes;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<String> m_playersAllowedToBeDisabled;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Version m_gameVersion;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_gameName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_gameRound;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<String, Collection<String>> m_playerNamesAndAlliancesInTurnOrder;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -35,6 +35,10 @@ public final class SaveGameFileChooser extends JFileChooser {
   /**
    * The available auto-saves that can be loaded by a headless game server.
    */
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:TypeName" // rename upon next incompatible release
+  })
   public enum AUTOSAVE_TYPE {
     AUTOSAVE(getHeadlessAutoSaveFile()),
 

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.gamePlayer;
 
 import java.lang.reflect.InvocationHandler;

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.gamePlayer;
 
 import games.strategy.engine.data.PlayerID;

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.gamePlayer;
 
 import games.strategy.engine.data.GameData;

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.gamePlayer;
 
 import games.strategy.engine.data.PlayerID;

--- a/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
@@ -4,6 +4,8 @@ import games.strategy.engine.data.Change;
 
 class ChangeSerializationWriter implements SerializationWriter {
   private static final long serialVersionUID = -3802807345707883606L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Change aChange;
 
   public ChangeSerializationWriter(final Change change) {

--- a/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
@@ -2,7 +2,10 @@ package games.strategy.engine.history;
 
 class EventChildWriter implements SerializationWriter {
   private static final long serialVersionUID = -7143658060171295697L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_text;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_renderingData;
 
   public EventChildWriter(final String text, final Object renderingData) {

--- a/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
@@ -2,7 +2,10 @@ package games.strategy.engine.history;
 
 class EventHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 6404070330823708974L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_eventName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Object m_renderingData;
 
   public EventHistorySerializer(final String eventName, final Object renderingData) {

--- a/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
@@ -16,7 +16,10 @@ import lombok.extern.java.Log;
 @Log
 public class HistoryWriter implements Serializable {
   private static final long serialVersionUID = 4230519614567508061L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final History m_history;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private HistoryNode m_current;
 
   public HistoryWriter(final History history) {

--- a/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
@@ -2,6 +2,8 @@ package games.strategy.engine.history;
 
 class RoundHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 9006488114384654514L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_roundNo;
 
   public RoundHistorySerializer(final int roundNo) {

--- a/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
@@ -16,7 +16,10 @@ import games.strategy.engine.data.GameData;
  */
 class SerializedHistory implements Serializable {
   private static final long serialVersionUID = -5808427923253751651L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<SerializationWriter> m_Writers = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final GameData m_data;
 
   public SerializedHistory(final History history, final GameData data, final List<Change> changes) {

--- a/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
@@ -4,9 +4,17 @@ import games.strategy.engine.data.PlayerID;
 
 class StepHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 3546486775516371557L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_stepName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_delegateName;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private final PlayerID m_playerID;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_displayName;
 
   public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerId,

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.engine.lobby.server.userDB;
 
 import java.io.Serializable;
@@ -14,11 +17,14 @@ import lombok.ToString;
  * A lobby user.
  */
 @EqualsAndHashCode
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 @ToString
 public final class DBUser implements Serializable {
   private static final long serialVersionUID = -5289923058375302916L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_email;
   private final Role userRole;
 

--- a/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -35,12 +35,18 @@ public abstract class AbstractForumPoster implements IForumPoster {
   private static final String USE_TRANSIENT_CREDENTIAL = "d0a11f0f-96d3-4303-8875-4965aefb2ce4";
 
   private static final long serialVersionUID = -734015230309508040L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_username = null;
   private transient String transientUsername;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_password = null;
   private transient String transientPassword;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_topicId = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_includeSaveGame = true;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_alsoPostAfterCombatMove = false;
   protected transient File saveGameFile = null;
   protected transient String turnSummaryRef = null;

--- a/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -65,16 +65,25 @@ public class GenericEmailSender implements IEmailSender {
     NONE, TLS
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private long m_timeout = TimeUnit.SECONDS.toMillis(60);
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_subjectPrefix;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_userName;
   private transient String transientUserName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_password;
   private transient String transientPassword;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_toAddress;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_host = "smptserver.example.com";
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_port = 25;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Encryption m_encryption;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_alsoPostAfterCombatMove = false;
   private boolean credentialsSaved = false;
   private boolean credentialsProtected = false;

--- a/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -27,12 +27,16 @@ import lombok.extern.java.Log;
  * although the PBEM games will always be local
  */
 @Log
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public class PBEMMessagePoster implements Serializable {
   public static final String FORUM_POSTER_PROP_NAME = "games.strategy.engine.pbem.IForumPoster";
   public static final String EMAIL_SENDER_PROP_NAME = "games.strategy.engine.pbem.IEmailSender";
   public static final String PBEM_GAME_PROP_NAME = "games.strategy.engine.pbem.PBEMMessagePoster";
   private static final long serialVersionUID = 2256265436928530566L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IForumPoster m_forumPoster;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IEmailSender m_emailSender;
   private transient File saveGameFile = null;
   private transient String turnSummary = null;

--- a/game-core/src/main/java/games/strategy/engine/random/DiceStatistic.java
+++ b/game-core/src/main/java/games/strategy/engine/random/DiceStatistic.java
@@ -8,10 +8,16 @@ import java.io.Serializable;
  */
 public class DiceStatistic implements Serializable {
   private static final long serialVersionUID = -1422839840110240480L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_average;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_total;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_median;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_stdDeviation;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final double m_variance;
 
   DiceStatistic(final double average, final int total, final double median, final double stdDeviation,

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -85,9 +85,13 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
     return rollers;
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Properties m_props;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_toAddress;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_ccAddress;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_gameId;
 
   public PropertiesDiceRoller(final Properties props) {

--- a/game-core/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
+++ b/game-core/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
@@ -23,9 +23,14 @@ import games.strategy.util.IntegerMap;
  */
 public class RandomStatsDetails implements Serializable {
   private static final long serialVersionUID = 69602197220912520L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<PlayerID, IntegerMap<Integer>> m_data;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Integer> m_totalMap;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final DiceStatistic m_totalStats;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<PlayerID, DiceStatistic> m_playerStats = new HashMap<>();
 
   RandomStatsDetails(final Map<PlayerID, IntegerMap<Integer>> randomStats, final int diceSides) {

--- a/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
@@ -8,6 +8,7 @@ import games.strategy.net.INode;
 /**
  * Uniquely identifies a cryptographic vault used to store random numbers on a particular node.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public class VaultID implements Serializable {
   private static final long serialVersionUID = 8863728184933393296L;
   private static long currentId;
@@ -16,9 +17,14 @@ public class VaultID implements Serializable {
     return currentId++;
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final INode m_generatedOn;
   // this is a unique and monotone increasing id
   // unique in this vm
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private final long m_uniqueID = getNextId();
 
   VaultID(final INode generatedOn) {

--- a/game-core/src/main/java/games/strategy/net/GUID.java
+++ b/game-core/src/main/java/games/strategy/net/GUID.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Backed by a java.rmi.dgc.VMID.
  * Written across the network often, so this class is externalizable to increase efficiency.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public final class GUID implements Externalizable {
   private static final long serialVersionUID = 8426441559602874190L;
   // this prefix is unique across vms

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -56,41 +56,63 @@ public class TripleAUnit extends Unit {
   public static final String LAUNCHED = "launched";
   public static final String AIRBORNE = "airborne";
   public static final String CHARGED_FLAT_FUEL_COST = "chargedFlatFuelCost";
+
   // the transport that is currently transporting us
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private TripleAUnit m_transportedBy = null;
   // the units we have unloaded this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Unit> m_unloaded = Collections.emptyList();
   // was this unit loaded this turn?
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasLoadedThisTurn = false;
   // the territory this unit was unloaded to this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Territory m_unloadedTo = null;
   // was this unit unloaded in combat phase this turn?
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasUnloadedInCombatPhase = false;
   // movement used this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_alreadyMoved = 0;
   // movement used this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bonusMovement = 0;
   // amount of damage unit has sustained
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_unitDamage = 0;
   // is this submarine submerged
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_submerged = false;
   // original owner of this unit
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private PlayerID m_originalOwner = null;
   // Was this unit in combat
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasInCombat = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasLoadedAfterCombat = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasAmphibious = false;
   // the territory this unit started in (for use with scrambling)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Territory m_originatedFrom = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasScrambled = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxScrambleCount = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_wasInAirBattle = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_disabled = false;
   // the number of airborne units launched by this unit this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_launched = 0;
   // was this unit airborne and launched this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_airborne = false;
   // was charged flat fuel cost already this turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_chargedFlatFuelCost = false;
 
   public static TripleAUnit get(final Unit u) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -43,18 +43,24 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   public static final String TRIGGER_CHANCE_FAILURE = "Trigger Rolling is a Failure!";
 
   // list of conditions that this condition can
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<RulesAttachment> m_conditions = new ArrayList<>();
   // contain
   // m_conditionType modifies the relationship of m_conditions
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_conditionType = AND;
   // will logically negate the entire condition, including contained conditions
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_invert = false;
   // chance (x out of y) that this action is successful when attempted, default = 1:1 = always
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_chance = DEFAULT_CHANCE;
   // successful
   // if chance fails, we should increment the chance by x
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_chanceIncrementOnFailure = 0;
   // if chance succeeds, we should decrement the chance by x
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_chanceDecrementOnSuccess = 0;
 
   protected AbstractConditionsAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -28,33 +28,46 @@ import lombok.extern.java.Log;
 @Log
 public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachment {
   private static final long serialVersionUID = 7224407193725789143L;
+
   // Please do not add new things to this class. Any new Player-Rules type of stuff should go in "PlayerAttachment".
   // These variables are related to a "rulesAttachment" that changes certain rules for the attached player. They are
   // not related to
   // conditions at all.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_movementRestrictionType = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String[] m_movementRestrictionTerritories = null;
   // allows placing units in any owned land
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_placementAnyTerritory = false;
   // allows placing units in any sea by owned land
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_placementAnySeaZone = false;
   // allows placing units in a captured territory
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_placementCapturedTerritory = false;
   // turns of the warning to the player when they produce more than they can place
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_unlimitedProduction = false;
   // can only place units in the capital
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_placementInCapitalRestricted = false;
   // enemy units will defend at 1
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_dominatingFirstRoundAttack = false;
   // negates m_dominatingFirstRoundAttack
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_negateDominatingFirstRoundAttack = false;
   // automatically produces 1 unit of a certain
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected IntegerMap<UnitType> m_productionPerXTerritories = new IntegerMap<>();
   // type per every X territories owned
   // stops the user from placing units in any territory that already contains more than this
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_placementPerTerritory = -1;
   // number of owned units
   // maximum number of units that can be placed in each territory.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_maxPlacePerTerritory = -1;
 
   // It would wreck most map xmls to move the rulesAttachment's to another class, so don't move them out of here

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -33,28 +33,37 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). Determines if we will be counting each for the
   // purposes of m_objectiveValue
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_countEach = false;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). The multiple that will be applied to m_objectiveValue
   // if m_countEach is true
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_eachMultiple = 1;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). Used with the next Territory conditions to
   // determine the number of territories needed to be valid (ex: m_alliedOwnershipTerritories)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_territoryCount = -1;
   // A list of players that can be used with
   // directOwnershipTerritories, directExclusionTerritories,
   // directPresenceTerritories, or any of the other territory lists
   // only used if the attachment begins with "objectiveAttachment"
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<PlayerID> m_players = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_objectiveValue = 0;
   // only matters for objectiveValue, does not affect the condition
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_uses = -1;
   // condition for what turn it is
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected Map<Integer, Integer> m_turns = null;
   // for on/off conditions
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_switch = true;
   // allows custom GameProperties
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_gameProperty = null;
 
   protected AbstractRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -30,14 +30,19 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   public static final String NOTIFICATION = "Notification";
   public static final String AFTER = "after";
   public static final String BEFORE = "before";
+
   // "setTrigger" is also a valid setter, and it just calls "setConditions" in AbstractConditionsAttachment. Kept for
   // backwards
   // compatibility.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_uses = -1;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_usedThisRound = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_notification = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_when = new ArrayList<>();
 
   protected AbstractTriggerAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -27,6 +27,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   public static final String ATTEMPTS_LEFT_THIS_TURN = "attemptsLeftThisTurn";
 
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected String m_text = "";
   /**
    * The cost in PUs to attempt this action.
@@ -34,14 +35,21 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    * @deprecated Replaced by costResources.
    */
   @Deprecated
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // remove upon next incompatible release
+      "checkstyle:MemberName" // remove upon next incompatible release
+  })
   protected int m_costPU = 0;
   // cost in any resources to attempt this action
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected IntegerMap<Resource> m_costResources = new IntegerMap<>();
   // how many times can you perform this action each round?
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_attemptsPerTurn = 1;
   // how many times are left to perform this action each round?
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_attemptsLeftThisTurn = 1;
   // which players should accept this action? this could be the player who is the target of this action in the case of
   // proposing a treaty or
@@ -49,6 +57,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   // especially for actions such as when france declares war on germany and it automatically causes UK to declare war as
   // well. it is good to
   // set "actionAccept" to "UK" so UK can accept this action to go through.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<PlayerID> m_actionAccept = new ArrayList<>();
 
   protected AbstractUserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -24,8 +24,11 @@ import games.strategy.util.CollectionUtils;
 public class CanalAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -1991066817386812634L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canalName = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<Territory> m_landTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_excludedUnits = null;
 
   public CanalAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -45,35 +45,50 @@ public class PlayerAttachment extends DefaultAttachment {
     return playerAttachment;
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_vps = 0;
   // need to store some data during a turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_captureVps = 0;
   // number of capitals needed before we lose all our money
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_retainCapitalNumber = 1;
   // number of capitals needed before we lose ability to gain money and produce units
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_retainCapitalProduceNumber = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_giveUnitControl = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_captureUnitOnEnteringBy = new ArrayList<>();
   // gives any technology researched to this player automatically
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_shareTechnology = new ArrayList<>();
   // allows these players to help pay for technology
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_helpPayTechCost = new ArrayList<>();
   // do we lose our money and have it disappear or is that money captured?
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_destroysPUs = false;
   // are we immune to being blockaded?
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_immuneToBlockade = false;
   // what resources can be used for suicide attacks, and
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<Resource> m_suicideAttackResources = new IntegerMap<>();
   // at what attack power
   // what can be hit by suicide attacks
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_suicideAttackTargets = null;
   // placement limits on a flexible per player basis
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<Triple<Integer, String, Set<UnitType>>> m_placementLimit = new HashSet<>();
 
   // movement limits on a flexible per player basis
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<Triple<Integer, String, Set<UnitType>>> m_movementLimit = new HashSet<>();
 
   // attacking limits on a flexible per player basis
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<Triple<Integer, String, Set<UnitType>>> m_attackingLimit = new HashSet<>();
 
   /** Creates new PlayerAttachment. */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -37,6 +37,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   private static final long serialVersionUID = 4392770599777282477L;
 
   // list of relationship changes to be performed if this action is performed sucessfully
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_relationshipChange = new ArrayList<>();
 
   public PoliticalActionAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -26,18 +26,29 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   public static final String PROPERTY_TRUE = Constants.RELATIONSHIP_PROPERTY_TRUE;
   public static final String PROPERTY_FALSE = Constants.RELATIONSHIP_PROPERTY_FALSE;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_archeType = ARCHETYPE_WAR;
-  // private final String m_helpsDefendAtSea = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_alliancesCanChainTogether = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_isDefaultWarPosition = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_upkeepCost = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_givesBackOriginalTerritories = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_canMoveThroughCanals = PROPERTY_DEFAULT;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_rocketsCanFlyOver = PROPERTY_DEFAULT;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -48,38 +48,57 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private static final long serialVersionUID = 7301965634079412516L;
 
   // condition for having techs
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<TechAdvance> m_techs = null;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_techCount = -1;
   // condition for having specific relationships
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_relationship = new ArrayList<>();
   // condition for being at war
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<PlayerID> m_atWarPlayers = null;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_atWarCount = -1;
   // condition for having destroyed at least X enemy non-neutral TUV (total unit value) [according to
   // the prices the defender pays for the units]
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private String m_destroyedTUV = null;
   // condition for having had a battle in some territory, attacker or defender, win
   // or lost, etc. these next 9 variables use m_territoryCount for determining the number needed.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, List<Territory>>> m_battle = new ArrayList<>();
   // ownership related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_alliedOwnershipTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_directOwnershipTerritories = null;
   // exclusion of units
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_alliedExclusionTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_directExclusionTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_enemyExclusionTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_enemySurfaceExclusionTerritories = null;
   // presence of units
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_directPresenceTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_alliedPresenceTerritories = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_enemyPresenceTerritories = null;
   // used with above 3 to determine the type of unit that must be present
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<String> m_unitPresence = new IntegerMap<>();
-
 
   /** Creates new RulesAttachment. */
   public RulesAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -64,36 +64,64 @@ public class TechAbilityAttachment extends DefaultAttachment {
   // unitAbilitiesGained Static Strings
   public static final String ABILITY_CAN_BLITZ = "canBlitz";
   public static final String ABILITY_CAN_BOMBARD = "canBombard";
+
   // attachment fields
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_attackBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_defenseBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_movementBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_radarBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_airAttackBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_airDefenseBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_productionBonus = new IntegerMap<>();
   // -1 means not set
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_minimumTerritoryValueForProductionBonus = -1;
   // -1 means not set
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_repairDiscount = -1;
   // -1 means not set
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_warBondDiceSides = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_warBondDiceNumber = 0;
   // -1 means not set // not needed because this is controlled in the unit attachment with
   // private int m_rocketDiceSides = -1;
   // bombingBonus and bombingMaxDieSides
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_rocketDiceNumber = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_rocketDistance = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_rocketNumberPerTerritory = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<UnitType, Set<String>> m_unitAbilitiesGained = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_airborneForces = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_airborneCapacity = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_airborneTypes = new HashSet<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_airborneDistance = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_airborneBases = new HashSet<>();
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private Map<String, Set<UnitType>> m_airborneTargettedByAA = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_attackRollsBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_defenseRollsBonus = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_bombingBonus = new IntegerMap<>();
 
   public TechAbilityAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -58,6 +58,7 @@ public class TechAttachment extends DefaultAttachment {
   private boolean increasedFactoryProduction = false;
   private boolean warBonds = false;
   private boolean mechanizedInfantry = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean aARadar = false;
   private boolean shipyards = false;
   // do not export at this point. currently map xml cannot

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -209,26 +209,44 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_unitProduction;
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_capital = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_originalFactory = false;
   // "setProduction" will set both m_production and m_unitProduction.
   // While "setProductionOnly" sets only m_production.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_production = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_victoryCity = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isImpassable = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private PlayerID m_originalOwner = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_convoyRoute = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private HashSet<Territory> m_convoyAttached = new HashSet<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ArrayList<PlayerID> m_changeUnitOwners = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ArrayList<PlayerID> m_captureUnitOnEnteringBy = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_navalBase = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_airBase = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_kamikazeZone = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_unitProduction = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_blockadeZone = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ArrayList<TerritoryEffect> m_territoryEffect = new ArrayList<>();
   // TODO: change to List<CaptureOwnershipChange> upon next incompatible release
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ArrayList<String> m_whenCapturedByGoesTo = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ResourceCollection m_resources = null;
 
   /** Creates new TerritoryAttachment. */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -24,9 +24,13 @@ import games.strategy.util.IntegerMap;
 public class TerritoryEffectAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 6379810228136325991L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_combatDefenseEffect = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_combatOffenseEffect = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<UnitType> m_noBlitz = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<UnitType> m_unitsNotAllowed = new ArrayList<>();
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -63,40 +63,69 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   private static final String PREFIX_CLEAR = "-clear-";
   private static final String PREFIX_RESET = "-reset-";
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private ProductionFrontier m_frontier = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_productionRule = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<TechAdvance> m_tech = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<String, Map<TechAdvance, Boolean>> m_availableTech = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Territory, IntegerMap<UnitType>> m_placement = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Territory, IntegerMap<UnitType>> m_removeUnits = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_purchase = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_resource = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_resourceCount = 0;
   // never use a map of other attachments, inside of an attachment. java will not be able to deserialize it.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<String, Boolean> m_support = null;
   // List of relationshipChanges that should be executed when this trigger hits.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_relationshipChange = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_victory = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_activateTrigger = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_changeOwnership = new ArrayList<>();
   // raw property changes below:
   //
   // really m_unitTypes, but we are not going to rename because it will break all existing maps
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<UnitType> m_unitType = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<String, String> m_unitAttachmentName = null; // covers UnitAttachment, UnitSupportAttachment
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_unitProperty = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Territory> m_territories = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<String, String> m_territoryAttachmentName = null; // covers TerritoryAttachment, CanalAttachment
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_territoryProperty = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_players = new ArrayList<>();
   // covers PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, UserActionAttachment
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<String, String> m_playerAttachmentName = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_playerProperty = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<RelationshipType> m_relationshipTypes = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<String, String> m_relationshipTypeAttachmentName = null; // covers RelationshipTypeAttachment
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_relationshipTypeProperty = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<TerritoryEffect> m_territoryEffects = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<String, String> m_territoryEffectAttachmentName = null; // covers TerritoryEffectAttachment
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_territoryEffectProperty = null;
 
   public TriggerAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -69,164 +69,285 @@ public class UnitAttachment extends DefaultAttachment {
 
   public static final String UNITSMAYNOTLANDONCARRIER = "unitsMayNotLandOnCarrier";
   public static final String UNITSMAYNOTLEAVEALLIEDCARRIER = "unitsMayNotLeaveAlliedCarrier";
+
   // movement related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAir = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isSea = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_movement = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canBlitz = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isKamikaze = false;
   // a colon delimited list of transports where this unit may invade from, it supports "none"
   // and if empty it allows you to invade from all
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_canInvadeOnlyFrom = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<Resource> m_fuelCost = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<Resource> m_fuelFlatCost = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canNotMoveDuringCombatMove = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<Integer, String> m_movementLimit = null;
   // combat related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_attack = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_defense = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isInfrastructure = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canBombard = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bombard = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isSub = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isDestroyer = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_artillery = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_artillerySupportable = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_unitSupportCount = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_isMarine = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isSuicide = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isSuicideOnHit = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<Integer, String> m_attackingLimit = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_attackRolls = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_defenseRolls = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_chooseBestRoll = false;
   // transportation related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isCombatTransport = false;
   // -1 if cant transport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_transportCapacity = -1;
   // -1 if cant be transported
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_transportCost = -1;
   // -1 if cant act as a carrier
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_carrierCapacity = -1;
   // -1 if cant land on a carrier
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_carrierCost = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAirTransport = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAirTransportable = false;
   // isInfantry is DEPRECATED, use isLandTransportable
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isInfantry = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isLandTransport = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isLandTransportable = false;
   // aa related
   // "isAA" and "isAAmovement" are also valid setters, used as shortcuts for calling multiple aa related setters. Must
   // keep.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAAforCombatOnly = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAAforBombingThisUnitOnly = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAAforFlyOverOnly = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isRocket = false;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private int m_attackAA = 1;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private int m_offensiveAttackAA = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_attackAAmaxDieSides = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_offensiveAttackAAmaxDieSides = -1;
   // -1 means infinite
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxAAattacks = -1;
   // -1 means infinite
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private int m_maxRoundsAA = 1;
   // default value for when it is not set
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private String m_typeAA = "AA";
   // null means targeting air units only
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private Set<UnitType> m_targetsAA = null;
   // if false, we cannot shoot more times than there are number of planes
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private boolean m_mayOverStackAA = false;
   // if false, we instantly kill anything our AA shot hits
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private boolean m_damageableAA = false;
   // if these enemy units are present, the gun does not fire at all
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_willNotFireIfPresent = new HashSet<>();
   // strategic bombing related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isStrategicBomber = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bombingMaxDieSides = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bombingBonus = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canIntercept = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canEscort = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canAirBattle = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_airDefense = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_airAttack = 0;
   // null means they can target any unit that can be damaged
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_bombingTargets = null;
   // production related
   // this has been split into canProduceUnits, isConstruction, canBeDamaged, and isInfrastructure
   // private boolean m_isFactory = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canProduceUnits = false;
   // -1 means either it can't produce any, or it produces at the value of the territory it is located in
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_canProduceXUnits = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_createsUnitsList = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<Resource> m_createsResourcesList = new IntegerMap<>();
   // damage related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_hitPoints = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canBeDamaged = false;
   // this is bombing damage, not hitpoints. default of 2 means that factories will take 2x the territory value
   // they are in, of damage.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxDamage = 2;
   // -1 if can't be disabled
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxOperationalDamage = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canDieFromReachingMaxDamage = false;
   // placement related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isConstruction = false;
   // can be any String except for "none" if isConstruction is true
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_constructionType = "none";
   // -1 if not set, is meaningless
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_constructionsPerTerrPerTypePerTurn = -1;
   // -1 if not set, is meaningless
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxConstructionsPerTypePerTerr = -1;
   // -1 means anywhere
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_canOnlyBePlacedInTerritoryValuedAtX = -1;
   // multiple colon delimited lists of the unit combos required for
   // this unit to be built somewhere. (units must be in same
   // territory, owned by player, not be disabled)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String[]> m_requiresUnits = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_consumesUnits = new IntegerMap<>();
   // multiple colon delimited lists of the unit combos required for
   // this unit to move into a territory. (units must be owned by player, not be disabled)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String[]> m_requiresUnitsToMove = new ArrayList<>();
   // a colon delimited list of territories where this unit may not be placed
   // also an allowed setter is "setUnitPlacementOnlyAllowedIn",
   // which just creates m_unitPlacementRestrictions with an inverted list of territories
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String[] m_unitPlacementRestrictions = null;
   // -1 if infinite (infinite is default)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxBuiltPerPlayer = -1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Tuple<Integer, String> m_placementLimit = null;
   // scrambling related
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_canScramble = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_isAirBase = false;
   // -1 if can't scramble
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxScrambleDistance = -1;
   // -1 for infinite
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxScrambleCount = -1;
   // special abilities
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_blockade = 0;
   // a colon delimited list of the units this unit can repair.
   // (units must be in same territory, unless this unit is land
   // and the repaired unit is sea)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_repairsUnits = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IntegerMap<UnitType> m_givesMovement = new IntegerMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, PlayerID>> m_destroyedWhenCapturedBy = new ArrayList<>();
   // also an allowed setter is "setDestroyedWhenCapturedFrom" which will just create m_destroyedWhenCapturedBy with a
   // specific list
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsDamagedChangesInto = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Integer, Tuple<Boolean, UnitType>> m_whenHitPointsRepairedChangesInto = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<String, Tuple<String, IntegerMap<UnitType>>> m_whenCapturedChangesInto = new LinkedHashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_whenCapturedSustainsDamage = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_canBeCapturedOnEnteringBy = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_canBeGivenByTerritoryTo = new ArrayList<>();
   // a set of information for dealing with special abilities or
   // loss of abilities when a unit takes x-y amount of damage
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>> m_whenCombatDamaged = new ArrayList<>();
   // a kind of support attachment for giving actual unit
   // attachment abilities or other to a unit, when in the
   // precense or on the same route with another unit
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_receivesAbilityWhenWith = new ArrayList<>();
   // currently used for: placement in original territories only
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<String> m_special = new HashSet<>();
   // Manually set TUV
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_tuv = -1;
 
   /** Creates new UnitAttachment. */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -27,29 +27,44 @@ import games.strategy.triplea.MapSupport;
 public class UnitSupportAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -3015679930172496082L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<UnitType> m_unitType = null;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_offence = false;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_defence = false;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_roll = false;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_strength = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bonus = 0;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_number = 0;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_allied = false;
   @InternalDoNotExport
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_enemy = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_bonusType = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<PlayerID> m_players = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_impArtTech = false;
   // strings
   // roll or strength
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_dice;
   // offence or defence
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_side;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_faction;
 
   public UnitSupportAttachment(final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -33,8 +33,8 @@ import games.strategy.util.Tuple;
 public class UserActionAttachment extends AbstractUserActionAttachment {
   private static final long serialVersionUID = 5268397563276055355L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<Tuple<String, String>> m_activateTrigger = new ArrayList<>();
-
 
   public UserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -31,11 +31,15 @@ import games.strategy.util.CollectionUtils;
 /**
  * Code to fire AA guns while in combat and non combat move.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 class AAInMoveUtil implements Serializable {
   private static final long serialVersionUID = 1787497998642717678L;
+
   private transient IDelegateBridge bridge;
   private transient PlayerID player;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Collection<Unit> m_casualties = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ExecutionStack m_executionStack = new ExecutionStack();
 
   AAInMoveUtil() {}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AARadarAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AARadarAdvance.java
@@ -8,6 +8,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 /**
  * A technology advance that provides anti-aircraft radar.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 final class AARadarAdvance extends TechAdvance {
   private static final long serialVersionUID = 6464021231625252901L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -23,37 +23,69 @@ import games.strategy.util.IntegerMap;
 
 abstract class AbstractBattle implements IBattle {
   private static final long serialVersionUID = 871090498661731337L;
+
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   final GUID m_battleID = new GUID();
   /**
    * In headless mode we should NOT access any Delegates. In headless mode we are just being used to calculate results
    * for an odds
    * calculator so we can skip some steps for efficiency.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_headless = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final Territory m_battleSite;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final PlayerID m_attacker;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   PlayerID m_defender;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final BattleTracker m_battleTracker;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   int m_round = 1;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final boolean m_isBombingRun;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_isAmphibious = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final BattleType m_battleType;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_isOver = false;
   /**
    * Dependent units, maps unit -> Collection of units, if unit is lost in a battle we are dependent on
    * then we lose the corresponding collection of units.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final Map<Unit, Collection<Unit>> m_dependentUnits = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   List<Unit> m_attackingUnits = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   List<Unit> m_defendingUnits = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   List<Unit> m_amphibiousLandAttackers = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   List<Unit> m_bombardingUnits = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   Collection<TerritoryEffect> m_territoryEffects;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   BattleResultDescription m_battleResultDescription;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   WhoWon m_whoWon = WhoWon.NOTFINISHED;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   int m_attackerLostTUV = 0;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   int m_defenderLostTUV = 0;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final GameData m_data;
 
   AbstractBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
@@ -5,8 +5,11 @@ import java.util.List;
 
 class AbstractMoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -4072966724295569322L;
+
   Serializable superState;
   // add other variables here
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public List<UndoableMove> m_movesToUndo;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public MovePerformer m_tempMovePerformer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -16,14 +16,18 @@ import games.strategy.triplea.delegate.dataObjects.AbstractMoveDescription;
  */
 public abstract class AbstractUndoableMove implements Serializable {
   private static final long serialVersionUID = -3164832285286161069L;
+
   /**
    * Stores the serialized state of the move and battle delegates (just
    * as if they were saved), and a CompositeChange that represents all the changes that
    * were made during the move.
    * Some moves (such as those following an aa fire) can't be undone.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final CompositeChange m_change;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected int m_index;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final Collection<Unit> m_units;
 
   public AbstractUndoableMove(final CompositeChange change, final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -46,12 +46,19 @@ public class AirBattle extends AbstractBattle {
   protected static final String DEFENDERS_FIRE = "Defenders Fire";
   protected static final String ATTACKERS_WITHDRAW = "Attackers Withdraw?";
   protected static final String DEFENDERS_WITHDRAW = "Defenders Withdraw?";
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final ExecutionStack m_stack = new ExecutionStack();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<String> m_steps;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final Collection<Unit> m_defendingWaitingToDie = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final Collection<Unit> m_attackingWaitingToDie = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_intercept = false;
   // -1 would mean forever until one side is eliminated. (default is 1 round)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final int m_maxRounds;
 
   AirBattle(final Territory battleSite, final boolean bombingRaid, final GameData data, final PlayerID attacker,
@@ -539,7 +546,10 @@ public class AirBattle extends AbstractBattle {
 
   class AttackersFire implements IExecutable {
     private static final long serialVersionUID = -5289634214875797408L;
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     DiceRoll m_dice;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     CasualtyDetails m_details;
 
     @Override
@@ -584,7 +594,10 @@ public class AirBattle extends AbstractBattle {
 
   class DefendersFire implements IExecutable {
     private static final long serialVersionUID = -7277182945495744003L;
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     DiceRoll m_dice;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     CasualtyDetails m_details;
 
     @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
@@ -4,6 +4,9 @@ import java.io.Serializable;
 
 class BaseDelegateState implements Serializable {
   private static final long serialVersionUID = 7130686697155151908L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_startBaseStepsFinished = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_endBaseStepsFinished = false;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -4,17 +4,27 @@ import java.io.Serializable;
 
 class BattleExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7899007486408723505L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   BattleTracker m_battleTracker = new BattleTracker();
-  // public OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToScramble;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToKamikazeSuicideAttacks;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToClearEmptyAirBattleAttacks;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToAddBombardmentSources;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToRecordBattleStatistics;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToCheckDefendingPlanesCanLand;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_needToCleanup;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   IBattle m_currentBattle;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -61,29 +61,40 @@ import lombok.extern.java.Log;
 @Log
 public class BattleTracker implements Serializable {
   private static final long serialVersionUID = 8806010984321554662L;
+
   // List of pending battles
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<IBattle> m_pendingBattles = new HashSet<>();
   // List of battle dependencies
   // maps blocked -> Collection of battles that must precede
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<IBattle, HashSet<IBattle>> m_dependencies = new HashMap<>();
   // enemy and neutral territories that have been conquered
   // blitzed is a subset of this
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_conquered = new HashSet<>();
   // blitzed territories
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_blitzed = new HashSet<>();
   // territories where a battle occurred
   // TODO: fix typo in name, 'fough' -> 'fought'
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_foughBattles = new HashSet<>();
   // list of territory we have conquered in a FinishedBattle and where from and if amphibious
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final HashMap<Territory, Map<Territory, Collection<Unit>>> m_finishedBattlesUnitAttackFromMap =
       new HashMap<>();
   // things like kamikaze suicide attacks disallow bombarding from that sea zone for that turn
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_noBombardAllowed = new HashSet<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Territory, Collection<Unit>> m_defendingAirThatCanNotLand =
       new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private BattleRecords m_battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<
       Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn =
           new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
@@ -4,8 +4,12 @@ import java.io.Serializable;
 
 class BidPurchaseExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 6896164200767186673L;
+
   Serializable superState;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   int m_bid;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   int m_spent;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   boolean m_hasBid;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -13,10 +13,13 @@ public class Die implements Serializable {
     MISS, HIT, IGNORED
   }
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final DieType m_type;
   // the value of the dice, 0 based
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_value;
   // this value is 1 based
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_rolledAt;
 
   public Die(final int value) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
@@ -8,8 +8,11 @@ import games.strategy.engine.data.PlayerID;
 
 class EndRoundExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 8770361633528374127L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_gameOver = false;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public Collection<PlayerID> m_winners = new ArrayList<>();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
@@ -4,8 +4,11 @@ import java.io.Serializable;
 
 class EndTurnExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -3939461840835898284L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_hasPostedTurnSummary;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -28,8 +28,13 @@ import games.strategy.engine.delegate.IDelegateBridge;
  */
 public class ExecutionStack implements Serializable {
   private static final long serialVersionUID = -8675285470515074530L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private IExecutable m_current;
-  @SuppressWarnings("JdkObsolete") // change to Deque/ArrayDeque upon next incompatible release
+  @SuppressWarnings({
+      "checkstyle:MemberName", // rename upon next incompatible release
+      "JdkObsolete" // change to Deque/ArrayDeque upon next incompatible release
+  })
   private final Stack<IExecutable> m_stack = new Stack<>();
 
   void execute(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -28,8 +28,11 @@ import games.strategy.util.IntegerMap;
  */
 public class FinishedBattle extends AbstractBattle {
   private static final long serialVersionUID = -5852495231826940879L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
   // maps Territory-> units (stores a collection of who is attacking from where, needed for undoing moves)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
 
   FinishedBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -23,28 +23,54 @@ public class Fire implements IExecutable {
 
   private static final long serialVersionUID = -3687054738070722403L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_stepName;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_firingUnits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_attackableUnits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final MustFightBattle.ReturnFire m_canReturnFire;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_text;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final MustFightBattle m_battle;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final PlayerID m_firingPlayer;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final PlayerID m_hitPlayer;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_defending;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Unit, Collection<Unit>> m_dependentUnits;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   private final GUID m_battleID;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private DiceRoll m_dice;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Collection<Unit> m_killed;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Collection<Unit> m_damaged;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private boolean m_confirmOwnCasualties = true;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_isHeadless;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Territory m_battleSite;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<TerritoryEffect> m_territoryEffects;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Unit> m_allEnemyUnitsAliveOrWaitingToDie;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_allFriendlyUnitsNotIncludingWaitingToDie;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_allEnemyUnitsNotIncludingWaitingToDie;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_isAmphibious;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_amphibiousLandAttackers;
 
   Fire(final Collection<Unit> attackableUnits, final MustFightBattle.ReturnFire canReturnFire,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
@@ -7,6 +7,8 @@ import games.strategy.triplea.attachments.TechAttachment;
 
 public class GenericTechAdvance extends TechAdvance {
   private static final long serialVersionUID = -5985281030083508185L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final TechAdvance m_advance;
 
   public GenericTechAdvance(final String name, final TechAdvance techAdvance, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -25,6 +25,8 @@ public interface IBattle extends Serializable {
 
   enum BattleType {
     NORMAL("Battle"), AIR_BATTLE("Air Battle"), AIR_RAID("Air Raid"), BOMBING_RAID("Bombing Raid");
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private final String m_type;
 
     BattleType(final String type) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 class InitializationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -9000446777655823735L;
+
   Serializable superState;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
@@ -7,9 +7,13 @@ import games.strategy.util.IntegerMap;
 
 class MoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 5352248885420819215L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToDoRockets;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public IntegerMap<Territory> m_PUsLost;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -38,12 +38,17 @@ import games.strategy.util.PredicateBuilder;
  */
 public class MovePerformer implements Serializable {
   private static final long serialVersionUID = 3752242292777658310L;
+
   private transient AbstractMoveDelegate moveDelegate;
   private transient IDelegateBridge bridge;
   private transient PlayerID player;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private AAInMoveUtil m_aaInMoveUtil;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ExecutionStack m_executionStack = new ExecutionStack();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private UndoableMove m_currentMove;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Unit, Collection<Unit>> m_newDependents;
   private Collection<Unit> arrivingUnits;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -75,26 +75,48 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private static final long serialVersionUID = 5879502298361231540L;
+
   // maps Territory-> units (stores a collection of who is attacking from where, needed for undoing moves)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_attackingWaitingToDie = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Set<Territory> m_attackingFrom = new HashSet<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_defendingWaitingToDie = new ArrayList<>();
   // keep track of all the units that die in the battle to show in the history window
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_killed = new ArrayList<>();
 
   // Our current execution state, we keep a stack of executables, this allows us to save our state and resume while in
   // the middle of a battle.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final ExecutionStack m_stack = new ExecutionStack();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private List<String> m_stepStrings;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   protected List<Unit> m_defendingAA;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   protected List<Unit> m_offensiveAA;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<String> m_defendingAAtypes;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<String> m_offensiveAAtypes;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Unit> m_attackingUnitsRetreated = new ArrayList<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Unit> m_defendingUnitsRetreated = new ArrayList<>();
   // -1 would mean forever until one side is eliminated (the default is infinite)
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_maxRounds;
 
   public MustFightBattle(final Territory battleSite, final PlayerID attacker, final GameData data,
@@ -2045,11 +2067,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_stack.push(new FireAA(true));
   }
 
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
   class FireAA implements IExecutable {
     private static final long serialVersionUID = -6406659798754841382L;
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private final boolean m_defending;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private DiceRoll m_dice;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private CasualtyDetails m_casualties;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     final Collection<Unit> m_casualtiesSoFar = new ArrayList<>();
 
     private FireAA(final boolean defending) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPUEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPUEndTurnDelegate.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.MapSupport;
  */
 @AutoSave(afterStepEnd = true)
 @MapSupport
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public class NoPUEndTurnDelegate extends EndTurnDelegate {
   @Override
   protected int getProduction(final Collection<Territory> territories) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -20,6 +20,7 @@ import games.strategy.util.IntegerMap;
  * At the end of the turn collect units, not income.
  */
 @MapSupport
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
 public class NoPUPurchaseDelegate extends PurchaseDelegate {
   private boolean isPacific;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -30,8 +30,12 @@ import games.strategy.util.CollectionUtils;
  */
 public class NonFightingBattle extends DependentBattle {
   private static final long serialVersionUID = -1699534010648145123L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_attackingFrom;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Territory> m_amphibiousAttackFrom;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Territory, Collection<Unit>> m_attackingFromMap;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
@@ -10,8 +10,11 @@ import games.strategy.engine.data.Unit;
 
 class PlaceExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -4926754941623641735L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public Map<Territory, Collection<Unit>> m_produced;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public List<UndoablePlacement> m_placements;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 
 class PurchaseExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 2326864364534284490L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
@@ -6,7 +6,9 @@ import games.strategy.engine.data.PlayerID;
 
 class RandomStartExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 607794506772555083L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public PlayerID m_currentPickingPlayer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 class SpecialMoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7781410008392307104L;
+
   Serializable superState;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -45,13 +45,24 @@ import games.strategy.util.Interruptibles;
 public class StrategicBombingRaidBattle extends AbstractBattle implements BattleStepStrings {
   private static final long serialVersionUID = 8490171037606078890L;
   private static final String RAID = "Strategic bombing raid";
+
   // these would be the factories or other targets. does not include aa.
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final HashMap<Unit, HashSet<Unit>> m_targets = new HashMap<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final ExecutionStack m_stack = new ExecutionStack();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<String> m_steps;
+  @SuppressWarnings({
+      "checkstyle:AbbreviationAsWordInName", // rename upon next incompatible release
+      "checkstyle:MemberName" // rename upon next incompatible release
+  })
   protected List<Unit> m_defendingAA;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected List<String> m_AAtypes;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_bombingRaidTotal;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final IntegerMap<Unit> m_bombingRaidDamage = new IntegerMap<>();
 
   /**
@@ -322,10 +333,15 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     getDisplay(bridge).listBattleSteps(m_battleID, m_steps);
   }
 
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
   class FireAA implements IExecutable {
     private static final long serialVersionUID = -4667856856747597406L;
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     DiceRoll m_dice;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     CasualtyDetails m_casualties;
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     final Collection<Unit> m_casualtiesSoFar = new ArrayList<>();
     Collection<Unit> validAttackingUnitsForThisRoll;
     final boolean determineAttackers;
@@ -523,6 +539,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
 
   class ConductBombing implements IExecutable {
     private static final long serialVersionUID = 5579796391988452213L;
+
+    @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
     private int[] m_dice;
 
     @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 class TechActivationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 1742776261442260882L;
+
   Serializable superState;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
@@ -8,8 +8,11 @@ import games.strategy.engine.data.PlayerID;
 
 class TechnologyExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -1375328472343199099L;
+
   Serializable superState;
   // add other variables here:
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public boolean m_needToInitialize;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   public HashMap<PlayerID, Collection<TechAdvance>> m_techs;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -28,20 +28,29 @@ import games.strategy.util.CollectionUtils;
  */
 public class UndoableMove extends AbstractUndoableMove {
   private static final long serialVersionUID = 8490182214651531358L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_reasonCantUndo;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_description;
   // this move is dependent on these moves
   // these moves cant be undone until this one has been
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<UndoableMove> m_iDependOn = new HashSet<>();
   // these moves depend on me
   // we cant be undone until this is empty
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<UndoableMove> m_dependOnMe = new HashSet<>();
   // list of countries we took over
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Territory> m_conquered = new HashSet<>();
   // transports loaded by this move
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Unit> m_loaded = new HashSet<>();
   // transports unloaded by this move
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Set<Unit> m_unloaded = new HashSet<>();
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Route m_route;
 
   public void addToConquered(final Territory t) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -17,7 +17,10 @@ import games.strategy.triplea.formatter.MyFormatter;
  */
 public class UndoablePlacement extends AbstractUndoableMove {
   private static final long serialVersionUID = -1493488646587233451L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Territory m_placeTerritory;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Territory m_producerTerritory;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/AbstractMoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/AbstractMoveDescription.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -7,6 +10,8 @@ import games.strategy.engine.data.Unit;
 
 public abstract class AbstractMoveDescription implements Serializable {
   private static final long serialVersionUID = -6615899716448836002L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_units;
 
   public AbstractMoveDescription(final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -16,6 +19,8 @@ import games.strategy.triplea.delegate.IBattle.BattleType;
  */
 public class BattleListing implements Serializable {
   private static final long serialVersionUID = 2700129486225793827L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<BattleType, Collection<Territory>> m_battles;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -63,7 +66,9 @@ public class BattleRecord implements Serializable {
   private Territory battleSite;
   private PlayerID attacker;
   private PlayerID defender;
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
   private int attackerLostTUV = 0;
+  @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
   private int defenderLostTUV = 0;
   private BattleResultDescription battleResultDescription;
   private final BattleType battleType;
@@ -95,7 +100,9 @@ public class BattleRecord implements Serializable {
     private final Territory battleSite;
     private final PlayerID attacker;
     private final PlayerID defender;
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
     private final int attackerLostTUV;
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next incompatible release
     private final int defenderLostTUV;
     private final BattleResultDescription battleResultDescription;
     private final BattleType battleType;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -21,6 +24,7 @@ import games.strategy.triplea.oddsCalculator.ta.BattleResults;
 public class BattleRecords implements Serializable {
   private static final long serialVersionUID = 1473664374777905497L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final HashMap<PlayerID, HashMap<GUID, BattleRecord>> m_records;
 
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyDetails.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.util.List;
@@ -6,6 +9,8 @@ import games.strategy.engine.data.Unit;
 
 public class CasualtyDetails extends CasualtyList {
   private static final long serialVersionUID = 2261683015991514918L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final boolean m_autoCalculated;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -9,7 +12,10 @@ import games.strategy.engine.data.Unit;
 
 public class CasualtyList implements Serializable {
   private static final long serialVersionUID = 6501752134047891398L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final List<Unit> m_killed;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected final List<Unit> m_damaged;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/FightBattleDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/FightBattleDetails.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import games.strategy.engine.data.Territory;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveDescription.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.util.Collection;
@@ -12,8 +15,12 @@ import games.strategy.engine.data.Unit;
 
 public class MoveDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = 2199608152808948043L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Route m_route;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Collection<Unit> m_transportsThatCanBeLoaded;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Unit, Collection<Unit>> m_dependentUnits;
 
   public MoveDescription(final Collection<Unit> units, final Route route,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveValidationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveValidationResult.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -10,10 +13,16 @@ import games.strategy.engine.data.Unit;
 
 public class MoveValidationResult implements Serializable, Comparable<MoveValidationResult> {
   private static final long serialVersionUID = 6648363112533514955L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_error = null;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<String> m_disallowedUnitWarnings;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Collection<Unit>> m_disallowedUnitsList;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<String> m_unresolvedUnitWarnings;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<Collection<Unit>> m_unresolvedUnitsList;
 
   public MoveValidationResult() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MustMoveWithDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/MustMoveWithDetails.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -14,9 +17,11 @@ import games.strategy.engine.data.Unit;
  */
 public class MustMoveWithDetails implements Serializable {
   private static final long serialVersionUID = 936060269327534445L;
+
   /**
    * Maps Unit -> Collection of units.
    */
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Map<Unit, Collection<Unit>> m_mapping;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -7,8 +10,12 @@ import games.strategy.engine.data.Unit;
 
 public class PlaceableUnits implements Serializable {
   private static final long serialVersionUID = 6572719978603199091L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private String m_errorMessage;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private Collection<Unit> m_units;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private int m_maxUnits;
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlacementDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/PlacementDescription.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.util.Collection;
@@ -7,6 +10,8 @@ import games.strategy.engine.data.Unit;
 
 public class PlacementDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = -3141153168992624631L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final Territory m_territory;
 
   public PlacementDescription(final Collection<Unit> units, final Territory territory) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import java.io.Serializable;
@@ -5,10 +8,16 @@ import java.util.List;
 
 public class TechResults implements Serializable {
   private static final long serialVersionUID = 5574673305892105782L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int[] m_rolls;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_hits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_remainder;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final List<String> m_advances;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final String m_errorString;
 
   public TechResults(final String errorString) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/dataObjects/TechRoll.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.delegate.dataObjects;
 
 import games.strategy.engine.data.PlayerID;

--- a/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/BattleResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/oddsCalculator/ta/BattleResults.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.triplea.oddsCalculator.ta;
 
 import java.util.List;
@@ -15,9 +18,13 @@ import games.strategy.util.CollectionUtils;
 public class BattleResults extends GameDataComponent {
   private static final long serialVersionUID = 1381361441940258702L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_battleRoundsFought;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final List<Unit> m_remainingAttackingUnits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   final List<Unit> m_remainingDefendingUnits;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final WhoWon m_whoWon;
 
   // FYI: do not save the battle in BattleResults. It is both too much memory overhead, and also causes problems with

--- a/game-core/src/main/java/games/strategy/twoIfBySea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/twoIfBySea/delegate/EndTurnDelegate.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.twoIfBySea.delegate;
 
 import games.strategy.engine.data.GameData;
@@ -11,6 +14,7 @@ import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
 
 @MapSupport
 public class EndTurnDelegate extends AbstractEndTurnDelegate {
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   protected boolean m_gameOver = false;
 
   public EndTurnDelegate() {}

--- a/game-core/src/main/java/games/strategy/twoIfBySea/delegate/InitDelegate.java
+++ b/game-core/src/main/java/games/strategy/twoIfBySea/delegate/InitDelegate.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.twoIfBySea.delegate;
 
 import games.strategy.engine.delegate.IDelegateBridge;

--- a/game-core/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// rename upon next incompatible release
+
 package games.strategy.twoIfBySea.delegate;
 
 import java.util.Collection;

--- a/game-core/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/game-core/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -15,6 +15,8 @@ import java.util.Set;
  */
 public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
+
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final LinkedHashMap<T, Integer> m_values;
 
   /** Creates new LinkedIntegerMap. */

--- a/game-core/src/main/java/games/strategy/util/Version.java
+++ b/game-core/src/main/java/games/strategy/util/Version.java
@@ -18,9 +18,13 @@ import javax.annotation.Nullable;
 public final class Version implements Serializable, Comparable<Version> {
   private static final long serialVersionUID = -4770210855326775333L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_major;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_minor;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_point;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next incompatible release
   private final int m_micro;
   private final String exactVersion;
 


### PR DESCRIPTION
## Overview

Resolves #4137.

Suppresses the remaining Checkstyle naming violations until they can be fixed in the upcoming incompatible release.  Just in case that takes longer than expected, the noise from these 700+ violations will no longer be present in the build logs.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

This PR should probably be merged after #4140.  The conflicts will be easier to resolve here.