### PR TITLE
Enforce maximum length constraint on lobby usernames

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -31,6 +31,9 @@ public final class DBUser implements Serializable {
 
   /** User name value object with validation methods. */
   public static class UserName {
+    private static final int MIN_LENGTH = 3;
+    private static final int MAX_LENGTH = 40;
+
     public final String userName;
 
     public UserName(final String userName) {
@@ -38,8 +41,13 @@ public final class DBUser implements Serializable {
     }
 
     String validate() {
-      if (userName == null || !userName.matches("[0-9a-zA-Z_-]+") || userName.length() <= 2) {
-        return "Names must be at least 3 characters long and can only contain alpha numeric characters, -, and _";
+      if ((userName == null)
+          || !userName.matches("[0-9a-zA-Z_-]+")
+          || (userName.length() < MIN_LENGTH)
+          || (userName.length() > MAX_LENGTH)) {
+        return String.format(
+            "Names must be between %d and %d characters long and can only contain alphanumeric characters, -, and _",
+            MIN_LENGTH, MAX_LENGTH);
       }
       if (userName.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())) {
         return LobbyConstants.LOBBY_WATCHER_NAME + " cannot be part of a name";

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 import org.triplea.lobby.common.LobbyConstants;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.util.Util;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -32,7 +34,8 @@ public final class DBUser implements Serializable {
   /** User name value object with validation methods. */
   public static class UserName {
     private static final int MIN_LENGTH = 3;
-    private static final int MAX_LENGTH = 40;
+    @VisibleForTesting
+    public static final int MAX_LENGTH = 40;
 
     public final String userName;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -41,18 +41,15 @@ public final class DBUser implements Serializable {
     }
 
     String validate() {
-      if ((userName == null)
-          || !userName.matches("[0-9a-zA-Z_-]+")
-          || (userName.length() < MIN_LENGTH)
-          || (userName.length() > MAX_LENGTH)) {
-        return String.format(
-            "Names must be between %d and %d characters long and can only contain alphanumeric characters, -, and _",
-            MIN_LENGTH, MAX_LENGTH);
-      }
-      if (userName.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())) {
+      if ((userName == null) || (userName.length() < MIN_LENGTH)) {
+        return "Name is too short (minimum " + MIN_LENGTH + " characters)";
+      } else if (userName.length() > MAX_LENGTH) {
+        return "Name is too long (maximum " + MAX_LENGTH + " characters)";
+      } else if (!userName.matches("[0-9a-zA-Z_-]+")) {
+        return "Name can only contain alphanumeric characters, hyphens (-), and underscores (_)";
+      } else if (userName.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())) {
         return LobbyConstants.LOBBY_WATCHER_NAME + " cannot be part of a name";
-      }
-      if (userName.toLowerCase().contains(LobbyConstants.ADMIN_USERNAME.toLowerCase())) {
+      } else if (userName.toLowerCase().contains(LobbyConstants.ADMIN_USERNAME.toLowerCase())) {
         return "Name can't contain the word " + LobbyConstants.ADMIN_USERNAME;
       }
       return null;

--- a/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
@@ -91,6 +91,7 @@ public class DbUserTest {
         "",
         "a",
         "ab", // still too short
+        "12345678901234567890123456789012345678901", // one character too long
         "ab*", // no special characters other than '-' and '_'
         "ab$",
         ".ab",
@@ -124,10 +125,9 @@ public class DbUserTest {
   public void userNameValidationWithValidNames() {
     Arrays.asList(
         "abc",
+        "1234567890123456789012345678901234567890", // maximum length
         "123",
-        "---",
-        // TODO: should we add a max length rule to user name validation?
-        "test_case_with_something_that_is_a_bit_longer_and_perhaps_even_should_be_considered_invalid")
+        "---")
         .forEach(validName -> {
           assertThat(
               "Expected name to be marked as valid: " + validName,

--- a/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.base.Strings;
+
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -91,7 +93,7 @@ public class DbUserTest {
         "",
         "a",
         "ab", // still too short
-        "12345678901234567890123456789012345678901", // one character too long
+        Strings.repeat("a", 41), // one character too long
         "ab*", // no special characters other than '-' and '_'
         "ab$",
         ".ab",
@@ -125,7 +127,7 @@ public class DbUserTest {
   public void userNameValidationWithValidNames() {
     Arrays.asList(
         "abc",
-        "1234567890123456789012345678901234567890", // maximum length
+        Strings.repeat("a", 40), // maximum length
         "123",
         "---")
         .forEach(validName -> {

--- a/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/DbUserTest.java
@@ -93,7 +93,7 @@ public class DbUserTest {
         "",
         "a",
         "ab", // still too short
-        Strings.repeat("a", 41), // one character too long
+        Strings.repeat("a", DBUser.UserName.MAX_LENGTH + 1),
         "ab*", // no special characters other than '-' and '_'
         "ab$",
         ".ab",
@@ -127,7 +127,7 @@ public class DbUserTest {
   public void userNameValidationWithValidNames() {
     Arrays.asList(
         "abc",
-        Strings.repeat("a", 40), // maximum length
+        Strings.repeat("a", DBUser.UserName.MAX_LENGTH),
         "123",
         "---")
         .forEach(validName -> {


### PR DESCRIPTION
## Overview

Related to #4141.

Enforces a maximum length constraint on lobby usernames.  Primarily to prevent anonymous users from logging in with names that violate the `ta_users.username` column schema.

I would have preferred to enforce the maximum length constraint by attempting to insert a new record with the anonymous username and use control flow by exception to fail the anonymous user authentication (and obviously rolling back the transaction if the insertion succeeded).  However, all of the validation is currently in the `DBUser$UserName` class, and I didn't want to redesign how this is done at this time.

## Functional Changes

* Enforce a maximum length constraint on all lobby usernames.  The constraint in the code matches the constraint in the database schema.  The constraint enforcement is performed on both the client and the server.

## Manual Testing Performed

* Verified attempting to login an anonymous user with a username length longer than 40 characters is presented with an Invalid Username error dialog.
* I repeated the above test with the client constraint enforcement code commented out and verified the server also fails the anonymous user authentication.

## Before & After Screen Shots

### Before

![invalid-username-before](https://user-images.githubusercontent.com/4826349/46574674-00686b80-c975-11e8-8c69-36894d17fab7.png)

### After

![invalid-username-after](https://user-images.githubusercontent.com/4826349/46574675-052d1f80-c975-11e8-9472-9554140889de.png)