### PR TITLE
Use type-safe wrapper for Boolean client settings

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -56,7 +56,7 @@ public final class Console {
       }
     });
 
-    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.saveAndFlush(String.valueOf(false)));
+    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.saveAndFlush(false));
     LookAndFeelSwingFrameListener.register(frame);
     frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     frame.getContentPane().setLayout(new BorderLayout());
@@ -80,7 +80,7 @@ public final class Console {
     actions.add(newLogLevelButton());
     SwingUtilities.invokeLater(frame::pack);
 
-    if (ClientSetting.showConsole.booleanValue()) {
+    if (ClientSetting.showConsole.value()) {
       SwingUtilities.invokeLater(() -> setVisible(true));
     }
   }

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -74,7 +74,7 @@ public enum ErrorMessage {
                 .toolTip("Shows the error console window with full error details.")
                 .actionListener(() -> {
                   hide();
-                  ClientSetting.showConsole.saveAndFlush("true");
+                  ClientSetting.showConsole.saveAndFlush(true);
                 })
                 .build())
             .addHorizontalGlue()

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -51,11 +51,11 @@ final class EngineVersionCheck {
   @VisibleForTesting
   static boolean isEngineUpdateCheckRequired(
       final LocalDate now,
-      final GameSetting<String> firstRunSetting,
+      final GameSetting<Boolean> firstRunSetting,
       final GameSetting<String> updateCheckDateSetting,
       final Runnable flushSetting) {
     // check at most once per 2 days (but still allow a 'first run message' for a new version of TripleA)
-    final boolean firstRun = firstRunSetting.booleanValue();
+    final boolean firstRun = firstRunSetting.value();
     final String encodedUpdateCheckDate = updateCheckDateSetting.value();
     if (!firstRun && !encodedUpdateCheckDate.trim().isEmpty()) {
       final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -113,7 +113,7 @@ public final class GameRunner {
     Thread.setDefaultUncaughtExceptionHandler((t, e) -> log.log(Level.SEVERE, e.getLocalizedMessage(), e));
     ClientSetting.initialize();
 
-    if (!ClientSetting.useExperimentalJavaFxUi.booleanValue()) {
+    if (!ClientSetting.useExperimentalJavaFxUi.value()) {
       Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
         LookAndFeel.initialize();
         final Console console = new Console();
@@ -147,7 +147,7 @@ public final class GameRunner {
       HttpProxy.updateSystemProxy();
     }
 
-    if (ClientSetting.useExperimentalJavaFxUi.booleanValue()) {
+    if (ClientSetting.useExperimentalJavaFxUi.value()) {
       Services.loadAny(JavaFxClientRunner.class).start(args);
     } else {
       SwingUtilities.invokeLater(() -> {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -139,7 +139,7 @@ public class MapDownloadController {
 
       @Override
       public boolean canPromptToDownload() {
-        return ClientSetting.promptToDownloadTutorialMap.booleanValue();
+        return ClientSetting.promptToDownloadTutorialMap.value();
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -635,7 +635,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
       return;
     }
     // we dont want to confirm enemy casualties
-    if (!ClientSetting.confirmEnemyCasualties.booleanValue()) {
+    if (!ClientSetting.confirmEnemyCasualties.value()) {
       return;
     }
     ui.getBattlePanel().confirmCasualties(battleId, message);

--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -1,0 +1,17 @@
+package games.strategy.triplea.settings;
+
+final class BooleanClientSetting extends ClientSetting<Boolean> {
+  BooleanClientSetting(final String name, final boolean defaultValue) {
+    super(name, defaultValue);
+  }
+
+  @Override
+  protected String formatValue(final Boolean value) {
+    return value.toString();
+  }
+
+  @Override
+  protected Boolean parseValue(final String encodedValue) {
+    return Boolean.valueOf(encodedValue);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -54,17 +54,17 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new StringClientSetting("BATTLE_CALC_SIMULATION_COUNT_DICE", 200);
   public static final ClientSetting<String> battleCalcSimulationCountLowLuck =
       new StringClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
-  public static final ClientSetting<String> confirmDefensiveRolls =
-      new StringClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
-  public static final ClientSetting<String> confirmEnemyCasualties =
-      new StringClientSetting("CONFIRM_ENEMY_CASUALTIES", false);
+  public static final ClientSetting<Boolean> confirmDefensiveRolls =
+      new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
+  public static final ClientSetting<Boolean> confirmEnemyCasualties =
+      new BooleanClientSetting("CONFIRM_ENEMY_CASUALTIES", false);
   public static final ClientSetting<String> defaultGameName =
       new StringClientSetting("DEFAULT_GAME_NAME_PREF", "Big World : 1942");
   public static final ClientSetting<String> defaultGameUri = new StringClientSetting("DEFAULT_GAME_URI_PREF");
   public static final ClientSetting<String> fasterArrowKeyScrollMultiplier =
       new StringClientSetting("FASTER_ARROW_KEY_SCROLL_MULTIPLIER", 2);
-  public static final ClientSetting<String> spaceBarConfirmsCasualties =
-      new StringClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
+  public static final ClientSetting<Boolean> spaceBarConfirmsCasualties =
+      new BooleanClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
   public static final ClientSetting<String> lobbyLastUsedHost = new StringClientSetting("LOBBY_LAST_USED_HOST");
   public static final ClientSetting<String> lobbyLastUsedPort = new StringClientSetting("LOBBY_LAST_USED_PORT");
   public static final ClientSetting<String> lookAndFeel =
@@ -85,28 +85,28 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new StringClientSetting("SERVER_OBSERVER_JOIN_WAIT_TIME", 180);
   public static final ClientSetting<String> serverStartGameSyncWaitTime =
       new StringClientSetting("SERVER_START_GAME_SYNC_WAIT_TIME", 180);
-  public static final ClientSetting<String> showBattlesWhenObserving =
-      new StringClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
-  public static final ClientSetting<String> showBetaFeatures = new StringClientSetting("SHOW_BETA_FEATURES", false);
-  public static final ClientSetting<String> showConsole = new StringClientSetting("SHOW_CONSOLE", false);
+  public static final ClientSetting<Boolean> showBattlesWhenObserving =
+      new BooleanClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
+  public static final ClientSetting<Boolean> showBetaFeatures = new BooleanClientSetting("SHOW_BETA_FEATURES", false);
+  public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE", false);
   public static final ClientSetting<String> testLobbyHost = new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<String> testLobbyPort = new StringClientSetting("TEST_LOBBY_PORT");
-  public static final ClientSetting<String> firstTimeThisVersion =
-      new StringClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
+  public static final ClientSetting<Boolean> firstTimeThisVersion =
+      new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<String> lastCheckForEngineUpdate =
       new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE");
   public static final ClientSetting<String> lastCheckForMapUpdates =
       new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES");
-  public static final ClientSetting<String> promptToDownloadTutorialMap =
-      new StringClientSetting("TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP", true);
+  public static final ClientSetting<Boolean> promptToDownloadTutorialMap =
+      new BooleanClientSetting("TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP", true);
   public static final ClientSetting<String> userMapsFolderPath = new StringClientSetting(
       "USER_MAPS_FOLDER_PATH",
       new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps"));
   public static final ClientSetting<String> wheelScrollAmount = new StringClientSetting("WHEEL_SCROLL_AMOUNT", 60);
   public static final ClientSetting<String> playerName =
       new StringClientSetting("PLAYER_NAME", SystemProperties.getUserName());
-  public static final ClientSetting<String> useExperimentalJavaFxUi =
-      new StringClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
+  public static final ClientSetting<Boolean> useExperimentalJavaFxUi =
+      new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
   public static final ClientSetting<String> loggingVerbosity =
       new StringClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -44,10 +44,6 @@ public interface GameSetting<T> {
     saveString(String.valueOf(newValue));
   }
 
-  default void save(final boolean newValue) {
-    saveString(String.valueOf(newValue));
-  }
-
   /**
    * Returns the current persisted string value of the setting.
    */
@@ -60,10 +56,6 @@ public interface GameSetting<T> {
 
   default int intValue() {
     return Integer.valueOf(stringValue());
-  }
-
-  default boolean booleanValue() {
-    return Boolean.valueOf(stringValue());
   }
 
   void resetAndFlush();

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -31,7 +31,7 @@ interface SaveFunction {
         selectionComponent.readValues()
             .entrySet()
             .stream()
-            .filter(entry -> !entry.getKey().value().equals(entry.getValue()))
+            .filter(entry -> !entry.getKey().stringValue().equals(entry.getValue()))
             .forEach(entry -> {
               entry.getKey().saveString(entry.getValue());
               successMsg.append(String.format("%s was updated to: %s\n", entry.getKey(), entry.getValue()));

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -221,9 +221,9 @@ final class SelectionComponentFactory {
   /**
    * yes/no radio buttons.
    */
-  static SelectionComponent<JComponent> booleanRadioButtons(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<JComponent> booleanRadioButtons(final ClientSetting<Boolean> clientSetting) {
     return new AlwaysValidInputSelectionComponent() {
-      final boolean initialSelection = clientSetting.booleanValue();
+      final boolean initialSelection = clientSetting.value();
       final JRadioButton yesButton = new JRadioButton("True");
       final JRadioButton noButton = new JRadioButton("False");
       final JPanel buttonPanel = JPanelBuilder.builder()
@@ -256,8 +256,8 @@ final class SelectionComponentFactory {
 
       @Override
       public void reset() {
-        yesButton.setSelected(clientSetting.booleanValue());
-        noButton.setSelected(!clientSetting.booleanValue());
+        yesButton.setSelected(clientSetting.value());
+        noButton.setSelected(!clientSetting.value());
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
@@ -15,10 +15,6 @@ final class StringClientSetting extends ClientSetting<String> {
     super(name, String.valueOf(defaultValue));
   }
 
-  StringClientSetting(final String name, final boolean defaultValue) {
-    super(name, String.valueOf(defaultValue));
-  }
-
   StringClientSetting(final String name, final File defaultValue) {
     super(name, defaultValue.getAbsolutePath());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -261,7 +261,7 @@ public class BattleDisplay extends JPanel {
     mapPanel.getUiContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.
-    if (!ClientSetting.confirmDefensiveRolls.booleanValue()) {
+    if (!ClientSetting.confirmDefensiveRolls.value()) {
       final int maxWaitTime = 1500;
       final Timer t = new Timer();
       t.schedule(new TimerTask() {
@@ -480,7 +480,7 @@ public class BattleDisplay extends JPanel {
                 Math.min(availHeight, size.height)));
           }
           final String[] options = {"Ok", "Cancel"};
-          final String focus = ClientSetting.spaceBarConfirmsCasualties.booleanValue() ? options[0] : null;
+          final String focus = ClientSetting.spaceBarConfirmsCasualties.value() ? options[0] : null;
           final int option = JOptionPane.showOptionDialog(BattleDisplay.this, chooserScrollPane,
               hit.getName() + " select casualties", JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, null, options,
               focus);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -233,7 +233,7 @@ public class BattlePanel extends ActionPanel {
             break;
           }
         }
-        if (ClientSetting.showBattlesWhenObserving.booleanValue() || foundHumanInBattle) {
+        if (ClientSetting.showBattlesWhenObserving.value() || foundHumanInBattle) {
           battleFrame.setVisible(true);
           battleFrame.validate();
           battleFrame.invalidate();

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -26,7 +26,7 @@ final class DebugMenu extends JMenu {
       add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
     }
 
-    add(SwingAction.of("Show Console", e -> ClientSetting.showConsole.saveAndFlush("true")))
+    add(SwingAction.of("Show Console", e -> ClientSetting.showConsole.saveAndFlush(true)))
         .setMnemonic(KeyEvent.VK_C);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
@@ -27,18 +27,18 @@ final class EngineVersionCheckTest {
   final class IsEngineUpdateCheckRequiredTest {
     private final LocalDate now = LocalDate.of(2008, 6, 1);
     @Mock
-    private GameSetting<String> firstRunSetting;
+    private GameSetting<Boolean> firstRunSetting;
     @Mock
     private GameSetting<String> updateCheckDateSetting;
     @Mock
     private Runnable flushSetting;
 
     private void givenFirstRun() {
-      when(firstRunSetting.booleanValue()).thenReturn(true);
+      when(firstRunSetting.value()).thenReturn(true);
     }
 
     private void givenNotFirstRun() {
-      when(firstRunSetting.booleanValue()).thenReturn(false);
+      when(firstRunSetting.value()).thenReturn(false);
     }
 
     private void givenEngineUpdateCheckNeverRun() {

--- a/game-core/src/test/java/games/strategy/triplea/settings/BooleanClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/BooleanClientSettingTest.java
@@ -1,0 +1,37 @@
+package games.strategy.triplea.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class BooleanClientSettingTest {
+  private final BooleanClientSetting clientSetting = new BooleanClientSetting("name", false);
+
+  @Nested
+  final class FormatValueTest {
+    @Test
+    void shouldReturnEncodedValue() {
+      assertThat(clientSetting.formatValue(false), is("false"));
+      assertThat(clientSetting.formatValue(true), is("true"));
+    }
+  }
+
+  @Nested
+  final class ParseValueTest {
+    @Test
+    void shouldReturnTrueWhenEncodedValueIsCaseInsensitiveTrue() {
+      assertThat(clientSetting.parseValue("true"), is(true));
+      assertThat(clientSetting.parseValue("TRUE"), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenEncodedValueIsNotCaseInsensitiveTrue() {
+      assertThat(clientSetting.parseValue(""), is(false));
+      assertThat(clientSetting.parseValue("false"), is(false));
+      assertThat(clientSetting.parseValue("FALSE"), is(false));
+      assertThat(clientSetting.parseValue("yes"), is(false));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -47,7 +47,7 @@ public class SaveFunctionTest {
     Mockito.when(mockSelectionComponent.isValid()).thenReturn(first);
     Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
     if (first) {
-      Mockito.when(mockSetting.value()).thenReturn("");
+      Mockito.when(mockSetting.stringValue()).thenReturn("");
     }
     Mockito.when(mockSelectionComponent2.isValid()).thenReturn(second);
     Mockito.when(mockSelectionComponent2.readValues()).thenReturn(ImmutableMap.of(mockSetting, "abc"));
@@ -82,7 +82,7 @@ public class SaveFunctionTest {
 
     Mockito.when(mockSelectionComponent.isValid()).thenReturn(true);
     Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
-    Mockito.when(mockSetting.value()).thenReturn("");
+    Mockito.when(mockSetting.stringValue()).thenReturn("");
 
     Mockito.when(mockSelectionComponent2.isValid()).thenReturn(false);
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -95,13 +95,13 @@ final class JavaFxSelectionComponentFactory {
     };
   }
 
-  static SelectionComponent<Region> toggleButton(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<Region> toggleButton(final ClientSetting<Boolean> clientSetting) {
     return new SelectionComponent<Region>() {
       final CheckBox checkBox = getCheckBox();
 
       private CheckBox getCheckBox() {
         final CheckBox checkBox = new CheckBox();
-        checkBox.setSelected(Boolean.parseBoolean(clientSetting.value()));
+        checkBox.setSelected(clientSetting.value());
         return checkBox;
       }
 
@@ -127,12 +127,12 @@ final class JavaFxSelectionComponentFactory {
 
       @Override
       public void resetToDefault() {
-        checkBox.selectedProperty().set(Boolean.parseBoolean(clientSetting.defaultValue()));
+        checkBox.selectedProperty().set(clientSetting.defaultValue());
       }
 
       @Override
       public void reset() {
-        checkBox.selectedProperty().set(Boolean.parseBoolean(clientSetting.value()));
+        checkBox.selectedProperty().set(clientSetting.value());
       }
     };
   }


### PR DESCRIPTION
## Overview

Converts all client settings that represent a Boolean value from `ClientSetting<String>` to `ClientSetting<Boolean>`.

## Functional Changes

None.

## Manual Testing Performed

Basic smoke testing of Boolean client settings in both Swing and JavaFX clients.