### PR TITLE
Checkstyle: Enforce newline at end of file

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -33,6 +33,7 @@
         <module name="FileTabCharacter">
             <property name="eachLine" value="true"/>
         </module>
+    <module name="NewlineAtEndOfFile"/>
 
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder"/>


### PR DESCRIPTION
## Overview

Based on https://github.com/triplea-game/triplea/pull/4132#discussion_r222181588.

Enables the Checkstyle NewlineAtEndOfFile rule.

## Functional Changes

None.

## Manual Testing Performed

Verified the build fails if a Java source file is missing a newline at the end of the file.

## Additional Review Notes

Someone on Windows should try running the `check` task locally (either before or after this PR is merged) to verify there are no failures.  By default, this rule searches for the system line separator at the end of the file.  I'm assuming y'all have your Git `core.autocrlf` set to `true`.  If that's not the case, we'll have to explicitly set the line ending to `lf` so it doesn't fail on Windows machines.