### PR TITLE
Suppress remaining Md5Crypt deprecation warnings

### DIFF
--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 public final class Md5CryptTest {
   @Nested
+  @SuppressWarnings("deprecation") // required for testing; remove upon next lobby-incompatible release
   public final class HashPasswordTest {
     @Test
     public void shouldReturnHashedPassword() {

--- a/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
@@ -117,6 +117,7 @@ public final class UserControllerIntegrationTest extends AbstractControllerTestC
     return BCrypt.hashpw(string, BCrypt.gensalt());
   }
 
+  @SuppressWarnings("deprecation") // required for testing; remove upon next lobby-incompatible release
   private static String md5Crypt(final String value) {
     return Md5Crypt.hashPassword(value, Md5Crypt.newSalt());
   }

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -78,6 +78,7 @@ public class LobbyLoginValidatorIntegrationTest {
         password);
   }
 
+  @SuppressWarnings("deprecation") // required for testing; remove upon next lobby-incompatible release
   private static String md5Crypt(final String value) {
     return Md5Crypt.hashPassword(value, Md5Crypt.newSalt());
   }

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -104,6 +104,7 @@ public final class LobbyLoginValidatorTest {
       return RsaAuthenticator.hashPasswordWithSalt(password);
     }
 
+    @SuppressWarnings("deprecation") // required for testing; remove upon next lobby-incompatible release
     final String md5Crypt(final String password) {
       return Md5Crypt.hashPassword(password, md5CryptSalt);
     }


### PR DESCRIPTION
## Overview

The remaining uses of `Md5Crypt#hashPassword()` are required for testing lobby server functionality used to support older lobby clients that still make use of Md5Crypt.  This PR simply suppresses those deprecation warnings with a note to remove the code upon the next lobby-incompatible release.

## Functional Changes

None.

## Manual Testing Performed

None.