### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.history package

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
@@ -4,14 +4,15 @@ import games.strategy.engine.data.Change;
 
 class ChangeSerializationWriter implements SerializationWriter {
   private static final long serialVersionUID = -3802807345707883606L;
-  private final Change aChange;
+
+  private final Change change;
 
   public ChangeSerializationWriter(final Change change) {
-    aChange = change;
+    this.change = change;
   }
 
   @Override
   public void write(final HistoryWriter writer) {
-    writer.addChange(aChange);
+    writer.addChange(change);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
@@ -2,16 +2,17 @@ package games.strategy.engine.history;
 
 class EventChildWriter implements SerializationWriter {
   private static final long serialVersionUID = -7143658060171295697L;
-  private final String m_text;
-  private final Object m_renderingData;
+
+  private final String text;
+  private final Object renderingData;
 
   public EventChildWriter(final String text, final Object renderingData) {
-    m_text = text;
-    m_renderingData = renderingData;
+    this.text = text;
+    this.renderingData = renderingData;
   }
 
   @Override
   public void write(final HistoryWriter writer) {
-    writer.addChildToEvent(new EventChild(m_text, m_renderingData));
+    writer.addChildToEvent(new EventChild(text, renderingData));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
@@ -2,19 +2,20 @@ package games.strategy.engine.history;
 
 class EventHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 6404070330823708974L;
-  private final String m_eventName;
-  private final Object m_renderingData;
+
+  private final String eventName;
+  private final Object renderingData;
 
   public EventHistorySerializer(final String eventName, final Object renderingData) {
-    m_eventName = eventName;
-    m_renderingData = renderingData;
+    this.eventName = eventName;
+    this.renderingData = renderingData;
   }
 
   @Override
   public void write(final HistoryWriter writer) {
-    writer.startEvent(m_eventName);
-    if (m_renderingData != null) {
-      writer.setRenderingData(m_renderingData);
+    writer.startEvent(eventName);
+    if (renderingData != null) {
+      writer.setRenderingData(renderingData);
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
@@ -2,14 +2,15 @@ package games.strategy.engine.history;
 
 class RoundHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 9006488114384654514L;
-  private final int m_roundNo;
+
+  private final int roundNo;
 
   public RoundHistorySerializer(final int roundNo) {
-    m_roundNo = roundNo;
+    this.roundNo = roundNo;
   }
 
   @Override
   public void write(final HistoryWriter writer) {
-    writer.startNextRound(m_roundNo);
+    writer.startNextRound(roundNo);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
@@ -16,11 +16,12 @@ import games.strategy.engine.data.GameData;
  */
 class SerializedHistory implements Serializable {
   private static final long serialVersionUID = -5808427923253751651L;
-  private final List<SerializationWriter> m_Writers = new ArrayList<>();
-  private final GameData m_data;
+
+  private final List<SerializationWriter> writers = new ArrayList<>();
+  private final GameData gameData;
 
   public SerializedHistory(final History history, final GameData data, final List<Change> changes) {
-    m_data = data;
+    gameData = data;
     final Enumeration<?> enumeration = ((DefaultMutableTreeNode) history.getRoot()).preorderEnumeration();
     enumeration.nextElement();
     int changeIndex = 0;
@@ -29,24 +30,24 @@ class SerializedHistory implements Serializable {
       // write the changes to the start of the node
       if (node instanceof IndexedHistoryNode) {
         while (changeIndex < ((IndexedHistoryNode) node).getChangeStartIndex()) {
-          m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
+          writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
           changeIndex++;
         }
       }
       // write the node itself
-      m_Writers.add(node.getWriter());
+      writers.add(node.getWriter());
     }
     // write out remaining changes
     while (changeIndex < changes.size()) {
-      m_Writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
+      writers.add(new ChangeSerializationWriter(changes.get(changeIndex)));
       changeIndex++;
     }
   }
 
   public Object readResolve() {
-    final History history = new History(m_data);
+    final History history = new History(gameData);
     final HistoryWriter historyWriter = history.getHistoryWriter();
-    for (final SerializationWriter element : m_Writers) {
+    for (final SerializationWriter element : writers) {
       element.write(historyWriter);
     }
     return history;

--- a/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
@@ -4,21 +4,22 @@ import games.strategy.engine.data.PlayerID;
 
 class StepHistorySerializer implements SerializationWriter {
   private static final long serialVersionUID = 3546486775516371557L;
-  private final String m_stepName;
-  private final String m_delegateName;
-  private final PlayerID m_playerID;
-  private final String m_displayName;
+
+  private final String stepName;
+  private final String delegateName;
+  private final PlayerID playerId;
+  private final String displayName;
 
   public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerId,
       final String displayName) {
-    m_stepName = stepName;
-    m_delegateName = delegateName;
-    m_playerID = playerId;
-    m_displayName = displayName;
+    this.stepName = stepName;
+    this.delegateName = delegateName;
+    this.playerId = playerId;
+    this.displayName = displayName;
   }
 
   @Override
   public void write(final HistoryWriter writer) {
-    writer.startNextStep(m_stepName, m_delegateName, m_playerID, m_displayName);
+    writer.startNextStep(stepName, delegateName, playerId, displayName);
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules within the `g.s.engine.history` package.

## Functional Changes

None.

## Manual Testing Performed

None.