### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.data.properties

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AEditableProperty.java
@@ -10,12 +10,13 @@ import javax.swing.JComponent;
  */
 public abstract class AEditableProperty implements IEditableProperty, Serializable, Comparable<AEditableProperty> {
   private static final long serialVersionUID = -5005729898242568847L;
-  private final String m_name;
-  private final String m_description;
+
+  private final String name;
+  private final String description;
 
   public AEditableProperty(final String name, final String description) {
-    m_name = name;
-    m_description = description;
+    this.name = name;
+    this.description = description;
   }
 
   @Override
@@ -25,12 +26,12 @@ public abstract class AEditableProperty implements IEditableProperty, Serializab
 
   @Override
   public String getName() {
-    return m_name;
+    return name;
   }
 
   @Override
   public String getDescription() {
-    return m_description;
+    return description;
   }
 
   @Override
@@ -42,17 +43,17 @@ public abstract class AEditableProperty implements IEditableProperty, Serializab
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(m_name);
+    return Objects.hashCode(name);
   }
 
   @Override
   public boolean equals(final Object other) {
-    return other instanceof AEditableProperty && ((AEditableProperty) other).m_name.equals(m_name);
+    return other instanceof AEditableProperty && ((AEditableProperty) other).name.equals(name);
   }
 
   @Override
   public int compareTo(final AEditableProperty other) {
-    return m_name.compareTo(other.getName());
+    return name.compareTo(other.getName());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
@@ -8,13 +8,14 @@ import javax.swing.JComponent;
 /**
  * Superclass for all implementations of {@link IEditableProperty}.
  */
-public abstract class AEditableProperty implements IEditableProperty, Serializable, Comparable<AEditableProperty> {
+public abstract class AbstractEditableProperty
+    implements IEditableProperty, Serializable, Comparable<AbstractEditableProperty> {
   private static final long serialVersionUID = -5005729898242568847L;
 
   private final String name;
   private final String description;
 
-  public AEditableProperty(final String name, final String description) {
+  public AbstractEditableProperty(final String name, final String description) {
     this.name = name;
     this.description = description;
   }
@@ -48,11 +49,11 @@ public abstract class AEditableProperty implements IEditableProperty, Serializab
 
   @Override
   public boolean equals(final Object other) {
-    return other instanceof AEditableProperty && ((AEditableProperty) other).name.equals(name);
+    return other instanceof AbstractEditableProperty && ((AbstractEditableProperty) other).name.equals(name);
   }
 
   @Override
-  public int compareTo(final AEditableProperty other) {
+  public int compareTo(final AbstractEditableProperty other) {
     return name.compareTo(other.getName());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -9,32 +9,33 @@ import javax.swing.JComponent;
 public class BooleanProperty extends AEditableProperty {
   // compatible with 0.9.0.2 saved games
   private static final long serialVersionUID = -7265501762343216435L;
-  private boolean mValue;
+
+  private boolean value;
 
   public BooleanProperty(final String name, final String description, final boolean defaultValue) {
     super(name, description);
-    mValue = defaultValue;
+    value = defaultValue;
   }
 
   @Override
   public Object getValue() {
-    return mValue ? Boolean.TRUE : Boolean.FALSE;
+    return value ? Boolean.TRUE : Boolean.FALSE;
   }
 
   @Override
   public void setValue(final Object value) throws IllegalArgumentException {
-    mValue = (Boolean) value;
+    this.value = (Boolean) value;
   }
 
   public void setValue(final boolean value) {
-    mValue = value;
+    this.value = value;
   }
 
   @Override
   public JComponent getEditorComponent() {
     final JCheckBox box = new JCheckBox("");
-    box.setSelected(mValue);
-    box.addActionListener(e -> mValue = box.isSelected());
+    box.setSelected(value);
+    box.addActionListener(e -> value = box.isSelected());
     return box;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -6,7 +6,7 @@ import javax.swing.JComponent;
 /**
  * Implementation of {@link IEditableProperty} for a Boolean value.
  */
-public class BooleanProperty extends AEditableProperty {
+public class BooleanProperty extends AbstractEditableProperty {
   // compatible with 0.9.0.2 saved games
   private static final long serialVersionUID = -7265501762343216435L;
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -16,7 +16,8 @@ import javax.swing.JTable;
  */
 public class CollectionProperty<T> extends AEditableProperty {
   private static final long serialVersionUID = 5338055034530377261L;
-  private List<T> m_values;
+
+  private List<T> values;
 
   /**
    * Initializes a new instance of the CollectionProperty class.
@@ -27,33 +28,33 @@ public class CollectionProperty<T> extends AEditableProperty {
    */
   public CollectionProperty(final String name, final String description, final Collection<T> values) {
     super(name, description);
-    m_values = new ArrayList<>(values);
+    this.values = new ArrayList<>(values);
   }
 
   @Override
   public Object getValue() {
-    return m_values;
+    return values;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public void setValue(final Object value) throws ClassCastException {
-    m_values = (List<T>) value;
+    values = (List<T>) value;
   }
 
   @Override
   public int getRowsNeeded() {
-    return (m_values == null ? 1 : Math.max(1, m_values.size()));
+    return (values == null ? 1 : Math.max(1, values.size()));
   }
 
   @Override
   public JComponent getEditorComponent() {
-    if (m_values == null) {
+    if (values == null) {
       return new JTable();
     }
-    final Object[][] tableD = new Object[m_values.size()][1];
-    for (int i = 0; i < m_values.size(); i++) {
-      tableD[i][0] = m_values.get(i);
+    final Object[][] tableD = new Object[values.size()][1];
+    for (int i = 0; i < values.size(); i++) {
+      tableD[i][0] = values.get(i);
     }
     final JTable table = new JTable(tableD, new Object[] {"Values: "});
     table.addFocusListener(new FocusListener() {
@@ -62,7 +63,7 @@ public class CollectionProperty<T> extends AEditableProperty {
 
       @Override
       public void focusLost(final FocusEvent e) {
-        // TODO: change m_values
+        // TODO: change values
       }
     });
     return table;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.data.properties;
 
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -56,17 +54,7 @@ public class CollectionProperty<T> extends AbstractEditableProperty {
     for (int i = 0; i < values.size(); i++) {
       tableD[i][0] = values.get(i);
     }
-    final JTable table = new JTable(tableD, new Object[] {"Values: "});
-    table.addFocusListener(new FocusListener() {
-      @Override
-      public void focusGained(final FocusEvent e) {}
-
-      @Override
-      public void focusLost(final FocusEvent e) {
-        // TODO: change values
-      }
-    });
-    return table;
+    return new JTable(tableD, new Object[] {"Values: "});
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -14,7 +14,7 @@ import javax.swing.JTable;
  *
  * @param <T> The type of elements in the collection.
  */
-public class CollectionProperty<T> extends AEditableProperty {
+public class CollectionProperty<T> extends AbstractEditableProperty {
   private static final long serialVersionUID = 5338055034530377261L;
 
   private List<T> values;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
@@ -19,7 +19,7 @@ import javax.swing.SwingUtilities;
  * change the color.
  * </p>
  */
-public class ColorProperty extends AEditableProperty {
+public class ColorProperty extends AbstractEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final int MAX_COLOR = 0xFFFFFF;
   private static final int MIN_COLOR = 0x000000;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -14,7 +14,7 @@ import games.strategy.ui.SwingComponents;
  *
  * @param <T> The type of the property value.
  */
-public class ComboProperty<T> extends AEditableProperty {
+public class ComboProperty<T> extends AbstractEditableProperty {
   private static final long serialVersionUID = -3098612299805630587L;
   public static final String POSSIBLE_VALUES_FIELD_NAME = "possibleValues";
   private final List<T> possibleValues;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -15,10 +15,11 @@ import games.strategy.engine.ClientFileSystemHelper;
  */
 public class DoubleProperty extends AEditableProperty {
   private static final long serialVersionUID = 5521967819500867581L;
-  private final double m_max;
-  private final double m_min;
-  private double m_value;
-  private final int m_places;
+
+  private final double max;
+  private final double min;
+  private double value;
+  private final int places;
 
   public DoubleProperty(final String name, final String description, final double max, final double min,
       final double def, final int numberOfPlaces) {
@@ -29,10 +30,10 @@ public class DoubleProperty extends AEditableProperty {
     if (def > max || def < min) {
       throw new IllegalThreadStateException("Default value out of range");
     }
-    m_max = max;
-    m_min = min;
-    m_places = numberOfPlaces;
-    m_value = roundToPlace(def, numberOfPlaces, RoundingMode.FLOOR);
+    this.max = max;
+    this.min = min;
+    places = numberOfPlaces;
+    value = roundToPlace(def, numberOfPlaces, RoundingMode.FLOOR);
   }
 
   private static double roundToPlace(final double number, final int places, final RoundingMode roundingMode) {
@@ -43,7 +44,7 @@ public class DoubleProperty extends AEditableProperty {
 
   @Override
   public Double getValue() {
-    return m_value;
+    return value;
   }
 
   @Override
@@ -55,12 +56,12 @@ public class DoubleProperty extends AEditableProperty {
           + "You should delete your option cache, located at "
           + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
     }
-    m_value = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
+    this.value = roundToPlace((Double) value, places, RoundingMode.FLOOR);
   }
 
   @Override
   public JComponent getEditorComponent() {
-    final JSpinner field = new JSpinner(new SpinnerNumberModel(m_value, m_min, m_max, 1.0));
+    final JSpinner field = new JSpinner(new SpinnerNumberModel(value, min, max, 1.0));
 
     // NB: Workaround for JSpinner default sizing algorithm when min/max values have very large magnitudes
     // (see: https://implementsblog.com/2012/11/26/java-gotcha-jspinner-preferred-size/)
@@ -69,7 +70,7 @@ public class DoubleProperty extends AEditableProperty {
       ((JSpinner.DefaultEditor) fieldEditor).getTextField().setColumns(10);
     }
 
-    field.addChangeListener(e -> m_value = (double) field.getValue());
+    field.addChangeListener(e -> value = (double) field.getValue());
     return field;
   }
 
@@ -78,11 +79,11 @@ public class DoubleProperty extends AEditableProperty {
     if (value instanceof Double) {
       final double d;
       try {
-        d = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
+        d = roundToPlace((Double) value, places, RoundingMode.FLOOR);
       } catch (final Exception e) {
         return false;
       }
-      return d <= m_max && d >= m_min;
+      return d <= max && d >= min;
     }
     return false;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -13,7 +13,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 /**
  * Implementation of {@link IEditableProperty} for a double-precision floating-point value.
  */
-public class DoubleProperty extends AEditableProperty {
+public class DoubleProperty extends AbstractEditableProperty {
   private static final long serialVersionUID = 5521967819500867581L;
 
   private final double max;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -27,8 +27,8 @@ public class FileProperty extends AEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final String[] defaultImageSuffixes = {"png", "jpg", "jpeg", "gif"};
 
-  private final String[] m_acceptableSuffixes;
-  private File m_file;
+  private final String[] acceptableSuffixes;
+  private File file;
 
   /**
    * Construct a new file property.
@@ -54,8 +54,8 @@ public class FileProperty extends AEditableProperty {
 
   public FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes) {
     super(name, description);
-    m_file = getFileIfExists(file);
-    m_acceptableSuffixes = acceptableSuffixes;
+    this.file = getFileIfExists(file);
+    this.acceptableSuffixes = acceptableSuffixes;
   }
 
   /**
@@ -65,12 +65,12 @@ public class FileProperty extends AEditableProperty {
    */
   @Override
   public Object getValue() {
-    return m_file;
+    return file;
   }
 
   @Override
   public void setValue(final Object value) throws ClassCastException {
-    m_file = (File) value;
+    file = (File) value;
   }
 
   /**
@@ -81,19 +81,19 @@ public class FileProperty extends AEditableProperty {
   @Override
   public JComponent getEditorComponent() {
     final JTextField label;
-    if (m_file == null) {
+    if (file == null) {
       label = new JTextField();
     } else {
-      label = new JTextField(m_file.getAbsolutePath());
+      label = new JTextField(file.getAbsolutePath());
     }
     label.setEditable(false);
     label.addMouseListener(new MouseListener() {
       @Override
       public void mouseClicked(final MouseEvent e) {
-        final File selection = getFileUsingDialog(m_acceptableSuffixes);
+        final File selection = getFileUsingDialog(acceptableSuffixes);
         if (selection != null) {
-          m_file = selection;
-          label.setText(m_file.getAbsolutePath());
+          file = selection;
+          label.setText(file.getAbsolutePath());
           // Ask Swing to repaint this label when it's convenient
           SwingUtilities.invokeLater(label::repaint);
         }
@@ -175,7 +175,7 @@ public class FileProperty extends AEditableProperty {
       return true;
     }
     if (value instanceof File) {
-      return Arrays.stream(m_acceptableSuffixes).anyMatch(suffix -> ((File) value).getName().endsWith(suffix));
+      return Arrays.stream(acceptableSuffixes).anyMatch(suffix -> ((File) value).getName().endsWith(suffix));
     }
     return false;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -23,7 +23,7 @@ import games.strategy.engine.framework.system.SystemProperties;
  * change the file.
  * </p>
  */
-public class FileProperty extends AEditableProperty {
+public class FileProperty extends AbstractEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final String[] defaultImageSuffixes = {"png", "jpg", "jpeg", "gif"};
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -16,7 +16,7 @@ import javax.swing.JComponent;
  * @param <T> String or something with a valid toString()
  * @param <U> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
-public class MapProperty<T, U> extends AEditableProperty {
+public class MapProperty<T, U> extends AbstractEditableProperty {
   private static final long serialVersionUID = -8021039503574228146L;
 
   private Map<T, U> map;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -18,13 +18,14 @@ import javax.swing.JComponent;
  */
 public class MapProperty<T, U> extends AEditableProperty {
   private static final long serialVersionUID = -8021039503574228146L;
-  private Map<T, U> m_map;
-  final List<IEditableProperty> m_properties = new ArrayList<>();
+
+  private Map<T, U> map;
+  final List<IEditableProperty> properties = new ArrayList<>();
 
   public MapProperty(final String name, final String description, final Map<T, U> map) {
     super(name, description);
-    m_map = map;
-    resetProperties(map, m_properties, name, description);
+    this.map = map;
+    resetProperties(map, properties, name, description);
   }
 
   @SuppressWarnings("unchecked")
@@ -57,29 +58,29 @@ public class MapProperty<T, U> extends AEditableProperty {
 
   @Override
   public int getRowsNeeded() {
-    return Math.max(1, m_properties.size());
+    return Math.max(1, properties.size());
   }
 
   @Override
   public Object getValue() {
-    return m_map;
+    return map;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public void setValue(final Object value) throws ClassCastException {
-    m_map = (Map<T, U>) value;
-    resetProperties(m_map, m_properties, this.getName(), this.getDescription());
+    map = (Map<T, U>) value;
+    resetProperties(map, properties, this.getName(), this.getDescription());
   }
 
   @Override
   public JComponent getEditorComponent() {
-    return new PropertiesUi(m_properties, true);
+    return new PropertiesUi(properties, true);
   }
 
   @Override
   public JComponent getViewComponent() {
-    return new PropertiesUi(m_properties, false);
+    return new PropertiesUi(properties, false);
   }
 
   @Override
@@ -92,10 +93,10 @@ public class MapProperty<T, U> extends AEditableProperty {
       try {
         @SuppressWarnings("unchecked")
         final Map<T, U> test = (Map<T, U>) value;
-        if (m_map != null && !m_map.isEmpty() && !test.isEmpty()) {
+        if (map != null && !map.isEmpty() && !test.isEmpty()) {
           T key = null;
           U val = null;
-          for (final Entry<T, U> entry : m_map.entrySet()) {
+          for (final Entry<T, U> entry : map.entrySet()) {
             if (entry.getValue() != null && entry.getKey() != null) {
               key = entry.getKey();
               val = entry.getValue();

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -10,7 +10,7 @@ import games.strategy.ui.IntTextField;
 /**
  * Implementation of {@link IEditableProperty} for an integer value.
  */
-public class NumberProperty extends AEditableProperty {
+public class NumberProperty extends AbstractEditableProperty {
   // compatible with 0.9.0.2 saved games
   private static final long serialVersionUID = 6826763550643504789L;
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -22,7 +22,7 @@ public class NumberProperty extends AEditableProperty {
   public static final String MIN_PROPERTY_NAME = "min";
   private final int min;
 
-  private int m_value;
+  private int value;
 
   public NumberProperty(final String name, final String description, final int max, final int min, final int def) {
     super(name, description);
@@ -34,12 +34,12 @@ public class NumberProperty extends AEditableProperty {
     }
     this.max = max;
     this.min = min;
-    m_value = def;
+    value = def;
   }
 
   @Override
   public Integer getValue() {
-    return m_value;
+    return value;
   }
 
   @Override
@@ -51,14 +51,14 @@ public class NumberProperty extends AEditableProperty {
           "Number properties are no longer stored as Strings. You should delete your option cache, located at "
               + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
     }
-    m_value = (Integer) value;
+    this.value = (Integer) value;
   }
 
   @Override
   public JComponent getEditorComponent() {
     final IntTextField field = new IntTextField(min, max);
-    field.setValue(m_value);
-    field.addChangeListener(aField -> m_value = aField.getValue());
+    field.setValue(value);
+    field.addChangeListener(aField -> value = aField.getValue());
     return field;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -12,24 +12,25 @@ import javax.swing.JTextField;
  */
 public class StringProperty extends AEditableProperty {
   private static final long serialVersionUID = 4382624884674152208L;
-  private String m_value;
+
+  private String value;
 
   public StringProperty(final String name, final String description, final String defaultValue) {
     super(name, description);
-    m_value = defaultValue;
+    value = defaultValue;
   }
 
   @Override
   public JComponent getEditorComponent() {
-    final JTextField text = new JTextField(m_value);
-    text.addActionListener(e -> m_value = text.getText());
+    final JTextField text = new JTextField(value);
+    text.addActionListener(e -> value = text.getText());
     text.addFocusListener(new FocusListener() {
       @Override
       public void focusGained(final FocusEvent e) {}
 
       @Override
       public void focusLost(final FocusEvent e) {
-        m_value = text.getText();
+        value = text.getText();
       }
     });
     final Dimension ourMinimum = new Dimension(80, 20);
@@ -40,12 +41,12 @@ public class StringProperty extends AEditableProperty {
 
   @Override
   public Object getValue() {
-    return m_value;
+    return value;
   }
 
   @Override
   public void setValue(final Object value) throws ClassCastException {
-    m_value = (String) value;
+    this.value = (String) value;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -10,7 +10,7 @@ import javax.swing.JTextField;
 /**
  * A string property with a simple text field editor.
  */
-public class StringProperty extends AEditableProperty {
+public class StringProperty extends AbstractEditableProperty {
   private static final long serialVersionUID = 4382624884674152208L;
 
   private String value;

--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -17,7 +17,7 @@ import javax.swing.JComponent;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import games.strategy.engine.data.properties.AEditableProperty;
+import games.strategy.engine.data.properties.AbstractEditableProperty;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.CollectionProperty;
 import games.strategy.engine.data.properties.ColorProperty;
@@ -40,7 +40,7 @@ import lombok.extern.java.Log;
  * @param <T> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
 @Log
-public class MapPropertyWrapper<T> extends AEditableProperty {
+public class MapPropertyWrapper<T> extends AbstractEditableProperty {
   private static final long serialVersionUID = 6406798101396215624L;
   private final IEditableProperty property;
   private final Method setter;


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in the `g.s.engine.data.properties` package.

## Functional Changes

None.

## Manual Testing Performed

None.