### PR TITLE
Synchronize Find Territory dialog with Territory tab

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/FindTerritoryAction.java
@@ -2,14 +2,9 @@ package games.strategy.triplea.ui;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 import javax.swing.AbstractAction;
-import javax.swing.Timer;
-
-import games.strategy.engine.data.Territory;
 
 /**
  * A UI action that prompts the user to select a territory by name and then centers the map on the selected territory.
@@ -31,45 +26,8 @@ public final class FindTerritoryAction extends AbstractAction {
     final SelectTerritoryDialog dialog = new SelectTerritoryDialog(
         frame,
         "Find Territory",
-        frame.getGame().getData().getMap().getTerritories());
-    dialog.open().ifPresent(this::showTerritory);
-  }
-
-  private void showTerritory(final Territory territory) {
-    final MapPanel mapPanel = frame.getMapPanel();
-    mapPanel.centerOn(territory);
-    TerritoryBorderAnimator.run(mapPanel, territory);
-  }
-
-  private static final class TerritoryBorderAnimator implements ActionListener {
-    private static final int FRAME_DELAY_IN_MS = 500;
-    private static final int TOTAL_FRAMES = 10;
-
-    private int frame;
-    private final MapPanel mapPanel;
-    private final Territory territory;
-
-    private TerritoryBorderAnimator(final MapPanel mapPanel, final Territory territory) {
-      this.mapPanel = mapPanel;
-      this.territory = territory;
-    }
-
-    static void run(final MapPanel mapPanel, final Territory territory) {
-      new Timer(FRAME_DELAY_IN_MS, new TerritoryBorderAnimator(mapPanel, territory)).start();
-    }
-
-    @Override
-    public void actionPerformed(final ActionEvent e) {
-      if ((frame % 2) == 0) {
-        mapPanel.setTerritoryOverlayForBorder(territory, Color.WHITE);
-      } else {
-        mapPanel.clearTerritoryOverlay(territory);
-      }
-      mapPanel.paintImmediately(mapPanel.getBounds());
-
-      if (++frame >= TOTAL_FRAMES) {
-        ((Timer) e.getSource()).stop();
-      }
-    }
+        frame.getGame().getData().getMap().getTerritories(),
+        frame.getMapPanel().getCurrentTerritory());
+    dialog.open().ifPresent(frame.getMapPanel()::centerOnAndHighlight);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryDialog.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
@@ -24,11 +25,16 @@ final class SelectTerritoryDialog extends JDialog {
   private Result result = Result.CANCEL;
   private final JComboBox<Territory> territoryComboBox;
 
-  SelectTerritoryDialog(final Frame owner, final String title, final Collection<Territory> territories) {
+  SelectTerritoryDialog(
+      final Frame owner,
+      final String title,
+      final Collection<Territory> territories,
+      final @Nullable Territory initialSelectedTerritory) {
     super(owner, title, true);
 
     territoryComboBox = JComboBoxBuilder.builder(Territory.class)
         .items(territories.stream().sorted().collect(Collectors.toList()))
+        .nullableSelectedItem(initialSelectedTerritory)
         .enableAutoComplete()
         .build();
     final JButton okButton = JButtonBuilder.builder()

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -30,7 +30,8 @@ class TerritoryDetailPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 1377022163587438988L;
   private final UiContext uiContext;
   private final JButton showOdds = new JButton("Battle Calculator (Ctrl-B)");
-  private Territory currentTerritory;
+  private final JButton findTerritoryButton;
+  private @Nullable Territory currentTerritory;
   private final TripleAFrame frame;
 
   TerritoryDetailPanel(final MapPanel mapPanel, final GameData data, final UiContext uiContext,
@@ -44,6 +45,10 @@ class TerritoryDetailPanel extends AbstractStatPanel {
         territoryChanged(territory);
       }
     });
+
+    findTerritoryButton = new JButton(new FindTerritoryAction(frame));
+    findTerritoryButton.setText(findTerritoryButton.getText() + " (Ctrl-F)");
+
     initLayout();
   }
 
@@ -69,6 +74,7 @@ class TerritoryDetailPanel extends AbstractStatPanel {
       return;
     }
     add(showOdds);
+    add(findTerritoryButton);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final String labelText;
     if (ta == null) {

--- a/game-core/src/main/java/swinglib/JComboBoxBuilder.java
+++ b/game-core/src/main/java/swinglib/JComboBoxBuilder.java
@@ -35,6 +35,7 @@ public final class JComboBoxBuilder<E> {
   private @Nullable Consumer<E> itemSelectedAction;
   private @Nullable String toolTip;
   private boolean autoCompleteEnabled;
+  private @Nullable E selectedItem;
 
   private JComboBoxBuilder(final Class<E> itemType) {
     this.itemType = itemType;
@@ -49,6 +50,10 @@ public final class JComboBoxBuilder<E> {
     @SuppressWarnings("unchecked")
     final E[] array = (E[]) Array.newInstance(itemType, items.size());
     final JComboBox<E> comboBox = new JComboBox<>(items.toArray(array));
+
+    if (selectedItem != null) {
+      comboBox.setSelectedItem(selectedItem);
+    }
 
     final @Nullable Consumer<E> myAction = this.itemSelectedAction;
     if (myAction != null) {
@@ -112,5 +117,15 @@ public final class JComboBoxBuilder<E> {
   public JComboBoxBuilder<E> enableAutoComplete() {
     autoCompleteEnabled = true;
     return this;
+  }
+
+  public JComboBoxBuilder<E> selectedItem(final E selectedItem) {
+    Preconditions.checkNotNull(selectedItem);
+    this.selectedItem = selectedItem;
+    return this;
+  }
+
+  public JComboBoxBuilder<E> nullableSelectedItem(final @Nullable E selectedItem) {
+    return (selectedItem != null) ? selectedItem(selectedItem) : this;
   }
 }

--- a/game-core/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/game-core/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Component;
 import java.awt.event.ItemEvent;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JComboBox;
@@ -14,6 +15,7 @@ import javax.swing.text.JTextComponent;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -62,15 +64,54 @@ class JComboBoxBuilderTest {
     MatcherAssert.assertThat(triggerCount.get(), Is.is(1));
   }
 
-  @Test
-  void enableAutoCompleteShouldChangeComboBoxEditorComponentDocumentType() {
-    final JComboBox<Object> comboBox = JComboBoxBuilder.builder(Object.class)
-        .item(new Object())
-        .enableAutoComplete()
-        .build();
+  @Nested
+  final class EnableAutoCompleteTest {
+    @Test
+    void shouldChangeComboBoxEditorComponentDocumentType() {
+      final JComboBox<Object> comboBox = JComboBoxBuilder.builder(Object.class)
+          .item(new Object())
+          .enableAutoComplete()
+          .build();
 
-    final Component editorComponent = comboBox.getEditor().getEditorComponent();
-    assertThat(editorComponent, is(instanceOf(JTextComponent.class)));
-    assertThat(((JTextComponent) editorComponent).getDocument(), is(instanceOf(AutoCompletion.class)));
+      final Component editorComponent = comboBox.getEditor().getEditorComponent();
+      assertThat(editorComponent, is(instanceOf(JTextComponent.class)));
+      assertThat(((JTextComponent) editorComponent).getDocument(), is(instanceOf(AutoCompletion.class)));
+    }
+  }
+
+  @Nested
+  final class SelectedItemTest {
+    @Test
+    void shouldSetSelectedItem() {
+      final JComboBox<String> comboBox = JComboBoxBuilder.builder(String.class)
+          .items(Arrays.asList("A", "B", "C"))
+          .selectedItem("B")
+          .build();
+
+      assertThat(comboBox.getSelectedItem(), is("B"));
+    }
+  }
+
+  @Nested
+  final class NullableSelectedItemTest {
+    @Test
+    void shouldSetSelectedItemWhenNonNull() {
+      final JComboBox<String> comboBox = JComboBoxBuilder.builder(String.class)
+          .items(Arrays.asList("A", "B", "C"))
+          .nullableSelectedItem("B")
+          .build();
+
+      assertThat(comboBox.getSelectedItem(), is("B"));
+    }
+
+    @Test
+    void shouldNotSetSelectedItemWhenNull() {
+      final JComboBox<String> comboBox = JComboBoxBuilder.builder(String.class)
+          .items(Arrays.asList("A", "B", "C"))
+          .nullableSelectedItem(null)
+          .build();
+
+      assertThat(comboBox.getSelectedItem(), is("A"));
+    }
   }
 }


### PR DESCRIPTION
## Overview

Synchronizes the Find Territory dialog with the current territory displayed in the Territory tab.

## Functional Changes

* Adds a **Find Territory** button to the Territory tab, as suggested in the forum.
* The combo box in the Find Territory dialog is initialized using the current territory displayed in the Territory tab (which is basically the last territory the mouse was over).
* When the Find Territory dialog is closed via **OK** (or an equivalent mechanism), the current territory displayed in the Territory tab is updated.

## Refactoring Changes

* Moved the territory border animation from `FindTerritoryAction` to `MapPanel`, where it seemed a more cohesive fit.

## Manual Testing Performed

* Verified the Find Territory dialog is initialized using the current territory displayed in the Territory tab.
* Verified the Find Territory dialog updates the current territory displayed in the Territory tab when the dialog is closed.

## Screen Shots

[find-territory-sync-with-territory-tab.zip](https://github.com/triplea-game/triplea/files/2448160/find-territory-sync-with-territory-tab.zip)