### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.data (T-U)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontier.java
@@ -14,32 +14,33 @@ import games.strategy.triplea.delegate.TechAdvance;
  */
 public class TechnologyFrontier extends GameDataComponent implements Iterable<TechAdvance> {
   private static final long serialVersionUID = -5245743727479551766L;
-  private final List<TechAdvance> m_techs = new ArrayList<>();
-  private List<TechAdvance> m_cachedTechs;
-  private final String m_name;
+
+  private final List<TechAdvance> techs = new ArrayList<>();
+  private List<TechAdvance> cachedTechs;
+  private final String name;
 
   public TechnologyFrontier(final String name, final GameData data) {
     super(data);
-    m_name = name;
+    this.name = name;
   }
 
   public TechnologyFrontier(final TechnologyFrontier other) {
     super(other.getData());
-    m_name = other.m_name;
-    m_techs.addAll(other.m_techs);
+    name = other.name;
+    techs.addAll(other.techs);
   }
 
   private void reorderTechsToMatchGameTechsOrder() {
     final GameData gameData = getData();
     if (gameData != null) {
-      m_techs.sort(Comparator.comparing(gameData.getTechnologyFrontier().getTechs()::indexOf));
-      m_cachedTechs = null;
+      techs.sort(Comparator.comparing(gameData.getTechnologyFrontier().getTechs()::indexOf));
+      cachedTechs = null;
     }
   }
 
   public void addAdvance(final TechAdvance t) {
-    m_cachedTechs = null;
-    m_techs.add(t);
+    cachedTechs = null;
+    techs.add(t);
     reorderTechsToMatchGameTechsOrder();
   }
 
@@ -50,32 +51,32 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   }
 
   public void removeAdvance(final TechAdvance t) {
-    if (!m_techs.contains(t)) {
+    if (!techs.contains(t)) {
       throw new IllegalStateException("Advance not present:" + t);
     }
-    m_cachedTechs = null;
-    m_techs.remove(t);
+    cachedTechs = null;
+    techs.remove(t);
   }
 
   public TechAdvance getAdvanceByProperty(final String property) {
-    return m_techs.stream()
+    return techs.stream()
         .filter(ta -> ta.getProperty().equals(property))
         .findAny()
         .orElse(null);
   }
 
   public TechAdvance getAdvanceByName(final String name) {
-    return m_techs.stream()
+    return techs.stream()
         .filter(ta -> ta.getName().equals(name))
         .findAny()
         .orElse(null);
   }
 
   public List<TechAdvance> getTechs() {
-    if (m_cachedTechs == null) {
-      m_cachedTechs = Collections.unmodifiableList(m_techs);
+    if (cachedTechs == null) {
+      cachedTechs = Collections.unmodifiableList(techs);
     }
-    return m_cachedTechs;
+    return cachedTechs;
   }
 
   @Override
@@ -84,21 +85,21 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
   }
 
   public String getName() {
-    return m_name;
+    return name;
   }
 
   public boolean isEmpty() {
-    return m_techs.isEmpty();
+    return techs.isEmpty();
   }
 
   @Override
   public String toString() {
-    return m_name;
+    return name;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(m_name);
+    return Objects.hashCode(name);
   }
 
   @Override
@@ -110,6 +111,6 @@ public class TechnologyFrontier extends GameDataComponent implements Iterable<Te
       return false;
     }
     final TechnologyFrontier other = (TechnologyFrontier) o;
