### PR TITLE
Fix invalid Travis deployment branch condition syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,7 @@ deploy:
     tags: false
     condition: "$TRIPLEA_RELEASE = true"
     repo: triplea-game/triplea
-    branches:
-      only:
-        - master
+    branch: master
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
## Overview

As discussed in #4245, the deployment branch syntax we've been using in _.travis.yml_ is incorrect and will always result in `master` being used as the sole deployment branch, regardless of what is specified in the configuration.  This PR simply mimics the fix in #4245 for `master`.

## Functional Changes

None.

## Manual Testing Performed

None.