### PR TITLE
Bump version to 1.10.0.0

### DIFF
--- a/game-core/src/main/resources/META-INF/triplea/product.properties
+++ b/game-core/src/main/resources/META-INF/triplea/product.properties
@@ -1,1 +1,1 @@
-version = 1.9.0.0.@buildId@
+version = 1.10.0.0.@buildId@

--- a/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
+++ b/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
@@ -14,6 +14,6 @@ final class ProductConfigurationIntegrationTest {
   void shouldReadPropertiesFromResource() {
     assertThat(
         productConfiguration.getVersion().getExactVersion(),
-        matchesPattern("1\\.9\\.0\\.0\\.(@buildId@|dev|\\d+)"));
+        matchesPattern("1\\.10\\.0\\.0\\.(@buildId@|dev|\\d+)"));
   }
 }

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -1,15 +1,26 @@
 - version: 1.9.0.0
   host: lobby.triplea-game.org
   port: 3304
-  message: |    
+  message: |
     Welcome to TripleA 1.9 - Got a question, please visit the forums: https://forums.triplea-game.org/
     No talking politics in the lobby! Take your political comments to a private game!
     Lobby Rules: https://forums.triplea-game.org/topic/4
-    
-    All automated hosts have been updated to use the latest stable engine 1.9.0.0.12226. It's recommended that 
-    all players download and install the latest release here: http://triplea-game.org/download/
-    
-    Have an idea on how to make TripleA better? If so please post a reply with 1-3 features/changes to this thread: 
+
+    All automated hosts have been updated to use the latest stable engine 1.9.0.0.12226. It's recommended that
+    all players download and install the latest release here: https://triplea-game.org/download/
+
+    Have an idea on how to make TripleA better? If so please post a reply with 1-3 features/changes to this thread:
     https://forums.triplea-game.org/topic/1032/most-wanted-features-changes
-    
-  error_message:  
+  error_message:
+- version: 1.10.0.0
+  host: lobby.triplea-game.org
+  port: 3304
+  message: |
+    Welcome to TripleA 1.10 - Got a question, please visit the forums: https://forums.triplea-game.org/
+    No talking politics in the lobby! Take your political comments to a private game!
+    Lobby Rules: https://forums.triplea-game.org/topic/4
+
+    THIS IS A BETA RELEASE! You will not be able to use most bots in the lobby unless they happen to be
+    running version 1.10. If you didn't expect to see this message, you should download the latest stable
+    release from https://triplea-game.org/download/ and use that installation instead.
+  error_message:


### PR DESCRIPTION
## Overview

Per #4218, bumps the product version to 1.10.0.0 to signal an incompatible release.

## Functional Changes

None.

## Manual Testing Performed

Verified the following:

* Could play a local game; could save and reload a game.
* Could play a network game with a headed server from the same branch.
* Could play a network game with a headless server from the same branch.
* Could connect to the production lobby.
* Manually modified the code to use the local _lobby_server.yaml_ and confirmed the entry for 1.10.0.0 is used instead of the entry for 1.9.0.0.