### PR TITLE
Remove deprecated IsInfantry methods

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1110,32 +1110,12 @@ public class UnitAttachment extends DefaultAttachment {
     m_isMarine = 0;
   }
 
-  @Deprecated
-  private void setIsInfantry(final String s) {
-    m_isInfantry = getBool(s);
-  }
-
-  @Deprecated
-  private void setIsInfantry(final Boolean s) {
-    m_isInfantry = s;
-  }
-
-  @Deprecated
-  public boolean getIsInfantry() {
-    return m_isInfantry;
-  }
-
-  @Deprecated
-  private void resetIsInfantry() {
-    m_isInfantry = false;
-  }
-
   private void setIsLandTransportable(final String s) {
-    m_isLandTransportable = getBool(s);
+    m_isLandTransportable = m_isInfantry = getBool(s);
   }
 
   private void setIsLandTransportable(final Boolean s) {
-    m_isLandTransportable = s;
+    m_isLandTransportable = m_isInfantry = s;
   }
 
   public boolean getIsLandTransportable() {
@@ -1143,7 +1123,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void resetIsLandTransportable() {
-    m_isLandTransportable = false;
+    m_isLandTransportable = m_isInfantry = false;
   }
 
   private void setIsLandTransport(final String s) {
@@ -2956,7 +2936,7 @@ public class UnitAttachment extends DefaultAttachment {
       tuples.add(Tuple.of("Is Kamikaze", "Can use all Movement to Attack Target"));
     }
 
-    if ((getIsInfantry() || getIsLandTransportable()) && playerHasMechInf(player)) {
+    if (getIsLandTransportable() && playerHasMechInf(player)) {
       tuples.add(Tuple.of("Can be Land Transported", ""));
     }
     if (getIsLandTransport() && playerHasMechInf(player)) {
@@ -3401,12 +3381,12 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsAirTransportable,
                 this::getIsAirTransportable,
                 this::resetIsAirTransportable))
-        .put("isInfantry",
+        .put("isInfantry", // kept for map compatibility; remove upon next map-incompatible release
             MutableProperty.of(
-                this::setIsInfantry,
-                this::setIsInfantry,
-                this::getIsInfantry,
-                this::resetIsInfantry))
+                this::setIsLandTransportable,
+                this::setIsLandTransportable,
+                this::getIsLandTransportable,
+                this::resetIsLandTransportable))
         .put("isLandTransport",
             MutableProperty.of(
                 this::setIsLandTransport,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -112,8 +112,6 @@ public class UnitAttachment extends DefaultAttachment {
   private int m_carrierCost = -1;
   private boolean m_isAirTransport = false;
   private boolean m_isAirTransportable = false;
-  // isInfantry is DEPRECATED, use isLandTransportable
-  private boolean m_isInfantry = false;
   private boolean m_isLandTransport = false;
   private boolean m_isLandTransportable = false;
   // aa related
@@ -1111,11 +1109,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void setIsLandTransportable(final String s) {
-    m_isLandTransportable = m_isInfantry = getBool(s);
+    m_isLandTransportable = getBool(s);
   }
 
   private void setIsLandTransportable(final Boolean s) {
-    m_isLandTransportable = m_isInfantry = s;
+    m_isLandTransportable = s;
   }
 
   public boolean getIsLandTransportable() {
@@ -1123,7 +1121,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void resetIsLandTransportable() {
-    m_isLandTransportable = m_isInfantry = false;
+    m_isLandTransportable = false;
   }
 
   private void setIsLandTransport(final String s) {
@@ -2439,13 +2437,13 @@ public class UnitAttachment extends DefaultAttachment {
   public void validate(final GameData data) throws GameParseException {
     if (m_isAir) {
       if (m_isSea /* || m_isFactory */ || m_isSub || m_transportCost != -1 || m_carrierCapacity != -1 || m_canBlitz
-          || m_canBombard || m_isMarine != 0 || m_isInfantry || m_isLandTransportable || m_isLandTransport
+          || m_canBombard || m_isMarine != 0 || m_isLandTransportable || m_isLandTransport
           || m_isAirTransportable || m_isCombatTransport) {
         throw new GameParseException("air units cannot have certain properties, " + thisErrorMsg());
       }
     } else if (m_isSea) {
       if (m_canBlitz || m_isAir /* || m_isFactory */ || m_isStrategicBomber || m_carrierCost != -1
-          || m_transportCost != -1 || m_isMarine != 0 || m_isInfantry || m_isLandTransportable || m_isLandTransport
+          || m_transportCost != -1 || m_isMarine != 0 || m_isLandTransportable || m_isLandTransport
           || m_isAirTransportable || m_isAirTransport || m_isKamikaze) {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
       }
@@ -2621,7 +2619,6 @@ public class UnitAttachment extends DefaultAttachment {
         + "  defenseRolls:" + m_defenseRolls
         + "  chooseBestRoll:" + m_chooseBestRoll
         + "  isMarine:" + m_isMarine
-        + "  isInfantry:" + m_isInfantry
         + "  isLandTransportable:" + m_isLandTransportable
         + "  isLandTransport:" + m_isLandTransport
         + "  isAirTransportable:" + m_isAirTransportable

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -705,10 +705,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsLandTransportable() {
-    return obj -> {
-      final UnitAttachment ua = UnitAttachment.get(obj.getType());
-      return ua.getIsLandTransportable() || ua.getIsInfantry();
-    };
+    return unit -> UnitAttachment.get(unit.getType()).getIsLandTransportable();
   }
 
   public static Predicate<Unit> unitIsNotLandTransportable() {


### PR DESCRIPTION
## Overview

`UnitAttachment#m_isInfantry` and its associated property methods were deprecated in #2673.  Handling the `isInfantry` map property must be retained in order to preserve compatibility with older maps that haven't been updated to use `isLandTransportable`.  However, the `isInfantry` property methods can be removed as long as the `isInfantry` map property is redirected to the `isLandTransportable` property and `m_isInfantry` is modified appropriately in the `isLandTransportable` property methods.

(NB: The exact approach taken in this PR wasn't possible at the time #2673 was submitted due to the use of reflection when initializing attachments.  However, thanks to #3042, redirecting one property to another is now incredibly simple.)

## Functional Changes

None.

## Manual Testing Performed

None, but several unit tests fail if the `isInfantry` map property is not handled properly (I observed the failures by commenting out the bodies of the `setIsInfantry()` and `resetIsInfantry()` methods).  The fact that they continue to pass after `isInfantry` is redirected to `isLandTransportable` should provide sufficient confidence.

## Additional Review Notes

I think this PR can be taken one step further.  Since we have decided to break save game and network compatibility, I think the `m_isInfantry` field can be completely removed.  As long as we redirect the `isInfantry` map property to the `isLandTransportable` handlers, we should be good.  @ron-murhammer, would appreciate your opinion on that assertion.