### PR TITLE
Checkstyle: Fix naming violations in g.s.triplea.delegate (P-U)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -110,8 +110,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   public Serializable saveState() {
     final PlaceExtendedDelegateState state = new PlaceExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_produced = produced;
-    state.m_placements = placements;
+    state.produced = produced;
+    state.placements = placements;
     return state;
   }
 
@@ -119,8 +119,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   public void loadState(final Serializable state) {
     final PlaceExtendedDelegateState s = (PlaceExtendedDelegateState) state;
     super.loadState(s.superState);
-    produced = s.m_produced;
-    placements = s.m_placements;
+    produced = s.produced;
+    placements = s.placements;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
@@ -10,8 +10,9 @@ import games.strategy.engine.data.Unit;
 
 class PlaceExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -4926754941623641735L;
+
   Serializable superState;
   // add other variables here:
-  public Map<Territory, Collection<Unit>> m_produced;
-  public List<UndoablePlacement> m_placements;
+  public Map<Territory, Collection<Unit>> produced;
+  public List<UndoablePlacement> placements;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -97,7 +97,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   public Serializable saveState() {
     final PurchaseExtendedDelegateState state = new PurchaseExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = needToInitialize;
+    state.needToInitialize = needToInitialize;
     return state;
   }
 
@@ -105,7 +105,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   public void loadState(final Serializable state) {
     final PurchaseExtendedDelegateState s = (PurchaseExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.needToInitialize;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
@@ -4,7 +4,8 @@ import java.io.Serializable;
 
 class PurchaseExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 2326864364534284490L;
+
   Serializable superState;
   // add other variables here:
-  public boolean m_needToInitialize;
+  public boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -60,7 +60,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   public Serializable saveState() {
     final RandomStartExtendedDelegateState state = new RandomStartExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_currentPickingPlayer = this.currentPickingPlayer;
+    state.currentPickingPlayer = this.currentPickingPlayer;
     return state;
   }
 
@@ -68,7 +68,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final RandomStartExtendedDelegateState s = (RandomStartExtendedDelegateState) state;
     super.loadState(s.superState);
-    this.currentPickingPlayer = s.m_currentPickingPlayer;
+    this.currentPickingPlayer = s.currentPickingPlayer;
   }
 
   private void setupBoard() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
@@ -6,7 +6,8 @@ import games.strategy.engine.data.PlayerID;
 
 class RandomStartExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 607794506772555083L;
+
   Serializable superState;
   // add other variables here:
-  public PlayerID m_currentPickingPlayer;
+  public PlayerID currentPickingPlayer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -76,7 +76,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   public Serializable saveState() {
     final SpecialMoveExtendedDelegateState state = new SpecialMoveExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = needToInitialize;
+    state.needToInitialize = needToInitialize;
     return state;
   }
 
@@ -84,7 +84,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   public void loadState(final Serializable state) {
     final SpecialMoveExtendedDelegateState s = (SpecialMoveExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.needToInitialize;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 class SpecialMoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7781410008392307104L;
+
   Serializable superState;
-  public boolean m_needToInitialize;
+  public boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -122,7 +122,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   public Serializable saveState() {
     final TechActivationExtendedDelegateState state = new TechActivationExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = needToInitialize;
+    state.needToInitialize = needToInitialize;
     return state;
   }
 
@@ -130,7 +130,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
   public void loadState(final Serializable state) {
     final TechActivationExtendedDelegateState s = (TechActivationExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
+    needToInitialize = s.needToInitialize;
   }
 
   // Return string representing all advances in collection

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 class TechActivationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 1742776261442260882L;
+
   Serializable superState;
-  public boolean m_needToInitialize;
+  public boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -103,8 +103,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   public Serializable saveState() {
     final TechnologyExtendedDelegateState state = new TechnologyExtendedDelegateState();
     state.superState = super.saveState();
-    state.m_needToInitialize = needToInitialize;
-    state.m_techs = techs;
+    state.needToInitialize = needToInitialize;
+    state.techs = techs;
     return state;
   }
 
@@ -112,8 +112,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   public void loadState(final Serializable state) {
     final TechnologyExtendedDelegateState s = (TechnologyExtendedDelegateState) state;
     super.loadState(s.superState);
-    needToInitialize = s.m_needToInitialize;
-    techs = s.m_techs;
+    needToInitialize = s.needToInitialize;
+    techs = s.techs;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
@@ -8,8 +8,9 @@ import games.strategy.engine.data.PlayerID;
 
 class TechnologyExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -1375328472343199099L;
+
   Serializable superState;
   // add other variables here:
-  public boolean m_needToInitialize;
-  Map<PlayerID, Collection<TechAdvance>> m_techs;
+  public boolean needToInitialize;
+  Map<PlayerID, Collection<TechAdvance>> techs;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -29,83 +29,84 @@ import games.strategy.util.CollectionUtils;
  */
 public class UndoableMove extends AbstractUndoableMove {
   private static final long serialVersionUID = 8490182214651531358L;
-  private String m_reasonCantUndo;
-  private String m_description;
+
+  private String reasonCantUndo;
+  private String description;
   // this move is dependent on these moves
   // these moves cant be undone until this one has been
-  private final Set<UndoableMove> m_iDependOn = new HashSet<>();
+  private final Set<UndoableMove> meDependOn = new HashSet<>();
   // these moves depend on me
   // we cant be undone until this is empty
-  private final Set<UndoableMove> m_dependOnMe = new HashSet<>();
+  private final Set<UndoableMove> dependOnMe = new HashSet<>();
   // list of countries we took over
-  private final Set<Territory> m_conquered = new HashSet<>();
+  private final Set<Territory> conquered = new HashSet<>();
   // transports loaded by this move
-  private final Set<Unit> m_loaded = new HashSet<>();
+  private final Set<Unit> loaded = new HashSet<>();
   // transports unloaded by this move
-  private final Set<Unit> m_unloaded = new HashSet<>();
-  private final Route m_route;
+  private final Set<Unit> unloaded = new HashSet<>();
+  private final Route route;
 
   public void addToConquered(final Territory t) {
-    m_conquered.add(t);
+    conquered.add(t);
   }
 
   public Route getRoute() {
-    return m_route;
+    return route;
   }
 
   public boolean getcanUndo() {
-    return m_reasonCantUndo == null && m_dependOnMe.isEmpty();
+    return reasonCantUndo == null && dependOnMe.isEmpty();
   }
 
   String getReasonCantUndo() {
-    if (m_reasonCantUndo != null) {
-      return m_reasonCantUndo;
-    } else if (!m_dependOnMe.isEmpty()) {
-      return "Move " + (m_dependOnMe.iterator().next().getIndex() + 1) + " must be undone first";
+    if (reasonCantUndo != null) {
+      return reasonCantUndo;
+    } else if (!dependOnMe.isEmpty()) {
+      return "Move " + (dependOnMe.iterator().next().getIndex() + 1) + " must be undone first";
     } else {
       throw new IllegalStateException("no reason");
     }
   }
 
   public void setCantUndo(final String reason) {
-    m_reasonCantUndo = reason;
+    reasonCantUndo = reason;
   }
 
   public void setDescription(final String description) {
-    m_description = description;
+    this.description = description;
   }
 
   public UndoableMove(final Collection<Unit> units, final Route route) {
     super(new CompositeChange(), units);
-    m_route = route;
+    this.route = route;
   }
 
   public void load(final Unit transport) {
-    m_loaded.add(transport);
+    loaded.add(transport);
   }
 
   public void unload(final Unit transport) {
-    m_unloaded.add(transport);
+    unloaded.add(transport);
   }
 
   @Override
   protected void undoSpecific(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     final BattleTracker battleTracker = DelegateFinder.battleDelegate(data).getBattleTracker();
-    battleTracker.undoBattle(m_route, units, bridge.getPlayerId(), bridge);
+    battleTracker.undoBattle(route, units, bridge.getPlayerId(), bridge);
     // clean up dependencies
-    for (final UndoableMove other : m_iDependOn) {
-      other.m_dependOnMe.remove(this);
+    for (final UndoableMove other : meDependOn) {
+      other.dependOnMe.remove(this);
     }
     // if we are moving out of a battle zone, mark it
     // this can happen for air units moving out of a battle zone
-    for (final IBattle battle : battleTracker.getPendingBattles(m_route.getStart(), null)) {
+    for (final IBattle battle : battleTracker.getPendingBattles(route.getStart(), null)) {
       if (battle == null || battle.isOver()) {
         continue;
       }
       for (final Unit unit : units) {
         final Route routeUnitUsedToMove =
-            DelegateFinder.moveDelegate(data).getRouteUsedToMoveInto(unit, m_route.getStart());
+            DelegateFinder.moveDelegate(data).getRouteUsedToMoveInto(unit, route.getStart());
         if (!battle.getBattleType().isBombingRun()) {
           // route units used to move will be null in the case
           // where an enemy sub is submerged in the territory, and another unit
@@ -165,56 +166,56 @@ public class UndoableMove extends AbstractUndoableMove {
       // if the other move has moves that depend on this
       if (!CollectionUtils.intersection(other.getUnits(), this.getUnits()).isEmpty()
           // if the other move has transports that we are loading
-          || !CollectionUtils.intersection(other.units, this.m_loaded).isEmpty()
+          || !CollectionUtils.intersection(other.units, this.loaded).isEmpty()
           // or we are moving through a previously conqueured territory
           // we should be able to take this out later
           // we need to add logic for this move to take over the same territories
           // when the other move is undone
-          || !CollectionUtils.intersection(other.m_conquered, m_route.getAllTerritories()).isEmpty()
+          || !CollectionUtils.intersection(other.conquered, route.getAllTerritories()).isEmpty()
           // or we are unloading transports that have moved in another turn
-          || !CollectionUtils.intersection(other.units, this.m_unloaded).isEmpty()
-          || !CollectionUtils.intersection(other.m_unloaded, this.m_unloaded).isEmpty()) {
-        m_iDependOn.add(other);
-        other.m_dependOnMe.add(this);
+          || !CollectionUtils.intersection(other.units, this.unloaded).isEmpty()
+          || !CollectionUtils.intersection(other.unloaded, this.unloaded).isEmpty()) {
+        meDependOn.add(other);
+        other.dependOnMe.add(this);
       }
     }
   }
 
   // for use with airborne moving
   public void addDependency(final UndoableMove undoableMove) {
-    m_iDependOn.add(undoableMove);
-    undoableMove.m_dependOnMe.add(this);
+    meDependOn.add(undoableMove);
+    undoableMove.dependOnMe.add(this);
   }
 
   public boolean wasTransportUnloaded(final Unit transport) {
-    return m_unloaded.contains(transport);
+    return unloaded.contains(transport);
   }
 
   public boolean wasTransportLoaded(final Unit transport) {
-    return m_loaded.contains(transport);
+    return loaded.contains(transport);
   }
 
   @Override
   public String toString() {
-    return "UndoableMove index;" + index + " description:" + m_description;
+    return "UndoableMove index;" + index + " description:" + description;
   }
 
   @Override
   public final String getMoveLabel() {
-    return m_route.getStart() + " -> " + m_route.getEnd();
+    return route.getStart() + " -> " + route.getEnd();
   }
 
   @Override
   public final Territory getEnd() {
-    return m_route.getEnd();
+    return route.getEnd();
   }
 
   public final Territory getStart() {
-    return m_route.getStart();
+    return route.getStart();
   }
 
   @Override
   protected final MoveDescription getDescriptionObject() {
-    return new MoveDescription(units, m_route);
+    return new MoveDescription(units, route);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoablePlacement.java
@@ -17,8 +17,9 @@ import games.strategy.triplea.formatter.MyFormatter;
  */
 public class UndoablePlacement extends AbstractUndoableMove {
   private static final long serialVersionUID = -1493488646587233451L;
-  private final Territory m_placeTerritory;
-  private Territory m_producerTerritory;
+
+  private final Territory placeTerritory;
+  private Territory producerTerritory;
 
   /**
    * This constructor initializes an UndoablePlacement objects with the passed parameters.
@@ -26,20 +27,20 @@ public class UndoablePlacement extends AbstractUndoableMove {
   public UndoablePlacement(final CompositeChange change, final Territory producerTerritory,
       final Territory placeTerritory, final Collection<Unit> units) {
     super(change, units);
-    m_placeTerritory = placeTerritory;
-    m_producerTerritory = producerTerritory;
+    this.placeTerritory = placeTerritory;
+    this.producerTerritory = producerTerritory;
   }
 
   public Territory getProducerTerritory() {
-    return m_producerTerritory;
+    return producerTerritory;
   }
 
   public void setProducerTerritory(final Territory producerTerritory) {
-    m_producerTerritory = producerTerritory;
+    this.producerTerritory = producerTerritory;
   }
 
   public Territory getPlaceTerritory() {
-    return m_placeTerritory;
+    return placeTerritory;
   }
 
   @Override
@@ -47,10 +48,10 @@ public class UndoablePlacement extends AbstractUndoableMove {
     final GameData data = bridge.getData();
     final AbstractPlaceDelegate currentDelegate = (AbstractPlaceDelegate) data.getSequence().getStep().getDelegate();
     final Map<Territory, Collection<Unit>> produced = currentDelegate.getProduced();
-    final Collection<Unit> units = produced.get(m_producerTerritory);
+    final Collection<Unit> units = produced.get(producerTerritory);
     units.removeAll(getUnits());
     if (units.isEmpty()) {
-      produced.remove(m_producerTerritory);
+      produced.remove(producerTerritory);
     }
     currentDelegate.setProduced(new HashMap<>(produced));
   }
@@ -61,19 +62,19 @@ public class UndoablePlacement extends AbstractUndoableMove {
   }
 
   private String getMoveLabel(final String separator) {
-    return m_producerTerritory.equals(m_placeTerritory)
-        ? m_placeTerritory.getName()
-        : m_producerTerritory.getName() + separator + m_placeTerritory.getName();
+    return producerTerritory.equals(placeTerritory)
+        ? placeTerritory.getName()
+        : producerTerritory.getName() + separator + placeTerritory.getName();
   }
 
   @Override
   public final Territory getEnd() {
-    return m_placeTerritory;
+    return placeTerritory;
   }
 
   @Override
   protected final PlacementDescription getDescriptionObject() {
-    return new PlacementDescription(units, m_placeTerritory);
+    return new PlacementDescription(units, placeTerritory);
   }
 
   @Override


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the following classes of the `g.s.triplea.delegate` package:

* `PlaceExtendedDelegateState`
* `PurchaseExtendedDelegateState`
* `RandomStartExtendedDelegateState`
* `SpecialMoveExtendedDelegateState`
* `StrategicBomberRaidBattle`
* `TechActivationExtendedDelegateState`
* `TechnologyExtendedDelegateState`
* `UndoableMove`
* `UndoablePlacement`

## Functional Changes

None.

## Manual Testing Performed

None.