### PR TITLE
Add Proof-of-Concept controller for moderation actions

### DIFF
--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -10,7 +10,9 @@ mainClassName = 'org.triplea.lobby.server.LobbyRunner'
 dependencies {
     implementation project(':game-core')
     implementation 'org.mindrot:jbcrypt:0.4'
+    implementation 'com.sparkjava:spark-core:2.8.0'
 
+    runtimeOnly 'org.slf4j:slf4j-simple:1.7.21'
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
 
     testImplementation project(':test-common')

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':game-core')
     implementation 'org.mindrot:jbcrypt:0.4'
     implementation 'com.sparkjava:spark-core:2.8.0'
+    implementation 'com.github.openjson:openjson:1.0.10'
 
     runtimeOnly 'org.slf4j:slf4j-simple:1.7.21'
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyRunner.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyRunner.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 
 import org.triplea.common.config.FilePropertyReader;
 import org.triplea.lobby.server.config.LobbyConfiguration;
+import org.triplea.lobby.server.controller.rest.ControllerHub;
 
 import games.strategy.util.ExitStatus;
 import lombok.extern.java.Log;
@@ -25,6 +26,7 @@ public final class LobbyRunner {
           new LobbyConfiguration(new FilePropertyReader("config/lobby/lobby.properties"));
       log.info("Starting lobby on port " + lobbyConfiguration.getPort());
       LobbyServer.start(lobbyConfiguration);
+      ControllerHub.initializeControllers(lobbyConfiguration);
       log.info("Lobby started");
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Failed to start lobby", e);

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
@@ -1,0 +1,14 @@
+package org.triplea.lobby.server.controller.rest;
+
+import static spark.Spark.path;
+
+import org.triplea.lobby.server.config.LobbyConfiguration;
+import org.triplea.lobby.server.db.Database;
+
+public class ControllerHub {
+
+  public static void initializeControllers(final LobbyConfiguration configuration) {
+    final Database database = new Database(configuration);
+    path("/api/v0", new ModeratorActionController(database)::initializeRoutes);
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
@@ -5,6 +5,9 @@ import static spark.Spark.path;
 import org.triplea.lobby.server.config.LobbyConfiguration;
 import org.triplea.lobby.server.db.Database;
 
+/**
+ * Main Routing class to connect all Controllers together.
+ */
 public class ControllerHub {
 
   public static void initializeControllers(final LobbyConfiguration configuration) {

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
@@ -1,17 +1,43 @@
 package org.triplea.lobby.server.controller.rest;
 
+import static spark.Spark.exception;
 import static spark.Spark.path;
 
 import org.triplea.lobby.server.config.LobbyConfiguration;
+import org.triplea.lobby.server.controller.rest.exception.BadAuthenticationException;
+import org.triplea.lobby.server.controller.rest.exception.InsufficientRightsException;
+import org.triplea.lobby.server.controller.rest.exception.InvalidParameterException;
 import org.triplea.lobby.server.db.Database;
+
+import com.github.openjson.JSONObject;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Main Routing class to connect all Controllers together.
  */
 public class ControllerHub {
 
+  private static final ImmutableMap<Class<? extends RuntimeException>, Integer> statusCodeMapping = ImmutableMap.of(
+      BadAuthenticationException.class, 401,
+      InsufficientRightsException.class, 401,
+      InvalidParameterException.class, 422
+  );
+
+  private static String exceptionToJson(final RuntimeException exception) {
+    return new JSONObject(ImmutableMap.of(
+        "status", "Error",
+        "type", exception.getClass().getName(),
+        "message", exception.getMessage()
+    )).toString();
+  }
+
   public static void initializeControllers(final LobbyConfiguration configuration) {
     final Database database = new Database(configuration);
+    statusCodeMapping.forEach((exceptionClass, status) -> exception(exceptionClass, (exception, req, res) -> {
+      res.status(status);
+      res.body(exceptionToJson(exception));
+    }));
+
     path("/api", new ModeratorActionController(database)::initializeRoutes);
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ControllerHub.java
@@ -12,6 +12,6 @@ public class ControllerHub {
 
   public static void initializeControllers(final LobbyConfiguration configuration) {
     final Database database = new Database(configuration);
-    path("/api/v0", new ModeratorActionController(database)::initializeRoutes);
+    path("/api", new ModeratorActionController(database)::initializeRoutes);
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
@@ -39,9 +39,9 @@ class ModeratorActionController {
   }
 
   static Map<String, String> parseBodyToMap(final String body) {
-    return Splitter.on('&').splitToList(body)
+    return Splitter.on('&').omitEmptyStrings().splitToList(body)
         .stream()
-        .map(Splitter.on('=')::splitToList)
+        .map(Splitter.on('=').omitEmptyStrings()::splitToList)
         .collect(Collectors.toMap(list -> list.get(0), list -> list.get(1)));
   }
 

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
@@ -1,0 +1,85 @@
+package org.triplea.lobby.server.controller.rest;
+
+import static spark.Spark.before;
+import static spark.Spark.halt;
+import static spark.Spark.path;
+import static spark.Spark.post;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.triplea.lobby.server.db.Database;
+import org.triplea.lobby.server.db.HashedPassword;
+import org.triplea.lobby.server.db.UserController;
+
+import com.google.common.base.Splitter;
+
+import games.strategy.engine.lobby.server.userDB.DBUser;
+import spark.Request;
+import spark.Response;
+
+class ModeratorActionController {
+  private final UserController controller;
+
+  ModeratorActionController(final Database database) {
+    this.controller = new UserController(database);
+  }
+
+
+  void initializeRoutes() {
+    path("/moderate", () -> {
+      before("/*", this::authorize);
+      post("/:username/set-permission/:rank", this::setRole);
+    });
+  }
+
+  static Map<String, String> parseBodyToMap(final String body) {
+    return Splitter.on('&').splitToList(body)
+        .stream()
+        .map(Splitter.on('=')::splitToList)
+        .collect(Collectors.toMap(list -> list.get(0), list -> list.get(1)));
+  }
+
+  void authorize(final Request req, final Response res) {
+    if (req.requestMethod().equals("POST")) {
+      final Map<String, String> bodyParams = parseBodyToMap(req.body());
+      final String username = bodyParams.get("username");
+      final String password = bodyParams.get("password");
+      if (username == null || password == null) {
+        halt(401, "{ code: \"Error\", reason: \"Missing parameter\"}");
+        return;
+      }
+      final DBUser user = controller.getUserByName(username);
+      if (user == null) {
+        halt(401, "{ code: \"Error\", reason: \"Invalid Username\"}");
+        return;
+      }
+      if (!user.isAdmin()) {
+        halt(401, "{ code: \"Error\", reason: \"Not a moderator\"}");
+        return;
+      }
+      if (!controller.login(username, new HashedPassword(password))) {
+        halt(401, "{ code: \"Error\", reason: \"Invalid Password\"}");
+        return;
+      }
+      return;
+    }
+    halt(405, "{ code: \"Error\", reason: \"Request must be a POST Request\"}");
+  }
+
+  String setRole(final Request req, final Response res) {
+    final DBUser user = controller.getUserByName(req.params(":username"));
+    if (user != null) {
+      try {
+        final DBUser.Role rank = DBUser.Role.valueOf(req.params(":rank"));
+        controller.makeAdmin(new DBUser(new DBUser.UserName(user.getName()),
+            new DBUser.UserEmail(user.getEmail()), rank));
+        return "{ code: \"Success\" }";
+      } catch (final IllegalArgumentException e) {
+        return "{ code: \"Error\", reason: \"Rank does not exist\"}";
+      }
+    }
+    return "{ code: \"Error\", reason: \"User does not exist\"}";
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/ModeratorActionController.java
@@ -5,7 +5,6 @@ import static spark.Spark.halt;
 import static spark.Spark.path;
 import static spark.Spark.post;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/BadAuthenticationException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/BadAuthenticationException.java
@@ -1,5 +1,9 @@
 package org.triplea.lobby.server.controller.rest.exception;
 
+/**
+ * An unchecked Exception indicating that the server could
+ * not authenticate the client based on the passed information.
+ */
 public class BadAuthenticationException extends RuntimeException {
 
   private static final long serialVersionUID = -2853430130032064791L;

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/BadAuthenticationException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/BadAuthenticationException.java
@@ -1,0 +1,10 @@
+package org.triplea.lobby.server.controller.rest.exception;
+
+public class BadAuthenticationException extends RuntimeException {
+
+  private static final long serialVersionUID = -2853430130032064791L;
+
+  public BadAuthenticationException(final String message) {
+    super(message);
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InsufficientRightsException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InsufficientRightsException.java
@@ -1,0 +1,9 @@
+package org.triplea.lobby.server.controller.rest.exception;
+
+public class InsufficientRightsException extends RuntimeException {
+  private static final long serialVersionUID = -7034723918553851436L;
+
+  public InsufficientRightsException(final String message) {
+    super(message);
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InsufficientRightsException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InsufficientRightsException.java
@@ -1,5 +1,10 @@
 package org.triplea.lobby.server.controller.rest.exception;
 
+/**
+ * An unchecked Exception indicating that the server could
+ * authenticate the client, but the user has insufficient rights
+ * to perform the requested operation.
+ */
 public class InsufficientRightsException extends RuntimeException {
   private static final long serialVersionUID = -7034723918553851436L;
 

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InvalidParameterException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InvalidParameterException.java
@@ -1,5 +1,9 @@
 package org.triplea.lobby.server.controller.rest.exception;
 
+/**
+ * An unchecked Exception indicating that the server
+ * expected a parameter of any kind that wasn't provided by the client.
+ */
 public class InvalidParameterException extends RuntimeException {
 
   private static final long serialVersionUID = -6215512355547003317L;

--- a/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InvalidParameterException.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/controller/rest/exception/InvalidParameterException.java
@@ -1,0 +1,10 @@
+package org.triplea.lobby.server.controller.rest.exception;
+
+public class InvalidParameterException extends RuntimeException {
+
+  private static final long serialVersionUID = -6215512355547003317L;
+
+  public InvalidParameterException(final String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds a working prototype that could be extended for all moderation commands to work with it.
I'd like to hear your opinion on the general class layout and the resulting dependencies on each other.
I'm also planning to read some properties from the lobby config to allow for HTTPS and custom port numbers.
Also we should probably introduce a sophisticated authentification system like JSON Web Tokens or something, so w don't have to pass the password every time, but could send a Bearer Token in the header instead.

## Functional Changes
The Lobby now launches a HTTP server as well, which can be communicated with using  simple HTTP requests.
Currently available endpoint (cURL):
Scheme:
```
curl \
-d "username=<moderator username>" \
-d "password=<moderator password>" \
http://localhost:4567/api/v0/moderate/<user to change role>/set-permission/<role>
```
Example:
```
curl \
-d "username=RoiEX" \
-d "password=23829f97d7095e1dbc6a5c4d001e76e3ebc3254d0<cropped>" \
http://localhost:4567/api/v0/moderate/RoiEX/set-permission/ADMIN
```

## Manual Testing Performed
I verified I could perform a couple of actions using curl.

##### Unrelated
During testing I noticed a potential security issue. Not sure how severe it is, but I'll describe it in gitter.