### PR TITLE
Enable GitHub releases from 1.9.0.0 release branch (try no. 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,7 @@ deploy:
     tags: false
     condition: "$TRIPLEA_RELEASE = true"
     repo: triplea-game/triplea
-    branches:
-      only:
-        - release/1.9.0.0
+    branch: release/1.9.0.0
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
#4238 didn't have the intended effect.  Apparently, we're using outdated YAML for the branch specification in the deployment phase.  Instead of reporting an error, Travis just assumes we meant `master` and proceeds normally.

This PR fixes the YAML based on the current Travis docs.  I tested this in my fork (with some additional changes, obviously) to verify the YAML syntax works as expected.  After this PR is merged, I'll submit a follow-up to fix the same invalid syntax on `master`.