### PR TITLE
Do not propagate lobby server SQLExceptions to client

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/db/AbstractController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/AbstractController.java
@@ -4,10 +4,14 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.logging.Level;
+
+import lombok.extern.java.Log;
 
 /**
  * Superclass for all DAO implementations.
  */
+@Log
 abstract class AbstractController {
   private final Database database;
 
@@ -19,5 +23,10 @@ abstract class AbstractController {
 
   final Connection newDatabaseConnection() throws SQLException {
     return database.newConnection();
+  }
+
+  static RuntimeException newDatabaseException(final String message, final SQLException e) {
+    log.log(Level.SEVERE, message, e);
+    return new IllegalStateException(String.format("%s (%s)", message, e.getMessage()));
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
@@ -23,8 +23,8 @@ public final class BadWordController extends AbstractController implements BadWo
       ps.setString(1, word);
       ps.execute();
       con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error inserting banned word:" + word, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error inserting banned word: " + word, e);
     }
   }
 
@@ -40,8 +40,8 @@ public final class BadWordController extends AbstractController implements BadWo
         badWords.add(rs.getString(1));
       }
       return badWords;
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error reading bad words", sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error reading bad words", e);
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BannedMacController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BannedMacController.java
@@ -55,7 +55,7 @@ public class BannedMacController extends TimedController implements BannedMacDao
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException("Error inserting banned mac: " + bannedUser.getHashedMacAddress(), e);
+      throw newDatabaseException("Error inserting banned mac: " + bannedUser.getHashedMacAddress(), e);
     }
   }
 
@@ -65,8 +65,8 @@ public class BannedMacController extends TimedController implements BannedMacDao
       ps.setString(1, mac);
       ps.execute();
       con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error deleting banned mac:" + mac, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error deleting banned mac: " + mac, e);
     }
   }
 
@@ -92,8 +92,8 @@ public class BannedMacController extends TimedController implements BannedMacDao
         }
         return Tuple.of(false, null);
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error for testing banned mac existence:" + mac, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error for testing banned mac existence: " + mac, e);
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BannedUsernameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BannedUsernameController.java
@@ -55,7 +55,7 @@ public class BannedUsernameController extends TimedController implements BannedU
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException("Error inserting banned username: " + bannedUser.getUsername(), e);
+      throw newDatabaseException("Error inserting banned username: " + bannedUser.getUsername(), e);
     }
   }
 
@@ -65,8 +65,8 @@ public class BannedUsernameController extends TimedController implements BannedU
       ps.setString(1, username);
       ps.execute();
       con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error deleting banned username:" + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error deleting banned username: " + username, e);
     }
   }
 
@@ -91,8 +91,8 @@ public class BannedUsernameController extends TimedController implements BannedU
         }
         return Tuple.of(false, null);
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error for testing banned username existence:" + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error for testing banned username existence: " + username, e);
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/MutedMacController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/MutedMacController.java
@@ -66,7 +66,7 @@ public class MutedMacController extends TimedController {
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException("Error inserting muted mac: " + mutedUser.getHashedMacAddress(), e);
+      throw newDatabaseException("Error inserting muted mac: " + mutedUser.getHashedMacAddress(), e);
     }
   }
 
@@ -76,8 +76,8 @@ public class MutedMacController extends TimedController {
       ps.setString(1, mac);
       ps.execute();
       con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error deleting muted mac:" + mac, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error deleting muted mac: " + mac, e);
     }
   }
 
@@ -116,8 +116,8 @@ public class MutedMacController extends TimedController {
         }
         return Optional.empty();
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error for testing muted mac existence:" + mac, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error for testing muted mac existence: " + mac, e);
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/MutedUsernameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/MutedUsernameController.java
@@ -66,7 +66,7 @@ public class MutedUsernameController extends TimedController {
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException("Error inserting muted username: " + mutedUser.getUsername(), e);
+      throw newDatabaseException("Error inserting muted username: " + mutedUser.getUsername(), e);
     }
   }
 
@@ -76,8 +76,8 @@ public class MutedUsernameController extends TimedController {
       ps.setString(1, username);
       ps.execute();
       con.commit();
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error deleting muted username:" + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error deleting muted username: " + username, e);
     }
   }
 
