### PR TITLE
Improve GameSetting API to accommodate unset typed values

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -18,7 +18,7 @@ public final class ArgParser {
    * Move command line arguments to system properties or client settings.
    */
   public static void handleCommandLineArgs(final String... args) {
-    ClientSetting.mapFolderOverride.save(ClientSetting.mapFolderOverride.defaultValue());
+    ClientSetting.mapFolderOverride.resetValue();
 
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {
       handleMapDownloadArg(args[0]);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -249,7 +249,7 @@ public class GameSelectorModel extends Observable {
   }
 
   private static void resetToFactoryDefault() {
-    ClientSetting.defaultGameUri.save(ClientSetting.defaultGameUri.defaultValue());
+    ClientSetting.defaultGameUri.resetValue();
     ClientSetting.flush();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.settings;
 
 final class BooleanClientSetting extends ClientSetting<Boolean> {
   BooleanClientSetting(final String name, final boolean defaultValue) {
-    super(name, defaultValue);
+    super(Boolean.class, name, defaultValue);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.settings;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -9,48 +10,58 @@ import javax.annotation.Nullable;
  * course of the game, either directly or indirectly. For example, default window size may saved here,
  * which could be set from a UI control or it could be based on the last window size used.
  *
- * <p>
- * All settings are typed but have an underlying string representation. Thus, implementations must provide methods for
- * converting a setting value between its typed form and its string form. While clients may use the
- * {@link #stringValue()} and {@link #saveString(String)} methods to load and save a setting value, respectively, one
- * should prefer the typed {@link #value()} and {@link #save(Object)} methods whenever possible to ensure type safety.
- * </p>
- *
  * @param <T> The type of the setting value.
  */
 public interface GameSetting<T> {
   /**
-   * Return true if the setting has been specified by the user or updated from default.
+   * Returns {@code true} if the setting has a value (either user-defined or the default).
    */
   boolean isSet();
 
   /**
-   * Queues a new string value for the setting, may not persist right away.
+   * Sets the current value of the setting using an untyped value.
    *
    * @param newValue The new setting value or {@code null} to clear the setting value. Clearing the setting value will
-   *        result in the default value being returned on future reads of the setting value.
+   *        result in the default value being returned on future reads of the setting value. If no default value is
+   *        defined for the setting, future reads will return an empty result.
+   *
+   * @throws ClassCastException If the type of of {@code newValue} is incompatible with the setting value type.
    */
-  void saveString(@Nullable String newValue);
+  void saveObject(@Nullable Object newValue);
 
   /**
-   * Queues a new typed value for the setting, may not persist right away.
+   * Sets the current value of the setting.
    *
    * @param newValue The new setting value or {@code null} to clear the setting value. Clearing the setting value will
-   *        result in the default value being returned on future reads of the setting value.
+   *        result in the default value being returned on future reads of the setting value. If no default value is
+   *        defined for the setting, future reads will return an empty result.
    */
   void save(@Nullable T newValue);
 
   /**
-   * Returns the current persisted string value of the setting.
+   * Returns the current value of the setting or the default value if the setting has no current value.
+   *
+   * @throws java.util.NoSuchElementException If the setting has no current or default value.
    */
-  String stringValue();
+  default T value() {
+    return getValue().get();
+  }
 
   /**
-   * Returns the current persisted typed value of the setting.
+   * Returns the default value of the setting or empty if the setting has no default value.
    */
-  T value();
+  Optional<T> getDefaultValue();
 
-  void resetAndFlush();
+  /**
+   * Returns the current value of the setting, the default value if the setting has no current value, or empty if the
+   * setting has no current or default value.
+   */
+  Optional<T> getValue();
+
+  /**
+   * Resets the setting to its default value or empty if it has no default value.
+   */
+  void resetValue();
 
   void addSaveListener(Consumer<String> listener);
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/HttpProxyChoiceClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/HttpProxyChoiceClientSetting.java
@@ -4,7 +4,7 @@ import games.strategy.engine.framework.system.HttpProxy;
 
 final class HttpProxyChoiceClientSetting extends ClientSetting<HttpProxy.ProxyChoice> {
   HttpProxyChoiceClientSetting(final String name, final HttpProxy.ProxyChoice defaultValue) {
-    super(name, defaultValue);
+    super(HttpProxy.ProxyChoice.class, name, defaultValue);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
@@ -2,11 +2,11 @@ package games.strategy.triplea.settings;
 
 final class IntegerClientSetting extends ClientSetting<Integer> {
   IntegerClientSetting(final String name) {
-    super(name);
+    super(Integer.class, name);
   }
 
   IntegerClientSetting(final String name, final int defaultValue) {
-    super(name, defaultValue);
+    super(Integer.class, name, defaultValue);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -1,9 +1,11 @@
 package games.strategy.triplea.settings;
 
-import java.util.Map;
+import java.util.Optional;
 
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
+
+import lombok.AllArgsConstructor;
 
 /**
  * Executes a 'save' action.
@@ -13,7 +15,8 @@ import javax.swing.JOptionPane;
  * Side effects: value of each setting is read from UI, validated, and valid values are persisted to system settings
  * </p>
  */
-interface SaveFunction {
+final class SaveFunction {
+  private SaveFunction() {}
 
   /**
    * Returns a result message after persisting settings.
@@ -31,15 +34,14 @@ interface SaveFunction {
         selectionComponent.readValues()
             .entrySet()
             .stream()
-            .filter(entry -> !entry.getKey().stringValue().equals(entry.getValue()))
+            .filter(entry -> !entry.getKey().getValue().equals(Optional.ofNullable(entry.getValue())))
             .forEach(entry -> {
-              entry.getKey().saveString(entry.getValue());
+              entry.getKey().saveObject(entry.getValue());
               successMsg.append(String.format("%s was updated to: %s\n", entry.getKey(), entry.getValue()));
             });
       } else {
-        final Map<GameSetting<?>, String> values = selectionComponent.readValues();
-        values.forEach((key, value) -> failMsg.append(String.format("Could not set %s to %s, %s\n",
-            key, value, selectionComponent.validValueDescription())));
+        selectionComponent.readValues().forEach((key, value) -> failMsg.append(
+            String.format("Could not set %s to %s, %s\n", key, value, selectionComponent.validValueDescription())));
       }
     });
 
@@ -49,7 +51,6 @@ interface SaveFunction {
     }
 
     final String fail = failMsg.toString();
-
 
     if (success.isEmpty() && fail.isEmpty()) {
       return new SaveResult("No changes saved", JOptionPane.WARNING_MESSAGE);
@@ -65,14 +66,9 @@ interface SaveFunction {
     return new SaveResult(success, JOptionPane.INFORMATION_MESSAGE);
   }
 
-
-  class SaveResult {
+  @AllArgsConstructor
+  static final class SaveResult {
     final String message;
     final int dialogType;
-
-    private SaveResult(final String message, final int dialogType) {
-      this.message = message;
-      this.dialogType = dialogType;
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -20,9 +20,10 @@ public interface SelectionComponent<T> {
 
   /**
    * Reads values stored in the UI components, returns a map of preference keys and the value represented in
-   * the corresponding UI component.
+   * the corresponding UI component. A {@code null} value in the map indicates the value should be reset to its default
+   * value.
    */
-  Map<GameSetting<?>, String> readValues();
+  Map<GameSetting<?>, /* @Nullable */ Object> readValues();
 
   void resetToDefault();
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
@@ -4,15 +4,15 @@ import java.io.File;
 
 final class StringClientSetting extends ClientSetting<String> {
   StringClientSetting(final String name) {
-    super(name);
+    super(String.class, name);
   }
 
   StringClientSetting(final String name, final String defaultValue) {
-    super(name, defaultValue);
+    super(String.class, name, defaultValue);
   }
 
   StringClientSetting(final String name, final File defaultValue) {
-    super(name, defaultValue.getAbsolutePath());
+    super(String.class, name, defaultValue.getAbsolutePath());
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -84,7 +84,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
     ArgParser.handleCommandLineArgs();
 
-    assertThat(ClientSetting.mapFolderOverride.value(), is(ClientSetting.mapFolderOverride.defaultValue()));
+    assertThat(ClientSetting.mapFolderOverride.getValue(), is(ClientSetting.mapFolderOverride.getDefaultValue()));
   }
 
   private interface TestData {

--- a/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
@@ -1,0 +1,165 @@
+package games.strategy.triplea.settings;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.NoSuchElementException;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture that verifies implementations of {@link GameSetting} obey the general contract of the interface.
+ */
+public abstract class AbstractGameSettingTestCase {
+  private static final @Nullable Integer NO_VALUE = null;
+  private static final Integer DEFAULT_VALUE = 0;
+  private static final Integer VALUE = 42;
+  private static final Integer OTHER_VALUE = 2112;
+
+  protected AbstractGameSettingTestCase() {}
+
+  /**
+   * Returns a new game setting with the specified current and default values.
+   *
+   * @param value The current value or {@code null} if no current value.
+   * @param defaultValue The default value or {@code null} if no default value.
+   */
+  protected abstract GameSetting<Integer> newGameSetting(@Nullable Integer value, @Nullable Integer defaultValue);
+
+  @Nested
+  final class GetDefaultValueTest {
+    @Test
+    void shouldReturnDefaultValueWhenDefaultValuePresent() {
+      assertThat(newGameSetting(NO_VALUE, DEFAULT_VALUE).getDefaultValue(), isPresentAndIs(DEFAULT_VALUE));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenDefaultValueAbsent() {
+      assertThat(newGameSetting(NO_VALUE, NO_VALUE).getDefaultValue(), isEmpty());
+    }
+  }
+
+  @Nested
+  final class GetValueTest {
+    @Test
+    void shouldReturnValueWhenValuePresentAndDefaultValuePresent() {
+      assertThat(newGameSetting(VALUE, DEFAULT_VALUE).getValue(), isPresentAndIs(VALUE));
+    }
+
+    @Test
+    void shouldReturnValueWhenValuePresentAndDefaultValueAbsent() {
+      assertThat(newGameSetting(VALUE, NO_VALUE).getValue(), isPresentAndIs(VALUE));
+    }
+
+    @Test
+    void shouldReturnDefaultValueWhenValueAbsentAndDefaultValuePresent() {
+      assertThat(newGameSetting(NO_VALUE, DEFAULT_VALUE).getValue(), isPresentAndIs(DEFAULT_VALUE));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenValueAbsentAndDefaultValueAbsent() {
+      assertThat(newGameSetting(NO_VALUE, NO_VALUE).getValue(), isEmpty());
+    }
+  }
+
+  @Nested
+  final class IsSetTest {
+    @Test
+    void shouldReturnTrueWhenValuePresentAndDefaultValuePresent() {
+      assertThat(newGameSetting(VALUE, DEFAULT_VALUE).isSet(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenValuePresentAndDefaultValueAbsent() {
+      assertThat(newGameSetting(VALUE, NO_VALUE).isSet(), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueAbsentAndDefaultValuePresent() {
+      assertThat(newGameSetting(NO_VALUE, DEFAULT_VALUE).isSet(), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueAbsentAndDefaultValueAbsent() {
+      assertThat(newGameSetting(NO_VALUE, NO_VALUE).isSet(), is(false));
+    }
+  }
+
+  @Nested
+  final class ResetValueTest {
+    @Test
+    void shouldSetValueToDefaultValueWhenDefaultValuePresent() {
+      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
+
+      gameSetting.resetValue();
+
+      assertThat(gameSetting.getValue(), isPresentAndIs(DEFAULT_VALUE));
+    }
+
+    @Test
+    void shouldSetValueToEmptyWhenDefaultValueAbsent() {
+      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, NO_VALUE);
+
+      gameSetting.resetValue();
+
+      assertThat(gameSetting.getValue(), isEmpty());
+    }
+  }
+
+  @Nested
+  final class SaveObjectTest {
+    @Test
+    void shouldResetValueWhenValueIsNull() {
+      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
+
+      gameSetting.saveObject(NO_VALUE);
+
+      assertThat(gameSetting.getValue(), isPresentAndIs(DEFAULT_VALUE));
+    }
+
+    @Test
+    void shouldSetValueWhenValueIsNonNullAndHasCorrectType() {
+      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
+
+      gameSetting.saveObject(OTHER_VALUE);
+
+      assertThat(gameSetting.getValue(), isPresentAndIs(OTHER_VALUE));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueIsNonNullAndHasWrongType() {
+      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
+
+      assertThrows(ClassCastException.class, () -> gameSetting.saveObject("2112"));
+    }
+  }
+
+  @Nested
+  final class ValueTest {
+    @Test
+    void shouldReturnValueWhenValuePresentAndDefaultValuePresent() {
+      assertThat(newGameSetting(VALUE, DEFAULT_VALUE).value(), is(VALUE));
+    }
+
+    @Test
+    void shouldReturnValueWhenValuePresentAndDefaultValueAbsent() {
+      assertThat(newGameSetting(VALUE, NO_VALUE).value(), is(VALUE));
+    }
+
+    @Test
+    void shouldReturnDefaultValueWhenValueAbsentAndDefaultValuePresent() {
+      assertThat(newGameSetting(NO_VALUE, DEFAULT_VALUE).value(), is(DEFAULT_VALUE));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueAbsentAndDefaultValueAbsent() {
+      assertThrows(NoSuchElementException.class, () -> newGameSetting(NO_VALUE, NO_VALUE).value());
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
@@ -1,0 +1,46 @@
+package games.strategy.triplea.settings;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+final class ClientSettingAsGameSettingTest extends AbstractGameSettingTestCase {
+  @Override
+  protected GameSetting<Integer> newGameSetting(final @Nullable Integer value, final @Nullable Integer defaultValue) {
+    final TestClientSetting clientSetting = new TestClientSetting(defaultValue);
+    if (value != null) {
+      clientSetting.save(value);
+    }
+    return clientSetting;
+  }
+
+  @BeforeEach
+  @SuppressWarnings("static-method")
+  void initializeClientSettingPreferences() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+  }
+
+  @AfterEach
+  @SuppressWarnings("static-method")
+  void uninitializeClientSettingPreferences() {
+    ClientSetting.resetPreferences();
+  }
+
+  private static final class TestClientSetting extends ClientSetting<Integer> {
+    TestClientSetting(final @Nullable Integer defaultValue) {
+      super(Integer.class, "name", defaultValue);
+    }
+
+    @Override
+    protected String formatValue(final Integer value) {
+      return value.toString();
+    }
+
+    @Override
+    protected Integer parseValue(final String encodedValue) {
+      return Integer.valueOf(encodedValue);
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.settings;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -27,16 +28,11 @@ final class ClientSettingTest {
   }
 
   @Nested
-  final class ValueTest extends AbstractClientSettingTestCase {
+  final class GetValueTest extends AbstractClientSettingTestCase {
     @Test
     void shouldReturnDefaultValueWhenParseValueThrowsException() {
       final String defaultValue = "defaultValue";
-      final ClientSetting<String> clientSetting = new ClientSetting<String>("name", defaultValue) {
-        @Override
-        protected String formatValue(final String value) {
-          return value;
-        }
-
+      final ClientSetting<String> clientSetting = new FakeClientSetting("name", defaultValue) {
         @Override
         protected String parseValue(final String encodedValue) {
           if (defaultValue.equals(encodedValue)) {
@@ -48,7 +44,7 @@ final class ClientSettingTest {
       };
       clientSetting.save("otherValue");
 
-      assertThat(clientSetting.value(), is(defaultValue));
+      assertThat(clientSetting.getValue(), isPresentAndIs(defaultValue));
     }
   }
 
@@ -59,7 +55,7 @@ final class ClientSettingTest {
 
     @Mock
     private Consumer<String> mockSaveListener;
-    private final ClientSetting<String> clientSetting = new StringClientSetting("TEST_SETTING");
+    private final ClientSetting<String> clientSetting = new FakeClientSetting("TEST_SETTING");
 
     @Test
     void saveActionListenerIsCalled() {
@@ -80,6 +76,37 @@ final class ClientSettingTest {
 
       Mockito.verify(mockSaveListener, Mockito.never())
           .accept(TEST_VALUE);
+    }
+  }
+
+  @Nested
+  final class ToStringTest {
+    @Test
+    void shouldReturnName() {
+      final String name = "name";
+      final ClientSetting<String> clientSetting = new FakeClientSetting(name);
+
+      assertThat(clientSetting.toString(), is(name));
+    }
+  }
+
+  private static class FakeClientSetting extends ClientSetting<String> {
+    FakeClientSetting(final String name) {
+      super(String.class, name);
+    }
+
+    FakeClientSetting(final String name, final String defaultValue) {
+      super(String.class, name, defaultValue);
+    }
+
+    @Override
+    protected String formatValue(final String value) {
+      return value;
+    }
+
+    @Override
+    protected String parseValue(final String encodedValue) {
+      return encodedValue;
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.Is.is;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.swing.JComponent;
@@ -47,7 +48,7 @@ public class SaveFunctionTest {
     Mockito.when(mockSelectionComponent.isValid()).thenReturn(first);
     Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
     if (first) {
-      Mockito.when(mockSetting.stringValue()).thenReturn("");
+      Mockito.when(mockSetting.getValue()).thenReturn(Optional.empty());
     }
     Mockito.when(mockSelectionComponent2.isValid()).thenReturn(second);
     Mockito.when(mockSelectionComponent2.readValues()).thenReturn(ImmutableMap.of(mockSetting, "abc"));
@@ -82,7 +83,7 @@ public class SaveFunctionTest {
 
     Mockito.when(mockSelectionComponent.isValid()).thenReturn(true);
     Mockito.when(mockSelectionComponent.readValues()).thenReturn(ImmutableMap.of(mockSetting, TestData.fakeValue));
-    Mockito.when(mockSetting.stringValue()).thenReturn("");
+    Mockito.when(mockSetting.getValue()).thenReturn(Optional.empty());
 
     Mockito.when(mockSelectionComponent2.isValid()).thenReturn(false);
 
@@ -94,7 +95,7 @@ public class SaveFunctionTest {
         + "which should only happen when settings were successfully saved.",
         callCount.get(), is(1));
 
-    Mockito.verify(mockSetting, Mockito.times(1)).saveString(TestData.fakeValue);
+    Mockito.verify(mockSetting).saveObject(TestData.fakeValue);
   }
 
   @Test

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -121,7 +121,7 @@ class SettingsPane extends StackPane {
         .map(SelectionComponent::readValues)
         .map(Map::entrySet)
         .flatMap(Collection::stream)
-        .forEach(entry -> entry.getKey().saveString(entry.getValue()));
+        .forEach(entry -> entry.getKey().saveObject(entry.getValue()));
     // TODO visual feedback
   }
 


### PR DESCRIPTION
## Overview

When the game setting framework only supported string values, unset values were represented as an empty string.  This representation broke down when non-string values were introduced because an empty string is not always a valid encoded form for every type (e.g. `Integer#parseInt()` will throw an exception when passed an empty string).

The primary purpose of this PR is to change the `GameSetting` API to accommodate such unset typed values.  This was done by introducing accessors that return `Optional<T>` so it's clear to the caller if a value (user-defined or default) is present or not.

The secondary purpose of this PR is to remove all knowledge about string values from the `GameSetting` API--this is now an implementation detail of `ClientSetting`.  I found that the `SelectionComponent` implementations were duplicating the format/parse logic of the `ClientSetting` subclasses.  In order to remove that knowledge from the selection components, I changed the return type of `SelectionComponent#readValues()` from `Map<GameSetting<?>, String>` to `Map<GameSetting<?>, @Nullable Object>`.  This allows the selection components to pass the same kind of typed objects they receive from the `GameSetting` accessors.  A `null` `Object` reference now has the same effect as an empty string value did previously: it clears the user-defined value and restores the default (if present).

## Functional Changes

* Fixed a bug in the JFX selection component `FileSelector` class.  A folder must be passed to `FileChooser#setInitialDirectory()`, whereas the code was passing a file.
* Fixed an issue in the Swing and JFX proxy setting selection components.  When resetting the values, the host/port text fields were cleared, but the underlying settings were not being saved.  So, while the user had the impression those values had been reset to the defaults, they would still be present in the preference store.

## Refactoring Changes

* Added methods to `GameSetting` to get the current and default values.  Both methods return `Optional<T>`.
* Renamed `GameSetting#resetAndFlush()` to `resetValue()`.  "Flushing" is an implementation concern of the `ClientSetting` class.
* Changed the `ClientSetting#resetValue()` implementation to clear the user-defined value rather than setting it to the default value.  There's a subtle difference between the two operations that would have become apparent in future PRs.
* Replaced calls of the form `clientSetting.save(clientSetting.defaultValue())` with `clientSetting.resetValue()`, as that makes the intention clearer.
* Changed `SaveFunction` from an interface to a class.  It seemed to be just a utility class; it is never implemented anywhere.
* Changed the return type of `SelectionComponent#readValues()` from `Map<GameSetting<?>, String>` to `Map<GameSetting<?>, @Nullable Object>` to hide the implementation detail that values are converted to-and-from strings.

## Manual Testing Performed

Pretty thoroughly tested both the Swing and JFX settings windows.  I didn't test every setting, but I ensured I tested at least one setting of each of the following types:

* Boolean
* Integer (with a default value)
* Integer (without a default value)
* String (without a default value)
* File
* Folder
* Proxy settings
* Combo box (Swing only; UI theme)

## Additional Review Notes

* There will probably be some follow-up PRs where I introduce helper methods for common `GameSetting` accessor patterns you'll see when reviewing this PR (e.g. `clientSetting.getValue().orElse("")`).