### PR TITLE
Checkstyle: Suppress naming violations in g.s.engine.lobby.server.userDB

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -36,6 +36,11 @@
     <module name="NewlineAtEndOfFile"/>
 
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE\-OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE\-ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
         <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -1,3 +1,6 @@
+// CHECKSTYLE-OFF: PackageName
+// move this class to lobby.common upon next lobby-incompatible release; it is shared between client and server
+
 package games.strategy.engine.lobby.server.userDB;
 
 import java.io.Serializable;
@@ -10,17 +13,18 @@ import games.strategy.util.Util;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-// TODO: move this class to lobby.common upon next incompatible release; it is shared between client and server
-
 /**
  * A lobby user.
  */
 @EqualsAndHashCode
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next lobby-incompatible release
 @ToString
 public final class DBUser implements Serializable {
   private static final long serialVersionUID = -5289923058375302916L;
 
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next lobby-incompatible release
   private final String m_name;
+  @SuppressWarnings("checkstyle:MemberName") // rename upon next lobby-incompatible release
   private final String m_email;
   private final Role userRole;
 


### PR DESCRIPTION
## Overview

Suppresses violations of the Checkstyle MemberName, PackageName, and AbbreviationAsWordInName rules within the `g.s.engine.lobby.server.userDB` package.  The naming violations in this package cannot be fixed at this time in order to maintain lobby compatibility.

## Functional Changes

None.

## Manual Testing Performed

None.