### PR TITLE
Use type-safe wrapper for file client settings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -65,9 +65,9 @@ public final class ClientContext {
   }
 
   public static List<DownloadFileDescription> getMapDownloadList() {
-    final String mapDownloadListUrl =
-        (ClientSetting.mapListOverride.isSet()) ? ClientSetting.mapListOverride.getValueOrThrow()
-            : UrlConstants.MAP_DOWNLOAD_LIST.toString();
+    final String mapDownloadListUrl = ClientSetting.mapListOverride.isSet()
+        ? ClientSetting.mapListOverride.getValueOrThrow().getAbsolutePath()
+        : UrlConstants.MAP_DOWNLOAD_LIST.toString();
 
     return new DownloadRunnable(mapDownloadListUrl).getDownloads();
   }

--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -109,8 +109,7 @@ public final class ClientFileSystemHelper {
    *         retained between engine installations. Users can override this location in settings.
    */
   public static File getUserMapsFolder() {
-    final String path = getUserMapsFolderPath(ClientSetting.userMapsFolderPath, ClientSetting.mapFolderOverride);
-    final File mapsFolder = new File(path);
+    final File mapsFolder = getUserMapsFolder(ClientSetting.userMapsFolderPath, ClientSetting.mapFolderOverride);
     if (!mapsFolder.exists()) {
       mapsFolder.mkdirs();
     }
@@ -121,12 +120,12 @@ public final class ClientFileSystemHelper {
   }
 
   @VisibleForTesting
-  static String getUserMapsFolderPath(
-      final GameSetting<String> currentUserMapsFolderPathSetting,
-      final GameSetting<String> overrideUserMapsFolderPathSetting) {
-    return overrideUserMapsFolderPathSetting.isSet()
-        ? overrideUserMapsFolderPathSetting.getValueOrThrow()
-        : currentUserMapsFolderPathSetting.getValueOrThrow();
+  static File getUserMapsFolder(
+      final GameSetting<File> currentUserMapsFolderSetting,
+      final GameSetting<File> overrideUserMapsFolderSetting) {
+    return overrideUserMapsFolderSetting.isSet()
+        ? overrideUserMapsFolderSetting.getValueOrThrow()
+        : currentUserMapsFolderSetting.getValueOrThrow();
   }
 
   /** Create a temporary file, checked exceptions are re-thrown as unchecked. */

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework;
 
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +43,7 @@ public final class ArgParser {
 
   private static void setSystemPropertyOrClientSetting(final String key, final String value) {
     if (CliProperties.MAP_FOLDER.equals(key)) {
-      ClientSetting.mapFolderOverride.saveAndFlush(value);
+      ClientSetting.mapFolderOverride.saveAndFlush(new File(value));
     } else {
       System.setProperty(key, value);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -591,7 +591,7 @@ public class HeadlessGameServer {
   private static void handleHeadlessGameServerArgs() {
     boolean printUsage = false;
 
-    final File mapFolder = new File(ClientSetting.mapFolderOverride.getValueOrThrow());
+    final File mapFolder = ClientSetting.mapFolderOverride.getValueOrThrow();
     if (!mapFolder.isDirectory()) {
       log.warning("Invalid '" + MAP_FOLDER + "' param, map folder must exist: '" + mapFolder + "'");
       printUsage = true;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -24,7 +24,7 @@ public final class GameFileSelector {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = GameRunner.newFileDialog();
       fileDialog.setMode(FileDialog.LOAD);
-      fileDialog.setDirectory(new File(ClientSetting.saveGamesFolderPath.getValueOrThrow()).getPath());
+      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().getPath());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -65,7 +65,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   @VisibleForTesting
   static File getAutoSaveFile(final String fileName) {
-    return Paths.get(ClientSetting.saveGamesFolderPath.getValueOrThrow(), "autoSave", fileName).toFile();
+    return Paths.get(ClientSetting.saveGamesFolderPath.getValueOrThrow().getPath(), "autoSave", fileName).toFile();
   }
 
   private static File getAutoSaveFile(final String baseFileName, final boolean headless) {
@@ -123,7 +123,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   private SaveGameFileChooser() {
     setFileFilter(createGameDataFileFilter());
-    final File saveGamesFolder = new File(ClientSetting.saveGamesFolderPath.getValueOrThrow());
+    final File saveGamesFolder = ClientSetting.saveGamesFolderPath.getValueOrThrow();
     ensureDirectoryExists(saveGamesFolder);
     setCurrentDirectory(saveGamesFolder);
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -73,13 +73,13 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> mapEdgeScrollSpeed = new IntegerClientSetting("MAP_EDGE_SCROLL_SPEED", 30);
   public static final ClientSetting<Integer> mapEdgeScrollZoneSize =
       new IntegerClientSetting("MAP_EDGE_SCROLL_ZONE_SIZE", 30);
-  public static final ClientSetting<String> mapFolderOverride = new StringClientSetting("MAP_FOLDER_OVERRIDE");
-  public static final ClientSetting<String> mapListOverride = new StringClientSetting("MAP_LIST_OVERRIDE");
+  public static final ClientSetting<File> mapFolderOverride = new FileClientSetting("MAP_FOLDER_OVERRIDE");
+  public static final ClientSetting<File> mapListOverride = new FileClientSetting("MAP_LIST_OVERRIDE");
   public static final ClientSetting<HttpProxy.ProxyChoice> proxyChoice =
       new HttpProxyChoiceClientSetting("PROXY_CHOICE", HttpProxy.ProxyChoice.NONE);
   public static final ClientSetting<String> proxyHost = new StringClientSetting("PROXY_HOST");
   public static final ClientSetting<Integer> proxyPort = new IntegerClientSetting("PROXY_PORT");
-  public static final ClientSetting<String> saveGamesFolderPath = new StringClientSetting(
+  public static final ClientSetting<File> saveGamesFolderPath = new FileClientSetting(
       "SAVE_GAMES_FOLDER_PATH",
       new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames"));
   public static final ClientSetting<Integer> serverObserverJoinWaitTime =
@@ -100,7 +100,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES");
   public static final ClientSetting<Boolean> promptToDownloadTutorialMap =
       new BooleanClientSetting("TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP", true);
-  public static final ClientSetting<String> userMapsFolderPath = new StringClientSetting(
+  public static final ClientSetting<File> userMapsFolderPath = new FileClientSetting(
       "USER_MAPS_FOLDER_PATH",
       new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps"));
   public static final ClientSetting<Integer> wheelScrollAmount = new IntegerClientSetting("WHEEL_SCROLL_AMOUNT", 60);

--- a/game-core/src/main/java/games/strategy/triplea/settings/FileClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/FileClientSetting.java
@@ -1,0 +1,23 @@
+package games.strategy.triplea.settings;
+
+import java.io.File;
+
+final class FileClientSetting extends ClientSetting<File> {
+  FileClientSetting(final String name) {
+    super(File.class, name);
+  }
+
+  FileClientSetting(final String name, final File defaultValue) {
+    super(File.class, name, defaultValue);
+  }
+
+  @Override
+  protected String formatValue(final File value) {
+    return value.getPath();
+  }
+
+  @Override
+  protected File parseValue(final String encodedValue) {
+    return new File(encodedValue);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -290,18 +290,13 @@ final class SelectionComponentFactory {
       final ClientSetting<File> clientSetting,
       final SwingComponents.FolderSelectionMode folderSelectionMode) {
     return new AlwaysValidInputSelectionComponent() {
-      final int expectedLength = 20;
-      final JTextField field = new JTextField(toString(clientSetting.getValue()), expectedLength);
+      final JTextField field = new JTextField(SelectionComponentUiUtils.toString(clientSetting.getValue()), 20);
       final JButton button = JButtonBuilder.builder()
           .title("Select")
           .actionListener(
               () -> SwingComponents.showJFileChooser(folderSelectionMode)
                   .ifPresent(file -> field.setText(file.getAbsolutePath())))
           .build();
-
-      private String toString(final Optional<File> file) {
-        return file.map(File::getAbsolutePath).orElse("");
-      }
 
       @Override
       public JComponent getUiComponent() {
@@ -323,12 +318,12 @@ final class SelectionComponentFactory {
 
       @Override
       public void resetToDefault() {
-        field.setText(toString(clientSetting.getDefaultValue()));
+        field.setText(SelectionComponentUiUtils.toString(clientSetting.getDefaultValue()));
       }
 
       @Override
       public void reset() {
-        field.setText(toString(clientSetting.getValue()));
+        field.setText(SelectionComponentUiUtils.toString(clientSetting.getValue()));
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.settings;
 
 import java.awt.Component;
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -281,22 +282,26 @@ final class SelectionComponentFactory {
   /**
    * File selection prompt.
    */
-  static SelectionComponent<JComponent> filePath(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<JComponent> filePath(final ClientSetting<File> clientSetting) {
     return selectFile(clientSetting, SwingComponents.FolderSelectionMode.FILES);
   }
 
   private static SelectionComponent<JComponent> selectFile(
-      final ClientSetting<String> clientSetting,
+      final ClientSetting<File> clientSetting,
       final SwingComponents.FolderSelectionMode folderSelectionMode) {
     return new AlwaysValidInputSelectionComponent() {
       final int expectedLength = 20;
-      final JTextField field = new JTextField(clientSetting.getValue().orElse(""), expectedLength);
+      final JTextField field = new JTextField(toString(clientSetting.getValue()), expectedLength);
       final JButton button = JButtonBuilder.builder()
           .title("Select")
           .actionListener(
               () -> SwingComponents.showJFileChooser(folderSelectionMode)
                   .ifPresent(file -> field.setText(file.getAbsolutePath())))
           .build();
+
+      private String toString(final Optional<File> file) {
+        return file.map(File::getAbsolutePath).orElse("");
+      }
 
       @Override
       public JComponent getUiComponent() {
@@ -313,17 +318,17 @@ final class SelectionComponentFactory {
       @Override
       public Map<GameSetting<?>, Object> readValues() {
         final String value = field.getText();
-        return Collections.singletonMap(clientSetting, value.isEmpty() ? null : value);
+        return Collections.singletonMap(clientSetting, value.isEmpty() ? null : new File(value));
       }
 
       @Override
       public void resetToDefault() {
-        field.setText(clientSetting.getDefaultValue().orElse(""));
+        field.setText(toString(clientSetting.getDefaultValue()));
       }
 
       @Override
       public void reset() {
-        field.setText(clientSetting.getValue().orElse(""));
+        field.setText(toString(clientSetting.getValue()));
       }
     };
   }
@@ -331,7 +336,7 @@ final class SelectionComponentFactory {
   /**
    * Folder selection prompt.
    */
-  static SelectionComponent<JComponent> folderPath(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<JComponent> folderPath(final ClientSetting<File> clientSetting) {
     return selectFile(clientSetting, SwingComponents.FolderSelectionMode.DIRECTORIES);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentUiUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentUiUtils.java
@@ -1,0 +1,22 @@
+package games.strategy.triplea.settings;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * A collection of methods useful for implementing the UI component of a {@link SelectionComponent}.
+ */
+public final class SelectionComponentUiUtils {
+  private SelectionComponentUiUtils() {}
+
+  /**
+   * Converts {@code file} into a string suitable for display in the UI.
+   */
+  public static String toString(final Optional<File> file) {
+    checkNotNull(file);
+
+    return file.map(File::getAbsolutePath).orElse("");
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.io.File;
-
 final class StringClientSetting extends ClientSetting<String> {
   StringClientSetting(final String name) {
     super(String.class, name);
@@ -9,10 +7,6 @@ final class StringClientSetting extends ClientSetting<String> {
 
   StringClientSetting(final String name, final String defaultValue) {
     super(String.class, name, defaultValue);
-  }
-
-  StringClientSetting(final String name, final File defaultValue) {
-    super(String.class, name, defaultValue.getAbsolutePath());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -70,7 +70,7 @@ public final class TripleAMenuBar extends JMenuBar {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = new FileDialog(frame);
       fileDialog.setMode(FileDialog.SAVE);
-      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow());
+      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().getAbsolutePath());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
 

--- a/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -69,33 +69,32 @@ public final class ClientFileSystemHelperTest {
 
   @ExtendWith(MockitoExtension.class)
   @Nested
-  public final class GetUserMapsFolderPathTest {
+  final class GetUserMapsFolderTest {
     @Mock
-    private GameSetting<String> currentSetting;
-
+    private GameSetting<File> currentSetting;
     @Mock
-    private GameSetting<String> overrideSetting;
+    private GameSetting<File> overrideSetting;
 
-    private String getUserMapsFolderPath() {
-      return ClientFileSystemHelper.getUserMapsFolderPath(currentSetting, overrideSetting);
+    private File getUserMapsFolder() {
+      return ClientFileSystemHelper.getUserMapsFolder(currentSetting, overrideSetting);
     }
 
     @Test
-    public void shouldReturnCurrentPathWhenOverridePathNotSet() {
+    void shouldReturnCurrentFolderWhenOverrideFolderNotSet() {
       when(overrideSetting.isSet()).thenReturn(false);
-      final String currentPath = "/path/to/current";
-      when(currentSetting.getValueOrThrow()).thenReturn(currentPath);
+      final File currentFolder = new File("/path/to/current");
+      when(currentSetting.getValueOrThrow()).thenReturn(currentFolder);
 
-      assertThat(getUserMapsFolderPath(), is(currentPath));
+      assertThat(getUserMapsFolder(), is(currentFolder));
     }
 
     @Test
-    public void shouldReturnOverridePathWhenOverridePathSet() {
+    void shouldReturnOverrideFolderWhenOverrideFolderSet() {
       when(overrideSetting.isSet()).thenReturn(true);
-      final String overridePath = "/path/to/override";
-      when(overrideSetting.getValueOrThrow()).thenReturn(overridePath);
+      final File overrideFolder = new File("/path/to/override");
+      when(overrideSetting.getValueOrThrow()).thenReturn(overrideFolder);
 
-      assertThat(getUserMapsFolderPath(), is(overridePath));
+      assertThat(getUserMapsFolder(), is(overrideFolder));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -6,6 +6,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+import java.io.File;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,17 +72,18 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void mapFolderOverrideClientSettingIsSetWhenSpecified() {
-    ClientSetting.mapFolderOverride.save("some value");
-    final String mapFolderPath = "/path/to/maps";
+    ClientSetting.mapFolderOverride.save(new File("some/path"));
+    final File mapFolder = new File("/path/to/maps");
 
-    ArgParser.handleCommandLineArgs("-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolderPath);
+    ArgParser
+        .handleCommandLineArgs("-P" + HeadlessGameServerCliParam.MAP_FOLDER.getLabel() + "=" + mapFolder.getPath());
 
-    assertThat(ClientSetting.mapFolderOverride.getValueOrThrow(), is(mapFolderPath));
+    assertThat(ClientSetting.mapFolderOverride.getValueOrThrow(), is(mapFolder));
   }
 
   @Test
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
-    ClientSetting.mapFolderOverride.save("some value");
+    ClientSetting.mapFolderOverride.save(new File("some/path"));
 
     ArgParser.handleCommandLineArgs();
 

--- a/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ui/SaveGameFileChooserTest.java
@@ -24,7 +24,7 @@ final class SaveGameFileChooserTest extends AbstractClientSettingTestCase {
   final class GetAutoSaveFileTest {
     @Test
     void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.saveGamesFolderPath.save(Paths.get("path", "to", "saves").toString());
+      ClientSetting.saveGamesFolderPath.save(Paths.get("path", "to", "saves").toFile());
 
       final String fileName = "savegame.tsvg";
       assertThat(getAutoSaveFile(fileName), is(Paths.get("path", "to", "saves", "autoSave", fileName).toFile()));

--- a/game-core/src/test/java/games/strategy/triplea/settings/FileClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/FileClientSettingTest.java
@@ -1,0 +1,31 @@
+package games.strategy.triplea.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class FileClientSettingTest {
+  private final FileClientSetting clientSetting = new FileClientSetting("name", new File("/path/to/file"));
+
+  @Nested
+  final class FormatValueTest {
+    @Test
+    void shouldReturnEncodedValue() {
+      assertThat(clientSetting.formatValue(new File("/absolute/path/to/file")), is("/absolute/path/to/file"));
+      assertThat(clientSetting.formatValue(new File("relative/path/to/file")), is("relative/path/to/file"));
+    }
+  }
+
+  @Nested
+  final class ParseValueTest {
+    @Test
+    void shouldReturnFile() {
+      assertThat(clientSetting.parseValue("/absolute/path/to/file"), is(new File("/absolute/path/to/file")));
+      assertThat(clientSetting.parseValue("relative/path/to/file"), is(new File("relative/path/to/file")));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/SelectionComponentUiUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SelectionComponentUiUtilsTest.java
@@ -1,0 +1,28 @@
+package games.strategy.triplea.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class SelectionComponentUiUtilsTest {
+  @Nested
+  final class ToStringOfOptionalFileTest {
+    @Test
+    void shouldReturnAbsolutePathOfFileWhenPresent() {
+      final File file = new File(".");
+
+      assertThat(SelectionComponentUiUtils.toString(Optional.of(file)), is(file.getAbsolutePath()));
+    }
+
+    @Test
+    void shouldReturnEmptyStringWhenAbsent() {
+      assertThat(SelectionComponentUiUtils.toString(Optional.empty()), is(emptyString()));
+    }
+  }
+}

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
@@ -184,11 +183,11 @@ final class JavaFxSelectionComponentFactory {
     };
   }
 
-  static SelectionComponent<Region> folderPath(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<Region> folderPath(final ClientSetting<File> clientSetting) {
     return new FolderSelector(clientSetting);
   }
 
-  static SelectionComponent<Region> filePath(final ClientSetting<String> clientSetting) {
+  static SelectionComponent<Region> filePath(final ClientSetting<File> clientSetting) {
     return new FileSelector(clientSetting);
   }
 
@@ -200,15 +199,15 @@ final class JavaFxSelectionComponentFactory {
   }
 
   private static final class FolderSelector extends Region implements SelectionComponent<Region> {
-    private final ClientSetting<String> clientSetting;
+    private final ClientSetting<File> clientSetting;
     private final TextField textField;
     private @Nullable File selectedFile;
 
-    FolderSelector(final ClientSetting<String> clientSetting) {
+    FolderSelector(final ClientSetting<File> clientSetting) {
       this.clientSetting = clientSetting;
-      final @Nullable File initialValue = clientSetting.getValue().map(File::new).orElse(null);
+      final @Nullable File initialValue = clientSetting.getValue().orElse(null);
       final HBox wrapper = new HBox();
-      textField = new TextField(clientSetting.getValue().orElse(""));
+      textField = new TextField(toString(clientSetting.getValue()));
       textField.prefColumnCountProperty().bind(Bindings.add(1, Bindings.length(textField.textProperty())));
       textField.setMaxWidth(Double.MAX_VALUE);
       textField.setDisable(true);
@@ -229,21 +228,28 @@ final class JavaFxSelectionComponentFactory {
       getChildren().add(wrapper);
     }
 
+    private static String toString(final Optional<File> file) {
+      return file.map(File::getAbsolutePath).orElse("");
+    }
+
     @Override
     public Map<GameSetting<?>, Object> readValues() {
-      return Collections.singletonMap(clientSetting, Objects.toString(selectedFile, null));
+      return Collections.singletonMap(clientSetting, selectedFile);
     }
 
     @Override
     public void resetToDefault() {
-      textField.setText(clientSetting.getDefaultValue().orElse(""));
-      selectedFile = clientSetting.getDefaultValue().map(File::new).orElse(null);
+      reset(clientSetting.getDefaultValue());
     }
 
     @Override
     public void reset() {
-      textField.setText(clientSetting.getValue().orElse(""));
-      selectedFile = clientSetting.getValue().map(File::new).orElse(null);
+      reset(clientSetting.getValue());
+    }
+
+    private void reset(final Optional<File> file) {
+      textField.setText(toString(file));
+      selectedFile = file.orElse(null);
     }
 
     @Override
@@ -263,15 +269,15 @@ final class JavaFxSelectionComponentFactory {
   }
 
   private static final class FileSelector extends Region implements SelectionComponent<Region> {
-    private final ClientSetting<String> clientSetting;
+    private final ClientSetting<File> clientSetting;
     private final TextField textField;
     private @Nullable File selectedFile;
 
-    FileSelector(final ClientSetting<String> clientSetting) {
+    FileSelector(final ClientSetting<File> clientSetting) {
       this.clientSetting = clientSetting;
-      final @Nullable File initialValue = clientSetting.getValue().map(File::new).orElse(null);
+      final @Nullable File initialValue = clientSetting.getValue().orElse(null);
       final HBox wrapper = new HBox();
-      textField = new TextField(clientSetting.getValue().orElse(""));
+      textField = new TextField(toString(clientSetting.getValue()));
       textField.prefColumnCountProperty().bind(Bindings.add(1, Bindings.length(textField.textProperty())));
       textField.setMaxWidth(Double.MAX_VALUE);
       textField.setMinWidth(100);
@@ -293,21 +299,28 @@ final class JavaFxSelectionComponentFactory {
       getChildren().add(wrapper);
     }
 
+    private static String toString(final Optional<File> file) {
+      return file.map(File::getAbsolutePath).orElse("");
+    }
+
     @Override
     public Map<GameSetting<?>, Object> readValues() {
-      return Collections.singletonMap(clientSetting, Objects.toString(selectedFile, null));
+      return Collections.singletonMap(clientSetting, selectedFile);
     }
 
     @Override
     public void resetToDefault() {
-      textField.setText(clientSetting.getDefaultValue().orElse(""));
-      selectedFile = clientSetting.getDefaultValue().map(File::new).orElse(null);
+      reset(clientSetting.getDefaultValue());
     }
 
     @Override
     public void reset() {
-      textField.setText(clientSetting.getValue().orElse(""));
-      selectedFile = clientSetting.getValue().map(File::new).orElse(null);
+      reset(clientSetting.getValue());
+    }
+
+    private void reset(final Optional<File> file) {
+      textField.setText(toString(file));
+      selectedFile = file.orElse(null);
     }
 
     @Override

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -14,6 +14,7 @@ import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.SelectionComponent;
+import games.strategy.triplea.settings.SelectionComponentUiUtils;
 import javafx.beans.binding.Bindings;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -207,7 +208,7 @@ final class JavaFxSelectionComponentFactory {
       this.clientSetting = clientSetting;
       final @Nullable File initialValue = clientSetting.getValue().orElse(null);
       final HBox wrapper = new HBox();
-      textField = new TextField(toString(clientSetting.getValue()));
+      textField = new TextField(SelectionComponentUiUtils.toString(clientSetting.getValue()));
       textField.prefColumnCountProperty().bind(Bindings.add(1, Bindings.length(textField.textProperty())));
       textField.setMaxWidth(Double.MAX_VALUE);
       textField.setDisable(true);
@@ -228,10 +229,6 @@ final class JavaFxSelectionComponentFactory {
       getChildren().add(wrapper);
     }
 
-    private static String toString(final Optional<File> file) {
-      return file.map(File::getAbsolutePath).orElse("");
-    }
-
     @Override
     public Map<GameSetting<?>, Object> readValues() {
       return Collections.singletonMap(clientSetting, selectedFile);
@@ -248,7 +245,7 @@ final class JavaFxSelectionComponentFactory {
     }
 
     private void reset(final Optional<File> file) {
-      textField.setText(toString(file));
+      textField.setText(SelectionComponentUiUtils.toString(file));
       selectedFile = file.orElse(null);
     }
 
@@ -277,7 +274,7 @@ final class JavaFxSelectionComponentFactory {
       this.clientSetting = clientSetting;
       final @Nullable File initialValue = clientSetting.getValue().orElse(null);
       final HBox wrapper = new HBox();
-      textField = new TextField(toString(clientSetting.getValue()));
+      textField = new TextField(SelectionComponentUiUtils.toString(clientSetting.getValue()));
       textField.prefColumnCountProperty().bind(Bindings.add(1, Bindings.length(textField.textProperty())));
       textField.setMaxWidth(Double.MAX_VALUE);
       textField.setMinWidth(100);
@@ -299,10 +296,6 @@ final class JavaFxSelectionComponentFactory {
       getChildren().add(wrapper);
     }
 
-    private static String toString(final Optional<File> file) {
-      return file.map(File::getAbsolutePath).orElse("");
-    }
-
     @Override
     public Map<GameSetting<?>, Object> readValues() {
       return Collections.singletonMap(clientSetting, selectedFile);
@@ -319,7 +312,7 @@ final class JavaFxSelectionComponentFactory {
     }
 
     private void reset(final Optional<File> file) {
-      textField.setText(toString(file));
+      textField.setText(SelectionComponentUiUtils.toString(file));
       selectedFile = file.orElse(null);
     }
 


### PR DESCRIPTION
## Overview

Converts all client settings that represent a file or folder from `ClientSetting<String>` to `ClientSetting<File>`.

## Functional Changes

None.

## Manual Testing Performed

Basic smoke testing of file/folder client settings in both Swing and JavaFX clients.