### PR TITLE
Fix NPE in CommentPanel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -10,6 +10,13 @@ import javax.imageio.ImageIO;
 
 import games.strategy.triplea.ResourceLoader;
 
+/**
+ * Superclass for all image factories.
+ *
+ * <p>
+ * Instances of this class are not thread safe, and its methods are intended to be called from the EDT.
+ * </p>
+ */
 public class ImageFactory {
   private final Map<String, Image> images = new HashMap<>();
   private ResourceLoader resourceLoader;

--- a/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -6,7 +6,7 @@ import java.awt.Insets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -30,8 +30,6 @@ import javax.swing.text.Document;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.tree.TreeNode;
-
-import org.triplea.common.util.concurrent.CompletableFutureUtils;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -98,10 +96,8 @@ class CommentPanel extends JPanel {
     save.setMargin(inset);
     save.setFocusable(false);
     for (final PlayerID playerId : data.getPlayerList().getPlayers()) {
-      final CompletableFuture<?> future = CompletableFuture
-          .supplyAsync(() -> frame.getUiContext().getFlagImageFactory().getSmallFlag(playerId))
-          .thenAccept(image -> SwingUtilities.invokeLater(() -> iconMap.put(playerId, new ImageIcon(image))));
-      CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to load small flag icon for " + playerId);
+      Optional.ofNullable(frame.getUiContext().getFlagImageFactory().getSmallFlag(playerId))
+          .ifPresent(image -> iconMap.put(playerId, new ImageIcon(image)));
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes #3880.

The methods of `ImageFactory` are not thread safe.  All calls (other than the one in `CommentPanel`) to `getSmallFlag()` are currently made from the EDT.  Presumably, the calls from `CommentPanel` were subject to some kind of race condition or other thread safety issue that caused `getSmallFlag()` to return `null` when invoked concurrently.  The `null` return value then caused the NPE.

The fix employed here is to simply move the `getSmallFlag()` call in `CommentPanel` back to the EDT.  This should avoid whatever race condition caused the `null` return value.

A further analysis of the `ImageFactory#getImage(String, boolean)` method showed that it could return `null` even if `throwIfNotFound` is true (e.g. `ImageIO#read()` may return `null`).  Therefore, the code in `CommentPanel` was further improved to defend against this possibility.

## Functional Changes

None.

## Manual Testing Performed

The race condition is difficult to repro, so I couldn't verify that directly.  However, I did verify the small flags are displayed as expected in the comment panel.