### PR TITLE
Fix determination of transported units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -856,7 +856,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             }
             // after that is applied, we have to make a map of all dependencies
             final Map<Unit, Collection<Unit>> dependenciesForMfb =
-                TransportTracker.transporting(attackingUnits);
+                TransportTracker.transportingWithAllPossibleUnits(attackingUnits);
             for (final Unit transport : CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport())) {
               // however, the map we add to the newly created battle, cannot hold any units that are NOT in this
               // territory.
@@ -873,8 +873,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   new ArrayList<>(CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport()));
               allNeighborUnits.addAll(t.getUnits().getMatches(Matches.unitIsLandAndOwnedBy(player)));
               final Map<Unit, Collection<Unit>> dependenciesForNeighbors =
-                  TransportTracker.transporting(CollectionUtils
-                      .getMatches(allNeighborUnits, Matches.unitIsTransport().negate()));
+                  TransportTracker.transportingWithAllPossibleUnits(
+                      CollectionUtils.getMatches(allNeighborUnits, Matches.unitIsTransport().negate()));
               dependencies.put(t, dependenciesForNeighbors);
             }
             mfb.addDependentUnits(dependencies.get(to));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -116,7 +116,7 @@ public class MovePerformer implements Serializable {
         // need to remove any dependents here
         if (aaCasualties != null) {
           aaCasualtiesWithDependents.addAll(aaCasualties);
-          final Map<Unit, Collection<Unit>> dependencies = TransportTracker.transporting(units);
+          final Map<Unit, Collection<Unit>> dependencies = TransportTracker.transportingWithAllPossibleUnits(units);
           for (final Unit u : aaCasualties) {
             final Collection<Unit> dependents = dependencies.get(u);
             if (dependents != null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -72,6 +72,26 @@ public class TransportTracker {
     return returnVal;
   }
 
+  /**
+   * Returns a map of transport -> collection of transported units.
+   * This method is identical to {@link #transporting(Collection)} except that it considers all elements in
+   * {@code units} as the possible units to transport (see {@link #transporting(Unit, Collection)}).
+   */
+  public static Map<Unit, Collection<Unit>> transportingWithAllPossibleUnits(final Collection<Unit> units) {
+    final Map<Unit, Collection<Unit>> returnVal = new HashMap<>();
+    for (final Unit transported : units) {
+      final Unit transport = transportedBy(transported);
+      Collection<Unit> transporting = null;
+      if (transport != null) {
+        transporting = transporting(transport, units);
+      }
+      if (transporting != null) {
+        returnVal.put(transport, transporting);
+      }
+    }
+    return returnVal;
+  }
+
   public static boolean isTransporting(final Unit transport) {
     return !((TripleAUnit) transport).getTransporting().isEmpty();
   }


### PR DESCRIPTION
## Overview

Fixes #4162.

The `TransportTracker#transporting(Collection<Unit>, Collection<Unit>)` method was mistakenly removed in #3931 and replaced with `transporting(Collection<Unit>)`.  This had the unintended side-effect of incorrectly determining which units are being transported during a retreat from an aborted amphibious assault.

The fix is to restore the method removed in #3931.

## Functional Changes

Restore the calls to the original method that considered all units in the argument for transport instead of the other overload that only considers the units _currently_ loaded on the transport (which is zero during an amphibious assault because the units are already considered offloaded).

## Refactoring Changes

The first parameter of the original method was unused.  Simply removing it causes an aliasing error because there is another overload with the same signature.  So I renamed the re-introduced method `transportingWithAllPossibleUnits()` to avoid the name collision and to hopefully better describe how the method differs from the standard `transporting()` method.  Alternative naming suggestions are welcome.

## Manual Testing Performed

Used the [save game](https://github.com/triplea-game/triplea/issues/4162#issuecomment-432148691) attached to #4162 to verify that when the amphibious assault is aborted due to the transports retreating during a scramble, the land battle in Scotland is removed from the pending battle list.