### PR TITLE
Fix exception when checking for engine update

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -55,18 +55,16 @@ final class EngineVersionCheck {
       final GameSetting<String> updateCheckDateSetting,
       final Runnable flushSetting) {
     // check at most once per 2 days (but still allow a 'first run message' for a new version of TripleA)
-    final boolean firstRun = firstRunSetting.value();
-    final String encodedUpdateCheckDate = updateCheckDateSetting.value();
-    if (!firstRun && !encodedUpdateCheckDate.trim().isEmpty()) {
-      final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
-      if (updateCheckDate.isAfter(now.minusDays(2))) {
-        return false;
-      }
+    final boolean updateCheckRequired = firstRunSetting.value()
+        || updateCheckDateSetting.getValue()
+            .map(encodedUpdateCheckDate -> !parseUpdateCheckDate(encodedUpdateCheckDate).isAfter(now.minusDays(2)))
+            .orElse(true);
+    if (!updateCheckRequired) {
+      return false;
     }
 
     updateCheckDateSetting.save(formatUpdateCheckDate(now));
     flushSetting.run();
-
     return true;
   }
 

--- a/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,11 +43,12 @@ final class EngineVersionCheckTest {
     }
 
     private void givenEngineUpdateCheckNeverRun() {
-      when(updateCheckDateSetting.value()).thenReturn("");
+      when(updateCheckDateSetting.getValue()).thenReturn(Optional.empty());
     }
 
     private void givenEngineUpdateCheckLastRunRelativeToNow(final long amountToAdd, final TemporalUnit unit) {
-      when(updateCheckDateSetting.value()).thenReturn(formatUpdateCheckDate(now.plus(amountToAdd, unit)));
+      when(updateCheckDateSetting.getValue())
+          .thenReturn(Optional.of(formatUpdateCheckDate(now.plus(amountToAdd, unit))));
     }
 
     private boolean whenIsEngineUpdateCheckRequired() {


### PR DESCRIPTION
## Overview

Fixes #4196.

`ClientSetting#lastCheckForEngineUpdate` has no default value, and thus the caller must check for the presence of the setting value before using it.  The one usage in `EngineVersionCheck` is the sole usage of `lastCheckForEngineUpdate`, so no other call sites require a similar update.

## Functional Changes

* Check for the presence of a value in the `lastCheckForEngineUpdate` client setting before attempting to use it.

## Manual Testing Performed

* Manually set `firstTimeThisVersion` to `false` and cleared the value for `lastCheckForEngineUpdate` to force the code to read `lastCheckForEngineUpdate` when it has no value.  Verified no exception occurred and the update check was run.

## Additional Review Notes

* I plan on searching for other calls to `GameSetting#value()` for client settings that do not have a default value to prevent similar exceptions from occurring.  This will be addressed in a follow-up PR.