### PR TITLE
Property generics

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -895,6 +895,7 @@ public final class GameParser {
         new NumberProperty(Constants.getPuIncomeBonus(playerId), null, 999, 0, 0)));
   }
 
+  @SuppressWarnings("unchecked")
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)
       throws GameParseException {
     // what type
@@ -906,7 +907,7 @@ public final class GameParser {
     }
     final Element child = (Element) children.get(0);
     final String childName = child.getNodeName();
-    final IEditableProperty editableProperty;
+    final IEditableProperty<?> editableProperty;
     switch (childName) {
       case "boolean":
         editableProperty = new BooleanProperty(name, null, Boolean.valueOf(defaultValue));
@@ -940,7 +941,7 @@ public final class GameParser {
       default:
         throw newGameParseException("Unrecognized property type:" + childName);
     }
-    data.getProperties().addEditableProperty(editableProperty);
+    data.getProperties().addEditableProperty((IEditableProperty<Object>) editableProperty);
   }
 
   private void parseOffset(final Node offsetAttributes) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -941,7 +941,7 @@ public final class GameParser {
       default:
         throw newGameParseException("Unrecognized property type:" + childName);
     }
-    data.getProperties().addEditableProperty((IEditableProperty<Object>) editableProperty);
+    data.getProperties().addEditableProperty(editableProperty);
   }
 
   private void parseOffset(final Node offsetAttributes) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -895,7 +895,6 @@ public final class GameParser {
         new NumberProperty(Constants.getPuIncomeBonus(playerId), null, 999, 0, 0)));
   }
 
-  @SuppressWarnings("unchecked")
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)
       throws GameParseException {
     // what type

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -161,19 +161,19 @@ public class GameDataExporter {
       final Field edPropField = GameProperties.class.getDeclaredField(GameProperties.EDITABLE_PROPERTIES_FIELD_NAME);
       edPropField.setAccessible(true);
       printConstantProperties((Map<String, Object>) conPropField.get(gameProperties));
-      printEditableProperties((Map<String, IEditableProperty>) edPropField.get(gameProperties));
+      printEditableProperties((Map<String, IEditableProperty<?>>) edPropField.get(gameProperties));
     } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
       log.log(Level.SEVERE, "An Error occured whilst trying trying to setup the Property List", e);
     }
     xmlfile.append("    </propertyList>\n");
   }
 
