### PR TITLE
Show Error Report button only when Show Beta Features enabled

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -115,11 +115,11 @@ public class MetaSetupPanel extends SetupPanel {
     add(helpButton, new GridBagConstraints(0, 10, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
 
-    if (ClientSetting.showBetaFeatures.isSet()) {
+    if (ClientSetting.showBetaFeatures.value()) {
       add(errorReportDemo, new GridBagConstraints(0, 11, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
           new Insets(10, 0, 0, 0), 0, 0));
     }
-    
+
     // top space
     add(new JPanel(), new GridBagConstraints(0, 100, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
         new Insets(0, 0, 0, 0), 0, 0));


### PR DESCRIPTION
## Overview

The new Error Report button is currently shown if the value of the Show Beta Features client setting is _set_, whereas it should only be shown if the value of the client setting is _True_.

## Functional Changes

The Error Report button is now only shown when the Show Beta Features client setting is set to True.

## Manual Testing Performed

* Verified the Error Report button is not displayed when Show Beta Features is False.
* Verified the Error Report button is displayed when Show Beta Features is True.