### PR TITLE
Error Prone: Fix equals incompatible type violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ subprojects {
             '-Xep:CatchAndPrintStackTrace:ERROR',
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
+            '-Xep:EqualsIncompatibleType:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',
             '-Xep:ImmutableEnumChecker:ERROR',
             '-Xep:InconsistentCapitalization:ERROR',

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -32,7 +32,7 @@ public class HttpProxy {
   }
 
   public static boolean isUsingSystemProxy() {
-    return ClientSetting.proxyChoice.value().equals(ProxyChoice.USE_SYSTEM_SETTINGS.toString());
+    return ClientSetting.proxyChoice.value().equals(ProxyChoice.USE_SYSTEM_SETTINGS);
   }
 
   /**


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsIncompatibleType rule.  This violation was introduced in #4151.

## Functional Changes

None.

## Manual Testing Performed

None.