### PR TITLE
Temporarily unlock map during Center Battle action

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -299,10 +299,14 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   void highlightTerritory(final Territory territory) {
+    highlightTerritory(territory, Integer.MAX_VALUE);
+  }
+
+  void highlightTerritory(final Territory territory, final int totalFrames) {
     withMapUnlocked(() -> {
       centerOn(territory);
       highlightedTerritory = territory;
-      territoryHighlighter.highlight(territory);
+      territoryHighlighter.highlight(territory, totalFrames);
     });
   }
 
@@ -865,13 +869,14 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   private final class TerritoryHighlighter {
-    private boolean overlayEnabled;
+    private int frame;
+    private int totalFrames;
     private @Nullable Territory territory;
     private final Timer timer = new Timer(500, e -> animateNextFrame());
 
-    void highlight(final Territory territory) {
+    void highlight(final Territory territory, final int totalFrames) {
       stopAnimation();
-      startAnimation(territory);
+      startAnimation(territory, totalFrames);
     }
 
     private void stopAnimation() {
@@ -884,9 +889,10 @@ public class MapPanel extends ImageScrollerLargeView {
       territory = null;
     }
 
-    private void startAnimation(final Territory territory) {
+    private void startAnimation(final Territory territory, final int totalFrames) {
       this.territory = territory;
-      overlayEnabled = true;
+      this.totalFrames = totalFrames;
+      frame = 0;
 
       timer.start();
     }
@@ -896,13 +902,16 @@ public class MapPanel extends ImageScrollerLargeView {
     }
 
     private void animateNextFrame() {
-      if (overlayEnabled) {
+      if ((frame % 2) == 0) {
         setTerritoryOverlayForBorder(territory, Color.WHITE);
       } else {
         clearTerritoryOverlay(territory);
       }
       paintImmediately(getBounds());
-      overlayEnabled = !overlayEnabled;
+
+      if (++frame >= totalFrames) {
+        stopAnimation();
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview

I came across this while testing #4187.  Similar to that scenario, the Center Battle action does not change the position of the map when Lock Map is enabled.  Lock Map should prevent automated map position changes, but the Center Battle action is manually triggered by the user, and should be permitted
to change the map position.

## Functional Changes

* The Center Battle action now works the same regardless of the Lock Map setting.

## Refactoring Changes

* Modified the applicable code in `BattlePanel` to reuse the new `highlightTerritory()` and `clearHighlightedTerritory()` methods in `MapPanel`.
* Changed `MapPanel#highlightTerritory()` to support a limited animation duration in addition to the previous indefinite duration (indefinite now being defined as ~34 years :smile:).

## Manual Testing Performed

* Verified the Center Battle command behaves the same when Lock Map is both enabled and disabled.
* Verified clicking Battle in Territory does **not** automatically center the territory when Lock Map is enabled; verified it does automatically center the territory when Lock Map is disabled.
* Verified the territory border animation is stopped prematurely if the user clicks the Battle in Territory button immediately after clicking the Center button.