### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.vault

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/game-core/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -10,7 +10,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.vault.Vault;
-import games.strategy.engine.vault.VaultID;
+import games.strategy.engine.vault.VaultId;
 
 /**
  * A random source that generates numbers using a secure algorithm shared
@@ -101,7 +101,7 @@ public class CryptoRandomSource implements IRandomSource {
     // generate numbers locally, and put them in the vault
     final int[] localRandom = plainRandom.getRandom(max, count, annotation);
     // lock it so the client knows that its there, but cant read it
-    final VaultID localId = vault.lock(intsToBytes(localRandom));
+    final VaultId localId = vault.lock(intsToBytes(localRandom));
     // ask the remote to generate numbers
     final IRemoteRandom remote =
         (IRemoteRandom) (game.getRemoteMessenger().getRemote(ServerGame.getRemoteRandomName(remotePlayer)));

--- a/game-core/src/main/java/games/strategy/engine/random/IRemoteRandom.java
+++ b/game-core/src/main/java/games/strategy/engine/random/IRemoteRandom.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.random;
 
 import games.strategy.engine.message.IRemote;
-import games.strategy.engine.vault.VaultID;
+import games.strategy.engine.vault.VaultId;
 
 /**
  * A service that generates random numbers. All generated numbers are stored in a cryptographic vault to prevent
@@ -14,7 +14,7 @@ public interface IRemoteRandom extends IRemote {
    * @param serverVaultId - the vaultID where the server has stored his numbers
    * @return the vault id for which we have locked the data
    */
-  int[] generate(int max, int count, String annotation, VaultID serverVaultId);
+  int[] generate(int max, int count, String annotation, VaultId serverVaultId);
 
   /**
    * unlock the random number last generated.

--- a/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -7,7 +7,7 @@ import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.VerifiedRandomNumbers;
 import games.strategy.engine.vault.NotUnlockedException;
 import games.strategy.engine.vault.Vault;
-import games.strategy.engine.vault.VaultID;
+import games.strategy.engine.vault.VaultId;
 
 /**
  * Default implementation of {@link IRemoteRandom}.
@@ -26,7 +26,7 @@ public class RemoteRandom implements IRemoteRandom {
   private final PlainRandomSource plainRandom = new PlainRandomSource();
   private final IGame game;
   // remembered from generate to unlock
-  private VaultID remoteVaultId;
+  private VaultId remoteVaultId;
   private String annotation;
   private int max;
   // have we recieved a generate request, but not a unlock request
@@ -41,7 +41,7 @@ public class RemoteRandom implements IRemoteRandom {
   }
 
   @Override
-  public int[] generate(final int max, final int count, final String annotation, final VaultID remoteVaultId)
+  public int[] generate(final int max, final int count, final String annotation, final VaultId remoteVaultId)
       throws IllegalStateException {
     if (waitingForUnlock) {
       throw new IllegalStateException("Being asked to generate random numbers, but we havent finished last generation. "

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -34,7 +34,7 @@ import games.strategy.engine.message.RemoteName;
  * </p>
  *
  * <p>
- * NOTE: to allow the data locked in the vault to be gc'd, the <code>release(VaultID id)</code> method
+ * NOTE: to allow the data locked in the vault to be gc'd, the <code>release(VaultId id)</code> method
  * should be called when it is no longer needed.
  * </p>
  */
