### PR TITLE
Update transport load algorithm to consider unit transport cost

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -99,7 +99,8 @@ public class ProTransportUtils {
       units.removeAll(unitsToIgnore);
 
       // Sort units by attack
-      units.sort(getDecreasingAttackComparator(player));
+      units.sort(Comparator.<Unit>comparingInt(u -> UnitAttachment.get(u.getType()).getTransportCost())
+          .thenComparing(getDecreasingAttackComparator(player)));
 
       // Get best units that can be loaded
       selectedUnits.addAll(selectUnitsToTransportFromList(transport, units));
@@ -111,12 +112,37 @@ public class ProTransportUtils {
     final List<Unit> selectedUnits = new ArrayList<>();
     final int capacity = UnitAttachment.get(transport.getType()).getTransportCapacity();
     int capacityCount = 0;
+
+    // Load as many units as possible
     for (final Unit unit : units) {
       final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
       if (cost <= (capacity - capacityCount)) {
         selectedUnits.add(unit);
         capacityCount += cost;
         if (capacityCount >= capacity) {
+          break;
+        }
+      }
+    }
+
+    // If extra space try to replace last unit with stronger unit
+    if (!selectedUnits.isEmpty() && capacityCount < capacity) {
+      final Unit lastUnit = selectedUnits.get(selectedUnits.size() - 1);
+      final int lastUnitCost = UnitAttachment.get(lastUnit.getType()).getTransportCost();
+      units.removeAll(selectedUnits);
+      Comparator<Unit> comparator;
+      if (Matches.unitIsLandTransport().test(transport)) {
+        comparator = Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
+            .thenComparing(getDecreasingAttackComparator(transport.getOwner()));
+      } else {
+        comparator = getDecreasingAttackComparator(transport.getOwner());
+      }
+      units.sort(comparator);
+      for (final Unit unit : units) {
+        final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
+        if (comparator.compare(unit, lastUnit) < 0 && (capacityCount - lastUnitCost + cost <= capacity)) {
+          selectedUnits.remove(lastUnit);
+          selectedUnits.add(unit);
           break;
         }
       }
@@ -173,13 +199,16 @@ public class ProTransportUtils {
         || units.isEmpty()) {
       return Collections.singletonList(unit);
     }
-    units.sort(Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
-        .thenComparing(getDecreasingAttackComparator(player)));
     final List<Unit> results = new ArrayList<>();
     results.add(unit);
     if (Matches.unitIsLandTransportWithoutCapacity().test(unit)) {
+      units.sort(Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
+          .thenComparing(getDecreasingAttackComparator(player)));
       results.add(units.get(0));
     } else {
+      units.sort(Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
+          .thenComparing(Comparator.<Unit>comparingInt(u -> UnitAttachment.get(u.getType()).getTransportCost()))
+          .thenComparing(getDecreasingAttackComparator(player)));
       results.addAll(selectUnitsToTransportFromList(unit, units));
     }
     return results;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -133,7 +133,7 @@ public class ProTransportUtils {
       final Unit lastUnit = selectedUnits.get(selectedUnits.size() - 1);
       final int lastUnitCost = UnitAttachment.get(lastUnit.getType()).getTransportCost();
       units.removeAll(selectedUnits);
-      Comparator<Unit> comparator;
+      final Comparator<Unit> comparator;
       if (Matches.unitIsLandTransport().test(transport)) {
         comparator = Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
             .thenComparing(getDecreasingAttackComparator(transport.getOwner()));
@@ -142,8 +142,11 @@ public class ProTransportUtils {
       }
       units.sort(comparator);
       for (final Unit unit : units) {
+        if (comparator.compare(unit, lastUnit) >= 0) {
+          break;
+        }
         final int cost = UnitAttachment.get(unit.getType()).getTransportCost();
-        if (comparator.compare(unit, lastUnit) < 0 && (capacityCount - lastUnitCost + cost <= capacity)) {
+        if (capacityCount - lastUnitCost + cost <= capacity) {
           selectedUnits.remove(lastUnit);
           selectedUnits.add(unit);
           break;
@@ -210,7 +213,7 @@ public class ProTransportUtils {
       results.add(units.get(0));
     } else {
       units.sort(Comparator.<Unit>comparingInt(u -> TripleAUnit.get(u).getMovementLeft())
-          .thenComparing(Comparator.<Unit>comparingInt(u -> UnitAttachment.get(u.getType()).getTransportCost()))
+          .thenComparingInt(u -> UnitAttachment.get(u.getType()).getTransportCost())
           .thenComparing(getDecreasingAttackComparator(player)));
       results.addAll(selectUnitsToTransportFromList(unit, units));
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -108,6 +108,9 @@ public class ProTransportUtils {
     return selectedUnits;
   }
 
+  /**
+   * Selects the best units to load on the transport from the given list.
+   */
   public static List<Unit> selectUnitsToTransportFromList(final Unit transport, final List<Unit> units) {
     final List<Unit> selectedUnits = new ArrayList<>();
     final int capacity = UnitAttachment.get(transport.getType()).getTransportCapacity();


### PR DESCRIPTION
## Overview
- Addresses AI transport behavior found here: https://forums.triplea-game.org/topic/73/iron-war-official-thread/398

## Functional Changes
- Add some checks/sorting to consider unit transport cost when selecting the best units to load

## Manual Testing Performed
- Tested on revised, v3, and Iron War to see AI behavior
- Here is an Iron War save that shows the AI think the UK can only amphib assault West Germany with 1 Inf, 1 L.Tank, 1 M.Tank, and 1 Art before changes then see it can with 5 Inf and 1 Art after: 
[test.zip](https://github.com/triplea-game/triplea/files/2556264/test.zip)

