### PR TITLE
Rocket fix

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -76,7 +76,6 @@ public interface Constants {
   String ROLL_AA_INDIVIDUALLY = "Roll AA Individually";
   String LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION = "Limit SBR Damage To Factory Production";
   String SBR_VICTORY_POINTS = "SBR Victory Points";
-  String ROCKET_ATTACKS_PER_FACTORY_INFINITE = "Rocket Attacks Per Factory Infinite";
   String LIMIT_SBR_DAMAGE_PER_TURN = "Limit SBR Damage Per Turn";
   String LIMIT_ROCKET_DAMAGE_PER_TURN = "Limit Rocket Damage Per Turn";
   String ALLIED_AIR_INDEPENDENT = "Allied Air Independent";

--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -60,6 +60,7 @@ public interface Constants {
   String PROJECTION_OF_POWER = "Projection of Power";
   String ALL_ROCKETS_ATTACK = "All Rockets Attack";
   String ROCKETS_CAN_FLY_OVER_IMPASSABLES = "Rockets Can Fly Over Impassables";
+  String TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR = "Target Rockets Sequentialy and After SBR";
   String NEUTRALS_ARE_IMPASSABLE = "Neutrals Are Impassable";
   String NEUTRALS_ARE_BLITZABLE = "Neutrals Are Blitzable";
   String PARTIAL_AMPHIBIOUS_RETREAT = "Partial Amphibious Retreat";

--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -60,7 +60,7 @@ public interface Constants {
   String PROJECTION_OF_POWER = "Projection of Power";
   String ALL_ROCKETS_ATTACK = "All Rockets Attack";
   String ROCKETS_CAN_FLY_OVER_IMPASSABLES = "Rockets Can Fly Over Impassables";
-  String TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR = "Target Rockets Sequentialy and After SBR";
+  String TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR = "Target Rockets Sequentially and After SBR";
   String NEUTRALS_ARE_IMPASSABLE = "Neutrals Are Impassable";
   String NEUTRALS_ARE_BLITZABLE = "Neutrals Are Blitzable";
   String PARTIAL_AMPHIBIOUS_RETREAT = "Partial Amphibious Retreat";

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -67,7 +67,7 @@ public final class Properties implements Constants {
   }
 
   /**
-   * Pacific Theater
+   * Pacific Theater.
    */
   public static boolean getPacificTheater(final GameData data) {
     return data.getProperties().get(PACIFIC_THEATER, false);

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -62,7 +62,11 @@ public final class Properties implements Constants {
     return data.getProperties().get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
   }
 
-  /*
+  public static boolean getSequentiallyTargetedRockets(final GameData data) {
+    return data.getProperties().get(TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR, false);
+  }
+
+  /**
    * Pacific Theater
    */
   public static boolean getPacificTheater(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -62,8 +62,8 @@ public final class Properties implements Constants {
     return data.getProperties().get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
   }
 
-  /**
-   * Pacific Theater.
+  /*
+   * Pacific Theater
    */
   public static boolean getPacificTheater(final GameData data) {
     return data.getProperties().get(PACIFIC_THEATER, false);

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -175,13 +175,6 @@ public final class Properties implements Constants {
   }
 
   /**
-   * Allow x rocket attack(s) per defending factory.
-   */
-  public static boolean getRocketAttacksPerFactoryInfinite(final GameData data) {
-    return data.getProperties().get(ROCKET_ATTACKS_PER_FACTORY_INFINITE, false);
-  }
-
-  /**
    * Are allied aircraft dependents of CVs.
    */
   public static boolean getAlliedAirIndependent(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -75,7 +75,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private int warBondDiceNumber = 0;
   private IntegerMap<UnitType> rocketDiceNumber = new IntegerMap<>();
   private int rocketDistance = 0;
-  private int rocketNumberPerTerritory = 0;
+  private int rocketNumberPerTerritory = 1;
   private Map<UnitType, Set<String>> unitAbilitiesGained = new HashMap<>();
   private boolean airborneForces = false;
   private IntegerMap<UnitType> airborneCapacity = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -132,11 +132,13 @@ public class TechAbilityAttachment extends DefaultAttachment {
   @VisibleForTesting
   static int sumNumbers(
       final ToIntFunction<TechAbilityAttachment> mapper,
+      final String attachmentType,
       final PlayerId player,
       final GameData data) {
     return TechTracker.getCurrentTechAdvances(player, data).stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
+        .filter(i -> i.getAttachedTo().toString().equals(attachmentType))
         .mapToInt(mapper)
         .filter(i -> i > 0)
         .sum();
@@ -364,7 +366,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getWarBondDiceSides(final PlayerId player, final GameData data) {
-    return sumNumbers(TechAbilityAttachment::getWarBondDiceSides, player, data);
+    return sumNumbers(TechAbilityAttachment::getWarBondDiceSides, TechAdvance.TECH_NAME_WAR_BONDS, player, data);
   }
 
   private void resetWarBondDiceSides() {
@@ -384,7 +386,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getWarBondDiceNumber(final PlayerId player, final GameData data) {
-    return sumNumbers(TechAbilityAttachment::getWarBondDiceNumber, player, data);
+    return sumNumbers(TechAbilityAttachment::getWarBondDiceNumber, TechAdvance.TECH_NAME_WAR_BONDS, player, data);
   }
 
   private void resetWarBondDiceNumber() {
@@ -436,7 +438,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getRocketDistance(final PlayerId player, final GameData data) {
-    return sumNumbers(TechAbilityAttachment::getRocketDistance, player, data);
+    return sumNumbers(TechAbilityAttachment::getRocketDistance, TechAdvance.TECH_NAME_ROCKETS, player, data);
   }
 
   private void resetRocketDistance() {
@@ -444,7 +446,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private void setRocketNumberPerTerritory(final String value) throws GameParseException {
-    rocketNumberPerTerritory = getIntInRange("rocketNumberPerTerritory", value, 200, false);
+    rocketNumberPerTerritory = getIntInRange("rocketNumberPerTerritory", value, 200, true);
   }
 
   private void setRocketNumberPerTerritory(final Integer value) {
@@ -456,11 +458,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getRocketNumberPerTerritory(final PlayerId player, final GameData data) {
-    return sumNumbers(TechAbilityAttachment::getRocketNumberPerTerritory, player, data);
+    return sumNumbers(TechAbilityAttachment::getRocketNumberPerTerritory, TechAdvance.TECH_NAME_ROCKETS, player, data);
   }
 
   private void resetRocketNumberPerTerritory() {
-    rocketNumberPerTerritory = 0;
+    rocketNumberPerTerritory = 1;
   }
 
   private void setUnitAbilitiesGained(final String value) throws GameParseException {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -90,7 +90,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       needToScramble = false;
     }
     if (needToCreateRockets) {
-      rocketHelper = new RocketsFireHelper(bridge, getData(), bridge.getPlayerId());
+      rocketHelper = RocketsFireHelper.setUpRockets(bridge);
       needToCreateRockets = false;
     }
     if (needToKamikazeSuicideAttacks) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -133,9 +133,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     super.end();
     needToInitialize = true;
     needToScramble = true;
+    needToCreateRockets = true;
     needToKamikazeSuicideAttacks = true;
     needToClearEmptyAirBattleAttacks = true;
     needToAddBombardmentSources = true;
+    needToFireRockets = true;
     needToRecordBattleStatistics = true;
     needToCleanup = true;
     needToCheckDefendingPlanesCanLand = true;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -107,7 +107,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     battleTracker.fightAirRaidsAndStrategicBombing(bridge);
     if (needToFireRockets) {
-      rocketHelper.fireRockets();
+      rocketHelper.fireRockets(bridge);
       needToFireRockets = false;
     }
     battleTracker.fightDefenselessBattles(bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -64,6 +64,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private boolean needToRecordBattleStatistics = true;
   private boolean needToCheckDefendingPlanesCanLand = true;
   private boolean needToCleanup = true;
+  private boolean needToCreateRockets = true;
+  private boolean needToFireRockets = true;
+  private RocketsFireHelper rocketHelper;
   private IBattle currentBattle = null;
 
   @Override
@@ -86,6 +89,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       doScrambling();
       needToScramble = false;
     }
+    if (needToCreateRockets) {
+      rocketHelper = new RocketsFireHelper(bridge, getData(), bridge.getPlayerId());
+      needToCreateRockets = false;
+    }
     if (needToKamikazeSuicideAttacks) {
       doKamikazeSuicideAttacks();
       needToKamikazeSuicideAttacks = false;
@@ -99,6 +106,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       needToAddBombardmentSources = false;
     }
     battleTracker.fightAirRaidsAndStrategicBombing(bridge);
+    if (needToFireRockets) {
+      rocketHelper.fireRockets();
+      needToFireRockets = false;
+    }
     battleTracker.fightDefenselessBattles(bridge);
     battleTracker.fightBattleIfOnlyOne(bridge);
   }
@@ -138,9 +149,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     state.battleTracker = battleTracker;
     state.needToInitialize = needToInitialize;
     state.needToScramble = needToScramble;
+    state.needToCreateRockets = needToCreateRockets;
     state.needToKamikazeSuicideAttacks = needToKamikazeSuicideAttacks;
     state.needToClearEmptyAirBattleAttacks = needToClearEmptyAirBattleAttacks;
     state.needToAddBombardmentSources = needToAddBombardmentSources;
+    state.needToFireRockets = needToFireRockets;
     state.needToRecordBattleStatistics = needToRecordBattleStatistics;
     state.needToCheckDefendingPlanesCanLand = needToCheckDefendingPlanesCanLand;
     state.needToCleanup = needToCleanup;
@@ -155,9 +168,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     battleTracker = s.battleTracker;
     needToInitialize = s.needToInitialize;
     needToScramble = s.needToScramble;
+    needToCreateRockets = s.needToCreateRockets;
     needToKamikazeSuicideAttacks = s.needToKamikazeSuicideAttacks;
     needToClearEmptyAirBattleAttacks = s.needToClearEmptyAirBattleAttacks;
     needToAddBombardmentSources = s.needToAddBombardmentSources;
+    needToFireRockets = s.needToFireRockets;
     needToRecordBattleStatistics = s.needToRecordBattleStatistics;
     needToCheckDefendingPlanesCanLand = s.needToCheckDefendingPlanesCanLand;
     needToCleanup = s.needToCleanup;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -10,9 +10,11 @@ class BattleExtendedDelegateState implements Serializable {
   BattleTracker battleTracker = new BattleTracker();
   public boolean needToInitialize;
   boolean needToScramble;
+  boolean needToCreateRockets;
   boolean needToKamikazeSuicideAttacks;
   boolean needToClearEmptyAirBattleAttacks;
   boolean needToAddBombardmentSources;
+  boolean needToFireRockets;
   boolean needToRecordBattleStatistics;
   boolean needToCheckDefendingPlanesCanLand;
   boolean needToCleanup;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -18,5 +18,6 @@ class BattleExtendedDelegateState implements Serializable {
   boolean needToRecordBattleStatistics;
   boolean needToCheckDefendingPlanesCanLand;
   boolean needToCleanup;
+  RocketsFireHelper rocketHelper;
   IBattle currentBattle;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -137,8 +137,8 @@ public final class GameStepPropertiesHelper {
   }
 
   /**
-   * Fire rockets after phase is over. Normally would occur after combat move for WW2v2 and WW2v3, and after noncombat
-   * move for WW2v1.
+   * Fire rockets after phase is over. This method is here for legacy support.
+   * Ideally, all maps with rockets will set PROPERY_fireRockets for move and battle phases.
    */
   static boolean isFireRockets(final GameData data) {
     data.acquireReadLock();
@@ -146,6 +146,9 @@ public final class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.FIRE_ROCKETS);
       if (prop != null) {
         return Boolean.parseBoolean(prop);
+      } else if (data.getSequence().getStep().getDelegate().getName().compareTo("battle") == 0) {
+        return games.strategy.triplea.Properties.getWW2V2(data)
+            || games.strategy.triplea.Properties.getWW2V3(data);
       } else if (Properties.getWW2V2(data) || Properties.getWW2V3(data)) {
         return isCombatDelegate(data);
       }
@@ -289,6 +292,7 @@ public final class GameStepPropertiesHelper {
   }
 
   private static boolean isCombatDelegate(final GameData data) {
+    // NonCombatMove endsWith CombatMove so check for NCM first
     return !data.getSequence().getStep().getName().endsWith("NonCombatMove")
         && data.getSequence().getStep().getName().endsWith("CombatMove");
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -137,28 +137,6 @@ public final class GameStepPropertiesHelper {
   }
 
   /**
-   * Fire rockets after phase is over. This method is here for legacy support.
-   * Ideally, all maps with rockets will set PROPERY_fireRockets for move and battle phases.
-   */
-  static boolean isFireRockets(final GameData data) {
-    data.acquireReadLock();
-    try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.FIRE_ROCKETS);
-      if (prop != null) {
-        return Boolean.parseBoolean(prop);
-      } else if (data.getSequence().getStep().getDelegate().getName().equals("battle")) {
-        return Properties.getWW2V2(data) || Properties.getWW2V3(data);
-      } else if (Properties.getWW2V2(data) || Properties.getWW2V3(data)) {
-        return isCombatDelegate(data);
-      }
-      return isNonCombatDelegate(data);
-
-    } finally {
-      data.releaseReadLock();
-    }
-  }
-
-  /**
    * Repairs damaged units. Normally would occur at either start of combat move or end of turn, depending.
    */
   static boolean isRepairUnits(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -146,9 +146,8 @@ public final class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.FIRE_ROCKETS);
       if (prop != null) {
         return Boolean.parseBoolean(prop);
-      } else if (data.getSequence().getStep().getDelegate().getName().compareTo("battle") == 0) {
-        return games.strategy.triplea.Properties.getWW2V2(data)
-            || games.strategy.triplea.Properties.getWW2V3(data);
+      } else if (data.getSequence().getStep().getDelegate().getName().equals("battle")) {
+        return Properties.getWW2V2(data) || Properties.getWW2V3(data);
       } else if (Properties.getWW2V2(data) || Properties.getWW2V3(data)) {
         return isCombatDelegate(data);
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -30,6 +30,7 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
+import games.strategy.triplea.delegate.RocketsFireHelper.RocketType;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
@@ -189,13 +190,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
       removeAirThatCantLand();
     }
 
-    // WW2V2/WW2V3, fires at end of combat move
-    // WW2V1, fires at end of non combat move
-    if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (needToDoRockets && TechTracker.hasRocket(bridge.getPlayerId())) {
-        RocketsFireHelper.fireRockets(bridge, bridge.getPlayerId());
-        needToDoRockets = false;
-      }
+    // WW2V2/WW2V3, fires at end of combat move, for legacy maps only
+    // WW2V1, fires at end of non combat move, for legacy maps only
+    if (needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
+      new RocketsFireHelper(bridge, bridge.getPlayerId(), RocketType.ww2v1);
+      needToDoRockets = false;
     }
 
     // do at the end of the round, if we do it at the start of non combat, then we may do it in the middle of the round,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -30,7 +30,6 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
-import games.strategy.triplea.delegate.RocketsFireHelper.RocketType;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -190,8 +190,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       removeAirThatCantLand();
     }
 
-    // WW2V2/WW2V3, fires at end of combat move, for legacy maps only
-    // WW2V1, fires at end of non combat move, for legacy maps only
+    // WW2V1, fires at end of non combat move.
     if (needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
       new RocketsFireHelper(bridge, bridge.getPlayerId(), RocketType.ww2v1);
       needToDoRockets = false;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -193,10 +193,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // WW2V1, fires at end of non combat move.
     // Other versions fire Rockets in BattleDelegate
     if (needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
-      if (TechTracker.hasRocket(bridge.getPlayerId())
-          && !Properties.getWW2V2(data) && !Properties.getAllRocketsAttack(data)) {
-        RocketsFireHelper.fireWW2V1(bridge);
-      }
+      RocketsFireHelper.fireWW2V1IfNeeded(bridge);
       needToDoRockets = false;
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -191,8 +191,12 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
 
     // WW2V1, fires at end of non combat move.
+    // Other versions fire Rockets in BattleDelegate
     if (needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
-      new RocketsFireHelper(bridge, bridge.getPlayerId(), RocketType.ww2v1);
+      if (TechTracker.hasRocket(bridge.getPlayerId())
+          && !Properties.getWW2V2(data) && !Properties.getAllRocketsAttack(data)) {
+        RocketsFireHelper.fireWW2V1(bridge);
+      }
       needToDoRockets = false;
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -135,7 +135,7 @@ public class RocketsFireHelper implements Serializable {
       final int maxAttacks = TechAbilityAttachment.getRocketNumberPerTerritory(player, data);
       for (final Territory t : previouslyAttackedTerritories.keySet()) {
         // negative Rocket Number per Territory == unlimited
-        if (maxAttacks < 0 || maxAttacks <= previouslyAttackedTerritories.get(t).intValue()) {
+        if (maxAttacks >= 0 && maxAttacks <= previouslyAttackedTerritories.get(t).intValue()) {
           targets.remove(t);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -73,7 +73,7 @@ public class RocketsFireHelper implements Serializable {
    */
   public static void fireWW2V1IfNeeded(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final PlayerID player = bridge.getPlayerId();
+    final PlayerId player = bridge.getPlayerId();
     // If we don't have rockets or aren't V1 then do nothing.
     if (!TechTracker.hasRocket(player) || Properties.getWW2V2(data) || Properties.getAllRocketsAttack(data)) {
       return;
@@ -128,7 +128,7 @@ public class RocketsFireHelper implements Serializable {
    */
   private void findRocketTargetsAndFireIfNeeded(final IDelegateBridge bridge, final boolean fireRocketsImmediately) {
     final GameData data = bridge.getData();
-    final PlayerID player = bridge.getPlayerId();
+    final PlayerId player = bridge.getPlayerId();
     final Map<Territory, Integer> previouslyAttackedTerritories = new LinkedHashMap<>();
     for (final Territory attackFrom : getTerritoriesWithRockets(data, player)) {
       final Set<Territory> targets = getTargetsWithinRange(attackFrom, data, player);
@@ -240,7 +240,7 @@ public class RocketsFireHelper implements Serializable {
   }
 
   private static Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data,
-      final PlayerID player) {
+      final PlayerId player) {
     final int maxDistance = TechAbilityAttachment.getRocketDistance(player, data);
     final Collection<Territory> possible = data.getMap().getNeighbors(territory, maxDistance);
     final Set<Territory> hasFactory = new HashSet<>();
@@ -270,8 +270,8 @@ public class RocketsFireHelper implements Serializable {
 
   private void fireRocket(final IDelegateBridge bridge, final GameData data, final Territory attackFrom,
       final Territory attackedTerritory) {
-    final PlayerID player = bridge.getPlayerId();
-    final PlayerID attacked = attackedTerritory.getOwner();
+    final PlayerId player = bridge.getPlayerId();
+    final PlayerId attacked = attackedTerritory.getOwner();
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final boolean damageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -1,10 +1,13 @@
 package games.strategy.triplea.delegate;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -35,7 +38,62 @@ import games.strategy.util.PredicateBuilder;
 /**
  * Logic to fire rockets.
  */
-public class RocketsFireHelper {
+public class RocketsFireHelper implements Serializable {
+  private static final long serialVersionUID = -3694482580987118444L;
+  private final Set<Territory> attackingFromTerritories = new HashSet<>();
+  private final Map<Territory, Territory> attackedTerritories = new LinkedHashMap<>();
+  private final Map<Territory, Unit> attackedUnits = new LinkedHashMap<>();
+  private boolean needToFindRocketTargets;
+
+  private RocketsFireHelper() {}
+
+  /**
+   * Rocket pseudo constructor for better than V1 rockets.
+   */
+  public static RocketsFireHelper setUpRockets(final IDelegateBridge bridge) {
+    final GameData data = bridge.getData();
+    final RocketsFireHelper helper = new RocketsFireHelper();
+    // WW2V2/WW2V3, now fires at the start of the BattleDelegate
+    // WW2V1, fires at end of non combat move so does not call here
+    helper.needToFindRocketTargets = false;
+    if ((isWW2V2(data) || isAllRocketsAttack(data))
+        && TechTracker.hasRocket(bridge.getPlayerId())) {
+      if (Properties.getSequentiallyTargetedRockets(data)) {
+        helper.needToFindRocketTargets = true;
+      } else {
+        helper.findRocketTargetsAndFireIfNeeded(bridge, false);
+      }
+    }
+    return helper;
+  }
+
+  /**
+   * Fire rockets if we are v1
+   * In this rule set, each player only gets one rocket attack per turn. 
+   */
+  public static void fireWW2V1IfNeeded(final IDelegateBridge bridge) {
+    final GameData data = bridge.getData();
+    final PlayerID player = bridge.getPlayerId();
+    // If we don't have rockets or aren't V1 then do nothing.
+    if (!TechTracker.hasRocket(player) || Properties.getWW2V2(data) || Properties.getAllRocketsAttack(data)) {
+      return;
+    }
+    final Set<Territory> rocketTerritories = getTerritoriesWithRockets(data, player);
+    final Set<Territory> targets = new HashSet<>();
+    for (final Territory territory : rocketTerritories) {
+      targets.addAll(getTargetsWithinRange(territory, data, player));
+    }
+    if (targets.isEmpty()) {
+      bridge.getHistoryWriter().startEvent(player.getName() + " has no targets to attack with rockets");
+      return;
+    }
+    final Territory attacked = getTarget(targets, bridge, null);
+
+    if (attacked != null) {
+      new RocketsFireHelper().fireRocket(bridge, data, null, attacked);
+    }
+  }
+
   private static boolean isWW2V2(final GameData data) {
     return Properties.getWW2V2(data);
   }
@@ -52,10 +110,6 @@ public class RocketsFireHelper {
     return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
   }
 
-  private static boolean isRocketAttacksPerFactoryInfinite(final GameData data) {
-    return Properties.getRocketAttacksPerFactoryInfinite(data);
-  }
-
   private static boolean isPuCap(final GameData data) {
     return Properties.getPuCap(data);
   }
@@ -68,64 +122,96 @@ public class RocketsFireHelper {
     return Properties.getLimitRocketAndSbrDamageToProduction(data);
   }
 
-  static void fireRockets(final IDelegateBridge bridge, final PlayerId player) {
+  /**
+   *  Find Rocket Targets and load up fire rockets for later execution if necessary.
+   *  Directly fired with Sequentially Targeted rockets.
+   */
+  private void findRocketTargetsAndFireIfNeeded(final IDelegateBridge bridge, final boolean fireRocketsImmediately) {
     final GameData data = bridge.getData();
-    final Set<Territory> rocketTerritories = getTerritoriesWithRockets(data, player);
-    if (rocketTerritories.isEmpty()) {
-      bridge.getHistoryWriter().startEvent(player.getName() + " has no rockets to fire");
-      return;
-    }
-    if (isWW2V2(data) || isAllRocketsAttack(data)) {
-      fireWW2V2(bridge, player, rocketTerritories);
-    } else {
-      fireWW2V1(bridge, player, rocketTerritories);
-    }
-  }
-
-  private static void fireWW2V2(
-      final IDelegateBridge bridge,
-      final PlayerId player,
-      final Set<Territory> rocketTerritories) {
-    final GameData data = bridge.getData();
-    final Set<Territory> attackedTerritories = new HashSet<>();
-    final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
-    for (final Territory territory : rocketTerritories) {
-      final Set<Territory> targets = getTargetsWithinRange(territory, data, player);
-      if (oneAttackPerTerritory) {
-        targets.removeAll(attackedTerritories);
+    final PlayerID player = bridge.getPlayerId();
+    final Map<Territory, Integer> previouslyAttackedTerritories = new LinkedHashMap<>();
+    for (final Territory attackFrom : getTerritoriesWithRockets(data, player)) {
+      final Set<Territory> targets = getTargetsWithinRange(attackFrom, data, player);
+      final int maxAttacks = TechAbilityAttachment.getRocketNumberPerTerritory(player, data);
+      for (final Territory t : previouslyAttackedTerritories.keySet()) {
+        // negative Rocket Number per Territory == unlimited
+        if (maxAttacks < 0 || maxAttacks <= previouslyAttackedTerritories.get(t).intValue()) {
+          targets.remove(t);
+        }
       }
       if (targets.isEmpty()) {
         continue;
       }
       // Ask the user where each rocket launcher should target.
-      final Territory target = getTarget(targets, bridge, territory);
-      if (target != null) {
-        if (oneAttackPerTerritory) {
-          attackedTerritories.add(target);
+      Territory targetTerritory;
+      while (true) {
+        targetTerritory = getTarget(targets, bridge, attackFrom);
+        if (targetTerritory == null) {
+          break;
         }
-        fireRocket(player, target, bridge, territory);
+        final Collection<Unit> enemyUnits = CollectionUtils.getMatches(targetTerritory.getUnits(),
+            Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
+        final Collection<Unit> enemyTargetsTotal = CollectionUtils.getMatches(
+            enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(targetTerritory).negate());
+        Unit unitTarget = null;
+        if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+          final Collection<Unit> rocketTargets = new ArrayList<>(
+              CollectionUtils.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player)));
+          final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
+          // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
+          // Not sure if that comment is still current
+          for (final Unit r : rocketTargets) {
+            legalTargetsForTheseRockets.addAll(UnitAttachment.get(r.getType()).getBombingTargets(data));
+          }
+          final Collection<Unit> enemyTargets =
+              CollectionUtils.getMatches(enemyTargetsTotal, Matches.unitIsOfTypes(legalTargetsForTheseRockets));
+          if (enemyTargets.isEmpty()) {
+            // TODO: this sucks
+            continue;
+          }
+          if (enemyTargets.size() == 1) {
+            unitTarget = enemyTargets.iterator().next();
+          } else {
+            final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
+            unitTarget = iplayer.whatShouldBomberBomb(targetTerritory, enemyTargets, rocketTargets);
+          }
+          if (unitTarget == null) {
+            continue;
+            // Ask them if they now want to attack a different territory
+          }
+        }
+        attackedTerritories.put(attackFrom, targetTerritory);
+        attackedUnits.put(attackFrom, unitTarget);
+        // Sequentially Targeted Rockets are target, fire, target, fire ...
+        // Sensible (non-sequential) Rockets are target, target, target, fire, fire, fire.
+        if (fireRocketsImmediately) {
+          fireRocket(bridge, data, attackFrom, targetTerritory);
+          break;
+        }
+        // Can't add this value above because it would cause the rocket to fire twice in a Sequentially Targeted rocket
+        // scenario
+        attackingFromTerritories.add(attackFrom);
+        break;
+      } // while (true)
+      if (targetTerritory != null) {
+        final Integer numAttacks = previouslyAttackedTerritories.get(targetTerritory);
+        previouslyAttackedTerritories.put(targetTerritory,
+            Integer.valueOf(numAttacks == null ? 1 : numAttacks.intValue() + 1));
       }
     }
   }
 
-  /** In this rule set, each player only gets one rocket attack per turn. */
-  private static void fireWW2V1(
-      final IDelegateBridge bridge,
-      final PlayerId player,
-      final Set<Territory> rocketTerritories) {
-    final GameData data = bridge.getData();
-    final Set<Territory> targets = new HashSet<>();
-    for (final Territory territory : rocketTerritories) {
-      targets.addAll(getTargetsWithinRange(territory, data, player));
-    }
-    if (targets.isEmpty()) {
-      bridge.getHistoryWriter().startEvent(player.getName() + " has no targets to attack with rockets");
-      return;
-    }
-    final Territory attacked = getTarget(targets, bridge, null);
-
-    if (attacked != null) {
-      fireRocket(player, attacked, bridge, null);
+  /**
+  *  Fire rockets which have been previously targetted (if any), or for Sequentially Targeted rockets target them too.
+  */
+  public void fireRockets(final IDelegateBridge bridge) {
+    if (needToFindRocketTargets) {
+      findRocketTargetsAndFireIfNeeded(bridge, true);
+    } else {
+      for (final Territory attackingFrom : attackingFromTerritories) {
+        // Roll dice for the rocket attack damage and apply it
+        fireRocket(bridge, bridge.getData(), attackingFrom, attackedTerritories.get(attackingFrom));
+      }
     }
   }
 
@@ -154,7 +240,7 @@ public class RocketsFireHelper {
   }
 
   private static Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data,
-      final PlayerId player) {
+      final PlayerID player) {
     final int maxDistance = TechAbilityAttachment.getRocketDistance(player, data);
     final Collection<Territory> possible = data.getMap().getNeighbors(territory, maxDistance);
     final Set<Territory> hasFactory = new HashSet<>();
@@ -182,10 +268,10 @@ public class RocketsFireHelper {
     return ((ITripleAPlayer) bridge.getRemotePlayer()).whereShouldRocketsAttack(targets, from);
   }
 
-  private static void fireRocket(final PlayerId player, final Territory attackedTerritory, final IDelegateBridge bridge,
-      final Territory attackFrom) {
-    final GameData data = bridge.getData();
-    final PlayerId attacked = attackedTerritory.getOwner();
+  private void fireRocket(final IDelegateBridge bridge, final GameData data, final Territory attackFrom,
+      final Territory attackedTerritory) {
+    final PlayerID player = bridge.getPlayerId();
+    final PlayerID attacked = attackedTerritory.getOwner();
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final boolean damageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
@@ -194,54 +280,22 @@ public class RocketsFireHelper {
     final Collection<Unit> enemyTargetsTotal =
         CollectionUtils.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).negate());
     final Collection<Unit> rockets;
+    final int numberOfAttacks;
     // attackFrom could be null if WW2V1
     if (attackFrom == null) {
-      rockets = null;
+      rockets = new ArrayList<>();
+      numberOfAttacks = 1;
     } else {
       rockets = new ArrayList<>(CollectionUtils.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player)));
+      numberOfAttacks = Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),
+          TechAbilityAttachment.getRocketDiceNumber(rockets, data));
     }
-    final int numberOfAttacks = (rockets == null ? 1
-        : Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),
-            TechAbilityAttachment.getRocketDiceNumber(rockets, data)));
     if (numberOfAttacks <= 0) {
       return;
     }
-    final Collection<Unit> targets = new ArrayList<>();
-    if (damageFromBombingDoneToUnits) {
-      // TODO: rockets needs to be completely redone to allow for multiple rockets to fire at different targets, etc
-      final Set<UnitType> legalTargetsForTheseRockets = new HashSet<>();
-      if (rockets == null) {
-        legalTargetsForTheseRockets.addAll(data.getUnitTypeList().getAllUnitTypes());
-      } else {
-        // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
-        for (final Unit r : rockets) {
-          legalTargetsForTheseRockets.addAll(UnitAttachment.get(r.getType()).getBombingTargets(data));
-        }
-      }
-      final Collection<Unit> enemyTargets =
-          CollectionUtils.getMatches(enemyTargetsTotal, Matches.unitIsOfTypes(legalTargetsForTheseRockets));
-      if (enemyTargets.isEmpty()) {
-        // TODO: this sucks
-        return;
-      }
-      Unit target = null;
-      if (enemyTargets.size() == 1) {
-        target = enemyTargets.iterator().next();
-      } else {
-        while (target == null) {
-          final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
-          target = iplayer.whatShouldBomberBomb(attackedTerritory, enemyTargets, rockets);
-        }
-      }
-      if (target == null) {
-        throw new IllegalStateException("No Targets in " + attackedTerritory.getName());
-      }
-      targets.add(target);
-    }
-    final boolean doNotUseBombingBonus =
-        !Properties.getUseBombingMaxDiceSidesAndBonus(data) || rockets == null;
-    int cost = 0;
     final String transcript;
+    final boolean doNotUseBombingBonus = !Properties.getUseBombingMaxDiceSidesAndBonus(data) || attackFrom == null;
+    int cost = 0;
     if (!Properties.getLowLuckDamageOnly(data)) {
       if (doNotUseBombingBonus) {
         // no low luck, and no bonus, so just roll based on the map's dice sides
@@ -283,13 +337,13 @@ public class RocketsFireHelper {
             // we are zero based
             cost += r + 1;
           }
-          transcript = "Rockets " + ("in " + attackFrom.getName()) + " roll: " + MyFormatter.asDice(rolls);
+          transcript = "Rockets in " + attackFrom.getName() + " roll: " + MyFormatter.asDice(rolls);
         } else {
           cost = highestBonus * numberOfAttacks;
-          transcript = "Rockets " + ("in " + attackFrom.getName()) + " do " + highestBonus + " damage for each rocket";
+          transcript = "Rockets in " + attackFrom.getName() + " do " + highestBonus + " damage for each rocket";
         }
       }
-    } else {
+    } else { // Low luck
       if (doNotUseBombingBonus) {
         // no bonus, so just roll based on the map's dice sides, but modify for LL
         final int maxDice = (data.getDiceSides() + 1) / 3;
@@ -339,27 +393,24 @@ public class RocketsFireHelper {
             // we are zero based
             cost += r + 1;
           }
-          transcript = "Rockets " + ("in " + attackFrom.getName()) + " roll: " + MyFormatter.asDice(rolls);
+          transcript = "Rockets in " + attackFrom.getName() + " roll: " + MyFormatter.asDice(rolls);
         } else {
           cost = highestBonus * numberOfAttacks;
-          transcript = "Rockets " + ("in " + attackFrom.getName()) + " do " + highestBonus + " damage for each rocket";
+          transcript = "Rockets in " + attackFrom.getName() + " do " + highestBonus + " damage for each rocket";
         }
       }
     }
     int territoryProduction = TerritoryAttachment.getProduction(attackedTerritory);
-    if (damageFromBombingDoneToUnits && !targets.isEmpty()) {
-      // we are doing damage to 'target', not to the territory
-      final Unit target = targets.iterator().next();
-      // UnitAttachment ua = UnitAttachment.get(target.getType());
-      final TripleAUnit taUnit = (TripleAUnit) target;
-      final int damageLimit = taUnit.getHowMuchMoreDamageCanThisUnitTake(target, attackedTerritory);
+    final TripleAUnit taUnit = attackFrom == null ? null : (TripleAUnit) attackedUnits.get(attackFrom);
+    if (damageFromBombingDoneToUnits && attackFrom != null) {
+      final int damageLimit = taUnit.getHowMuchMoreDamageCanThisUnitTake(taUnit, attackedTerritory);
       cost = Math.max(0, Math.min(cost, damageLimit));
       final int totalDamage = taUnit.getUnitDamage() + cost;
       // Record production lost
       // DelegateFinder.moveDelegate(data).PUsLost(attackedTerritory, cost);
       // apply the hits to the targets
       final IntegerMap<Unit> damageMap = new IntegerMap<>();
-      damageMap.put(target, totalDamage);
+      damageMap.put(taUnit, totalDamage);
       bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
       // attackedTerritory.notifyChanged();
       // in WW2V2, limit rocket attack cost to production value of factory.
@@ -376,14 +427,14 @@ public class RocketsFireHelper {
     }
     // Record the PUs lost
     DelegateFinder.moveDelegate(data).pusLost(attackedTerritory, cost);
-    if (damageFromBombingDoneToUnits && !targets.isEmpty()) {
+    if (damageFromBombingDoneToUnits && taUnit != null) {
       getRemote(bridge).reportMessage(
           "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to "
-              + targets.iterator().next(),
+              + taUnit,
           "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to "
-              + targets.iterator().next());
+              + taUnit);
       bridge.getHistoryWriter().startEvent("Rocket attack in " + attackedTerritory.getName() + " does " + cost
-          + " damage to " + targets.iterator().next());
+          + " damage to " + taUnit);
     } else {
       cost *= Properties.getPuMultiplier(data);
       getRemote(bridge).reportMessage("Rocket attack in " + attackedTerritory.getName() + " costs:" + cost,
@@ -399,7 +450,7 @@ public class RocketsFireHelper {
       final Change rocketCharge = ChangeFactory.changeResourcesChange(attacked, pus, -cost);
       bridge.addChange(rocketCharge);
     }
-    bridge.getHistoryWriter().addChildToEvent(transcript, rockets == null ? null : new ArrayList<>(rockets));
+    bridge.getHistoryWriter().addChildToEvent(transcript, attackFrom == null ? null : new ArrayList<>(rockets));
     // this is null in WW2V1
     if (attackFrom != null) {
       if (!rockets.isEmpty()) {
@@ -411,8 +462,10 @@ public class RocketsFireHelper {
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)
-    if (targets.stream().anyMatch(Matches.unitCanDieFromReachingMaxDamage())) {
-      final List<Unit> unitsCanDie = CollectionUtils.getMatches(targets, Matches.unitCanDieFromReachingMaxDamage());
+    final Collection<Unit> targetUnitCol = taUnit == null ? enemyTargetsTotal : Collections.singleton(taUnit);
+    if (targetUnitCol.stream().anyMatch(Matches.unitCanDieFromReachingMaxDamage())) {
+      final List<Unit> unitsCanDie =
+          CollectionUtils.getMatches(targetUnitCol, Matches.unitCanDieFromReachingMaxDamage());
       unitsCanDie.retainAll(
           CollectionUtils.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));
       if (!unitsCanDie.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1013,8 +1013,8 @@ public final class TripleAFrame extends JFrame {
         .map(comps -> {
           final JPanel panel = comps.getFirst();
           final JList<?> list = comps.getSecond();
-          final String[] options = {"OK"};
-          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
+          final String[] options = {"OK", "Cancel"};
+          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
               JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
           if (selection == 0) {
             selected.set((Unit) list.getSelectedValue());

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1014,7 +1014,8 @@ public final class TripleAFrame extends JFrame {
           final JPanel panel = comps.getFirst();
           final JList<?> list = comps.getSecond();
           final String[] options = {"OK", "Cancel"};
-          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
+          final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message,
+              JOptionPane.OK_CANCEL_OPTION,
               JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
           if (selection == 0) {
             selected.set((Unit) list.getSelectedValue());

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
+import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.UnitType;
@@ -34,7 +35,8 @@ import games.strategy.util.IntegerMap;
 public class TechAbilityAttachmentTest {
 
   private final GameData data = mock(GameData.class);
-  private final TechAbilityAttachment attachment = spy(new TechAbilityAttachment("", null, data));
+  private final TechAbilityAttachment attachment = spy(new TechAbilityAttachment("",
+      new NamedAttachable("test", data), data));
   private final UnitTypeList list = mock(UnitTypeList.class);
   private final UnitType dummyUnitType = mock(UnitType.class);
   private final String name = "Test Name";
@@ -177,7 +179,7 @@ public class TechAbilityAttachmentTest {
     final int result = TechAbilityAttachment.sumNumbers(a -> {
       assertEquals(attachment, a);
       return counter.getAndUpdate(i -> i * -10);
-    }, mock(PlayerId.class), data);
+    }, "NamedAttachable{name=test}", mock(PlayerId.class), data);
     assertEquals(101, result);
   }
 }


### PR DESCRIPTION
## Overview
Refer #4289.
Fixes a few problems with Rockets including #3846.
In the older games rockets will work as at present but for Global 1940 and derivatives, Rockets will now be considered after scrambling in all cases. Normally there will be rocket targeting, strategic bombing, rocket firing but there will be a map option to have strategic bombing happening before rocket targeting to support the unfortunate rule clarification.

## Functional Changes
See above.

## Manual Testing Performed
- ..

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Reproducing my answers from #4289.
Re: ROCKET_ATTACKS_PER_FACTORY_INFINITE

At one point the property was used but somewhere along the line this function was moved to TechAbilityAttachment.

Re: Why was the default changed of RocketNumberPerTerritory to 1
Setting to 0 just caused rockets not to work. It may have been overridden by the INFINITE property not 100% sure now. In any event it didn't make much sense to have a non functional attribute and a property which did the same thing.


<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
