### PR TITLE
Checkstyle: Fix naming violations in g.s.engine.framework.headlessGameServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -20,12 +20,12 @@ import java.util.zip.GZIPOutputStream;
 import javax.swing.JOptionPane;
 
 import org.apache.commons.io.IOUtils;
+import org.triplea.game.server.HeadlessGameServer;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -14,6 +14,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import org.triplea.game.server.HeadlessGameServer;
+
 import games.strategy.engine.GameOverException;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -28,7 +30,6 @@ import games.strategy.engine.delegate.DelegateExecutionManager;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.delegate.IPersistentDelegate;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.IObserverWaitingToJoin;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -15,9 +15,10 @@ import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import org.triplea.game.server.HeadlessGameServer;
+
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -30,6 +30,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 
+import org.triplea.game.server.HeadlessGameServer;
+
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.ChatPanel;
@@ -43,7 +45,6 @@ import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameState;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
 import games.strategy.engine.framework.startup.login.ClientLoginValidator;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -20,6 +20,7 @@ import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.lobby.common.ILobbyGameController;
 import org.triplea.lobby.common.IRemoteHostUtils;
 import org.triplea.lobby.common.LobbyConstants;
@@ -30,7 +31,6 @@ import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.events.GameStepListener;
 import games.strategy.engine.framework.IGame;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.message.IRemoteMessenger;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/RemoteHostUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/RemoteHostUtils.java
@@ -2,9 +2,9 @@ package games.strategy.engine.framework.startup.ui;
 
 import java.util.Set;
 
+import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.lobby.common.IRemoteHostUtils;
 
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -11,13 +11,14 @@ import java.util.stream.StreamSupport;
 
 import javax.swing.JOptionPane;
 
+import org.triplea.game.server.HeadlessGameServer;
+
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.engine.message.IRemote;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Constants;

--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -34,7 +34,7 @@ import lombok.extern.java.Log;
  */
 @Log
 @Immutable
-public final class AvailableGames {
+final class AvailableGames {
   private static final String ZIP_EXTENSION = ".zip";
   private final Map<String, URI> availableGames;
   private final Set<String> availableMapFolderOrZipNames;
@@ -151,7 +151,7 @@ public final class AvailableGames {
   /**
    * Can return null.
    */
-  public GameData getGameData(final String gameName) {
+  GameData getGameData(final String gameName) {
     return Optional.ofNullable(availableGames.get(gameName))
         .map(uri -> parse(uri).orElse(null))
         .orElse(null);
@@ -169,7 +169,7 @@ public final class AvailableGames {
     return Optional.empty();
   }
 
-  public boolean containsMapName(final String mapNameProperty) {
+  boolean containsMapName(final String mapNameProperty) {
     return availableMapFolderOrZipNames.contains(mapNameProperty)
         || availableMapFolderOrZipNames.contains(mapNameProperty + "-master");
   }

--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.framework.headlessGameServer;
+package org.triplea.game.server;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.framework.headlessGameServer;
+package org.triplea.game.server;
 
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_HOSTED_BY;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
@@ -24,7 +24,7 @@ import games.strategy.util.Interruptibles;
 /**
  * Server setup model.
  */
-public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
+class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   private final List<Observer> listeners = new CopyOnWriteArrayList<>();
   private final ServerModel model;
   private final GameSelectorModel gameSelectorModel;
@@ -93,7 +93,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     return model.getChatPanel();
   }
 
-  public ServerModel getModel() {
+  ServerModel getModel() {
     return model;
   }
 
@@ -142,5 +142,4 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   public boolean showCancelButton() {
     return true;
   }
-
 }

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.framework.headlessGameServer;
+package org.triplea.game.server;
 
 import java.util.List;
 import java.util.Map;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.framework.headlessGameServer;
+package org.triplea.game.server;
 
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
@@ -8,7 +8,7 @@ import games.strategy.engine.framework.startup.ui.ISetupPanel;
 /**
  * Setup panel model for headless server.
  */
-public class HeadlessServerSetupPanelModel extends SetupPanelModel {
+class HeadlessServerSetupPanelModel extends SetupPanelModel {
   HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel) {
     super(gameSelectorModel);
   }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,7 +1,5 @@
 package org.triplea.game.server;
 
-import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
-
 /**
  * Runs a headless game server.
  */


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle PackageName rule in the `g.s.engine.framework.headlessGameServer` package.  The types in this package will eventually be moved to the `game-headless` project.  Thus, I renamed the package to `org.triplea.game.server` in anticipation of that move.

## Functional Changes

None.

## Refactoring Changes

* Reduced accessibility of the affected types from public to package-private, where possible, now that they are in the same package as `HeadlessGameRunner`.

## Manual Testing Performed

* Built the headless game server artifact, verified I could connect to it through the lobby, and started a bot-hosted game.

## Additional Review Notes

Please wait to merge each subsequent Checkstyle PR until the previous Bot Checkstyle threshold update PR has been merged.  This will avoid a flood of unnecessary threshold update PRs being generated.