### PR TITLE
Checkstyle: Fix naming violations in g.s.triplea.delegate (A-B)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -32,10 +32,11 @@ import games.strategy.util.CollectionUtils;
  */
 class AAInMoveUtil implements Serializable {
   private static final long serialVersionUID = 1787497998642717678L;
+
   private transient IDelegateBridge bridge;
   private transient PlayerID player;
-  private Collection<Unit> m_casualties = new ArrayList<>();
-  private final ExecutionStack m_executionStack = new ExecutionStack();
+  private Collection<Unit> casualties = new ArrayList<>();
+  private final ExecutionStack executionStack = new ExecutionStack();
 
   AAInMoveUtil() {}
 
@@ -70,11 +71,11 @@ class AAInMoveUtil implements Serializable {
    */
   Collection<Unit> fireAa(final Route route, final Collection<Unit> units, final Comparator<Unit> decreasingMovement,
       final UndoableMove currentMove) {
-    if (m_executionStack.isEmpty()) {
+    if (executionStack.isEmpty()) {
       populateExecutionStack(route, units, decreasingMovement, currentMove);
     }
-    m_executionStack.execute(bridge);
-    return m_casualties;
+    executionStack.execute(bridge);
+    return casualties;
   }
 
   /**
@@ -113,7 +114,7 @@ class AAInMoveUtil implements Serializable {
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
           // get rid of units already killed, so we don't target them twice
-          validTargetedUnitsForThisRoll.removeAll(m_casualties);
+          validTargetedUnitsForThisRoll.removeAll(casualties);
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
             dice[0] = DiceRoll.rollAa(validTargetedUnitsForThisRoll, currentPossibleAa, AAInMoveUtil.this.bridge,
                 territory, true);
@@ -154,8 +155,8 @@ class AAInMoveUtil implements Serializable {
         }
       };
       // push in reverse order of execution
-      m_executionStack.push(selectCasualties);
-      m_executionStack.push(rollDice);
+      executionStack.push(selectCasualties);
+      executionStack.push(rollDice);
     }
   }
 
@@ -176,7 +177,7 @@ class AAInMoveUtil implements Serializable {
       });
     }
     Collections.reverse(executables);
-    m_executionStack.push(executables);
+    executionStack.push(executables);
   }
 
   Collection<Territory> getTerritoriesWhereAaWillFire(final Route route, final Collection<Unit> units) {
@@ -190,7 +191,7 @@ class AAInMoveUtil implements Serializable {
     if (GameStepPropertiesHelper.isNonCombatMove(data, false) && !alwaysOnAa) {
       return Collections.emptyList();
     }
-    // can't rely on m_player being the unit owner in Edit Mode
+    // can't rely on player being the unit owner in Edit Mode
     // look at the units being moved to determine allies and enemies
     final PlayerID movingPlayer = movingPlayer(units);
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
@@ -279,10 +280,10 @@ class AAInMoveUtil implements Serializable {
         MyFormatter.unitsToTextNoOwner(casualties.getKilled()) + " lost in " + territory.getName(),
         new ArrayList<>(casualties.getKilled()));
     allFriendlyUnits.removeAll(casualties.getKilled());
-    if (m_casualties == null) {
-      m_casualties = new ArrayList<>(casualties.getKilled());
+    if (this.casualties == null) {
+      this.casualties = new ArrayList<>(casualties.getKilled());
     } else {
-      m_casualties.addAll(casualties.getKilled());
+      this.casualties.addAll(casualties.getKilled());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -30,7 +30,7 @@ import games.strategy.util.CollectionUtils;
 /**
  * Code to fire AA guns while in combat and non combat move.
  */
-class AAInMoveUtil implements Serializable {
+class AaInMoveUtil implements Serializable {
   private static final long serialVersionUID = 1787497998642717678L;
 
   private transient IDelegateBridge bridge;
@@ -38,9 +38,9 @@ class AAInMoveUtil implements Serializable {
   private Collection<Unit> casualties = new ArrayList<>();
   private final ExecutionStack executionStack = new ExecutionStack();
 
-  AAInMoveUtil() {}
+  AaInMoveUtil() {}
 
-  public AAInMoveUtil initialize(final IDelegateBridge bridge) {
+  public AaInMoveUtil initialize(final IDelegateBridge bridge) {
     this.bridge = bridge;
     this.player = bridge.getPlayerId();
     return this;
@@ -116,7 +116,7 @@ class AAInMoveUtil implements Serializable {
           // get rid of units already killed, so we don't target them twice
           validTargetedUnitsForThisRoll.removeAll(casualties);
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
-            dice[0] = DiceRoll.rollAa(validTargetedUnitsForThisRoll, currentPossibleAa, AAInMoveUtil.this.bridge,
+            dice[0] = DiceRoll.rollAa(validTargetedUnitsForThisRoll, currentPossibleAa, AaInMoveUtil.this.bridge,
                 territory, true);
           }
         }
@@ -130,10 +130,10 @@ class AAInMoveUtil implements Serializable {
             final int hitCount = dice[0].getHits();
             if (hitCount == 0) {
               if (currentTypeAa.equals("AA")) {
-                AAInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_MISS,
+                AaInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_MISS,
                     findDefender(currentPossibleAa, territory));
               } else {
-                AAInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(
+                AaInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(
                     SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
                     findDefender(currentPossibleAa, territory));
               }
@@ -141,10 +141,10 @@ class AAInMoveUtil implements Serializable {
                   "No " + currentTypeAa + " hits in " + territory.getName());
             } else {
               if (currentTypeAa.equals("AA")) {
-                AAInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
+                AaInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
                     findDefender(currentPossibleAa, territory));
               } else {
-                AAInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(
+                AaInMoveUtil.this.bridge.getSoundChannelBroadcaster().playSoundForAll(
                     SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                     findDefender(currentPossibleAa, territory));
               }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaRadarAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaRadarAdvance.java
@@ -8,10 +8,10 @@ import games.strategy.triplea.attachments.TechAttachment;
 /**
  * A technology advance that provides anti-aircraft radar.
  */
-final class AARadarAdvance extends TechAdvance {
+final class AaRadarAdvance extends TechAdvance {
   private static final long serialVersionUID = 6464021231625252901L;
 
-  public AARadarAdvance(final GameData data) {
+  public AaRadarAdvance(final GameData data) {
     super(TECH_NAME_AA_RADAR, data);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -55,8 +55,8 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     final AbstractMoveExtendedDelegateState state = new AbstractMoveExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_movesToUndo = movesToUndo;
-    state.m_tempMovePerformer = tempMovePerformer;
+    state.movesToUndo = movesToUndo;
+    state.tempMovePerformer = tempMovePerformer;
     return state;
   }
 
@@ -66,10 +66,10 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     super.loadState(s.superState);
     // if the undo state wasnt saved, then dont load it. prevents overwriting undo state when we restore from an undo
     // move
-    if (s.m_movesToUndo != null) {
-      movesToUndo = s.m_movesToUndo;
+    if (s.movesToUndo != null) {
+      movesToUndo = s.movesToUndo;
     }
-    tempMovePerformer = s.m_tempMovePerformer;
+    tempMovePerformer = s.tempMovePerformer;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
@@ -5,8 +5,9 @@ import java.util.List;
 
 class AbstractMoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -4072966724295569322L;
+
   Serializable superState;
   // add other variables here
-  public List<UndoableMove> m_movesToUndo;
-  public MovePerformer m_tempMovePerformer;
+  public List<UndoableMove> movesToUndo;
+  public MovePerformer tempMovePerformer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -16,19 +16,20 @@ import games.strategy.triplea.delegate.data.AbstractMoveDescription;
  */
 public abstract class AbstractUndoableMove implements Serializable {
   private static final long serialVersionUID = -3164832285286161069L;
+
   /**
    * Stores the serialized state of the move and battle delegates (just
    * as if they were saved), and a CompositeChange that represents all the changes that
    * were made during the move.
    * Some moves (such as those following an aa fire) can't be undone.
    */
-  protected final CompositeChange m_change;
-  protected int m_index;
-  protected final Collection<Unit> m_units;
+  protected final CompositeChange change;
+  protected int index;
+  protected final Collection<Unit> units;
 
   public AbstractUndoableMove(final CompositeChange change, final Collection<Unit> units) {
-    m_change = change;
-    m_units = units;
+    this.change = change;
+    this.units = units;
   }
 
   public boolean containsAnyOf(final Set<Unit> units) {
@@ -44,33 +45,33 @@ public abstract class AbstractUndoableMove implements Serializable {
   }
 
   private boolean containsUnit(final Unit unit) {
-    return m_units.contains(unit);
+    return units.contains(unit);
   }
 
   final void undo(final IDelegateBridge delegateBridge) {
     // undo any changes to the game data
     delegateBridge.getHistoryWriter().startEvent(
         delegateBridge.getPlayerId().getName() + " undo move " + (getIndex() + 1) + ".", getDescriptionObject());
-    delegateBridge.addChange(m_change.invert());
+    delegateBridge.addChange(change.invert());
     undoSpecific(delegateBridge);
   }
 
   protected abstract void undoSpecific(IDelegateBridge bridge);
 
   public final void addChange(final Change change) {
-    m_change.add(change);
+    this.change.add(change);
   }
 
   public Collection<Unit> getUnits() {
-    return m_units;
+    return units;
   }
 
   public int getIndex() {
-    return m_index;
+    return index;
   }
 
   public void setIndex(final int index) {
-    m_index = index;
+    this.index = index;
   }
 
   public abstract String getMoveLabel();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseDelegateState.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 class BaseDelegateState implements Serializable {
   private static final long serialVersionUID = 7130686697155151908L;
-  public boolean m_startBaseStepsFinished = false;
-  public boolean m_endBaseStepsFinished = false;
+
+  public boolean startBaseStepsFinished = false;
+  public boolean endBaseStepsFinished = false;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -60,16 +60,16 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   @Override
   public Serializable saveState() {
     final BaseDelegateState state = new BaseDelegateState();
-    state.m_startBaseStepsFinished = startBaseStepsFinished;
-    state.m_endBaseStepsFinished = endBaseStepsFinished;
+    state.startBaseStepsFinished = startBaseStepsFinished;
+    state.endBaseStepsFinished = endBaseStepsFinished;
     return state;
   }
 
   @Override
   public void loadState(final Serializable state) {
     final BaseDelegateState s = (BaseDelegateState) state;
-    startBaseStepsFinished = s.m_startBaseStepsFinished;
-    endBaseStepsFinished = s.m_endBaseStepsFinished;
+    startBaseStepsFinished = s.startBaseStepsFinished;
+    endBaseStepsFinished = s.endBaseStepsFinished;
   }
 
   private void triggerWhenTriggerAttachments(final String beforeOrAfter) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -138,16 +138,16 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final BattleExtendedDelegateState state = new BattleExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_battleTracker = battleTracker;
-    state.m_needToInitialize = needToInitialize;
-    state.m_needToScramble = needToScramble;
-    state.m_needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
-    state.m_needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
-    state.m_needToAddBombardmentSources = needToAddBombardmentSources;
-    state.m_needToRecordBattleStatistics = needToRecordBattleStatistics;
-    state.m_needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
-    state.m_needToCleanup = needToCleanup;
-    state.m_currentBattle = currentBattle;
+    state.battleTracker = battleTracker;
+    state.needToInitialize = needToInitialize;
+    state.needToScramble = needToScramble;
+    state.needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
+    state.needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
+    state.needToAddBombardmentSources = needToAddBombardmentSources;
+    state.needToRecordBattleStatistics = needToRecordBattleStatistics;
+    state.needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
+    state.needToCleanup = needToCleanup;
+    state.currentBattle = currentBattle;
     return state;
   }
 
@@ -155,16 +155,16 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   public void loadState(final Serializable state) {
     final BattleExtendedDelegateState s = (BattleExtendedDelegateState) state;
     super.loadState(s.superState);
-    battleTracker = s.m_battleTracker;
-    needToInitialize = s.m_needToInitialize;
-    needToScramble = s.m_needToScramble;
-    needToKamikazeSuicideAttacks = s.m_needToKamikazeSuicideAttacks;
-    needToClearEmptyAirBattleAttacks = s.m_needToClearEmptyAirBattleAttacks;
-    needToAddBombardmentSources = s.m_needToAddBombardmentSources;
-    needToRecordBattleStatistics = s.m_needToRecordBattleStatistics;
-    needToCheckDefendingPlanesCanLand = s.m_needToCheckDefendingPlanesCanLand;
-    needToCleanup = s.m_needToCleanup;
-    currentBattle = s.m_currentBattle;
+    battleTracker = s.battleTracker;
+    needToInitialize = s.needToInitialize;
+    needToScramble = s.needToScramble;
+    needToKamikazeSuicideAttacks = s.needToKamikazeSuicideAttacks;
+    needToClearEmptyAirBattleAttacks = s.needToClearEmptyAirBattleAttacks;
+    needToAddBombardmentSources = s.needToAddBombardmentSources;
+    needToRecordBattleStatistics = s.needToRecordBattleStatistics;
+    needToCheckDefendingPlanesCanLand = s.needToCheckDefendingPlanesCanLand;
+    needToCleanup = s.needToCleanup;
+    currentBattle = s.currentBattle;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -4,17 +4,17 @@ import java.io.Serializable;
 
 class BattleExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7899007486408723505L;
+
   Serializable superState;
   // add other variables here:
-  BattleTracker m_battleTracker = new BattleTracker();
-  // public OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
-  public boolean m_needToInitialize;
-  boolean m_needToScramble;
-  boolean m_needToKamikazeSuicideAttacks;
-  boolean m_needToClearEmptyAirBattleAttacks;
-  boolean m_needToAddBombardmentSources;
-  boolean m_needToRecordBattleStatistics;
-  boolean m_needToCheckDefendingPlanesCanLand;
-  boolean m_needToCleanup;
-  IBattle m_currentBattle;
+  BattleTracker battleTracker = new BattleTracker();
+  public boolean needToInitialize;
+  boolean needToScramble;
+  boolean needToKamikazeSuicideAttacks;
+  boolean needToClearEmptyAirBattleAttacks;
+  boolean needToAddBombardmentSources;
+  boolean needToRecordBattleStatistics;
+  boolean needToCheckDefendingPlanesCanLand;
+  boolean needToCleanup;
+  IBattle currentBattle;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -60,31 +60,29 @@ import lombok.extern.java.Log;
 @Log
 public class BattleTracker implements Serializable {
   private static final long serialVersionUID = 8806010984321554662L;
+
   // List of pending battles
-  private final Set<IBattle> m_pendingBattles = new HashSet<>();
+  private final Set<IBattle> pendingBattles = new HashSet<>();
   // List of battle dependencies
   // maps blocked -> Collection of battles that must precede
-  private final Map<IBattle, Set<IBattle>> m_dependencies = new HashMap<>();
+  private final Map<IBattle, Set<IBattle>> dependencies = new HashMap<>();
   // enemy and neutral territories that have been conquered
   // blitzed is a subset of this
-  private final Set<Territory> m_conquered = new HashSet<>();
+  private final Set<Territory> conquered = new HashSet<>();
   // blitzed territories
-  private final Set<Territory> m_blitzed = new HashSet<>();
+  private final Set<Territory> blitzed = new HashSet<>();
   // territories where a battle occurred
-  // TODO: fix typo in name, 'fough' -> 'fought'
-  private final Set<Territory> m_foughBattles = new HashSet<>();
+  private final Set<Territory> foughtBattles = new HashSet<>();
   // list of territory we have conquered in a FinishedBattle and where from and if amphibious
-  private final Map<Territory, Map<Territory, Collection<Unit>>> m_finishedBattlesUnitAttackFromMap =
-      new HashMap<>();
+  private final Map<Territory, Map<Territory, Collection<Unit>>> finishedBattlesUnitAttackFromMap = new HashMap<>();
   // things like kamikaze suicide attacks disallow bombarding from that sea zone for that turn
-  private final Set<Territory> m_noBombardAllowed = new HashSet<>();
-  private final Map<Territory, Collection<Unit>> m_defendingAirThatCanNotLand =
-      new HashMap<>();
-  private BattleRecords m_battleRecords = null;
+  private final Set<Territory> noBombardAllowed = new HashSet<>();
+  private final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = new HashMap<>();
+  private BattleRecords battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
   private final Collection<
-      Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn =
+      Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>> relationshipChangesThisTurn =
           new ArrayList<>();
 
   /**
@@ -97,7 +95,7 @@ public class BattleTracker implements Serializable {
   }
 
   void addToConquered(final Territory territory) {
-    m_conquered.add(territory);
+    conquered.add(territory);
   }
 
   /**
@@ -106,11 +104,11 @@ public class BattleTracker implements Serializable {
    * @param t referring territory.
    */
   public boolean wasConquered(final Territory t) {
-    return m_conquered.contains(t);
+    return conquered.contains(t);
   }
 
   public Set<Territory> getConquered() {
-    return m_conquered;
+    return conquered;
   }
 
   /**
@@ -119,28 +117,28 @@ public class BattleTracker implements Serializable {
    * @param t referring territory.
    */
   public boolean wasBlitzed(final Territory t) {
-    return m_blitzed.contains(t);
+    return blitzed.contains(t);
   }
 
   public boolean wasBattleFought(final Territory t) {
-    return m_foughBattles.contains(t);
+    return foughtBattles.contains(t);
   }
 
   public boolean noBombardAllowedFromHere(final Territory t) {
-    return m_noBombardAllowed.contains(t);
+    return noBombardAllowed.contains(t);
   }
 
   public void addNoBombardAllowedFromHere(final Territory t) {
-    m_noBombardAllowed.add(t);
+    noBombardAllowed.add(t);
   }
 
   public Map<Territory, Map<Territory, Collection<Unit>>> getFinishedBattlesUnitAttackFromMap() {
-    return m_finishedBattlesUnitAttackFromMap;
+    return finishedBattlesUnitAttackFromMap;
   }
 
   public void addRelationshipChangesThisTurn(final PlayerID p1, final PlayerID p2, final RelationshipType oldRelation,
       final RelationshipType newRelation) {
-    m_relationshipChangesThisTurn.add(Tuple.of(
+    relationshipChangesThisTurn.add(Tuple.of(
         Tuple.of(p1, p2),
         Tuple.of(oldRelation, newRelation)));
   }
@@ -163,7 +161,7 @@ public class BattleTracker implements Serializable {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
     for (final Tuple<Tuple<PlayerID, PlayerID>,
-        Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
+        Tuple<RelationshipType, RelationshipType>> t : relationshipChangesThisTurn) {
       final Tuple<PlayerID, PlayerID> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
         if (!players.getSecond().equals(p2)) {
@@ -187,17 +185,17 @@ public class BattleTracker implements Serializable {
   }
 
   void clearFinishedBattles(final IDelegateBridge bridge) {
-    for (final IBattle battle : new ArrayList<>(m_pendingBattles)) {
+    for (final IBattle battle : new ArrayList<>(pendingBattles)) {
       if (FinishedBattle.class.isAssignableFrom(battle.getClass())) {
         final FinishedBattle finished = (FinishedBattle) battle;
-        m_finishedBattlesUnitAttackFromMap.put(finished.getTerritory(), finished.getAttackingFromMap());
+        finishedBattlesUnitAttackFromMap.put(finished.getTerritory(), finished.getAttackingFromMap());
         finished.fight(bridge);
       }
     }
   }
 
   void clearEmptyAirBattleAttacks(final IDelegateBridge bridge) {
-    for (final IBattle battle : new ArrayList<>(m_pendingBattles)) {
+    for (final IBattle battle : new ArrayList<>(pendingBattles)) {
       if (AirBattle.class.isAssignableFrom(battle.getClass())) {
         final AirBattle airBattle = (AirBattle) battle;
         airBattle.updateDefendingUnits();
@@ -210,7 +208,7 @@ public class BattleTracker implements Serializable {
 
   void undoBattle(final Route route, final Collection<Unit> units, final PlayerID player,
       final IDelegateBridge bridge) {
-    for (final IBattle battle : new ArrayList<>(m_pendingBattles)) {
+    for (final IBattle battle : new ArrayList<>(pendingBattles)) {
       if (battle.getTerritory().equals(route.getEnd())) {
         battle.removeAttack(route, units);
         if (battle.isEmpty()) {
@@ -223,9 +221,9 @@ public class BattleTracker implements Serializable {
     // We must look at all territories,
     // because we could have conquered the end territory if there are no units there
     for (final Territory current : route.getAllTerritories()) {
-      if (!relationshipTracker.isAllied(current.getOwner(), player) && m_conquered.contains(current)) {
-        m_conquered.remove(current);
-        m_blitzed.remove(current);
+      if (!relationshipTracker.isAllied(current.getOwner(), player) && conquered.contains(current)) {
+        conquered.remove(current);
+        blitzed.remove(current);
       }
     }
     // say they weren't in combat
@@ -237,12 +235,12 @@ public class BattleTracker implements Serializable {
   }
 
   private void removeBattleForUndo(final PlayerID player, final IBattle battle) {
-    if (m_battleRecords != null) {
-      m_battleRecords.removeBattle(player, battle.getBattleId());
+    if (battleRecords != null) {
+      battleRecords.removeBattle(player, battle.getBattleId());
     }
-    m_pendingBattles.remove(battle);
-    m_dependencies.remove(battle);
-    for (final Collection<IBattle> battles : m_dependencies.values()) {
+    pendingBattles.remove(battle);
+    dependencies.remove(battle);
+    for (final Collection<IBattle> battles : dependencies.values()) {
       battles.remove(battle);
     }
   }
@@ -259,7 +257,7 @@ public class BattleTracker implements Serializable {
     IBattle battle = getPendingBattle(route.getEnd(), true, BattleType.BOMBING_RAID);
     if (battle == null) {
       battle = new StrategicBombingRaidBattle(route.getEnd(), data, attacker, this);
-      m_pendingBattles.add(battle);
+      pendingBattles.add(battle);
       getBattleRecords().addBattle(attacker, battle.getBattleId(), route.getEnd(), battle.getBattleType());
     }
     final Change change = battle.addAttackChange(route, units, targets);
@@ -343,7 +341,7 @@ public class BattleTracker implements Serializable {
         getPendingBattle(route.getEnd(), bombingRun, (bombingRun ? BattleType.AIR_RAID : BattleType.AIR_BATTLE));
     if (battle == null) {
       battle = new AirBattle(route.getEnd(), bombingRun, data, attacker, this);
-      m_pendingBattles.add(battle);
+      pendingBattles.add(battle);
       getBattleRecords().addBattle(attacker, battle.getBattleId(), route.getEnd(), battle.getBattleType());
     }
     final Change change = battle.addAttackChange(route, units, null);
@@ -405,15 +403,15 @@ public class BattleTracker implements Serializable {
     // we handle the end of the route later
     conquered.remove(route.getEnd());
     final Collection<Territory> blitzed = CollectionUtils.getMatches(conquered, Matches.territoryIsBlitzable(id, data));
-    m_blitzed.addAll(CollectionUtils.getMatches(blitzed, Matches.isTerritoryEnemy(id, data)));
-    m_conquered.addAll(CollectionUtils.getMatches(conquered, Matches.isTerritoryEnemy(id, data)));
+    this.blitzed.addAll(CollectionUtils.getMatches(blitzed, Matches.isTerritoryEnemy(id, data)));
+    this.conquered.addAll(CollectionUtils.getMatches(conquered, Matches.isTerritoryEnemy(id, data)));
     for (final Territory current : conquered) {
       IBattle nonFight = getPendingBattle(current, false, BattleType.NORMAL);
       // TODO: if we ever want to scramble to a blitzed territory, then we need to fix this
       if (nonFight == null) {
         nonFight = new FinishedBattle(current, id, this, false, BattleType.NORMAL, data,
             BattleRecord.BattleResultDescription.CONQUERED, WhoWon.ATTACKER);
-        m_pendingBattles.add(nonFight);
+        pendingBattles.add(nonFight);
         getBattleRecords().addBattle(id, nonFight.getBattleId(), current, nonFight.getBattleType());
       }
       final Change change = nonFight.addAttackChange(route, units, null);
@@ -437,7 +435,7 @@ public class BattleTracker implements Serializable {
         IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
         if (nonFight == null) {
           nonFight = new NonFightingBattle(route.getEnd(), id, this, data);
-          m_pendingBattles.add(nonFight);
+          pendingBattles.add(nonFight);
           getBattleRecords().addBattle(id, nonFight.getBattleId(), route.getEnd(), nonFight.getBattleType());
         }
         final Change change = nonFight.addAttackChange(route, units, null);
@@ -451,15 +449,15 @@ public class BattleTracker implements Serializable {
       } else {
         if (Matches.isTerritoryEnemy(id, data).test(route.getEnd())) {
           if (Matches.territoryIsBlitzable(id, data).test(route.getEnd())) {
-            m_blitzed.add(route.getEnd());
+            this.blitzed.add(route.getEnd());
           }
-          m_conquered.add(route.getEnd());
+          this.conquered.add(route.getEnd());
         }
         IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
         if (nonFight == null) {
           nonFight = new FinishedBattle(route.getEnd(), id, this, false, BattleType.NORMAL, data,
               BattleRecord.BattleResultDescription.CONQUERED, WhoWon.ATTACKER);
-          m_pendingBattles.add(nonFight);
+          pendingBattles.add(nonFight);
           getBattleRecords().addBattle(id, nonFight.getBattleId(), route.getEnd(), nonFight.getBattleType());
         }
         final Change change = nonFight.addAttackChange(route, units, null);
@@ -671,7 +669,7 @@ public class BattleTracker implements Serializable {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id);
       } else if (ta.getCapital() != null) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, id);
-      } else if (m_blitzed.contains(territory) && arrivedUnits.stream().anyMatch(Matches.unitCanBlitz())) {
+      } else if (blitzed.contains(territory) && arrivedUnits.stream().anyMatch(Matches.unitCanBlitz())) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_BLITZ, id);
       } else {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_LAND, id);
@@ -904,7 +902,7 @@ public class BattleTracker implements Serializable {
     // If there are no pending battles- add one for units already in the combat zone
     if (battle == null) {
       battle = new MustFightBattle(site, id, data, this);
-      m_pendingBattles.add(battle);
+      pendingBattles.add(battle);
       getBattleRecords().addBattle(id, battle.getBattleId(), site, battle.getBattleType());
     }
     // Add the units that moved into the battle
@@ -936,7 +934,7 @@ public class BattleTracker implements Serializable {
   }
 
   public IBattle getPendingBattle(final Territory t, final boolean bombing, final BattleType type) {
-    for (final IBattle battle : m_pendingBattles) {
+    for (final IBattle battle : pendingBattles) {
       if (battle.getTerritory().equals(t) && battle.isBombingRun() == bombing) {
         if (type == null || type == battle.getBattleType()) {
           return battle;
@@ -950,7 +948,7 @@ public class BattleTracker implements Serializable {
     if (guid == null) {
       return null;
     }
-    for (final IBattle battle : m_pendingBattles) {
+    for (final IBattle battle : pendingBattles) {
       if (guid.equals(battle.getBattleId())) {
         return battle;
       }
@@ -960,7 +958,7 @@ public class BattleTracker implements Serializable {
 
   Collection<IBattle> getPendingBattles(final Territory t, final BattleType type) {
     final Collection<IBattle> battles = new HashSet<>();
-    for (final IBattle battle : m_pendingBattles) {
+    for (final IBattle battle : pendingBattles) {
       if (battle.getTerritory().equals(t) && (type == null || type == battle.getBattleType())) {
         battles.add(battle);
       }
@@ -974,7 +972,7 @@ public class BattleTracker implements Serializable {
    * @param bombing whether only battles where there is bombing.
    */
   public Collection<Territory> getPendingBattleSites(final boolean bombing) {
-    final Collection<IBattle> pending = new HashSet<>(m_pendingBattles);
+    final Collection<IBattle> pending = new HashSet<>(pendingBattles);
     final Collection<Territory> battles = new ArrayList<>();
     for (final IBattle battle : pending) {
       if (battle != null && !battle.isEmpty() && battle.isBombingRun() == bombing) {
@@ -986,7 +984,7 @@ public class BattleTracker implements Serializable {
 
   BattleListing getPendingBattleSites() {
     final Map<BattleType, Collection<Territory>> battles = new HashMap<>();
-    final Collection<IBattle> pending = new HashSet<>(m_pendingBattles);
+    final Collection<IBattle> pending = new HashSet<>(pendingBattles);
     for (final IBattle battle : pending) {
       if (battle != null && !battle.isEmpty()) {
         Collection<Territory> territories = battles.get(battle.getBattleType());
@@ -1006,7 +1004,7 @@ public class BattleTracker implements Serializable {
    * @param blocked the battle that is blocked.
    */
   public Collection<IBattle> getDependentOn(final IBattle blocked) {
-    final Collection<IBattle> dependent = m_dependencies.get(blocked);
+    final Collection<IBattle> dependent = dependencies.get(blocked);
     if (dependent == null) {
       return Collections.emptyList();
     }
@@ -1019,21 +1017,21 @@ public class BattleTracker implements Serializable {
    * @param blocking the battle that is blocking the other battles.
    */
   public Collection<IBattle> getBlocked(final IBattle blocking) {
-    return m_dependencies.keySet().stream()
+    return dependencies.keySet().stream()
         .filter(current -> getDependentOn(current).contains(blocking))
         .collect(Collectors.toList());
   }
 
   public void addDependency(final IBattle blocked, final IBattle blocking) {
-    m_dependencies.putIfAbsent(blocked, new HashSet<>());
-    m_dependencies.get(blocked).add(blocking);
+    dependencies.putIfAbsent(blocked, new HashSet<>());
+    dependencies.get(blocked).add(blocking);
   }
 
   private void removeDependency(final IBattle blocked, final IBattle blocking) {
-    final Collection<IBattle> dependencies = m_dependencies.get(blocked);
+    final Collection<IBattle> dependencies = this.dependencies.get(blocked);
     dependencies.remove(blocking);
     if (dependencies.isEmpty()) {
-      m_dependencies.remove(blocked);
+      this.dependencies.remove(blocked);
     }
   }
 
@@ -1045,8 +1043,8 @@ public class BattleTracker implements Serializable {
       for (final IBattle current : getBlocked(battle)) {
         removeDependency(current, battle);
       }
-      m_pendingBattles.remove(battle);
-      m_foughBattles.add(battle.getTerritory());
+      pendingBattles.remove(battle);
+      foughtBattles.add(battle.getTerritory());
       try {
         DelegateFinder.battleDelegate(data).clearCurrentBattle(battle);
       } catch (final IllegalStateException e) {
@@ -1060,48 +1058,48 @@ public class BattleTracker implements Serializable {
   }
 
   public void clear() {
-    m_finishedBattlesUnitAttackFromMap.clear();
-    m_pendingBattles.clear();
-    m_blitzed.clear();
-    m_foughBattles.clear();
-    m_conquered.clear();
-    m_dependencies.clear();
-    m_defendingAirThatCanNotLand.clear();
-    m_noBombardAllowed.clear();
-    m_relationshipChangesThisTurn.clear();
+    finishedBattlesUnitAttackFromMap.clear();
+    pendingBattles.clear();
+    blitzed.clear();
+    foughtBattles.clear();
+    conquered.clear();
+    dependencies.clear();
+    defendingAirThatCanNotLand.clear();
+    noBombardAllowed.clear();
+    relationshipChangesThisTurn.clear();
   }
 
   void addToDefendingAirThatCanNotLand(final Collection<Unit> units, final Territory szTerritoryTheyAreIn) {
-    Collection<Unit> current = m_defendingAirThatCanNotLand.get(szTerritoryTheyAreIn);
+    Collection<Unit> current = defendingAirThatCanNotLand.get(szTerritoryTheyAreIn);
     if (current == null) {
       current = new ArrayList<>();
     }
     current.addAll(units);
-    m_defendingAirThatCanNotLand.put(szTerritoryTheyAreIn, current);
+    defendingAirThatCanNotLand.put(szTerritoryTheyAreIn, current);
   }
 
   public Map<Territory, Collection<Unit>> getDefendingAirThatCanNotLand() {
-    return m_defendingAirThatCanNotLand;
+    return defendingAirThatCanNotLand;
   }
 
   public void clearBattleRecords() {
-    if (m_battleRecords != null) {
-      m_battleRecords.clear();
-      m_battleRecords = null;
+    if (battleRecords != null) {
+      battleRecords.clear();
+      battleRecords = null;
     }
   }
 
   BattleRecords getBattleRecords() {
-    if (m_battleRecords == null) {
-      m_battleRecords = new BattleRecords();
+    if (battleRecords == null) {
+      battleRecords = new BattleRecords();
     }
-    return m_battleRecords;
+    return battleRecords;
   }
 
   void sendBattleRecordsToGameData(final IDelegateBridge bridge) {
-    if (m_battleRecords != null && !m_battleRecords.isEmpty()) {
+    if (battleRecords != null && !battleRecords.isEmpty()) {
       bridge.getHistoryWriter().startEvent("Recording Battle Statistics");
-      bridge.addChange(ChangeFactory.addBattleRecords(m_battleRecords, bridge.getData()));
+      bridge.addChange(ChangeFactory.addBattleRecords(battleRecords, bridge.getData()));
     }
   }
 
@@ -1190,7 +1188,7 @@ public class BattleTracker implements Serializable {
 
   @Override
   public String toString() {
-    return "BattleTracker:" + "\n" + "Conquered:" + m_conquered + "\n" + "Blitzed:" + m_blitzed + "\n" + "Fought:"
-        + m_foughBattles + "\n" + "Pending:" + m_pendingBattles;
+    return "BattleTracker:" + "\n" + "Conquered:" + conquered + "\n" + "Blitzed:" + blitzed + "\n" + "Fought:"
+        + foughtBattles + "\n" + "Pending:" + pendingBattles;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -105,9 +105,9 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   public Serializable saveState() {
     final BidPurchaseExtendedDelegateState state = new BidPurchaseExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_bid = bid;
-    state.m_hasBid = hasBid;
-    state.m_spent = this.spent;
+    state.bid = bid;
+    state.hasBid = hasBid;
+    state.spent = this.spent;
     return state;
   }
 
@@ -115,8 +115,8 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   public void loadState(final Serializable state) {
     final BidPurchaseExtendedDelegateState s = (BidPurchaseExtendedDelegateState) state;
     super.loadState(s.superState);
-    bid = s.m_bid;
-    spent = s.m_spent;
-    hasBid = s.m_hasBid;
+    bid = s.bid;
+    spent = s.spent;
+    hasBid = s.hasBid;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseExtendedDelegateState.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 class BidPurchaseExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 6896164200767186673L;
+
   Serializable superState;
-  int m_bid;
-  int m_spent;
-  boolean m_hasBid;
+  int bid;
+  int spent;
+  boolean hasBid;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -583,7 +583,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
 
     // allow user to cancel move if aa guns will fire
-    final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
+    final AaInMoveUtil aaInMoveUtil = new AaInMoveUtil();
     aaInMoveUtil.initialize(bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -41,7 +41,7 @@ public class MovePerformer implements Serializable {
   private transient AbstractMoveDelegate moveDelegate;
   private transient IDelegateBridge bridge;
   private transient PlayerID player;
-  private AAInMoveUtil m_aaInMoveUtil;
+  private AaInMoveUtil m_aaInMoveUtil;
   private final ExecutionStack m_executionStack = new ExecutionStack();
   private UndoableMove m_currentMove;
   private Map<Unit, Collection<Unit>> m_newDependents;
@@ -450,7 +450,7 @@ public class MovePerformer implements Serializable {
    */
   private Collection<Unit> fireAa(final Route route, final Collection<Unit> units) {
     if (m_aaInMoveUtil == null) {
-      m_aaInMoveUtil = new AAInMoveUtil();
+      m_aaInMoveUtil = new AaInMoveUtil();
     }
     m_aaInMoveUtil.initialize(bridge);
     final Collection<Unit> unitsToRemove =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -39,8 +39,6 @@ import games.strategy.util.IntegerMap;
  */
 @MapSupport
 public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDelegate {
-  // protected Map<ICondition, Boolean> m_testedConditions = null;
-  // private final boolean m_needToInitialize = true;
   /** Creates new PoliticsDelegate. */
   public PoliticsDelegate() {}
 
@@ -72,7 +70,6 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
     chainAlliancesTogether(bridge);
     givesBackOriginalTerritories(bridge);
-    // m_needToInitialize = true;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -118,7 +118,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return errorMsg.append(result.getUnresolvedUnitWarning(0)).append(numErrorsMsg).toString();
     }
     // allow user to cancel move if aa guns will fire
-    final AAInMoveUtil aaInMoveUtil = new AAInMoveUtil();
+    final AaInMoveUtil aaInMoveUtil = new AaInMoveUtil();
     aaInMoveUtil.initialize(bridge);
     final Collection<Territory> aaFiringTerritores = aaInMoveUtil.getTerritoriesWhereAaWillFire(route, units);
     if (!aaFiringTerritores.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -63,7 +63,7 @@ public abstract class TechAdvance extends NamedAttachable {
     preDefinedTechMap.put(TECH_PROPERTY_SUPER_SUBS, SuperSubsAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_JET_POWER, JetPowerAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_IMPROVED_SHIPYARDS, ImprovedShipyardsAdvance.class);
-    preDefinedTechMap.put(TECH_PROPERTY_AA_RADAR, AARadarAdvance.class);
+    preDefinedTechMap.put(TECH_PROPERTY_AA_RADAR, AaRadarAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_LONG_RANGE_AIRCRAFT, LongRangeAircraftAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_HEAVY_BOMBER, HeavyBomberAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_IMPROVED_ARTILLERY_SUPPORT, ImprovedArtillerySupportAdvance.class);
@@ -110,7 +110,7 @@ public abstract class TechAdvance extends NamedAttachable {
     tf.addAdvance(new SuperSubsAdvance(tf.getData()));
     tf.addAdvance(new JetPowerAdvance(tf.getData()));
     tf.addAdvance(new ImprovedShipyardsAdvance(tf.getData()));
-    tf.addAdvance(new AARadarAdvance(tf.getData()));
+    tf.addAdvance(new AaRadarAdvance(tf.getData()));
     tf.addAdvance(new LongRangeAircraftAdvance(tf.getData()));
     tf.addAdvance(new HeavyBomberAdvance(tf.getData()));
     tf.addAdvance(new ImprovedArtillerySupportAdvance(tf.getData()));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -92,7 +92,7 @@ public class UndoableMove extends AbstractUndoableMove {
   protected void undoSpecific(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     final BattleTracker battleTracker = DelegateFinder.battleDelegate(data).getBattleTracker();
-    battleTracker.undoBattle(m_route, m_units, bridge.getPlayerId(), bridge);
+    battleTracker.undoBattle(m_route, units, bridge.getPlayerId(), bridge);
     // clean up dependencies
     for (final UndoableMove other : m_iDependOn) {
       other.m_dependOnMe.remove(this);
@@ -103,7 +103,7 @@ public class UndoableMove extends AbstractUndoableMove {
       if (battle == null || battle.isOver()) {
         continue;
       }
-      for (final Unit unit : m_units) {
+      for (final Unit unit : units) {
         final Route routeUnitUsedToMove =
             DelegateFinder.moveDelegate(data).getRouteUsedToMoveInto(unit, m_route.getStart());
         if (!battle.getBattleType().isBombingRun()) {
@@ -149,7 +149,7 @@ public class UndoableMove extends AbstractUndoableMove {
       }
     }
     // Clear any temporary dependents
-    MovePanel.clearDependents(m_units);
+    MovePanel.clearDependents(units);
   }
 
   /**
@@ -165,14 +165,14 @@ public class UndoableMove extends AbstractUndoableMove {
       // if the other move has moves that depend on this
       if (!CollectionUtils.intersection(other.getUnits(), this.getUnits()).isEmpty()
           // if the other move has transports that we are loading
-          || !CollectionUtils.intersection(other.m_units, this.m_loaded).isEmpty()
+          || !CollectionUtils.intersection(other.units, this.m_loaded).isEmpty()
           // or we are moving through a previously conqueured territory
           // we should be able to take this out later
           // we need to add logic for this move to take over the same territories
           // when the other move is undone
           || !CollectionUtils.intersection(other.m_conquered, m_route.getAllTerritories()).isEmpty()
           // or we are unloading transports that have moved in another turn
-          || !CollectionUtils.intersection(other.m_units, this.m_unloaded).isEmpty()
+          || !CollectionUtils.intersection(other.units, this.m_unloaded).isEmpty()
           || !CollectionUtils.intersection(other.m_unloaded, this.m_unloaded).isEmpty()) {
         m_iDependOn.add(other);
         other.m_dependOnMe.add(this);
@@ -196,7 +196,7 @@ public class UndoableMove extends AbstractUndoableMove {
 
   @Override
   public String toString() {
-    return "UndoableMove index;" + m_index + " description:" + m_description;
+    return "UndoableMove index;" + index + " description:" + m_description;
   }
 
   @Override
@@ -215,6 +215,6 @@ public class UndoableMove extends AbstractUndoableMove {
 
   @Override
   protected final MoveDescription getDescriptionObject() {
-    return new MoveDescription(m_units, m_route);
+    return new MoveDescription(units, m_route);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -73,11 +73,11 @@ public class UndoablePlacement extends AbstractUndoableMove {
 
   @Override
   protected final PlacementDescription getDescriptionObject() {
-    return new PlacementDescription(m_units, m_placeTerritory);
+    return new PlacementDescription(units, m_placeTerritory);
   }
 
   @Override
   public String toString() {
-    return getMoveLabel(" produces in ") + ": " + MyFormatter.unitsToTextNoOwner(m_units);
+    return getMoveLabel(" produces in ") + ": " + MyFormatter.unitsToTextNoOwner(units);
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the following classes of the `g.s.triplea.delegate` package:

* `AAInMoveUtil`
* `AARadarAdvance`
* `AbstractMoveExtendedDelegateState`
* `AbstractUndoableMove`
* `AirBattle`
* `BaseDelegateState`
* `BattleExtendedDelegateState`
* `BattleTracker`
* `BidPurchaseExtendedDelegateState`

## Functional Changes

None.

## Manual Testing Performed

None.