### PR TITLE
Checkstyle: Fix or suppress naming violations in g.s.triplea.delegate (M-N)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -219,9 +219,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
   public Serializable saveState() {
     final MoveExtendedDelegateState state = new MoveExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = needToInitialize;
-    state.m_needToDoRockets = needToDoRockets;
-    state.m_PUsLost = pusLost;
+    state.needToInitialize = needToInitialize;
+    state.needToDoRockets = needToDoRockets;
+    state.pusLost = pusLost;
     return state;
   }
 
@@ -229,9 +229,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
   public void loadState(final Serializable state) {
     final MoveExtendedDelegateState s = (MoveExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
-    needToDoRockets = s.m_needToDoRockets;
-    pusLost = s.m_PUsLost;
+    needToInitialize = s.needToInitialize;
+    needToDoRockets = s.needToDoRockets;
+    pusLost = s.pusLost;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
@@ -7,9 +7,10 @@ import games.strategy.util.IntegerMap;
 
 class MoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 5352248885420819215L;
+
   Serializable superState;
   // add other variables here:
-  public boolean m_needToInitialize;
-  public boolean m_needToDoRockets;
-  public IntegerMap<Territory> m_PUsLost;
+  public boolean needToInitialize;
+  public boolean needToDoRockets;
+  public IntegerMap<Territory> pusLost;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPUEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPUEndTurnDelegate.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.MapSupport;
  */
 @AutoSave(afterStepEnd = true)
 @MapSupport
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // map compatibility; rename upon next map-incompatible release
 public class NoPUEndTurnDelegate extends EndTurnDelegate {
   @Override
   protected int getProduction(final Collection<Territory> territories) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -20,6 +20,7 @@ import games.strategy.util.IntegerMap;
  * At the end of the turn collect units, not income.
  */
 @MapSupport
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // map compatibility; rename upon next map-incompatible release
 public class NoPUPurchaseDelegate extends PurchaseDelegate {
   private boolean isPacific;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -29,9 +29,10 @@ import games.strategy.util.CollectionUtils;
  */
 public class NonFightingBattle extends DependentBattle {
   private static final long serialVersionUID = -1699534010648145123L;
-  private final Set<Territory> m_attackingFrom;
-  private final Collection<Territory> m_amphibiousAttackFrom;
-  private final Map<Territory, Collection<Unit>> m_attackingFromMap;
+
+  private final Set<Territory> attackingFrom;
+  private final Collection<Territory> amphibiousAttackFrom;
+  private final Map<Territory, Collection<Unit>> attackingFromMap;
 
   /**
    * Constructor. Suppress checkstyle warning.
@@ -39,9 +40,9 @@ public class NonFightingBattle extends DependentBattle {
   public NonFightingBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,
       final GameData data) {
     super(battleSite, attacker, battleTracker, data);
-    m_attackingFromMap = new HashMap<>();
-    m_attackingFrom = new HashSet<>();
-    m_amphibiousAttackFrom = new ArrayList<>();
+    attackingFromMap = new HashMap<>();
+    attackingFrom = new HashSet<>();
+    amphibiousAttackFrom = new ArrayList<>();
   }
 
   @Override
@@ -56,9 +57,9 @@ public class NonFightingBattle extends DependentBattle {
       }
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
-    m_attackingFrom.add(attackingFrom);
+    this.attackingFrom.add(attackingFrom);
     attackingUnits.addAll(units);
-    final Collection<Unit> attackingFromMapUnits = m_attackingFromMap.computeIfAbsent(attackingFrom,
+    final Collection<Unit> attackingFromMapUnits = attackingFromMap.computeIfAbsent(attackingFrom,
         k -> new ArrayList<>());
     attackingFromMapUnits.addAll(units);
     // are we amphibious
@@ -108,14 +109,14 @@ public class NonFightingBattle extends DependentBattle {
       return;
     }
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
-    Collection<Unit> attackingFromMapUnits = m_attackingFromMap.get(attackingFrom);
+    Collection<Unit> attackingFromMapUnits = attackingFromMap.get(attackingFrom);
     // handle possible null pointer
     if (attackingFromMapUnits == null) {
       attackingFromMapUnits = new ArrayList<>();
     }
     attackingFromMapUnits.removeAll(units);
     if (attackingFromMapUnits.isEmpty()) {
-      m_attackingFrom.remove(attackingFrom);
+      this.attackingFrom.remove(attackingFrom);
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
@@ -168,16 +169,16 @@ public class NonFightingBattle extends DependentBattle {
 
   @Override
   public Collection<Territory> getAttackingFrom() {
-    return m_attackingFrom;
+    return attackingFrom;
   }
 
   @Override
   public Map<Territory, Collection<Unit>> getAttackingFromMap() {
-    return m_attackingFromMap;
+    return attackingFromMap;
   }
 
   @Override
   public Collection<Territory> getAmphibiousAttackTerritories() {
-    return m_amphibiousAttackFrom;
+    return amphibiousAttackFrom;
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the following classes of the `g.s.triplea.delegate` package:

* `MoveExtendedDelegateState`
* `MovePerformer`
* `MustFightBattle`
* `NonFightingBattle`

Suppresses violations of the Checkstyle AbbreviationAsWordInName rule in the following classes of the `g.s.triplea.delegate` package:

* `NoPUEndTurnDelegate`
* `NoPUPurchaseDelegate`

These types cannot be renamed in order to maintain map compatibility.  (AFAICT, `XmlGameElementMapper` does not perform a case-insensitive comparison.)

## Functional Changes

None.

## Manual Testing Performed

None.