### PR TITLE
Use type-safe wrapper for integer client settings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
@@ -64,9 +64,9 @@ public final class LobbyServerPropertiesFetcher {
   @VisibleForTesting
   static Optional<LobbyServerProperties> getTestOverrideProperties(
       final GameSetting<String> testLobbyHostSetting,
-      final GameSetting<String> testLobbyPortSetting) {
+      final GameSetting<Integer> testLobbyPortSetting) {
     if (testLobbyHostSetting.isSet() && testLobbyPortSetting.isSet()) {
-      return Optional.of(new LobbyServerProperties(testLobbyHostSetting.value(), testLobbyPortSetting.intValue()));
+      return Optional.of(new LobbyServerProperties(testLobbyHostSetting.value(), testLobbyPortSetting.value()));
     }
 
     return Optional.empty();
@@ -101,7 +101,7 @@ public final class LobbyServerPropertiesFetcher {
       // graceful recovery case, use the last lobby address we knew about
       return new LobbyServerProperties(
           ClientSetting.lobbyLastUsedHost.value(),
-          ClientSetting.lobbyLastUsedPort.intValue());
+          ClientSetting.lobbyLastUsedPort.value());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -211,7 +211,7 @@ public class ServerGame extends AbstractGame {
         }
       }, "Waiting on observer to finish joining: " + newNode.getName()).start();
       try {
-        if (!waitOnObserver.await(ClientSetting.serverObserverJoinWaitTime.intValue(), TimeUnit.SECONDS)) {
+        if (!waitOnObserver.await(ClientSetting.serverObserverJoinWaitTime.value(), TimeUnit.SECONDS)) {
           nonBlockingObserver.cannotJoinGame("Taking too long to join.");
         }
       } catch (final InterruptedException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -154,7 +154,7 @@ public class ServerLauncher extends AbstractLauncher {
       if (abortLaunch) {
         serverReady.countDownAll();
       }
-      if (!serverReady.await(ClientSetting.serverStartGameSyncWaitTime.intValue(), TimeUnit.SECONDS)) {
+      if (!serverReady.await(ClientSetting.serverStartGameSyncWaitTime.value(), TimeUnit.SECONDS)) {
         log.warning("Aborting launch - waiting for clients to be ready timed out!");
         abortLaunch = true;
       }
@@ -184,7 +184,7 @@ public class ServerLauncher extends AbstractLauncher {
           // wait for the connection handler to notice, and shut us down
           Interruptibles.await(() -> {
             if (!abortLaunch
-                && !errorLatch.await(ClientSetting.serverObserverJoinWaitTime.intValue(), TimeUnit.SECONDS)) {
+                && !errorLatch.await(ClientSetting.serverObserverJoinWaitTime.value(), TimeUnit.SECONDS)) {
               log.warning("Waiting on error latch timed out!");
             }
           });

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -40,16 +42,14 @@ public class HttpProxy {
    */
   public static void updateSystemProxy() {
     final Optional<InetSocketAddress> address = getSystemProxy();
-
-    final String host;
-    final String port;
-
+    final @Nullable String host;
+    final @Nullable Integer port;
     if (!address.isPresent()) {
-      host = "";
-      port = "";
+      host = null;
+      port = null;
     } else {
       host = Strings.nullToEmpty(address.get().getHostName()).trim();
-      port = host.isEmpty() ? "" : String.valueOf(address.get().getPort());
+      port = host.isEmpty() ? null : address.get().getPort();
     }
 
     ClientSetting.proxyHost.save(host);
@@ -85,15 +85,11 @@ public class HttpProxy {
    * Attaches proxy host and port values, if any, to the http request parameter.
    */
   public static void addProxy(final HttpRequestBase request) {
-    final String host = ClientSetting.proxyHost.value();
-    final String port = ClientSetting.proxyPort.value();
-
-    if (Strings.emptyToNull(host) != null && Strings.emptyToNull(port) != null) {
+    if (ClientSetting.proxyHost.isSet() && ClientSetting.proxyPort.isSet()) {
       request.setConfig(RequestConfig
           .copy(request.getConfig())
-          .setProxy(new HttpHost(host, Integer.parseInt(port)))
+          .setProxy(new HttpHost(ClientSetting.proxyHost.value(), ClientSetting.proxyPort.value()))
           .build());
     }
   }
-
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -630,6 +630,6 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
    * Pause the game to allow the human player to see what is going on.
    */
   protected static void pause() {
-    Interruptibles.sleep(ClientSetting.aiPauseDuration.intValue());
+    Interruptibles.sleep(ClientSetting.aiPauseDuration.value());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -259,6 +259,6 @@ public class ProUtils {
    * Pause the game to allow the human player to see what is going on.
    */
   public static void pause() {
-    Interruptibles.sleep(ClientSetting.aiPauseDuration.intValue());
+    Interruptibles.sleep(ClientSetting.aiPauseDuration.value());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -152,8 +152,8 @@ class OddsCalculatorPanel extends JPanel {
     numRuns.setMax(20000);
 
     final int simulationCount = Properties.getLowLuck(data)
-        ? ClientSetting.battleCalcSimulationCountLowLuck.intValue()
-        : ClientSetting.battleCalcSimulationCountDice.intValue();
+        ? ClientSetting.battleCalcSimulationCountLowLuck.value()
+        : ClientSetting.battleCalcSimulationCountDice.value();
     numRuns.setValue(simulationCount);
     retreatAfterXRounds.setColumns(4);
     retreatAfterXRounds.setMin(-1);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -48,12 +48,13 @@ import lombok.extern.java.Log;
  */
 @Log
 public abstract class ClientSetting<T> implements GameSetting<T> {
-  public static final ClientSetting<String> aiPauseDuration = new StringClientSetting("AI_PAUSE_DURATION", 400);
-  public static final ClientSetting<String> arrowKeyScrollSpeed = new StringClientSetting("ARROW_KEY_SCROLL_SPEED", 70);
-  public static final ClientSetting<String> battleCalcSimulationCountDice =
-      new StringClientSetting("BATTLE_CALC_SIMULATION_COUNT_DICE", 200);
-  public static final ClientSetting<String> battleCalcSimulationCountLowLuck =
-      new StringClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
+  public static final ClientSetting<Integer> aiPauseDuration = new IntegerClientSetting("AI_PAUSE_DURATION", 400);
+  public static final ClientSetting<Integer> arrowKeyScrollSpeed =
+      new IntegerClientSetting("ARROW_KEY_SCROLL_SPEED", 70);
+  public static final ClientSetting<Integer> battleCalcSimulationCountDice =
+      new IntegerClientSetting("BATTLE_CALC_SIMULATION_COUNT_DICE", 200);
+  public static final ClientSetting<Integer> battleCalcSimulationCountLowLuck =
+      new IntegerClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
   public static final ClientSetting<Boolean> confirmDefensiveRolls =
       new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
   public static final ClientSetting<Boolean> confirmEnemyCasualties =
@@ -61,36 +62,36 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<String> defaultGameName =
       new StringClientSetting("DEFAULT_GAME_NAME_PREF", "Big World : 1942");
   public static final ClientSetting<String> defaultGameUri = new StringClientSetting("DEFAULT_GAME_URI_PREF");
-  public static final ClientSetting<String> fasterArrowKeyScrollMultiplier =
-      new StringClientSetting("FASTER_ARROW_KEY_SCROLL_MULTIPLIER", 2);
+  public static final ClientSetting<Integer> fasterArrowKeyScrollMultiplier =
+      new IntegerClientSetting("FASTER_ARROW_KEY_SCROLL_MULTIPLIER", 2);
   public static final ClientSetting<Boolean> spaceBarConfirmsCasualties =
       new BooleanClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
   public static final ClientSetting<String> lobbyLastUsedHost = new StringClientSetting("LOBBY_LAST_USED_HOST");
-  public static final ClientSetting<String> lobbyLastUsedPort = new StringClientSetting("LOBBY_LAST_USED_PORT");
+  public static final ClientSetting<Integer> lobbyLastUsedPort = new IntegerClientSetting("LOBBY_LAST_USED_PORT");
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
-  public static final ClientSetting<String> mapEdgeScrollSpeed = new StringClientSetting("MAP_EDGE_SCROLL_SPEED", 30);
-  public static final ClientSetting<String> mapEdgeScrollZoneSize =
-      new StringClientSetting("MAP_EDGE_SCROLL_ZONE_SIZE", 30);
+  public static final ClientSetting<Integer> mapEdgeScrollSpeed = new IntegerClientSetting("MAP_EDGE_SCROLL_SPEED", 30);
+  public static final ClientSetting<Integer> mapEdgeScrollZoneSize =
+      new IntegerClientSetting("MAP_EDGE_SCROLL_ZONE_SIZE", 30);
   public static final ClientSetting<String> mapFolderOverride = new StringClientSetting("MAP_FOLDER_OVERRIDE");
   public static final ClientSetting<String> mapListOverride = new StringClientSetting("MAP_LIST_OVERRIDE");
   public static final ClientSetting<HttpProxy.ProxyChoice> proxyChoice =
       new HttpProxyChoiceClientSetting("PROXY_CHOICE", HttpProxy.ProxyChoice.NONE);
   public static final ClientSetting<String> proxyHost = new StringClientSetting("PROXY_HOST");
-  public static final ClientSetting<String> proxyPort = new StringClientSetting("PROXY_PORT");
+  public static final ClientSetting<Integer> proxyPort = new IntegerClientSetting("PROXY_PORT");
   public static final ClientSetting<String> saveGamesFolderPath = new StringClientSetting(
       "SAVE_GAMES_FOLDER_PATH",
       new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames"));
-  public static final ClientSetting<String> serverObserverJoinWaitTime =
-      new StringClientSetting("SERVER_OBSERVER_JOIN_WAIT_TIME", 180);
-  public static final ClientSetting<String> serverStartGameSyncWaitTime =
-      new StringClientSetting("SERVER_START_GAME_SYNC_WAIT_TIME", 180);
+  public static final ClientSetting<Integer> serverObserverJoinWaitTime =
+      new IntegerClientSetting("SERVER_OBSERVER_JOIN_WAIT_TIME", 180);
+  public static final ClientSetting<Integer> serverStartGameSyncWaitTime =
+      new IntegerClientSetting("SERVER_START_GAME_SYNC_WAIT_TIME", 180);
   public static final ClientSetting<Boolean> showBattlesWhenObserving =
       new BooleanClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
   public static final ClientSetting<Boolean> showBetaFeatures = new BooleanClientSetting("SHOW_BETA_FEATURES", false);
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE", false);
   public static final ClientSetting<String> testLobbyHost = new StringClientSetting("TEST_LOBBY_HOST");
-  public static final ClientSetting<String> testLobbyPort = new StringClientSetting("TEST_LOBBY_PORT");
+  public static final ClientSetting<Integer> testLobbyPort = new IntegerClientSetting("TEST_LOBBY_PORT");
   public static final ClientSetting<Boolean> firstTimeThisVersion =
       new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<String> lastCheckForEngineUpdate =
@@ -102,7 +103,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<String> userMapsFolderPath = new StringClientSetting(
       "USER_MAPS_FOLDER_PATH",
       new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps"));
-  public static final ClientSetting<String> wheelScrollAmount = new StringClientSetting("WHEEL_SCROLL_AMOUNT", 60);
+  public static final ClientSetting<Integer> wheelScrollAmount = new IntegerClientSetting("WHEEL_SCROLL_AMOUNT", 60);
   public static final ClientSetting<String> playerName =
       new StringClientSetting("PLAYER_NAME", SystemProperties.getUserName());
   public static final ClientSetting<Boolean> useExperimentalJavaFxUi =
@@ -115,6 +116,13 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   private final String name;
   private final String encodedDefaultValue;
   private final Collection<Consumer<String>> onSaveActions = new CopyOnWriteArrayList<>();
+
+  protected ClientSetting(final String name) {
+    Preconditions.checkNotNull(name);
+
+    this.name = name;
+    this.encodedDefaultValue = "";
+  }
 
   protected ClientSetting(final String name, final T defaultValue) {
     Preconditions.checkNotNull(name);
@@ -245,6 +253,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
    * @throws IllegalArgumentException If the encoded string value is malformed.
    */
   protected abstract T parseValue(String encodedValue);
+
+  public final String defaultStringValue() {
+    return encodedDefaultValue;
+  }
 
   public final T defaultValue() {
     // allow exceptions to propagate; default value should always be parseable

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -40,10 +40,6 @@ public interface GameSetting<T> {
    */
   void save(@Nullable T newValue);
 
-  default void save(final int newValue) {
-    saveString(String.valueOf(newValue));
-  }
-
   /**
    * Returns the current persisted string value of the setting.
    */
@@ -53,10 +49,6 @@ public interface GameSetting<T> {
    * Returns the current persisted typed value of the setting.
    */
   T value();
-
-  default int intValue() {
-    return Integer.valueOf(stringValue());
-  }
 
   void resetAndFlush();
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
@@ -1,0 +1,21 @@
+package games.strategy.triplea.settings;
+
+final class IntegerClientSetting extends ClientSetting<Integer> {
+  IntegerClientSetting(final String name) {
+    super(name);
+  }
+
+  IntegerClientSetting(final String name, final int defaultValue) {
+    super(name, defaultValue);
+  }
+
+  @Override
+  protected String formatValue(final Integer value) {
+    return value.toString();
+  }
+
+  @Override
+  protected Integer parseValue(final String encodedValue) {
+    return Integer.valueOf(encodedValue);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -38,7 +38,7 @@ final class SelectionComponentFactory {
   static SelectionComponent<JComponent> proxySettings(
       final ClientSetting<HttpProxy.ProxyChoice> proxyChoiceClientSetting,
       final ClientSetting<String> proxyHostClientSetting,
-      final ClientSetting<String> proxyPortClientSetting) {
+      final ClientSetting<Integer> proxyPortClientSetting) {
     return new SelectionComponent<JComponent>() {
       final HttpProxy.ProxyChoice proxyChoice = proxyChoiceClientSetting.value();
       final JRadioButton noneButton = new JRadioButton("None", proxyChoice == HttpProxy.ProxyChoice.NONE);
@@ -47,7 +47,7 @@ final class SelectionComponentFactory {
       final JRadioButton userButton =
           new JRadioButton("Use These Settings:", proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
       final JTextField hostText = new JTextField(proxyHostClientSetting.value(), 20);
-      final JTextField portText = new JTextField(proxyPortClientSetting.value(), 6);
+      final JTextField portText = new JTextField(proxyPortClientSetting.stringValue(), 6);
       final JPanel radioPanel = JPanelBuilder.builder()
           .verticalBoxLayout()
           .addLeftJustified(noneButton)
@@ -133,7 +133,7 @@ final class SelectionComponentFactory {
       public void resetToDefault() {
         ClientSetting.flush();
         hostText.setText(proxyHostClientSetting.defaultValue());
-        portText.setText(proxyPortClientSetting.defaultValue());
+        portText.setText(proxyPortClientSetting.defaultStringValue());
         setProxyChoice(proxyChoiceClientSetting.defaultValue());
       }
 
@@ -148,7 +148,7 @@ final class SelectionComponentFactory {
       public void reset() {
         ClientSetting.flush();
         hostText.setText(proxyHostClientSetting.value());
-        portText.setText(proxyPortClientSetting.value());
+        portText.setText(proxyPortClientSetting.stringValue());
         setProxyChoice(proxyChoiceClientSetting.value());
       }
     };
@@ -163,7 +163,7 @@ final class SelectionComponentFactory {
    * Text field that only accepts numbers between a certain range.
    */
   static SelectionComponent<JComponent> intValueRange(
-      final ClientSetting<String> clientSetting,
+      final ClientSetting<Integer> clientSetting,
       final int lo,
       final int hi) {
     return intValueRange(clientSetting, lo, hi, false);
@@ -172,11 +172,14 @@ final class SelectionComponentFactory {
   /**
    * Text field that only accepts numbers between a certain range.
    */
-  static SelectionComponent<JComponent> intValueRange(final ClientSetting<String> clientSetting, final int lo,
-      final int hi, final boolean allowUnset) {
+  static SelectionComponent<JComponent> intValueRange(
+      final ClientSetting<Integer> clientSetting,
+      final int lo,
+      final int hi,
+      final boolean allowUnset) {
     return new SelectionComponent<JComponent>() {
       private final JSpinner component = new JSpinner(new SpinnerNumberModel(
-          toValidIntValue(clientSetting.value()), lo - (allowUnset ? 1 : 0), hi, 1));
+          toValidIntValue(clientSetting.stringValue()), lo - (allowUnset ? 1 : 0), hi, 1));
 
       @Override
       public JComponent getUiComponent() {
@@ -208,12 +211,12 @@ final class SelectionComponentFactory {
 
       @Override
       public void resetToDefault() {
-        component.setValue(toValidIntValue(clientSetting.defaultValue()));
+        component.setValue(toValidIntValue(clientSetting.defaultStringValue()));
       }
 
       @Override
       public void reset() {
-        component.setValue(toValidIntValue(clientSetting.value()));
+        component.setValue(toValidIntValue(clientSetting.stringValue()));
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
@@ -4,15 +4,11 @@ import java.io.File;
 
 final class StringClientSetting extends ClientSetting<String> {
   StringClientSetting(final String name) {
-    this(name, "");
+    super(name);
   }
 
   StringClientSetting(final String name, final String defaultValue) {
     super(name, defaultValue);
-  }
-
-  StringClientSetting(final String name, final int defaultValue) {
-    super(name, String.valueOf(defaultValue));
   }
 
   StringClientSetting(final String name, final File defaultValue) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1758,8 +1758,8 @@ public final class TripleAFrame extends JFrame {
 
   private int computeScrollSpeed() {
     return isCtrlPressed
-        ? ClientSetting.arrowKeyScrollSpeed.intValue() * ClientSetting.fasterArrowKeyScrollMultiplier.intValue()
-        : ClientSetting.arrowKeyScrollSpeed.intValue();
+        ? ClientSetting.arrowKeyScrollSpeed.value() * ClientSetting.fasterArrowKeyScrollMultiplier.value()
+        : ClientSetting.arrowKeyScrollSpeed.value();
   }
 
   private void showEditMode() {

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -100,9 +100,9 @@ public class ImageScrollerLargeView extends JComponent {
         int dx = 0;
         int dy = 0;
         if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) == InputEvent.SHIFT_DOWN_MASK) {
-          dx = e.getWheelRotation() * ClientSetting.wheelScrollAmount.intValue();
+          dx = e.getWheelRotation() * ClientSetting.wheelScrollAmount.value();
         } else {
-          dy = e.getWheelRotation() * ClientSetting.wheelScrollAmount.intValue();
+          dy = e.getWheelRotation() * ClientSetting.wheelScrollAmount.value();
         }
         // Update the model, which will handle its own clamping or wrapping depending on the map.
         this.model.set(this.model.getX() + dx, this.model.getY() + dy);
@@ -266,15 +266,15 @@ public class ImageScrollerLargeView extends JComponent {
   private void scroll() {
     int dy = 0;
     if ((edge & TOP) != 0) {
-      dy = -ClientSetting.mapEdgeScrollSpeed.intValue();
+      dy = -ClientSetting.mapEdgeScrollSpeed.value();
     } else if ((edge & BOTTOM) != 0) {
-      dy = ClientSetting.mapEdgeScrollSpeed.intValue();
+      dy = ClientSetting.mapEdgeScrollSpeed.value();
     }
     int dx = 0;
     if ((edge & LEFT) != 0) {
-      dx = -ClientSetting.mapEdgeScrollSpeed.intValue();
+      dx = -ClientSetting.mapEdgeScrollSpeed.value();
     } else if ((edge & RIGHT) != 0) {
-      dx = ClientSetting.mapEdgeScrollSpeed.intValue();
+      dx = ClientSetting.mapEdgeScrollSpeed.value();
     }
 
     dx = (int) (dx / scale);
@@ -290,14 +290,14 @@ public class ImageScrollerLargeView extends JComponent {
 
   private static int getNewEdge(final int x, final int y, final int width, final int height) {
     int newEdge = NONE;
-    if (x < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
+    if (x < ClientSetting.mapEdgeScrollZoneSize.value()) {
       newEdge += LEFT;
-    } else if (width - x < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
+    } else if (width - x < ClientSetting.mapEdgeScrollZoneSize.value()) {
       newEdge += RIGHT;
     }
-    if (y < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
+    if (y < ClientSetting.mapEdgeScrollZoneSize.value()) {
       newEdge += TOP;
-    } else if (height - y < ClientSetting.mapEdgeScrollZoneSize.intValue()) {
+    } else if (height - y < ClientSetting.mapEdgeScrollZoneSize.value()) {
       newEdge += BOTTOM;
     }
     return newEdge;

--- a/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcherTest.java
@@ -75,7 +75,7 @@ public class LobbyServerPropertiesFetcherTest {
     private GameSetting<String> testLobbyHostSetting;
 
     @Mock
-    private GameSetting<String> testLobbyPortSetting;
+    private GameSetting<Integer> testLobbyPortSetting;
 
     private Optional<LobbyServerProperties> result;
 
@@ -98,7 +98,7 @@ public class LobbyServerPropertiesFetcherTest {
 
     private void givenTestLobbyPortIsSetTo(final int port) {
       when(testLobbyPortSetting.isSet()).thenReturn(true);
-      when(testLobbyPortSetting.intValue()).thenReturn(port);
+      when(testLobbyPortSetting.value()).thenReturn(port);
     }
 
     private void whenGetTestOverrideProperties() {

--- a/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
@@ -1,0 +1,42 @@
+package games.strategy.triplea.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class IntegerClientSettingTest {
+  private final IntegerClientSetting clientSetting = new IntegerClientSetting("name", 0);
+
+  @Nested
+  final class FormatValueTest {
+    @Test
+    void shouldReturnEncodedValue() {
+      assertThat(clientSetting.formatValue(Integer.MIN_VALUE), is("-2147483648"));
+      assertThat(clientSetting.formatValue(-1), is("-1"));
+      assertThat(clientSetting.formatValue(0), is("0"));
+      assertThat(clientSetting.formatValue(1), is("1"));
+      assertThat(clientSetting.formatValue(Integer.MAX_VALUE), is("2147483647"));
+    }
+  }
+
+  @Nested
+  final class ParseValueTest {
+    @Test
+    void shouldReturnIntegerWhenEncodedValueIsLegal() {
+      assertThat(clientSetting.parseValue("-2147483648"), is(Integer.MIN_VALUE));
+      assertThat(clientSetting.parseValue("-1"), is(-1));
+      assertThat(clientSetting.parseValue("0"), is(0));
+      assertThat(clientSetting.parseValue("1"), is(1));
+      assertThat(clientSetting.parseValue("2147483647"), is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEncodedValueIsIllegal() {
+      assertThrows(NumberFormatException.class, () -> clientSetting.parseValue(""));
+      assertThrows(NumberFormatException.class, () -> clientSetting.parseValue("a123"));
+    }
+  }
+}

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -31,14 +31,14 @@ final class JavaFxSelectionComponentFactory {
   private JavaFxSelectionComponentFactory() {}
 
   static SelectionComponent<Region> intValueRange(
-      final ClientSetting<String> clientSetting,
+      final ClientSetting<Integer> clientSetting,
       final int minValue,
       final int maxValue) {
     return intValueRange(clientSetting, minValue, maxValue, false);
   }
 
   static SelectionComponent<Region> intValueRange(
-      final ClientSetting<String> clientSetting,
+      final ClientSetting<Integer> clientSetting,
       final int minValue,
       final int maxValue,
       final boolean allowUnset) {
@@ -50,7 +50,7 @@ final class JavaFxSelectionComponentFactory {
         final Spinner<Integer> spinner = new Spinner<>(
             minValue - (allowUnset ? 1 : 0),
             maxValue,
-            getIntegerFromString(clientSetting.value()));
+            getIntegerFromString(clientSetting.stringValue()));
         spinner.setEditable(true);
         return spinner;
       }
@@ -85,12 +85,12 @@ final class JavaFxSelectionComponentFactory {
 
       @Override
       public void resetToDefault() {
-        spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.defaultValue()));
+        spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.defaultStringValue()));
       }
 
       @Override
       public void reset() {
-        spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.value()));
+        spinner.getValueFactory().setValue(getIntegerFromString(clientSetting.stringValue()));
       }
     };
   }
@@ -190,7 +190,7 @@ final class JavaFxSelectionComponentFactory {
   static SelectionComponent<Region> proxySettings(
       final ClientSetting<HttpProxy.ProxyChoice> proxyChoiceClientSetting,
       final ClientSetting<String> proxyHostClientSetting,
-      final ClientSetting<String> proxyPortClientSetting) {
+      final ClientSetting<Integer> proxyPortClientSetting) {
     return new ProxySetting(proxyChoiceClientSetting, proxyHostClientSetting, proxyPortClientSetting);
   }
 
@@ -324,7 +324,7 @@ final class JavaFxSelectionComponentFactory {
   private static final class ProxySetting extends Region implements SelectionComponent<Region> {
     private final ClientSetting<HttpProxy.ProxyChoice> proxyChoiceClientSetting;
     private final ClientSetting<String> proxyHostClientSetting;
-    private final ClientSetting<String> proxyPortClientSetting;
+    private final ClientSetting<Integer> proxyPortClientSetting;
     private final RadioButton noneButton;
     private final RadioButton systemButton;
     private final RadioButton userButton;
@@ -334,7 +334,7 @@ final class JavaFxSelectionComponentFactory {
     ProxySetting(
         final ClientSetting<HttpProxy.ProxyChoice> proxyChoiceClientSetting,
         final ClientSetting<String> proxyHostClientSetting,
-        final ClientSetting<String> proxyPortClientSetting) {
+        final ClientSetting<Integer> proxyPortClientSetting) {
       this.proxyChoiceClientSetting = proxyChoiceClientSetting;
       this.proxyHostClientSetting = proxyHostClientSetting;
       this.proxyPortClientSetting = proxyPortClientSetting;
@@ -347,7 +347,7 @@ final class JavaFxSelectionComponentFactory {
       userButton = new RadioButton("Use These Settings:");
       userButton.setSelected(proxyChoice == HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
       hostText = new TextField(proxyHostClientSetting.value());
-      portText = new TextField(proxyPortClientSetting.value());
+      portText = new TextField(proxyPortClientSetting.stringValue());
       final VBox radioPanel = new VBox();
       radioPanel.getChildren().addAll(
           noneButton,
@@ -387,7 +387,7 @@ final class JavaFxSelectionComponentFactory {
     public void resetToDefault() {
       ClientSetting.flush();
       hostText.setText(proxyHostClientSetting.defaultValue());
-      portText.setText(proxyPortClientSetting.defaultValue());
+      portText.setText(proxyPortClientSetting.defaultStringValue());
       setProxyChoice(proxyChoiceClientSetting.defaultValue());
     }
 
@@ -401,7 +401,7 @@ final class JavaFxSelectionComponentFactory {
     public void reset() {
       ClientSetting.flush();
       hostText.setText(proxyHostClientSetting.value());
-      portText.setText(proxyPortClientSetting.value());
+      portText.setText(proxyPortClientSetting.stringValue());
       setProxyChoice(proxyChoiceClientSetting.value());
     }
 


### PR DESCRIPTION
## Overview

Converts all client settings that represent an integer value from `ClientSetting<String>` to `ClientSetting<Integer>`.

## Functional Changes

None.

## Manual Testing Performed

Basic smoke testing of integer client settings in both Swing and JavaFX clients, including cases where the setting value is not set (e.g. network proxy port).

## Additional Review Notes

This is an incomplete change.  The integer `SelectionComponent`s still rely on the string value.  To convert them to directly use the integer value will require an API change in `GameSetting` that allows the interface to express the absence of a typed value (e.g. using `Optional<T>`).  That API change will touch a lot of code, so I decided it would be best done in a separate, follow-up PR.