-    return m_name.equals(other.getName());
+    return name.equals(other.getName());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
@@ -11,22 +11,23 @@ import games.strategy.triplea.delegate.TechAdvance;
  */
 public class TechnologyFrontierList extends GameDataComponent {
   private static final long serialVersionUID = 2958122401265284935L;
-  private final List<TechnologyFrontier> m_technologyFrontiers = new ArrayList<>();
+
+  private final List<TechnologyFrontier> technologyFrontiers = new ArrayList<>();
 
   public TechnologyFrontierList(final GameData data) {
     super(data);
   }
 
   public void addTechnologyFrontier(final TechnologyFrontier tf) {
-    m_technologyFrontiers.add(tf);
+    technologyFrontiers.add(tf);
   }
 
   public int size() {
-    return m_technologyFrontiers.size();
+    return technologyFrontiers.size();
   }
 
   public TechnologyFrontier getTechnologyFrontier(final String name) {
-    for (final TechnologyFrontier tf : m_technologyFrontiers) {
+    for (final TechnologyFrontier tf : technologyFrontiers) {
       if (tf.getName().equals(name)) {
         return tf;
       }
@@ -36,13 +37,13 @@ public class TechnologyFrontierList extends GameDataComponent {
 
   public List<TechAdvance> getAdvances() {
     final List<TechAdvance> techs = new ArrayList<>();
-    for (final TechnologyFrontier t : m_technologyFrontiers) {
+    for (final TechnologyFrontier t : technologyFrontiers) {
       techs.addAll(t.getTechs());
     }
     return techs;
   }
 
   public List<TechnologyFrontier> getFrontiers() {
-    return Collections.unmodifiableList(m_technologyFrontiers);
+    return Collections.unmodifiableList(technologyFrontiers);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -9,12 +9,13 @@ import javax.annotation.Nullable;
  */
 public class Territory extends NamedAttachable implements NamedUnitHolder, Comparable<Territory> {
   private static final long serialVersionUID = -6390555051736721082L;
-  private final boolean m_water;
-  private PlayerID m_owner = PlayerID.NULL_PLAYERID;
-  private final UnitCollection m_units;
+
+  private final boolean water;
+  private PlayerID owner = PlayerID.NULL_PLAYERID;
+  private final UnitCollection units;
   // In a grid-based game, stores the coordinate of the Territory
   @SuppressWarnings("unused")
-  private final int[] m_coordinate;
+  private final int[] coordinate;
 
   public Territory(final String name, final GameData data) {
     this(name, false, data);
@@ -23,36 +24,36 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   /** Creates new Territory. */
   public Territory(final String name, final boolean water, final GameData data) {
     super(name, data);
-    m_water = water;
-    m_units = new UnitCollection(this, getData());
-    m_coordinate = null;
+    this.water = water;
+    units = new UnitCollection(this, getData());
+    coordinate = null;
   }
 
   /** Creates new Territory. */
   public Territory(final String name, final boolean water, final GameData data, final int... coordinate) {
     super(name, data);
-    m_water = water;
-    m_units = new UnitCollection(this, getData());
+    this.water = water;
+    units = new UnitCollection(this, getData());
     if (data.getMap().isCoordinateValid(coordinate)) {
-      m_coordinate = coordinate;
+      this.coordinate = coordinate;
     } else {
       throw new IllegalArgumentException("Invalid coordinate: " + coordinate[0] + "," + coordinate[1]);
     }
   }
 
   public boolean isWater() {
-    return m_water;
+    return water;
   }
 
   /**
    * Returns the territory owner; will be {@link PlayerID#NULL_PLAYERID} if the territory is not owned.
    */
   public PlayerID getOwner() {
-    return m_owner;
+    return owner;
   }
 
   public void setOwner(final @Nullable PlayerID owner) {
-    m_owner = Optional.ofNullable(owner).orElse(PlayerID.NULL_PLAYERID);
+    this.owner = Optional.ofNullable(owner).orElse(PlayerID.NULL_PLAYERID);
     getData().notifyTerritoryOwnerChanged(this);
   }
 
@@ -61,7 +62,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
    */
   @Override
   public UnitCollection getUnits() {
-    return m_units;
+    return units;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -22,10 +22,11 @@ import lombok.extern.java.Log;
 @Log
 public class Unit extends GameDataComponent implements DynamicallyModifiable {
   private static final long serialVersionUID = -7906193079642776282L;
-  private PlayerID m_owner;
-  private final GUID m_uid;
-  private int m_hits = 0;
-  private final UnitType m_type;
+
+  private PlayerID owner;
+  private final GUID id;
+  private int hits = 0;
+  private final UnitType type;
 
   /**
    * Creates new Unit. Owner can be null.
@@ -40,38 +41,38 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     checkNotNull(type);
     checkNotNull(id);
 
-    m_type = type;
-    m_uid = id;
+    this.type = type;
+    this.id = id;
 
     setOwner(owner);
   }
 
   public GUID getId() {
-    return m_uid;
+    return id;
   }
 
   public UnitType getType() {
-    return m_type;
+    return type;
   }
 
   public PlayerID getOwner() {
-    return m_owner;
+    return owner;
   }
 
   public UnitAttachment getUnitAttachment() {
-    return (UnitAttachment) m_type.getAttachment("unitAttachment");
+    return (UnitAttachment) type.getAttachment("unitAttachment");
   }
 
   public int getHits() {
-    return m_hits;
+    return hits;
   }
 
   public void setHits(final int hits) {
-    m_hits = hits;
+    this.hits = hits;
   }
 
   public void setOwner(final @Nullable PlayerID player) {
-    m_owner = Optional.ofNullable(player).orElse(PlayerID.NULL_PLAYERID);
+    owner = Optional.ofNullable(player).orElse(PlayerID.NULL_PLAYERID);
   }
 
   @Override
@@ -80,48 +81,48 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
       return false;
     }
     final Unit other = (Unit) o;
-    return this.m_uid.equals(other.m_uid);
+    return this.id.equals(other.id);
   }
 
   public boolean isEquivalent(final Unit unit) {
-    return m_type != null && m_type.equals(unit.getType())
-        && m_owner != null && m_owner.equals(unit.getOwner())
-        && m_hits == unit.getHits();
+    return type != null && type.equals(unit.getType())
+        && owner != null && owner.equals(unit.getOwner())
+        && hits == unit.getHits();
   }
 
   @Override
   public int hashCode() {
-    if (m_type == null || m_owner == null || m_uid == null || this.getData() == null) {
+    if (type == null || owner == null || id == null || this.getData() == null) {
       final String text =
           "Unit.toString() -> Possible java de-serialization error: "
-              + (m_type == null ? "Unit of UNKNOWN TYPE" : m_type.getName()) + " owned by " + (m_owner == null
+              + (type == null ? "Unit of UNKNOWN TYPE" : type.getName()) + " owned by " + (owner == null
                   ? "UNKNOWN OWNER"
-                  : m_owner.getName())
+                  : owner.getName())
               + " with id: " + getId();
       UnitDeserializationErrorLazyMessage.printError(text);
       return 0;
     }
-    return Objects.hashCode(m_uid);
+    return Objects.hashCode(id);
   }
 
   @Override
   public String toString() {
     // TODO: none of these should happen,... except that they did a couple times.
-    if (m_type == null || m_owner == null || m_uid == null || this.getData() == null) {
+    if (type == null || owner == null || id == null || this.getData() == null) {
       final String text =
           "Unit.toString() -> Possible java de-serialization error: "
-              + (m_type == null ? "Unit of UNKNOWN TYPE" : m_type.getName()) + " owned by " + (m_owner == null
+              + (type == null ? "Unit of UNKNOWN TYPE" : type.getName()) + " owned by " + (owner == null
                   ? "UNKNOWN OWNER"
-                  : m_owner.getName())
+                  : owner.getName())
               + " with id: " + getId();
       UnitDeserializationErrorLazyMessage.printError(text);
       return text;
     }
-    return m_type.getName() + " owned by " + m_owner.getName();
+    return type.getName() + " owned by " + owner.getName();
   }
 
   public String toStringNoOwner() {
-    return m_type.getName();
+    return type.getName();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -18,8 +18,9 @@ import games.strategy.util.IntegerMap;
  */
 public class UnitCollection extends GameDataComponent implements Collection<Unit> {
   private static final long serialVersionUID = -3534037864426122864L;
-  private final List<Unit> m_units = new ArrayList<>();
-  private final NamedUnitHolder m_holder;
+
+  private final List<Unit> units = new ArrayList<>();
+  private final NamedUnitHolder holder;
 
   /**
    * Creates new UnitCollection.
@@ -29,53 +30,53 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
    */
   public UnitCollection(final NamedUnitHolder holder, final GameData data) {
     super(data);
-    m_holder = holder;
+    this.holder = holder;
   }
 
   @Override
   public boolean add(final Unit unit) {
-    final boolean result = m_units.add(unit);
-    m_holder.notifyChanged();
+    final boolean result = units.add(unit);
+    holder.notifyChanged();
     return result;
   }
 
   @Override
   public boolean addAll(final Collection<? extends Unit> units) {
-    final boolean result = m_units.addAll(units);
-    m_holder.notifyChanged();
+    final boolean result = this.units.addAll(units);
+    holder.notifyChanged();
     return result;
   }
 
   @Override
   public boolean removeAll(final Collection<?> units) {
-    final boolean result = m_units.removeAll(units);
-    m_holder.notifyChanged();
+    final boolean result = this.units.removeAll(units);
+    holder.notifyChanged();
     return result;
   }
 
   public int getUnitCount() {
-    return m_units.size();
+    return units.size();
   }
 
   int getUnitCount(final UnitType type) {
-    return (int) m_units.stream().filter(u -> u.getType().equals(type)).count();
+    return (int) units.stream().filter(u -> u.getType().equals(type)).count();
   }
 
   public int getUnitCount(final UnitType type, final PlayerID owner) {
-    return (int) m_units.stream().filter(u -> u.getType().equals(type) && u.getOwner().equals(owner)).count();
+    return (int) units.stream().filter(u -> u.getType().equals(type) && u.getOwner().equals(owner)).count();
   }
 
   int getUnitCount(final PlayerID owner) {
-    return (int) m_units.stream().filter(u -> u.getOwner().equals(owner)).count();
+    return (int) units.stream().filter(u -> u.getOwner().equals(owner)).count();
   }
 
   @Override
   public boolean containsAll(final Collection<?> units) {
     // much faster for large sets
-    if (m_units.size() > 500 && units.size() > 500) {
-      return new HashSet<>(m_units).containsAll(units);
+    if (this.units.size() > 500 && units.size() > 500) {
+      return new HashSet<>(this.units).containsAll(units);
     }
-    return m_units.containsAll(units);
+    return this.units.containsAll(units);
   }
 
   /**
@@ -92,7 +93,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
       throw new IllegalArgumentException("value must be positiive.  Instead its:" + maxUnits);
     }
     final Collection<Unit> units = new ArrayList<>();
-    for (final Unit current : m_units) {
+    for (final Unit current : this.units) {
       if (current.getType().equals(type)) {
         units.add(current);
         if (units.size() == maxUnits) {
@@ -117,7 +118,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   public Collection<Unit> getUnits() {
-    return new ArrayList<>(m_units);
+    return new ArrayList<>(units);
   }
 
   /**
@@ -141,18 +142,18 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
    */
   public IntegerMap<UnitType> getUnitsByType(final PlayerID id) {
     final IntegerMap<UnitType> count = new IntegerMap<>();
-    m_units.stream().filter(unit -> unit.getOwner().equals(id)).forEach(unit -> count.add(unit.getType(), 1));
+    units.stream().filter(unit -> unit.getOwner().equals(id)).forEach(unit -> count.add(unit.getType(), 1));
     return count;
   }
 
   @Override
   public int size() {
-    return m_units.size();
+    return units.size();
   }
 
   @Override
   public boolean isEmpty() {
-    return m_units.isEmpty();
+    return units.isEmpty();
   }
 
   /**
@@ -160,7 +161,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
    */
   public Set<PlayerID> getPlayersWithUnits() {
     // note nulls are handled by PlayerID.NULL_PLAYERID
-    return m_units.stream().map(Unit::getOwner).collect(Collectors.toSet());
+    return units.stream().map(Unit::getOwner).collect(Collectors.toSet());
   }
 
   /**
@@ -168,7 +169,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
    */
   public IntegerMap<PlayerID> getPlayerUnitCounts() {
     final IntegerMap<PlayerID> count = new IntegerMap<>();
-    m_units.forEach(unit -> count.add(unit.getOwner(), 1));
+    units.forEach(unit -> count.add(unit.getOwner(), 1));
     return count;
   }
 
@@ -177,29 +178,29 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   public NamedUnitHolder getHolder() {
-    return m_holder;
+    return holder;
   }
 
   public boolean allMatch(final Predicate<Unit> matcher) {
-    return m_units.stream().allMatch(matcher);
+    return units.stream().allMatch(matcher);
   }
 
   public boolean anyMatch(final Predicate<Unit> matcher) {
-    return m_units.stream().anyMatch(matcher);
+    return units.stream().anyMatch(matcher);
   }
 
   public int countMatches(final Predicate<Unit> predicate) {
-    return CollectionUtils.countMatches(m_units, predicate);
+    return CollectionUtils.countMatches(units, predicate);
   }
 
   public List<Unit> getMatches(final Predicate<Unit> predicate) {
-    return CollectionUtils.getMatches(m_units, predicate);
+    return CollectionUtils.getMatches(units, predicate);
   }
 
   @Override
   public String toString() {
     final StringBuilder buf = new StringBuilder();
-    buf.append("Unit collecion held by ").append(m_holder.getName());
+    buf.append("Unit collecion held by ").append(holder.getName());
     buf.append(" units:");
     final IntegerMap<UnitType> units = getUnitsByType();
     for (final UnitType unit : units.keySet()) {
@@ -210,39 +211,39 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
 
   @Override
   public Iterator<Unit> iterator() {
-    return Collections.unmodifiableList(m_units).iterator();
+    return Collections.unmodifiableList(units).iterator();
   }
 
   @Override
   public boolean contains(final Object object) {
-    return m_units.contains(object);
+    return units.contains(object);
   }
 
   @Override
   public Object[] toArray() {
-    return m_units.toArray();
+    return units.toArray();
   }
 
   @Override
   public <T> T[] toArray(final T[] array) {
-    return m_units.toArray(array);
+    return units.toArray(array);
   }
 
   @Override
   public boolean remove(final Object object) {
-    final boolean result = m_units.remove(object);
-    m_holder.notifyChanged();
+    final boolean result = units.remove(object);
+    holder.notifyChanged();
     return result;
   }
 
   @Override
   public boolean retainAll(final Collection<?> collection) {
-    return m_units.retainAll(collection);
+    return units.retainAll(collection);
   }
 
   @Override
   public void clear() {
-    m_units.clear();
-    m_holder.notifyChanged();
+    units.clear();
+    holder.notifyChanged();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
@@ -10,28 +10,29 @@ import games.strategy.util.IntegerMap;
  */
 public class UnitHitsChange extends Change {
   private static final long serialVersionUID = 2862726651812142713L;
-  private final IntegerMap<Unit> m_hits;
-  private final IntegerMap<Unit> m_undoHits;
+
+  private final IntegerMap<Unit> hits;
+  private final IntegerMap<Unit> undoHits;
 
   private UnitHitsChange(final IntegerMap<Unit> hits, final IntegerMap<Unit> undoHits) {
-    m_hits = hits;
-    m_undoHits = undoHits;
+    this.hits = hits;
+    this.undoHits = undoHits;
   }
 
   public UnitHitsChange(final IntegerMap<Unit> hits) {
-    m_hits = new IntegerMap<>(hits);
-    m_undoHits = new IntegerMap<>();
-    for (final Unit item : m_hits.keySet()) {
-      m_undoHits.put(item, item.getHits());
+    this.hits = new IntegerMap<>(hits);
+    undoHits = new IntegerMap<>();
+    for (final Unit item : this.hits.keySet()) {
+      undoHits.put(item, item.getHits());
     }
   }
 
   @Override
   protected void perform(final GameData data) {
-    for (final Unit item : m_hits.keySet()) {
-      item.setHits(m_hits.getInt(item));
+    for (final Unit item : hits.keySet()) {
+      item.setHits(hits.getInt(item));
     }
-    final Set<Unit> units = m_hits.keySet();
+    final Set<Unit> units = hits.keySet();
     for (final Territory element : data.getMap().getTerritories()) {
       if (CollectionUtils.someIntersect(element.getUnits().getUnits(), units)) {
         element.notifyChanged();
@@ -41,6 +42,6 @@ public class UnitHitsChange extends Change {
 
   @Override
   public Change invert() {
-    return new UnitHitsChange(m_undoHits, m_hits);
+    return new UnitHitsChange(undoHits, hits);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -12,7 +12,8 @@ import java.util.Set;
  */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
-  private final Map<String, UnitType> m_unitTypes = new LinkedHashMap<>();
+
+  private final Map<String, UnitType> unitTypes = new LinkedHashMap<>();
 
   /**
    * Creates new UnitTypeCollection.
@@ -24,11 +25,11 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   }
 
   protected void addUnitType(final UnitType type) {
-    m_unitTypes.put(type.getName(), type);
+    unitTypes.put(type.getName(), type);
   }
 
   public UnitType getUnitType(final String name) {
-    return m_unitTypes.get(name);
+    return unitTypes.get(name);
   }
 
   /**
@@ -37,7 +38,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   public Set<UnitType> getUnitTypes(final String[] names) {
     final Set<UnitType> types = new HashSet<>();
     for (final String name : names) {
-      final UnitType type = m_unitTypes.get(name);
+      final UnitType type = unitTypes.get(name);
       if (type == null) {
         return null;
       }
@@ -47,15 +48,15 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   }
 
   public int size() {
-    return m_unitTypes.size();
+    return unitTypes.size();
   }
 
   @Override
   public Iterator<UnitType> iterator() {
-    return m_unitTypes.values().iterator();
+    return unitTypes.values().iterator();
   }
 
   public Set<UnitType> getAllUnitTypes() {
-    return new LinkedHashSet<>(m_unitTypes.values());
+    return new LinkedHashSet<>(unitTypes.values());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitsList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitsList.java
@@ -14,24 +14,25 @@ import games.strategy.net.GUID;
  */
 public class UnitsList implements Serializable, Iterable<Unit> {
   private static final long serialVersionUID = -3134052492257867416L;
+
   // TODO - fix this, all units are never gcd
-  private final Map<GUID, Unit> m_allUnits = new HashMap<>();
+  private final Map<GUID, Unit> allUnits = new HashMap<>();
 
   UnitsList() {}
 
   public Unit get(final GUID id) {
-    return m_allUnits.get(id);
+    return allUnits.get(id);
   }
 
   public void put(final Unit unit) {
-    m_allUnits.put(unit.getId(), unit);
+    allUnits.put(unit.getId(), unit);
   }
 
   /*
    * Gets all units currently in the game
    */
   public Collection<Unit> getUnits() {
-    return Collections.unmodifiableCollection(m_allUnits.values());
+    return Collections.unmodifiableCollection(allUnits.values());
   }
 
   @Override


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName rule in classes beginning with T-U within the `g.s.engine.data` package.

## Functional Changes

None.

## Manual Testing Performed

None.