### PR TITLE
Client settings: Commit Spinner value when focus is lost

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -49,7 +49,7 @@ final class JavaFxSelectionComponentFactory {
       final int maxValue,
       final boolean allowUnset) {
     return new SelectionComponent<Region>() {
-      final Spinner<Integer> spinner = createSpinner();
+      private final Spinner<Integer> spinner = createSpinner();
 
       private Spinner<Integer> createSpinner() {
         final Spinner<Integer> spinner = new Spinner<>(
@@ -57,6 +57,11 @@ final class JavaFxSelectionComponentFactory {
             maxValue,
             getIntegerFromOptional(clientSetting.getValue()));
         spinner.setEditable(true);
+        spinner.focusedProperty().addListener((observable, oldValue, newValue) -> {
+          if (!newValue) {
+            spinner.increment(0); // hack to force editor to commit value when losing focus
+          }
+        });
         return spinner;
       }
 


### PR DESCRIPTION
## Overview

Fixes a bug I discovered recently due to all the manual testing I've been doing around the client settings.

In the JFX UI client settings, typing a value into a spinner control does not actually commit the value to the model unless <kbd>Enter</kbd> is pressed.  Thus, when clicking **Save Settings**, the new value is not persisted, even though it is displayed in the UI.  This seems counter-intuitive, as most users would expect the value to stick without having to press <kbd>Enter</kbd>.

This PR ensures the new value is stored in the model when the spinner control loses focus.  The solution employed here is a bit of a hack that I gleaned from [here](https://stackoverflow.com/a/39380146/3900879).  Apparently, there's no way via the `Spinner` API to configure the desired behavior.

## Functional Changes

* `Spinner` controls in the JFX client settings UI now commit their value to the model upon losing focus.

## Manual Testing Performed

* Verified that changing the lobby port override setting (without pressing <kbd>Enter</kbd> and without using the spinner's up/down buttons) was persisted after clicking **Save Settings**.