### PR TITLE
Improve hit differential grouping for AA dice

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -163,7 +163,8 @@ public class DiceRoll implements Externalizable {
     }
     final double expectedHits = ((double) totalPower) / chosenDiceSizeForAll;
     final DiceRoll roll = new DiceRoll(sortedDice, hits, expectedHits);
-    final String annotation = typeAa + " fire in " + location + " : " + MyFormatter.asDice(roll);
+    final String annotation = defendingAa.get(0).getOwner().getName() + " roll " + typeAa + " dice in " + location
+        + " : " + MyFormatter.asDice(roll);
     bridge.getHistoryWriter().addChildToEvent(annotation, roll);
     return roll;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -400,7 +400,7 @@ public class HistoryLog extends JFrame {
 
   @VisibleForTesting
   static String parseHitDifferentialKeyFromDiceRollMessage(final String message) {
-    final Pattern diceRollPattern = Pattern.compile("^(\\w+) roll(?: (\\w+))? dice");
+    final Pattern diceRollPattern = Pattern.compile("^(.+) roll(?: (.+))? dice");
     final Matcher matcher = diceRollPattern.matcher(message);
     if (matcher.find()) {
       return matcher.group(1) + " " + Optional.ofNullable(matcher.group(2)).orElse("regular");

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -236,7 +237,7 @@ public class HistoryLog extends JFrame {
             } else {
               // dice roll
               logWriter.print(indent + moreIndent + diceMsg1);
-              final String player = parsePlayerNameFromDiceRollMessage(diceMsg1);
+              final String hitDifferentialKey = parseHitDifferentialKeyFromDiceRollMessage(diceMsg1);
               final DiceRoll diceRoll = (DiceRoll) details;
               final int hits = diceRoll.getHits();
               int rolls = 0;
@@ -247,11 +248,7 @@ public class HistoryLog extends JFrame {
               logWriter.println(" " + hits + "/" + rolls + " hits, "
                   + String.format("%.2f", expectedHits) + " expected hits");
               final double hitDifferential = hits - expectedHits;
-              if (hitDifferentialMap.containsKey(player)) {
-                hitDifferentialMap.put(player, hitDifferentialMap.get(player) + hitDifferential);
-              } else {
-                hitDifferentialMap.put(player, hitDifferential);
-              }
+              hitDifferentialMap.merge(hitDifferentialKey, hitDifferential, Double::sum);
             }
           } else if (details instanceof MoveDescription) {
             // movement
@@ -402,8 +399,15 @@ public class HistoryLog extends JFrame {
   }
 
   @VisibleForTesting
-  static String parsePlayerNameFromDiceRollMessage(final String message) {
-    return message.contains(" roll ") ? message.substring(0, message.indexOf(" roll ")) : message;
+  static String parseHitDifferentialKeyFromDiceRollMessage(final String message) {
+    final Pattern diceRollPattern = Pattern.compile("^(\\w+) roll(?: (\\w+))? dice");
+    final Matcher matcher = diceRollPattern.matcher(message);
+    if (matcher.find()) {
+      return matcher.group(1) + " " + Optional.ofNullable(matcher.group(2)).orElse("regular");
+    }
+
+    final int lastColonIndex = message.lastIndexOf(" :");
+    return (lastColonIndex != -1) ? message.substring(0, lastColonIndex) : message;
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
@@ -1,6 +1,6 @@
 package games.strategy.triplea.ui.history;
 
-import static games.strategy.triplea.ui.history.HistoryLog.parsePlayerNameFromDiceRollMessage;
+import static games.strategy.triplea.ui.history.HistoryLog.parseHitDifferentialKeyFromDiceRollMessage;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -9,20 +9,29 @@ import org.junit.jupiter.api.Test;
 
 final class HistoryLogTest {
   @Nested
-  final class ParsePlayerNameFromDiceRollMessageTest {
-
+  final class ParseHitDifferentialKeyFromDiceRollMessageTest {
     @Test
-    void shouldParsePlayerName() {
+    void shouldReturnPlayerNameAndRegularDiceTypeWhenMessageContainsRegularDiceRoll() {
       assertThat(
-          parsePlayerNameFromDiceRollMessage("Japanese roll dice for 1 battleship in Australia, round 2 :"),
-          is("Japanese"));
+          parseHitDifferentialKeyFromDiceRollMessage("Russians roll dice for 1 fighter in Karelia S.S.R., round 3 :"),
+          is("Russians regular"));
     }
 
     @Test
-    void shouldParsePlayerNameWithoutRoll() {
+    void shouldReturnPlayerNameAndAaDiceTypeWhenMessageContainsAaDiceRoll() {
       assertThat(
-          parsePlayerNameFromDiceRollMessage("Japanese"),
-          is("Japanese"));
+          parseHitDifferentialKeyFromDiceRollMessage("Russians roll AA dice in Karelia S.S.R. :"),
+          is("Russians AA"));
+    }
+
+    @Test
+    void shouldReturnMessageWithoutTrailingColonWhenMessageDoesNotContainDiceRoll() {
+      assertThat(
+          parseHitDifferentialKeyFromDiceRollMessage("AA fire in Karelia S.S.R."),
+          is("AA fire in Karelia S.S.R."));
+      assertThat(
+          parseHitDifferentialKeyFromDiceRollMessage("AA fire in Karelia S.S.R. :"),
+          is("AA fire in Karelia S.S.R."));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/history/HistoryLogTest.java
@@ -13,23 +13,39 @@ final class HistoryLogTest {
     @Test
     void shouldReturnPlayerNameAndRegularDiceTypeWhenMessageContainsRegularDiceRoll() {
       assertThat(
+          "player name with only word characters",
           parseHitDifferentialKeyFromDiceRollMessage("Russians roll dice for 1 fighter in Karelia S.S.R., round 3 :"),
           is("Russians regular"));
+      assertThat(
+          "player name with spaces",
+          parseHitDifferentialKeyFromDiceRollMessage("West Germans roll dice for 1 fighter in Germany, round 2 :"),
+          is("West Germans regular"));
     }
 
     @Test
     void shouldReturnPlayerNameAndAaDiceTypeWhenMessageContainsAaDiceRoll() {
       assertThat(
+          "player name and dice type with only word characters",
           parseHitDifferentialKeyFromDiceRollMessage("Russians roll AA dice in Karelia S.S.R. :"),
           is("Russians AA"));
+      assertThat(
+          "player name with spaces",
+          parseHitDifferentialKeyFromDiceRollMessage("West Germans roll AA dice in Germany :"),
+          is("West Germans AA"));
+      assertThat(
+          "dice type with non-word characters",
+          parseHitDifferentialKeyFromDiceRollMessage("West Germans roll A.A. dice in Germany :"),
+          is("West Germans A.A."));
     }
 
     @Test
     void shouldReturnMessageWithoutTrailingColonWhenMessageDoesNotContainDiceRoll() {
       assertThat(
+          "message without trailing colon",
           parseHitDifferentialKeyFromDiceRollMessage("AA fire in Karelia S.S.R."),
           is("AA fire in Karelia S.S.R."));
       assertThat(
+          "message with trailing colon",
           parseHitDifferentialKeyFromDiceRollMessage("AA fire in Karelia S.S.R. :"),
           is("AA fire in Karelia S.S.R."));
     }


### PR DESCRIPTION
## Overview

Follow-up to a discussion in #4020.

Improves how hit differential statistics are presented for AA dice.  Previously, AA fire in each territory was grouped in a separate category (e.g. "AA fire in Karelia S.S.R.").  With this PR, all AA dice for a player are now grouped together in a single category (e.g. "Russians AA").

## Functional Changes

* Changed the history annotation for AA dice rolls.
    * Included the player name at the start of the string.
    * Changed the phrase `<aaType> fire` to `roll <aaType> dice`.
* Changed hit differential map entries to be keyed off both the player name and the type of dice roll.
    * Regular (non-AA) dice rolls are named "regular", as recommended in #4020.

## Manual Testing Performed

Ran a few battles in Classic with AA guns.  The before and after history log results are below.

## Before & After Screen Shots

### Before

```
Game History

    Round: 1

        Combat - Germans
            Battle in Karelia S.S.R.
                Germans attack with 3 armour, 1 bomber, 3 fighters and 3 infantry
                Russians defend with 1 aaGun, 1 armour, 1 factory, 1 fighter and 3 infantry
                    AA fire in Karelia S.S.R. : 1/4 hits, 0.67 expected hits
                    1 fighter owned by the Germans lost in Karelia S.S.R.
                    Germans roll dice for 3 armour, 1 bomber, 2 fighters and 3 infantry in Karelia S.S.R., round 2 : 4/9 hits, 3.67 expected hits
                    Russians roll dice for 1 armour, 1 fighter and 3 infantry in Karelia S.S.R., round 2 : 2/5 hits, 2.00 expected hits
                    3 infantry owned by the Russians, 1 armour owned by the Russians and 2 infantry owned by the Germans lost in Karelia S.S.R.
                    Germans roll dice for 3 armour, 1 bomber, 2 fighters and 1 infantry in Karelia S.S.R., round 3 : 5/7 hits, 3.33 expected hits
                    Russians roll dice for 1 fighter in Karelia S.S.R., round 3 : 0/1 hits, 0.67 expected hits
                    1 fighter owned by the Russians lost in Karelia S.S.R.
                Germans win, taking Karelia S.S.R. from Russians with 3 armour, 1 bomber, 2 fighters and 1 infantry remaining. Battle score for attacker is 8
                Casualties for Germans: 1 fighter and 2 infantry
                Casualties for Russians: 1 armour, 1 fighter and 3 infantry
            Battle in Russia
                Germans attack with 5 fighters
                Russians defend with 1 aaGun, 2 armour, 1 factory, 1 fighter and 4 infantry
                    AA fire in Russia : 0/5 hits, 0.83 expected hits
                    Germans roll dice for 5 fighters in Russia, round 2 : 2/5 hits, 2.50 expected hits
                    Russians roll dice for 2 armour, 1 fighter and 4 infantry in Russia, round 2 : 0/7 hits, 2.67 expected hits
                    2 infantry owned by the Russians lost in Russia
                    Germans roll dice for 5 fighters in Russia, round 3 : 2/5 hits, 2.50 expected hits
                    Russians roll dice for 2 armour, 1 fighter and 2 infantry in Russia, round 3 : 4/5 hits, 2.00 expected hits
                    2 infantry owned by the Russians and 4 fighters owned by the Germans lost in Russia
                    Germans roll dice for 1 fighter in Russia, round 4 : 1/1 hits, 0.50 expected hits
                    Russians roll dice for 2 armour and 1 fighter in Russia, round 4 : 1/3 hits, 1.33 expected hits
                    1 armour owned by the Russians and 1 fighter owned by the Germans lost in Russia
                Russians win with 1 armour and 1 fighter remaining. Battle score for attacker is -43
                Casualties for Russians: 1 armour and 4 infantry
                Casualties for Germans: 5 fighters

        Non Combat Move - Germans

Combat Hit Differential Summary :

    Germans : 1.50
    AA fire in Russia : : -0.83
    AA fire in Karelia S.S.R. : : 0.33
    Russians : -1.67
```

### After

```
Game History

    Round: 1

        Combat - Germans
            Battle in Karelia S.S.R.
                Germans attack with 3 armour, 1 bomber, 3 fighters and 3 infantry
                Russians defend with 1 aaGun, 1 armour, 1 factory, 1 fighter and 3 infantry
                    Russians roll AA dice in Karelia S.S.R. : 0/4 hits, 0.67 expected hits
                    Germans roll dice for 3 armour, 1 bomber, 3 fighters and 3 infantry in Karelia S.S.R., round 2 : 5/10 hits, 4.17 expected hits
                    Russians roll dice for 1 armour, 1 fighter and 3 infantry in Karelia S.S.R., round 2 : 2/5 hits, 2.00 expected hits
                    3 infantry owned by the Russians, 1 fighter owned by the Russians, 1 armour owned by the Russians and 2 infantry owned by the Germans lost in Karelia S.S.R.
                Germans win, taking Karelia S.S.R. from Russians with 3 armour, 1 bomber, 3 fighters and 1 infantry remaining. Battle score for attacker is 20
                Casualties for Germans: 2 infantry
                Casualties for Russians: 1 armour, 1 fighter and 3 infantry
            Battle in Russia
                Germans attack with 5 fighters
                Russians defend with 1 aaGun, 2 armour, 1 factory, 1 fighter and 4 infantry
                    Russians roll AA dice in Russia : 1/5 hits, 0.83 expected hits
                    1 fighter owned by the Germans lost in Russia
                    Germans roll dice for 4 fighters in Russia, round 2 : 2/4 hits, 2.00 expected hits
                    Russians roll dice for 2 armour, 1 fighter and 4 infantry in Russia, round 2 : 3/7 hits, 2.67 expected hits
                    2 infantry owned by the Russians and 3 fighters owned by the Germans lost in Russia
                    Germans roll dice for 1 fighter in Russia, round 3 : 1/1 hits, 0.50 expected hits
                    Russians roll dice for 2 armour, 1 fighter and 2 infantry in Russia, round 3 : 1/5 hits, 2.00 expected hits
                    1 infantry owned by the Russians and 1 fighter owned by the Germans lost in Russia
                Russians win with 2 armour, 1 fighter and 1 infantry remaining. Battle score for attacker is -51
                Casualties for Germans: 5 fighters
                Casualties for Russians: 3 infantry

        Non Combat Move - Germans

Combat Hit Differential Summary :

    Russians regular : -0.67
    Germans regular : 1.33
    Russians AA : -0.50
```

## Additional Review Notes

* I did not remove the territory name from the dice roll annotations, as suggested in #4020.  The territory name appears in all child events of a battle, even though it is redundant.  I didn't want to remove it from just AA dice rolls, or even all dice rolls, as that would leave an inconsistent appearance among the events as a whole.  Removal of the redundant territory name should probably be done in a separate PR where it can be addressed everywhere at once,