### PR TITLE
Use official Substance dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,6 @@ subprojects {
 
     repositories {
         jcenter()
-        maven {
-            url 'https://jitpack.io'
-        }
     }
 
     dependencies {

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -22,8 +22,7 @@ dependencies {
 
     implementation project(':game-core')
 
-    runtimeOnly 'com.github.kirill-grouchnikov:substance:5d33cea' // v8.0.02 + Jitpack build fix
-    runtimeOnly 'com.github.kirill-grouchnikov:trident:v1.5.00'
+    runtimeOnly 'org.pushing-pixels:radiance-substance:1.0.0'
 
     if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
         testCompileOnly remoteLib(javaFxRuntimeUrl)


### PR DESCRIPTION
## Overview

Substance has finally been published to Maven Central. :tada: 

## Functional Changes

None.

## Manual Testing Performed

* Smoke tested a local game to ensure my selected Substance L&F looked correct.
* Changed my L&F to a few other Substance flavors (including Graphite) to verify they were available (I didn't go through the entire list).