### PR TITLE
Add logic to remove isSuicide units from air landing on carrier checks

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -537,7 +537,15 @@ public class AirMovementValidator {
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
     ownedAir.addAll(CollectionUtils.getMatches(units, ownedAirMatch));
-    // sort the list by shortest range first so those birds will get first pick of landingspots
+
+    // Remove suicide units if combat move and any enemy units at destination
+    final Collection<Unit> enemyUnitsAtEnd =
+        route.getEnd().getUnits().getMatches(Matches.enemyUnit(player, player.getData()));
+    if (!enemyUnitsAtEnd.isEmpty() && GameStepPropertiesHelper.isCombatMove(player.getData())) {
+      ownedAir.removeIf(Matches.unitIsSuicide());
+    }
+
+    // Sort the list by shortest range first so those birds will get first pick of landingspots
     ownedAir.sort(getLowestToHighestMovementComparatorIncludingUnitsNotYetMoved(route));
     return ownedAir;
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1214,6 +1214,10 @@ public class WW2V3Year41Test {
   @Test
   public void testBomberWithTankOverWaterParatroopers() {
     final PlayerID germans = germans(gameData);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
+    advanceToStep(bridge, "CombatMove");
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory germany = territory("Germany", gameData);
@@ -1232,6 +1236,10 @@ public class WW2V3Year41Test {
   public void testBomberTankOverWater() {
     // can't transport a tank over water using a bomber
     final PlayerID germans = germans(gameData);
+    final IDelegateBridge bridge = newDelegateBridge(germans);
+    advanceToStep(bridge, "CombatMove");
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     final Territory sz5 = territory("5 Sea Zone", gameData);
     final Territory germany = territory("Germany", gameData);
     final Territory karelia = territory("Karelia S.S.R.", gameData);


### PR DESCRIPTION
Addresses: https://forums.triplea-game.org/topic/73/iron-war-official-thread/395

When checking for valid carrier landing locations for air units, isSuicide air units which are attacking should be ignored (missiles, bombs, etc). This only impacts a few advanced maps which use these types of units (Iron War being the one the issue was reported on and the fix was tested on).