### PR TITLE
Rocket fixes

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -76,7 +76,6 @@ public interface Constants {
   String ROLL_AA_INDIVIDUALLY = "Roll AA Individually";
   String LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION = "Limit SBR Damage To Factory Production";
   String SBR_VICTORY_POINTS = "SBR Victory Points";
-  String ROCKET_ATTACKS_PER_FACTORY_INFINITE = "Rocket Attacks Per Factory Infinite";
   String LIMIT_SBR_DAMAGE_PER_TURN = "Limit SBR Damage Per Turn";
   String LIMIT_ROCKET_DAMAGE_PER_TURN = "Limit Rocket Damage Per Turn";
   String ALLIED_AIR_INDEPENDENT = "Allied Air Independent";

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -63,6 +63,10 @@ public final class Properties implements Constants {
     return data.getProperties().get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
   }
 
+  public static boolean getStrictRockets(final GameData data) {
+    return data.getProperties().get("Strictly rule compliant rockets", false);
+  }
+
   /*
    * Pacific Theater
    */
@@ -178,13 +182,6 @@ public final class Properties implements Constants {
    */
   public static boolean getSbrVictoryPoints(final GameData data) {
     return data.getProperties().get(SBR_VICTORY_POINTS, false);
-  }
-
-  /**
-   * Allow x rocket attack(s) per defending factory.
-   */
-  public static boolean getRocketAttacksPerFactoryInfinite(final GameData data) {
-    return data.getProperties().get(ROCKET_ATTACKS_PER_FACTORY_INFINITE, false);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -80,7 +80,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private int warBondDiceNumber = 0;
   private IntegerMap<UnitType> rocketDiceNumber = new IntegerMap<>();
   private int rocketDistance = 0;
-  private int rocketNumberPerTerritory = 0;
+  private int rocketNumberPerTerritory = 1;
   private Map<UnitType, Set<String>> unitAbilitiesGained = new HashMap<>();
   private boolean airborneForces = false;
   private IntegerMap<UnitType> airborneCapacity = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -67,6 +67,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private boolean needToRecordBattleStatistics = true;
   private boolean needToCheckDefendingPlanesCanLand = true;
   private boolean needToCleanup = true;
+  private boolean needToCreateRockets = true;
+  private boolean needToFireRockets = true;
+  private RocketsFireHelper rocketHelper;
   private IBattle currentBattle = null;
 
   @Override
@@ -89,6 +92,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       doScrambling();
       needToScramble = false;
     }
+    if (needToCreateRockets) {
+      rocketHelper = new RocketsFireHelper(bridge, getData(), bridge.getPlayerId());
+      needToCreateRockets = false;
+    }
     if (needToKamikazeSuicideAttacks) {
       doKamikazeSuicideAttacks();
       needToKamikazeSuicideAttacks = false;
@@ -102,6 +109,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       needToAddBombardmentSources = false;
     }
     battleTracker.fightAirRaidsAndStrategicBombing(bridge);
+    if (needToFireRockets) {
+      rocketHelper.fireRockets();
+      needToFireRockets = false;
+    }
     battleTracker.fightDefenselessBattles(bridge);
     battleTracker.fightBattleIfOnlyOne(bridge);
   }
@@ -138,16 +149,18 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final BattleExtendedDelegateState state = new BattleExtendedDelegateState();
     state.superState = super.saveState();
     // add other variables to state here:
-    state.m_battleTracker = battleTracker;
-    state.m_needToInitialize = needToInitialize;
-    state.m_needToScramble = needToScramble;
-    state.m_needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
-    state.m_needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
-    state.m_needToAddBombardmentSources = needToAddBombardmentSources;
-    state.m_needToRecordBattleStatistics = needToRecordBattleStatistics;
-    state.m_needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
-    state.m_needToCleanup = needToCleanup;
-    state.m_currentBattle = currentBattle;
+    state.battleTracker = battleTracker;
+    state.needToInitialize = needToInitialize;
+    state.needToScramble = needToScramble;
+    state.needToCreateRockets = needToCreateRockets;
+    state.needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
+    state.needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
+    state.needToAddBombardmentSources = needToAddBombardmentSources;
+    state.needToFireRockets = needToFireRockets;
+    state.needToRecordBattleStatistics = needToRecordBattleStatistics;
+    state.needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
+    state.needToCleanup = needToCleanup;
+    state.currentBattle = currentBattle;
     return state;
   }
 
