### PR TITLE
Checkstyle: Fix naming violations in g.s.triplea.delegate (D-I)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -222,8 +222,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     final EndTurnExtendedDelegateState state = new EndTurnExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_needToInitialize = needToInitialize;
-    state.m_hasPostedTurnSummary = hasPostedTurnSummary;
+    state.needToInitialize = needToInitialize;
+    state.hasPostedTurnSummary = hasPostedTurnSummary;
     return state;
   }
 
@@ -231,8 +231,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   public void loadState(final Serializable state) {
     final EndTurnExtendedDelegateState s = (EndTurnExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
-    hasPostedTurnSummary = s.m_hasPostedTurnSummary;
+    needToInitialize = s.needToInitialize;
+    hasPostedTurnSummary = s.hasPostedTurnSummary;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -13,42 +13,42 @@ public class Die implements Serializable {
     MISS, HIT, IGNORED
   }
 
-  private final DieType m_type;
+  private final DieType type;
   // the value of the dice, 0 based
-  private final int m_value;
+  private final int value;
   // this value is 1 based
-  private final int m_rolledAt;
+  private final int rolledAt;
 
   public Die(final int value) {
     this(value, -1, DieType.MISS);
   }
 
   Die(final int value, final int rolledAt, final DieType type) {
-    m_type = type;
-    m_value = value;
-    m_rolledAt = rolledAt;
+    this.type = type;
+    this.value = value;
+    this.rolledAt = rolledAt;
   }
 
   public Die.DieType getType() {
-    return m_type;
+    return type;
   }
 
   public int getValue() {
-    return m_value;
+    return value;
   }
 
   int getRolledAt() {
-    return m_rolledAt;
+    return rolledAt;
   }
 
   // compress to an int
   // we write a lot of dice over the network and to the saved
   // game, so we want to make this fairly efficient
   int getCompressedValue() {
-    if (m_value > 255 || m_rolledAt > 255) {
+    if (value > 255 || rolledAt > 255) {
       throw new IllegalStateException("too big to serialize");
     }
-    return (m_rolledAt << 8) + (m_value << 16) + (m_type.ordinal());
+    return (rolledAt << 8) + (value << 16) + (type.ordinal());
   }
 
   // read from an int
@@ -65,19 +65,19 @@ public class Die implements Serializable {
       return false;
     }
     final Die other = (Die) o;
-    return other.m_type == this.m_type && other.m_value == this.m_value && other.m_rolledAt == this.m_rolledAt;
+    return other.type == this.type && other.value == this.value && other.rolledAt == this.rolledAt;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(m_value, m_rolledAt);
+    return Objects.hash(value, rolledAt);
   }
 
   @Override
   public String toString() {
-    if (m_rolledAt < 0) {
-      return "Die roll:" + m_value + (m_type == DieType.IGNORED ? " type:" + m_type : "");
+    if (rolledAt < 0) {
+      return "Die roll:" + value + (type == DieType.IGNORED ? " type:" + type : "");
     }
-    return "Die roll:" + m_value + " rolled at:" + m_rolledAt + " type:" + m_type;
+    return "Die roll:" + value + " rolled at:" + rolledAt + " type:" + type;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -187,8 +187,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   public Serializable saveState() {
     final EndRoundExtendedDelegateState state = new EndRoundExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_gameOver = gameOver;
-    state.m_winners = winners;
+    state.gameOver = gameOver;
+    state.winners = winners;
     return state;
   }
 
@@ -196,8 +196,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final EndRoundExtendedDelegateState s = (EndRoundExtendedDelegateState) state;
     super.loadState(s.superState);
-    gameOver = s.m_gameOver;
-    winners = s.m_winners;
+    gameOver = s.gameOver;
+    winners = s.winners;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
@@ -8,8 +8,9 @@ import games.strategy.engine.data.PlayerID;
 
 class EndRoundExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 8770361633528374127L;
+
   Serializable superState;
   // add other variables here:
-  public boolean m_gameOver = false;
-  public Collection<PlayerID> m_winners = new ArrayList<>();
+  public boolean gameOver = false;
+  public Collection<PlayerID> winners = new ArrayList<>();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
@@ -4,8 +4,9 @@ import java.io.Serializable;
 
 class EndTurnExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -3939461840835898284L;
+
   Serializable superState;
   // add other variables here:
-  public boolean m_needToInitialize;
-  public boolean m_hasPostedTurnSummary;
+  public boolean needToInitialize;
+  public boolean hasPostedTurnSummary;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -27,9 +27,10 @@ import games.strategy.util.IntegerMap;
  */
 public class FinishedBattle extends AbstractBattle {
   private static final long serialVersionUID = -5852495231826940879L;
-  private final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
+
+  private final Collection<Territory> amphibiousAttackFrom = new ArrayList<>();
   // maps Territory-> units (stores a collection of who is attacking from where, needed for undoing moves)
-  private final Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
+  private final Map<Territory, Collection<Unit>> attackingFromMap = new HashMap<>();
 
   FinishedBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,
       final boolean isBombingRun, final BattleType battleType, final GameData data,
@@ -67,13 +68,13 @@ public class FinishedBattle extends AbstractBattle {
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
     attackingUnits.addAll(units);
-    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.computeIfAbsent(attackingFrom,
+    final Collection<Unit> attackingFromMapUnits = attackingFromMap.computeIfAbsent(attackingFrom,
         k -> new ArrayList<>());
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
         && units.stream().anyMatch(Matches.unitIsLand())) {
-      m_amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
+      amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
       amphibiousLandAttackers.addAll(CollectionUtils.getMatches(units, Matches.unitIsLand()));
       isAmphibious = true;
     }
@@ -88,7 +89,7 @@ public class FinishedBattle extends AbstractBattle {
       return;
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
-    Collection<Unit> attackingFromMapUnits = m_attackingFromMap.get(attackingFrom);
+    Collection<Unit> attackingFromMapUnits = attackingFromMap.get(attackingFrom);
     // handle possible null pointer
     if (attackingFromMapUnits == null) {
       attackingFromMapUnits = new ArrayList<>();
@@ -102,9 +103,9 @@ public class FinishedBattle extends AbstractBattle {
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
       if (attackingFromMapUnits.stream().noneMatch(Matches.unitIsLand())) {
-        m_amphibiousAttackFrom.remove(attackingFrom);
+        amphibiousAttackFrom.remove(attackingFrom);
         // do we have any amphibious attacks left?
-        isAmphibious = !m_amphibiousAttackFrom.isEmpty();
+        isAmphibious = !amphibiousAttackFrom.isEmpty();
       }
     }
     for (final Collection<Unit> dependent : dependentUnits.values()) {
@@ -145,6 +146,6 @@ public class FinishedBattle extends AbstractBattle {
   }
 
   Map<Territory, Collection<Unit>> getAttackingFromMap() {
-    return m_attackingFromMap;
+    return attackingFromMap;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -23,29 +23,29 @@ public class Fire implements IExecutable {
 
   private static final long serialVersionUID = -3687054738070722403L;
 
-  private final String m_stepName;
-  private final Collection<Unit> m_firingUnits;
-  private final Collection<Unit> m_attackableUnits;
-  private final MustFightBattle.ReturnFire m_canReturnFire;
-  private final String m_text;
-  private final MustFightBattle m_battle;
-  private final PlayerID m_firingPlayer;
-  private final PlayerID m_hitPlayer;
-  private final boolean m_defending;
-  private final Map<Unit, Collection<Unit>> m_dependentUnits;
-  private final GUID m_battleID;
-  private DiceRoll m_dice;
-  private Collection<Unit> m_killed;
-  private Collection<Unit> m_damaged;
-  private boolean m_confirmOwnCasualties = true;
-  private final boolean m_isHeadless;
-  private final Territory m_battleSite;
-  private final Collection<TerritoryEffect> m_territoryEffects;
-  private final List<Unit> m_allEnemyUnitsAliveOrWaitingToDie;
-  private final Collection<Unit> m_allFriendlyUnitsNotIncludingWaitingToDie;
-  private final Collection<Unit> m_allEnemyUnitsNotIncludingWaitingToDie;
-  private final boolean m_isAmphibious;
-  private final Collection<Unit> m_amphibiousLandAttackers;
+  private final String stepName;
+  private final Collection<Unit> firingUnits;
+  private final Collection<Unit> attackableUnits;
+  private final MustFightBattle.ReturnFire canReturnFire;
+  private final String text;
+  private final MustFightBattle battle;
+  private final PlayerID firingPlayer;
+  private final PlayerID hitPlayer;
+  private final boolean defending;
+  private final Map<Unit, Collection<Unit>> dependentUnits;
+  private final GUID battleId;
+  private DiceRoll dice;
+  private Collection<Unit> killed;
+  private Collection<Unit> damaged;
+  private boolean confirmOwnCasualties = true;
+  private final boolean isHeadless;
+  private final Territory battleSite;
+  private final Collection<TerritoryEffect> territoryEffects;
+  private final List<Unit> allEnemyUnitsAliveOrWaitingToDie;
+  private final Collection<Unit> allFriendlyUnitsNotIncludingWaitingToDie;
+  private final Collection<Unit> allEnemyUnitsNotIncludingWaitingToDie;
+  private final boolean isAmphibious;
+  private final Collection<Unit> amphibiousLandAttackers;
 
   Fire(final Collection<Unit> attackableUnits, final MustFightBattle.ReturnFire canReturnFire,
       final PlayerID firingPlayer, final PlayerID hitPlayer, final Collection<Unit> firingUnits, final String stepName,
@@ -53,54 +53,54 @@ public class Fire implements IExecutable {
       final Map<Unit, Collection<Unit>> dependentUnits, final boolean headless,
       final Territory battleSite, final Collection<TerritoryEffect> territoryEffects,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
-    m_attackableUnits = CollectionUtils.getMatches(attackableUnits, Matches.unitIsNotInfrastructure());
-    m_canReturnFire = canReturnFire;
-    m_firingUnits = firingUnits;
-    m_stepName = stepName;
-    m_text = text;
-    m_battle = battle;
-    m_hitPlayer = hitPlayer;
-    m_firingPlayer = firingPlayer;
-    m_defending = defending;
-    m_dependentUnits = dependentUnits;
-    m_isHeadless = headless;
-    m_battleID = battle.getBattleId();
-    m_battleSite = battleSite;
-    m_territoryEffects = territoryEffects;
-    m_allEnemyUnitsAliveOrWaitingToDie = allEnemyUnitsAliveOrWaitingToDie;
-    m_allFriendlyUnitsNotIncludingWaitingToDie =
-        m_defending ? m_battle.getDefendingUnits() : m_battle.getAttackingUnits();
-    m_allEnemyUnitsNotIncludingWaitingToDie =
-        !m_defending ? m_battle.getDefendingUnits() : m_battle.getAttackingUnits();
-    m_isAmphibious = m_battle.isAmphibious();
-    m_amphibiousLandAttackers = m_battle.getAmphibiousLandAttackers();
+    this.attackableUnits = CollectionUtils.getMatches(attackableUnits, Matches.unitIsNotInfrastructure());
+    this.canReturnFire = canReturnFire;
+    this.firingUnits = firingUnits;
+    this.stepName = stepName;
+    this.text = text;
+    this.battle = battle;
+    this.hitPlayer = hitPlayer;
+    this.firingPlayer = firingPlayer;
+    this.defending = defending;
+    this.dependentUnits = dependentUnits;
+    isHeadless = headless;
+    battleId = battle.getBattleId();
+    this.battleSite = battleSite;
+    this.territoryEffects = territoryEffects;
+    this.allEnemyUnitsAliveOrWaitingToDie = allEnemyUnitsAliveOrWaitingToDie;
+    allFriendlyUnitsNotIncludingWaitingToDie =
+        this.defending ? this.battle.getDefendingUnits() : this.battle.getAttackingUnits();
+    allEnemyUnitsNotIncludingWaitingToDie =
+        !this.defending ? this.battle.getDefendingUnits() : this.battle.getAttackingUnits();
+    isAmphibious = this.battle.isAmphibious();
+    amphibiousLandAttackers = this.battle.getAmphibiousLandAttackers();
   }
 
   private void rollDice(final IDelegateBridge bridge) {
-    if (m_dice != null) {
+    if (dice != null) {
       throw new IllegalStateException("Already rolled");
     }
-    final List<Unit> units = new ArrayList<>(m_firingUnits);
+    final List<Unit> units = new ArrayList<>(firingUnits);
     final String annotation;
-    if (m_isHeadless) {
+    if (isHeadless) {
       annotation = "";
     } else {
-      annotation = DiceRoll.getAnnotation(units, m_firingPlayer, m_battle);
+      annotation = DiceRoll.getAnnotation(units, firingPlayer, battle);
     }
-    m_dice = DiceRoll.rollDice(units, m_defending, m_firingPlayer, bridge, m_battle, annotation, m_territoryEffects,
-        m_allEnemyUnitsAliveOrWaitingToDie);
+    dice = DiceRoll.rollDice(units, defending, firingPlayer, bridge, battle, annotation, territoryEffects,
+        allEnemyUnitsAliveOrWaitingToDie);
   }
 
   private void selectCasualties(final IDelegateBridge bridge) {
-    final int hitCount = m_dice.getHits();
-    AbstractBattle.getDisplay(bridge).notifyDice(m_dice, m_stepName);
+    final int hitCount = dice.getHits();
+    AbstractBattle.getDisplay(bridge).notifyDice(dice, stepName);
     final int countTransports =
-        CollectionUtils.countMatches(m_attackableUnits, Matches.unitIsTransport().and(Matches.unitIsSea()));
+        CollectionUtils.countMatches(attackableUnits, Matches.unitIsTransport().and(Matches.unitIsSea()));
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
-      final Collection<Unit> nonTransports = CollectionUtils.getMatches(m_attackableUnits,
+      final Collection<Unit> nonTransports = CollectionUtils.getMatches(attackableUnits,
           Matches.unitIsNotTransportButCouldBeCombatTransport().or(Matches.unitIsNotSea()));
-      final Collection<Unit> transportsOnly = CollectionUtils.getMatches(m_attackableUnits,
+      final Collection<Unit> transportsOnly = CollectionUtils.getMatches(attackableUnits,
           Matches.unitIsTransportButNotCombatTransport().and(Matches.unitIsSea()));
       final int numPossibleHits = AbstractBattle.getMaxHits(nonTransports);
       // more hits than combat units
@@ -123,68 +123,68 @@ public class Fire implements IExecutable {
               CollectionUtils.getNMatches(playerTransports, transportsToRemove,
                   Matches.unitIsTransportButNotCombatTransport()));
         }
-        m_killed = nonTransports;
-        m_damaged = Collections.emptyList();
+        killed = nonTransports;
+        damaged = Collections.emptyList();
         if (extraHits > transportsOnly.size()) {
           extraHits = transportsOnly.size();
         }
-        message = BattleCalculator.selectCasualties(m_stepName, m_hitPlayer, transportsOnly,
-            m_allEnemyUnitsNotIncludingWaitingToDie, m_firingPlayer, m_allFriendlyUnitsNotIncludingWaitingToDie,
-            m_isAmphibious, m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, m_text, m_dice,
-            !m_defending, m_battleID, m_isHeadless, extraHits, true);
-        m_killed.addAll(message.getKilled());
-        m_confirmOwnCasualties = true;
+        message = BattleCalculator.selectCasualties(stepName, hitPlayer, transportsOnly,
+            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
+            !defending, battleId, isHeadless, extraHits, true);
+        killed.addAll(message.getKilled());
+        confirmOwnCasualties = true;
       } else if (hitCount == numPossibleHits) { // exact number of combat units
-        m_killed = nonTransports;
-        m_damaged = Collections.emptyList();
-        m_confirmOwnCasualties = true;
+        killed = nonTransports;
+        damaged = Collections.emptyList();
+        confirmOwnCasualties = true;
       } else { // less than possible number
-        message = BattleCalculator.selectCasualties(m_stepName, m_hitPlayer, nonTransports,
-            m_allEnemyUnitsNotIncludingWaitingToDie, m_firingPlayer, m_allFriendlyUnitsNotIncludingWaitingToDie,
-            m_isAmphibious, m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, m_text, m_dice,
-            !m_defending, m_battleID, m_isHeadless, m_dice.getHits(), true);
-        m_killed = message.getKilled();
-        m_damaged = message.getDamaged();
-        m_confirmOwnCasualties = message.getAutoCalculated();
+        message = BattleCalculator.selectCasualties(stepName, hitPlayer, nonTransports,
+            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
+            !defending, battleId, isHeadless, dice.getHits(), true);
+        killed = message.getKilled();
+        damaged = message.getDamaged();
+        confirmOwnCasualties = message.getAutoCalculated();
       }
     } else { // not isTransportCasualtiesRestricted
       // they all die
-      if (hitCount >= AbstractBattle.getMaxHits(m_attackableUnits)) {
-        m_killed = m_attackableUnits;
-        m_damaged = Collections.emptyList();
+      if (hitCount >= AbstractBattle.getMaxHits(attackableUnits)) {
+        killed = attackableUnits;
+        damaged = Collections.emptyList();
         // everything died, so we need to confirm
-        m_confirmOwnCasualties = true;
+        confirmOwnCasualties = true;
       } else { // Choose casualties
         final CasualtyDetails message;
-        message = BattleCalculator.selectCasualties(m_stepName, m_hitPlayer, m_attackableUnits,
-            m_allEnemyUnitsNotIncludingWaitingToDie, m_firingPlayer, m_allFriendlyUnitsNotIncludingWaitingToDie,
-            m_isAmphibious, m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, m_text, m_dice,
-            !m_defending, m_battleID, m_isHeadless, m_dice.getHits(), true);
-        m_killed = message.getKilled();
-        m_damaged = message.getDamaged();
-        m_confirmOwnCasualties = message.getAutoCalculated();
+        message = BattleCalculator.selectCasualties(stepName, hitPlayer, attackableUnits,
+            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
+            !defending, battleId, isHeadless, dice.getHits(), true);
+        killed = message.getKilled();
+        damaged = message.getDamaged();
+        confirmOwnCasualties = message.getAutoCalculated();
       }
     }
   }
 
   private void notifyCasualties(final IDelegateBridge bridge) {
-    if (m_isHeadless) {
+    if (isHeadless) {
       return;
     }
-    AbstractBattle.getDisplay(bridge).casualtyNotification(m_battleID, m_stepName, m_dice, m_hitPlayer,
-        new ArrayList<>(m_killed), new ArrayList<>(m_damaged), m_dependentUnits);
+    AbstractBattle.getDisplay(bridge).casualtyNotification(battleId, stepName, dice, hitPlayer,
+        new ArrayList<>(killed), new ArrayList<>(damaged), dependentUnits);
     // execute in a separate thread to allow either player to click continue first.
     final Thread t = new Thread(() -> {
       try {
-        AbstractBattle.getRemote(m_firingPlayer, bridge).confirmEnemyCasualties(m_battleID, "Press space to continue",
-            m_hitPlayer);
+        AbstractBattle.getRemote(firingPlayer, bridge).confirmEnemyCasualties(battleId, "Press space to continue",
+            hitPlayer);
       } catch (final Exception e) {
         // someone else will deal with this, ignore
       }
     }, "Click to continue waiter");
     t.start();
-    if (m_confirmOwnCasualties) {
-      AbstractBattle.getRemote(m_hitPlayer, bridge).confirmOwnCasualties(m_battleID, "Press space to continue");
+    if (confirmOwnCasualties) {
+      AbstractBattle.getRemote(hitPlayer, bridge).confirmOwnCasualties(battleId, "Press space to continue");
     }
     bridge.leaveDelegateExecution();
     Interruptibles.join(t);
@@ -220,11 +220,11 @@ public class Fire implements IExecutable {
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
         notifyCasualties(bridge);
-        if (m_damaged != null) {
-          m_battle.markDamaged(m_damaged, bridge);
+        if (damaged != null) {
+          battle.markDamaged(damaged, bridge);
         }
-        m_battle.removeCasualties(m_killed, m_canReturnFire, !m_defending, bridge);
-        m_battle.removeSuicideOnHitCasualties(m_firingUnits, m_dice.getHits(), m_defending, bridge);
+        battle.removeCasualties(killed, canReturnFire, !defending, bridge);
+        battle.removeSuicideOnHitCasualties(firingUnits, dice.getHits(), defending, bridge);
       }
     };
     stack.push(notifyCasualties);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
@@ -7,33 +7,34 @@ import games.strategy.triplea.attachments.TechAttachment;
 
 public class GenericTechAdvance extends TechAdvance {
   private static final long serialVersionUID = -5985281030083508185L;
-  private final TechAdvance m_advance;
+
+  private final TechAdvance advance;
 
   public GenericTechAdvance(final String name, final TechAdvance techAdvance, final GameData data) {
     super(name, data);
-    m_advance = techAdvance;
+    advance = techAdvance;
   }
 
   @Override
   public String getProperty() {
-    return (m_advance != null) ? m_advance.getProperty() : getName();
+    return (advance != null) ? advance.getProperty() : getName();
   }
 
   @Override
   public void perform(final PlayerID id, final IDelegateBridge bridge) {
-    if (m_advance != null) {
-      m_advance.perform(id, bridge);
+    if (advance != null) {
+      advance.perform(id, bridge);
     }
   }
 
   public TechAdvance getAdvance() {
-    return m_advance;
+    return advance;
   }
 
   @Override
   public boolean hasTech(final TechAttachment ta) {
-    if (m_advance != null) {
-      return m_advance.hasTech(ta);
+    if (advance != null) {
+      return advance.hasTech(ta);
     }
     // this can be null!!!
     final Boolean has = ta.hasGenericTech(getName());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -25,25 +25,26 @@ public interface IBattle extends Serializable {
 
   enum BattleType {
     NORMAL("Battle"), AIR_BATTLE("Air Battle"), AIR_RAID("Air Raid"), BOMBING_RAID("Bombing Raid");
-    private final String m_type;
+
+    private final String type;
 
     BattleType(final String type) {
-      m_type = type;
+      this.type = type;
     }
 
     @Override
     public String toString() {
-      return m_type;
+      return type;
     }
 
     // if it has the word "Raid" in it, then it is a bombing battle
     public boolean isBombingRun() {
-      return m_type.contains("Raid");
+      return type.contains("Raid");
     }
 
     // if it has the word "Air" in it, then it is an air battle
     public boolean isAirPreBattleOrPreRaid() {
-      return m_type.contains("Air");
+      return type.contains("Air");
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -60,7 +60,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
     final InitializationExtendedDelegateState state = new InitializationExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_needToInitialize = this.needToInitialize;
+    state.needToInitialize = this.needToInitialize;
     return state;
   }
 
@@ -68,7 +68,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final InitializationExtendedDelegateState s = (InitializationExtendedDelegateState) state;
     super.loadState(s.superState);
-    this.needToInitialize = s.m_needToInitialize;
+    this.needToInitialize = s.needToInitialize;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 class InitializationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -9000446777655823735L;
+
   Serializable superState;
-  public boolean m_needToInitialize;
+  public boolean needToInitialize;
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the following classes of the `g.s.triplea.delegate` package:

* `Die`
* `EndRoundExtendedDelegateState`
* `EndTurnExtendedDelegateState`
* `FinishedBattle`
* `Fire`
* `GenericTechAdvance`
* `IBattle`
* `InitializationExtendedDelegateState`

## Functional Changes

None.

## Manual Testing Performed

None.