### PR TITLE
Properly handle client settings lacking default values

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -25,17 +25,15 @@ final class UpdatedMapsCheck {
       final GameSetting<String> updateCheckDateSetting,
       final Runnable flushSetting) {
     // check at most once per month
-    final String encodedUpdateCheckDate = updateCheckDateSetting.value();
-    if (!encodedUpdateCheckDate.trim().isEmpty()) {
-      final LocalDate updateCheckDate = parseUpdateCheckDate(encodedUpdateCheckDate);
-      if (updateCheckDate.isAfter(now.minusMonths(1))) {
-        return false;
-      }
+    final boolean updateCheckRequired = updateCheckDateSetting.getValue()
+        .map(encodedUpdateCheckDate -> !parseUpdateCheckDate(encodedUpdateCheckDate).isAfter(now.minusMonths(1)))
+        .orElse(true);
+    if (!updateCheckRequired) {
+      return false;
     }
 
     updateCheckDateSetting.save(formatUpdateCheckDate(now));
     flushSetting.run();
-
     return true;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
@@ -85,8 +85,7 @@ public final class LobbyServerPropertiesFetcher {
       ClientSetting.flush();
       return downloadedProps;
     } catch (final IOException e) {
-
-      if (!ClientSetting.lobbyLastUsedHost.isSet()) {
+      if (!ClientSetting.lobbyLastUsedHost.isSet() || !ClientSetting.lobbyLastUsedPort.isSet()) {
         log.log(Level.SEVERE,
             String.format("Failed to download lobby server property file from %s; "
                 + "Please verify your internet connection and try again.",
@@ -94,11 +93,11 @@ public final class LobbyServerPropertiesFetcher {
             e);
         throw new RuntimeException(e);
       }
+
+      // graceful recovery case, use the last lobby address we knew about
       log.log(Level.SEVERE, "Encountered an error while downloading lobby property file: " + lobbyPropsUrl
           + ", will attempt to connect to the lobby at its last known address. If this problem keeps happening, "
           + "you may be seeing network troubles, or the lobby may not be available.", e);
-
-      // graceful recovery case, use the last lobby address we knew about
       return new LobbyServerProperties(
           ClientSetting.lobbyLastUsedHost.value(),
           ClientSetting.lobbyLastUsedPort.value());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -209,7 +209,7 @@ public class GameSelectorModel extends Observable {
    * on startup.
    */
   public void loadDefaultGameSameThread() {
-    final String userPreferredDefaultGameUri = ClientSetting.defaultGameUri.value();
+    final String userPreferredDefaultGameUri = ClientSetting.defaultGameUri.getValue().orElse("");
 
     // we don't want to load a game file by default that is not within the map folders we can load. (ie: if a previous
     // version of triplea

--- a/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,11 +33,12 @@ final class UpdatedMapsCheckTest {
     private Runnable flushSetting;
 
     private void givenMapUpdateCheckNeverRun() {
-      when(updateCheckDateSetting.value()).thenReturn("");
+      when(updateCheckDateSetting.getValue()).thenReturn(Optional.empty());
     }
 
     private void givenMapUpdateCheckLastRunRelativeToNow(final long amountToAdd, final TemporalUnit unit) {
-      when(updateCheckDateSetting.value()).thenReturn(formatUpdateCheckDate(now.plus(amountToAdd, unit)));
+      when(updateCheckDateSetting.getValue())
+          .thenReturn(Optional.of(formatUpdateCheckDate(now.plus(amountToAdd, unit))));
     }
 
     private boolean whenIsMapUpdateCheckRequired() {


### PR DESCRIPTION
## Overview

Follow-up to #4197.  Resolves other scenarios where a client setting lacking a default value may throw an exception when `value()` is called.  All call sites were updated to either check for the presence of a value before requesting it or using an appropriate default in the local context.

## Functional Changes

* Guard against an exception being thrown from `GameSetting#value()` for the following client settings that lack a default value:
    * `defaultGameUri`
    * `lastCheckForMapUpdates`
    * `lobbyLastUserPort`

## Manual Testing Performed

* `defaultGameUri`: None.
* `lastCheckForMapUpdates`: None.  Unit tests cover this setting.
* `lobbyLastUsedPort`: Manually modified my local preferences to set `lobbyLastUsedHost` but clear `lobbyLastUsedPort`.  Verified `NoSuchElementException` is not thrown.