### PR TITLE
Extract MockDelegateBridge class

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -170,7 +170,7 @@ public abstract class AbstractDelegateTestCase {
     assertNotNull(string, string);
   }
 
-  protected final IDelegateBridge getDelegateBridge(final PlayerID player) {
+  protected final IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -170,7 +170,7 @@ public abstract class AbstractDelegateTestCase {
     assertNotNull(string, string);
   }
 
-  protected IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+  protected final IDelegateBridge getDelegateBridge(final PlayerID player) {
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -34,7 +34,7 @@ public class AirThatCantLandUtilTest {
     fighterType = GameDataTestUtil.fighter(gameData);
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -54,7 +54,7 @@ public class AirThatCantLandUtilTest {
   public void testSimple() {
     final PlayerID player = americansPlayer;
     // everything can land
-    final IDelegateBridge bridge = getDelegateBridge(player);
+    final IDelegateBridge bridge = newDelegateBridge(player);
     final AirThatCantLandUtil util = new AirThatCantLandUtil(bridge);
     assertTrue(util.getTerritoriesWhereAirCantLand(player).isEmpty());
   }
@@ -62,7 +62,7 @@ public class AirThatCantLandUtilTest {
   @Test
   public void testCantLandEnemyTerritory() {
     final PlayerID player = americansPlayer;
-    final IDelegateBridge bridge = getDelegateBridge(player);
+    final IDelegateBridge bridge = newDelegateBridge(player);
     final Territory balkans = gameData.getMap().getTerritory("Balkans");
     final Change addAir = ChangeFactory.addUnits(balkans, fighterType.create(2, player));
     gameData.performChange(addAir);
@@ -78,7 +78,7 @@ public class AirThatCantLandUtilTest {
   @Test
   public void testCantLandWater() {
     final PlayerID player = americansPlayer;
-    final IDelegateBridge bridge = getDelegateBridge(player);
+    final IDelegateBridge bridge = newDelegateBridge(player);
     final Territory sz55 = gameData.getMap().getTerritory("55 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz55, fighterType.create(2, player));
     gameData.performChange(addAir);
@@ -93,7 +93,7 @@ public class AirThatCantLandUtilTest {
   @Test
   public void testSpareNextToFactory() {
     final PlayerID player = americansPlayer;
-    final IDelegateBridge bridge = getDelegateBridge(player);
+    final IDelegateBridge bridge = newDelegateBridge(player);
     final Territory sz55 = gameData.getMap().getTerritory("55 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz55, fighterType.create(2, player));
     gameData.performChange(addAir);
@@ -106,7 +106,7 @@ public class AirThatCantLandUtilTest {
   public void testCantLandCarrier() {
     // 1 carrier in the region, but three fighters, make sure we cant land
     final PlayerID player = americansPlayer;
-    final IDelegateBridge bridge = getDelegateBridge(player);
+    final IDelegateBridge bridge = newDelegateBridge(player);
     final Territory sz52 = gameData.getMap().getTerritory("52 Sea Zone");
     final Change addAir = ChangeFactory.addUnits(sz52, fighterType.create(2, player));
     gameData.performChange(addAir);
@@ -123,7 +123,7 @@ public class AirThatCantLandUtilTest {
   public void testCanLandNeighborCarrier() {
     final PlayerID japanese = GameDataTestUtil.japanese(gameData);
     final PlayerID americans = GameDataTestUtil.americans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
@@ -172,7 +172,7 @@ public class AirThatCantLandUtilTest {
   public void testCanLandMultiNeighborCarriers() {
     final PlayerID japanese = GameDataTestUtil.japanese(gameData);
     final PlayerID americans = GameDataTestUtil.americans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
@@ -224,7 +224,7 @@ public class AirThatCantLandUtilTest {
   public void testCanLandNeighborLandV2() {
     final PlayerID japanese = GameDataTestUtil.japanese(gameData);
     final PlayerID americans = GameDataTestUtil.americans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
@@ -269,7 +269,7 @@ public class AirThatCantLandUtilTest {
   public void testCanLandNeighborLandWithRetreatedBattleV2() {
     final PlayerID japanese = GameDataTestUtil.japanese(gameData);
     final PlayerID americans = GameDataTestUtil.americans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     // Get necessary sea zones and unit types for this test
     final Territory sz9 = gameData.getMap().getTerritory("9 Sea Zone");
     final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -1,8 +1,8 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,7 +35,7 @@ public class AirThatCantLandUtilTest {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   private static String fight(final BattleDelegate battle, final Territory territory, final boolean bombing) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -4,14 +4,13 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
 import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
-import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge;
 import static games.strategy.triplea.delegate.GameDataTestUtil.makeGameLowLuck;
 import static games.strategy.triplea.delegate.GameDataTestUtil.setSelectAaCasualties;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.thenGetRandomShouldHaveBeenCalled;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withRemotePlayer;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withRemotePlayer;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -66,7 +65,7 @@ public class BattleCalculatorTest {
   @BeforeEach
   public void setUp() throws Exception {
     final GameData data = TestMapGameData.REVISED.getGameData();
-    bridge = getDelegateBridge(british(data), data);
+    bridge = MockDelegateBridge.newInstance(data, british(data));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -1,11 +1,10 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.assertError;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
-import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ public class BigWorldTest {
     final Territory sz28 = territory("SZ 28 Eastern Mediterranean", gameData);
     final Territory sz27 = territory("SZ 27 Aegean Sea", gameData);
     final Territory sz29 = territory("SZ 29 Black Sea", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData), gameData);
+    final IDelegateBridge bridge = MockDelegateBridge.newInstance(gameData, british(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -2,9 +2,9 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
-import static games.strategy.triplea.delegate.GameDataTestUtil.thenGetRandomShouldHaveBeenCalled;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -42,7 +42,7 @@ public class DiceRollTest {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -41,7 +41,7 @@ public class DiceRollTest {
     gameData = TestMapGameData.LHTR.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -50,7 +50,7 @@ public class DiceRollTest {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final IBattle battle = mock(IBattle.class);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> infantry = infantryType.create(1, russians);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(westRussia);
@@ -79,7 +79,7 @@ public class DiceRollTest {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final IBattle battle = mock(IBattle.class);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> infantry = infantryType.create(1, russians);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(westRussia);
@@ -107,7 +107,7 @@ public class DiceRollTest {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final IBattle battle = mock(IBattle.class);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> units = infantryType.create(1, russians);
     final UnitType artillery = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_ARTILLERY);
@@ -124,7 +124,7 @@ public class DiceRollTest {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final IBattle battle = mock(IBattle.class);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     // Add 1 artillery
     final UnitType artillery = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_ARTILLERY);
     final List<Unit> units = artillery.create(1, russians);
@@ -149,7 +149,7 @@ public class DiceRollTest {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final IBattle battle = mock(IBattle.class);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> units = infantryType.create(3, russians);
     // 3 infantry on defense should produce exactly one hit, without rolling the dice
@@ -166,7 +166,7 @@ public class DiceRollTest {
     final PlayerID americans = GameDataTestUtil.americans(gameData);
     final UnitType marine = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
     final List<Unit> attackers = marine.create(1, americans);
-    final IDelegateBridge bridge = getDelegateBridge(americans);
+    final IDelegateBridge bridge = newDelegateBridge(americans);
     whenGetRandom(bridge).thenAnswer(withValues(1));
     final IBattle battle = mock(IBattle.class);
     when(battle.getAmphibiousLandAttackers()).thenReturn(attackers);
@@ -184,7 +184,7 @@ public class DiceRollTest {
     final PlayerID americans = GameDataTestUtil.americans(gameData);
     final UnitType marine = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
     final List<Unit> attackers = marine.create(3, americans);
-    final IDelegateBridge bridge = getDelegateBridge(americans);
+    final IDelegateBridge bridge = newDelegateBridge(americans);
     final IBattle battle = mock(IBattle.class);
     when(battle.getAmphibiousLandAttackers()).thenReturn(attackers);
     when(battle.isAmphibious()).thenReturn(true);
@@ -201,7 +201,7 @@ public class DiceRollTest {
     final PlayerID americans = GameDataTestUtil.americans(gameData);
     final UnitType marine = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
     final List<Unit> attackers = marine.create(1, americans);
-    final IDelegateBridge bridge = getDelegateBridge(americans);
+    final IDelegateBridge bridge = newDelegateBridge(americans);
     whenGetRandom(bridge).thenAnswer(withValues(1));
     final IBattle battle = mock(IBattle.class);
     when(battle.getAmphibiousLandAttackers()).thenReturn(Collections.emptyList());
@@ -219,7 +219,7 @@ public class DiceRollTest {
     final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
     final List<Unit> aaGunList = aaGunType.create(1, germans);
     GameDataTestUtil.addTo(westRussia, aaGunList);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     final List<Unit> bombers = bomber(gameData).create(1, british(gameData));
     whenGetRandom(bridge)
         .thenAnswer(withValues(0)) // aa hits at 0 (0 based)
@@ -244,7 +244,7 @@ public class DiceRollTest {
     GameDataTestUtil.addTo(westRussia, aaGunList);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     List<Unit> fighterList = fighterType.create(1, russians);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     whenGetRandom(bridge)
         .thenAnswer(withValues(0)) // aa hits at 0 (0 based)
         .thenAnswer(withValues(1)); // aa misses at 1 (0 based)
@@ -279,7 +279,7 @@ public class DiceRollTest {
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     final List<Unit> fighterList = fighterType.create(6, russians);
     TripleAUnit.get(fighterList.get(0)).setAlreadyMoved(1);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     // aa hits at 0 (0 based)
     final DiceRoll hit = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
@@ -301,7 +301,7 @@ public class DiceRollTest {
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     List<Unit> fighterList = fighterType.create(1, russians);
     TechAttachment.get(germans).setAaRadar("true");
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     whenGetRandom(bridge)
         .thenAnswer(withValues(1)) // aa radar hits at 1 (0 based)
         .thenAnswer(withValues(2)); // aa misses at 2 (0 based)
@@ -328,7 +328,7 @@ public class DiceRollTest {
   public void testHeavyBombers() throws Exception {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
@@ -345,7 +345,7 @@ public class DiceRollTest {
   public void testHeavyBombersDefend() throws Exception {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
@@ -362,7 +362,7 @@ public class DiceRollTest {
   public void testLhtrBomberDefend() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     final List<Unit> bombers =
         gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0));
@@ -378,7 +378,7 @@ public class DiceRollTest {
   public void testHeavyBombersLhtr() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
@@ -397,7 +397,7 @@ public class DiceRollTest {
   public void testHeavyBombersLhtr2() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
@@ -415,7 +415,7 @@ public class DiceRollTest {
   public void testHeavyBombersDefendLhtr() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
@@ -441,7 +441,7 @@ public class DiceRollTest {
     assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(1));
     assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(1));
     // hb, for revised 2 on attack, 1 on defence
-    final IDelegateBridge testDelegateBridge = getDelegateBridge(british);
+    final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // lhtr hb, 2 for both

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -1,27 +1,13 @@
 package games.strategy.triplea.delegate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
-import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.OngoingStubbing;
-import org.mockito.verification.VerificationMode;
 
-import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -32,20 +18,8 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.IEditableProperty;
-import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.engine.history.DelegateHistoryWriter;
-import games.strategy.engine.history.History;
-import games.strategy.engine.history.HistoryWriter;
-import games.strategy.engine.history.IDelegateHistoryWriter;
-import games.strategy.engine.message.ChannelMessenger;
-import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
-import games.strategy.net.IServerMessenger;
-import games.strategy.net.Node;
-import games.strategy.sound.ISound;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
-import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.util.IntegerMap;
 import junit.framework.AssertionFailedError;
 
@@ -411,83 +385,6 @@ public final class GameDataTestUtil {
    */
   static BidPlaceDelegate bidPlaceDelegate(final GameData data) {
     return (BidPlaceDelegate) data.getDelegateList().getDelegate("placeBid");
-  }
-
-  /**
-   * Returns a delegate bridge suitable for testing the given player and game data.
-   *
-   * @return A mock that can be configured using standard Mockito idioms.
-   */
-  static IDelegateBridge getDelegateBridge(final PlayerID playerId, final GameData gameData) {
-    final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
-    doAnswer(invocation -> {
-      final Change change = invocation.getArgument(0);
-      gameData.performChange(change);
-      return null;
-    }).when(delegateBridge).addChange(any());
-    when(delegateBridge.getData()).thenReturn(gameData);
-    when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(mock(ITripleADisplay.class));
-    final IDelegateHistoryWriter delegateHistoryWriter = newFakeDelegateHistoryWriter(gameData);
-    when(delegateBridge.getHistoryWriter()).thenReturn(delegateHistoryWriter);
-    when(delegateBridge.getPlayerId()).thenReturn(playerId);
-    final ITripleAPlayer remotePlayer = mock(ITripleAPlayer.class);
-    when(delegateBridge.getRemotePlayer()).thenReturn(remotePlayer);
-    when(delegateBridge.getRemotePlayer(any())).thenReturn(remotePlayer);
-    when(delegateBridge.getSoundChannelBroadcaster()).thenReturn(mock(ISound.class));
-    return delegateBridge;
-  }
-
-  private static IDelegateHistoryWriter newFakeDelegateHistoryWriter(final GameData gameData) {
-    final HistoryWriter historyWriter = new HistoryWriter(new History(gameData));
-    historyWriter.startNextStep("", "", PlayerID.NULL_PLAYERID, "");
-    final IServerMessenger serverMessenger = mock(IServerMessenger.class);
-    try {
-      when(serverMessenger.getLocalNode()).thenReturn(new Node("dummy", InetAddress.getLocalHost(), 0));
-    } catch (final UnknownHostException e) {
-      throw new IllegalStateException("test cannot run without network interface", e);
-    }
-    when(serverMessenger.isServer()).thenReturn(true);
-    return new DelegateHistoryWriter(new ChannelMessenger(new UnifiedMessenger(serverMessenger)));
-  }
-
-  static OngoingStubbing<int[]> whenGetRandom(final IDelegateBridge delegateBridge) {
-    return when(delegateBridge.getRandom(anyInt(), anyInt(), any(), any(), anyString()));
-  }
-
-  static Answer<int[]> withValues(final int... values) {
-    return invocation -> {
-      final int count = invocation.getArgument(1);
-      assertEquals(values.length, count, "count of requested random values does not match");
-      return values;
-    };
-  }
-
-  static void thenGetRandomShouldHaveBeenCalled(
-      final IDelegateBridge delegateBridge,
-      final VerificationMode verificationMode) {
-    verify(delegateBridge, verificationMode).getRandom(anyInt(), anyInt(), any(), any(), anyString());
-  }
-
-  static ITripleAPlayer withRemotePlayer(final IDelegateBridge delegateBridge) {
-    return (ITripleAPlayer) delegateBridge.getRemotePlayer();
-  }
-
-  static void advanceToStep(final IDelegateBridge delegateBridge, final String stepName) {
-    final GameData gameData = delegateBridge.getData();
-    gameData.acquireWriteLock();
-    try {
-      final int length = gameData.getSequence().size();
-      int i = 0;
-      while ((i < length) && (gameData.getSequence().getStep().getName().indexOf(stepName) == -1)) {
-        gameData.getSequence().next();
-        i++;
-      }
-      if ((i > length) && (gameData.getSequence().getStep().getName().indexOf(stepName) == -1)) {
-        throw new IllegalArgumentException("Step not found: " + stepName);
-      }
-    } finally {
-      gameData.releaseWriteLock();
-    }
   }
 
   static void load(final Collection<Unit> units, final Route route) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -1,10 +1,10 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withRemotePlayer;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withRemotePlayer;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,7 +47,7 @@ public class LhtrTest {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -46,7 +46,7 @@ public class LhtrTest {
     gameData = TestMapGameData.LHTR.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -55,7 +55,7 @@ public class LhtrTest {
     final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
@@ -83,7 +83,7 @@ public class LhtrTest {
     final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
@@ -107,7 +107,7 @@ public class LhtrTest {
     final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
@@ -130,7 +130,7 @@ public class LhtrTest {
     // before the advance, subs defend and attack at 2
     assertEquals(2, attachment.getDefense(japanese));
     assertEquals(2, attachment.getAttack(japanese));
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     TechTracker.addAdvance(japanese, bridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_SUPER_SUBS, gameData, japanese));
     // after tech advance, this is now 3
@@ -154,7 +154,7 @@ public class LhtrTest {
         uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
     addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // aa guns rolls 3, misses, bomber rolls 2 dice at 3 and 4
@@ -185,7 +185,7 @@ public class LhtrTest {
         uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
     addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // aa guns rolls 3,3 both miss, bomber 1 rolls 2 dice at 3,4 and bomber 2 rolls dice at 1,2

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
@@ -1,0 +1,114 @@
+package games.strategy.triplea.delegate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.OngoingStubbing;
+import org.mockito.verification.VerificationMode;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.history.DelegateHistoryWriter;
+import games.strategy.engine.history.History;
+import games.strategy.engine.history.HistoryWriter;
+import games.strategy.engine.history.IDelegateHistoryWriter;
+import games.strategy.engine.message.ChannelMessenger;
+import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
+import games.strategy.net.IServerMessenger;
+import games.strategy.net.Node;
+import games.strategy.sound.ISound;
+import games.strategy.triplea.player.ITripleAPlayer;
+import games.strategy.triplea.ui.display.ITripleADisplay;
+
+final class MockDelegateBridge {
+  private MockDelegateBridge() {}
+
+  /**
+   * Returns a new delegate bridge suitable for testing the given game data and player.
+   *
+   * @return A mock that can be configured using standard Mockito idioms.
+   */
+  static IDelegateBridge newInstance(final GameData gameData, final PlayerID playerId) {
+    final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
+    doAnswer(invocation -> {
+      final Change change = invocation.getArgument(0);
+      gameData.performChange(change);
+      return null;
+    }).when(delegateBridge).addChange(any());
+    when(delegateBridge.getData()).thenReturn(gameData);
+    when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(mock(ITripleADisplay.class));
+    final IDelegateHistoryWriter delegateHistoryWriter = newFakeDelegateHistoryWriter(gameData);
+    when(delegateBridge.getHistoryWriter()).thenReturn(delegateHistoryWriter);
+    when(delegateBridge.getPlayerId()).thenReturn(playerId);
+    final ITripleAPlayer remotePlayer = mock(ITripleAPlayer.class);
+    when(delegateBridge.getRemotePlayer()).thenReturn(remotePlayer);
+    when(delegateBridge.getRemotePlayer(any())).thenReturn(remotePlayer);
+    when(delegateBridge.getSoundChannelBroadcaster()).thenReturn(mock(ISound.class));
+    return delegateBridge;
+  }
+
+  private static IDelegateHistoryWriter newFakeDelegateHistoryWriter(final GameData gameData) {
+    final HistoryWriter historyWriter = new HistoryWriter(new History(gameData));
+    historyWriter.startNextStep("", "", PlayerID.NULL_PLAYERID, "");
+    final IServerMessenger serverMessenger = mock(IServerMessenger.class);
+    try {
+      when(serverMessenger.getLocalNode()).thenReturn(new Node("dummy", InetAddress.getLocalHost(), 0));
+    } catch (final UnknownHostException e) {
+      throw new IllegalStateException("test cannot run without network interface", e);
+    }
+    when(serverMessenger.isServer()).thenReturn(true);
+    return new DelegateHistoryWriter(new ChannelMessenger(new UnifiedMessenger(serverMessenger)));
+  }
+
+  static OngoingStubbing<int[]> whenGetRandom(final IDelegateBridge delegateBridge) {
+    return when(delegateBridge.getRandom(anyInt(), anyInt(), any(), any(), anyString()));
+  }
+
+  static Answer<int[]> withValues(final int... values) {
+    return invocation -> {
+      final int count = invocation.getArgument(1);
+      assertEquals(values.length, count, "count of requested random values does not match");
+      return values;
+    };
+  }
+
+  static void thenGetRandomShouldHaveBeenCalled(
+      final IDelegateBridge delegateBridge,
+      final VerificationMode verificationMode) {
+    verify(delegateBridge, verificationMode).getRandom(anyInt(), anyInt(), any(), any(), anyString());
+  }
+
+  static ITripleAPlayer withRemotePlayer(final IDelegateBridge delegateBridge) {
+    return (ITripleAPlayer) delegateBridge.getRemotePlayer();
+  }
+
+  static void advanceToStep(final IDelegateBridge delegateBridge, final String stepName) {
+    final GameData gameData = delegateBridge.getData();
+    gameData.acquireWriteLock();
+    try {
+      final int length = gameData.getSequence().size();
+      int i = 0;
+      while ((i < length) && (gameData.getSequence().getStep().getName().indexOf(stepName) == -1)) {
+        gameData.getSequence().next();
+        i++;
+      }
+      if ((i > length) && (gameData.getSequence().getStep().getName().indexOf(stepName) == -1)) {
+        throw new IllegalArgumentException("Step not found: " + stepName);
+      }
+    } finally {
+      gameData.releaseWriteLock();
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -1,9 +1,9 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -35,7 +35,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @BeforeEach
   public void setupMoveDelegate() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
@@ -494,7 +494,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testTransportCantLoadUnloadAfterBattle() {
-    bridge = super.getDelegateBridge(russians);
+    bridge = newDelegateBridge(russians);
     advanceToStep(bridge, "russianCombatMove");
     westEurope.setOwner(russians);
     // Attacking force
@@ -519,7 +519,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testLoadUnloadLoadMoveTransports() {
-    bridge = super.getDelegateBridge(japanese);
+    bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "japaneseCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
@@ -939,7 +939,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testReloadTransportAfterRetreatAmphibious() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
@@ -1001,7 +1001,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testReloadTransportAfterDyingAmphibious() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
@@ -1063,7 +1063,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testReloadTransportAfterRetreatAllied() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
@@ -1119,7 +1119,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testReloadTransportAfterDyingAllied() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
@@ -1239,7 +1239,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
 
   @Test
   public void testAaCantMoveToConquered() {
-    bridge = super.getDelegateBridge(japanese);
+    bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "japaneseCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -1,13 +1,13 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.move;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.thenGetRandomShouldHaveBeenCalled;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 
@@ -32,7 +32,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     addTo(sz33, GameDataTestUtil.americanCruiser(twwGameData).create(1, usa));
     final Territory sz40 = territory("40 Sea Zone", twwGameData);
     addTo(sz40, GameDataTestUtil.germanMine(twwGameData).create(1, germany));
-    final IDelegateBridge bridge = GameDataTestUtil.getDelegateBridge(usa, twwGameData);
+    final IDelegateBridge bridge = MockDelegateBridge.newInstance(twwGameData, usa);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(twwGameData).start();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -93,7 +93,7 @@ public class PacificTest extends AbstractDelegateTestCase {
     sz24 = gameData.getMap().getTerritory("24 Sea Zone");
     sz25 = gameData.getMap().getTerritory("25 Sea Zone");
     sz27 = gameData.getMap().getTerritory("27 Sea Zone");
-    bridge = getDelegateBridge(americans);
+    bridge = newDelegateBridge(americans);
     advanceToStep(bridge, "japaneseCombatMove");
     delegate = new MoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
@@ -234,7 +234,7 @@ public class PacificTest extends AbstractDelegateTestCase {
 
   @Test
   public void testJapaneseDestroyerTransport() {
-    bridge = getDelegateBridge(japanese);
+    bridge = newDelegateBridge(japanese);
     delegate = new MoveDelegate();
     delegate.initialize("MoveDelegate", "MoveDelegate");
     delegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -1,8 +1,8 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -99,11 +99,6 @@ public class PacificTest extends AbstractDelegateTestCase {
     delegate.initialize("MoveDelegate", "MoveDelegate");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-  }
-
-  @Override
-  protected IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -26,7 +26,7 @@ public class PactOfSteel2Test {
     gameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -40,7 +40,7 @@ public class PactOfSteel2Test {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final PlayerID russians = GameDataTestUtil.russians(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     // this National Objective russia has to own at least 3 of the 5 territories by itself
     final RulesAttachment russianEasternEurope =
         RulesAttachment.get(russians, "objectiveAttachmentRussians1_EasternEurope");

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -27,7 +27,7 @@ public class PactOfSteel2Test {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -30,7 +30,7 @@ public class PlaceDelegateTest extends AbstractDelegateTestCase {
 
   @BeforeEach
   public void setupPlaceDelegate() {
-    bridge = super.getDelegateBridge(british);
+    bridge = newDelegateBridge(british);
     delegate = new PlaceDelegate();
     delegate.initialize("place");
     delegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -10,7 +10,6 @@ import static games.strategy.triplea.delegate.BattleStepStrings.SUBS_FIRE;
 import static games.strategy.triplea.delegate.BattleStepStrings.SUBS_SUBMERGE;
 import static games.strategy.triplea.delegate.GameDataTestUtil.aaGun;
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
 import static games.strategy.triplea.delegate.GameDataTestUtil.assertError;
@@ -34,11 +33,12 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withRemotePlayer;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withRemotePlayer;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -123,7 +123,7 @@ public class RevisedTest {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -122,7 +122,7 @@ public class RevisedTest {
     gameData = TestMapGameData.REVISED.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -132,7 +132,7 @@ public class RevisedTest {
     final Territory sz1 = gameData.getMap().getTerritory("1 Sea Zone");
     final Territory sz11 = gameData.getMap().getTerritory("11 Sea Zone");
     final Territory sz9 = gameData.getMap().getTerritory("9 Sea Zone");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -157,7 +157,7 @@ public class RevisedTest {
     // before the advance, subs defend and attack at 2
     assertEquals(2, attachment.getDefense(japanese));
     assertEquals(2, attachment.getAttack(japanese));
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     TechTracker.addAdvance(japanese, bridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_SUPER_SUBS, gameData, japanese));
     // after tech advance, this is now 3
@@ -175,7 +175,7 @@ public class RevisedTest {
     sub.setSubmerged(true);
     // now move to attack it
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -193,7 +193,7 @@ public class RevisedTest {
   public void testRetreatBug() {
     final PlayerID russians = GameDataTestUtil.russians(gameData);
     final PlayerID americans = GameDataTestUtil.americans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(russians);
+    final IDelegateBridge bridge = newDelegateBridge(russians);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
@@ -246,7 +246,7 @@ public class RevisedTest {
   public void testContinuedBattles() {
     final PlayerID russians = GameDataTestUtil.russians(gameData);
     final PlayerID germans = germans(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -292,7 +292,7 @@ public class RevisedTest {
     final PlayerID british = british(gameData);
     final PlayerID americans = americans(gameData);
     final Territory uk = territory("United Kingdom", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -308,7 +308,7 @@ public class RevisedTest {
 
   @Test
   public void testBidPlace() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "BidPlace");
     bidPlaceDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     bidPlaceDelegate(gameData).start();
@@ -327,7 +327,7 @@ public class RevisedTest {
   public void testOverFlyBombersDies() {
     final PlayerID british = british(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -348,7 +348,7 @@ public class RevisedTest {
   public void testMultipleOverFlyBombersDies() {
     final PlayerID british = british(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -377,7 +377,7 @@ public class RevisedTest {
     // it should not appear in the battle
     final PlayerID british = british(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -400,7 +400,7 @@ public class RevisedTest {
     final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -420,7 +420,7 @@ public class RevisedTest {
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -453,7 +453,7 @@ public class RevisedTest {
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -499,7 +499,7 @@ public class RevisedTest {
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -538,7 +538,7 @@ public class RevisedTest {
     gameData.performChange(change);
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -568,7 +568,7 @@ public class RevisedTest {
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -621,7 +621,7 @@ public class RevisedTest {
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -665,7 +665,7 @@ public class RevisedTest {
     // german sub tries to attack a transport in non combat
     // should be an error
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -681,7 +681,7 @@ public class RevisedTest {
     // german sub tries to attack a transport in non combat
     // should be an error
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -697,7 +697,7 @@ public class RevisedTest {
     // german sub tries to attack a transport in non combat
     // should be an error
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -717,7 +717,7 @@ public class RevisedTest {
     gameData.performChange(c);
     // new move delegate
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(japanese);
+    final IDelegateBridge bridge = newDelegateBridge(japanese);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -775,7 +775,7 @@ public class RevisedTest {
     final String preOwner = fic.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
     // Set up the move delegate
-    IDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
+    IDelegateBridge delegateBridge = newDelegateBridge(british(gameData));
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -802,7 +802,7 @@ public class RevisedTest {
      * add a VALID JAPANESE attack
      */
     // Set up battle
-    delegateBridge = getDelegateBridge(japanese(gameData));
+    delegateBridge = newDelegateBridge(japanese(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -824,7 +824,7 @@ public class RevisedTest {
      * add a VALID AMERICAN attack
      */
     // Set up battle
-    delegateBridge = getDelegateBridge(americans(gameData));
+    delegateBridge = newDelegateBridge(americans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -856,7 +856,7 @@ public class RevisedTest {
     addTo(germany, bombers);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany), bombers, null);
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     // aa guns rolls 0 and hits
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final int pusBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
@@ -880,7 +880,7 @@ public class RevisedTest {
     addTo(germany, bombers);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany), bombers, null);
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     // should be exactly 3 rolls total. would be exactly 2 rolls if the number of units being shot at = max dice side of
     // the AA gun, because
     // the casualty selection roll would not happen in LL
@@ -912,7 +912,7 @@ public class RevisedTest {
     addTo(germany, bombers);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany), bombers, null);
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     // aa guns rolls 0 and hits, next 5 dice are for the bombing raid cost for the
     // surviving bombers
     whenGetRandom(bridge)
@@ -939,7 +939,7 @@ public class RevisedTest {
         uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
     addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // aa guns rolls 3, misses, bomber rolls 2 dice at 3
@@ -958,7 +958,7 @@ public class RevisedTest {
     final String attacker = "British";
     final Territory attacked = territory("Libya", gameData);
     final Territory from = territory("Anglo Egypt", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -980,7 +980,7 @@ public class RevisedTest {
     // 1 destroyer attacks 1 destroyer
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1002,7 +1002,7 @@ public class RevisedTest {
     // 1 sub attacks 1 sub
     addTo(from, submarine(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1040,7 +1040,7 @@ public class RevisedTest {
     addTo(from, submarine(gameData).create(2, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1099,7 +1099,7 @@ public class RevisedTest {
     addTo(from, battleship(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(3, germans(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1160,7 +1160,7 @@ public class RevisedTest {
     addTo(from, submarine(gameData).create(1, british(gameData)));
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1200,7 +1200,7 @@ public class RevisedTest {
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
     addTo(attacked, battleship(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1262,7 +1262,7 @@ public class RevisedTest {
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1296,7 +1296,7 @@ public class RevisedTest {
   @Test
   public void testUnplacedDie() {
     final PlaceDelegate del = placeDelegate(gameData);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(gameData)));
+    del.setDelegateBridgeAndPlayer(newDelegateBridge(british(gameData)));
     del.start();
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     del.end();
@@ -1307,7 +1307,7 @@ public class RevisedTest {
   @Test
   public void testRocketsDontFireInConquered() {
     final MoveDelegate move = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
@@ -1326,7 +1326,7 @@ public class RevisedTest {
   public void testTechRolls() {
     // Set up the test
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans);
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     advanceToStep(delegateBridge, "germanTech");
     final TechnologyDelegate techDelegate = techDelegate(gameData);
     techDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -1382,7 +1382,7 @@ public class RevisedTest {
     addTo(sz6, destroyer(gameData).create(2, british));
     addTo(sz5, transport(gameData).create(3, germans));
     addTo(germany, armour(gameData).create(3, germans));
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     givenRemotePlayerWillSelectDefaultCasualties(bridge);
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1419,7 +1419,7 @@ public class RevisedTest {
   public void testCanalMovePass() {
     final Territory sz15 = territory("15 Sea Zone", gameData);
     final Territory sz34 = territory("34 Sea Zone", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -1435,7 +1435,7 @@ public class RevisedTest {
     final Territory sz34 = territory("34 Sea Zone", gameData);
     // clear the british in sz 15
     removeFrom(sz15, sz15.getUnits().getUnits());
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
@@ -1,12 +1,11 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
-import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge;
 import static games.strategy.triplea.delegate.GameDataTestUtil.load;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -27,7 +26,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 public final class UnitComparatorTest {
   private static void startCombatMoveFor(final PlayerID playerId, final GameData gameData) {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(playerId, gameData);
+    final IDelegateBridge bridge = MockDelegateBridge.newInstance(gameData, playerId);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -1,6 +1,6 @@
 package games.strategy.triplea.delegate;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,7 +52,7 @@ public class VictoryTest {
     gameData = TestMapGameData.VICTORY_TEST.getGameData();
     italians = GameDataTestUtil.italians(gameData);
     germans = GameDataTestUtil.germans(gameData);
-    testBridge = GameDataTestUtil.getDelegateBridge(italians, gameData);
+    testBridge = MockDelegateBridge.newInstance(gameData, italians);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -139,7 +139,7 @@ public class WW2V3Year41Test {
     gameData = TestMapGameData.WW2V3_1941.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -156,7 +156,7 @@ public class WW2V3Year41Test {
   public void testAaCasualtiesLowLuckMixedRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
     givePlayerRadar(germans(gameData));
@@ -182,7 +182,7 @@ public class WW2V3Year41Test {
   public void testAaCasualtiesLowLuckMixedWithRollingRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
     givePlayerRadar(germans(gameData));
@@ -213,7 +213,7 @@ public class WW2V3Year41Test {
   public void testAaCasualtiesLowLuckMixedWithRollingMissRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
     givePlayerRadar(germans(gameData));
@@ -250,7 +250,7 @@ public class WW2V3Year41Test {
     final Territory sz12 = gameData.getMap().getTerritory("12 Sea Zone");
     final PlayerID british = GameDataTestUtil.british(gameData);
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -270,7 +270,7 @@ public class WW2V3Year41Test {
   @Test
   public void testUnplacedDie() {
     final PlaceDelegate del = placeDelegate(gameData);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(gameData)));
+    del.setDelegateBridgeAndPlayer(newDelegateBridge(british(gameData)));
     del.start();
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     del.end();
@@ -281,7 +281,7 @@ public class WW2V3Year41Test {
   @Test
   public void testPlaceEmpty() {
     final PlaceDelegate del = placeDelegate(gameData);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(gameData)));
+    del.setDelegateBridgeAndPlayer(newDelegateBridge(british(gameData)));
     del.start();
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     final String error = del.placeUnits(Collections.emptyList(), territory("United Kingdom", gameData),
@@ -293,7 +293,7 @@ public class WW2V3Year41Test {
   public void testTechTokens() {
     // Set up the test
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans);
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     advanceToStep(delegateBridge, "germanTech");
     final TechnologyDelegate techDelegate = techDelegate(gameData);
     techDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -330,7 +330,7 @@ public class WW2V3Year41Test {
     final PlayerID british = british(gameData);
     addTo(gibraltar, infantry(gameData).create(1, british));
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -353,7 +353,7 @@ public class WW2V3Year41Test {
   public void testLoadedTransportAttackKillsLoadedUnits() {
     final PlayerID british = british(gameData);
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "britishCombatMove");
     givenRemotePlayerWillSelectAttackSubs(bridge);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -387,7 +387,7 @@ public class WW2V3Year41Test {
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -411,7 +411,7 @@ public class WW2V3Year41Test {
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -438,7 +438,7 @@ public class WW2V3Year41Test {
     // Add a russian factory
     addTo(eastPoland, factory(gameData).create(1, russians(gameData)));
     MoveDelegate moveDelegate = moveDelegate(gameData);
-    IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -454,7 +454,7 @@ public class WW2V3Year41Test {
     // Add a russian factory
     addTo(eastPoland, aaGun(gameData).create(1, russians(gameData)));
     moveDelegate = moveDelegate(gameData);
-    delegateBridge = getDelegateBridge(germans(gameData));
+    delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -472,7 +472,7 @@ public class WW2V3Year41Test {
     final Territory germany = territory("Germany", gameData);
     addTo(poland, aaGun(gameData).create(1, germans(gameData)));
     MoveDelegate moveDelegate = moveDelegate(gameData);
-    IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -491,7 +491,7 @@ public class WW2V3Year41Test {
     final Territory sz5 = territory("5 Sea Zone", gameData);
     addTo(finland, aaGun(gameData).create(1, germans(gameData)));
     moveDelegate = moveDelegate(gameData);
-    delegateBridge = getDelegateBridge(germans(gameData));
+    delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -511,7 +511,7 @@ public class WW2V3Year41Test {
     map.add(aaGun, 1);
     // Set up the test
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    delegateBridge = getDelegateBridge(germans);
+    delegateBridge = newDelegateBridge(germans);
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     advanceToStep(delegateBridge, "Place");
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -527,7 +527,7 @@ public class WW2V3Year41Test {
   public void testMechanizedInfantry() {
     // Set up tech
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_MECHANIZED_INFANTRY, gameData, germans));
     // Set up the move delegate
@@ -571,7 +571,7 @@ public class WW2V3Year41Test {
   public void testJetPower() {
     // Set up tech
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_JET_POWER, gameData, germans));
     // Set up the territories
@@ -600,7 +600,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testBidPlace() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "BidPlace");
     bidPlaceDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     bidPlaceDelegate(gameData).start();
@@ -619,7 +619,7 @@ public class WW2V3Year41Test {
   public void testFactoryPlace() {
     // Set up game
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(british(gameData));
     // Set up the territories
     final Territory egypt = territory("Union of South Africa", gameData);
     // Set up the unit types
@@ -651,7 +651,7 @@ public class WW2V3Year41Test {
      */
     // Set up game
     final PlayerID chinese = GameDataTestUtil.chinese(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(chinese);
+    final IDelegateBridge delegateBridge = newDelegateBridge(chinese);
     advanceToStep(delegateBridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -720,7 +720,7 @@ public class WW2V3Year41Test {
   public void testPlaceInOccupiedSeaZone() {
     // Set up game
     final PlayerID germans = GameDataTestUtil.germans(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans);
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     // Clear all units from the SZ and add an enemy unit
     final Territory sz5 = territory("5 Sea Zone", gameData);
     removeFrom(sz5, sz5.getUnits().getUnits());
@@ -743,7 +743,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testMoveUnitsThroughSubs() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "britishNonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -755,7 +755,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testMoveUnitsThroughTransports() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "britishCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -767,7 +767,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testMoveUnitsThroughTransports2() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "britishNonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -781,7 +781,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testLoadThroughSubs() {
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "britishNonCombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -804,7 +804,7 @@ public class WW2V3Year41Test {
   @Test
   public void testAttackUndoAndAttackAgain() {
     final MoveDelegate move = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(italians(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(italians(gameData));
     advanceToStep(bridge, "CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
@@ -836,7 +836,7 @@ public class WW2V3Year41Test {
     // 1 sub attacks 1 sub
     addTo(from, submarine(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -871,7 +871,7 @@ public class WW2V3Year41Test {
     addTo(from, submarine(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -905,7 +905,7 @@ public class WW2V3Year41Test {
     addTo(from, submarine(gameData).create(1, british(gameData)));
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -940,7 +940,7 @@ public class WW2V3Year41Test {
     addTo(from, destroyer(gameData).create(1, british(gameData)));
     addTo(attacked, submarine(gameData).create(1, germans(gameData)));
     addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -973,7 +973,7 @@ public class WW2V3Year41Test {
   @Test
   public void testLimitBombardtoNumberOfUnloaded() {
     final MoveDelegate move = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(italians(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(italians(gameData));
     givenRemotePlayerWillSelectShoreBombard(bridge);
     advanceToStep(bridge, "CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
@@ -1021,7 +1021,7 @@ public class WW2V3Year41Test {
   @Test
   public void testBombardStrengthVariable() {
     final MoveDelegate move = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(italians(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(italians(gameData));
     givenRemotePlayerWillSelectShoreBombard(bridge);
     advanceToStep(bridge, "CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
@@ -1085,7 +1085,7 @@ public class WW2V3Year41Test {
   @Test
   public void testAmphAttackUndoAndAttackAgainBombard() {
     final MoveDelegate move = moveDelegate(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(italians(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(italians(gameData));
     givenRemotePlayerWillSelectShoreBombard(bridge);
     advanceToStep(bridge, "CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
@@ -1125,7 +1125,7 @@ public class WW2V3Year41Test {
     addTo(sz8, carrier(gameData).create(1, british(gameData)));
     addTo(sz8, fighter(gameData).create(1, americans(gameData)));
     final Route route = new Route(sz8, sz1);
-    final IDelegateBridge bridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1150,7 +1150,7 @@ public class WW2V3Year41Test {
     addTo(sz40, fighter(gameData).create(1, italians(gameData)));
     addTo(madagascar, fighter(gameData).create(2, germans));
     final Route route = gameData.getMap().getRoute(madagascar, sz40);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1166,7 +1166,7 @@ public class WW2V3Year41Test {
     final Territory germany = territory("Germany", gameData);
     final Territory poland = territory("Poland", gameData);
     TechAttachment.get(germans).setMechanizedInfantry("true");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1184,7 +1184,7 @@ public class WW2V3Year41Test {
     final Territory france = territory("France", gameData);
     final Territory germany = territory("Germany", gameData);
     TechAttachment.get(germans).setMechanizedInfantry("true");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1252,7 +1252,7 @@ public class WW2V3Year41Test {
     final PlayerID germans = germans(gameData);
     final Territory germany = territory("Germany", gameData);
     final Territory nwe = territory("Northwestern Europe", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1273,7 +1273,7 @@ public class WW2V3Year41Test {
     final Territory nwe = territory("Northwestern Europe", gameData);
     final Territory poland = territory("Poland", gameData);
     final Territory eastPoland = territory("East Poland", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1295,7 +1295,7 @@ public class WW2V3Year41Test {
     final Territory bulgaria = territory("Bulgaria Romania", gameData);
     final Territory poland = territory("Poland", gameData);
     final Territory ukraine = territory("Ukraine", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1319,7 +1319,7 @@ public class WW2V3Year41Test {
     // Territory nwe = territory("Northwestern Europe", gameData);
     final Territory poland = territory("Poland", gameData);
     final Territory eastPoland = territory("East Poland", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1343,7 +1343,7 @@ public class WW2V3Year41Test {
     final Territory poland = territory("Poland", gameData);
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory beloRussia = territory("Belorussia", gameData);
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1380,7 +1380,7 @@ public class WW2V3Year41Test {
     // Clear East Poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     // Set up test
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1407,7 +1407,7 @@ public class WW2V3Year41Test {
   @Test
   public void testDefencelessTransportsDie() {
     final PlayerID british = british(gameData);
-    final IDelegateBridge bridge = getDelegateBridge(british);
+    final IDelegateBridge bridge = newDelegateBridge(british);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1438,7 +1438,7 @@ public class WW2V3Year41Test {
     // germans have 1 carrier to place
     addTo(germans, carrier(gameData).create(1, germans), gameData);
     // start the move phase
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1454,7 +1454,7 @@ public class WW2V3Year41Test {
   @Test
   public void testFighterCantHoverWithNoCarrierToPlace() {
     // start the move phase
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1473,7 +1473,7 @@ public class WW2V3Year41Test {
     final Territory germany = territory("Germany", gameData);
     final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
+    del.setDelegateBridgeAndPlayer(newDelegateBridge(germans(gameData)));
     del.start();
     // Set up player
     final PlayerID germans = GameDataTestUtil.germans(gameData);
@@ -1498,7 +1498,7 @@ public class WW2V3Year41Test {
      * INCREASED_FACTORY_PRODUCTION repairs
      */
     // Set up INCREASED_FACTORY_PRODUCTION
-    final IDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_INCREASED_FACTORY_PRODUCTION, gameData, germans));
     // damage a factory
@@ -1524,7 +1524,7 @@ public class WW2V3Year41Test {
     final Territory germany = territory("Germany", gameData);
     final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
+    del.setDelegateBridgeAndPlayer(newDelegateBridge(germans(gameData)));
     del.start();
     // dame a factory
     final IntegerMap<Unit> startHits = new IntegerMap<>();
@@ -1547,7 +1547,7 @@ public class WW2V3Year41Test {
   public void testOccupiedTerrOfAttachment() {
     // Set up test
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(british(gameData));
     // Set up the move delegate
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     advanceToStep(delegateBridge, "CombatMove");
@@ -1580,7 +1580,7 @@ public class WW2V3Year41Test {
   public void testOccupiedTerrOfAttachmentWithCapital() throws GameParseException {
     // Set up test
     final PlayerID british = GameDataTestUtil.british(gameData);
-    final IDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(british(gameData));
     // Set up the move delegate
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     advanceToStep(delegateBridge, "CombatMove");
@@ -1618,7 +1618,7 @@ public class WW2V3Year41Test {
 
   @Test
   public void testTwoStepBlitz() {
-    final IDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
+    final IDelegateBridge delegateBridge = newDelegateBridge(british(gameData));
     // Set up the territories
     final Territory libya = territory("Libya", gameData);
     final Territory egypt = territory("Egypt", gameData);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -10,7 +10,6 @@ import static games.strategy.triplea.delegate.BattleStepStrings.SUBS_FIRE;
 import static games.strategy.triplea.delegate.BattleStepStrings.SUBS_SUBMERGE;
 import static games.strategy.triplea.delegate.GameDataTestUtil.aaGun;
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleDelegate;
@@ -37,11 +36,12 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
-import static games.strategy.triplea.delegate.GameDataTestUtil.whenGetRandom;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withRemotePlayer;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withValues;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
+import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withRemotePlayer;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -140,7 +140,7 @@ public class WW2V3Year41Test {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   private static String fight(final BattleDelegate battle, final Territory territory) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
-import static games.strategy.triplea.delegate.GameDataTestUtil.advanceToStep;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.battleship;
 import static games.strategy.triplea.delegate.GameDataTestUtil.carrier;
@@ -13,7 +12,8 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.withRemotePlayer;
+import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.withRemotePlayer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,7 +41,7 @@ public class WW2V3Year42Test {
   }
 
   private IDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, gameData);
+    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -40,7 +40,7 @@ public class WW2V3Year42Test {
     gameData = TestMapGameData.WW2V3_1942.getGameData();
   }
 
-  private IDelegateBridge getDelegateBridge(final PlayerID player) {
+  private IDelegateBridge newDelegateBridge(final PlayerID player) {
     return MockDelegateBridge.newInstance(gameData, player);
   }
 
@@ -50,7 +50,7 @@ public class WW2V3Year42Test {
     final Territory sz12 = gameData.getMap().getTerritory("12 Sea Zone");
     final PlayerID germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -71,7 +71,7 @@ public class WW2V3Year42Test {
     final Territory germany = territory("Germany", gameData);
     final PlayerID germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
-    final IDelegateBridge bridge = getDelegateBridge(germans);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
@@ -97,7 +97,7 @@ public class WW2V3Year42Test {
     final Territory sz7 = territory("7 Sea Zone", gameData);
     // add a russian battlship
     addTo(sz5, battleship(gameData).create(1, russians(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -123,7 +123,7 @@ public class WW2V3Year42Test {
     // add an allied carrier and a fighter
     addTo(sz5, carrier(gameData).create(1, italians(gameData)));
     addTo(sz5, fighter(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -147,7 +147,7 @@ public class WW2V3Year42Test {
     final Territory sz7 = territory("7 Sea Zone", gameData);
     // add a russian battlship
     addTo(sz5, battleship(gameData).create(1, russians(gameData)));
-    final IDelegateBridge bridge = getDelegateBridge(germans(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();


### PR DESCRIPTION
## Overview

The first commit extracts the new methods that were recently added to support mocking `IDelegateBridge` in order to remove `ITestDelegateBridge`.  They didn't seem to be very cohesive as a part of `GameDataTestUtil`, as they really had nothing to do with `GameData`, so I moved them to a new `MockDelegateBridge` utility class.

The second commit simply renames all occurrences of `getDelegateBridge()` to `newDelegateBridge()` to clearly indicate that a new instance is being created rather than reusing some fixture-level instance.

## Functional Changes

None.

## Refactoring Changes

I reversed the parameters of the new `MockDelegateBridge#newInstance()` method to match what one would normally see throughout the engine domain objects (i.e. a `GameData` instance preceding a `GameDataComponent` instance).

## Manual Testing Performed

None.