### PR TITLE
Fix determination of transported units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -856,7 +856,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             }
             // after that is applied, we have to make a map of all dependencies
             final Map<Unit, Collection<Unit>> dependenciesForMfb =
-                TransportTracker.transporting(attackingUnits);
+                TransportTracker.transportingWithAllPossibleUnits(attackingUnits);
             for (final Unit transport : CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport())) {
               // however, the map we add to the newly created battle, cannot hold any units that are NOT in this
               // territory.
@@ -873,8 +873,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   new ArrayList<>(CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport()));
               allNeighborUnits.addAll(t.getUnits().getMatches(Matches.unitIsLandAndOwnedBy(player)));
               final Map<Unit, Collection<Unit>> dependenciesForNeighbors =
-                  TransportTracker.transporting(CollectionUtils
-                      .getMatches(allNeighborUnits, Matches.unitIsTransport().negate()));
+                  TransportTracker.transportingWithAllPossibleUnits(
+                      CollectionUtils.getMatches(allNeighborUnits, Matches.unitIsTransport().negate()));
               dependencies.put(t, dependenciesForNeighbors);
             }
             mfb.addDependentUnits(dependencies.get(to));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -116,7 +116,7 @@ public class MovePerformer implements Serializable {
         // need to remove any dependents here
         if (aaCasualties != null) {
           aaCasualtiesWithDependents.addAll(aaCasualties);
-          final Map<Unit, Collection<Unit>> dependencies = TransportTracker.transporting(units);
+          final Map<Unit, Collection<Unit>> dependencies = TransportTracker.transportingWithAllPossibleUnits(units);
           for (final Unit u : aaCasualties) {
             final Collection<Unit> dependents = dependencies.get(u);
             if (dependents != null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -59,18 +60,33 @@ public class TransportTracker {
    * Returns a map of transport -> collection of transported units.
    */
   public static Map<Unit, Collection<Unit>> transporting(final Collection<Unit> units) {
+    return transporting(units, TransportTracker::transporting);
+  }
+
+  private static Map<Unit, Collection<Unit>> transporting(
+      final Collection<Unit> units,
+      final Function<Unit, Collection<Unit>> getUnitsTransportedByTransport) {
     final Map<Unit, Collection<Unit>> returnVal = new HashMap<>();
     for (final Unit transported : units) {
       final Unit transport = transportedBy(transported);
       Collection<Unit> transporting = null;
       if (transport != null) {
-        transporting = transporting(transport);
+        transporting = getUnitsTransportedByTransport.apply(transport);
       }
       if (transporting != null) {
         returnVal.put(transport, transporting);
       }
     }
     return returnVal;
+  }
+
+  /**
+   * Returns a map of transport -> collection of transported units.
+   * This method is identical to {@link #transporting(Collection)} except that it considers all elements in
+   * {@code units} as the possible units to transport (see {@link #transporting(Unit, Collection)}).
+   */
+  public static Map<Unit, Collection<Unit>> transportingWithAllPossibleUnits(final Collection<Unit> units) {
+    return transporting(units, transport -> transporting(transport, units));
   }
 
   public static boolean isTransporting(final Unit transport) {


### PR DESCRIPTION
## Overview

Fixes #4162 on `master`.  This PR is simply a cherry-pick of #4252.

## Changes

See #4252.

## Manual Testing Performed

I created a 1.10-compatible save game similar to the 1.9-compatible save game used to test #4252.  I used it to re-run the tests listed in #4252.