@@ -50,12 +50,12 @@ public class Vault {
   private static final byte[] KNOWN_VAL = new byte[] {0xC, 0xA, 0xF, 0xE, 0xB, 0xA, 0xB, 0xE};
   private final KeyGenerator keyGen;
   private final IChannelMessenger channelMessenger;
-  // Maps VaultID -> SecretKey
-  private final ConcurrentMap<VaultID, SecretKey> secretKeys = new ConcurrentHashMap<>();
-  // maps ValutID -> encrypted byte[]
-  private final ConcurrentMap<VaultID, byte[]> unverifiedValues = new ConcurrentHashMap<>();
-  // maps VaultID -> byte[]
-  private final ConcurrentMap<VaultID, byte[]> verifiedValues = new ConcurrentHashMap<>();
+  // Maps VaultId -> SecretKey
+  private final ConcurrentMap<VaultId, SecretKey> secretKeys = new ConcurrentHashMap<>();
+  // maps VaultId -> encrypted byte[]
+  private final ConcurrentMap<VaultId, byte[]> unverifiedValues = new ConcurrentHashMap<>();
+  // maps VaultId -> byte[]
+  private final ConcurrentMap<VaultId, byte[]> verifiedValues = new ConcurrentHashMap<>();
   private final Object waitForLock = new Object();
 
   /**
@@ -113,8 +113,8 @@ public class Vault {
    * @param data - the data to lock
    * @return the VaultId of the data
    */
-  public VaultID lock(final byte[] data) {
-    final VaultID id = new VaultID(channelMessenger.getLocalNode());
+  public VaultId lock(final byte[] data) {
+    final VaultId id = new VaultId(channelMessenger.getLocalNode());
     final SecretKey key = keyGen.generateKey();
     if (secretKeys.putIfAbsent(id, key) != null) {
       throw new IllegalStateException("dupliagte id:" + id);
@@ -164,7 +164,7 @@ public class Vault {
    *
    * @param id - the vault id to unlock
    */
-  public void unlock(final VaultID id) {
+  public void unlock(final VaultId id) {
     if (!id.getGeneratedOn().equals(channelMessenger.getLocalNode())) {
       throw new IllegalArgumentException("Cant unlock data that wasnt locked on this node");
     }
@@ -180,14 +180,14 @@ public class Vault {
    *
    * @return - has this id been unlocked
    */
-  public boolean isUnlocked(final VaultID id) {
+  public boolean isUnlocked(final VaultId id) {
     return verifiedValues.containsKey(id);
   }
 
   /**
    * Get the unlocked data.
    */
-  public byte[] get(final VaultID id) throws NotUnlockedException {
+  public byte[] get(final VaultId id) throws NotUnlockedException {
     if (verifiedValues.containsKey(id)) {
       return verifiedValues.get(id);
     } else if (unverifiedValues.containsKey(id)) {
@@ -200,12 +200,12 @@ public class Vault {
   /**
    * Do we know about the given vault id.
    */
-  public boolean knowsAbout(final VaultID id) {
+  public boolean knowsAbout(final VaultId id) {
     return verifiedValues.containsKey(id) || unverifiedValues.containsKey(id);
   }
 
-  public List<VaultID> knownIds() {
-    final List<VaultID> knownIds = new ArrayList<>(verifiedValues.keySet());
+  public List<VaultId> knownIds() {
+    final List<VaultId> knownIds = new ArrayList<>(verifiedValues.keySet());
     knownIds.addAll(unverifiedValues.keySet());
     return knownIds;
   }
@@ -221,13 +221,13 @@ public class Vault {
    * If the id has already been released, then nothing will happen.
    * </p>
    */
-  public void release(final VaultID id) {
+  public void release(final VaultId id) {
     getRemoteBroadcaster().release(id);
   }
 
   private final IRemoteVault remoteVault = new IRemoteVault() {
     @Override
-    public void addLockedValue(final VaultID id, final byte[] data) {
+    public void addLockedValue(final VaultId id, final byte[] data) {
       if (id.getGeneratedOn().equals(channelMessenger.getLocalNode())) {
         return;
       }
@@ -240,7 +240,7 @@ public class Vault {
     }
 
     @Override
-    public void unlock(final VaultID id, final byte[] secretKeyBytes) {
+    public void unlock(final VaultId id, final byte[] secretKeyBytes) {
       if (id.getGeneratedOn().equals(channelMessenger.getLocalNode())) {
         return;
       }
@@ -281,7 +281,7 @@ public class Vault {
     }
 
     @Override
-    public void release(final VaultID id) {
+    public void release(final VaultId id) {
       unverifiedValues.remove(id);
       verifiedValues.remove(id);
     }
@@ -291,7 +291,7 @@ public class Vault {
    * Waits until we know about a given vault id.
    * waits for at most timeout milliseconds
    */
-  public void waitForId(final VaultID id, final long timeoutMs) {
+  public void waitForId(final VaultId id, final long timeoutMs) {
     if (timeoutMs <= 0) {
       throw new IllegalArgumentException("Must suppply positive timeout argument");
     }
@@ -316,7 +316,7 @@ public class Vault {
   /**
    * Wait until the given id is unlocked.
    */
-  public void waitForIdToUnlock(final VaultID id, final long timeout) {
+  public void waitForIdToUnlock(final VaultId id, final long timeout) {
     if (timeout <= 0) {
       throw new IllegalArgumentException("Must suppply positive timeout argument");
     }
@@ -338,11 +338,11 @@ public class Vault {
   }
 
   interface IRemoteVault extends IChannelSubscribor {
-    void addLockedValue(VaultID id, byte[] data);
+    void addLockedValue(VaultId id, byte[] data);
 
-    void unlock(VaultID id, byte[] secretKeyBytes);
+    void unlock(VaultId id, byte[] secretKeyBytes);
 
-    void release(VaultID id);
+    void release(VaultId id);
   }
 }
 

--- a/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/VaultID.java
@@ -16,17 +16,17 @@ public class VaultID implements Serializable {
     return currentId++;
   }
 
-  private final INode m_generatedOn;
+  private final INode generatedOn;
   // this is a unique and monotone increasing id
   // unique in this vm
-  private final long m_uniqueID = getNextId();
+  private final long uniqueId = getNextId();
 
   VaultID(final INode generatedOn) {
-    m_generatedOn = generatedOn;
+    this.generatedOn = generatedOn;
   }
 
   INode getGeneratedOn() {
-    return m_generatedOn;
+    return generatedOn;
   }
 
   @Override
@@ -35,16 +35,16 @@ public class VaultID implements Serializable {
       return false;
     }
     final VaultID other = (VaultID) o;
-    return other.m_generatedOn.equals(this.m_generatedOn) && other.m_uniqueID == this.m_uniqueID;
+    return other.generatedOn.equals(this.generatedOn) && other.uniqueId == this.uniqueId;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(m_uniqueID, m_generatedOn.getName());
+    return Objects.hash(uniqueId, generatedOn.getName());
   }
 
   @Override
   public String toString() {
-    return "VaultID generated on:" + m_generatedOn + " id:" + m_uniqueID;
+    return "VaultID generated on:" + generatedOn + " id:" + uniqueId;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/vault/VaultId.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/VaultId.java
@@ -8,7 +8,7 @@ import games.strategy.net.INode;
 /**
  * Uniquely identifies a cryptographic vault used to store random numbers on a particular node.
  */
-public class VaultID implements Serializable {
+public class VaultId implements Serializable {
   private static final long serialVersionUID = 8863728184933393296L;
   private static long currentId;
 
@@ -21,7 +21,7 @@ public class VaultID implements Serializable {
   // unique in this vm
   private final long uniqueId = getNextId();
 
-  VaultID(final INode generatedOn) {
+  VaultId(final INode generatedOn) {
     this.generatedOn = generatedOn;
   }
 
@@ -31,10 +31,10 @@ public class VaultID implements Serializable {
 
   @Override
   public boolean equals(final Object o) {
-    if (!(o instanceof VaultID)) {
+    if (!(o instanceof VaultId)) {
       return false;
     }
-    final VaultID other = (VaultID) o;
+    final VaultId other = (VaultId) o;
     return other.generatedOn.equals(this.generatedOn) && other.uniqueId == this.uniqueId;
   }
 
@@ -45,6 +45,6 @@ public class VaultID implements Serializable {
 
   @Override
   public String toString() {
-    return "VaultID generated on:" + generatedOn + " id:" + uniqueId;
+    return "VaultId generated on:" + generatedOn + " id:" + uniqueId;
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -64,7 +64,7 @@ public class VaultTest {
     // RemoteMessenger remoteMessenger = new RemoteMessenger(unifiedMessenger);
     final Vault vault = new Vault(channelMessenger);
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
-    final VaultID id = vault.lock(data);
+    final VaultId id = vault.lock(data);
     vault.unlock(id);
     assertArrayEquals(data, vault.get(id));
     vault.release(id);
@@ -76,7 +76,7 @@ public class VaultTest {
    */
   public void temporarilyDisabledSoPleaseRunManuallytestServerLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
-    final VaultID id = serverVault.lock(data);
+    final VaultId id = serverVault.lock(data);
     clientVault.waitForId(id, 1000);
     assertTrue(clientVault.knowsAbout(id));
     serverVault.unlock(id);
@@ -90,7 +90,7 @@ public class VaultTest {
   @Test
   public void testClientLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
-    final VaultID id = clientVault.lock(data);
+    final VaultId id = clientVault.lock(data);
     serverVault.waitForId(id, 1000);
     assertTrue(serverVault.knowsAbout(id));
     clientVault.unlock(id);
@@ -108,8 +108,8 @@ public class VaultTest {
   public void temporarilyDisabledSoPleaseRunManuallytestMultiple() throws NotUnlockedException {
     final byte[] data1 = new byte[] {0, 1, 2, 3, 4, 5};
     final byte[] data2 = new byte[] {0xE, 0xF, 2, 1, 3, 1, 2, 12, 3, 31, 124, 12, 1};
-    final VaultID id1 = serverVault.lock(data1);
-    final VaultID id2 = serverVault.lock(data2);
+    final VaultId id1 = serverVault.lock(data1);
+    final VaultId id2 = serverVault.lock(data2);
     clientVault.waitForId(id1, 2000);
     clientVault.waitForId(id2, 2000);
     assertTrue(clientVault.knowsAbout(id1));


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in classes within the `g.s.engine.vault` package.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

Please wait to merge each subsequent Checkstyle PR until the previous Bot Checkstyle threshold update PR has been merged.  This will avoid a flood of unnecessary threshold update PRs being generated.