### PR TITLE
Error Prone: Fix class can be static violation

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -112,8 +112,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
   /**
    * RelatedPlayers is a class of 2 players that are related, used in relationships.
    */
-  @SuppressWarnings("ClassCanBeStatic") // TODO: make class static upon next incompatible release
-  public class RelatedPlayers implements Serializable {
+  public static final class RelatedPlayers implements Serializable {
     private static final long serialVersionUID = 2124258606502106751L;
 
     /**

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -124,7 +124,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
     private final PlayerID player1;
     private final PlayerID player2;
 
-    public RelatedPlayers(final PlayerID player1, final PlayerID player2) {
+    RelatedPlayers(final PlayerID player1, final PlayerID player2) {
       this.player1 = player1;
       this.player2 = player2;
     }

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -110,19 +110,16 @@ public class RelationshipTracker extends RelationshipInterpreter {
   }
 
   /**
-   * RelatedPlayers is a class of 2 players that are related, used in relationships.
+   * Two players that are related; used in relationships.
+   *
+   * <p>
+   * This class overrides {@link #equals(Object)} and {@link #hashCode()} such that the order of the players is not
+   * considered when instances of this class are used as keys in a hash container. For example, if you added an entry
+   * with the key (p1, p2), you can retrieve it with either the key (p1, p2) or (p2, p1).
+   * </p>
    */
   public static final class RelatedPlayers implements Serializable {
     private static final long serialVersionUID = 2124258606502106751L;
-
-    /**
-     * override hashCode to make sure that each new instance of this class can be matched in the Hashtable
-     * even if it was put in as (p1,p2) and you want to get it out as (p2,p1).
-     */
-    @Override
-    public int hashCode() {
-      return Objects.hashCode(player1) + Objects.hashCode(player2);
-    }
 
     private final PlayerID player1;
     private final PlayerID player2;
@@ -140,6 +137,11 @@ public class RelationshipTracker extends RelationshipInterpreter {
             || (relatedPlayers2.player2.equals(player1) && relatedPlayers2.player1.equals(player2));
       }
       return super.equals(object);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(player1) + Objects.hashCode(player2);
     }
 
     @Override

--- a/game-core/src/test/java/games/strategy/engine/data/RelationshipTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RelationshipTrackerTest.java
@@ -1,0 +1,47 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import games.strategy.engine.data.RelationshipTracker.RelatedPlayers;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+final class RelationshipTrackerTest {
+  @Nested
+  final class RelatedPlayersTest {
+    @Nested
+    final class EqualsAndHashCodeTest {
+      private final GameData gameData = new GameData();
+      private final PlayerID player1 = new PlayerID("red", gameData);
+      private final PlayerID player2 = new PlayerID("black", gameData);
+
+      @Test
+      void shouldBeEquatableAndHashable() {
+        EqualsVerifier.forClass(RelatedPlayers.class)
+            .withPrefabValues(PlayerID.class, player1, player2)
+            .suppress(Warning.NULL_FIELDS)
+            .verify();
+      }
+
+      @Test
+      void shouldBeEqualToOtherWithOppositePlayers() {
+        final RelatedPlayers relatedPlayers1 = new RelatedPlayers(player1, player2);
+        final RelatedPlayers relatedPlayers2 = new RelatedPlayers(player2, player1);
+
+        assertThat(relatedPlayers1.equals(relatedPlayers2), is(true));
+      }
+
+      @Test
+      void shouldHaveSameHashCodeAsOtherWithOppositePlayers() {
+        final RelatedPlayers relatedPlayers1 = new RelatedPlayers(player1, player2);
+        final RelatedPlayers relatedPlayers2 = new RelatedPlayers(player2, player1);
+
+        assertThat(relatedPlayers1.hashCode(), is(relatedPlayers2.hashCode()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes a violation of the Error Prone ClassCanBeStatic rule in the `RelationshipTracker$RelatedPlayers` class.  This violation was previously suppressed in order to maintain compatibility.

## Functional Changes

None.

## Refactoring Changes

* Reordered methods in this class so they appear after fields and constructors.
* Moved the comment explaining how the player order in this class is not considered in comparisons in order to make it more prominent.

## Manual Testing Performed

None.  But added unit tests for the `equals()` and `hashCode()` methods of `RelatedPlayers` while I was here.