### PR TITLE
Checkstyle: Fix naming violations in attachments (T-U)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -191,7 +191,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   public int getProduction() {
-    return m_production;
+    return production;
   }
 
   /**
@@ -206,30 +206,30 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   public int getUnitProduction() {
-    return m_unitProduction;
+    return unitProduction;
   }
 
-  private String m_capital = null;
-  private boolean m_originalFactory = false;
-  // "setProduction" will set both m_production and m_unitProduction.
-  // While "setProductionOnly" sets only m_production.
-  private int m_production = 0;
-  private int m_victoryCity = 0;
-  private boolean m_isImpassable = false;
-  private PlayerID m_originalOwner = null;
-  private boolean m_convoyRoute = false;
-  private HashSet<Territory> m_convoyAttached = new HashSet<>();
-  private ArrayList<PlayerID> m_changeUnitOwners = new ArrayList<>();
-  private ArrayList<PlayerID> m_captureUnitOnEnteringBy = new ArrayList<>();
-  private boolean m_navalBase = false;
-  private boolean m_airBase = false;
-  private boolean m_kamikazeZone = false;
-  private int m_unitProduction = 0;
-  private boolean m_blockadeZone = false;
-  private ArrayList<TerritoryEffect> m_territoryEffect = new ArrayList<>();
+  private String capital = null;
+  private boolean originalFactory = false;
+  // "setProduction" will set both production and unitProduction.
+  // While "setProductionOnly" sets only production.
+  private int production = 0;
+  private int victoryCity = 0;
+  private boolean isImpassable = false;
+  private PlayerID originalOwner = null;
+  private boolean convoyRoute = false;
+  private HashSet<Territory> convoyAttached = new HashSet<>();
+  private ArrayList<PlayerID> changeUnitOwners = new ArrayList<>();
+  private ArrayList<PlayerID> captureUnitOnEnteringBy = new ArrayList<>();
+  private boolean navalBase = false;
+  private boolean airBase = false;
+  private boolean kamikazeZone = false;
+  private int unitProduction = 0;
+  private boolean blockadeZone = false;
+  private ArrayList<TerritoryEffect> territoryEffect = new ArrayList<>();
   // TODO: change to List<CaptureOwnershipChange> upon next incompatible release
-  private ArrayList<String> m_whenCapturedByGoesTo = new ArrayList<>();
-  private ResourceCollection m_resources = null;
+  private ArrayList<String> whenCapturedByGoesTo = new ArrayList<>();
+  private ResourceCollection resources = null;
 
   /** Creates new TerritoryAttachment. */
   public TerritoryAttachment(final String name, final Attachable attachable, final GameData gameData) {
@@ -238,11 +238,11 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   private void setResources(final String value) throws GameParseException {
     if (value == null) {
-      m_resources = null;
+      resources = null;
       return;
     }
-    if (m_resources == null) {
-      m_resources = new ResourceCollection(getData());
+    if (resources == null) {
+      resources = new ResourceCollection(getData());
     }
     final String[] s = splitOnColon(value);
     final int amount = getInt(s[0]);
@@ -253,19 +253,19 @@ public class TerritoryAttachment extends DefaultAttachment {
     if (resource == null) {
       throw new GameParseException("No resource named: " + s[1] + thisErrorMsg());
     }
-    m_resources.putResource(resource, amount);
+    resources.putResource(resource, amount);
   }
 
   private void setResources(final ResourceCollection value) {
-    m_resources = value;
+    resources = value;
   }
 
   public ResourceCollection getResources() {
-    return m_resources;
+    return resources;
   }
 
   private void resetResources() {
-    m_resources = null;
+    resources = null;
   }
 
   private void setIsImpassable(final String value) {
@@ -273,47 +273,47 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setIsImpassable(final boolean value) {
-    m_isImpassable = value;
+    isImpassable = value;
   }
 
   public boolean getIsImpassable() {
-    return m_isImpassable;
+    return isImpassable;
   }
 
   private void resetIsImpassable() {
-    m_isImpassable = false;
+    isImpassable = false;
   }
 
   public void setCapital(final String value) throws GameParseException {
     if (value == null) {
-      m_capital = null;
+      capital = null;
       return;
     }
     final PlayerID p = getData().getPlayerList().getPlayerId(value);
     if (p == null) {
       throw new GameParseException("No Player named: " + value + thisErrorMsg());
     }
-    m_capital = value;
+    capital = value;
   }
 
   public boolean isCapital() {
-    return m_capital != null;
+    return capital != null;
   }
 
   public String getCapital() {
-    return m_capital;
+    return capital;
   }
 
   private void resetCapital() {
-    m_capital = null;
+    capital = null;
   }
 
   private void setVictoryCity(final int value) {
-    m_victoryCity = value;
+    victoryCity = value;
   }
 
   public int getVictoryCity() {
-    return m_victoryCity;
+    return victoryCity;
   }
 
   private void setOriginalFactory(final String value) {
@@ -321,15 +321,15 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setOriginalFactory(final boolean value) {
-    m_originalFactory = value;
+    originalFactory = value;
   }
 
   public boolean getOriginalFactory() {
-    return m_originalFactory;
+    return originalFactory;
   }
 
   private void resetOriginalFactory() {
-    m_originalFactory = false;
+    originalFactory = false;
   }
 
   /**
@@ -338,9 +338,9 @@ public class TerritoryAttachment extends DefaultAttachment {
    * used when parsing game XML since it passes string values.
    */
   private void setProduction(final String value) {
-    m_production = getInt(value);
+    production = getInt(value);
     // do NOT remove. unitProduction should always default to production
-    m_unitProduction = m_production;
+    unitProduction = production;
   }
 
   /**
@@ -349,71 +349,71 @@ public class TerritoryAttachment extends DefaultAttachment {
    * used when working with game history since it passes Integer values.
    */
   private void setProduction(final Integer value) {
-    m_production = value;
+    production = value;
     // do NOT remove. unitProduction should always default to production
-    m_unitProduction = m_production;
+    unitProduction = production;
   }
 
   /**
    * Resets production and unitProduction (or just "production" in a map xml) of a territory to the default value.
    */
   private void resetProduction() {
-    m_production = 0;
+    production = 0;
     // do NOT remove. unitProduction should always default to production
-    m_unitProduction = m_production;
+    unitProduction = production;
   }
 
   /**
-   * Sets only m_production.
+   * Sets only production.
    */
   private void setProductionOnly(final String value) {
-    m_production = getInt(value);
+    production = getInt(value);
   }
 
   private void setUnitProduction(final int value) {
-    m_unitProduction = value;
+    unitProduction = value;
   }
 
   /**
    * Should not be set by a game xml during attachment parsing, but CAN be set by initialization parsing.
    */
   public void setOriginalOwner(final PlayerID player) {
-    m_originalOwner = player;
+    originalOwner = player;
   }
 
   private void setOriginalOwner(final String player) throws GameParseException {
     if (player == null) {
-      m_originalOwner = null;
+      originalOwner = null;
     }
     final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(player);
     if (tempPlayer == null) {
       throw new GameParseException("No player named: " + player + thisErrorMsg());
     }
-    m_originalOwner = tempPlayer;
+    originalOwner = tempPlayer;
   }
 
   public PlayerID getOriginalOwner() {
-    return m_originalOwner;
+    return originalOwner;
   }
 
   private void resetOriginalOwner() {
-    m_originalOwner = null;
+    originalOwner = null;
   }
 
   private void setConvoyRoute(final String value) {
-    m_convoyRoute = getBool(value);
+    convoyRoute = getBool(value);
   }
 
   private void setConvoyRoute(final Boolean value) {
-    m_convoyRoute = value;
+    convoyRoute = value;
   }
 
   public boolean getConvoyRoute() {
-    return m_convoyRoute;
+    return convoyRoute;
   }
 
   private void resetConvoyRoute() {
-    m_convoyRoute = false;
+    convoyRoute = false;
   }
 
   private void setChangeUnitOwners(final String value) throws GameParseException {
@@ -421,9 +421,9 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_changeUnitOwners.add(tempPlayer);
+        changeUnitOwners.add(tempPlayer);
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
-        m_changeUnitOwners.clear();
+        changeUnitOwners.clear();
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -431,15 +431,15 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setChangeUnitOwners(final ArrayList<PlayerID> value) {
-    m_changeUnitOwners = value;
+    changeUnitOwners = value;
   }
 
   public ArrayList<PlayerID> getChangeUnitOwners() {
-    return m_changeUnitOwners;
+    return changeUnitOwners;
   }
 
   private void resetChangeUnitOwners() {
-    m_changeUnitOwners = new ArrayList<>();
+    changeUnitOwners = new ArrayList<>();
   }
 
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
@@ -447,7 +447,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_captureUnitOnEnteringBy.add(tempPlayer);
+        captureUnitOnEnteringBy.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -455,15 +455,15 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setCaptureUnitOnEnteringBy(final ArrayList<PlayerID> value) {
-    m_captureUnitOnEnteringBy = value;
+    captureUnitOnEnteringBy = value;
   }
 
   public ArrayList<PlayerID> getCaptureUnitOnEnteringBy() {
-    return m_captureUnitOnEnteringBy;
+    return captureUnitOnEnteringBy;
   }
 
   private void resetCaptureUnitOnEnteringBy() {
-    m_captureUnitOnEnteringBy = new ArrayList<>();
+    captureUnitOnEnteringBy = new ArrayList<>();
   }
 
   @VisibleForTesting
@@ -479,23 +479,23 @@ public class TerritoryAttachment extends DefaultAttachment {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
     }
-    m_whenCapturedByGoesTo.add(value);
+    whenCapturedByGoesTo.add(value);
   }
 
   private void setWhenCapturedByGoesTo(final ArrayList<String> value) {
-    m_whenCapturedByGoesTo = value;
+    whenCapturedByGoesTo = value;
   }
 
   private ArrayList<String> getWhenCapturedByGoesTo() {
-    return m_whenCapturedByGoesTo;
+    return whenCapturedByGoesTo;
   }
 
   private void resetWhenCapturedByGoesTo() {
-    m_whenCapturedByGoesTo = new ArrayList<>();
+    whenCapturedByGoesTo = new ArrayList<>();
   }
 
   public Collection<CaptureOwnershipChange> getCaptureOwnershipChanges() {
-    return m_whenCapturedByGoesTo.stream()
+    return whenCapturedByGoesTo.stream()
         .map(this::parseCaptureOwnershipChange)
         .collect(Collectors.toList());
   }
@@ -514,7 +514,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final String name : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(name);
       if (effect != null) {
-        m_territoryEffect.add(effect);
+        territoryEffect.add(effect);
       } else {
         throw new GameParseException("No TerritoryEffect named: " + name + thisErrorMsg());
       }
@@ -522,15 +522,15 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   private void setTerritoryEffect(final ArrayList<TerritoryEffect> value) {
-    m_territoryEffect = value;
+    territoryEffect = value;
   }
 
   public ArrayList<TerritoryEffect> getTerritoryEffect() {
-    return m_territoryEffect;
+    return territoryEffect;
   }
 
   private void resetTerritoryEffect() {
-    m_territoryEffect = new ArrayList<>();
+    territoryEffect = new ArrayList<>();
   }
 
   private void setConvoyAttached(final String value) throws GameParseException {
@@ -542,84 +542,84 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (territory == null) {
         throw new GameParseException("No territory called:" + subString + thisErrorMsg());
       }
-      m_convoyAttached.add(territory);
+      convoyAttached.add(territory);
     }
   }
 
   private void setConvoyAttached(final HashSet<Territory> value) {
-    m_convoyAttached = value;
+    convoyAttached = value;
   }
 
   public HashSet<Territory> getConvoyAttached() {
-    return m_convoyAttached;
+    return convoyAttached;
   }
 
   private void resetConvoyAttached() {
-    m_convoyAttached = new HashSet<>();
+    convoyAttached = new HashSet<>();
   }
 
   private void setNavalBase(final String value) {
-    m_navalBase = getBool(value);
+    navalBase = getBool(value);
   }
 
   private void setNavalBase(final Boolean value) {
-    m_navalBase = value;
+    navalBase = value;
   }
 
   public boolean getNavalBase() {
-    return m_navalBase;
+    return navalBase;
   }
 
   private void resetNavalBase() {
-    m_navalBase = false;
+    navalBase = false;
   }
 
   private void setAirBase(final String value) {
-    m_airBase = getBool(value);
+    airBase = getBool(value);
   }
 
   private void setAirBase(final Boolean value) {
-    m_airBase = value;
+    airBase = value;
   }
 
   public boolean getAirBase() {
-    return m_airBase;
+    return airBase;
   }
 
   private void resetAirBase() {
-    m_airBase = false;
+    airBase = false;
   }
 
   private void setKamikazeZone(final String value) {
-    m_kamikazeZone = getBool(value);
+    kamikazeZone = getBool(value);
   }
 
   private void setKamikazeZone(final Boolean value) {
-    m_kamikazeZone = value;
+    kamikazeZone = value;
   }
 
   public boolean getKamikazeZone() {
-    return m_kamikazeZone;
+    return kamikazeZone;
   }
 
   private void resetKamikazeZone() {
-    m_kamikazeZone = false;
+    kamikazeZone = false;
   }
 
   private void setBlockadeZone(final String value) {
-    m_blockadeZone = getBool(value);
+    blockadeZone = getBool(value);
   }
 
   private void setBlockadeZone(final Boolean value) {
-    m_blockadeZone = value;
+    blockadeZone = value;
   }
 
   public boolean getBlockadeZone() {
-    return m_blockadeZone;
+    return blockadeZone;
   }
 
   private void resetBlockadeZone() {
-    m_blockadeZone = false;
+    blockadeZone = false;
   }
 
   public static Set<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(final Territory t, final GameData data) {
@@ -667,89 +667,89 @@ public class TerritoryAttachment extends DefaultAttachment {
         sb.append(br);
       }
     }
-    if (m_isImpassable) {
+    if (isImpassable) {
       sb.append("Is Impassable");
       sb.append(br);
     }
-    if (m_capital != null && m_capital.length() > 0) {
-      sb.append("A Capital of ").append(m_capital);
+    if (capital != null && capital.length() > 0) {
+      sb.append("A Capital of ").append(capital);
       sb.append(br);
     }
-    if (m_victoryCity != 0) {
+    if (victoryCity != 0) {
       sb.append("Is a Victory location");
       sb.append(br);
     }
-    if (m_kamikazeZone) {
+    if (kamikazeZone) {
       sb.append("Is Kamikaze Zone");
       sb.append(br);
     }
-    if (m_blockadeZone) {
+    if (blockadeZone) {
       sb.append("Is a Blockade Zone");
       sb.append(br);
     }
-    if (m_navalBase) {
+    if (navalBase) {
       sb.append("Is a Naval Base");
       sb.append(br);
     }
-    if (m_airBase) {
+    if (airBase) {
       sb.append("Is an Air Base");
       sb.append(br);
     }
-    if (m_convoyRoute) {
-      if (!m_convoyAttached.isEmpty()) {
-        sb.append("Needs: ").append(MyFormatter.defaultNamedToTextList(m_convoyAttached)).append(br);
+    if (convoyRoute) {
+      if (!convoyAttached.isEmpty()) {
+        sb.append("Needs: ").append(MyFormatter.defaultNamedToTextList(convoyAttached)).append(br);
       }
       final Set<Territory> requiredBy = getWhatTerritoriesThisIsUsedInConvoysFor(t, getData());
       if (!requiredBy.isEmpty()) {
         sb.append("Required By: ").append(MyFormatter.defaultNamedToTextList(requiredBy)).append(br);
       }
     }
-    if (m_changeUnitOwners != null && !m_changeUnitOwners.isEmpty()) {
+    if (changeUnitOwners != null && !changeUnitOwners.isEmpty()) {
       sb.append("Units May Change Ownership Here");
       sb.append(br);
     }
-    if (m_captureUnitOnEnteringBy != null && !m_captureUnitOnEnteringBy.isEmpty()) {
+    if (captureUnitOnEnteringBy != null && !captureUnitOnEnteringBy.isEmpty()) {
       sb.append("May Allow The Capture of Some Units");
       sb.append(br);
     }
-    if (m_whenCapturedByGoesTo != null && !m_whenCapturedByGoesTo.isEmpty()) {
+    if (whenCapturedByGoesTo != null && !whenCapturedByGoesTo.isEmpty()) {
       sb.append("Captured By -> Ownership Goes To");
       sb.append(br);
-      for (final String value : m_whenCapturedByGoesTo) {
+      for (final String value : whenCapturedByGoesTo) {
         final String[] s = splitOnColon(value);
         sb.append(s[0]).append(" -> ").append(s[1]);
         sb.append(br);
       }
     }
     sb.append(br);
-    if (!t.isWater() && m_unitProduction > 0
+    if (!t.isWater() && unitProduction > 0
         && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())) {
       sb.append("Base Unit Production: ");
-      sb.append(m_unitProduction);
+      sb.append(unitProduction);
       sb.append(br);
     }
-    if (m_production > 0 || (m_resources != null && m_resources.toString().length() > 0)) {
+    if (production > 0 || (resources != null && resources.toString().length() > 0)) {
       sb.append("Production: ");
       sb.append(br);
-      if (m_production > 0) {
-        sb.append("&nbsp;&nbsp;&nbsp;&nbsp;").append(m_production).append(" PUs");
+      if (production > 0) {
+        sb.append("&nbsp;&nbsp;&nbsp;&nbsp;").append(production).append(" PUs");
         sb.append(br);
       }
-      if (m_resources != null) {
+      if (resources != null) {
         if (useHtml) {
           sb.append("&nbsp;&nbsp;&nbsp;&nbsp;")
-              .append((m_resources.toStringForHtml()).replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
+              .append((resources.toStringForHtml()).replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
         } else {
-          sb.append(m_resources.toString());
+          sb.append(resources.toString());
         }
         sb.append(br);
       }
     }
-    if (!m_territoryEffect.isEmpty()) {
+    if (!territoryEffect.isEmpty()) {
       sb.append("Territory Effects: ");
       sb.append(br);
     }
-    sb.append(m_territoryEffect.stream()
+    sb.append(territoryEffect.stream()
         .map(TerritoryEffect::getName)
         .map(name -> "&nbsp;&nbsp;&nbsp;&nbsp;" + name + br)
         .collect(Collectors.joining()));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -24,10 +24,10 @@ import games.strategy.util.IntegerMap;
 public class TerritoryEffectAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 6379810228136325991L;
 
-  private IntegerMap<UnitType> m_combatDefenseEffect = new IntegerMap<>();
-  private IntegerMap<UnitType> m_combatOffenseEffect = new IntegerMap<>();
-  private List<UnitType> m_noBlitz = new ArrayList<>();
-  private List<UnitType> m_unitsNotAllowed = new ArrayList<>();
+  private IntegerMap<UnitType> combatDefenseEffect = new IntegerMap<>();
+  private IntegerMap<UnitType> combatOffenseEffect = new IntegerMap<>();
+  private List<UnitType> noBlitz = new ArrayList<>();
+  private List<UnitType> unitsNotAllowed = new ArrayList<>();
 
   /**
    * Creates new TerritoryEffectAttachment.
@@ -52,15 +52,15 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   private void setCombatDefenseEffect(final IntegerMap<UnitType> value) {
-    m_combatDefenseEffect = value;
+    combatDefenseEffect = value;
   }
 
   private IntegerMap<UnitType> getCombatDefenseEffect() {
-    return new IntegerMap<>(m_combatDefenseEffect);
+    return new IntegerMap<>(combatDefenseEffect);
   }
 
   private void resetCombatDefenseEffect() {
-    m_combatDefenseEffect = new IntegerMap<>();
+    combatDefenseEffect = new IntegerMap<>();
   }
 
   private void setCombatOffenseEffect(final String combatOffenseEffect) throws GameParseException {
@@ -68,15 +68,15 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   }
 
   private void setCombatOffenseEffect(final IntegerMap<UnitType> value) {
-    m_combatOffenseEffect = value;
+    combatOffenseEffect = value;
   }
 
   private IntegerMap<UnitType> getCombatOffenseEffect() {
-    return new IntegerMap<>(m_combatOffenseEffect);
+    return new IntegerMap<>(combatOffenseEffect);
   }
 
   private void resetCombatOffenseEffect() {
-    m_combatOffenseEffect = new IntegerMap<>();
+    combatOffenseEffect = new IntegerMap<>();
   }
 
   @InternalDoNotExport
@@ -95,15 +95,15 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
         throw new GameParseException("No unit called:" + unitTypeToProduce + thisErrorMsg());
       }
       if (defending) {
-        m_combatDefenseEffect.put(ut, effect);
+        combatDefenseEffect.put(ut, effect);
       } else {
-        m_combatOffenseEffect.put(ut, effect);
+        combatOffenseEffect.put(ut, effect);
       }
     }
   }
 
   public int getCombatEffect(final UnitType type, final boolean defending) {
-    return defending ? m_combatDefenseEffect.getInt(type) : m_combatOffenseEffect.getInt(type);
+    return defending ? combatDefenseEffect.getInt(type) : combatOffenseEffect.getInt(type);
   }
 
   private void setNoBlitz(final String noBlitzUnitTypes) throws GameParseException {
@@ -116,20 +116,20 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
       if (ut == null) {
         throw new GameParseException("No unit called:" + unitTypeName + thisErrorMsg());
       }
-      m_noBlitz.add(ut);
+      noBlitz.add(ut);
     }
   }
 
   private void setNoBlitz(final List<UnitType> value) {
-    m_noBlitz = value;
+    noBlitz = value;
   }
 
   public List<UnitType> getNoBlitz() {
-    return new ArrayList<>(m_noBlitz);
+    return new ArrayList<>(noBlitz);
   }
 
   private void resetNoBlitz() {
-    m_noBlitz = new ArrayList<>();
+    noBlitz = new ArrayList<>();
   }
 
   private void setUnitsNotAllowed(final String unitsNotAllowedUnitTypes) throws GameParseException {
@@ -142,20 +142,20 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
       if (ut == null) {
         throw new GameParseException("No unit called:" + unitTypeName + thisErrorMsg());
       }
-      m_unitsNotAllowed.add(ut);
+      unitsNotAllowed.add(ut);
     }
   }
 
   private void setUnitsNotAllowed(final List<UnitType> value) {
-    m_unitsNotAllowed = value;
+    unitsNotAllowed = value;
   }
 
   public List<UnitType> getUnitsNotAllowed() {
-    return new ArrayList<>(m_unitsNotAllowed);
+    return new ArrayList<>(unitsNotAllowed);
   }
 
   private void resetUnitsNotAllowed() {
-    m_unitsNotAllowed = new ArrayList<>();
+    unitsNotAllowed = new ArrayList<>();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -27,30 +27,30 @@ import games.strategy.triplea.MapSupport;
 public class UnitSupportAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -3015679930172496082L;
 
-  private Set<UnitType> m_unitType = null;
+  private Set<UnitType> unitType = null;
   @InternalDoNotExport
-  private boolean m_offence = false;
+  private boolean offence = false;
   @InternalDoNotExport
-  private boolean m_defence = false;
+  private boolean defence = false;
   @InternalDoNotExport
-  private boolean m_roll = false;
+  private boolean roll = false;
   @InternalDoNotExport
-  private boolean m_strength = false;
-  private int m_bonus = 0;
-  private int m_number = 0;
+  private boolean strength = false;
+  private int bonus = 0;
+  private int number = 0;
   @InternalDoNotExport
-  private boolean m_allied = false;
+  private boolean allied = false;
   @InternalDoNotExport
-  private boolean m_enemy = false;
-  private String m_bonusType = null;
-  private List<PlayerID> m_players = new ArrayList<>();
-  private boolean m_impArtTech = false;
+  private boolean enemy = false;
+  private String bonusType = null;
+  private List<PlayerID> players = new ArrayList<>();
+  private boolean impArtTech = false;
   // strings
   // roll or strength
-  private String m_dice;
+  private String dice;
   // offence or defence
-  private String m_side;
-  private String m_faction;
+  private String side;
+  private String faction;
 
   public UnitSupportAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -81,40 +81,40 @@ public class UnitSupportAttachment extends DefaultAttachment {
 
   private void setUnitType(final String names) throws GameParseException {
     if (names == null) {
-      m_unitType = null;
+      unitType = null;
       return;
     }
-    m_unitType = new HashSet<>();
+    unitType = new HashSet<>();
     for (final String element : splitOnColon(names)) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
         throw new GameParseException("Could not find unitType. name:" + element + thisErrorMsg());
       }
-      m_unitType.add(type);
+      unitType.add(type);
     }
   }
 
   private void setUnitType(final Set<UnitType> value) {
-    m_unitType = value;
+    unitType = value;
   }
 
   private void resetUnitType() {
-    m_unitType = null;
+    unitType = null;
   }
 
   private void setFaction(final String faction) throws GameParseException {
-    m_faction = faction;
+    this.faction = faction;
     if (faction == null) {
       resetFaction();
       return;
     }
-    m_allied = false;
-    m_enemy = false;
+    allied = false;
+    enemy = false;
     for (final String element : splitOnColon(faction)) {
       if (element.equalsIgnoreCase("allied")) {
-        m_allied = true;
+        allied = true;
       } else if (element.equalsIgnoreCase("enemy")) {
-        m_enemy = true;
+        enemy = true;
       } else {
         throw new GameParseException(faction + " faction must be allied, or enemy" + thisErrorMsg());
       }
@@ -122,12 +122,12 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   private String getFaction() {
-    return m_faction;
+    return faction;
   }
 
   private void resetFaction() {
-    m_allied = false;
-    m_enemy = false;
+    allied = false;
+    enemy = false;
   }
 
   private void setSide(final String side) throws GameParseException {
@@ -135,28 +135,28 @@ public class UnitSupportAttachment extends DefaultAttachment {
       resetSide();
       return;
     }
-    m_defence = false;
-    m_offence = false;
+    defence = false;
+    offence = false;
     for (final String element : splitOnColon(side)) {
       if (element.equalsIgnoreCase("defence")) {
-        m_defence = true;
+        defence = true;
       } else if (element.equalsIgnoreCase("offence")) {
-        m_offence = true;
+        offence = true;
       } else {
         throw new GameParseException(side + " side must be defence or offence" + thisErrorMsg());
       }
     }
-    m_side = side;
+    this.side = side;
   }
 
   private String getSide() {
-    return m_side;
+    return side;
   }
 
   private void resetSide() {
-    m_side = null;
-    m_offence = false;
-    m_defence = false;
+    side = null;
+    offence = false;
+    defence = false;
   }
 
   private void setDice(final String dice) throws GameParseException {
@@ -164,60 +164,60 @@ public class UnitSupportAttachment extends DefaultAttachment {
       resetDice();
       return;
     }
-    m_roll = false;
-    m_strength = false;
+    roll = false;
+    strength = false;
     for (final String element : splitOnColon(dice)) {
       if (element.equalsIgnoreCase("roll")) {
-        m_roll = true;
+        roll = true;
       } else if (element.equalsIgnoreCase("strength")) {
-        m_strength = true;
+        strength = true;
       } else {
         throw new GameParseException(dice + " dice must be roll or strength" + thisErrorMsg());
       }
     }
-    m_dice = dice;
+    this.dice = dice;
   }
 
   private String getDice() {
-    return m_dice;
+    return dice;
   }
 
   private void resetDice() {
-    m_dice = null;
-    m_roll = false;
-    m_strength = false;
+    dice = null;
+    roll = false;
+    strength = false;
   }
 
   private void setBonus(final String bonus) {
-    m_bonus = getInt(bonus);
+    this.bonus = getInt(bonus);
   }
 
   private void setBonus(final int bonus) {
-    m_bonus = bonus;
+    this.bonus = bonus;
   }
 
   private void resetBonus() {
-    m_bonus = 0;
+    bonus = 0;
   }
 
   private void setNumber(final String number) {
-    m_number = getInt(number);
+    this.number = getInt(number);
   }
 
   private void setNumber(final int number) {
-    m_number = number;
+    this.number = number;
   }
 
   private void resetNumber() {
-    m_number = 0;
+    number = 0;
   }
 
   private void setBonusType(final String type) {
-    m_bonusType = type;
+    bonusType = type;
   }
 
   private void resetBonusType() {
-    m_bonusType = null;
+    bonusType = null;
   }
 
   private void setPlayers(final String names) throws GameParseException {
@@ -227,76 +227,76 @@ public class UnitSupportAttachment extends DefaultAttachment {
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
       }
-      m_players.add(player);
+      players.add(player);
     }
   }
 
   private void setPlayers(final List<PlayerID> value) {
-    m_players = value;
+    players = value;
   }
 
   public List<PlayerID> getPlayers() {
-    return m_players;
+    return players;
   }
 
   private void resetPlayers() {
-    m_players = new ArrayList<>();
+    players = new ArrayList<>();
   }
 
   private void setImpArtTech(final String tech) {
-    m_impArtTech = getBool(tech);
+    impArtTech = getBool(tech);
   }
 
   private void setImpArtTech(final boolean tech) {
-    m_impArtTech = tech;
+    impArtTech = tech;
   }
 
   private void resetImpArtTech() {
-    m_impArtTech = false;
+    impArtTech = false;
   }
 
   public Set<UnitType> getUnitType() {
-    return m_unitType;
+    return unitType;
   }
 
   public int getNumber() {
-    return m_number;
+    return number;
   }
 
   public int getBonus() {
-    return m_bonus;
+    return bonus;
   }
 
   public boolean getAllied() {
-    return m_allied;
+    return allied;
   }
 
   public boolean getEnemy() {
-    return m_enemy;
+    return enemy;
   }
 
   public boolean getRoll() {
-    return m_roll;
+    return roll;
   }
 
   public boolean getStrength() {
-    return m_strength;
+    return strength;
   }
 
   public boolean getDefence() {
-    return m_defence;
+    return defence;
   }
 
   public boolean getOffence() {
-    return m_offence;
+    return offence;
   }
 
   public String getBonusType() {
-    return m_bonusType;
+    return bonusType;
   }
 
   public boolean getImpArtTech() {
-    return m_impArtTech;
+    return impArtTech;
   }
 
   /*
@@ -345,10 +345,10 @@ public class UnitSupportAttachment extends DefaultAttachment {
     if (types == null) {
       return;
     }
-    if (m_unitType == null) {
-      m_unitType = new HashSet<>();
+    if (unitType == null) {
+      unitType = new HashSet<>();
     }
-    m_unitType.addAll(types);
+    unitType.addAll(types);
   }
 
   @InternalDoNotExport

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -33,8 +33,7 @@ import games.strategy.util.Tuple;
 public class UserActionAttachment extends AbstractUserActionAttachment {
   private static final long serialVersionUID = 5268397563276055355L;
 
-  private List<Tuple<String, String>> m_activateTrigger = new ArrayList<>();
-
+  private List<Tuple<String, String>> activateTrigger = new ArrayList<>();
 
   public UserActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -86,19 +85,19 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     getBool(s[3]);
     getBool(s[4]);
     getBool(s[5]);
-    m_activateTrigger.add(Tuple.of(s[0], options));
+    activateTrigger.add(Tuple.of(s[0], options));
   }
 
   private void setActivateTrigger(final List<Tuple<String, String>> value) {
-    m_activateTrigger = value;
+    activateTrigger = value;
   }
 
   private List<Tuple<String, String>> getActivateTrigger() {
-    return m_activateTrigger;
+    return activateTrigger;
   }
 
   private void resetActivateTrigger() {
-    m_activateTrigger = new ArrayList<>();
+    activateTrigger = new ArrayList<>();
   }
 
   public static void fireTriggers(final UserActionAttachment actionAttachment,


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in the `TerritoryAttachment`, `TerritoryEffectAttachment`, `UnitSupportAttachment`, and `UserActionAttachment` classes.

## Functional Changes

None.

## Manual Testing Performed

None.