### PR TITLE
Temporarily unlock map during Find Territory operation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -288,21 +288,35 @@ public class MapPanel extends ImageScrollerLargeView {
     return highlightedUnits;
   }
 
-  public boolean centerOn(final @Nullable Territory territory) {
+  public void centerOn(final @Nullable Territory territory) {
     if (territory == null || uiContext.getLockMap()) {
-      return false;
+      return;
     }
     final Point p = uiContext.getMapData().getCenter(territory);
     // when centering don't want the map to wrap around,
     // eg if centering on hawaii
     super.setTopLeft((int) (p.x - (getScaledWidth() / 2)), (int) (p.y - (getScaledHeight() / 2)));
-    return true;
   }
 
   void highlightTerritory(final Territory territory) {
-    if (centerOn(territory)) {
+    withMapUnlocked(() -> {
+      centerOn(territory);
       highlightedTerritory = territory;
       territoryHighlighter.highlight(territory);
+    });
+  }
+
+  private void withMapUnlocked(final Runnable runnable) {
+    final boolean lockMap = uiContext.getLockMap();
+    if (lockMap) {
+      uiContext.setLockMap(false);
+    }
+    try {
+      runnable.run();
+    } finally {
+      if (lockMap) {
+        uiContext.setLockMap(true);
+      }
     }
   }
 


### PR DESCRIPTION
## Overview

Fixes the issue reported here: https://forums.triplea-game.org/topic/1026/find-province-command/43.

If the user has Lock Map enabled, the Find Territory dialog does nothing.  This PR changes the behavior to temporarily disable Lock Map during Find Territory so the map can be re-centered.

## Functional Changes

* Temporarily set Lock Map to `false` while highlighting a territory.  Restore it to its original value after the map is centered.

## Manual Testing Performed

Verified the Find Territory dialog behaves as expected when Lock Map is both `true` and `false`.