### PR TITLE
Use Runnables#doNothing() instead of no-op lambda

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentOddsCalculator.java
@@ -16,6 +16,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
+import com.google.common.util.concurrent.Runnables;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -58,8 +60,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
   private final Runnable dataLoadedAction;
 
   public ConcurrentOddsCalculator(final String threadNamePrefix) {
-    this(threadNamePrefix, () -> {
-    });
+    this(threadNamePrefix, Runnables.doNothing());
   }
 
   ConcurrentOddsCalculator(final String threadNamePrefix, final Runnable dataLoadedAction) {

--- a/game-core/src/test/java/games/strategy/engine/auto/health/check/LocalSystemCheckerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/health/check/LocalSystemCheckerTest.java
@@ -6,11 +6,11 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Runnables;
 
 public class LocalSystemCheckerTest {
 
-  private static final SystemCheck PASSING_CHECK = new SystemCheck("no op", () -> {
-  });
+  private static final SystemCheck PASSING_CHECK = new SystemCheck("no op", Runnables.doNothing());
   private static final SystemCheck FAILING_CHECK =
       new SystemCheck("throws exception", () -> {
         throw new RuntimeException(new Exception("test"));

--- a/game-core/src/test/java/games/strategy/engine/auto/health/check/SystemCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/health/check/SystemCheckTest.java
@@ -7,14 +7,15 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.util.concurrent.Runnables;
+
 public class SystemCheckTest {
 
   private final Exception testException = new Exception("Testing");
 
   @Test
   public void testPassingSystemCheck() {
-    final SystemCheck check = new SystemCheck("msg", () -> {
-    });
+    final SystemCheck check = new SystemCheck("msg", Runnables.doNothing());
 
     assertThat(check.wasSuccess(), is(true));
     assertThat(check.getResultMessage(), is("msg: true"));

--- a/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/game-core/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -9,6 +9,7 @@ import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Runnables;
 
 import games.strategy.engine.data.annotations.InternalDoNotExport;
 
@@ -77,8 +78,7 @@ public final class FakeAttachment implements IAttachment {
   @Override
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
-        .put("name", MutableProperty.ofString(this::setName, this::getName, () -> {
-        }))
+        .put("name", MutableProperty.ofString(this::setName, this::getName, Runnables.doNothing()))
         .build();
   }
 }

--- a/game-core/src/test/java/games/strategy/test/TestUtil.java
+++ b/game-core/src/test/java/games/strategy/test/TestUtil.java
@@ -1,5 +1,7 @@
 package games.strategy.test;
 
+import com.google.common.util.concurrent.Runnables;
+
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
 
@@ -19,7 +21,6 @@ public final class TestUtil {
    */
   public static void waitForSwingThreads() {
     // add a no-op action to the end of the swing event queue, and then wait for it
-    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
-    }));
+    Interruptibles.await(() -> SwingAction.invokeAndWait(Runnables.doNothing()));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Runnables;
 
 @ExtendWith(MockitoExtension.class)
 public class SaveFunctionTest {
@@ -34,8 +35,7 @@ public class SaveFunctionTest {
   public void messageOnValidIsInformation() {
     givenValidationResults(true, true);
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
-        });
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
     MatcherAssert.assertThat("There will always be a message back to the user",
         result.message.isEmpty(), is(false));
@@ -58,8 +58,7 @@ public class SaveFunctionTest {
     givenValidationResults(false, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
-        });
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
     MatcherAssert.assertThat(result.message.isEmpty(), is(false));
     MatcherAssert.assertThat(result.dialogType, is(JOptionPane.WARNING_MESSAGE));
@@ -70,8 +69,7 @@ public class SaveFunctionTest {
     givenValidationResults(true, false);
 
     final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), () -> {
-        });
+        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
     MatcherAssert.assertThat(result.message.isEmpty(), is(false));
     MatcherAssert.assertThat("At least one value was not updated, should be warning message type",

--- a/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
+++ b/game-core/src/test/java/games/strategy/util/InterruptiblesTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.common.util.concurrent.Runnables;
+
 import games.strategy.util.function.ThrowingRunnable;
 
 @ExtendWith(MockitoExtension.class)
@@ -113,8 +115,7 @@ public final class InterruptiblesTest {
   public final class JoinTest {
     @Test
     public void shouldWaitUntilThreadIsDead() {
-      final Thread thread = new Thread(() -> {
-      });
+      final Thread thread = new Thread(Runnables.doNothing());
       thread.start();
 
       assertTimeoutPreemptively(Duration.ofSeconds(5L), () -> {

--- a/game-core/src/test/java/swinglib/JButtonBuilderTest.java
+++ b/game-core/src/test/java/swinglib/JButtonBuilderTest.java
@@ -12,6 +12,8 @@ import javax.swing.JButton;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.util.concurrent.Runnables;
+
 class JButtonBuilderTest {
 
   @Test
@@ -19,8 +21,7 @@ class JButtonBuilderTest {
     final String value = "testing title";
     final JButton button = JButtonBuilder.builder()
         .title(value)
-        .actionListener(() -> {
-        })
+        .actionListener(Runnables.doNothing())
         .build();
     assertThat(button.getText(), is(value));
   }
@@ -50,8 +51,7 @@ class JButtonBuilderTest {
   @Test
   void titleIsRequired() {
     assertThrows(NullPointerException.class, () -> JButtonBuilder.builder()
-        .actionListener(() -> {
-        })
+        .actionListener(Runnables.doNothing())
         .build());
   }
 


### PR DESCRIPTION
## Overview

Use Guava's `Runnables#doNothing()` instead of the lambda `() -> {}`.  Slightly improves readability due to the Eclipse formatter's desire to replace

```
() -> {}
```

with

```
() -> {
}
```

## Functional Changes

None.

## Manual Testing Performed

None.