-  private void printEditableProperties(final Map<String, IEditableProperty> editableProperties) {
+  private void printEditableProperties(final Map<String, IEditableProperty<?>> editableProperties) {
     editableProperties.values().forEach(this::printEditableProperty);
   }
 
   @SuppressWarnings("unchecked")
-  private void printEditableProperty(final IEditableProperty prop) {
+  private void printEditableProperty(final IEditableProperty<?> prop) {
     String typeString = "";
     String value = "" + prop.getValue();
     if (prop.getClass().equals(BooleanProperty.class)) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
@@ -11,7 +11,7 @@ import javax.swing.JComponent;
  * @param <T> The generic Type of the value being stored.
  */
 public abstract class AbstractEditableProperty<T>
-    implements IEditableProperty<T>, Serializable, Comparable<AbstractEditableProperty<T>> {
+    implements IEditableProperty<T>, Serializable, Comparable<AbstractEditableProperty<?>> {
   private static final long serialVersionUID = -5005729898242568847L;
 
   private final String name;
@@ -51,11 +51,11 @@ public abstract class AbstractEditableProperty<T>
 
   @Override
   public boolean equals(final Object other) {
-    return other instanceof AbstractEditableProperty && ((AbstractEditableProperty) other).name.equals(name);
+    return other instanceof AbstractEditableProperty && ((AbstractEditableProperty<?>) other).name.equals(name);
   }
 
   @Override
-  public int compareTo(final AbstractEditableProperty other) {
+  public int compareTo(final AbstractEditableProperty<?> other) {
     return name.compareTo(other.getName());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
@@ -8,8 +8,8 @@ import javax.swing.JComponent;
 /**
  * Superclass for all implementations of {@link IEditableProperty}.
  */
-public abstract class AbstractEditableProperty
-    implements IEditableProperty, Serializable, Comparable<AbstractEditableProperty> {
+public abstract class AbstractEditableProperty<T>
+    implements IEditableProperty<T>, Serializable, Comparable<AbstractEditableProperty<T>> {
   private static final long serialVersionUID = -5005729898242568847L;
 
   private final String name;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/AbstractEditableProperty.java
@@ -7,6 +7,8 @@ import javax.swing.JComponent;
 
 /**
  * Superclass for all implementations of {@link IEditableProperty}.
+ *
+ * @param <T> The generic Type of the value being stored.
  */
 public abstract class AbstractEditableProperty<T>
     implements IEditableProperty<T>, Serializable, Comparable<AbstractEditableProperty<T>> {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -6,8 +6,7 @@ import javax.swing.JComponent;
 /**
  * Implementation of {@link IEditableProperty} for a Boolean value.
  */
-public class BooleanProperty extends AbstractEditableProperty {
-  // compatible with 0.9.0.2 saved games
+public class BooleanProperty extends AbstractEditableProperty<Boolean> {
   private static final long serialVersionUID = -7265501762343216435L;
 
   private boolean value;
@@ -18,13 +17,13 @@ public class BooleanProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public Boolean getValue() {
     return value ? Boolean.TRUE : Boolean.FALSE;
   }
 
   @Override
-  public void setValue(final Object value) throws IllegalArgumentException {
-    this.value = (Boolean) value;
+  public void setValue(final Boolean value) throws IllegalArgumentException {
+    this.value = value;
   }
 
   public void setValue(final boolean value) {
@@ -40,7 +39,7 @@ public class BooleanProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
-    return value instanceof Boolean;
+  public boolean validate(final Boolean value) {
+    return value != null;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -39,7 +39,7 @@ public class BooleanProperty extends AbstractEditableProperty<Boolean> {
   }
 
   @Override
-  public boolean validate(final Boolean value) {
-    return value != null;
+  public boolean validate(final Object value) {
+    return value instanceof Boolean;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -18,11 +18,11 @@ public class BooleanProperty extends AbstractEditableProperty<Boolean> {
 
   @Override
   public Boolean getValue() {
-    return value ? Boolean.TRUE : Boolean.FALSE;
+    return value;
   }
 
   @Override
-  public void setValue(final Boolean value) throws IllegalArgumentException {
+  public void setValue(final Boolean value) {
     this.value = value;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -57,7 +57,7 @@ public class CollectionProperty<T> extends AbstractEditableProperty<List<T>> {
   }
 
   @Override
-  public boolean validate(final List<T> value) {
-    return value != null;
+  public boolean validate(final Object value) {
+    return value instanceof List;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -12,7 +12,7 @@ import javax.swing.JTable;
  *
  * @param <T> The type of elements in the collection.
  */
-public class CollectionProperty<T> extends AbstractEditableProperty {
+public class CollectionProperty<T> extends AbstractEditableProperty<List<T>> {
   private static final long serialVersionUID = 5338055034530377261L;
 
   private List<T> values;
@@ -30,14 +30,13 @@ public class CollectionProperty<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public List<T> getValue() {
     return values;
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public void setValue(final Object value) throws ClassCastException {
-    values = (List<T>) value;
+  public void setValue(final List<T> value) {
+    values = value;
   }
 
   @Override
@@ -58,7 +57,7 @@ public class CollectionProperty<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
-    return value != null && List.class.isAssignableFrom(value.getClass());
+  public boolean validate(final List<T> value) {
+    return value != null;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
@@ -87,6 +87,6 @@ public class ColorProperty extends AbstractEditableProperty<Color> {
 
   @Override
   public boolean validate(final Object value) {
-    return value == null || value instanceof Color;
+    return (value == null) || (value instanceof Color);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
@@ -3,8 +3,8 @@ package games.strategy.engine.data.properties;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 
 import javax.swing.JColorChooser;
 import javax.swing.JComponent;
@@ -19,7 +19,7 @@ import javax.swing.SwingUtilities;
  * change the color.
  * </p>
  */
-public class ColorProperty extends AbstractEditableProperty {
+public class ColorProperty extends AbstractEditableProperty<Color> {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final int MAX_COLOR = 0xFFFFFF;
   private static final int MIN_COLOR = 0x000000;
@@ -44,16 +44,16 @@ public class ColorProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public Color getValue() {
     return color;
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
+  public void setValue(final Color value) {
     if (value == null) {
       color = Color.black;
     } else {
-      color = (Color) value;
+      color = value;
     }
   }
 
@@ -69,7 +69,7 @@ public class ColorProperty extends AbstractEditableProperty {
         g2.fill(g2.getClip());
       }
     };
-    label.addMouseListener(new MouseListener() {
+    label.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(final MouseEvent e) {
         final Color colorSelected =
@@ -81,24 +81,12 @@ public class ColorProperty extends AbstractEditableProperty {
           SwingUtilities.invokeLater(label::repaint);
         }
       }
-
-      @Override
-      public void mouseEntered(final MouseEvent e) {}
-
-      @Override
-      public void mouseExited(final MouseEvent e) {}
-
-      @Override
-      public void mousePressed(final MouseEvent e) {}
-
-      @Override
-      public void mouseReleased(final MouseEvent e) {}
     });
     return label;
   }
 
   @Override
-  public boolean validate(final Object value) {
-    return (value == null) || (value instanceof Color);
+  public boolean validate(final Color value) {
+    return true;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
@@ -86,7 +86,7 @@ public class ColorProperty extends AbstractEditableProperty<Color> {
   }
 
   @Override
-  public boolean validate(final Color value) {
-    return true;
+  public boolean validate(final Object value) {
+    return value == null || value instanceof Color;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -14,7 +14,7 @@ import games.strategy.ui.SwingComponents;
  *
  * @param <T> The type of the property value.
  */
-public class ComboProperty<T> extends AbstractEditableProperty {
+public class ComboProperty<T> extends AbstractEditableProperty<T> {
   private static final long serialVersionUID = -3098612299805630587L;
   public static final String POSSIBLE_VALUES_FIELD_NAME = "possibleValues";
   private final List<T> possibleValues;
@@ -40,14 +40,13 @@ public class ComboProperty<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public T getValue() {
     return value;
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public void setValue(final Object value) throws ClassCastException {
-    this.value = (T) value;
+  public void setValue(final T value) {
+    this.value = value;
   }
 
   @Override
@@ -59,7 +58,7 @@ public class ComboProperty<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
+  public boolean validate(final T value) {
     return possibleValues != null && possibleValues.contains(value);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -58,7 +58,7 @@ public class ComboProperty<T> extends AbstractEditableProperty<T> {
   }
 
   @Override
-  public boolean validate(final T value) {
+  public boolean validate(final Object value) {
     return possibleValues != null && possibleValues.contains(value);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -1,14 +1,11 @@
 package games.strategy.engine.data.properties;
 
-import java.io.File;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import javax.swing.JComponent;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
-
-import games.strategy.engine.ClientFileSystemHelper;
 
 /**
  * Implementation of {@link IEditableProperty} for a double-precision floating-point value.

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -2,14 +2,18 @@ package games.strategy.engine.data.properties;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.logging.Level;
 
 import javax.swing.JComponent;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
+import lombok.extern.java.Log;
+
 /**
  * Implementation of {@link IEditableProperty} for a double-precision floating-point value.
  */
+@Log
 public class DoubleProperty extends AbstractEditableProperty<Double> {
   private static final long serialVersionUID = 5521967819500867581L;
 
@@ -30,13 +34,11 @@ public class DoubleProperty extends AbstractEditableProperty<Double> {
     this.max = max;
     this.min = min;
     places = numberOfPlaces;
-    value = roundToPlace(def, numberOfPlaces, RoundingMode.FLOOR);
+    value = roundToPlace(def, numberOfPlaces);
   }
 
-  private static double roundToPlace(final double number, final int places, final RoundingMode roundingMode) {
-    BigDecimal bd = new BigDecimal(number);
-    bd = bd.setScale(places, roundingMode);
-    return bd.doubleValue();
+  private static double roundToPlace(final double number, final int places) {
+    return new BigDecimal(number).setScale(places, RoundingMode.FLOOR).doubleValue();
   }
 
   @Override
@@ -46,7 +48,7 @@ public class DoubleProperty extends AbstractEditableProperty<Double> {
 
   @Override
   public void setValue(final Double value) {
-    this.value = roundToPlace(value, places, RoundingMode.FLOOR);
+    this.value = roundToPlace(value, places);
   }
 
   @Override
@@ -65,12 +67,15 @@ public class DoubleProperty extends AbstractEditableProperty<Double> {
   }
 
   @Override
-  public boolean validate(final Double value) {
-    try {
-      final double d = roundToPlace(value, places, RoundingMode.FLOOR);
-      return d <= max && d >= min;
-    } catch (final Exception e) {
-      return false;
+  public boolean validate(final Object value) {
+    if (value instanceof Double) {
+      try {
+        final double d = roundToPlace((Double) value, places);
+        return d <= max && d >= min;
+      } catch (final Exception e) {
+        log.log(Level.WARNING, "Error during evaluation", e);
+      }
     }
+    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -2,18 +2,14 @@ package games.strategy.engine.data.properties;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.logging.Level;
 
 import javax.swing.JComponent;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 
-import lombok.extern.java.Log;
-
 /**
  * Implementation of {@link IEditableProperty} for a double-precision floating-point value.
  */
-@Log
 public class DoubleProperty extends AbstractEditableProperty<Double> {
   private static final long serialVersionUID = 5521967819500867581L;
 
@@ -69,12 +65,8 @@ public class DoubleProperty extends AbstractEditableProperty<Double> {
   @Override
   public boolean validate(final Object value) {
     if (value instanceof Double) {
-      try {
-        final double d = roundToPlace((Double) value, places);
-        return d <= max && d >= min;
-      } catch (final Exception e) {
-        log.log(Level.WARNING, "Error during evaluation", e);
-      }
+      final double d = roundToPlace((Double) value, places);
+      return d <= max && d >= min;
     }
     return false;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -13,7 +13,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 /**
  * Implementation of {@link IEditableProperty} for a double-precision floating-point value.
  */
-public class DoubleProperty extends AbstractEditableProperty {
+public class DoubleProperty extends AbstractEditableProperty<Double> {
   private static final long serialVersionUID = 5521967819500867581L;
 
   private final double max;
@@ -48,15 +48,8 @@ public class DoubleProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
-    if (value instanceof String) {
-      // warn developer which have run with the option cache when Number properties were stored as strings
-      // todo (kg) remove at a later point
-      throw new RuntimeException("Double and Number properties are no longer stored as Strings. "
-          + "You should delete your option cache, located at "
-          + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
-    }
-    this.value = roundToPlace((Double) value, places, RoundingMode.FLOOR);
+  public void setValue(final Double value) {
+    this.value = roundToPlace(value, places, RoundingMode.FLOOR);
   }
 
   @Override
@@ -75,16 +68,12 @@ public class DoubleProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
-    if (value instanceof Double) {
-      final double d;
-      try {
-        d = roundToPlace((Double) value, places, RoundingMode.FLOOR);
-      } catch (final Exception e) {
-        return false;
-      }
+  public boolean validate(final Double value) {
+    try {
+      final double d = roundToPlace(value, places, RoundingMode.FLOOR);
       return d <= max && d >= min;
+    } catch (final Exception e) {
+      return false;
     }
-    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.data.properties;
 
 import java.awt.FileDialog;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
@@ -23,7 +24,7 @@ import games.strategy.engine.framework.system.SystemProperties;
  * change the file.
  * </p>
  */
-public class FileProperty extends AbstractEditableProperty {
+public class FileProperty extends AbstractEditableProperty<File> {
   private static final long serialVersionUID = 6826763550643504789L;
   private static final String[] defaultImageSuffixes = {"png", "jpg", "jpeg", "gif"};
 
@@ -52,7 +53,7 @@ public class FileProperty extends AbstractEditableProperty {
     this(name, description, file, defaultImageSuffixes);
   }
 
-  public FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes) {
+  private FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes) {
     super(name, description);
     this.file = getFileIfExists(file);
     this.acceptableSuffixes = acceptableSuffixes;
@@ -64,13 +65,13 @@ public class FileProperty extends AbstractEditableProperty {
    * @return The file associated with this property
    */
   @Override
-  public Object getValue() {
+  public File getValue() {
     return file;
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
-    file = (File) value;
+  public void setValue(final File value) {
+    file = value;
   }
 
   /**
@@ -87,7 +88,7 @@ public class FileProperty extends AbstractEditableProperty {
       label = new JTextField(file.getAbsolutePath());
     }
     label.setEditable(false);
-    label.addMouseListener(new MouseListener() {
+    label.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(final MouseEvent e) {
         final File selection = getFileUsingDialog(acceptableSuffixes);
@@ -98,18 +99,6 @@ public class FileProperty extends AbstractEditableProperty {
           SwingUtilities.invokeLater(label::repaint);
         }
       }
-
-      @Override
-      public void mouseEntered(final MouseEvent e) {}
-
-      @Override
-      public void mouseExited(final MouseEvent e) {}
-
-      @Override
-      public void mousePressed(final MouseEvent e) {}
-
-      @Override
-      public void mouseReleased(final MouseEvent e) {}
     });
     return label;
   }
@@ -170,13 +159,10 @@ public class FileProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
+  public boolean validate(final File value) {
     if (value == null) {
       return true;
     }
-    if (value instanceof File) {
-      return Arrays.stream(acceptableSuffixes).anyMatch(suffix -> ((File) value).getName().endsWith(suffix));
-    }
-    return false;
+    return Arrays.stream(acceptableSuffixes).anyMatch(suffix -> value.getName().endsWith(suffix));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -154,10 +154,13 @@ public class FileProperty extends AbstractEditableProperty<File> {
   }
 
   @Override
-  public boolean validate(final File value) {
+  public boolean validate(final Object value) {
     if (value == null) {
       return true;
     }
-    return Arrays.stream(acceptableSuffixes).anyMatch(suffix -> value.getName().endsWith(suffix));
+    if (value instanceof File) {
+      return Arrays.stream(acceptableSuffixes).anyMatch(suffix -> ((File) value).getName().endsWith(suffix));
+    }
+    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.properties;
 import java.awt.FileDialog;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
@@ -50,13 +49,9 @@ public class FileProperty extends AbstractEditableProperty<File> {
 
 
   public FileProperty(final String name, final String description, final File file) {
-    this(name, description, file, defaultImageSuffixes);
-  }
-
-  private FileProperty(final String name, final String description, final File file, final String[] acceptableSuffixes) {
     super(name, description);
     this.file = getFileIfExists(file);
-    this.acceptableSuffixes = acceptableSuffixes;
+    this.acceptableSuffixes = defaultImageSuffixes;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -195,7 +195,6 @@ public class GameProperties extends GameDataComponent {
     applyListToChangeProperties(editableProperties, gamePropertiesToBeChanged);
   }
 
-  @SuppressWarnings("unchecked")
   private static void applyListToChangeProperties(final List<IEditableProperty<?>> editableProperties,
       final GameProperties gamePropertiesToBeChanged) {
     if (editableProperties == null || editableProperties.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -170,13 +170,13 @@ public class GameProperties extends GameDataComponent {
    * @throws ClassCastException If {@code byteArray} contains an object other than a list of editable properties.
    */
   @SuppressWarnings("unchecked")
-  public static List<IEditableProperty<Object>> readEditableProperties(final byte[] bytes)
+  public static List<IEditableProperty<?>> readEditableProperties(final byte[] bytes)
       throws IOException, ClassCastException {
     return IoUtils.readFromMemory(bytes, is -> {
       try (InputStream bis = new BufferedInputStream(is);
           InputStream gzipis = new GZIPInputStream(bis);
           ObjectInputStream ois = new ObjectInputStream(gzipis)) {
-        return (List<IEditableProperty<Object>>) ois.readObject();
+        return (List<IEditableProperty<?>>) ois.readObject();
       } catch (final ClassNotFoundException e) {
         throw new IOException(e);
       }
@@ -185,7 +185,7 @@ public class GameProperties extends GameDataComponent {
 
   public static void applyByteMapToChangeProperties(final byte[] byteArray,
       final GameProperties gamePropertiesToBeChanged) {
-    List<IEditableProperty<Object>> editableProperties = null;
+    List<IEditableProperty<?>> editableProperties = null;
     try {
       editableProperties = readEditableProperties(byteArray);
     } catch (final ClassCastException | IOException e) {
@@ -196,19 +196,19 @@ public class GameProperties extends GameDataComponent {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> void applyListToChangeProperties(final List<IEditableProperty<T>> editableProperties,
+  private static void applyListToChangeProperties(final List<IEditableProperty<?>> editableProperties,
       final GameProperties gamePropertiesToBeChanged) {
     if (editableProperties == null || editableProperties.isEmpty()) {
       return;
     }
-    for (final IEditableProperty<T> prop : editableProperties) {
+    for (final IEditableProperty<?> prop : editableProperties) {
       if (prop == null || prop.getName() == null) {
         continue;
       }
-      final IEditableProperty<T> p = (IEditableProperty<T>) gamePropertiesToBeChanged.editableProperties
+      final IEditableProperty<?> p = gamePropertiesToBeChanged.editableProperties
           .get(prop.getName());
-      if (p != null && prop.getName().equals(p.getName()) && p.validate(prop.getValue())) {
-        p.setValue(prop.getValue());
+      if (p != null && prop.getName().equals(p.getName())) {
+        p.setValueIfValid(prop.getValue());
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -36,7 +36,7 @@ public class GameProperties extends GameDataComponent {
 
   // keep this in sync with the corresponding property, this name is used by reflection
   public static final String EDITABLE_PROPERTIES_FIELD_NAME = "editableProperties";
-  private final Map<String, IEditableProperty<Object>> editableProperties = new HashMap<>();
+  private final Map<String, IEditableProperty<?>> editableProperties = new HashMap<>();
 
   // This list is used to keep track of order properties were
   // added.
@@ -111,7 +111,7 @@ public class GameProperties extends GameDataComponent {
     return (String) value;
   }
 
-  public void addEditableProperty(final IEditableProperty<Object> property) {
+  public void addEditableProperty(final IEditableProperty<?> property) {
     // add to the editable properties
     editableProperties.put(property.getName(), property);
     ordering.add(property.getName());
@@ -122,8 +122,8 @@ public class GameProperties extends GameDataComponent {
    *
    * @return a list of IEditableProperty
    */
-  public List<IEditableProperty<Object>> getEditableProperties() {
-    final List<IEditableProperty<Object>> properties = new ArrayList<>();
+  public List<IEditableProperty<?>> getEditableProperties() {
+    final List<IEditableProperty<?>> properties = new ArrayList<>();
     for (final String propertyName : ordering) {
       if (editableProperties.containsKey(propertyName)) {
         properties.add(editableProperties.get(propertyName));

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -149,7 +149,8 @@ public class GameProperties extends GameDataComponent {
    *
    * @throws IOException If an I/O error occurs while writing the list of editable properties.
    */
-  public static byte[] writeEditableProperties(final List<? extends IEditableProperty<?>> editableProperties) throws IOException {
+  public static byte[] writeEditableProperties(final List<? extends IEditableProperty<?>> editableProperties)
+      throws IOException {
     return IoUtils.writeToMemory(os -> {
       try (OutputStream gzipos = new GZIPOutputStream(os);
           ObjectOutputStream oos = new ObjectOutputStream(gzipos)) {
@@ -204,7 +205,8 @@ public class GameProperties extends GameDataComponent {
       if (prop == null || prop.getName() == null) {
         continue;
       }
-      final IEditableProperty<T> p = (IEditableProperty<T>) gamePropertiesToBeChanged.editableProperties.get(prop.getName());
+      final IEditableProperty<T> p = (IEditableProperty<T>) gamePropertiesToBeChanged.editableProperties
+          .get(prop.getName());
       if (p != null && prop.getName().equals(p.getName()) && p.validate(prop.getValue())) {
         p.setValue(prop.getValue());
       }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -204,8 +204,7 @@ public class GameProperties extends GameDataComponent {
       if (prop == null || prop.getName() == null) {
         continue;
       }
-      final IEditableProperty<?> p = gamePropertiesToBeChanged.editableProperties
-          .get(prop.getName());
+      final IEditableProperty<?> p = gamePropertiesToBeChanged.editableProperties.get(prop.getName());
       if (p != null && prop.getName().equals(p.getName())) {
         p.setValueIfValid(prop.getValue());
       }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -52,9 +52,17 @@ public interface IEditableProperty<T> {
   int getRowsNeeded();
 
   @SuppressWarnings("unchecked")
-  default void setValueIfValid(final Object object) {
+  default boolean setValueIfValid(final Object object) {
     if (validate(object)) {
       setValue((T) object);
+      return true;
+    }
+    return false;
+  }
+
+  default void validateAndSet(final Object object) {
+    if (!setValueIfValid(object)) {
+      throw new IllegalStateException("Invalid value " + object + " for class " + getClass().getCanonicalName());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -51,6 +51,7 @@ public interface IEditableProperty<T> {
 
   int getRowsNeeded();
 
+  @SuppressWarnings("unchecked")
   default void setValueIfValid(final Object object) {
     if (validate(object)) {
       setValue((T) object);

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -62,7 +62,7 @@ public interface IEditableProperty<T> {
 
   default void validateAndSet(final Object object) {
     if (!setValueIfValid(object)) {
-      throw new IllegalStateException("Invalid value " + object + " for class " + getClass().getCanonicalName());
+      throw new IllegalArgumentException("Invalid value " + object + " for class " + getClass().getCanonicalName());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -4,6 +4,8 @@ import javax.swing.JComponent;
 
 /**
  * An editable property.
+ *
+ * @param <T> The generic Type of the value being stored.
  */
 public interface IEditableProperty<T> {
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -5,7 +5,7 @@ import javax.swing.JComponent;
 /**
  * An editable property.
  */
-public interface IEditableProperty {
+public interface IEditableProperty<T> {
   /**
    * get the name of the property.
    *
@@ -18,21 +18,19 @@ public interface IEditableProperty {
    *
    * @return the value
    */
-  Object getValue();
+  T getValue();
 
   /**
    * Indicates the object is a valid object for setting as our value.
    */
-  boolean validate(Object value);
+  boolean validate(T value);
 
   /**
    * Set the value of the property (programmatically), GUI would normally use the editor.
    *
    * @param value the new value
-   * @throws ClassCastException
-   *         if the type of value is wrong
    */
-  void setValue(Object value) throws ClassCastException;
+  void setValue(T value);
 
   /**
    * Returns the component used to edit this property.

--- a/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -25,7 +25,7 @@ public interface IEditableProperty<T> {
   /**
    * Indicates the object is a valid object for setting as our value.
    */
-  boolean validate(T value);
+  boolean validate(Object value);
 
   /**
    * Set the value of the property (programmatically), GUI would normally use the editor.
@@ -50,4 +50,10 @@ public interface IEditableProperty<T> {
   String getDescription();
 
   int getRowsNeeded();
+
+  default void setValueIfValid(final Object object) {
+    if (validate(object)) {
+      setValue((T) object);
+    }
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -86,10 +86,6 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
 
   @Override
   public boolean validate(final Object value) {
-    if (value == null) {
-      // is this ok? no idea, no maps or anything use this
-      return false;
-    }
     if (value instanceof Map) {
       try {
         @SuppressWarnings("unchecked")

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -119,7 +119,8 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
       } catch (final Exception e) {
         return false;
       }
+      return true;
     }
-    return true;
+    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -85,36 +85,40 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
   }
 
   @Override
-  public boolean validate(final Map<T, U> value) {
+  @SuppressWarnings("unchecked")
+  public boolean validate(final Object value) {
     if (value == null) {
       // is this ok? no idea, no maps or anything use this
       return false;
     }
-    try {
-      if (map != null && !map.isEmpty() && !value.isEmpty()) {
-        T key = null;
-        U val = null;
-        for (final Entry<T, U> entry : map.entrySet()) {
-          if (entry.getValue() != null && entry.getKey() != null) {
-            key = entry.getKey();
-            val = entry.getValue();
-            break;
+    if (value instanceof Map) {
+      final Map<T, U> test = (Map<T, U>) value;
+      try {
+        if (map != null && !map.isEmpty() && !test.isEmpty()) {
+          T key = null;
+          U val = null;
+          for (final Entry<T, U> entry : map.entrySet()) {
+            if (entry.getValue() != null && entry.getKey() != null) {
+              key = entry.getKey();
+              val = entry.getValue();
+              break;
+            }
           }
-        }
-        if (key != null) {
-          for (final Entry<T, U> entry : value.entrySet()) {
-            if (entry.getKey() != null && entry.getValue() != null
-                && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
-                    || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
-              return false;
+          if (key != null) {
+            for (final Entry<T, U> entry : test.entrySet()) {
+              if (entry.getKey() != null && entry.getValue() != null
+                  && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
+                  || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
+                return false;
+              }
             }
           }
         }
+        final List<IEditableProperty<U>> testProps = new ArrayList<>();
+        resetProperties(test, testProps, this.getName(), this.getDescription());
+      } catch (final Exception e) {
+        return false;
       }
-      final List<IEditableProperty<U>> testProps = new ArrayList<>();
-      resetProperties(value, testProps, this.getName(), this.getDescription());
-    } catch (final Exception e) {
-      return false;
     }
     return true;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -91,9 +91,9 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
       return false;
     }
     if (value instanceof Map) {
-      @SuppressWarnings("unchecked")
-      final Map<T, U> test = (Map<T, U>) value;
       try {
+        @SuppressWarnings("unchecked")
+        final Map<T, U> test = (Map<T, U>) value;
         if (map != null && !map.isEmpty() && !test.isEmpty()) {
           T key = null;
           U val = null;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -85,13 +85,13 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public boolean validate(final Object value) {
     if (value == null) {
       // is this ok? no idea, no maps or anything use this
       return false;
     }
     if (value instanceof Map) {
+      @SuppressWarnings("unchecked")
       final Map<T, U> test = (Map<T, U>) value;
       try {
         if (map != null && !map.isEmpty() && !test.isEmpty()) {
@@ -108,7 +108,7 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
             for (final Entry<T, U> entry : test.entrySet()) {
               if (entry.getKey() != null && entry.getValue() != null
                   && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
-                  || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
+                      || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
                 return false;
               }
             }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -16,11 +16,11 @@ import javax.swing.JComponent;
  * @param <T> String or something with a valid toString()
  * @param <U> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
-public class MapProperty<T, U> extends AbstractEditableProperty {
+public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
   private static final long serialVersionUID = -8021039503574228146L;
 
   private Map<T, U> map;
-  final List<IEditableProperty> properties = new ArrayList<>();
+  final List<IEditableProperty<U>> properties = new ArrayList<>();
 
   public MapProperty(final String name, final String description, final Map<T, U> map) {
     super(name, description);
@@ -29,26 +29,28 @@ public class MapProperty<T, U> extends AbstractEditableProperty {
   }
 
   @SuppressWarnings("unchecked")
-  private void resetProperties(final Map<T, U> map, final List<IEditableProperty> properties, final String name,
+  private void resetProperties(final Map<T, U> map, final List<IEditableProperty<U>> properties, final String name,
       final String description) {
     properties.clear();
     for (final Entry<T, U> entry : map.entrySet()) {
       final String key = (String) entry.getKey();
       final U value = entry.getValue();
       if (value instanceof Boolean) {
-        properties.add(new BooleanProperty(key, description, ((Boolean) value)));
+        properties.add((IEditableProperty<U>) new BooleanProperty(key, description, ((Boolean) value)));
       } else if (value instanceof Color) {
-        properties.add(new ColorProperty(key, description, ((Color) value)));
+        properties.add((IEditableProperty<U>) new ColorProperty(key, description, ((Color) value)));
       } else if (value instanceof File) {
-        properties.add(new FileProperty(key, description, ((File) value)));
+        properties.add((IEditableProperty<U>) new FileProperty(key, description, ((File) value)));
       } else if (value instanceof String) {
-        properties.add(new StringProperty(key, description, ((String) value)));
+        properties.add((IEditableProperty<U>) new StringProperty(key, description, ((String) value)));
       } else if (value instanceof Collection) {
-        properties.add(new CollectionProperty<>(name, description, ((Collection<U>) value)));
+        properties.add((IEditableProperty<U>) new CollectionProperty<>(name, description, ((Collection<U>) value)));
       } else if (value instanceof Integer) {
-        properties.add(new NumberProperty(key, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) value)));
+        properties.add((IEditableProperty<U>) new NumberProperty(key, description,
+            Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) value)));
       } else if (value instanceof Double) {
-        properties.add(new DoubleProperty(key, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) value), 5));
+        properties.add((IEditableProperty<U>) new DoubleProperty(key, description,
+            Double.MAX_VALUE, Double.MIN_VALUE, ((Double) value), 5));
       } else {
         throw new IllegalArgumentException(
             "Cannot instantiate MapProperty with: " + value.getClass().getCanonicalName());
@@ -62,14 +64,13 @@ public class MapProperty<T, U> extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public Map<T, U> getValue() {
     return map;
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public void setValue(final Object value) throws ClassCastException {
-    map = (Map<T, U>) value;
+  public void setValue(final Map<T, U> value) {
+    map = value;
     resetProperties(map, properties, this.getName(), this.getDescription());
   }
 
@@ -84,42 +85,37 @@ public class MapProperty<T, U> extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
+  public boolean validate(final Map<T, U> value) {
     if (value == null) {
       // is this ok? no idea, no maps or anything use this
       return false;
     }
-    if (Map.class.isAssignableFrom(value.getClass())) {
-      try {
-        @SuppressWarnings("unchecked")
-        final Map<T, U> test = (Map<T, U>) value;
-        if (map != null && !map.isEmpty() && !test.isEmpty()) {
-          T key = null;
-          U val = null;
-          for (final Entry<T, U> entry : map.entrySet()) {
-            if (entry.getValue() != null && entry.getKey() != null) {
-              key = entry.getKey();
-              val = entry.getValue();
-              break;
-            }
+    try {
+      if (map != null && !map.isEmpty() && !value.isEmpty()) {
+        T key = null;
+        U val = null;
+        for (final Entry<T, U> entry : map.entrySet()) {
+          if (entry.getValue() != null && entry.getKey() != null) {
+            key = entry.getKey();
+            val = entry.getValue();
+            break;
           }
-          if (key != null) {
-            for (final Entry<T, U> entry : test.entrySet()) {
-              if (entry.getKey() != null && entry.getValue() != null
-                  && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
-                      || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
-                return false;
-              }
+        }
+        if (key != null) {
+          for (final Entry<T, U> entry : value.entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null
+                && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
+                    || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
+              return false;
             }
           }
         }
-        final List<IEditableProperty> testProps = new ArrayList<>();
-        resetProperties(test, testProps, this.getName(), this.getDescription());
-      } catch (final Exception e) {
-        return false;
       }
-      return true;
+      final List<IEditableProperty<U>> testProps = new ArrayList<>();
+      resetProperties(value, testProps, this.getName(), this.getDescription());
+    } catch (final Exception e) {
+      return false;
     }
-    return false;
+    return true;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -52,7 +52,11 @@ public class NumberProperty extends AbstractEditableProperty<Integer> {
   }
 
   @Override
-  public boolean validate(final Integer value) {
-    return value <= max && value >= min;
+  public boolean validate(final Object value) {
+    if (value instanceof Integer) {
+      final int i = (int) value;
+      return i <= max && i >= min;
+    }
+    return false;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -1,24 +1,20 @@
 package games.strategy.engine.data.properties;
 
-import java.io.File;
-
 import javax.swing.JComponent;
 
-import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.ui.IntTextField;
 
 /**
  * Implementation of {@link IEditableProperty} for an integer value.
  */
-public class NumberProperty extends AbstractEditableProperty {
-  // compatible with 0.9.0.2 saved games
+public class NumberProperty extends AbstractEditableProperty<Integer> {
   private static final long serialVersionUID = 6826763550643504789L;
 
-  // Keep this in sync with the matchin property name, used by reflection.
+  // Keep this in sync with the matching property name, used by reflection.
   public static final String MAX_PROPERTY_NAME = "max";
   private final int max;
 
-  // Keep this in sync with the matchin property name, used by reflection.
+  // Keep this in sync with the matching property name, used by reflection.
   public static final String MIN_PROPERTY_NAME = "min";
   private final int min;
 
@@ -43,15 +39,8 @@ public class NumberProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
-    if (value instanceof String) {
-      // warn developer which have run with the option cache when Number properties were stored as strings
-      // todo (kg) remove at a later point
-      throw new RuntimeException(
-          "Number properties are no longer stored as Strings. You should delete your option cache, located at "
-              + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
-    }
-    this.value = (Integer) value;
+  public void setValue(final Integer value) {
+    this.value = value;
   }
 
   @Override
@@ -63,11 +52,7 @@ public class NumberProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
-    if (value instanceof Integer) {
-      final int i = (int) value;
-      return i <= max && i >= min;
-    }
-    return false;
+  public boolean validate(final Integer value) {
+    return value <= max && value >= min;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/PropertiesUi.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/PropertiesUi.java
@@ -21,9 +21,9 @@ public class PropertiesUi extends JPanel {
     this(gameProperties.getEditableProperties(), editable);
   }
 
-  public PropertiesUi(final List<? extends IEditableProperty> properties, final boolean editable) {
+  public PropertiesUi(final List<? extends IEditableProperty<?>> properties, final boolean editable) {
     init();
-    for (final IEditableProperty property : properties) {
+    for (final IEditableProperty<?> property : properties) {
       // Limit it to 14 rows then start a new column
       // Don't know if this is the most elegant solution, but it works.
       if (nextRow >= 15) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -50,7 +50,7 @@ public class StringProperty extends AbstractEditableProperty<String> {
   }
 
   @Override
-  public boolean validate(final String value) {
-    return true;
+  public boolean validate(final Object value) {
+    return value == null || value instanceof String;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -10,7 +10,7 @@ import javax.swing.JTextField;
 /**
  * A string property with a simple text field editor.
  */
-public class StringProperty extends AbstractEditableProperty {
+public class StringProperty extends AbstractEditableProperty<String> {
   private static final long serialVersionUID = 4382624884674152208L;
 
   private String value;
@@ -40,17 +40,17 @@ public class StringProperty extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public String getValue() {
     return value;
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
-    this.value = (String) value;
+  public void setValue(final String value) {
+    this.value = value;
   }
 
   @Override
-  public boolean validate(final Object value) {
-    return value == null || value instanceof String;
+  public boolean validate(final String value) {
+    return true;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
@@ -39,7 +39,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       return;
     }
     try {
-      final List<IEditableProperty<Object>> properties = GameProperties.readEditableProperties(oldBytes);
+      final List<IEditableProperty<?>> properties = GameProperties.readEditableProperties(oldBytes);
       final PropertiesUi pui = new PropertiesUi(properties, true);
       final JScrollPane scroll = new JScrollPane(pui);
       scroll.setBorder(null);

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
@@ -39,7 +39,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       return;
     }
     try {
-      final List<IEditableProperty> properties = GameProperties.readEditableProperties(oldBytes);
+      final List<IEditableProperty<Object>> properties = GameProperties.readEditableProperties(oldBytes);
       final PropertiesUi pui = new PropertiesUi(properties, true);
       final JScrollPane scroll = new JScrollPane(pui);
       scroll.setBorder(null);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -338,7 +338,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           || data.getProperties().getEditableProperties().isEmpty()) {
         return null;
       }
-      final List<IEditableProperty<Object>> currentEditableProperties = data.getProperties().getEditableProperties();
+      final List<IEditableProperty<?>> currentEditableProperties = data.getProperties().getEditableProperties();
 
       try {
         return GameProperties.writeEditableProperties(currentEditableProperties);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -338,7 +338,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           || data.getProperties().getEditableProperties().isEmpty()) {
         return null;
       }
-      final List<IEditableProperty> currentEditableProperties = data.getProperties().getEditableProperties();
+      final List<IEditableProperty<Object>> currentEditableProperties = data.getProperties().getEditableProperties();
 
       try {
         return GameProperties.writeEditableProperties(currentEditableProperties);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -68,10 +68,10 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
         try (InputStream is = new FileInputStream(cache);
             ObjectInputStream in = new ObjectInputStream(is)) {
           final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
-          for (final IEditableProperty<Object> property : gameData.getProperties().getEditableProperties()) {
+          for (final IEditableProperty<?> property : gameData.getProperties().getEditableProperties()) {
             final Serializable ser = serializedMap.get(property.getName());
             if (ser != null) {
-              property.setValue(ser);
+              property.setValueIfValid(ser);
             }
           }
         }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -38,7 +38,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   @Override
   public void cacheGameProperties(final GameData gameData) {
     final Map<String, Object> serializableMap = new HashMap<>();
-    for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
+    for (final IEditableProperty<?> property : gameData.getProperties().getEditableProperties()) {
       if (property.getValue() instanceof Serializable) {
         serializableMap.put(property.getName(), property.getValue());
       }
@@ -68,7 +68,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
         try (InputStream is = new FileInputStream(cache);
             ObjectInputStream in = new ObjectInputStream(is)) {
           final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
-          for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
+          for (final IEditableProperty<Object> property : gameData.getProperties().getEditableProperties()) {
             final Serializable ser = serializedMap.get(property.getName());
             if (ser != null) {
               property.setValue(ser);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -71,7 +71,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
           for (final IEditableProperty<?> property : gameData.getProperties().getEditableProperties()) {
             final Serializable ser = serializedMap.get(property.getName());
             if (ser != null) {
-              property.setValueIfValid(ser);
+              property.validateAndSet(ser);
             }
           }
         }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -181,7 +181,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
   private void setOriginalPropertiesMap(final GameData data) {
     originalPropertiesMap.clear();
     if (data != null) {
-      for (final IEditableProperty property : data.getProperties().getEditableProperties()) {
+      for (final IEditableProperty<?> property : data.getProperties().getEditableProperties()) {
         originalPropertiesMap.put(property.getName(), property.getValue());
       }
     }
@@ -190,7 +190,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
   private void selectGameOptions() {
     // backup current game properties before showing dialog
     final Map<String, Object> currentPropertiesMap = new HashMap<>();
-    for (final IEditableProperty property : model.getGameData().getProperties().getEditableProperties()) {
+    for (final IEditableProperty<?> property : model.getGameData().getProperties().getEditableProperties()) {
       currentPropertiesMap.put(property.getName(), property.getValue());
     }
     final PropertiesUi panel = new PropertiesUi(model.getGameData().getProperties(), true);
@@ -208,13 +208,13 @@ public class GameSelectorPanel extends JPanel implements Observer {
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {
       // restore properties, if cancel was pressed, or window was closed
-      for (final IEditableProperty property : model.getGameData().getProperties().getEditableProperties()) {
+      for (final IEditableProperty<Object> property : model.getGameData().getProperties().getEditableProperties()) {
         property.setValue(currentPropertiesMap.get(property.getName()));
       }
     } else if (buttonPressed.equals(reset)) {
       if (!originalPropertiesMap.isEmpty()) {
         // restore properties, if cancel was pressed, or window was closed
-        for (final IEditableProperty property : model.getGameData().getProperties().getEditableProperties()) {
+        for (final IEditableProperty<Object> property : model.getGameData().getProperties().getEditableProperties()) {
           property.setValue(originalPropertiesMap.get(property.getName()));
         }
         selectGameOptions();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -208,14 +208,14 @@ public class GameSelectorPanel extends JPanel implements Observer {
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {
       // restore properties, if cancel was pressed, or window was closed
-      for (final IEditableProperty<Object> property : model.getGameData().getProperties().getEditableProperties()) {
-        property.setValue(currentPropertiesMap.get(property.getName()));
+      for (final IEditableProperty<?> property : model.getGameData().getProperties().getEditableProperties()) {
+        property.setValueIfValid(currentPropertiesMap.get(property.getName()));
       }
     } else if (buttonPressed.equals(reset)) {
       if (!originalPropertiesMap.isEmpty()) {
         // restore properties, if cancel was pressed, or window was closed
-        for (final IEditableProperty<Object> property : model.getGameData().getProperties().getEditableProperties()) {
-          property.setValue(originalPropertiesMap.get(property.getName()));
+        for (final IEditableProperty<?> property : model.getGameData().getProperties().getEditableProperties()) {
+          property.setValueIfValid(originalPropertiesMap.get(property.getName()));
         }
         selectGameOptions();
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -209,13 +209,13 @@ public class GameSelectorPanel extends JPanel implements Observer {
     if (buttonPressed == null || buttonPressed.equals(cancel)) {
       // restore properties, if cancel was pressed, or window was closed
       for (final IEditableProperty<?> property : model.getGameData().getProperties().getEditableProperties()) {
-        property.setValueIfValid(currentPropertiesMap.get(property.getName()));
+        property.validateAndSet(currentPropertiesMap.get(property.getName()));
       }
     } else if (buttonPressed.equals(reset)) {
       if (!originalPropertiesMap.isEmpty()) {
         // restore properties, if cancel was pressed, or window was closed
         for (final IEditableProperty<?> property : model.getGameData().getProperties().getEditableProperties()) {
-          property.setValueIfValid(originalPropertiesMap.get(property.getName()));
+          property.validateAndSet(originalPropertiesMap.get(property.getName()));
         }
         selectGameOptions();
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -26,14 +26,14 @@ public class PropertiesSelector {
    * @return pressed button
    */
   public static Object getButton(final JComponent parent, final String title,
-      final List<IEditableProperty> properties, final Object... buttonOptions) {
+      final List<? extends IEditableProperty<?>> properties, final Object... buttonOptions) {
     final Supplier<Object> action = () -> showDialog(parent, title, properties, buttonOptions);
     return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action)).result
         .orElse(JOptionPane.UNINITIALIZED_VALUE);
   }
 
   private static Object showDialog(final JComponent parent, final String title,
-      final List<IEditableProperty> properties, final Object... buttonOptions) {
+      final List<? extends IEditableProperty<?>> properties, final Object... buttonOptions) {
     final PropertiesUi panel = new PropertiesUi(properties, true);
     final JScrollPane scroll = new JScrollPane(panel);
     scroll.setBorder(null);

--- a/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
@@ -7,7 +7,7 @@ import games.strategy.engine.data.properties.BooleanProperty;
  */
 class SoundOptionCheckBox extends BooleanProperty {
   private static final long serialVersionUID = 5774074488487286103L;
-  final String clipName;
+  private final String clipName;
 
   /**
    * Initializes a new instance of the SoundOptionsCheckBox class.
@@ -15,7 +15,7 @@ class SoundOptionCheckBox extends BooleanProperty {
    * @param clipName sound file name.
    * @param title title to display
    */
-  public SoundOptionCheckBox(final String clipName, final String title) {
+  SoundOptionCheckBox(final String clipName, final String title) {
     super(title, null, true);
     if (ClipPlayer.getInstance().isMuted(clipName)) {
       setValue(false);
@@ -23,7 +23,7 @@ class SoundOptionCheckBox extends BooleanProperty {
     this.clipName = clipName;
   }
 
-  public String getClipName() {
+  String getClipName() {
     return clipName;
   }
 }

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -8,7 +8,6 @@ import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
-import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.framework.ui.PropertiesSelector;
 
 /**

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -35,27 +35,27 @@ public final class SoundOptions {
     final String selectAll = "All";
     final String selectNone = "None";
 
-    final List<IEditableProperty> properties = SoundPath.getSoundOptions();
+    final List<SoundOptionCheckBox> properties = SoundPath.getSoundOptions();
     final Object pressedButton = PropertiesSelector.getButton(parent, "Sound Options", properties,
         ok, selectAll, selectNone, cancel);
     if (pressedButton == null || pressedButton.equals(cancel)) {
       return;
     }
     if (pressedButton.equals(ok)) {
-      for (final IEditableProperty property : properties) {
-        clipPlayer.setMute(((SoundOptionCheckBox) property).getClipName(), !(Boolean) property.getValue());
+      for (final SoundOptionCheckBox property : properties) {
+        clipPlayer.setMute(property.getClipName(), !(Boolean) property.getValue());
       }
       clipPlayer.saveSoundPreferences();
     } else if (pressedButton.equals(selectAll)) {
-      for (final IEditableProperty property : properties) {
+      for (final SoundOptionCheckBox property : properties) {
         property.setValue(true);
-        clipPlayer.setMute(((SoundOptionCheckBox) property).getClipName(), false);
+        clipPlayer.setMute(property.getClipName(), false);
       }
       clipPlayer.saveSoundPreferences();
     } else if (pressedButton.equals(selectNone)) {
-      for (final IEditableProperty property : properties) {
+      for (final SoundOptionCheckBox property : properties) {
         property.setValue(false);
-        clipPlayer.setMute(((SoundOptionCheckBox) property).getClipName(), true);
+        clipPlayer.setMute(property.getClipName(), true);
       }
       clipPlayer.saveSoundPreferences();
     }

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -42,7 +42,7 @@ public final class SoundOptions {
     }
     if (pressedButton.equals(ok)) {
       for (final SoundOptionCheckBox property : properties) {
-        clipPlayer.setMute(property.getClipName(), !(Boolean) property.getValue());
+        clipPlayer.setMute(property.getClipName(), !property.getValue());
       }
       clipPlayer.saveSoundPreferences();
     } else if (pressedButton.equals(selectAll)) {

--- a/game-core/src/main/java/games/strategy/sound/SoundPath.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundPath.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import games.strategy.engine.data.properties.IEditableProperty;
-
 /**
  * Contains the sound file names and the directory of all sound files.
  */
@@ -140,7 +138,7 @@ public class SoundPath {
     return soundOptions;
   }
 
-  static List<IEditableProperty> getSoundOptions() {
+  static List<SoundOptionCheckBox> getSoundOptions() {
     return getAllSoundOptionsWithDescription().entrySet().stream()
         .map(e -> new SoundOptionCheckBox(e.getKey(), e.getValue()))
         .collect(Collectors.toList());

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -441,13 +441,13 @@ final class ViewMenu extends JMenu {
         frame.getMapPanel().resetMap();
       } else if (result == 0) {
         MapImage.setPropertyMapFont(new Font("Ariel", Font.BOLD, fontsize.getValue()));
-        MapImage.setPropertyTerritoryNameAndPuAndCommentColor((Color) territoryNameColor.getValue());
-        MapImage.setPropertyUnitCountColor((Color) unitCountColor.getValue());
-        MapImage.setPropertyUnitCountOutline((Color) unitCountOutline.getValue());
-        MapImage.setPropertyUnitFactoryDamageColor((Color) factoryDamageColor.getValue());
-        MapImage.setPropertyUnitFactoryDamageOutline((Color) factoryDamageOutline.getValue());
-        MapImage.setPropertyUnitHitDamageColor((Color) hitDamageColor.getValue());
-        MapImage.setPropertyUnitHitDamageOutline((Color) hitDamageOutline.getValue());
+        MapImage.setPropertyTerritoryNameAndPuAndCommentColor(territoryNameColor.getValue());
+        MapImage.setPropertyUnitCountColor(unitCountColor.getValue());
+        MapImage.setPropertyUnitCountOutline(unitCountOutline.getValue());
+        MapImage.setPropertyUnitFactoryDamageColor(factoryDamageColor.getValue());
+        MapImage.setPropertyUnitFactoryDamageOutline(factoryDamageOutline.getValue());
+        MapImage.setPropertyUnitHitDamageColor(hitDamageColor.getValue());
+        MapImage.setPropertyUnitHitDamageOutline(hitDamageOutline.getValue());
         frame.getMapPanel().resetMap();
       }
     });

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -390,7 +390,7 @@ final class ViewMenu extends JMenu {
 
   private void addMapFontAndColorEditorMenu() {
     final Action mapFontOptions = SwingAction.of("Edit Map Font and Color", e -> {
-      final List<IEditableProperty> properties = new ArrayList<>();
+      final List<IEditableProperty<?>> properties = new ArrayList<>();
       final NumberProperty fontsize =
           new NumberProperty("Font Size", null, 60, 0, MapImage.getPropertyMapFont().getSize());
       final ColorProperty territoryNameColor = new ColorProperty("Territory Name and PU Color", null,

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.ui.menubar;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;

--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -152,7 +152,7 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
   }
 
   @Override
-  public boolean validate(final T value) {
+  public boolean validate(final Object value) {
     return property.validate(value);
   }
 

--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -51,29 +51,29 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
     super(name, description);
     this.setter = setter;
 
+    final IEditableProperty<?> property;
 
     if (defaultValue instanceof Boolean) {
-      property = (IEditableProperty<T>) new BooleanProperty(name, description, ((Boolean) defaultValue));
+      property = new BooleanProperty(name, description, ((Boolean) defaultValue));
     } else if (defaultValue instanceof Color) {
-      property = (IEditableProperty<T>) new ColorProperty(name, description, ((Color) defaultValue));
+      property = new ColorProperty(name, description, ((Color) defaultValue));
     } else if (defaultValue instanceof File) {
-      property = (IEditableProperty<T>) new FileProperty(name, description, ((File) defaultValue));
+      property = new FileProperty(name, description, ((File) defaultValue));
     } else if (defaultValue instanceof String) {
-      property = (IEditableProperty<T>) new StringProperty(name, description, ((String) defaultValue));
+      property = new StringProperty(name, description, ((String) defaultValue));
     } else if (defaultValue instanceof Collection) {
-      property = (IEditableProperty<T>) new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
+      property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
     } else if (defaultValue instanceof Map) {
-      property = (IEditableProperty<T>) new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
+      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
     } else if (defaultValue instanceof Integer) {
-      property = (IEditableProperty<T>) new NumberProperty(name, description,
-          Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
+      property = new NumberProperty(name, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
     } else if (defaultValue instanceof Double) {
-      property = (IEditableProperty<T>) new DoubleProperty(name, description,
-          Double.MAX_VALUE, Double.MIN_VALUE, ((Double) defaultValue), 5);
+      property = new DoubleProperty(name, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) defaultValue), 5);
     } else {
       throw new IllegalArgumentException(
           "Cannot instantiate PropertyWrapper with: " + defaultValue.getClass().getCanonicalName());
     }
+    this.property = (IEditableProperty<T>) property;
   }
 
   @Override

--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -40,38 +40,36 @@ import lombok.extern.java.Log;
  * @param <T> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
 @Log
-public class MapPropertyWrapper<T> extends AbstractEditableProperty {
+public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
   private static final long serialVersionUID = 6406798101396215624L;
-  private final IEditableProperty property;
+  private final IEditableProperty<T> property;
   private final Method setter;
 
-  // TODO: remove the `getter` field when we can, kept around for serialization compatibility
-  @SuppressWarnings("unused")
-  private final Method getter = null;
 
+  @SuppressWarnings("unchecked")
   private MapPropertyWrapper(final String name, final String description, final T defaultValue, final Method setter) {
     super(name, description);
     this.setter = setter;
 
 
     if (defaultValue instanceof Boolean) {
-      property = new BooleanProperty(name, description, ((Boolean) defaultValue));
+      property = (IEditableProperty<T>) new BooleanProperty(name, description, ((Boolean) defaultValue));
     } else if (defaultValue instanceof Color) {
-      property = new ColorProperty(name, description, ((Color) defaultValue));
+      property = (IEditableProperty<T>) new ColorProperty(name, description, ((Color) defaultValue));
     } else if (defaultValue instanceof File) {
-      property = new FileProperty(name, description, ((File) defaultValue));
+      property = (IEditableProperty<T>) new FileProperty(name, description, ((File) defaultValue));
     } else if (defaultValue instanceof String) {
-      property = new StringProperty(name, description, ((String) defaultValue));
+      property = (IEditableProperty<T>) new StringProperty(name, description, ((String) defaultValue));
     } else if (defaultValue instanceof Collection) {
-      property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
+      property = (IEditableProperty<T>) new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
     } else if (defaultValue instanceof Map) {
-      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
+      property = (IEditableProperty<T>) new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
     } else if (defaultValue instanceof Integer) {
-      property =
-          new NumberProperty(name, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
+      property = (IEditableProperty<T>) new NumberProperty(name, description,
+          Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
     } else if (defaultValue instanceof Double) {
-      property =
-          new DoubleProperty(name, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) defaultValue), 5);
+      property = (IEditableProperty<T>) new DoubleProperty(name, description,
+          Double.MAX_VALUE, Double.MIN_VALUE, ((Double) defaultValue), 5);
     } else {
       throw new IllegalArgumentException(
           "Cannot instantiate PropertyWrapper with: " + defaultValue.getClass().getCanonicalName());
@@ -84,12 +82,12 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public Object getValue() {
+  public T getValue() {
     return property.getValue();
   }
 
   @Override
-  public void setValue(final Object value) throws ClassCastException {
+  public void setValue(final T value) {
     property.setValue(value);
   }
 
@@ -154,7 +152,7 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty {
   }
 
   @Override
-  public boolean validate(final Object value) {
+  public boolean validate(final T value) {
     return property.validate(value);
   }
 

--- a/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
@@ -14,13 +14,13 @@ final class GamePropertiesTest {
   final class ReadWriteEditablePropertiesTest {
     @Test
     void shouldBeAbleToRoundTripEditableProperties() throws Exception {
-      final List<IEditableProperty> expected = Arrays.asList(
+      final List<StringProperty> expected = Arrays.asList(
           new StringProperty("name1", "description1", "value1"),
           new StringProperty("name2", "description2", "value2"),
           new StringProperty("name3", "description3", "value3"));
 
       final byte[] bytes = GameProperties.writeEditableProperties(expected);
-      final List<IEditableProperty> actual = GameProperties.readEditableProperties(bytes);
+      final List<IEditableProperty<Object>> actual = GameProperties.readEditableProperties(bytes);
 
       assertThat(actual, is(expected));
     }

--- a/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
@@ -20,7 +20,7 @@ final class GamePropertiesTest {
           new StringProperty("name3", "description3", "value3"));
 
       final byte[] bytes = GameProperties.writeEditableProperties(expected);
-      final List<IEditableProperty<Object>> actual = GameProperties.readEditableProperties(bytes);
+      final List<IEditableProperty<?>> actual = GameProperties.readEditableProperties(bytes);
 
       assertThat(actual, is(expected));
     }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -439,7 +439,7 @@ public final class GameDataTestUtil {
   }
 
   static void setSelectAaCasualties(final GameData data, final boolean val) {
-    for (final IEditableProperty property : data.getProperties().getEditableProperties()) {
+    for (final IEditableProperty<?> property : data.getProperties().getEditableProperties()) {
       if (property.getName().equals(Constants.CHOOSE_AA)) {
         ((BooleanProperty) property).setValue(val);
         return;
@@ -449,7 +449,7 @@ public final class GameDataTestUtil {
   }
 
   static void makeGameLowLuck(final GameData data) {
-    for (final IEditableProperty property : data.getProperties().getEditableProperties()) {
+    for (final IEditableProperty<?> property : data.getProperties().getEditableProperties()) {
       if (property.getName().equals(Constants.LOW_LUCK)) {
         ((BooleanProperty) property).setValue(true);
         return;


### PR DESCRIPTION
## Overview
As announced in #4280 this PR adds a generic type parameter for IEditableProperty subclasses and the interface itself in order to avoid boilerplate code that casts types around.
There are some places where this turned out better than on other places, so don't hesitate to tell me about your suggestions, there are a some unchecked casts left that are not really avoidable in my opinion.

## Functional Changes
None.

## Manual Testing Performed
I verified I could play a normal game without any ClassCastExceptions.