### PR TITLE
Fix political actions button text

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -173,7 +173,7 @@ public class PoliticsPanel extends ActionPanel {
           GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, insets, 0, 0));
       final JButton button = getMap().getUiContext().getResourceImageFactory().getResourcesButton(
           new ResourceCollection(getData(), paa.getCostResources()),
-          UserActionText.getInstance().getButtonText(paa.getText()));
+          PoliticsText.getInstance().getButtonText(paa.getText()));
       button.addActionListener(ae -> {
         selectPoliticalActionButton.setEnabled(false);
         doneButton.setEnabled(false);


### PR DESCRIPTION
## Overview

Fixes #4175.

## Functional Changes

Use `PoliticsText` instead of `UserActionText` within `PoliticsPanel`.

## Manual Testing Performed

Verified the correct action button text is displayed in the `PoliticsPanel` using the scenario described by the OP in #4175.