### PR TITLE
Checkstyle: Suppress naming violations in GUID

### DIFF
--- a/game-core/src/main/java/games/strategy/net/GUID.java
+++ b/game-core/src/main/java/games/strategy/net/GUID.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Backed by a java.rmi.dgc.VMID.
  * Written across the network often, so this class is externalizable to increase efficiency.
  */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName") // rename upon next lobby-incompatible release
 public final class GUID implements Externalizable {
   private static final long serialVersionUID = 8426441559602874190L;
   // this prefix is unique across vms


### PR DESCRIPTION
## Overview

Suppresses a violation of the Checkstyle AbbreviationAsWordInName rule in the `GUID` class.  This type is used by the lobby server and client via the `ILobbyGameBroadcaster` and `ILobbyGameController` RMI interfaces and cannot be renamed without breaking lobby compatibility.

## Functional Changes

None.

## Manual Testing Performed

None.