### PR TITLE
Checkstyle: Fix naming violations in attachments (C-R)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -24,9 +24,9 @@ import games.strategy.util.CollectionUtils;
 public class CanalAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -1991066817386812634L;
 
-  private String m_canalName = null;
-  private Set<Territory> m_landTerritories = null;
-  private Set<UnitType> m_excludedUnits = null;
+  private String canalName = null;
+  private Set<Territory> landTerritories = null;
+  private Set<UnitType> excludedUnits = null;
 
   public CanalAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -70,23 +70,23 @@ public class CanalAttachment extends DefaultAttachment {
 
   private void setCanalName(final String name) {
     if (name == null) {
-      m_canalName = null;
+      canalName = null;
       return;
     }
-    m_canalName = name;
+    canalName = name;
   }
 
   public String getCanalName() {
-    return m_canalName;
+    return canalName;
   }
 
   private void resetCanalName() {
-    m_canalName = null;
+    canalName = null;
   }
 
   private void setLandTerritories(final String landTerritories) {
     if (landTerritories == null) {
-      m_landTerritories = null;
+      this.landTerritories = null;
       return;
     }
     final HashSet<Territory> terrs = new HashSet<>();
@@ -97,34 +97,34 @@ public class CanalAttachment extends DefaultAttachment {
       }
       terrs.add(territory);
     }
-    m_landTerritories = terrs;
+    this.landTerritories = terrs;
   }
 
   private void setLandTerritories(final Set<Territory> value) {
-    m_landTerritories = value;
+    landTerritories = value;
   }
 
   public Set<Territory> getLandTerritories() {
-    return m_landTerritories;
+    return landTerritories;
   }
 
   private void resetLandTerritories() {
-    m_landTerritories = null;
+    landTerritories = null;
   }
 
   private void setExcludedUnits(final String value) {
     if (value == null) {
-      m_excludedUnits = null;
+      excludedUnits = null;
       return;
     }
-    if (m_excludedUnits == null) {
-      m_excludedUnits = new HashSet<>();
+    if (excludedUnits == null) {
+      excludedUnits = new HashSet<>();
     }
     if (value.equalsIgnoreCase("NONE")) {
       return;
     }
     if (value.equalsIgnoreCase("ALL")) {
-      m_excludedUnits.addAll(getData().getUnitTypeList().getAllUnitTypes());
+      excludedUnits.addAll(getData().getUnitTypeList().getAllUnitTypes());
       return;
     }
     for (final String name : splitOnColon(value)) {
@@ -132,39 +132,39 @@ public class CanalAttachment extends DefaultAttachment {
       if (ut == null) {
         throw new IllegalStateException("Canals: No UnitType called: " + name + thisErrorMsg());
       }
-      m_excludedUnits.add(ut);
+      excludedUnits.add(ut);
     }
   }
 
   private void setExcludedUnits(final Set<UnitType> value) {
-    m_excludedUnits = value;
+    excludedUnits = value;
   }
 
   public Set<UnitType> getExcludedUnits() {
-    if (m_excludedUnits == null) {
+    if (excludedUnits == null) {
       return new HashSet<>(
           CollectionUtils.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir()));
     }
-    return m_excludedUnits;
+    return excludedUnits;
   }
 
   private void resetExcludedUnits() {
-    m_excludedUnits = null;
+    excludedUnits = null;
   }
 
   @Override
   public void validate(final GameData data) throws GameParseException {
-    if (m_canalName == null) {
+    if (canalName == null) {
       throw new GameParseException("Canals must have a canalName set!" + thisErrorMsg());
     }
-    if (m_landTerritories == null || m_landTerritories.size() == 0) {
-      throw new GameParseException("Canal named " + m_canalName + " must have landTerritories set!" + thisErrorMsg());
+    if (landTerritories == null || landTerritories.size() == 0) {
+      throw new GameParseException("Canal named " + canalName + " must have landTerritories set!" + thisErrorMsg());
     }
     final Set<Territory> territories = new HashSet<>();
     for (final Territory t : data.getMap()) {
       final Set<CanalAttachment> canalAttachments = get(t);
       for (final CanalAttachment canalAttachment : canalAttachments) {
-        if (canalAttachment.getCanalName().equals(m_canalName)) {
+        if (canalAttachment.getCanalName().equals(canalName)) {
           territories.add(t);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -45,36 +45,36 @@ public class PlayerAttachment extends DefaultAttachment {
     return playerAttachment;
   }
 
-  private int m_vps = 0;
+  private int vps = 0;
   // need to store some data during a turn
-  private int m_captureVps = 0;
+  private int captureVps = 0;
   // number of capitals needed before we lose all our money
-  private int m_retainCapitalNumber = 1;
+  private int retainCapitalNumber = 1;
   // number of capitals needed before we lose ability to gain money and produce units
-  private int m_retainCapitalProduceNumber = 1;
-  private List<PlayerID> m_giveUnitControl = new ArrayList<>();
-  private List<PlayerID> m_captureUnitOnEnteringBy = new ArrayList<>();
+  private int retainCapitalProduceNumber = 1;
+  private List<PlayerID> giveUnitControl = new ArrayList<>();
+  private List<PlayerID> captureUnitOnEnteringBy = new ArrayList<>();
   // gives any technology researched to this player automatically
-  private List<PlayerID> m_shareTechnology = new ArrayList<>();
+  private List<PlayerID> shareTechnology = new ArrayList<>();
   // allows these players to help pay for technology
-  private List<PlayerID> m_helpPayTechCost = new ArrayList<>();
+  private List<PlayerID> helpPayTechCost = new ArrayList<>();
   // do we lose our money and have it disappear or is that money captured?
-  private boolean m_destroysPUs = false;
+  private boolean destroysPus = false;
   // are we immune to being blockaded?
-  private boolean m_immuneToBlockade = false;
+  private boolean immuneToBlockade = false;
   // what resources can be used for suicide attacks, and
-  private IntegerMap<Resource> m_suicideAttackResources = new IntegerMap<>();
+  private IntegerMap<Resource> suicideAttackResources = new IntegerMap<>();
   // at what attack power
   // what can be hit by suicide attacks
-  private Set<UnitType> m_suicideAttackTargets = null;
+  private Set<UnitType> suicideAttackTargets = null;
   // placement limits on a flexible per player basis
-  private Set<Triple<Integer, String, Set<UnitType>>> m_placementLimit = new HashSet<>();
+  private Set<Triple<Integer, String, Set<UnitType>>> placementLimit = new HashSet<>();
 
   // movement limits on a flexible per player basis
-  private Set<Triple<Integer, String, Set<UnitType>>> m_movementLimit = new HashSet<>();
+  private Set<Triple<Integer, String, Set<UnitType>>> movementLimit = new HashSet<>();
 
   // attacking limits on a flexible per player basis
-  private Set<Triple<Integer, String, Set<UnitType>>> m_attackingLimit = new HashSet<>();
+  private Set<Triple<Integer, String, Set<UnitType>>> attackingLimit = new HashSet<>();
 
   /** Creates new PlayerAttachment. */
   public PlayerAttachment(final String name, final Attachable attachable, final GameData gameData) {
@@ -105,19 +105,19 @@ public class PlayerAttachment extends DefaultAttachment {
         types.add(ut);
       }
     }
-    m_placementLimit.add(Triple.of(max, s[1], types));
+    placementLimit.add(Triple.of(max, s[1], types));
   }
 
   private void setPlacementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
-    m_placementLimit = value;
+    placementLimit = value;
   }
 
   private Set<Triple<Integer, String, Set<UnitType>>> getPlacementLimit() {
-    return m_placementLimit;
+    return placementLimit;
   }
 
   private void resetPlacementLimit() {
-    m_placementLimit = new HashSet<>();
+    placementLimit = new HashSet<>();
   }
 
   private void setMovementLimit(final String value) throws GameParseException {
@@ -144,19 +144,19 @@ public class PlayerAttachment extends DefaultAttachment {
         types.add(ut);
       }
     }
-    m_movementLimit.add(Triple.of(max, s[1], types));
+    movementLimit.add(Triple.of(max, s[1], types));
   }
 
   private void setMovementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
-    m_movementLimit = value;
+    movementLimit = value;
   }
 
   private Set<Triple<Integer, String, Set<UnitType>>> getMovementLimit() {
-    return m_movementLimit;
+    return movementLimit;
   }
 
   private void resetMovementLimit() {
-    m_movementLimit = new HashSet<>();
+    movementLimit = new HashSet<>();
   }
 
   private void setAttackingLimit(final String value) throws GameParseException {
@@ -183,19 +183,19 @@ public class PlayerAttachment extends DefaultAttachment {
         types.add(ut);
       }
     }
-    m_attackingLimit.add(Triple.of(max, s[1], types));
+    attackingLimit.add(Triple.of(max, s[1], types));
   }
 
   private void setAttackingLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
-    m_attackingLimit = value;
+    attackingLimit = value;
   }
 
   private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
-    return m_attackingLimit;
+    return attackingLimit;
   }
 
   private void resetAttackingLimit() {
-    m_attackingLimit = new HashSet<>();
+    attackingLimit = new HashSet<>();
   }
 
   public static boolean getCanTheseUnitsMoveWithoutViolatingStackingLimit(final String limitType,
@@ -254,11 +254,11 @@ public class PlayerAttachment extends DefaultAttachment {
 
   private void setSuicideAttackTargets(final String value) throws GameParseException {
     if (value == null) {
-      m_suicideAttackTargets = null;
+      suicideAttackTargets = null;
       return;
     }
-    if (m_suicideAttackTargets == null) {
-      m_suicideAttackTargets = new HashSet<>();
+    if (suicideAttackTargets == null) {
+      suicideAttackTargets = new HashSet<>();
     }
     final String[] s = splitOnColon(value);
     for (final String u : s) {
@@ -266,20 +266,20 @@ public class PlayerAttachment extends DefaultAttachment {
       if (ut == null) {
         throw new GameParseException("suicideAttackTargets: no such unit called " + u + thisErrorMsg());
       }
-      m_suicideAttackTargets.add(ut);
+      suicideAttackTargets.add(ut);
     }
   }
 
   private void setSuicideAttackTargets(final Set<UnitType> value) {
-    m_suicideAttackTargets = value;
+    suicideAttackTargets = value;
   }
 
   public Set<UnitType> getSuicideAttackTargets() {
-    return m_suicideAttackTargets;
+    return suicideAttackTargets;
   }
 
   private void resetSuicideAttackTargets() {
-    m_suicideAttackTargets = null;
+    suicideAttackTargets = null;
   }
 
   private void setSuicideAttackResources(final String value) throws GameParseException {
@@ -295,75 +295,75 @@ public class PlayerAttachment extends DefaultAttachment {
     if (r == null) {
       throw new GameParseException("no such resource: " + s[1] + thisErrorMsg());
     }
-    m_suicideAttackResources.put(r, attackValue);
+    suicideAttackResources.put(r, attackValue);
   }
 
   private void setSuicideAttackResources(final IntegerMap<Resource> value) {
-    m_suicideAttackResources = value;
+    suicideAttackResources = value;
   }
 
   public IntegerMap<Resource> getSuicideAttackResources() {
-    return m_suicideAttackResources;
+    return suicideAttackResources;
   }
 
   private void resetSuicideAttackResources() {
-    m_suicideAttackResources = new IntegerMap<>();
+    suicideAttackResources = new IntegerMap<>();
   }
 
   private void setVps(final int value) {
-    m_vps = value;
+    vps = value;
   }
 
   public int getVps() {
-    return m_vps;
+    return vps;
   }
 
   private void setCaptureVps(final String value) {
-    m_captureVps = getInt(value);
+    captureVps = getInt(value);
   }
 
   private void setCaptureVps(final Integer value) {
-    m_captureVps = value;
+    captureVps = value;
   }
 
   public int getCaptureVps() {
-    return m_captureVps;
+    return captureVps;
   }
 
   private void resetCaptureVps() {
-    m_captureVps = 0;
+    captureVps = 0;
   }
 
   private void setRetainCapitalNumber(final String value) {
-    m_retainCapitalNumber = getInt(value);
+    retainCapitalNumber = getInt(value);
   }
 
   private void setRetainCapitalNumber(final Integer value) {
-    m_retainCapitalNumber = value;
+    retainCapitalNumber = value;
   }
 
   public int getRetainCapitalNumber() {
-    return m_retainCapitalNumber;
+    return retainCapitalNumber;
   }
 
   private void resetRetainCapitalNumber() {
-    m_retainCapitalNumber = 1;
+    retainCapitalNumber = 1;
   }
 
   private void setRetainCapitalProduceNumber(final String value) {
-    m_retainCapitalProduceNumber = getInt(value);
+    retainCapitalProduceNumber = getInt(value);
   }
 
   private void setRetainCapitalProduceNumber(final Integer value) {
-    m_retainCapitalProduceNumber = value;
+    retainCapitalProduceNumber = value;
   }
 
   int getRetainCapitalProduceNumber() {
-    return m_retainCapitalProduceNumber;
+    return retainCapitalProduceNumber;
   }
 
   private void resetRetainCapitalProduceNumber() {
-    m_retainCapitalProduceNumber = 1;
+    retainCapitalProduceNumber = 1;
   }
 
   private void setGiveUnitControl(final String value) throws GameParseException {
@@ -371,7 +371,7 @@ public class PlayerAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_giveUnitControl.add(tempPlayer);
+        giveUnitControl.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -379,15 +379,15 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setGiveUnitControl(final List<PlayerID> value) {
-    m_giveUnitControl = value;
+    giveUnitControl = value;
   }
 
   public List<PlayerID> getGiveUnitControl() {
-    return m_giveUnitControl;
+    return giveUnitControl;
   }
 
   private void resetGiveUnitControl() {
-    m_giveUnitControl = new ArrayList<>();
+    giveUnitControl = new ArrayList<>();
   }
 
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
@@ -395,7 +395,7 @@ public class PlayerAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_captureUnitOnEnteringBy.add(tempPlayer);
+        captureUnitOnEnteringBy.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -403,15 +403,15 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setCaptureUnitOnEnteringBy(final List<PlayerID> value) {
-    m_captureUnitOnEnteringBy = value;
+    captureUnitOnEnteringBy = value;
   }
 
   public List<PlayerID> getCaptureUnitOnEnteringBy() {
-    return m_captureUnitOnEnteringBy;
+    return captureUnitOnEnteringBy;
   }
 
   private void resetCaptureUnitOnEnteringBy() {
-    m_captureUnitOnEnteringBy = new ArrayList<>();
+    captureUnitOnEnteringBy = new ArrayList<>();
   }
 
   private void setShareTechnology(final String value) throws GameParseException {
@@ -419,7 +419,7 @@ public class PlayerAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_shareTechnology.add(tempPlayer);
+        shareTechnology.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -427,15 +427,15 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setShareTechnology(final List<PlayerID> value) {
-    m_shareTechnology = value;
+    shareTechnology = value;
   }
 
   public List<PlayerID> getShareTechnology() {
-    return m_shareTechnology;
+    return shareTechnology;
   }
 
   private void resetShareTechnology() {
-    m_shareTechnology = new ArrayList<>();
+    shareTechnology = new ArrayList<>();
   }
 
   private void setHelpPayTechCost(final String value) throws GameParseException {
@@ -443,7 +443,7 @@ public class PlayerAttachment extends DefaultAttachment {
     for (final String name : temp) {
       final PlayerID tempPlayer = getData().getPlayerList().getPlayerId(name);
       if (tempPlayer != null) {
-        m_helpPayTechCost.add(tempPlayer);
+        helpPayTechCost.add(tempPlayer);
       } else {
         throw new GameParseException("No player named: " + name + thisErrorMsg());
       }
@@ -451,47 +451,47 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setHelpPayTechCost(final List<PlayerID> value) {
-    m_helpPayTechCost = value;
+    helpPayTechCost = value;
   }
 
   public List<PlayerID> getHelpPayTechCost() {
-    return m_helpPayTechCost;
+    return helpPayTechCost;
   }
 
   private void resetHelpPayTechCost() {
-    m_helpPayTechCost = new ArrayList<>();
+    helpPayTechCost = new ArrayList<>();
   }
 
   private void setDestroysPUs(final String value) {
-    m_destroysPUs = getBool(value);
+    destroysPus = getBool(value);
   }
 
   private void setDestroysPUs(final Boolean value) {
-    m_destroysPUs = value;
+    destroysPus = value;
   }
 
   public boolean getDestroysPUs() {
-    return m_destroysPUs;
+    return destroysPus;
   }
 
   private void resetDestroysPUs() {
-    m_destroysPUs = false;
+    destroysPus = false;
   }
 
   private void setImmuneToBlockade(final String value) {
-    m_immuneToBlockade = getBool(value);
+    immuneToBlockade = getBool(value);
   }
 
   private void setImmuneToBlockade(final Boolean value) {
-    m_immuneToBlockade = value;
+    immuneToBlockade = value;
   }
 
   public boolean getImmuneToBlockade() {
-    return m_immuneToBlockade;
+    return immuneToBlockade;
   }
 
   private void resetImmuneToBlockade() {
-    m_immuneToBlockade = false;
+    immuneToBlockade = false;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -37,7 +37,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   private static final long serialVersionUID = 4392770599777282477L;
 
   // list of relationship changes to be performed if this action is performed sucessfully
-  private List<String> m_relationshipChange = new ArrayList<>();
+  private List<String> relationshipChange = new ArrayList<>();
 
   public PoliticalActionAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -98,23 +98,23 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[2] + " unknown in: " + getName() + thisErrorMsg());
     }
-    m_relationshipChange.add(relChange);
+    relationshipChange.add(relChange);
   }
 
   private void setRelationshipChange(final List<String> value) {
-    m_relationshipChange = value;
+    relationshipChange = value;
   }
 
   private List<String> getRelationshipChange() {
-    return m_relationshipChange;
+    return relationshipChange;
   }
 
   private void resetRelationshipChange() {
-    m_relationshipChange = new ArrayList<>();
+    relationshipChange = new ArrayList<>();
   }
 
   public List<RelationshipChange> getRelationshipChanges() {
-    return m_relationshipChange.stream()
+    return relationshipChange.stream()
         .map(this::parseRelationshipChange)
         .collect(Collectors.toList());
   }
@@ -134,7 +134,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
    */
   public Set<PlayerID> getOtherPlayers() {
     final Set<PlayerID> otherPlayers = new LinkedHashSet<>();
-    for (final String relationshipChange : m_relationshipChange) {
+    for (final String relationshipChange : this.relationshipChange) {
       final String[] s = splitOnColon(relationshipChange);
       otherPlayers.add(getData().getPlayerList().getPlayerId(s[0]));
       otherPlayers.add(getData().getPlayerList().getPlayerId(s[1]));
@@ -159,7 +159,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   @Override
   public void validate(final GameData data) throws GameParseException {
     super.validate(data);
-    if (m_relationshipChange.isEmpty()) {
+    if (relationshipChange.isEmpty()) {
       throw new GameParseException("value: relationshipChange can't be empty" + thisErrorMsg());
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -26,19 +26,18 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   public static final String PROPERTY_TRUE = Constants.RELATIONSHIP_PROPERTY_TRUE;
   public static final String PROPERTY_FALSE = Constants.RELATIONSHIP_PROPERTY_FALSE;
 
-  private String m_archeType = ARCHETYPE_WAR;
-  // private final String m_helpsDefendAtSea = PROPERTY_DEFAULT;
-  private String m_canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
-  private String m_canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
-  private String m_alliancesCanChainTogether = PROPERTY_DEFAULT;
-  private String m_isDefaultWarPosition = PROPERTY_DEFAULT;
-  private String m_upkeepCost = PROPERTY_DEFAULT;
-  private String m_canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
-  private String m_canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
-  private String m_givesBackOriginalTerritories = PROPERTY_DEFAULT;
-  private String m_canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
-  private String m_canMoveThroughCanals = PROPERTY_DEFAULT;
-  private String m_rocketsCanFlyOver = PROPERTY_DEFAULT;
+  private String archeType = ARCHETYPE_WAR;
+  private String canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
+  private String canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
+  private String alliancesCanChainTogether = PROPERTY_DEFAULT;
+  private String isDefaultWarPosition = PROPERTY_DEFAULT;
+  private String upkeepCost = PROPERTY_DEFAULT;
+  private String canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
+  private String canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
+  private String givesBackOriginalTerritories = PROPERTY_DEFAULT;
+  private String canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
+  private String canMoveThroughCanals = PROPERTY_DEFAULT;
+  private String rocketsCanFlyOver = PROPERTY_DEFAULT;
 
   /**
    * Creates new RelationshipTypeAttachment.
@@ -82,7 +81,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       case ARCHETYPE_WAR:
       case ARCHETYPE_ALLIED:
       case ARCHETYPE_NEUTRAL:
-        m_archeType = lowerArcheType;
+        this.archeType = lowerArcheType;
         break;
       default:
         throw new GameParseException("archeType must be " + ARCHETYPE_WAR + "," + ARCHETYPE_ALLIED + " or "
@@ -95,11 +94,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * isNeutral, isAllied or isWar().
    */
   public String getArcheType() {
-    return m_archeType;
+    return archeType;
   }
 
   private void resetArcheType() {
-    m_archeType = ARCHETYPE_WAR;
+    archeType = ARCHETYPE_WAR;
   }
 
   /**
@@ -110,11 +109,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * @param canFlyOver should be "true", "false" or "default"
    */
   private void setCanMoveAirUnitsOverOwnedLand(final String canFlyOver) {
-    m_canMoveAirUnitsOverOwnedLand = canFlyOver;
+    canMoveAirUnitsOverOwnedLand = canFlyOver;
   }
 
   private String getCanMoveAirUnitsOverOwnedLand() {
-    return m_canMoveAirUnitsOverOwnedLand;
+    return canMoveAirUnitsOverOwnedLand;
   }
 
   /**
@@ -125,78 +124,78 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    * @return whether in this relationshipType you can fly over other territories
    */
   public boolean canMoveAirUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
-    if (m_canMoveAirUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
+    if (canMoveAirUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isWar() || isAllied();
     }
-    return m_canMoveAirUnitsOverOwnedLand.equals(PROPERTY_TRUE);
+    return canMoveAirUnitsOverOwnedLand.equals(PROPERTY_TRUE);
   }
 
   private void resetCanMoveAirUnitsOverOwnedLand() {
-    m_canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
+    canMoveAirUnitsOverOwnedLand = PROPERTY_DEFAULT;
   }
 
   private void setCanMoveLandUnitsOverOwnedLand(final String canFlyOver) {
-    m_canMoveLandUnitsOverOwnedLand = canFlyOver;
+    canMoveLandUnitsOverOwnedLand = canFlyOver;
   }
 
   private String getCanMoveLandUnitsOverOwnedLand() {
-    return m_canMoveLandUnitsOverOwnedLand;
+    return canMoveLandUnitsOverOwnedLand;
   }
 
   public boolean canMoveLandUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
-    if (m_canMoveLandUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
+    if (canMoveLandUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isWar() || isAllied();
     }
-    return m_canMoveLandUnitsOverOwnedLand.equals(PROPERTY_TRUE);
+    return canMoveLandUnitsOverOwnedLand.equals(PROPERTY_TRUE);
   }
 
   private void resetCanMoveLandUnitsOverOwnedLand() {
-    m_canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
+    canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;
   }
 
   private void setCanLandAirUnitsOnOwnedLand(final String canLandAir) {
-    m_canLandAirUnitsOnOwnedLand = canLandAir;
+    canLandAirUnitsOnOwnedLand = canLandAir;
   }
 
   private String getCanLandAirUnitsOnOwnedLand() {
-    return m_canLandAirUnitsOnOwnedLand;
+    return canLandAirUnitsOnOwnedLand;
   }
 
   public boolean canLandAirUnitsOnOwnedLand() {
     // War: false, Allied: true, Neutral: false
-    if (m_canLandAirUnitsOnOwnedLand.equals(PROPERTY_DEFAULT)) {
+    if (canLandAirUnitsOnOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isAllied();
     }
-    return m_canLandAirUnitsOnOwnedLand.equals(PROPERTY_TRUE);
+    return canLandAirUnitsOnOwnedLand.equals(PROPERTY_TRUE);
   }
 
   private void resetCanLandAirUnitsOnOwnedLand() {
-    m_canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
+    canLandAirUnitsOnOwnedLand = PROPERTY_DEFAULT;
   }
 
   private void setCanTakeOverOwnedTerritory(final String canTakeOver) {
-    m_canTakeOverOwnedTerritory = canTakeOver;
+    canTakeOverOwnedTerritory = canTakeOver;
   }
 
   private String getCanTakeOverOwnedTerritory() {
-    return m_canTakeOverOwnedTerritory;
+    return canTakeOverOwnedTerritory;
   }
 
   public boolean canTakeOverOwnedTerritory() {
     // War: true, Allied: false, Neutral: false
-    if (m_canTakeOverOwnedTerritory.equals(PROPERTY_DEFAULT)) {
+    if (canTakeOverOwnedTerritory.equals(PROPERTY_DEFAULT)) {
       return isWar();
     }
-    return m_canTakeOverOwnedTerritory.equals(PROPERTY_TRUE);
+    return canTakeOverOwnedTerritory.equals(PROPERTY_TRUE);
   }
 
   private void resetCanTakeOverOwnedTerritory() {
-    m_canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
+    canTakeOverOwnedTerritory = PROPERTY_DEFAULT;
   }
 
   private void setUpkeepCost(final String integerCost) throws GameParseException {
     if (integerCost.equals(PROPERTY_DEFAULT)) {
-      m_upkeepCost = PROPERTY_DEFAULT;
+      upkeepCost = PROPERTY_DEFAULT;
     } else {
       final String[] s = splitOnColon(integerCost);
       if (s.length < 1 || s.length > 2) {
@@ -218,19 +217,19 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
                 "upkeepCost must have either: " + UPKEEP_FLAT + " or " + UPKEEP_PERCENTAGE + thisErrorMsg());
         }
       }
-      m_upkeepCost = integerCost;
+      upkeepCost = integerCost;
     }
   }
 
   public String getUpkeepCost() {
-    if (m_upkeepCost.equals(PROPERTY_DEFAULT)) {
+    if (upkeepCost.equals(PROPERTY_DEFAULT)) {
       return String.valueOf(0);
     }
-    return m_upkeepCost;
+    return upkeepCost;
   }
 
   private void resetUpkeepCost() {
-    m_upkeepCost = PROPERTY_DEFAULT;
+    upkeepCost = PROPERTY_DEFAULT;
   }
 
   private void setAlliancesCanChainTogether(final String value) throws GameParseException {
@@ -238,22 +237,22 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("alliancesCanChainTogether must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_alliancesCanChainTogether = value;
+    alliancesCanChainTogether = value;
   }
 
   private String getAlliancesCanChainTogether() {
-    return m_alliancesCanChainTogether;
+    return alliancesCanChainTogether;
   }
 
   public boolean canAlliancesChainTogether() {
-    return !m_alliancesCanChainTogether.equals(PROPERTY_DEFAULT)
+    return !alliancesCanChainTogether.equals(PROPERTY_DEFAULT)
         && !isWar()
         && !isNeutral()
-        && m_alliancesCanChainTogether.equals(PROPERTY_TRUE);
+        && alliancesCanChainTogether.equals(PROPERTY_TRUE);
   }
 
   private void resetAlliancesCanChainTogether() {
-    m_alliancesCanChainTogether = PROPERTY_DEFAULT;
+    alliancesCanChainTogether = PROPERTY_DEFAULT;
   }
 
   private void setIsDefaultWarPosition(final String value) throws GameParseException {
@@ -261,22 +260,22 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("isDefaultWarPosition must be either " + PROPERTY_DEFAULT + " or " + PROPERTY_FALSE
           + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_isDefaultWarPosition = value;
+    isDefaultWarPosition = value;
   }
 
   private String getIsDefaultWarPosition() {
-    return m_isDefaultWarPosition;
+    return isDefaultWarPosition;
   }
 
   public boolean isDefaultWarPosition() {
-    return !m_isDefaultWarPosition.equals(PROPERTY_DEFAULT)
+    return !isDefaultWarPosition.equals(PROPERTY_DEFAULT)
         && !isAllied()
         && !isNeutral()
-        && m_isDefaultWarPosition.equals(PROPERTY_TRUE);
+        && isDefaultWarPosition.equals(PROPERTY_TRUE);
   }
 
   private void resetIsDefaultWarPosition() {
-    m_isDefaultWarPosition = PROPERTY_DEFAULT;
+    isDefaultWarPosition = PROPERTY_DEFAULT;
   }
 
   private void setGivesBackOriginalTerritories(final String value) throws GameParseException {
@@ -284,20 +283,20 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("givesBackOriginalTerritories must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_givesBackOriginalTerritories = value;
+    givesBackOriginalTerritories = value;
   }
 
   private String getGivesBackOriginalTerritories() {
-    return m_givesBackOriginalTerritories;
+    return givesBackOriginalTerritories;
   }
 
   public boolean givesBackOriginalTerritories() {
-    return !m_givesBackOriginalTerritories.equals(PROPERTY_DEFAULT)
-        && m_givesBackOriginalTerritories.equals(PROPERTY_TRUE);
+    return !givesBackOriginalTerritories.equals(PROPERTY_DEFAULT)
+        && givesBackOriginalTerritories.equals(PROPERTY_TRUE);
   }
 
   private void resetGivesBackOriginalTerritories() {
-    m_givesBackOriginalTerritories = PROPERTY_DEFAULT;
+    givesBackOriginalTerritories = PROPERTY_DEFAULT;
   }
 
   private void setCanMoveIntoDuringCombatMove(final String value) throws GameParseException {
@@ -305,21 +304,21 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_canMoveIntoDuringCombatMove = value;
+    canMoveIntoDuringCombatMove = value;
   }
 
   private String getCanMoveIntoDuringCombatMove() {
-    return m_canMoveIntoDuringCombatMove;
+    return canMoveIntoDuringCombatMove;
   }
 
   public boolean canMoveIntoDuringCombatMove() {
     // this property is not affected by any archetype.
-    return m_canMoveIntoDuringCombatMove.equals(PROPERTY_DEFAULT)
-        || m_canMoveIntoDuringCombatMove.equals(PROPERTY_TRUE);
+    return canMoveIntoDuringCombatMove.equals(PROPERTY_DEFAULT)
+        || canMoveIntoDuringCombatMove.equals(PROPERTY_TRUE);
   }
 
   private void resetCanMoveIntoDuringCombatMove() {
-    m_canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
+    canMoveIntoDuringCombatMove = PROPERTY_DEFAULT;
   }
 
   private void setCanMoveThroughCanals(final String value) throws GameParseException {
@@ -327,23 +326,23 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_canMoveThroughCanals = value;
+    canMoveThroughCanals = value;
   }
 
   private String getCanMoveThroughCanals() {
-    return m_canMoveThroughCanals;
+    return canMoveThroughCanals;
   }
 
   public boolean canMoveThroughCanals() {
     // only allied can move through canals normally
-    if (m_canMoveThroughCanals.equals(PROPERTY_DEFAULT)) {
+    if (canMoveThroughCanals.equals(PROPERTY_DEFAULT)) {
       return isAllied();
     }
-    return m_canMoveThroughCanals.equals(PROPERTY_TRUE);
+    return canMoveThroughCanals.equals(PROPERTY_TRUE);
   }
 
   private void resetCanMoveThroughCanals() {
-    m_canMoveThroughCanals = PROPERTY_DEFAULT;
+    canMoveThroughCanals = PROPERTY_DEFAULT;
   }
 
   private void setRocketsCanFlyOver(final String value) throws GameParseException {
@@ -351,41 +350,41 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
-    m_rocketsCanFlyOver = value;
+    rocketsCanFlyOver = value;
   }
 
   private String getRocketsCanFlyOver() {
-    return m_rocketsCanFlyOver;
+    return rocketsCanFlyOver;
   }
 
   public boolean canRocketsFlyOver() {
     // rockets can normally fly over everyone.
-    return m_rocketsCanFlyOver.equals(PROPERTY_DEFAULT) || m_rocketsCanFlyOver.equals(PROPERTY_TRUE);
+    return rocketsCanFlyOver.equals(PROPERTY_DEFAULT) || rocketsCanFlyOver.equals(PROPERTY_TRUE);
   }
 
   private void resetRocketsCanFlyOver() {
-    m_rocketsCanFlyOver = PROPERTY_DEFAULT;
+    rocketsCanFlyOver = PROPERTY_DEFAULT;
   }
 
   /**
    * Indicates whether this relationship is based on the WAR_ARCHETYPE.
    */
   public boolean isWar() {
-    return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_WAR);
+    return archeType.equals(RelationshipTypeAttachment.ARCHETYPE_WAR);
   }
 
   /**
    * Indicates whether this relationship is based on the ALLIED_ARCHETYPE.
    */
   public boolean isAllied() {
-    return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_ALLIED);
+    return archeType.equals(RelationshipTypeAttachment.ARCHETYPE_ALLIED);
   }
 
   /**
    * Indicates whether this relationship is based on the NEUTRAL_ARCHETYPE.
    */
   public boolean isNeutral() {
-    return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_NEUTRAL);
+    return archeType.equals(RelationshipTypeAttachment.ARCHETYPE_NEUTRAL);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -48,38 +48,37 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private static final long serialVersionUID = 7301965634079412516L;
 
   // condition for having techs
-  private List<TechAdvance> m_techs = null;
+  private List<TechAdvance> techs = null;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
-  private int m_techCount = -1;
+  private int techCount = -1;
   // condition for having specific relationships
-  private List<String> m_relationship = new ArrayList<>();
+  private List<String> relationship = new ArrayList<>();
   // condition for being at war
-  private Set<PlayerID> m_atWarPlayers = null;
+  private Set<PlayerID> atWarPlayers = null;
   @InternalDoNotExport
   // Do Not Export (do not include in IAttachment).
-  private int m_atWarCount = -1;
+  private int atWarCount = -1;
   // condition for having destroyed at least X enemy non-neutral TUV (total unit value) [according to
   // the prices the defender pays for the units]
-  private String m_destroyedTUV = null;
+  private String destroyedTuv = null;
   // condition for having had a battle in some territory, attacker or defender, win
   // or lost, etc. these next 9 variables use territoryCount for determining the number needed.
-  private List<Tuple<String, List<Territory>>> m_battle = new ArrayList<>();
+  private List<Tuple<String, List<Territory>>> battle = new ArrayList<>();
   // ownership related
-  private String[] m_alliedOwnershipTerritories = null;
-  private String[] m_directOwnershipTerritories = null;
+  private String[] alliedOwnershipTerritories = null;
+  private String[] directOwnershipTerritories = null;
   // exclusion of units
-  private String[] m_alliedExclusionTerritories = null;
-  private String[] m_directExclusionTerritories = null;
-  private String[] m_enemyExclusionTerritories = null;
-  private String[] m_enemySurfaceExclusionTerritories = null;
+  private String[] alliedExclusionTerritories = null;
+  private String[] directExclusionTerritories = null;
+  private String[] enemyExclusionTerritories = null;
+  private String[] enemySurfaceExclusionTerritories = null;
   // presence of units
-  private String[] m_directPresenceTerritories = null;
-  private String[] m_alliedPresenceTerritories = null;
-  private String[] m_enemyPresenceTerritories = null;
+  private String[] directPresenceTerritories = null;
+  private String[] alliedPresenceTerritories = null;
+  private String[] enemyPresenceTerritories = null;
   // used with above 3 to determine the type of unit that must be present
-  private IntegerMap<String> m_unitPresence = new IntegerMap<>();
-
+  private IntegerMap<String> unitPresence = new IntegerMap<>();
 
   /** Creates new RulesAttachment. */
   public RulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
@@ -152,7 +151,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
 
   private void setDestroyedTuv(final String value) throws GameParseException {
     if (value == null) {
-      m_destroyedTUV = null;
+      destroyedTuv = null;
       return;
     }
     final String[] s = splitOnColon(value);
@@ -168,15 +167,15 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (!(s[1].equals("currentRound") || s[1].equals("allRounds"))) {
       throw new GameParseException("destroyedTUV value must be currentRound or allRounds" + thisErrorMsg());
     }
-    m_destroyedTUV = value;
+    destroyedTuv = value;
   }
 
   private String getDestroyedTuv() {
-    return m_destroyedTUV;
+    return destroyedTuv;
   }
 
   private void resetDestroyedTuv() {
-    m_destroyedTUV = null;
+    destroyedTuv = null;
   }
 
   private void setBattle(final String value) throws GameParseException {
@@ -214,19 +213,19 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
       terrs.add(t);
     }
-    m_battle.add(Tuple.of((s[0] + ":" + s[1] + ":" + s[2] + ":" + s[3]), terrs));
+    battle.add(Tuple.of((s[0] + ":" + s[1] + ":" + s[2] + ":" + s[3]), terrs));
   }
 
   private void setBattle(final List<Tuple<String, List<Territory>>> value) {
-    m_battle = value;
+    battle = value;
   }
 
   private List<Tuple<String, List<Territory>>> getBattle() {
-    return m_battle;
+    return battle;
   }
 
   private void resetBattle() {
-    m_battle = new ArrayList<>();
+    battle = new ArrayList<>();
   }
 
   /**
@@ -260,211 +259,211 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       throw new GameParseException("numberOfRoundsExisting should be a number between -1 and 100000.  -1 should be "
           + "default value if you don't know what to put" + thisErrorMsg());
     }
-    m_relationship.add((s.length == 3) ? (value + ":-1") : value);
+    relationship.add((s.length == 3) ? (value + ":-1") : value);
   }
 
   private void setRelationship(final List<String> value) {
-    m_relationship = value;
+    relationship = value;
   }
 
   private List<String> getRelationship() {
-    return m_relationship;
+    return relationship;
   }
 
   private void resetRelationship() {
-    m_relationship = new ArrayList<>();
+    relationship = new ArrayList<>();
   }
 
   private void setAlliedOwnershipTerritories(final String value) {
     if (value == null) {
-      m_alliedOwnershipTerritories = null;
+      alliedOwnershipTerritories = null;
       return;
     }
-    m_alliedOwnershipTerritories = splitOnColon(value);
-    validateNames(m_alliedOwnershipTerritories);
+    alliedOwnershipTerritories = splitOnColon(value);
+    validateNames(alliedOwnershipTerritories);
   }
 
   private void setAlliedOwnershipTerritories(final String[] value) {
-    m_alliedOwnershipTerritories = value;
+    alliedOwnershipTerritories = value;
   }
 
   private String[] getAlliedOwnershipTerritories() {
-    return m_alliedOwnershipTerritories;
+    return alliedOwnershipTerritories;
   }
 
   private void resetAlliedOwnershipTerritories() {
-    m_alliedOwnershipTerritories = null;
+    alliedOwnershipTerritories = null;
   }
 
   // exclusion types = controlled, controlledNoWater, original, all, or list
   private void setAlliedExclusionTerritories(final String value) {
     if (value == null) {
-      m_alliedExclusionTerritories = null;
+      alliedExclusionTerritories = null;
       return;
     }
-    m_alliedExclusionTerritories = splitOnColon(value);
-    validateNames(m_alliedExclusionTerritories);
+    alliedExclusionTerritories = splitOnColon(value);
+    validateNames(alliedExclusionTerritories);
   }
 
   private void setAlliedExclusionTerritories(final String[] value) {
-    m_alliedExclusionTerritories = value;
+    alliedExclusionTerritories = value;
   }
 
   private String[] getAlliedExclusionTerritories() {
-    return m_alliedExclusionTerritories;
+    return alliedExclusionTerritories;
   }
 
   private void resetAlliedExclusionTerritories() {
-    m_alliedExclusionTerritories = null;
+    alliedExclusionTerritories = null;
   }
 
   private void setDirectExclusionTerritories(final String value) {
     if (value == null) {
-      m_directExclusionTerritories = null;
+      directExclusionTerritories = null;
       return;
     }
-    m_directExclusionTerritories = splitOnColon(value);
-    validateNames(m_directExclusionTerritories);
+    directExclusionTerritories = splitOnColon(value);
+    validateNames(directExclusionTerritories);
   }
 
   private void setDirectExclusionTerritories(final String[] value) {
-    m_directExclusionTerritories = value;
+    directExclusionTerritories = value;
   }
 
   private String[] getDirectExclusionTerritories() {
-    return m_directExclusionTerritories;
+    return directExclusionTerritories;
   }
 
   private void resetDirectExclusionTerritories() {
-    m_directExclusionTerritories = null;
+    directExclusionTerritories = null;
   }
 
   // exclusion types = original or list
   private void setEnemyExclusionTerritories(final String value) {
     if (value == null) {
-      m_enemyExclusionTerritories = null;
+      enemyExclusionTerritories = null;
       return;
     }
-    m_enemyExclusionTerritories = splitOnColon(value);
-    validateNames(m_enemyExclusionTerritories);
+    enemyExclusionTerritories = splitOnColon(value);
+    validateNames(enemyExclusionTerritories);
   }
 
   private void setEnemyExclusionTerritories(final String[] value) {
-    m_enemyExclusionTerritories = value;
+    enemyExclusionTerritories = value;
   }
 
   private String[] getEnemyExclusionTerritories() {
-    return m_enemyExclusionTerritories;
+    return enemyExclusionTerritories;
   }
 
   private void resetEnemyExclusionTerritories() {
-    m_enemyExclusionTerritories = null;
+    enemyExclusionTerritories = null;
   }
 
   private void setDirectPresenceTerritories(final String value) {
     if (value == null) {
-      m_directPresenceTerritories = null;
+      directPresenceTerritories = null;
       return;
     }
-    m_directPresenceTerritories = splitOnColon(value);
-    validateNames(m_directPresenceTerritories);
+    directPresenceTerritories = splitOnColon(value);
+    validateNames(directPresenceTerritories);
   }
 
   private void setDirectPresenceTerritories(final String[] value) {
-    m_directPresenceTerritories = value;
+    directPresenceTerritories = value;
   }
 
   private String[] getDirectPresenceTerritories() {
-    return m_directPresenceTerritories;
+    return directPresenceTerritories;
   }
 
   private void resetDirectPresenceTerritories() {
-    m_directPresenceTerritories = null;
+    directPresenceTerritories = null;
   }
 
   private void setAlliedPresenceTerritories(final String value) {
     if (value == null) {
-      m_alliedPresenceTerritories = null;
+      alliedPresenceTerritories = null;
       return;
     }
-    m_alliedPresenceTerritories = splitOnColon(value);
-    validateNames(m_alliedPresenceTerritories);
+    alliedPresenceTerritories = splitOnColon(value);
+    validateNames(alliedPresenceTerritories);
   }
 
   private void setAlliedPresenceTerritories(final String[] value) {
-    m_alliedPresenceTerritories = value;
+    alliedPresenceTerritories = value;
   }
 
   private String[] getAlliedPresenceTerritories() {
-    return m_alliedPresenceTerritories;
+    return alliedPresenceTerritories;
   }
 
   private void resetAlliedPresenceTerritories() {
-    m_alliedPresenceTerritories = null;
+    alliedPresenceTerritories = null;
   }
 
   private void setEnemyPresenceTerritories(final String value) {
     if (value == null) {
-      m_enemyPresenceTerritories = null;
+      enemyPresenceTerritories = null;
       return;
     }
-    m_enemyPresenceTerritories = splitOnColon(value);
-    validateNames(m_enemyPresenceTerritories);
+    enemyPresenceTerritories = splitOnColon(value);
+    validateNames(enemyPresenceTerritories);
   }
 
   private void setEnemyPresenceTerritories(final String[] value) {
-    m_enemyPresenceTerritories = value;
+    enemyPresenceTerritories = value;
   }
 
   private String[] getEnemyPresenceTerritories() {
-    return m_enemyPresenceTerritories;
+    return enemyPresenceTerritories;
   }
 
   private void resetEnemyPresenceTerritories() {
-    m_enemyPresenceTerritories = null;
+    enemyPresenceTerritories = null;
   }
 
   // exclusion types = original or list
   private void setEnemySurfaceExclusionTerritories(final String value) {
     if (value == null) {
-      m_enemySurfaceExclusionTerritories = null;
+      enemySurfaceExclusionTerritories = null;
       return;
     }
-    m_enemySurfaceExclusionTerritories = splitOnColon(value);
-    validateNames(m_enemySurfaceExclusionTerritories);
+    enemySurfaceExclusionTerritories = splitOnColon(value);
+    validateNames(enemySurfaceExclusionTerritories);
   }
 
   private void setEnemySurfaceExclusionTerritories(final String[] value) {
-    m_enemySurfaceExclusionTerritories = value;
+    enemySurfaceExclusionTerritories = value;
   }
 
   private String[] getEnemySurfaceExclusionTerritories() {
-    return m_enemySurfaceExclusionTerritories;
+    return enemySurfaceExclusionTerritories;
   }
 
   private void resetEnemySurfaceExclusionTerritories() {
-    m_enemySurfaceExclusionTerritories = null;
+    enemySurfaceExclusionTerritories = null;
   }
 
   private void setDirectOwnershipTerritories(final String value) {
     if (value == null) {
-      m_directOwnershipTerritories = null;
+      directOwnershipTerritories = null;
       return;
     }
-    m_directOwnershipTerritories = splitOnColon(value);
-    validateNames(m_directOwnershipTerritories);
+    directOwnershipTerritories = splitOnColon(value);
+    validateNames(directOwnershipTerritories);
   }
 
   private void setDirectOwnershipTerritories(final String[] value) {
-    m_directOwnershipTerritories = value;
+    directOwnershipTerritories = value;
   }
 
   private String[] getDirectOwnershipTerritories() {
-    return m_directOwnershipTerritories;
+    return directOwnershipTerritories;
   }
 
   private void resetDirectOwnershipTerritories() {
-    m_directOwnershipTerritories = null;
+    directOwnershipTerritories = null;
   }
 
   private void setUnitPresence(final String value) throws GameParseException {
@@ -485,32 +484,32 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         throw new GameParseException("No unit called: " + unitTypeToProduce + thisErrorMsg());
       }
     }
-    m_unitPresence.put(value.replaceFirst(s[0] + ":", ""), n);
+    unitPresence.put(value.replaceFirst(s[0] + ":", ""), n);
   }
 
   private void setUnitPresence(final IntegerMap<String> value) {
-    m_unitPresence = value;
+    unitPresence = value;
   }
 
   private IntegerMap<String> getUnitPresence() {
-    return m_unitPresence;
+    return unitPresence;
   }
 
   private void resetUnitPresence() {
-    m_unitPresence = new IntegerMap<>();
+    unitPresence = new IntegerMap<>();
   }
 
   private int getAtWarCount() {
-    return m_atWarCount;
+    return atWarCount;
   }
 
   private int getTechCount() {
-    return m_techCount;
+    return techCount;
   }
 
   private void setAtWarPlayers(final String players) throws GameParseException {
     if (players == null) {
-      m_atWarPlayers = null;
+      atWarPlayers = null;
       return;
     }
     final String[] s = splitOnColon(players);
@@ -520,38 +519,38 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     int count = -1;
     try {
       count = getInt(s[0]);
-      m_atWarCount = count;
+      atWarCount = count;
     } catch (final Exception e) {
-      m_atWarCount = 0;
+      atWarCount = 0;
     }
     if (s.length == 1 && count != -1) {
       throw new GameParseException("Empty enemy list" + thisErrorMsg());
     }
-    m_atWarPlayers = new HashSet<>();
+    atWarPlayers = new HashSet<>();
     for (int i = count == -1 ? 0 : 1; i < s.length; i++) {
       final PlayerID player = getData().getPlayerList().getPlayerId(s[i]);
       if (player == null) {
         throw new GameParseException("Could not find player. name:" + s[i] + thisErrorMsg());
       }
-      m_atWarPlayers.add(player);
+      atWarPlayers.add(player);
     }
   }
 
   private void setAtWarPlayers(final Set<PlayerID> value) {
-    m_atWarPlayers = value;
+    atWarPlayers = value;
   }
 
   private Set<PlayerID> getAtWarPlayers() {
-    return m_atWarPlayers;
+    return atWarPlayers;
   }
 
   private void resetAtWarPlayers() {
-    m_atWarPlayers = null;
+    atWarPlayers = null;
   }
 
   private void setTechs(final String newTechs) throws GameParseException {
     if (newTechs == null) {
-      m_techs = null;
+      techs = null;
       return;
     }
     final String[] s = splitOnColon(newTechs);
@@ -561,14 +560,14 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     int count = -1;
     try {
       count = getInt(s[0]);
-      m_techCount = count;
+      techCount = count;
     } catch (final Exception e) {
-      m_techCount = 0;
+      techCount = 0;
     }
     if (s.length == 1 && count != -1) {
       throw new GameParseException("Empty tech list" + thisErrorMsg());
     }
-    m_techs = new ArrayList<>();
+    techs = new ArrayList<>();
     for (int i = count == -1 ? 0 : 1; i < s.length; i++) {
       TechAdvance ta = getData().getTechnologyFrontier().getAdvanceByProperty(s[i]);
       if (ta == null) {
@@ -577,20 +576,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       if (ta == null) {
         throw new GameParseException("Technology not found :" + Arrays.toString(s) + thisErrorMsg());
       }
-      m_techs.add(ta);
+      techs.add(ta);
     }
   }
 
   private void setTechs(final List<TechAdvance> value) {
-    m_techs = value;
+    techs = value;
   }
 
   private List<TechAdvance> getTechs() {
-    return m_techs;
+    return techs;
   }
 
   private void resetTechs() {
-    m_techs = null;
+    techs = null;
   }
 
   @Override
@@ -770,16 +769,16 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     if (objectiveMet && getAtWarPlayers() != null) {
       objectiveMet = checkAtWar(playerAttachedTo, getAtWarPlayers(), getAtWarCount(), data);
     }
-    if (objectiveMet && m_techs != null) {
+    if (objectiveMet && techs != null) {
       objectiveMet = checkTechs(playerAttachedTo, data);
     }
     // check for relationships
-    if (objectiveMet && m_relationship.size() > 0) {
+    if (objectiveMet && relationship.size() > 0) {
       objectiveMet = checkRelationships();
     }
     // check for battle stats
-    if (objectiveMet && m_destroyedTUV != null) {
-      final String[] s = splitOnColon(m_destroyedTUV);
+    if (objectiveMet && destroyedTuv != null) {
+      final String[] s = splitOnColon(destroyedTuv);
       final int requiredDestroyedTuv = getInt(s[0]);
       if (requiredDestroyedTuv >= 0) {
         final boolean justCurrentRound = s[1].equals("currentRound");
@@ -794,10 +793,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       }
     }
     // check for battles
-    if (objectiveMet && !m_battle.isEmpty()) {
+    if (objectiveMet && !battle.isEmpty()) {
       final BattleRecordsList brl = data.getBattleRecordsList();
       final int round = data.getSequence().getRound();
-      for (final Tuple<String, List<Territory>> entry : m_battle) {
+      for (final Tuple<String, List<Territory>> entry : battle) {
         final String[] type = splitOnColon(entry.getFirst());
         // they could be "any", and if they are "any" then this would be null, which is good!
         final PlayerID attacker = data.getPlayerList().getPlayerId(type[0]);
@@ -860,7 +859,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
    * @return whether all relationships as are required are set correctly.
    */
   private boolean checkRelationships() {
-    for (final String encodedRelationCheck : m_relationship) {
+    for (final String encodedRelationCheck : relationship) {
       final String[] relationCheck = splitOnColon(encodedRelationCheck);
       final PlayerID p1 = getData().getPlayerList().getPlayerId(relationCheck[0]);
       final PlayerID p2 = getData().getPlayerList().getPlayerId(relationCheck[1]);
@@ -1114,30 +1113,30 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private boolean checkTechs(final PlayerID player, final GameData data) {
     int found = 0;
     for (final TechAdvance a : TechTracker.getCurrentTechAdvances(player, data)) {
-      if (m_techs.contains(a)) {
+      if (techs.contains(a)) {
         found++;
       }
     }
-    if (m_techCount == 0) {
-      return m_techCount == found;
+    if (techCount == 0) {
+      return techCount == found;
     }
     if (getCountEach()) {
       eachMultiple = found;
     }
-    return found >= m_techCount;
+    return found >= techCount;
   }
 
   @Override
   public void validate(final GameData data) {
-    validateNames(m_alliedOwnershipTerritories);
-    validateNames(m_enemyExclusionTerritories);
-    validateNames(m_enemySurfaceExclusionTerritories);
-    validateNames(m_alliedExclusionTerritories);
-    validateNames(m_directExclusionTerritories);
-    validateNames(m_directOwnershipTerritories);
-    validateNames(m_directPresenceTerritories);
-    validateNames(m_alliedPresenceTerritories);
-    validateNames(m_enemyPresenceTerritories);
+    validateNames(alliedOwnershipTerritories);
+    validateNames(enemyExclusionTerritories);
+    validateNames(enemySurfaceExclusionTerritories);
+    validateNames(alliedExclusionTerritories);
+    validateNames(directExclusionTerritories);
+    validateNames(directOwnershipTerritories);
+    validateNames(directPresenceTerritories);
+    validateNames(alliedPresenceTerritories);
+    validateNames(enemyPresenceTerritories);
   }
 
   @Override


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the following classes:

* `CanalAttachment`
* `PlayerAttachment`
* `PoliticalActionAttachment`
* `RelationshipTypeAttachment`
* `RulesAttachment`

## Functional Changes

None.

## Manual Testing Performed

None.