### PR TITLE
Checkstyle: Fix naming violations in attachment superclasses

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -43,31 +43,31 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   public static final String TRIGGER_CHANCE_FAILURE = "Trigger Rolling is a Failure!";
 
   // list of conditions that this condition can
-  protected List<RulesAttachment> m_conditions = new ArrayList<>();
+  protected List<RulesAttachment> conditions = new ArrayList<>();
   // contain
-  // m_conditionType modifies the relationship of m_conditions
-  protected String m_conditionType = AND;
+  // conditionType modifies the relationship of conditions
+  protected String conditionType = AND;
   // will logically negate the entire condition, including contained conditions
-  protected boolean m_invert = false;
+  protected boolean invert = false;
   // chance (x out of y) that this action is successful when attempted, default = 1:1 = always
-  protected String m_chance = DEFAULT_CHANCE;
+  protected String chance = DEFAULT_CHANCE;
   // successful
   // if chance fails, we should increment the chance by x
-  protected int m_chanceIncrementOnFailure = 0;
+  protected int chanceIncrementOnFailure = 0;
   // if chance succeeds, we should decrement the chance by x
-  protected int m_chanceDecrementOnSuccess = 0;
+  protected int chanceDecrementOnSuccess = 0;
 
   protected AbstractConditionsAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
   protected void setConditions(final String conditions) throws GameParseException {
-    if (m_conditions == null) {
-      m_conditions = new ArrayList<>();
+    if (this.conditions == null) {
+      this.conditions = new ArrayList<>();
     }
     final Collection<PlayerID> playerIDs = getData().getPlayerList().getPlayers();
     for (final String subString : splitOnColon(conditions)) {
-      m_conditions.add(playerIDs.stream()
+      this.conditions.add(playerIDs.stream()
           .map(p -> p.getAttachment(subString))
           .map(RulesAttachment.class::cast)
           .filter(Objects::nonNull)
@@ -77,24 +77,24 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   private void setConditions(final List<RulesAttachment> value) {
-    m_conditions = value;
+    conditions = value;
   }
 
   @Override
   public List<RulesAttachment> getConditions() {
-    return m_conditions;
+    return conditions;
   }
 
   protected void resetConditions() {
-    m_conditions = new ArrayList<>();
+    conditions = new ArrayList<>();
   }
 
   private void setInvert(final boolean s) {
-    m_invert = s;
+    invert = s;
   }
 
   private boolean getInvert() {
-    return m_invert;
+    return invert;
   }
 
   @VisibleForTesting
@@ -103,7 +103,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     if (uppercaseValue.matches("AND|X?OR|\\d+(?:-\\d+)?")) {
       final String[] split = splitOnHyphen(uppercaseValue);
       if (split.length != 2 || Integer.parseInt(split[1]) > Integer.parseInt(split[0])) {
-        m_conditionType = uppercaseValue;
+        conditionType = uppercaseValue;
         return;
       }
     }
@@ -118,11 +118,11 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   private String getConditionType() {
-    return m_conditionType;
+    return conditionType;
   }
 
   private void resetConditionType() {
-    m_conditionType = AND;
+    conditionType = AND;
   }
 
   /**
@@ -262,18 +262,18 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       throw new GameParseException(
           "Invalid chance declaration: " + chance + " format: \"1:10\" for 10% chance" + thisErrorMsg());
     }
-    m_chance = chance;
+    this.chance = chance;
   }
 
   /**
    * Returns the number you need to roll to get the action to succeed format "1:10" for 10% chance.
    */
   private String getChance() {
-    return m_chance;
+    return chance;
   }
 
   private void resetChance() {
-    m_chance = DEFAULT_CHANCE;
+    chance = DEFAULT_CHANCE;
   }
 
   public int getChanceToHit() {
@@ -285,31 +285,31 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   private void setChanceIncrementOnFailure(final int value) {
-    m_chanceIncrementOnFailure = value;
+    chanceIncrementOnFailure = value;
   }
 
   public int getChanceIncrementOnFailure() {
-    return m_chanceIncrementOnFailure;
+    return chanceIncrementOnFailure;
   }
 
   private void setChanceDecrementOnSuccess(final int value) {
-    m_chanceDecrementOnSuccess = value;
+    chanceDecrementOnSuccess = value;
   }
 
   public int getChanceDecrementOnSuccess() {
-    return m_chanceDecrementOnSuccess;
+    return chanceDecrementOnSuccess;
   }
 
   public void changeChanceDecrementOrIncrementOnSuccessOrFailure(final IDelegateBridge delegateBridge,
       final boolean success,
       final boolean historyChild) {
     if (success) {
-      if (m_chanceDecrementOnSuccess == 0) {
+      if (chanceDecrementOnSuccess == 0) {
         return;
       }
       final int oldToHit = getChanceToHit();
       final int diceSides = getChanceDiceSides();
-      final int newToHit = Math.max(0, Math.min(diceSides, (oldToHit - m_chanceDecrementOnSuccess)));
+      final int newToHit = Math.max(0, Math.min(diceSides, (oldToHit - chanceDecrementOnSuccess)));
       if (newToHit == oldToHit) {
         return;
       }
@@ -318,12 +318,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
           .startEvent("Success changes chance for " + MyFormatter.attachmentNameToText(getName()) + " to " + newChance);
       delegateBridge.addChange(ChangeFactory.attachmentPropertyChange(this, newChance, CHANCE));
     } else {
-      if (m_chanceIncrementOnFailure == 0) {
+      if (chanceIncrementOnFailure == 0) {
         return;
       }
       final int oldToHit = getChanceToHit();
       final int diceSides = getChanceDiceSides();
-      final int newToHit = Math.max(0, Math.min(diceSides, (oldToHit + m_chanceIncrementOnFailure)));
+      final int newToHit = Math.max(0, Math.min(diceSides, (oldToHit + chanceIncrementOnFailure)));
       if (newToHit == oldToHit) {
         return;
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -21,7 +21,7 @@ import lombok.extern.java.Log;
  * from the Rules Attachment things that are part of conditions and national objectives. <br>
  * In other words, things like placementAnyTerritory (allows placing in any territory without need of a factory),
  * or movementRestrictionTerritories (restricts movement to certain territories), would go in This class.
- * While things like m_alliedOwnershipTerritories (a conditions for testing ownership of territories,
+ * While things like alliedOwnershipTerritories (a conditions for testing ownership of territories,
  * or objectiveValue (the money given if the condition is true), would NOT go in This class. <br>
  * Please do not add new things to this class. Any new Player-Rules type of stuff should go in "PlayerAttachment".
  */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -19,8 +19,8 @@ import lombok.extern.java.Log;
 /**
  * The purpose of this class is to separate the Rules Attachment variables and methods that affect Players,
  * from the Rules Attachment things that are part of conditions and national objectives. <br>
- * In other words, things like m_placementAnyTerritory (allows placing in any territory without need of a factory),
- * or m_movementRestrictionTerritories (restricts movement to certain territories), would go in This class.
+ * In other words, things like placementAnyTerritory (allows placing in any territory without need of a factory),
+ * or movementRestrictionTerritories (restricts movement to certain territories), would go in This class.
  * While things like m_alliedOwnershipTerritories (a conditions for testing ownership of territories,
  * or m_objectiveValue (the money given if the condition is true), would NOT go in This class. <br>
  * Please do not add new things to this class. Any new Player-Rules type of stuff should go in "PlayerAttachment".
@@ -32,30 +32,30 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   // These variables are related to a "rulesAttachment" that changes certain rules for the attached player. They are
   // not related to
   // conditions at all.
-  protected String m_movementRestrictionType = null;
-  protected String[] m_movementRestrictionTerritories = null;
+  protected String movementRestrictionType = null;
+  protected String[] movementRestrictionTerritories = null;
   // allows placing units in any owned land
-  protected boolean m_placementAnyTerritory = false;
+  protected boolean placementAnyTerritory = false;
   // allows placing units in any sea by owned land
-  protected boolean m_placementAnySeaZone = false;
+  protected boolean placementAnySeaZone = false;
   // allows placing units in a captured territory
-  protected boolean m_placementCapturedTerritory = false;
+  protected boolean placementCapturedTerritory = false;
   // turns of the warning to the player when they produce more than they can place
-  protected boolean m_unlimitedProduction = false;
+  protected boolean unlimitedProduction = false;
   // can only place units in the capital
-  protected boolean m_placementInCapitalRestricted = false;
+  protected boolean placementInCapitalRestricted = false;
   // enemy units will defend at 1
-  protected boolean m_dominatingFirstRoundAttack = false;
-  // negates m_dominatingFirstRoundAttack
-  protected boolean m_negateDominatingFirstRoundAttack = false;
+  protected boolean dominatingFirstRoundAttack = false;
+  // negates dominatingFirstRoundAttack
+  protected boolean negateDominatingFirstRoundAttack = false;
   // automatically produces 1 unit of a certain
-  protected IntegerMap<UnitType> m_productionPerXTerritories = new IntegerMap<>();
+  protected IntegerMap<UnitType> productionPerXTerritories = new IntegerMap<>();
   // type per every X territories owned
   // stops the user from placing units in any territory that already contains more than this
-  protected int m_placementPerTerritory = -1;
+  protected int placementPerTerritory = -1;
   // number of owned units
   // maximum number of units that can be placed in each territory.
-  protected int m_maxPlacePerTerritory = -1;
+  protected int maxPlacePerTerritory = -1;
 
   // It would wreck most map xmls to move the rulesAttachment's to another class, so don't move them out of here
   // please!
@@ -108,42 +108,42 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
 
   private void setMovementRestrictionTerritories(final String value) {
     if (value == null) {
-      m_movementRestrictionTerritories = null;
+      movementRestrictionTerritories = null;
       return;
     }
-    m_movementRestrictionTerritories = splitOnColon(value);
-    validateNames(m_movementRestrictionTerritories);
+    movementRestrictionTerritories = splitOnColon(value);
+    validateNames(movementRestrictionTerritories);
   }
 
   private void setMovementRestrictionTerritories(final String[] value) {
-    m_movementRestrictionTerritories = value;
+    movementRestrictionTerritories = value;
   }
 
   public String[] getMovementRestrictionTerritories() {
-    return m_movementRestrictionTerritories;
+    return movementRestrictionTerritories;
   }
 
   private void resetMovementRestrictionTerritories() {
-    m_movementRestrictionTerritories = null;
+    movementRestrictionTerritories = null;
   }
 
   private void setMovementRestrictionType(final String value) throws GameParseException {
     if (value == null) {
-      m_movementRestrictionType = null;
+      movementRestrictionType = null;
       return;
     }
     if (!(value.equals("disallowed") || value.equals("allowed"))) {
       throw new GameParseException("movementRestrictionType must be allowed or disallowed" + thisErrorMsg());
     }
-    m_movementRestrictionType = value;
+    movementRestrictionType = value;
   }
 
   public String getMovementRestrictionType() {
-    return m_movementRestrictionType;
+    return movementRestrictionType;
   }
 
   private void resetMovementRestrictionType() {
-    m_movementRestrictionType = null;
+    movementRestrictionType = null;
   }
 
   private void setProductionPerXTerritories(final String value) throws GameParseException {
@@ -167,168 +167,168 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     if (n <= 0) {
       throw new GameParseException("productionPerXTerritories must be a positive integer" + thisErrorMsg());
     }
-    m_productionPerXTerritories.put(ut, n);
+    productionPerXTerritories.put(ut, n);
   }
 
   private void setProductionPerXTerritories(final IntegerMap<UnitType> value) {
-    m_productionPerXTerritories = value;
+    productionPerXTerritories = value;
   }
 
   public IntegerMap<UnitType> getProductionPerXTerritories() {
-    return m_productionPerXTerritories;
+    return productionPerXTerritories;
   }
 
   private void resetProductionPerXTerritories() {
-    m_productionPerXTerritories = new IntegerMap<>();
+    productionPerXTerritories = new IntegerMap<>();
   }
 
   private void setPlacementPerTerritory(final String value) {
-    m_placementPerTerritory = getInt(value);
+    placementPerTerritory = getInt(value);
   }
 
   private void setPlacementPerTerritory(final Integer value) {
-    m_placementPerTerritory = value;
+    placementPerTerritory = value;
   }
 
   public int getPlacementPerTerritory() {
-    return m_placementPerTerritory;
+    return placementPerTerritory;
   }
 
   private void resetPlacementPerTerritory() {
-    m_placementPerTerritory = -1;
+    placementPerTerritory = -1;
   }
 
   private void setMaxPlacePerTerritory(final String value) {
-    m_maxPlacePerTerritory = getInt(value);
+    maxPlacePerTerritory = getInt(value);
   }
 
   private void setMaxPlacePerTerritory(final Integer value) {
-    m_maxPlacePerTerritory = value;
+    maxPlacePerTerritory = value;
   }
 
   public int getMaxPlacePerTerritory() {
-    return m_maxPlacePerTerritory;
+    return maxPlacePerTerritory;
   }
 
   private void resetMaxPlacePerTerritory() {
-    m_maxPlacePerTerritory = -1;
+    maxPlacePerTerritory = -1;
   }
 
   private void setPlacementAnyTerritory(final String value) {
-    m_placementAnyTerritory = getBool(value);
+    placementAnyTerritory = getBool(value);
   }
 
   private void setPlacementAnyTerritory(final Boolean value) {
-    m_placementAnyTerritory = value;
+    placementAnyTerritory = value;
   }
 
   public boolean getPlacementAnyTerritory() {
-    return m_placementAnyTerritory;
+    return placementAnyTerritory;
   }
 
   private void resetPlacementAnyTerritory() {
-    m_placementAnyTerritory = false;
+    placementAnyTerritory = false;
   }
 
   private void setPlacementAnySeaZone(final String value) {
-    m_placementAnySeaZone = getBool(value);
+    placementAnySeaZone = getBool(value);
   }
 
   private void setPlacementAnySeaZone(final Boolean value) {
-    m_placementAnySeaZone = value;
+    placementAnySeaZone = value;
   }
 
   public boolean getPlacementAnySeaZone() {
-    return m_placementAnySeaZone;
+    return placementAnySeaZone;
   }
 
   private void resetPlacementAnySeaZone() {
-    m_placementAnySeaZone = false;
+    placementAnySeaZone = false;
   }
 
   private void setPlacementCapturedTerritory(final String value) {
-    m_placementCapturedTerritory = getBool(value);
+    placementCapturedTerritory = getBool(value);
   }
 
   private void setPlacementCapturedTerritory(final Boolean value) {
-    m_placementCapturedTerritory = value;
+    placementCapturedTerritory = value;
   }
 
   public boolean getPlacementCapturedTerritory() {
-    return m_placementCapturedTerritory;
+    return placementCapturedTerritory;
   }
 
   private void resetPlacementCapturedTerritory() {
-    m_placementCapturedTerritory = false;
+    placementCapturedTerritory = false;
   }
 
   private void setPlacementInCapitalRestricted(final String value) {
-    m_placementInCapitalRestricted = getBool(value);
+    placementInCapitalRestricted = getBool(value);
   }
 
   private void setPlacementInCapitalRestricted(final Boolean value) {
-    m_placementInCapitalRestricted = value;
+    placementInCapitalRestricted = value;
   }
 
   public boolean getPlacementInCapitalRestricted() {
-    return m_placementInCapitalRestricted;
+    return placementInCapitalRestricted;
   }
 
   private void resetPlacementInCapitalRestricted() {
-    m_placementInCapitalRestricted = false;
+    placementInCapitalRestricted = false;
   }
 
   private void setUnlimitedProduction(final String value) {
-    m_unlimitedProduction = getBool(value);
+    unlimitedProduction = getBool(value);
   }
 
   private void setUnlimitedProduction(final Boolean value) {
-    m_unlimitedProduction = value;
+    unlimitedProduction = value;
   }
 
   public boolean getUnlimitedProduction() {
-    return m_unlimitedProduction;
+    return unlimitedProduction;
   }
 
   private void resetUnlimitedProduction() {
-    m_unlimitedProduction = false;
+    unlimitedProduction = false;
   }
 
   private void setDominatingFirstRoundAttack(final String value) {
-    m_dominatingFirstRoundAttack = getBool(value);
+    dominatingFirstRoundAttack = getBool(value);
   }
 
   private void setDominatingFirstRoundAttack(final Boolean value) {
-    m_dominatingFirstRoundAttack = value;
+    dominatingFirstRoundAttack = value;
   }
 
   public boolean getDominatingFirstRoundAttack() {
-    return m_dominatingFirstRoundAttack;
+    return dominatingFirstRoundAttack;
   }
 
   private void resetDominatingFirstRoundAttack() {
-    m_dominatingFirstRoundAttack = false;
+    dominatingFirstRoundAttack = false;
   }
 
   private void setNegateDominatingFirstRoundAttack(final String value) {
-    m_negateDominatingFirstRoundAttack = getBool(value);
+    negateDominatingFirstRoundAttack = getBool(value);
   }
 
   private void setNegateDominatingFirstRoundAttack(final Boolean value) {
-    m_negateDominatingFirstRoundAttack = value;
+    negateDominatingFirstRoundAttack = value;
   }
 
   public boolean getNegateDominatingFirstRoundAttack() {
-    return m_negateDominatingFirstRoundAttack;
+    return negateDominatingFirstRoundAttack;
   }
 
   private void resetNegateDominatingFirstRoundAttack() {
-    m_negateDominatingFirstRoundAttack = false;
+    negateDominatingFirstRoundAttack = false;
   }
 
   @Override
   public void validate(final GameData data) {
-    validateNames(m_movementRestrictionTerritories);
+    validateNames(movementRestrictionTerritories);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -22,7 +22,7 @@ import lombok.extern.java.Log;
  * In other words, things like placementAnyTerritory (allows placing in any territory without need of a factory),
  * or movementRestrictionTerritories (restricts movement to certain territories), would go in This class.
  * While things like m_alliedOwnershipTerritories (a conditions for testing ownership of territories,
- * or m_objectiveValue (the money given if the condition is true), would NOT go in This class. <br>
+ * or objectiveValue (the money given if the condition is true), would NOT go in This class. <br>
  * Please do not add new things to this class. Any new Player-Rules type of stuff should go in "PlayerAttachment".
  */
 @Log

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -40,7 +40,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   protected int eachMultiple = 1;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). Used with the next Territory conditions to
-  // determine the number of territories needed to be valid (ex: m_alliedOwnershipTerritories)
+  // determine the number of territories needed to be valid (ex: alliedOwnershipTerritories)
   protected int territoryCount = -1;
   // A list of players that can be used with
   // directOwnershipTerritories, directExclusionTerritories,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -32,30 +32,30 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
 
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). Determines if we will be counting each for the
-  // purposes of m_objectiveValue
-  protected boolean m_countEach = false;
+  // purposes of objectiveValue
+  protected boolean countEach = false;
   @InternalDoNotExport
-  // Do Not Export (do not include in IAttachment). The multiple that will be applied to m_objectiveValue
-  // if m_countEach is true
-  protected int m_eachMultiple = 1;
+  // Do Not Export (do not include in IAttachment). The multiple that will be applied to objectiveValue
+  // if countEach is true
+  protected int eachMultiple = 1;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment). Used with the next Territory conditions to
   // determine the number of territories needed to be valid (ex: m_alliedOwnershipTerritories)
-  protected int m_territoryCount = -1;
+  protected int territoryCount = -1;
   // A list of players that can be used with
   // directOwnershipTerritories, directExclusionTerritories,
   // directPresenceTerritories, or any of the other territory lists
   // only used if the attachment begins with "objectiveAttachment"
-  protected List<PlayerID> m_players = new ArrayList<>();
-  protected int m_objectiveValue = 0;
+  protected List<PlayerID> players = new ArrayList<>();
+  protected int objectiveValue = 0;
   // only matters for objectiveValue, does not affect the condition
-  protected int m_uses = -1;
+  protected int uses = -1;
   // condition for what turn it is
-  protected Map<Integer, Integer> m_turns = null;
+  protected Map<Integer, Integer> turns = null;
   // for on/off conditions
-  protected boolean m_switch = true;
+  protected boolean switched = true;
   // allows custom GameProperties
-  protected String m_gameProperty = null;
+  protected String gameProperty = null;
 
   protected AbstractRulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -68,20 +68,20 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + p + thisErrorMsg());
       }
-      m_players.add(player);
+      players.add(player);
     }
   }
 
   private void setPlayers(final List<PlayerID> value) {
-    m_players = value;
+    players = value;
   }
 
   protected List<PlayerID> getPlayers() {
-    return m_players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : m_players;
+    return players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerID) getAttachedTo())) : players;
   }
 
   private void resetPlayers() {
-    m_players = new ArrayList<>();
+    players = new ArrayList<>();
   }
 
   @Override
@@ -92,19 +92,19 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   private void setObjectiveValue(final String value) {
-    m_objectiveValue = getInt(value);
+    objectiveValue = getInt(value);
   }
 
   private void setObjectiveValue(final int value) {
-    m_objectiveValue = value;
+    objectiveValue = value;
   }
 
   public int getObjectiveValue() {
-    return m_objectiveValue;
+    return objectiveValue;
   }
 
   private void resetObjectiveValue() {
-    m_objectiveValue = 0;
+    objectiveValue = 0;
   }
 
   /**
@@ -117,15 +117,15 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   @InternalDoNotExport
   protected void setTerritoryCount(final String value) {
     if (value.equals("each")) {
-      m_territoryCount = 1;
-      m_countEach = true;
+      territoryCount = 1;
+      countEach = true;
     } else {
-      m_territoryCount = getInt(value);
+      territoryCount = getInt(value);
     }
   }
 
   public int getTerritoryCount() {
-    return m_territoryCount;
+    return territoryCount;
   }
 
   /**
@@ -137,19 +137,19 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     if (!getCountEach()) {
       return 1;
     }
-    return m_eachMultiple;
+    return eachMultiple;
   }
 
   protected boolean getCountEach() {
-    return m_countEach;
+    return countEach;
   }
 
   private void setUses(final String s) {
-    m_uses = getInt(s);
+    uses = getInt(s);
   }
 
   private void setUses(final int u) {
-    m_uses = u;
+    uses = u;
   }
 
   /**
@@ -158,51 +158,51 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
    * be tested for in isSatisfied.
    */
   public int getUses() {
-    return m_uses;
+    return uses;
   }
 
   private void resetUses() {
-    m_uses = -1;
+    uses = -1;
   }
 
   private void setSwitch(final String value) {
-    m_switch = getBool(value);
+    switched = getBool(value);
   }
 
   private void setSwitch(final Boolean value) {
-    m_switch = value;
+    switched = value;
   }
 
   private boolean getSwitch() {
-    return m_switch;
+    return switched;
   }
 
   private void resetSwitch() {
-    m_switch = true;
+    switched = true;
   }
 
   private void setGameProperty(final String value) {
-    m_gameProperty = value;
+    gameProperty = value;
   }
 
   private String getGameProperty() {
-    return m_gameProperty;
+    return gameProperty;
   }
 
   boolean getGamePropertyState(final GameData data) {
-    return m_gameProperty != null && data.getProperties().get(m_gameProperty, false);
+    return gameProperty != null && data.getProperties().get(gameProperty, false);
   }
 
   private void resetGameProperty() {
-    m_gameProperty = null;
+    gameProperty = null;
   }
 
   private void setRounds(final String rounds) throws GameParseException {
     if (rounds == null) {
-      m_turns = null;
+      turns = null;
       return;
     }
-    m_turns = new HashMap<>();
+    turns = new HashMap<>();
     final String[] s = splitOnColon(rounds);
     if (s.length < 1) {
       throw new GameParseException("Empty turn list" + thisErrorMsg());
@@ -225,7 +225,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
           end = getInt(s2[1]);
         }
       }
-      m_turns.put(start, end);
+      turns.put(start, end);
     }
   }
 
@@ -234,21 +234,21 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   private void setTurns(final Map<Integer, Integer> value) {
-    m_turns = value;
+    turns = value;
   }
 
   private Map<Integer, Integer> getTurns() {
-    return m_turns;
+    return turns;
   }
 
   private void resetTurns() {
-    m_turns = null;
+    turns = null;
   }
 
   protected boolean checkTurns(final GameData data) {
     final int turn = data.getSequence().getRound();
-    for (final int t : m_turns.keySet()) {
-      if (turn >= t && turn <= m_turns.get(t)) {
+    for (final int t : turns.keySet()) {
+      if (turn >= t && turn <= turns.get(t)) {
         return true;
       }
     }
@@ -390,7 +390,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         }
       }
       if (name.equals("each")) {
-        m_countEach = true;
+        countEach = true;
         if (mustSetTerritoryCount) {
           haveSetCount = true;
           setTerritoryCount(String.valueOf(1));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -33,12 +33,12 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   // "setTrigger" is also a valid setter, and it just calls "setConditions" in AbstractConditionsAttachment. Kept for
   // backwards
   // compatibility.
-  private int m_uses = -1;
+  private int uses = -1;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
-  private boolean m_usedThisRound = false;
-  private String m_notification = null;
-  private List<Tuple<String, String>> m_when = new ArrayList<>();
+  private boolean usedThisRound = false;
+  private String notification = null;
+  private List<Tuple<String, String>> when = new ArrayList<>();
 
   protected AbstractTriggerAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -89,27 +89,27 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   }
 
   public void setUses(final int u) {
-    m_uses = u;
+    uses = u;
   }
 
   private void setUsedThisRound(final String s) {
-    m_usedThisRound = getBool(s);
+    usedThisRound = getBool(s);
   }
 
   public void setUsedThisRound(final boolean usedThisRound) {
-    m_usedThisRound = usedThisRound;
+    this.usedThisRound = usedThisRound;
   }
 
   protected boolean getUsedThisRound() {
-    return m_usedThisRound;
+    return usedThisRound;
   }
 
   private void resetUsedThisRound() {
-    m_usedThisRound = false;
+    usedThisRound = false;
   }
 
   public int getUses() {
-    return m_uses;
+    return uses;
   }
 
   private void setWhen(final String when) throws GameParseException {
@@ -120,44 +120,44 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     if (!(s[0].equals(AFTER) || s[0].equals(BEFORE))) {
       throw new GameParseException("when must start with: " + BEFORE + " or " + AFTER + thisErrorMsg());
     }
-    m_when.add(Tuple.of(s[0], s[1]));
+    this.when.add(Tuple.of(s[0], s[1]));
   }
 
   private void setWhen(final List<Tuple<String, String>> value) {
-    m_when = value;
+    when = value;
   }
 
   protected List<Tuple<String, String>> getWhen() {
-    return m_when;
+    return when;
   }
 
   private void resetWhen() {
-    m_when = new ArrayList<>();
+    when = new ArrayList<>();
   }
 
   private void setNotification(final String notification) {
     if (notification == null) {
-      m_notification = null;
+      this.notification = null;
       return;
     }
-    m_notification = notification;
+    this.notification = notification;
   }
 
   protected String getNotification() {
-    return m_notification;
+    return notification;
   }
 
   private void resetNotification() {
-    m_notification = null;
+    notification = null;
   }
 
   protected void use(final IDelegateBridge bridge) {
     // instead of using up a "use" with every action, we will instead use up a "use" if the trigger is fired during this
     // round
     // this is in order to let a trigger that contains multiple actions, fire all of them in a single use
-    // we only do this for things that do not have m_when set. triggers with m_when set have their uses modified
+    // we only do this for things that do not have when set. triggers with when set have their uses modified
     // elsewhere.
-    if (!m_usedThisRound && m_uses > 0 && m_when.isEmpty()) {
+    if (!usedThisRound && uses > 0 && when.isEmpty()) {
       bridge.addChange(ChangeFactory.attachmentPropertyChange(this, true, "usedThisRound"));
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -251,7 +251,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
 
   @Override
   public void validate(final GameData data) throws GameParseException {
-    if (m_conditions == null) {
+    if (conditions == null) {
       throw new GameParseException("must contain at least one condition: " + thisErrorMsg());
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -27,29 +27,29 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   public static final String ATTEMPTS_LEFT_THIS_TURN = "attemptsLeftThisTurn";
 
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
-  protected String m_text = "";
+  protected String text = "";
   /**
    * The cost in PUs to attempt this action.
    *
    * @deprecated Replaced by costResources.
    */
   @Deprecated
-  protected int m_costPU = 0;
+  protected int costPu = 0;
   // cost in any resources to attempt this action
-  protected IntegerMap<Resource> m_costResources = new IntegerMap<>();
+  protected IntegerMap<Resource> costResources = new IntegerMap<>();
   // how many times can you perform this action each round?
-  protected int m_attemptsPerTurn = 1;
+  protected int attemptsPerTurn = 1;
   // how many times are left to perform this action each round?
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
-  protected int m_attemptsLeftThisTurn = 1;
+  protected int attemptsLeftThisTurn = 1;
   // which players should accept this action? this could be the player who is the target of this action in the case of
   // proposing a treaty or
   // the players in your 'alliance' in case you want to declare war...
   // especially for actions such as when france declares war on germany and it automatically causes UK to declare war as
   // well. it is good to
   // set "actionAccept" to "UK" so UK can accept this action to go through.
-  protected List<PlayerID> m_actionAccept = new ArrayList<>();
+  protected List<PlayerID> actionAccept = new ArrayList<>();
 
   protected AbstractUserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -63,18 +63,18 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private void setText(final String text) {
-    m_text = text;
+    this.text = text;
   }
 
   /**
    * Returns the Key that is used in politicstext.properties or other .properties for all the texts.
    */
   public String getText() {
-    return m_text;
+    return text;
   }
 
   private void resetText() {
-    m_text = "";
+    text = "";
   }
 
   @Deprecated
@@ -85,17 +85,17 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   @Deprecated
   public void setCostPu(final Integer s) {
     final Resource r = getData().getResourceList().getResource(Constants.PUS);
-    m_costResources.put(r, s);
+    costResources.put(r, s);
   }
 
   @Deprecated
   public int getCostPu() {
-    return m_costPU;
+    return costPu;
   }
 
   @Deprecated
   private void resetCostPu() {
-    m_costPU = 0;
+    costPu = 0;
   }
 
   private void setCostResources(final String value) throws GameParseException {
@@ -110,19 +110,19 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
       throw new GameParseException("costResources: No resource called: " + resourceToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
-    m_costResources.put(r, n);
+    costResources.put(r, n);
   }
 
   public void setCostResources(final IntegerMap<Resource> value) {
-    m_costResources = value;
+    costResources = value;
   }
 
   public IntegerMap<Resource> getCostResources() {
-    return m_costResources;
+    return costResources;
   }
 
   private void resetCostResources() {
-    m_costResources = new IntegerMap<>();
+    costResources = new IntegerMap<>();
   }
 
   private void setActionAccept(final String value) throws GameParseException {
@@ -130,7 +130,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_actionAccept.add(tempPlayer);
+        actionAccept.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -138,18 +138,18 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private void setActionAccept(final List<PlayerID> value) {
-    m_actionAccept = value;
+    actionAccept = value;
   }
 
   /**
    * Returns a list of players that must accept this action before it takes effect.
    */
   public List<PlayerID> getActionAccept() {
-    return m_actionAccept;
+    return actionAccept;
   }
 
   private void resetActionAccept() {
-    m_actionAccept = new ArrayList<>();
+    actionAccept = new ArrayList<>();
   }
 
   /**
@@ -158,28 +158,28 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    * @param s the amount of times you can try this Action per Round.
    */
   private void setAttemptsPerTurn(final String s) {
-    m_attemptsPerTurn = getInt(s);
-    setAttemptsLeftThisTurn(m_attemptsPerTurn);
+    attemptsPerTurn = getInt(s);
+    setAttemptsLeftThisTurn(attemptsPerTurn);
   }
 
   private void setAttemptsPerTurn(final Integer s) {
-    m_attemptsPerTurn = s;
-    setAttemptsLeftThisTurn(m_attemptsPerTurn);
+    attemptsPerTurn = s;
+    setAttemptsLeftThisTurn(attemptsPerTurn);
   }
 
   /**
    * Returns the amount of times you can try this Action per Round.
    */
   private int getAttemptsPerTurn() {
-    return m_attemptsPerTurn;
+    return attemptsPerTurn;
   }
 
   private void resetAttemptsPerTurn() {
-    m_attemptsPerTurn = 1;
+    attemptsPerTurn = 1;
   }
 
   private void setAttemptsLeftThisTurn(final int attempts) {
-    m_attemptsLeftThisTurn = attempts;
+    attemptsLeftThisTurn = attempts;
   }
 
   private void setAttemptsLeftThisTurn(final String attempts) {
@@ -187,31 +187,31 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   private int getAttemptsLeftThisTurn() {
-    return m_attemptsLeftThisTurn;
+    return attemptsLeftThisTurn;
   }
 
   private void resetAttemptsLeftThisTurn() {
-    m_attemptsLeftThisTurn = 1;
+    attemptsLeftThisTurn = 1;
   }
 
   public void resetAttempts(final IDelegateBridge bridge) {
-    if (m_attemptsLeftThisTurn != m_attemptsPerTurn) {
-      bridge.addChange(ChangeFactory.attachmentPropertyChange(this, m_attemptsPerTurn, ATTEMPTS_LEFT_THIS_TURN));
+    if (attemptsLeftThisTurn != attemptsPerTurn) {
+      bridge.addChange(ChangeFactory.attachmentPropertyChange(this, attemptsPerTurn, ATTEMPTS_LEFT_THIS_TURN));
     }
   }
 
   public void useAttempt(final IDelegateBridge bridge) {
     bridge
-        .addChange(ChangeFactory.attachmentPropertyChange(this, (m_attemptsLeftThisTurn - 1), ATTEMPTS_LEFT_THIS_TURN));
+        .addChange(ChangeFactory.attachmentPropertyChange(this, (attemptsLeftThisTurn - 1), ATTEMPTS_LEFT_THIS_TURN));
   }
 
   public boolean hasAttemptsLeft() {
-    return m_attemptsLeftThisTurn > 0;
+    return attemptsLeftThisTurn > 0;
   }
 
   @Override
   public void validate(final GameData data) throws GameParseException {
-    if (m_text.trim().length() <= 0) {
+    if (text.trim().length() <= 0) {
       throw new GameParseException("value: text can't be empty" + thisErrorMsg());
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -59,7 +59,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
    * Indicates there is no condition to this action or if the condition is satisfied.
    */
   public boolean canPerform(final HashMap<ICondition, Boolean> testedConditions) {
-    return m_conditions == null || isSatisfied(testedConditions);
+    return conditions == null || isSatisfied(testedConditions);
   }
 
   private void setText(final String text) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -63,7 +63,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   // the prices the defender pays for the units]
   private String m_destroyedTUV = null;
   // condition for having had a battle in some territory, attacker or defender, win
-  // or lost, etc. these next 9 variables use m_territoryCount for determining the number needed.
+  // or lost, etc. these next 9 variables use territoryCount for determining the number needed.
   private List<Tuple<String, List<Territory>>> m_battle = new ArrayList<>();
   // ownership related
   private String[] m_alliedOwnershipTerritories = null;
@@ -620,14 +620,14 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     }
     // check switch (on/off)
     if (objectiveMet) {
-      objectiveMet = m_switch;
+      objectiveMet = switched;
     }
     // check turn limits
-    if (objectiveMet && m_turns != null) {
+    if (objectiveMet && turns != null) {
       objectiveMet = checkTurns(data);
     }
     // check custom game property options
-    if (objectiveMet && m_gameProperty != null) {
+    if (objectiveMet && gameProperty != null) {
       objectiveMet = this.getGamePropertyState(data);
     }
     // Check for unit presence (Veqryn)
@@ -789,7 +789,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           objectiveMet = false;
         }
         if (getCountEach()) {
-          m_eachMultiple = destroyedTuvForThisRoundSoFar;
+          eachMultiple = destroyedTuvForThisRoundSoFar;
         }
       }
     }
@@ -957,7 +957,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     if (getCountEach()) {
-      m_eachMultiple = numberMet;
+      eachMultiple = numberMet;
     }
     return satisfied;
   }
@@ -1036,7 +1036,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     if (getCountEach()) {
-      m_eachMultiple = numberMet;
+      eachMultiple = numberMet;
     }
     return satisfied;
   }
@@ -1065,7 +1065,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     if (getCountEach()) {
-      m_eachMultiple = numberMet;
+      eachMultiple = numberMet;
     }
     return satisfied;
   }
@@ -1090,7 +1090,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     if (getCountEach()) {
-      m_eachMultiple = numberMet;
+      eachMultiple = numberMet;
     }
     return satisfied;
   }
@@ -1106,7 +1106,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       return found == 0;
     }
     if (getCountEach()) {
-      m_eachMultiple = found;
+      eachMultiple = found;
     }
     return found >= count;
   }
@@ -1122,7 +1122,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       return m_techCount == found;
     }
     if (getCountEach()) {
-      m_eachMultiple = found;
+      eachMultiple = found;
     }
     return found >= m_techCount;
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -612,11 +612,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final List<PlayerID> players = getPlayers();
     final GameData data = delegateBridge.getData();
     // check meta conditions (conditions which hold other conditions)
-    if (m_conditions.size() > 0) {
+    if (conditions.size() > 0) {
       final Map<ICondition, Boolean> actualTestedConditions = Optional.ofNullable(testedConditions)
           .orElseGet(() -> testAllConditionsRecursive(
-              getAllConditionsRecursive(new HashSet<>(m_conditions), null), null, delegateBridge));
-      objectiveMet = areConditionsMet(new ArrayList<>(m_conditions), actualTestedConditions, m_conditionType);
+              getAllConditionsRecursive(new HashSet<>(conditions), null), null, delegateBridge));
+      objectiveMet = areConditionsMet(new ArrayList<>(conditions), actualTestedConditions, conditionType);
     }
     // check switch (on/off)
     if (objectiveMet) {
@@ -851,7 +851,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             .reportMessage(notificationMessage, notificationMessage);
       }
     }
-    return objectiveMet != m_invert;
+    return objectiveMet != invert;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -145,7 +145,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   public Set<PlayerID> getOtherPlayers() {
     final HashSet<PlayerID> otherPlayers = new HashSet<>();
     otherPlayers.add((PlayerID) this.getAttachedTo());
-    otherPlayers.addAll(m_actionAccept);
+    otherPlayers.addAll(actionAccept);
     return otherPlayers;
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/AbstractConditionsAttachmentTest.java
@@ -25,31 +25,31 @@ public class AbstractConditionsAttachmentTest {
   @Test
   public void testSetConditionType_validValues() throws Exception {
     instance.setConditionType("OR");
-    assertEquals("OR", instance.m_conditionType);
+    assertEquals("OR", instance.conditionType);
     instance.setConditionType("AND");
-    assertEquals("AND", instance.m_conditionType);
+    assertEquals("AND", instance.conditionType);
     instance.setConditionType("XOR");
-    assertEquals("XOR", instance.m_conditionType);
+    assertEquals("XOR", instance.conditionType);
     instance.setConditionType("00000012345656");
-    assertEquals("00000012345656", instance.m_conditionType);
+    assertEquals("00000012345656", instance.conditionType);
     instance.setConditionType("0-9");
-    assertEquals("0-9", instance.m_conditionType);
+    assertEquals("0-9", instance.conditionType);
     instance.setConditionType("0987654321-1234567890");
-    assertEquals("0987654321-1234567890", instance.m_conditionType);
+    assertEquals("0987654321-1234567890", instance.conditionType);
   }
 
   @Test
   public void testSetConditionType_validLowercase() throws Exception {
     instance.setConditionType("or");
-    assertEquals("OR", instance.m_conditionType);
+    assertEquals("OR", instance.conditionType);
     instance.setConditionType("and");
-    assertEquals("AND", instance.m_conditionType);
+    assertEquals("AND", instance.conditionType);
     instance.setConditionType("xor");
-    assertEquals("XOR", instance.m_conditionType);
+    assertEquals("XOR", instance.conditionType);
     instance.setConditionType("123");
-    assertEquals("123", instance.m_conditionType);
+    assertEquals("123", instance.conditionType);
     instance.setConditionType("123-456");
-    assertEquals("123-456", instance.m_conditionType);
+    assertEquals("123-456", instance.conditionType);
   }
 
   @Test


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in the `Abstract*Attachment` classes.

## Functional Changes

None.

## Manual Testing Performed

None.