@@ -155,16 +168,18 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   public void loadState(final Serializable state) {
     final BattleExtendedDelegateState s = (BattleExtendedDelegateState) state;
     super.loadState(s.superState);
-    battleTracker = s.m_battleTracker;
-    needToInitialize = s.m_needToInitialize;
-    needToScramble = s.m_needToScramble;
-    needToKamikazeSuicideAttacks = s.m_needToKamikazeSuicideAttacks;
-    needToClearEmptyAirBattleAttacks = s.m_needToClearEmptyAirBattleAttacks;
-    needToAddBombardmentSources = s.m_needToAddBombardmentSources;
-    needToRecordBattleStatistics = s.m_needToRecordBattleStatistics;
-    needToCheckDefendingPlanesCanLand = s.m_needToCheckDefendingPlanesCanLand;
-    needToCleanup = s.m_needToCleanup;
-    currentBattle = s.m_currentBattle;
+    battleTracker = s.battleTracker;
+    needToInitialize = s.needToInitialize;
+    needToScramble = s.needToScramble;
+    needToCreateRockets = s.needToCreateRockets;
+    needToKamikazeSuicideAttacks = s.needToKamikazeSuicideAttacks;
+    needToClearEmptyAirBattleAttacks = s.needToClearEmptyAirBattleAttacks;
+    needToAddBombardmentSources = s.needToAddBombardmentSources;
+    needToFireRockets = s.needToFireRockets;
+    needToRecordBattleStatistics = s.needToRecordBattleStatistics;
+    needToCheckDefendingPlanesCanLand = s.needToCheckDefendingPlanesCanLand;
+    needToCleanup = s.needToCleanup;
+    currentBattle = s.currentBattle;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -6,15 +6,17 @@ class BattleExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7899007486408723505L;
   Serializable superState;
   // add other variables here:
-  BattleTracker m_battleTracker = new BattleTracker();
+  BattleTracker battleTracker = new BattleTracker();
   // public OriginalOwnerTracker m_originalOwnerTracker = new OriginalOwnerTracker();
-  public boolean m_needToInitialize;
-  boolean m_needToScramble;
-  boolean m_needToKamikazeSuicideAttacks;
-  boolean m_needToClearEmptyAirBattleAttacks;
-  boolean m_needToAddBombardmentSources;
-  boolean m_needToRecordBattleStatistics;
-  boolean m_needToCheckDefendingPlanesCanLand;
-  boolean m_needToCleanup;
-  IBattle m_currentBattle;
+  public boolean needToInitialize;
+  boolean needToScramble;
+  boolean needToCreateRockets;
+  boolean needToKamikazeSuicideAttacks;
+  boolean needToClearEmptyAirBattleAttacks;
+  boolean needToAddBombardmentSources;
+  boolean needToFireRockets;
+  boolean needToRecordBattleStatistics;
+  boolean needToCheckDefendingPlanesCanLand;
+  boolean needToCleanup;
+  IBattle currentBattle;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -137,8 +137,8 @@ public final class GameStepPropertiesHelper {
   }
 
   /**
-   * Fire rockets after phase is over. Normally would occur after combat move for WW2v2 and WW2v3, and after noncombat
-   * move for WW2v1.
+   * Fire rockets after phase is over. This method is here for legacy support.
+   * Ideally, all maps with rockets will set PROPERY_fireRockets for move and battle phases.
    */
   static boolean isFireRockets(final GameData data) {
     data.acquireReadLock();
@@ -146,6 +146,9 @@ public final class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.FIRE_ROCKETS);
       if (prop != null) {
         return Boolean.parseBoolean(prop);
+      } else if (data.getSequence().getStep().getDelegate().getName().compareTo("battle") == 0) {
+        return games.strategy.triplea.Properties.getWW2V2(data)
+            || games.strategy.triplea.Properties.getWW2V3(data);
       } else if (Properties.getWW2V2(data) || Properties.getWW2V3(data)) {
         return isCombatDelegate(data);
       }
@@ -289,6 +292,7 @@ public final class GameStepPropertiesHelper {
   }
 
   private static boolean isCombatDelegate(final GameData data) {
+    // NonCombatMove endsWith CombatMove so check for NCM first
     return !data.getSequence().getStep().getName().endsWith("NonCombatMove")
         && data.getSequence().getStep().getName().endsWith("CombatMove");
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -31,6 +31,7 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
+import games.strategy.triplea.delegate.RocketsFireHelper.RocketType;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
@@ -191,13 +192,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
       removeAirThatCantLand();
     }
 
-    // WW2V2/WW2V3, fires at end of combat move
-    // WW2V1, fires at end of non combat move
-    if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (needToDoRockets && TechTracker.hasRocket(bridge.getPlayerId())) {
-        RocketsFireHelper.fireRockets(bridge, bridge.getPlayerId());
-        needToDoRockets = false;
-      }
+    // WW2V2/WW2V3, fires at end of combat move, for legacy maps only
+    // WW2V1, fires at end of non combat move, for legacy maps only
+    if (needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
+      new RocketsFireHelper(bridge, bridge.getPlayerId(), RocketType.ww2v1);
+      needToDoRockets = false;
     }
 
     // do at the end of the round, if we do it at the start of non combat, then we may do it in the middle of the round,

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1014,8 +1014,8 @@ public final class TripleAFrame extends JFrame {
         .map(comps -> {
           final JPanel panel = comps.getFirst();
           final JList<?> list = comps.getSecond();
-          final String[] options = {"OK"};
-          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
+          final String[] options = {"OK", "Cancel"};
+          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
               JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
           if (selection == 0) {
             selected.set((Unit) list.getSelectedValue());


### PR DESCRIPTION
## Overview
Fixes a few problems with Rockets including #3846.
In the older games rockets will work as at present but for Global 1940 and derivatives, Rockets will now be considered after scrambling in all cases. Normally there will be rocket targeting, strategic bombing, rocket firing but there will be a map option to have strategic bombing happening before rocket targeting to support the unfortunate rule clarification.

## Functional Changes
See above

## Manual Testing Performed
- ..
Tested v1, v2, Global with and without the option.

Seems to work.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
I don't understand why I'm getting "Can't automatically merge"

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
