### PR TITLE
Prefer checkNotNull() over explicitly raising precondition exception

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * A game data change that captures a change to an attachment property value.
  */
@@ -28,9 +30,8 @@ public class ChangeAttachmentChange extends Change {
    * @param property The property by String name.
    */
   public ChangeAttachmentChange(final IAttachment attachment, final Object newValue, final String property) {
-    if (attachment == null) {
-      throw new IllegalArgumentException("No attachment, newValue:" + newValue + " property:" + property);
-    }
+    checkNotNull(attachment, "null attachment; newValue: " + newValue + ", property: " + property);
+
     attachedTo = attachment.getAttachedTo();
     attachmentName = attachment.getName();
     oldValue = attachment.getPropertyOrThrow(property).getValue();
@@ -45,9 +46,8 @@ public class ChangeAttachmentChange extends Change {
    */
   public ChangeAttachmentChange(final IAttachment attachment, final Object newValue, final String property,
       final boolean resetFirst) {
-    if (attachment == null) {
-      throw new IllegalArgumentException("No attachment, newValue:" + newValue + " property:" + property);
-    }
+    checkNotNull(attachment, "null attachment; newValue: " + newValue + ", property: " + property);
+
     attachedTo = attachment.getAttachedTo();
     clearFirst = resetFirst;
     attachmentName = attachment.getName();

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultNamed.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.Objects;
@@ -16,9 +18,12 @@ public class DefaultNamed extends GameDataComponent implements Named {
 
   public DefaultNamed(final String name, final GameData data) {
     super(data);
-    if (name == null || name.length() == 0) {
-      throw new IllegalArgumentException("Name must not be null");
+
+    checkNotNull(name);
+    if (name.length() == 0) {
+      throw new IllegalArgumentException("Name must not be empty");
     }
+
     this.name = name;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -48,9 +50,8 @@ public class GameObjectStreamData implements Externalizable {
   }
 
   Named getReference(final GameData data) {
-    if (data == null) {
-      throw new IllegalArgumentException("Data cant be null");
-    }
+    checkNotNull(data);
+
     data.acquireReadLock();
     try {
       switch (type) {

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,7 +76,6 @@ public class Route implements Serializable, Iterable<Territory> {
    */
   public static Route join(final Route r1, final Route r2) {
     if (r1 == null || r2 == null) {
-      // throw new IllegalArgumentException("route cant be null r1:" + r1 + " r2:" + r2);
       return null;
     }
     if (r1.numberOfSteps() == 0) {
@@ -124,9 +125,8 @@ public class Route implements Serializable, Iterable<Territory> {
    * Set the start of this route.
    */
   public void setStart(final Territory newStartTerritory) {
-    if (newStartTerritory == null) {
-      throw new IllegalStateException("Null territory");
-    }
+    checkNotNull(newStartTerritory);
+
     start = newStartTerritory;
   }
 
@@ -158,9 +158,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * Add the given territory to the end of the route.
    */
   public void add(final Territory territory) {
-    if (territory == null) {
-      throw new IllegalStateException("Null territory");
-    }
+    checkNotNull(territory);
     if (territory.equals(start) || steps.contains(territory)) {
       throw new IllegalArgumentException(String.format(
           "Loops not allowed in steps, route: %s, new territory: %s", this, territory));

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -14,12 +16,9 @@ class AddAvailableTech extends Change {
   private final PlayerID player;
 
   public AddAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {
-    if (front == null) {
-      throw new IllegalArgumentException("Null tech category");
-    }
-    if (tech == null) {
-      throw new IllegalArgumentException("Null tech");
-    }
+    checkNotNull(front);
+    checkNotNull(tech);
+
     this.tech = tech;
     frontier = front;
     this.player = player;

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionFrontier;
@@ -12,12 +14,9 @@ class AddProductionRule extends Change {
   private final ProductionFrontier frontier;
 
   public AddProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
-    if (rule == null) {
-      throw new IllegalArgumentException("Null rule");
-    }
-    if (frontier == null) {
-      throw new IllegalArgumentException("Null frontier");
-    }
+    checkNotNull(rule);
+    checkNotNull(frontier);
+
     this.rule = rule;
     this.frontier = frontier;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AttachmentPropertyReset.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -17,9 +19,8 @@ class AttachmentPropertyReset extends Change {
   private final String property;
 
   AttachmentPropertyReset(final IAttachment attachment, final String property) {
-    if (attachment == null) {
-      throw new IllegalArgumentException("No attachment, property:" + property);
-    }
+    checkNotNull(attachment, "null attachment; property: " + property);
+
     attachedTo = attachment.getAttachedTo();
     attachmentName = attachment.getName();
     oldValue = attachment.getPropertyOrThrow(property).getValue();

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
@@ -15,9 +17,8 @@ class GenericTechChange extends Change {
   private final String property;
 
   GenericTechChange(final TechAttachment attachment, final boolean newValue, final String property) {
-    if (attachment == null) {
-      throw new IllegalArgumentException("No attachment, newValue:" + newValue + " property:" + property);
-    }
+    checkNotNull(attachment, "null attachment; newValue: " + newValue + ", property: " + property);
+
     attachedTo = attachment.getAttachedTo();
     attachmentName = attachment.getName();
     oldValue = attachment.hasGenericTech(property);

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -14,12 +16,9 @@ class RemoveAvailableTech extends Change {
   private final PlayerID player;
 
   public RemoveAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerID player) {
-    if (front == null) {
-      throw new IllegalArgumentException("Null tech category");
-    }
-    if (tech == null) {
-      throw new IllegalArgumentException("Null tech");
-    }
+    checkNotNull(front);
+    checkNotNull(tech);
+
     this.tech = tech;
     frontier = front;
     this.player = player;

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.changefactory;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionFrontier;
@@ -12,12 +14,9 @@ class RemoveProductionRule extends Change {
   private final ProductionFrontier frontier;
 
   public RemoveProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
-    if (rule == null) {
-      throw new IllegalArgumentException("Null rule");
-    }
-    if (frontier == null) {
-      throw new IllegalArgumentException("Null frontier");
-    }
+    checkNotNull(rule);
+    checkNotNull(frontier);
+
     this.rule = rule;
     this.frontier = frontier;
   }

--- a/game-core/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.gamePlayer;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -36,12 +38,9 @@ public class DefaultPlayerBridge implements IPlayerBridge {
   public DefaultPlayerBridge(final IGame game) {
     this.game = game;
     final GameStepListener gameStepListener = (stepName, delegateName, player, round, displayName) -> {
-      if (stepName == null) {
-        throw new IllegalArgumentException("Null step");
-      }
-      if (delegateName == null) {
-        throw new IllegalArgumentException("Null delegate");
-      }
+      checkNotNull(stepName);
+      checkNotNull(delegateName);
+
       this.stepName = stepName;
       currentDelegate = delegateName;
     };

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.message;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -30,9 +32,7 @@ public class RemoteMethodCall implements Externalizable {
 
   public RemoteMethodCall(final String remoteName, final String methodName, final Object[] args,
       final Class<?>[] argTypes, final Class<?> remoteInterface) {
-    if (argTypes == null) {
-      throw new IllegalArgumentException("ArgTypes are null");
-    }
+    checkNotNull(argTypes);
     if (args == null && argTypes.length != 0) {
       throw new IllegalArgumentException("args but no types");
     }

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteName.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.message;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import javax.annotation.concurrent.Immutable;
 
 import lombok.Getter;
@@ -14,9 +16,7 @@ public final class RemoteName {
   private final Class<?> clazz;
 
   public RemoteName(final String name, final Class<?> clazz) {
-    if (clazz == null) {
-      throw new IllegalArgumentException("Class cannot be null. Remote Name: " + name);
-    }
+    checkNotNull(clazz, "null class; remote name: " + name);
     if (!clazz.isInterface()) {
       throw new IllegalArgumentException("Not an interface. Remote Name: " + name);
     }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.message.unifiedmessenger;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -19,12 +21,9 @@ public abstract class InvocationResults implements Externalizable {
   public InvocationResults() {}
 
   public InvocationResults(final RemoteMethodCallResults results, final GUID methodCallId) {
-    if (results == null) {
-      throw new IllegalArgumentException("Null results");
-    }
-    if (methodCallId == null) {
-      throw new IllegalArgumentException("Null id");
-    }
+    checkNotNull(results);
+    checkNotNull(methodCallId);
+
     this.results = results;
     this.methodCallId = methodCallId;
   }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.message.unifiedmessenger;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -178,13 +180,12 @@ public class UnifiedMessenger {
   }
 
   public void removeImplementor(final String name, final Object implementor) {
+    checkNotNull(implementor);
+
     synchronized (endPointMutex) {
       final EndPoint endPoint = localEndPoints.get(name);
       if (endPoint == null) {
         throw new IllegalStateException("No end point for:" + name);
-      }
-      if (implementor == null) {
-        throw new IllegalArgumentException("null implementor");
       }
       final boolean noneLeft = endPoint.removeImplementor(implementor);
       if (noneLeft) {

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -1,5 +1,7 @@
 package games.strategy.net;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
@@ -663,9 +665,8 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
 
   @Override
   public void socketError(final SocketChannel channel, final Exception error) {
-    if (channel == null) {
-      throw new IllegalArgumentException("Null channel");
-    }
+    checkNotNull(channel);
+
     // already closed, dont report it again
     final INode node = channelToNode.get(channel);
     if (node != null) {

--- a/game-core/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Encoder.java
@@ -1,5 +1,7 @@
 package games.strategy.net.nio;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -28,11 +30,9 @@ class Encoder {
   }
 
   void write(final SocketChannel to, final MessageHeader header) {
+    checkNotNull(to);
     if (header.getFrom() == null) {
       throw new IllegalArgumentException("No from node");
-    }
-    if (to == null) {
-      throw new IllegalArgumentException("No to channel!");
     }
     try {
       final byte[] bytes = IoUtils.writeToMemory(os -> write(header, objectStreamFactory.create(os), to));

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -1,5 +1,7 @@
 package games.strategy.net.nio;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
@@ -59,12 +61,9 @@ public class NioSocket implements ErrorReporter {
    * @param header The message header to send.
    */
   public void send(final SocketChannel to, final MessageHeader header) {
-    if (to == null) {
-      throw new IllegalArgumentException("to cant be null!");
-    }
-    if (header == null) {
-      throw new IllegalArgumentException("header cant be null");
-    }
+    checkNotNull(to);
+    checkNotNull(header);
+
     encoder.write(to, header);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -144,9 +144,8 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   public boolean isSatisfied(
       final Map<ICondition, Boolean> testedConditions,
       final IDelegateBridge delegateBridge) {
-    if (testedConditions == null) {
-      throw new IllegalStateException("testedCondititions cannot be null");
-    }
+    checkNotNull(testedConditions);
+
     if (testedConditions.containsKey(this)) {
       return testedConditions.get(this);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -247,10 +249,9 @@ public abstract class TechAdvance extends NamedAttachable {
    * Returns all possible tech categories for this player.
    */
   public static List<TechnologyFrontier> getPlayerTechCategories(final PlayerID player) {
-    if (player != null) {
-      return player.getTechnologyFrontierList().getFrontiers();
-    }
-    throw new IllegalStateException("Player cannot be null");
+    checkNotNull(player);
+
+    return player.getTechnologyFrontierList().getFrontiers();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -34,9 +36,9 @@ public class TerritoryEffectHelper {
   }
 
   private static boolean unitTypeLoosesBlitz(final UnitType type, final Territory location) {
-    if (location == null || type == null) {
-      throw new IllegalStateException("Location and UnitType cannot be null");
-    }
+    checkNotNull(type);
+    checkNotNull(location);
+
     for (final TerritoryEffect effect : getEffects(location)) {
       if (TerritoryEffectAttachment.get(effect).getNoBlitz().contains(type)) {
         return true;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyList.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyList.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,12 +20,9 @@ public class CasualtyList implements Serializable {
    * @param damaged (can have multiple of the same unit, to show multiple hits to that unit)
    */
   public CasualtyList(final List<Unit> killed, final List<Unit> damaged) {
-    if (killed == null) {
-      throw new IllegalArgumentException("null killed");
-    }
-    if (damaged == null) {
-      throw new IllegalArgumentException("null damaged");
-    }
+    checkNotNull(killed);
+    checkNotNull(damaged);
+
     this.killed = new ArrayList<>(killed);
     this.damaged = new ArrayList<>(damaged);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.ui.screen.drawable;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
@@ -21,9 +23,8 @@ public class CapitolMarkerDrawable implements IDrawable {
   private final UiContext uiContext;
 
   public CapitolMarkerDrawable(final PlayerID player, final Territory location, final UiContext uiContext) {
-    if (player == null) {
-      throw new IllegalStateException("no player for capitol:" + location);
-    }
+    checkNotNull(player, "null player; capitol: " + location);
+
     this.player = player.getName();
     this.location = location.getName();
     this.uiContext = uiContext;

--- a/game-core/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -12,9 +14,8 @@ public class WrappedInvocationHandler implements InvocationHandler {
   private final Object delegate;
 
   public WrappedInvocationHandler(final Object delegate) {
-    if (delegate == null) {
-      throw new IllegalArgumentException("delegate cant be null");
-    }
+    checkNotNull(delegate);
+
     this.delegate = delegate;
   }
 


### PR DESCRIPTION
## Overview

Prefers the use of Guava's `checkNotNull()` over explicitly raising an unchecked precondition violation exception.  For example, something like

```java
if (param == null) {
  throw new IllegalArgumentException("param must not be null");
}
```

is replaced with

```java
checkNotNull(param);
```

In all cases, this changes the unchecked exception thrown from either `IllegalArgumentException` or `IllegalStateException` to `NullPointerException`, so the exception _may_ bypass some existing exception handler.  However, as these precondition violations are programmer errors, they should be crashing the application instead of being possibly suppressed.

## Functional Changes

None.

## Manual Testing Performed

None.