### PR TITLE
Improve network proxy client setting layout

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -53,13 +53,20 @@ final class SelectionComponentFactory {
       final JTextField portText = new JTextField(proxyPortClientSetting.value(), 6);
       final JPanel radioPanel = JPanelBuilder.builder()
           .verticalBoxLayout()
-          .add(noneButton)
-          .add(systemButton)
-          .add(userButton)
-          .add(new JLabel("Proxy Host: "))
-          .add(hostText)
-          .add(new JLabel("Proxy Port: "))
-          .add(portText)
+          .addLeftJustified(noneButton)
+          .addLeftJustified(systemButton)
+          .addLeftJustified(userButton)
+          .addLeftJustified(JPanelBuilder.builder()
+              .horizontalBoxLayout()
+              .addHorizontalStrut(getRadioButtonLabelHorizontalOffset())
+              .add(JPanelBuilder.builder()
+                  .verticalBoxLayout()
+                  .addLeftJustified(new JLabel("Proxy Host:"))
+                  .addLeftJustified(hostText)
+                  .addLeftJustified(new JLabel("Proxy Port:"))
+                  .addLeftJustified(portText)
+                  .build())
+              .build())
           .build();
       final ActionListener enableUserSettings = e -> {
         if (userButton.isSelected()) {
@@ -158,6 +165,11 @@ final class SelectionComponentFactory {
         setProxyChoice(proxyChoiceClientSetting.value());
       }
     };
+  }
+
+  private static int getRadioButtonLabelHorizontalOffset() {
+    final JRadioButton radioButton = new JRadioButton("\u200B"); // zero-width space
+    return radioButton.getPreferredSize().width - radioButton.getInsets().right;
   }
 
   /**

--- a/game-core/src/main/java/swinglib/JPanelBuilder.java
+++ b/game-core/src/main/java/swinglib/JPanelBuilder.java
@@ -301,6 +301,17 @@ public class JPanelBuilder {
     return this;
   }
 
+  /**
+   * Adds {@code component} to the panel and ensures it will be left-justified in the final layout. Primarily for use
+   * with vertical box layouts.
+   */
+  public JPanelBuilder addLeftJustified(final Component component) {
+    final Box box = Box.createHorizontalBox();
+    box.add(component);
+    box.add(Box.createHorizontalGlue());
+    return add(box);
+  }
+
   public JPanelBuilder add(final Component component) {
     components.add(new Pair<>(component, new PanelProperties(BorderLayoutPosition.DEFAULT)));
     return this;


### PR DESCRIPTION
## Overview

Improves the layout of the network proxy client setting controls.

## Functional Changes

* Ensure all controls are left-aligned.
* Add a horizontal offset for the custom proxy host/port so they visually appear to be grouped under **Use These Settings:**.

## Manual Testing Performed

Visually inspected the network proxy client setting control layout in both SubstanceTwilight and Nimbus.

## Before & After Screen Shots

### Before

![network-proxy-client-setting-layout-before](https://user-images.githubusercontent.com/4826349/46567183-ac21a500-c8fc-11e8-8343-9128ce7d8c02.png)

### After

![network-proxy-client-setting-layout-after](https://user-images.githubusercontent.com/4826349/46567185-b0e65900-c8fc-11e8-9ce5-c9f749a68d69.png)