### PR TITLE
Use convinient shortcuts for random code

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1023,8 +1023,7 @@ public class BattleTracker implements Serializable {
   }
 
   public void addDependency(final IBattle blocked, final IBattle blocking) {
-    dependencies.putIfAbsent(blocked, new HashSet<>());
-    dependencies.get(blocked).add(blocking);
+    dependencies.computeIfAbsent(blocked, k -> new HashSet<>()).add(blocking);
   }
 
   private void removeDependency(final IBattle blocked, final IBattle blocking) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -67,8 +67,8 @@ public class FinishedBattle extends AbstractBattle {
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
     attackingUnits.addAll(units);
-    m_attackingFromMap.putIfAbsent(attackingFrom, new ArrayList<>());
-    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.get(attackingFrom);
+    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.computeIfAbsent(attackingFrom,
+        i -> new ArrayList<>());
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -58,8 +58,8 @@ public class NonFightingBattle extends DependentBattle {
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
     m_attackingFrom.add(attackingFrom);
     attackingUnits.addAll(units);
-    m_attackingFromMap.putIfAbsent(attackingFrom, new ArrayList<>());
-    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.get(attackingFrom);
+    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.computeIfAbsent(attackingFrom,
+        i -> new ArrayList<>());
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
@@ -160,14 +160,9 @@ public class NonFightingBattle extends DependentBattle {
   /**
    * Add dependent Units. Uninformative comment to suppress checkstyle warning.
    */
-  public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
-    for (final Unit holder : dependencies.keySet()) {
-      final Collection<Unit> transporting = dependencies.get(holder);
-      if (dependentUnits.get(holder) != null) {
-        dependentUnits.get(holder).addAll(transporting);
-      } else {
-        dependentUnits.put(holder, new LinkedHashSet<>(transporting));
-      }
+  void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
+    for (final Map.Entry<Unit, Collection<Unit>> entry : dependencies.entrySet()) {
+      dependentUnits.computeIfAbsent(entry.getKey(), k -> new LinkedHashSet<>()).addAll(entry.getValue());
     }
   }
 


### PR DESCRIPTION
## Overview
This is a change inspired by some changed code I spotted in #4257
It uses compute* methods instead of getting and setting for potential performance optimizations (i.e. he has of an object doesn't need to be calculated 2 times etc.)

## Functional Changes
None.

## Manual Testing Performed
None.