@@ -116,8 +116,8 @@ public class MutedUsernameController extends TimedController {
         }
         return Optional.empty();
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error for testing muted username existence:" + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error for testing muted username existence: " + username, e);
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -43,8 +43,8 @@ public final class UserController extends AbstractController implements UserDao 
         }
         return null;
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error getting password for user: " + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error getting password for user: " + username, e);
     }
   }
 
@@ -57,8 +57,8 @@ public final class UserController extends AbstractController implements UserDao 
       try (ResultSet rs = ps.executeQuery()) {
         return rs.next();
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error testing for existence of user:" + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error testing for existence of user: " + username, e);
     }
   }
 
@@ -82,7 +82,7 @@ public final class UserController extends AbstractController implements UserDao 
       }
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException(String.format("Error updating name: %s email: %s pwd: %s",
+      throw newDatabaseException(String.format("Error updating name: %s, email: %s, (masked) pwd: %s",
           user.getName(), user.getEmail(), hashedPassword.mask()), e);
     }
   }
@@ -111,7 +111,7 @@ public final class UserController extends AbstractController implements UserDao 
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new IllegalStateException(String.format("Error while trying to make %s an admin", user.getName()), e);
+      throw newDatabaseException(String.format("Error while trying to make %s an admin", user.getName()), e);
     }
   }
 
@@ -130,7 +130,7 @@ public final class UserController extends AbstractController implements UserDao 
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
-      throw new RuntimeException(String.format("Error inserting name: %s, email: %s, (masked) pwd: %s",
+      throw newDatabaseException(String.format("Error inserting name: %s, email: %s, (masked) pwd: %s",
           user.getName(), user.getEmail(), hashedPassword.mask()), e);
     }
   }
@@ -167,9 +167,9 @@ public final class UserController extends AbstractController implements UserDao 
         con.commit();
         return true;
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException(
-          String.format("Error validating password name: %s pwd: %s", username, hashedPassword.mask()), sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException(
+          String.format("Error validating password name: %s, (masked) pwd: %s", username, hashedPassword.mask()), e);
     }
   }
 
@@ -188,8 +188,8 @@ public final class UserController extends AbstractController implements UserDao 
             new DBUser.UserEmail(rs.getString("email")),
             rs.getBoolean("admin") ? DBUser.Role.ADMIN : DBUser.Role.NOT_ADMIN);
       }
-    } catch (final SQLException sqle) {
-      throw new IllegalStateException("Error getting user: " + username, sqle);
+    } catch (final SQLException e) {
+      throw newDatabaseException("Error getting user: " + username, e);
     }
   }
 }


### PR DESCRIPTION
## Overview

Fixes #4141.

When a Postgres database error occurs, the Postgres driver throws a custom subclass of `SQLException`.  This subclass is defined in the Postgres JDBC driver library, and thus is not available to clients because they do not declare this dependency.  When a client attempts to deserialize such an exception, it triggers a `ClassNotFoundException`.  This not only hides the original exception from the client, but it has the side effect of disconnecting the client (most likely a mod) from the server.

This PR fixes the issue by ensuring the custom subclass is never serialized across the wire to the client to avoid the `ClassNotFoundException`.  An alternative fix would have been to make the client depend on the Postgres JDBC driver library, but bringing in an almost 1 MiB jar just for this case didn't seem productive. 

## Functional Changes

* `SQLException`s raised within the lobby server are no longer propagated to the client.
    * The `SQLException` message is preserved in the unchecked exception ultimately sent to the client.
    * The original `SQLException` is sent to the server log for reference during troubleshooting.

## Manual Testing Performed

* Manually triggered an exception to occur when banning a username where the username exceeds the maximum length of the corresponding database column (by essentially reverting #4153).
    * Verified the client was notified of the error, but the client did not disconnect from the server.
    * Verified the error reported in the client's Error Console contained the message from the `SQLException` but the `SQLException` itself did not appear in the stack trace.
    * Verified the server log contained the stack trace for the `SQLException`.