### PR TITLE
Change GameSetting listeners to accept GameSetting that triggered change

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -50,8 +50,8 @@ public final class Console {
   public Console() {
     setLogLevel(getDefaultLogLevel());
 
-    ClientSetting.showConsole.addSaveListener(newValue -> {
-      if (newValue.equals(String.valueOf(true))) {
+    ClientSetting.showConsole.addSaveListener(gameSetting -> {
+      if (gameSetting.getValueOrThrow()) {
         SwingUtilities.invokeLater(() -> setVisible(true));
       }
     });

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -39,8 +39,8 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void initialize() {
-    ClientSetting.lookAndFeel.addSaveListener(newValue -> {
-      setupLookAndFeel(newValue);
+    ClientSetting.lookAndFeel.addSaveListener(gameSetting -> {
+      setupLookAndFeel(gameSetting.getValueOrThrow());
       SettingsWindow.updateLookAndFeel();
       JOptionPane.showMessageDialog(
           null,

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
@@ -6,6 +6,7 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.GameSetting;
 import games.strategy.ui.SwingComponents;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,7 @@ import lombok.AllArgsConstructor;
  * </pre>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public final class LookAndFeelSwingFrameListener implements Consumer<String> {
+public final class LookAndFeelSwingFrameListener implements Consumer<GameSetting<String>> {
   private final JFrame component;
 
   /**
@@ -29,14 +30,14 @@ public final class LookAndFeelSwingFrameListener implements Consumer<String> {
    * component. Listener removal is also handled and is attached to the window close event.
    */
   public static void register(final JFrame component) {
-    final Consumer<String> listener = new LookAndFeelSwingFrameListener(component);
+    final Consumer<GameSetting<String>> listener = new LookAndFeelSwingFrameListener(component);
     ClientSetting.lookAndFeel.addSaveListener(listener);
     SwingComponents.addWindowClosingListener(component,
         () -> ClientSetting.lookAndFeel.removeSaveListener(listener));
   }
 
   @Override
-  public void accept(final String s) {
+  public void accept(final GameSetting<String> gameSetting) {
     SwingUtilities.updateComponentTreeUI(component);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
@@ -119,7 +118,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   private final Class<T> type;
   private final String name;
   private final @Nullable T defaultValue;
-  private final Collection<Consumer<String>> onSaveActions = new CopyOnWriteArrayList<>();
+  private final Collection<Consumer<GameSetting<T>>> onSaveActions = new CopyOnWriteArrayList<>();
 
   /**
    * Initializes a new instance of {@code ClientSetting} with no default value.
@@ -163,13 +162,13 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   }
 
   @Override
-  public final void addSaveListener(final Consumer<String> saveListener) {
+  public final void addSaveListener(final Consumer<GameSetting<T>> saveListener) {
     Preconditions.checkNotNull(saveListener);
     onSaveActions.add(saveListener);
   }
 
   @Override
-  public final void removeSaveListener(final Consumer<String> saveListener) {
+  public final void removeSaveListener(final Consumer<GameSetting<T>> saveListener) {
     onSaveActions.remove(saveListener);
   }
 
@@ -221,14 +220,13 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   }
 
   private void saveString(final @Nullable String newValue) {
-    final String value = Strings.nullToEmpty(newValue);
-    onSaveActions.forEach(saveAction -> saveAction.accept(value));
-
-    if (value.isEmpty()) {
+    if (newValue == null) {
       getPreferences().remove(name);
     } else {
       getPreferences().put(name, newValue);
     }
+
+    onSaveActions.forEach(saveAction -> saveAction.accept(this));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -62,7 +62,7 @@ public interface GameSetting<T> {
    */
   void resetValue();
 
-  void addSaveListener(Consumer<String> listener);
+  void addSaveListener(Consumer<GameSetting<T>> listener);
 
-  void removeSaveListener(Consumer<String> listener);
+  void removeSaveListener(Consumer<GameSetting<T>> listener);
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -3,6 +3,9 @@ package games.strategy.triplea.settings;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.function.Consumer;
 
@@ -10,7 +13,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -50,21 +52,26 @@ final class ClientSettingTest {
 
   @ExtendWith(MockitoExtension.class)
   @Nested
-  final class SaveActionTest extends AbstractClientSettingTestCase {
+  final class SaveListenerTest extends AbstractClientSettingTestCase {
     private static final String TEST_VALUE = "value";
 
     @Mock
-    private Consumer<String> mockSaveListener;
+    private Consumer<GameSetting<String>> mockSaveListener;
     private final ClientSetting<String> clientSetting = new FakeClientSetting("TEST_SETTING");
 
     @Test
-    void saveActionListenerIsCalled() {
+    void saveListenerIsCalled() {
+      doAnswer(invocation -> {
+        @SuppressWarnings("unchecked")
+        final GameSetting<String> gameSetting = (GameSetting<String>) invocation.getArgument(0);
+        assertThat(gameSetting.getValue(), isPresentAndIs(TEST_VALUE));
+        return null;
+      }).when(mockSaveListener).accept(clientSetting);
       clientSetting.addSaveListener(mockSaveListener);
 
       clientSetting.save(TEST_VALUE);
 
-      Mockito.verify(mockSaveListener, Mockito.times(1))
-          .accept(TEST_VALUE);
+      verify(mockSaveListener).accept(clientSetting);
     }
 
     @Test
@@ -74,8 +81,7 @@ final class ClientSettingTest {
 
       clientSetting.save(TEST_VALUE);
 
-      Mockito.verify(mockSaveListener, Mockito.never())
-          .accept(TEST_VALUE);
+      verify(mockSaveListener, never()).accept(clientSetting);
     }
   }
 


### PR DESCRIPTION
## Overview

Changes the `GameSetting` listener to accept a parameter of type `GameSetting<T>` rather than `String`.  This removes the need to always convert the new game setting value to a string for the benefit of the listener.  The listener can now use the full `GameSetting` API to interrogate the setting.

## Functional Changes

None.

## Manual Testing Performed

Verified the **Show Console** and **Look and Feel** setting listeners are invoked as expected when the corresponding setting is changed from the Swing client.