### PR TITLE
Change headless server remote access password hash algorithm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ subprojects {
 
     ext {
         hamcrestVersion = '2.0.0.0'
+        jbcryptVersion = '0.4'
         junitJupiterVersion = '5.3.1'
         mockitoVersion = '2.22.0'
         postgresqlVersion = '42.2.2'
@@ -65,9 +66,9 @@ subprojects {
 
         implementation 'com.google.guava:guava:24.1-jre'
 
+        testImplementation 'com.github.npathai:hamcrest-optional:2.0.0'
         testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.0'
         testImplementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
-        testImplementation "com.github.npathai:hamcrest-optional:2.0.0"
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
         testImplementation 'org.junit-pioneer:junit-pioneer:0.1.2'
         testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
+    implementation "org.mindrot:jbcrypt:$jbcryptVersion"
     implementation 'org.yaml:snakeyaml:1.19'
 
     testImplementation project(':test-common')

--- a/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -26,6 +26,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import org.mindrot.jbcrypt.BCrypt;
+
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
@@ -48,7 +50,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.util.ExitStatus;
 import games.strategy.util.Interruptibles;
-import games.strategy.util.Md5Crypt;
 import games.strategy.util.Util;
 import lombok.extern.java.Log;
 
@@ -234,11 +235,11 @@ public class HeadlessGameServer {
   }
 
   public String getSalt() {
-    return Md5Crypt.newSalt();
+    return BCrypt.gensalt();
   }
 
   private static String hashPassword(final String password, final String salt) {
-    return Md5Crypt.hashPassword(password, salt);
+    return BCrypt.hashpw(password, salt);
   }
 
   public String remoteShutdown(final String hashedPassword, final String salt) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -22,6 +22,7 @@ import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 
+import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.lobby.common.IModeratorController;
 import org.triplea.lobby.common.LobbyConstants;
 
@@ -32,7 +33,6 @@ import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.net.Node;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.Md5Crypt;
 
 class LobbyGamePanel extends JPanel {
   private static final long serialVersionUID = -2576314388949606337L;
@@ -324,7 +324,7 @@ class LobbyGamePanel extends JPanel {
   }
 
   private static String hashPassword(final String password, final String salt) {
-    return Md5Crypt.hashPassword(password, salt);
+    return BCrypt.hashpw(password, salt);
   }
 
   private INode getLobbyWatcherNodeForTableRow(final int selectedIndex) {

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -9,7 +9,7 @@ mainClassName = 'org.triplea.lobby.server.LobbyRunner'
 
 dependencies {
     implementation project(':game-core')
-    implementation 'org.mindrot:jbcrypt:0.4'
+    implementation "org.mindrot:jbcrypt:$jbcryptVersion"
 
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
 


### PR DESCRIPTION
## Overview

Changes the hash algorithm used for the headless server remote access password from MD5Crypt to bcrypt.  The signatures of the headless server remote control methods in `IModeratorController` and `IRemoteHostUtils` were not modified to support this change, and thus lobby compatibility should not be affected.

## Functional Changes

* The headless server remote access password is now hashed using bcrypt instead of the deprecated MD5Crypt algorithm.

## Manual Testing Performed

Using the following configuration:

* client: this branch
* headless server: this branch
* lobby: 11996

I verified that, as a mod, I could remotely shut down a password-protected bot connected to the lobby.  I also verified that entering the wrong password results in the expected error message (invalid password).