### PR TITLE
Fix broken reflection in GameDataExporter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -539,16 +539,9 @@ public class GameDataExporter {
     xmlfile.append("\n");
     xmlfile.append("        <sequence>\n");
     for (final GameStep step : data.getSequence()) {
-      try {
-        final Field delegateField = GameStep.class.getDeclaredField("m_delegate"); // TODO: unchecked reflection
-        delegateField.setAccessible(true);
-        final String delegate = (String) delegateField.get(step);
-        xmlfile.append("            <step name=\"").append(step.getName()).append("\" delegate=\"").append(delegate)
-            .append("\"");
-      } catch (final NullPointerException | NoSuchFieldException | IllegalArgumentException
-          | IllegalAccessException e) {
-        log.log(Level.SEVERE, "An Error occured whilst trying to sequence in game " + data.getGameName(), e);
-      }
+      xmlfile.append("            <step");
+      xmlfile.append(" name=\"").append(step.getName()).append("\"");
+      xmlfile.append(" delegate=\"").append(step.getDelegate().getName()).append("\"");
       if (step.getPlayerId() != null) {
         xmlfile.append(" player=\"").append(step.getPlayerId().getName()).append("\"");
       }


### PR DESCRIPTION
## Overview

Fixing the Checkstyle MemberName violations in `GameStep` (#4285) broke `GameDataExporter` because it relies on reflection to get the name of the delegate associated with the step.  The fix is to avoid using reflection and simply get the delegate name via the `GameStep` API.

## Functional Changes

None.

## Manual Testing Performed

Exported game XML using this branch and using 1.9.0.0.12226.  Compared the two XML files and verified the `<step>` elements were identical.