### PR TITLE
Promote build to fourth version number

### DIFF
--- a/game-core/src/main/resources/META-INF/triplea/product.properties
+++ b/game-core/src/main/resources/META-INF/triplea/product.properties
@@ -1,1 +1,1 @@
-version = 1.9.0.0.@buildId@
+version = 1.9.0.@buildId@

--- a/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
+++ b/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
@@ -14,6 +14,6 @@ final class ProductConfigurationIntegrationTest {
   void shouldReadPropertiesFromResource() {
     assertThat(
         productConfiguration.getVersion().getExactVersion(),
-        matchesPattern("1\\.9\\.0\\.0\\.(@buildId@|dev|\\d+)"));
+        matchesPattern("1\\.9\\.0\\.(@buildId@|dev|\\d+)"));
   }
 }


### PR DESCRIPTION
## Overview
Promotes the build number to become the fourth version number. This makes it visible in a number of places and gets rid of the highly frustrating (IMO) idea that bits of Triple A which print the version number don't give any meaningful information.

## Functional Changes
See above

## Manual Testing Performed
- ..None

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Refer to #2483.

Not sure how to test all this but I thought I'd put in a PR anyway. Should at least set off the travis build to give us a testable version.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
