### PR TITLE
Use dynamic heap size for installers

### DIFF
--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -59,9 +59,8 @@
       </java>
       <includedFiles />
       <unextractableFiles />
-      <vmOptionsFile mode="content" overwriteMode="3" fileMode="644">
-        <content>-Xmx2G
--Xms2G</content>
+      <vmOptionsFile mode="none" overwriteMode="3" fileMode="644">
+        <content />
       </vmOptionsFile>
       <customScript mode="1" file="">
         <content />
@@ -685,6 +684,49 @@ return true;</string>
                     <object class="com.install4j.runtime.beans.actions.desktop.RegisterAddRemoveAction">
                       <void property="itemName">
                         <string>${compiler:sys.fullName} ${compiler:sys.version}</string>
+                      </void>
+                    </object>
+                  </java>
+                </serializedBean>
+                <condition />
+              </action>
+              <action name="" id="458" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.SetVariableAction" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" rollbackBarrierExitCode="0" multiExec="false" failureStrategy="2" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.control.SetVariableAction">
+                      <void property="script">
+                        <object class="com.install4j.api.beans.ScriptProperty">
+                          <void property="value">
+                            <string>final boolean is32BitJavaRuntime = "x86".equals(System.getProperty("os.arch"));
+final long halfMemoryMiB = Math.round(SystemInfo.getPhysicalMemory() * 0.5 / 1024L / 1024L);
+return Math.min(is32BitJavaRuntime ? 1024L : 2048L, halfMemoryMiB);</string>
+                          </void>
+                        </object>
+                      </void>
+                      <void property="variableName">
+                        <string>heapSizeMiB</string>
+                      </void>
+                    </object>
+                  </java>
+                </serializedBean>
+                <condition />
+              </action>
+              <action name="" id="457" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.AddVmOptionsAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" rollbackBarrierExitCode="0" multiExec="false" failureStrategy="2" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.misc.AddVmOptionsAction">
+                      <void property="launcherId">
+                        <string>33</string>
+                      </void>
+                      <void property="vmOptions">
+                        <array class="java.lang.String" length="2">
+                          <void index="0">
+                            <string>-Xmx${installer:heapSizeMiB}M</string>
+                          </void>
+                          <void index="1">
+                            <string>-Xms${installer:heapSizeMiB}M</string>
+                          </void>
+                        </array>
                       </void>
                     </object>
                   </java>


### PR DESCRIPTION
## Overview

Fixes #4255.  **Note that this is a hotfix for the `release/1.9.0.0` branch.**

The installers currently hard-code the values of the `-Xmx` and `-Xms` VM parameters to 2 GiB on all platforms.  However, this fails on Windows x86 because 32-bit Windows only allocates, at most, 2 GiB of user space (3 GiB if an appropriate boot-loader switch is used).  Therefore, we need to calculate these VM parameters dynamically based on the user's environment.

## Functional Changes

Changed the hard-coded `-Xmx` and `-Xms` VM parameters to use the following algorithm instead:

* Initially use half of available physical memory
* If a 32-bit JVM, use no more than 1 GiB
* If a 64-bit JVM, use no more than 2 GiB

## Manual Testing Performed

* Tested the Unix installer on a 64-bit OS with 8 GiB of physical memory and verified the VM options were set to 2 GiB.
* Tested the Windows x86 installer on a 64-bit OS with 16 GiB of physical memory and verified the VM options were set to 1 GiB.
* Tested the Windows x86_64 installer on a 64-bit OS with 16 GiB of physical memory and verified the VM options were set to 2 GiB.

**:warning: The macOS installer was not tested! :warning:**