### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.data.changefactory

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
@@ -7,29 +7,30 @@ import games.strategy.engine.data.IAttachment;
 
 class AddAttachmentChange extends Change {
   private static final long serialVersionUID = -21015135248288454L;
-  private final IAttachment m_attachment;
-  private final String m_originalAttachmentName;
-  private final Attachable m_originalAttachable;
-  private final Attachable m_attachable;
-  private final String m_name;
+
+  private final IAttachment attachment;
+  private final String originalAttachmentName;
+  private final Attachable originalAttachable;
+  private final Attachable attachable;
+  private final String name;
 
   public AddAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
-    m_attachment = attachment;
-    m_originalAttachmentName = attachment.getName();
-    m_originalAttachable = attachment.getAttachedTo();
-    m_attachable = attachable;
-    m_name = name;
+    this.attachment = attachment;
+    originalAttachmentName = attachment.getName();
+    originalAttachable = attachment.getAttachedTo();
+    this.attachable = attachable;
+    this.name = name;
   }
 
   @Override
   protected void perform(final GameData data) {
-    m_attachable.addAttachment(m_name, m_attachment);
-    m_attachment.setName(m_name);
-    m_attachment.setAttachedTo(m_attachable);
+    attachable.addAttachment(name, attachment);
+    attachment.setName(name);
+    attachment.setAttachedTo(attachable);
   }
 
   @Override
   public Change invert() {
-    return new RemoveAttachmentChange(m_attachment, m_originalAttachable, m_originalAttachmentName);
+    return new RemoveAttachmentChange(attachment, originalAttachable, originalAttachmentName);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
@@ -8,9 +8,10 @@ import games.strategy.triplea.delegate.TechAdvance;
 
 class AddAvailableTech extends Change {
   private static final long serialVersionUID = 5664428883866434959L;
-  private final TechAdvance m_tech;
-  private final TechnologyFrontier m_frontier;
-  private final PlayerID m_player;
+
+  private final TechAdvance tech;
+  private final TechnologyFrontier frontier;
+  private final PlayerID player;
 
   public AddAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {
     if (front == null) {
@@ -19,19 +20,19 @@ class AddAvailableTech extends Change {
     if (tech == null) {
       throw new IllegalArgumentException("Null tech");
     }
-    m_tech = tech;
-    m_frontier = front;
-    m_player = player;
+    this.tech = tech;
+    frontier = front;
+    this.player = player;
   }
 
   @Override
   public void perform(final GameData data) {
-    final TechnologyFrontier front = m_player.getTechnologyFrontierList().getTechnologyFrontier(m_frontier.getName());
-    front.addAdvance(m_tech);
+    final TechnologyFrontier front = player.getTechnologyFrontierList().getTechnologyFrontier(frontier.getName());
+    front.addAdvance(tech);
   }
 
   @Override
   public Change invert() {
-    return new RemoveAvailableTech(m_frontier, m_tech, m_player);
+    return new RemoveAvailableTech(frontier, tech, player);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddBattleRecordsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddBattleRecordsChange.java
@@ -9,22 +9,23 @@ import games.strategy.triplea.delegate.data.BattleRecords;
 
 class AddBattleRecordsChange extends Change {
   private static final long serialVersionUID = -6927678548172402611L;
-  private final BattleRecords m_recordsToAdd;
-  private final int m_round;
+
+  private final BattleRecords recordsToAdd;
+  private final int round;
 
   AddBattleRecordsChange(final BattleRecords battleRecords, final GameData data) {
-    m_round = data.getSequence().getRound();
+    round = data.getSequence().getRound();
     // make a copy because this is only done once, and only externally from battle
     // tracker, and the source will be cleared (battle tracker clears out the records
     // each turn)
-    m_recordsToAdd = new BattleRecords(battleRecords);
+    recordsToAdd = new BattleRecords(battleRecords);
   }
 
   AddBattleRecordsChange(final BattleRecords battleRecords, final int round) {
-    m_round = round;
+    this.round = round;
     // do not make a copy, this is only called from RemoveBattleRecordsChange, and we make a copy when we
     // perform, so no need for another copy.
-    m_recordsToAdd = battleRecords;
+    recordsToAdd = battleRecords;
   }
 
   @Override
@@ -32,21 +33,21 @@ class AddBattleRecordsChange extends Change {
     final Map<Integer, BattleRecords> currentRecords = data.getBattleRecordsList().getBattleRecordsMap();
     // make a copy because otherwise ours will be
     // cleared when we RemoveBattleRecordsChange
-    BattleRecordsList.addRecords(currentRecords, m_round, new BattleRecords(m_recordsToAdd));
+    BattleRecordsList.addRecords(currentRecords, round, new BattleRecords(recordsToAdd));
   }
 
   @Override
   public Change invert() {
-    return new RemoveBattleRecordsChange(m_recordsToAdd, m_round);
+    return new RemoveBattleRecordsChange(recordsToAdd, round);
   }
 
   @Override
   public String toString() {
     // This only occurs when serialization went badly, or something cannot be serialized.
-    if (m_recordsToAdd == null) {
+    if (recordsToAdd == null) {
       throw new IllegalStateException(
           "Records cannot be null (most likely caused by improper or impossible serialization)");
     }
-    return "Adding Battle Records: " + m_recordsToAdd;
+    return "Adding Battle Records: " + recordsToAdd;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
@@ -7,8 +7,9 @@ import games.strategy.engine.data.ProductionRule;
 
 class AddProductionRule extends Change {
   private static final long serialVersionUID = 2583955907289570063L;
-  private final ProductionRule m_rule;
-  private final ProductionFrontier m_frontier;
+
+  private final ProductionRule rule;
+  private final ProductionFrontier frontier;
 
   public AddProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
     if (rule == null) {
@@ -17,17 +18,17 @@ class AddProductionRule extends Change {
     if (frontier == null) {
       throw new IllegalArgumentException("Null frontier");
     }
-    m_rule = rule;
-    m_frontier = frontier;
+    this.rule = rule;
+    this.frontier = frontier;
   }
 
   @Override
   public void perform(final GameData data) {
-    m_frontier.addRule(m_rule);
+    frontier.addRule(rule);
   }
 
   @Override
   public Change invert() {
-    return new RemoveProductionRule(m_rule, m_frontier);
+    return new RemoveProductionRule(rule, frontier);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -14,35 +14,36 @@ import games.strategy.engine.data.UnitHolder;
  */
 class AddUnits extends Change {
   private static final long serialVersionUID = 2694342784633196289L;
-  private final String m_name;
-  private final Collection<Unit> m_units;
-  private final String m_type;
+
+  private final String name;
+  private final Collection<Unit> units;
+  private final String type;
 
   AddUnits(final UnitCollection collection, final Collection<Unit> units) {
-    m_units = new ArrayList<>(units);
-    m_name = collection.getHolder().getName();
-    m_type = collection.getHolder().getType();
+    this.units = new ArrayList<>(units);
+    name = collection.getHolder().getName();
+    type = collection.getHolder().getType();
   }
 
   AddUnits(final String name, final String type, final Collection<Unit> units) {
-    m_units = new ArrayList<>(units);
-    m_type = type;
-    m_name = name;
+    this.units = new ArrayList<>(units);
+    this.type = type;
+    this.name = name;
   }
 
   @Override
   public Change invert() {
-    return new RemoveUnits(m_name, m_type, m_units);
+    return new RemoveUnits(name, type, units);
   }
 
   @Override
   protected void perform(final GameData data) {
-    final UnitHolder holder = data.getUnitHolder(m_name, m_type);
-    holder.getUnits().addAll(m_units);
+    final UnitHolder holder = data.getUnitHolder(name, type);
+    holder.getUnits().addAll(units);
   }
 
   @Override
   public String toString() {
-    return "Add unit change.  Add to:" + m_name + " units:" + m_units;
+    return "Add unit change.  Add to:" + name + " units:" + units;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
@@ -10,43 +10,44 @@ import games.strategy.engine.data.IAttachment;
  */
 class AttachmentPropertyReset extends Change {
   private static final long serialVersionUID = 9208154387325299072L;
-  private final Attachable m_attachedTo;
-  private final String m_attachmentName;
-  private final Object m_oldValue;
-  private final String m_property;
+
+  private final Attachable attachedTo;
+  private final String attachmentName;
+  private final Object oldValue;
+  private final String property;
 
   AttachmentPropertyReset(final IAttachment attachment, final String property) {
     if (attachment == null) {
       throw new IllegalArgumentException("No attachment, property:" + property);
     }
-    m_attachedTo = attachment.getAttachedTo();
-    m_attachmentName = attachment.getName();
-    m_oldValue = attachment.getPropertyOrThrow(property).getValue();
-    m_property = property;
+    attachedTo = attachment.getAttachedTo();
+    attachmentName = attachment.getName();
+    oldValue = attachment.getPropertyOrThrow(property).getValue();
+    this.property = property;
   }
 
   AttachmentPropertyReset(final Attachable attachTo, final String attachmentName, final Object oldValue,
       final String property) {
-    m_attachmentName = attachmentName;
-    m_attachedTo = attachTo;
-    m_oldValue = oldValue;
-    m_property = property;
+    this.attachmentName = attachmentName;
+    attachedTo = attachTo;
+    this.oldValue = oldValue;
+    this.property = property;
   }
 
   @Override
   public void perform(final GameData data) {
-    final IAttachment attachment = m_attachedTo.getAttachment(m_attachmentName);
-    attachment.getPropertyOrThrow(m_property).resetValue();
+    final IAttachment attachment = attachedTo.getAttachment(attachmentName);
+    attachment.getPropertyOrThrow(property).resetValue();
   }
 
   @Override
   public Change invert() {
-    return new AttachmentPropertyResetUndo(m_attachedTo, m_attachmentName, m_oldValue, m_property);
+    return new AttachmentPropertyResetUndo(attachedTo, attachmentName, oldValue, property);
   }
 
   @Override
   public String toString() {
-    return "AttachmentPropertyClear attached to:" + m_attachedTo + " name:" + m_attachmentName + ", reset old value:"
-        + m_oldValue;
+    return "AttachmentPropertyClear attached to:" + attachedTo + " name:" + attachmentName + ", reset old value:"
+        + oldValue;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyResetUndo.java
@@ -8,41 +8,42 @@ import games.strategy.engine.data.MutableProperty;
 
 class AttachmentPropertyResetUndo extends Change {
   private static final long serialVersionUID = 5943939650116851332L;
-  private final Attachable m_attachedTo;
-  private final String m_attachmentName;
-  private final Object m_newValue;
-  private final String m_property;
+
+  private final Attachable attachedTo;
+  private final String attachmentName;
+  private final Object newValue;
+  private final String property;
 
   AttachmentPropertyResetUndo(final Attachable attachTo, final String attachmentName, final Object newValue,
       final String property) {
-    m_attachmentName = attachmentName;
-    m_attachedTo = attachTo;
-    m_newValue = newValue;
-    m_property = property;
+    this.attachmentName = attachmentName;
+    attachedTo = attachTo;
+    this.newValue = newValue;
+    this.property = property;
   }
 
   @Override
   public void perform(final GameData data) {
-    final IAttachment attachment = m_attachedTo.getAttachment(m_attachmentName);
+    final IAttachment attachment = attachedTo.getAttachment(attachmentName);
     try {
-      attachment.getPropertyOrThrow(m_property).setValue(m_newValue);
+      attachment.getPropertyOrThrow(property).setValue(newValue);
     } catch (final MutableProperty.InvalidValueException e) {
       throw new IllegalStateException(
           String.format(
               "failed to set value '%s' on property '%s' for attachment '%s' associated with '%s'",
-              m_newValue, m_property, m_attachmentName, m_attachedTo),
+              newValue, property, attachmentName, attachedTo),
           e);
     }
   }
 
   @Override
   public Change invert() {
-    return new AttachmentPropertyReset(m_attachedTo, m_attachmentName, m_newValue, m_property);
+    return new AttachmentPropertyReset(attachedTo, attachmentName, newValue, property);
   }
 
   @Override
   public String toString() {
-    return "AttachmentPropertyClearUndo attached to:" + m_attachedTo + " name:" + m_attachmentName + " new value:"
-        + m_newValue;
+    return "AttachmentPropertyClearUndo attached to:" + attachedTo + " name:" + attachmentName + " new value:"
+        + newValue;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeResourceChange.java
@@ -11,40 +11,41 @@ import games.strategy.engine.data.ResourceCollection;
  */
 class ChangeResourceChange extends Change {
   private static final long serialVersionUID = -2304294240555842126L;
-  private final String m_player;
-  private final String m_resource;
-  private final int m_quantity;
+
+  private final String playerName;
+  private final String resourceName;
+  private final int quantity;
 
   ChangeResourceChange(final PlayerID player, final Resource resource, final int quantity) {
-    m_player = player.getName();
-    m_resource = resource.getName();
-    m_quantity = quantity;
+    playerName = player.getName();
+    resourceName = resource.getName();
+    this.quantity = quantity;
   }
 
-  private ChangeResourceChange(final String player, final String resource, final int quantity) {
-    m_player = player;
-    m_resource = resource;
-    m_quantity = quantity;
+  private ChangeResourceChange(final String playerName, final String resourceName, final int quantity) {
+    this.playerName = playerName;
+    this.resourceName = resourceName;
+    this.quantity = quantity;
   }
 
   @Override
   public Change invert() {
-    return new ChangeResourceChange(m_player, m_resource, -m_quantity);
+    return new ChangeResourceChange(playerName, resourceName, -quantity);
   }
 
   @Override
   protected void perform(final GameData data) {
-    final Resource resource = data.getResourceList().getResource(m_resource);
-    final ResourceCollection resources = data.getPlayerList().getPlayerId(m_player).getResources();
-    if (m_quantity > 0) {
-      resources.addResource(resource, m_quantity);
-    } else if (m_quantity < 0) {
-      resources.removeResource(resource, -m_quantity);
+    final Resource resource = data.getResourceList().getResource(resourceName);
+    final ResourceCollection resources = data.getPlayerList().getPlayerId(playerName).getResources();
+    if (quantity > 0) {
+      resources.addResource(resource, quantity);
+    } else if (quantity < 0) {
+      resources.removeResource(resource, -quantity);
     }
   }
 
   @Override
   public String toString() {
-    return "Change resource.  Resource:" + m_resource + " quantity:" + m_quantity + " Player:" + m_player;
+    return "Change resource.  Resource:" + resourceName + " quantity:" + quantity + " Player:" + playerName;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
@@ -7,46 +7,47 @@ import games.strategy.triplea.attachments.TechAttachment;
 
 class GenericTechChange extends Change {
   private static final long serialVersionUID = -2439447526511535571L;
-  private final Attachable m_attachedTo;
-  private final String m_attachmentName;
-  private final boolean m_newValue;
-  private final boolean m_oldValue;
-  private final String m_property;
+
+  private final Attachable attachedTo;
+  private final String attachmentName;
+  private final boolean newValue;
+  private final boolean oldValue;
+  private final String property;
 
   GenericTechChange(final TechAttachment attachment, final boolean newValue, final String property) {
     if (attachment == null) {
       throw new IllegalArgumentException("No attachment, newValue:" + newValue + " property:" + property);
     }
-    m_attachedTo = attachment.getAttachedTo();
-    m_attachmentName = attachment.getName();
-    m_oldValue = attachment.hasGenericTech(property);
-    m_newValue = newValue;
-    m_property = property;
+    attachedTo = attachment.getAttachedTo();
+    attachmentName = attachment.getName();
+    oldValue = attachment.hasGenericTech(property);
+    this.newValue = newValue;
+    this.property = property;
   }
 
   public GenericTechChange(final Attachable attachTo, final String attachmentName, final boolean newValue,
       final boolean oldValue, final String property) {
-    m_attachmentName = attachmentName;
-    m_attachedTo = attachTo;
-    m_newValue = newValue;
-    m_oldValue = oldValue;
-    m_property = property;
+    this.attachmentName = attachmentName;
+    attachedTo = attachTo;
+    this.newValue = newValue;
+    this.oldValue = oldValue;
+    this.property = property;
   }
 
   @Override
   public void perform(final GameData data) {
-    final TechAttachment attachment = (TechAttachment) m_attachedTo.getAttachment(m_attachmentName);
-    attachment.setGenericTech(m_property, m_newValue);
+    final TechAttachment attachment = (TechAttachment) attachedTo.getAttachment(attachmentName);
+    attachment.setGenericTech(property, newValue);
   }
 
   @Override
   public Change invert() {
-    return new GenericTechChange(m_attachedTo, m_attachmentName, m_oldValue, m_newValue, m_property);
+    return new GenericTechChange(attachedTo, attachmentName, oldValue, newValue, property);
   }
 
   @Override
   public String toString() {
-    return "GenericTechChange attached to:" + m_attachedTo + " name:" + m_attachmentName + " new value:" + m_newValue
-        + " old value:" + m_oldValue;
+    return "GenericTechChange attached to:" + attachedTo + " name:" + attachmentName + " new value:" + newValue
+        + " old value:" + oldValue;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -13,53 +13,54 @@ import games.strategy.engine.data.Unit;
  */
 public class ObjectPropertyChange extends Change {
   private static final long serialVersionUID = 4218093376094170940L;
-  private final Unit m_object;
-  private String m_property;
-  private final Object m_newValue;
-  private final Object m_oldValue;
+
+  private final Unit object;
+  private String property;
+  private final Object newValue;
+  private final Object oldValue;
 
   ObjectPropertyChange(final Unit object, final String property, final Object newValue) {
-    m_object = object;
-    m_property = property.intern();
-    m_newValue = newValue;
-    m_oldValue = object.getPropertyOrThrow(property).getValue();
+    this.object = object;
+    this.property = property.intern();
+    this.newValue = newValue;
+    oldValue = object.getPropertyOrThrow(property).getValue();
   }
 
   private ObjectPropertyChange(final Unit object, final String property, final Object newValue,
       final Object oldValue) {
-    m_object = object;
+    this.object = object;
     // prevent multiple copies of the property names being held in the game
-    m_property = property.intern();
-    m_newValue = newValue;
-    m_oldValue = oldValue;
+    this.property = property.intern();
+    this.newValue = newValue;
+    this.oldValue = oldValue;
   }
 
   private void readObject(final ObjectInputStream stream) throws IOException, ClassNotFoundException {
     stream.defaultReadObject();
-    m_property = m_property.intern();
+    property = property.intern();
   }
 
   @Override
   public Change invert() {
-    return new ObjectPropertyChange(m_object, m_property, m_oldValue, m_newValue);
+    return new ObjectPropertyChange(object, property, oldValue, newValue);
   }
 
   @Override
   protected void perform(final GameData data) {
     try {
-      m_object.getPropertyOrThrow(m_property).setValue(m_newValue);
+      object.getPropertyOrThrow(property).setValue(newValue);
     } catch (final MutableProperty.InvalidValueException e) {
       throw new IllegalStateException(
           String.format(
               "failed to set value '%s' on property '%s' for object '%s'",
-              m_newValue, m_property, m_object),
+              newValue, property, object),
           e);
     }
   }
 
   @Override
   public String toString() {
-    return "Property change, unit:" + m_object + " property:" + m_property + " newValue:" + m_newValue + " oldValue:"
-        + m_oldValue;
+    return "Property change, unit:" + object + " property:" + property + " newValue:" + newValue + " oldValue:"
+        + oldValue;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
@@ -10,26 +10,27 @@ import games.strategy.engine.data.Territory;
  */
 class OwnerChange extends Change {
   private static final long serialVersionUID = -5938125380623744929L;
+
   /**
    * Either new or old owner can be null.
    */
-  private final String m_old;
-  private final String m_new;
-  private final String m_territory;
+  private final String oldOwnerName;
+  private final String newOwnerName;
+  private final String territoryName;
 
   /**
    * newOwner can be null.
    */
   OwnerChange(final Territory territory, final PlayerID newOwner) {
-    m_territory = territory.getName();
-    m_new = getName(newOwner);
-    m_old = getName(territory.getOwner());
+    territoryName = territory.getName();
+    newOwnerName = getName(newOwner);
+    oldOwnerName = getName(territory.getOwner());
   }
 
-  private OwnerChange(final String name, final String newOwner, final String oldOwner) {
-    m_territory = name;
-    m_new = newOwner;
-    m_old = oldOwner;
+  private OwnerChange(final String territoryName, final String newOwnerName, final String oldOwnerName) {
+    this.territoryName = territoryName;
+    this.newOwnerName = newOwnerName;
+    this.oldOwnerName = oldOwnerName;
   }
 
   private static String getName(final PlayerID player) {
@@ -48,17 +49,17 @@ class OwnerChange extends Change {
 
   @Override
   public Change invert() {
-    return new OwnerChange(m_territory, m_old, m_new);
+    return new OwnerChange(territoryName, oldOwnerName, newOwnerName);
   }
 
   @Override
   protected void perform(final GameData data) {
     // both names could be null
-    data.getMap().getTerritory(m_territory).setOwner(getPlayerId(m_new, data));
+    data.getMap().getTerritory(territoryName).setOwner(getPlayerId(newOwnerName, data));
   }
 
   @Override
   public String toString() {
-    return m_new + " takes " + m_territory + " from " + m_old;
+    return newOwnerName + " takes " + territoryName + " from " + oldOwnerName;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -15,51 +15,53 @@ import games.strategy.net.GUID;
  * Changes ownership of a unit.
  */
 class PlayerOwnerChange extends Change {
-  /**
-   * Maps unit id -> owner as String.
-   */
-  private final Map<GUID, String> m_old;
-  private final Map<GUID, String> m_new;
-  private final String m_location;
   private static final long serialVersionUID = -9154938431233632882L;
 
-  PlayerOwnerChange(final Collection<Unit> units, final PlayerID newOwner, final Territory location) {
-    m_old = new HashMap<>();
-    m_new = new HashMap<>();
-    m_location = location.getName();
+  private final Map<GUID, String> oldOwnerNamesByUnitId;
+  private final Map<GUID, String> newOwnerNamesByUnitId;
+  private final String territoryName;
+
+  PlayerOwnerChange(final Collection<Unit> units, final PlayerID newOwner, final Territory territory) {
+    oldOwnerNamesByUnitId = new HashMap<>();
+    newOwnerNamesByUnitId = new HashMap<>();
+    territoryName = territory.getName();
     for (final Unit unit : units) {
-      m_old.put(unit.getId(), unit.getOwner().getName());
-      m_new.put(unit.getId(), newOwner.getName());
+      oldOwnerNamesByUnitId.put(unit.getId(), unit.getOwner().getName());
+      newOwnerNamesByUnitId.put(unit.getId(), newOwner.getName());
     }
   }
 
-  PlayerOwnerChange(final Map<GUID, String> newOwner, final Map<GUID, String> oldOwner, final String location) {
-    m_old = oldOwner;
-    m_new = newOwner;
-    m_location = location;
+  PlayerOwnerChange(
+      final Map<GUID, String> newOwnerNamesByUnitId,
+      final Map<GUID, String> oldOwnerNamesByUnitId,
+      final String territoryName) {
+    this.oldOwnerNamesByUnitId = oldOwnerNamesByUnitId;
+    this.newOwnerNamesByUnitId = newOwnerNamesByUnitId;
+    this.territoryName = territoryName;
   }
 
   @Override
   public Change invert() {
-    return new PlayerOwnerChange(m_old, m_new, m_location);
+    return new PlayerOwnerChange(oldOwnerNamesByUnitId, newOwnerNamesByUnitId, territoryName);
   }
 
   @Override
   protected void perform(final GameData data) {
-    for (final GUID id : m_new.keySet()) {
+    for (final GUID id : newOwnerNamesByUnitId.keySet()) {
       final Unit unit = data.getUnits().get(id);
-      if (!m_old.get(id).equals(unit.getOwner().getName())) {
-        throw new IllegalStateException("Wrong owner, expecting" + m_old.get(id) + " but got " + unit.getOwner());
+      if (!oldOwnerNamesByUnitId.get(id).equals(unit.getOwner().getName())) {
+        throw new IllegalStateException("Wrong owner, expecting" + oldOwnerNamesByUnitId.get(id)
+            + " but got " + unit.getOwner());
       }
-      final String owner = m_new.get(id);
+      final String owner = newOwnerNamesByUnitId.get(id);
       final PlayerID player = data.getPlayerList().getPlayerId(owner);
       unit.setOwner(player);
     }
-    data.getMap().getTerritory(m_location).notifyChanged();
+    data.getMap().getTerritory(territoryName).notifyChanged();
   }
 
   @Override
   public String toString() {
-    return "Some units change owners in territory " + m_location;
+    return "Some units change owners in territory " + territoryName;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/PlayerWhoAmIChange.java
@@ -6,35 +6,36 @@ import games.strategy.engine.data.PlayerID;
 
 class PlayerWhoAmIChange extends Change {
   private static final long serialVersionUID = -1486914230174337300L;
-  private final String m_startWhoAmI;
-  private final String m_endWhoAmI;
-  private final String m_player;
+
+  private final String startWhoAmI;
+  private final String endWhoAmI;
+  private final String playerName;
 
   PlayerWhoAmIChange(final String newWhoAmI, final PlayerID player) {
-    m_startWhoAmI = player.getWhoAmI();
-    m_endWhoAmI = newWhoAmI;
-    m_player = player.getName();
+    startWhoAmI = player.getWhoAmI();
+    endWhoAmI = newWhoAmI;
+    playerName = player.getName();
   }
 
-  PlayerWhoAmIChange(final String startWhoAmI, final String endWhoAmI, final String player) {
-    m_startWhoAmI = startWhoAmI;
-    m_endWhoAmI = endWhoAmI;
-    m_player = player;
+  PlayerWhoAmIChange(final String startWhoAmI, final String endWhoAmI, final String playerName) {
+    this.startWhoAmI = startWhoAmI;
+    this.endWhoAmI = endWhoAmI;
+    this.playerName = playerName;
   }
 
   @Override
   protected void perform(final GameData data) {
-    final PlayerID player = data.getPlayerList().getPlayerId(m_player);
-    player.setWhoAmI(m_endWhoAmI);
+    final PlayerID player = data.getPlayerList().getPlayerId(playerName);
+    player.setWhoAmI(endWhoAmI);
   }
 
   @Override
   public Change invert() {
-    return new PlayerWhoAmIChange(m_endWhoAmI, m_startWhoAmI, m_player);
+    return new PlayerWhoAmIChange(endWhoAmI, startWhoAmI, playerName);
   }
 
   @Override
   public String toString() {
-    return m_player + " changed from " + m_startWhoAmI + " to " + m_endWhoAmI;
+    return playerName + " changed from " + startWhoAmI + " to " + endWhoAmI;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ProductionFrontierChange.java
@@ -9,32 +9,33 @@ import games.strategy.engine.data.ProductionFrontier;
  * Change a players production frontier.
  */
 class ProductionFrontierChange extends Change {
-  private final String m_startFrontier;
-  private final String m_endFrontier;
-  private final String m_player;
   private static final long serialVersionUID = 3336145814067456701L;
 
+  private final String startFrontierName;
+  private final String endFrontierName;
+  private final String playerName;
+
   ProductionFrontierChange(final ProductionFrontier newFrontier, final PlayerID player) {
-    m_startFrontier = player.getProductionFrontier().getName();
-    m_endFrontier = newFrontier.getName();
-    m_player = player.getName();
+    startFrontierName = player.getProductionFrontier().getName();
+    endFrontierName = newFrontier.getName();
+    playerName = player.getName();
   }
 
-  ProductionFrontierChange(final String startFrontier, final String endFrontier, final String player) {
-    m_startFrontier = startFrontier;
-    m_endFrontier = endFrontier;
-    m_player = player;
+  ProductionFrontierChange(final String startFrontierName, final String endFrontierName, final String playerName) {
+    this.startFrontierName = startFrontierName;
+    this.endFrontierName = endFrontierName;
+    this.playerName = playerName;
   }
 
   @Override
   protected void perform(final GameData data) {
-    final PlayerID player = data.getPlayerList().getPlayerId(m_player);
-    final ProductionFrontier frontier = data.getProductionFrontierList().getProductionFrontier(m_endFrontier);
+    final PlayerID player = data.getPlayerList().getPlayerId(playerName);
+    final ProductionFrontier frontier = data.getProductionFrontierList().getProductionFrontier(endFrontierName);
     player.setProductionFrontier(frontier);
   }
 
   @Override
   public Change invert() {
-    return new ProductionFrontierChange(m_endFrontier, m_startFrontier, m_player);
+    return new ProductionFrontierChange(endFrontierName, startFrontierName, playerName);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -13,41 +13,45 @@ import games.strategy.util.CollectionUtils;
  */
 class RelationshipChange extends Change {
   private static final long serialVersionUID = 2694339584633196289L;
-  private final String m_player1;
-  private final String m_player2;
-  private final String m_OldRelation;
-  private final String m_NewRelation;
 
-  RelationshipChange(final PlayerID player1, final PlayerID player2, final RelationshipType oldRelation,
-      final RelationshipType newRelation) {
-    m_player1 = player1.getName();
-    m_player2 = player2.getName();
-    m_OldRelation = oldRelation.getName();
-    m_NewRelation = newRelation.getName();
+  private final String player1Name;
+  private final String player2Name;
+  private final String oldRelationshipTypeName;
+  private final String newRelationshipTypeName;
+
+  RelationshipChange(final PlayerID player1, final PlayerID player2, final RelationshipType oldRelationshipType,
+      final RelationshipType newRelationshipType) {
+    player1Name = player1.getName();
+    player2Name = player2.getName();
+    oldRelationshipTypeName = oldRelationshipType.getName();
+    newRelationshipTypeName = newRelationshipType.getName();
   }
 
-  private RelationshipChange(final String player1, final String player2, final String oldRelation,
-      final String newRelation) {
-    m_player1 = player1;
-    m_player2 = player2;
-    m_OldRelation = oldRelation;
-    m_NewRelation = newRelation;
+  private RelationshipChange(final String player1Name, final String player2Name, final String oldRelationshipTypeName,
+      final String newRelationshipTypeName) {
+    this.player1Name = player1Name;
+    this.player2Name = player2Name;
+    this.oldRelationshipTypeName = oldRelationshipTypeName;
+    this.newRelationshipTypeName = newRelationshipTypeName;
   }
 
   @Override
   public Change invert() {
-    return new RelationshipChange(m_player1, m_player2, m_NewRelation, m_OldRelation);
+    return new RelationshipChange(player1Name, player2Name, newRelationshipTypeName, oldRelationshipTypeName);
   }
 
   @Override
   protected void perform(final GameData data) {
-    data.getRelationshipTracker().setRelationship(data.getPlayerList().getPlayerId(m_player1),
-        data.getPlayerList().getPlayerId(m_player2), data.getRelationshipTypeList().getRelationshipType(m_NewRelation));
+    data.getRelationshipTracker().setRelationship(
+        data.getPlayerList().getPlayerId(player1Name),
+        data.getPlayerList().getPlayerId(player2Name),
+        data.getRelationshipTypeList().getRelationshipType(newRelationshipTypeName));
     // now redraw territories in case of new hostility
-    if (Matches.relationshipTypeIsAtWar().test(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
+    if (Matches.relationshipTypeIsAtWar()
+        .test(data.getRelationshipTypeList().getRelationshipType(newRelationshipTypeName))) {
       for (final Territory t : CollectionUtils.getMatches(data.getMap().getTerritories(),
-          Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(m_player1))
-              .and(Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(m_player2))))) {
+          Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(player1Name))
+              .and(Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerId(player2Name))))) {
         t.notifyChanged();
       }
     }
@@ -55,7 +59,7 @@ class RelationshipChange extends Change {
 
   @Override
   public String toString() {
-    return "Add relation change. " + m_player1 + " and " + m_player2 + " change from " + m_OldRelation + " to "
-        + m_NewRelation;
+    return "Add relation change. " + player1Name + " and " + player2Name
+        + " change from " + oldRelationshipTypeName + " to " + newRelationshipTypeName;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
@@ -7,32 +7,33 @@ import games.strategy.engine.data.IAttachment;
 
 class RemoveAttachmentChange extends Change {
   private static final long serialVersionUID = 6365648682759047674L;
-  private final IAttachment m_attachment;
-  private final String m_originalAttachmentName;
-  private final Attachable m_originalAttachable;
-  private final Attachable m_attachable;
-  private final String m_name;
+
+  private final IAttachment attachment;
+  private final String originalAttachmentName;
+  private final Attachable originalAttachable;
+  private final Attachable attachable;
+  private final String name;
 
   public RemoveAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
-    m_attachment = attachment;
-    m_originalAttachmentName = attachment.getName();
-    m_originalAttachable = attachment.getAttachedTo();
-    m_attachable = attachable;
-    m_name = name;
+    this.attachment = attachment;
+    originalAttachmentName = attachment.getName();
+    originalAttachable = attachment.getAttachedTo();
+    this.attachable = attachable;
+    this.name = name;
   }
 
   @Override
   protected void perform(final GameData data) {
-    m_originalAttachable.removeAttachment(m_originalAttachmentName);
-    m_attachment.setAttachedTo(m_attachable);
-    m_attachment.setName(m_name);
-    if (m_attachable != null && m_name != null) {
-      m_attachable.addAttachment(m_name, m_attachment);
+    originalAttachable.removeAttachment(originalAttachmentName);
+    attachment.setAttachedTo(attachable);
+    attachment.setName(name);
+    if (attachable != null && name != null) {
+      attachable.addAttachment(name, attachment);
     }
   }
 
   @Override
   public Change invert() {
-    return new AddAttachmentChange(m_attachment, m_originalAttachable, m_originalAttachmentName);
+    return new AddAttachmentChange(attachment, originalAttachable, originalAttachmentName);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
@@ -8,9 +8,10 @@ import games.strategy.triplea.delegate.TechAdvance;
 
 class RemoveAvailableTech extends Change {
   private static final long serialVersionUID = 6131447662760022521L;
-  private final TechAdvance m_tech;
-  private final TechnologyFrontier m_frontier;
-  private final PlayerID m_player;
+
+  private final TechAdvance tech;
+  private final TechnologyFrontier frontier;
+  private final PlayerID player;
 
   public RemoveAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {
     if (front == null) {
@@ -19,19 +20,19 @@ class RemoveAvailableTech extends Change {
     if (tech == null) {
       throw new IllegalArgumentException("Null tech");
     }
-    m_tech = tech;
-    m_frontier = front;
-    m_player = player;
+    this.tech = tech;
+    frontier = front;
+    this.player = player;
   }
 
   @Override
   public void perform(final GameData data) {
-    final TechnologyFrontier front = m_player.getTechnologyFrontierList().getTechnologyFrontier(m_frontier.getName());
-    front.removeAdvance(m_tech);
+    final TechnologyFrontier front = player.getTechnologyFrontierList().getTechnologyFrontier(frontier.getName());
+    front.removeAdvance(tech);
   }
 
   @Override
   public Change invert() {
-    return new AddAvailableTech(m_frontier, m_tech, m_player);
+    return new AddAvailableTech(frontier, tech, player);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
@@ -9,35 +9,36 @@ import games.strategy.triplea.delegate.data.BattleRecords;
 
 class RemoveBattleRecordsChange extends Change {
   private static final long serialVersionUID = 3286634991233029854L;
-  private final BattleRecords m_recordsToRemove;
-  private final int m_round;
+
+  private final BattleRecords recordsToRemove;
+  private final int round;
 
   RemoveBattleRecordsChange(final BattleRecords battleRecords, final int round) {
-    m_round = round;
+    this.round = round;
     // do not make a copy, this is only called from AddBattleRecordsChange, and we make a copy when we
     // perform, so no need for another copy.
-    m_recordsToRemove = battleRecords;
+    recordsToRemove = battleRecords;
   }
 
   @Override
   protected void perform(final GameData data) {
     final Map<Integer, BattleRecords> currentRecords = data.getBattleRecordsList().getBattleRecordsMap();
     // make a copy else we will get a concurrent modification error
-    BattleRecordsList.removeRecords(currentRecords, m_round, new BattleRecords(m_recordsToRemove));
+    BattleRecordsList.removeRecords(currentRecords, round, new BattleRecords(recordsToRemove));
   }
 
   @Override
   public Change invert() {
-    return new AddBattleRecordsChange(m_recordsToRemove, m_round);
+    return new AddBattleRecordsChange(recordsToRemove, round);
   }
 
   @Override
   public String toString() {
     // This only occurs when serialization went badly, or something cannot be serialized.
-    if (m_recordsToRemove == null) {
+    if (recordsToRemove == null) {
       throw new IllegalStateException(
-          "Records cannot be null (most likely caused by improper or impossible serialization): " + m_recordsToRemove);
+          "Records cannot be null (most likely caused by improper or impossible serialization): " + recordsToRemove);
     }
-    return "Adding Battle Records: " + m_recordsToRemove;
+    return "Adding Battle Records: " + recordsToRemove;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
@@ -7,8 +7,9 @@ import games.strategy.engine.data.ProductionRule;
 
 class RemoveProductionRule extends Change {
   private static final long serialVersionUID = 2312599802275503095L;
-  private final ProductionRule m_rule;
-  private final ProductionFrontier m_frontier;
+
+  private final ProductionRule rule;
+  private final ProductionFrontier frontier;
 
   public RemoveProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
     if (rule == null) {
@@ -17,17 +18,17 @@ class RemoveProductionRule extends Change {
     if (frontier == null) {
       throw new IllegalArgumentException("Null frontier");
     }
-    m_rule = rule;
-    m_frontier = frontier;
+    this.rule = rule;
+    this.frontier = frontier;
   }
 
   @Override
   public void perform(final GameData data) {
-    m_frontier.removeRule(m_rule);
+    frontier.removeRule(rule);
   }
 
   @Override
   public Change invert() {
-    return new AddProductionRule(m_rule, m_frontier);
+    return new AddProductionRule(rule, frontier);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
@@ -11,37 +11,38 @@ import games.strategy.engine.data.UnitHolder;
 
 class RemoveUnits extends Change {
   private static final long serialVersionUID = -6410444472951010568L;
-  private final String m_name;
-  private final Collection<Unit> m_units;
-  private final String m_type;
+
+  private final String name;
+  private final Collection<Unit> units;
+  private final String type;
 
   RemoveUnits(final UnitCollection collection, final Collection<Unit> units) {
     this(collection.getHolder().getName(), collection.getHolder().getType(), units);
   }
 
   RemoveUnits(final String name, final String type, final Collection<Unit> units) {
-    m_units = new ArrayList<>(units);
-    m_name = name;
-    m_type = type;
+    this.units = new ArrayList<>(units);
+    this.name = name;
+    this.type = type;
   }
 
   @Override
   public Change invert() {
-    return new AddUnits(m_name, m_type, m_units);
+    return new AddUnits(name, type, units);
   }
 
   @Override
   protected void perform(final GameData data) {
-    final UnitHolder holder = data.getUnitHolder(m_name, m_type);
-    if (!holder.getUnits().containsAll(m_units)) {
-      throw new IllegalStateException("Not all units present in:" + m_name + ".  Trying to remove:" + m_units
+    final UnitHolder holder = data.getUnitHolder(name, type);
+    if (!holder.getUnits().containsAll(units)) {
+      throw new IllegalStateException("Not all units present in:" + name + ".  Trying to remove:" + units
           + " present:" + holder.getUnits().getUnits());
     }
-    holder.getUnits().removeAll(m_units);
+    holder.getUnits().removeAll(units);
   }
 
   @Override
   public String toString() {
-    return "Remove unit change. Remove from:" + m_name + " units:" + m_units;
+    return "Remove unit change. Remove from:" + name + " units:" + units;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/SetPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/SetPropertyChange.java
@@ -6,29 +6,30 @@ import games.strategy.engine.data.properties.GameProperties;
 
 class SetPropertyChange extends Change {
   private static final long serialVersionUID = -1377597975513821508L;
-  private final String m_property;
-  private final Object m_value;
-  private final Object m_oldValue;
+
+  private final String property;
+  private final Object value;
+  private final Object oldValue;
 
   SetPropertyChange(final String property, final Object value, final GameProperties properties) {
-    m_property = property;
-    m_value = value;
-    m_oldValue = properties.get(property);
+    this.property = property;
+    this.value = value;
+    oldValue = properties.get(property);
   }
 
   private SetPropertyChange(final String property, final Object value, final Object oldValue) {
-    m_property = property;
-    m_value = value;
-    m_oldValue = oldValue;
+    this.property = property;
+    this.value = value;
+    this.oldValue = oldValue;
   }
 
   @Override
   public Change invert() {
-    return new SetPropertyChange(m_property, m_oldValue, m_value);
+    return new SetPropertyChange(property, oldValue, value);
   }
 
   @Override
   protected void perform(final GameData data) {
-    data.getProperties().set(m_property, m_value);
+    data.getProperties().set(property, value);
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in classes within the `g.s.engine.data.changefactory` package.

In several cases, simply removing the `m_` prefix yielded an invalid variable name (e.g. `new`).  I determined that the variable in question actually represented the name of something, and so added a `Name` suffix, as well as an additional adjective to describe what entity the name referred to.  To be consistent, I renamed the other fields of the enclosing class to follow the same pattern.  So, for example, you may see more complex renames such as `m_new` -> `newOwnerName`.  This also required some line wrapping due to increased line lengths.

## Functional Changes

None.

## Manual Testing Performed

None.