### PR TITLE
Extract auto-save specific types

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/AutoSaveFileUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/AutoSaveFileUtils.java
@@ -1,0 +1,74 @@
+package games.strategy.engine.framework;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_HOSTED_BY;
+import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
+import static games.strategy.engine.framework.GameDataFileUtils.addExtension;
+import static games.strategy.util.StringUtils.capitalize;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+/**
+ * Provides methods for getting the names of auto-save files periodically generated during a game.
+ */
+public final class AutoSaveFileUtils {
+  private AutoSaveFileUtils() {}
+
+  @VisibleForTesting
+  static File getAutoSaveFile(final String fileName) {
+    return ClientSetting.saveGamesFolderPath.getValueOrThrow().resolve(Paths.get("autoSave", fileName)).toFile();
+  }
+
+  private static File getAutoSaveFile(final String baseFileName, final boolean headless) {
+    return getAutoSaveFile(getAutoSaveFileName(baseFileName, headless));
+  }
+
+  @VisibleForTesting
+  static String getAutoSaveFileName(final String baseFileName, final boolean headless) {
+    if (headless) {
+      final String prefix = System.getProperty(TRIPLEA_NAME, System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
+      if (!prefix.isEmpty()) {
+        return prefix + "_" + baseFileName;
+      }
+    }
+    return baseFileName;
+  }
+
+  public static File getHeadlessAutoSaveFile() {
+    return getAutoSaveFile(addExtension("autosave"), true);
+  }
+
+  public static File getOddRoundAutoSaveFile(final boolean headless) {
+    return getAutoSaveFile(addExtension("autosave_round_odd"), headless);
+  }
+
+  public static File getEvenRoundAutoSaveFile(final boolean headless) {
+    return getAutoSaveFile(addExtension("autosave_round_even"), headless);
+  }
+
+  public static File getLostConnectionAutoSaveFile(final LocalDateTime localDateTime) {
+    checkNotNull(localDateTime);
+
+    return getAutoSaveFile(
+        addExtension("connection_lost_on_" + DateTimeFormatter.ofPattern("MMM_dd_'at'_HH_mm").format(localDateTime)));
+  }
+
+  public static File getBeforeStepAutoSaveFile(final String stepName, final boolean headless) {
+    checkNotNull(stepName);
+
+    return getAutoSaveFile(addExtension("autosaveBefore" + capitalize(stepName)), headless);
+  }
+
+  public static File getAfterStepAutoSaveFile(final String stepName, final boolean headless) {
+    checkNotNull(stepName);
+
+    return getAutoSaveFile(addExtension("autosaveAfter" + capitalize(stepName)), headless);
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
@@ -1,0 +1,45 @@
+package games.strategy.engine.framework;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * The types of auto-saves that can be loaded by a headless game server.
+ */
+public enum HeadlessAutoSaveType {
+  AUTOSAVE(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
+
+  /**
+   * A second auto-save that a headless game server will alternate between (the other being {@link #AUTOSAVE}).
+   *
+   * @deprecated No longer supported. If an old client happens to request this auto-save, it now forwards to the
+   *             same file as {@link #AUTOSAVE} instead of simply doing nothing. Remove upon next stable release (i.e.
+   *             once no stable client will ever request this auto-save).
+   */
+  @Deprecated
+  AUTOSAVE2(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
+
+  AUTOSAVE_ODD(AutoSaveFileUtils.getOddRoundAutoSaveFile(true)),
+
+  AUTOSAVE_EVEN(AutoSaveFileUtils.getEvenRoundAutoSaveFile(true)),
+
+  AUTOSAVE_END_TURN(AutoSaveFileUtils.getBeforeStepAutoSaveFile("EndTurn", true)),
+
+  AUTOSAVE_BEFORE_BATTLE(AutoSaveFileUtils.getBeforeStepAutoSaveFile("Battle", true)),
+
+  AUTOSAVE_AFTER_BATTLE(AutoSaveFileUtils.getAfterStepAutoSaveFile("Battle", true)),
+
+  AUTOSAVE_AFTER_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("CombatMove", true)),
+
+  AUTOSAVE_AFTER_NON_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("NonCombatMove", true));
+
+  private final Path path;
+
+  HeadlessAutoSaveType(final File file) {
+    path = file.toPath();
+  }
+
+  public File getFile() {
+    return path.toFile();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -32,7 +32,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.delegate.IPersistentDelegate;
 import games.strategy.engine.framework.startup.mc.IObserverWaitingToJoin;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.history.DelegateHistoryWriter;
 import games.strategy.engine.history.Event;
 import games.strategy.engine.history.EventChild;
@@ -353,7 +352,7 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSaveBefore(final IDelegate delegate) {
-    saveGame(SaveGameFileChooser.getBeforeStepAutoSaveFile(delegate.getName(), HeadlessGameServer.headless()));
+    saveGame(AutoSaveFileUtils.getBeforeStepAutoSaveFile(delegate.getName(), HeadlessGameServer.headless()));
   }
 
   @Override
@@ -444,8 +443,8 @@ public class ServerGame extends AbstractGame {
     if (gameData.getSequence().next()) {
       gameData.getHistory().getHistoryWriter().startNextRound(gameData.getSequence().getRound());
       saveGame(gameData.getSequence().getRound() % 2 == 0
-          ? SaveGameFileChooser.getEvenRoundAutoSaveFile(headless)
-          : SaveGameFileChooser.getOddRoundAutoSaveFile(headless));
+          ? AutoSaveFileUtils.getEvenRoundAutoSaveFile(headless)
+          : AutoSaveFileUtils.getOddRoundAutoSaveFile(headless));
     }
     if (autoSaveThisDelegate && !currentStep.getName().endsWith("Move")) {
       autoSaveAfter(currentDelegate, headless);
@@ -453,13 +452,13 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSaveAfter(final String stepName, final boolean headless) {
-    saveGame(SaveGameFileChooser.getAfterStepAutoSaveFile(stepName, headless));
+    saveGame(AutoSaveFileUtils.getAfterStepAutoSaveFile(stepName, headless));
   }
 
   private void autoSaveAfter(final IDelegate delegate, final boolean headless) {
     final String typeName = delegate.getClass().getTypeName();
     final String stepName = typeName.substring(typeName.lastIndexOf('.') + 1).replaceFirst("Delegate$", "");
-    saveGame(SaveGameFileChooser.getAfterStepAutoSaveFile(stepName, headless));
+    saveGame(AutoSaveFileUtils.getAfterStepAutoSaveFile(stepName, headless));
   }
 
   private void endStep() {

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeToAutosaveClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeToAutosaveClientAction.java
@@ -7,7 +7,7 @@ import javax.swing.AbstractAction;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.net.IClientMessenger;
 
 /**
@@ -17,10 +17,10 @@ public class ChangeToAutosaveClientAction extends AbstractAction {
   private static final long serialVersionUID = 1972868158345085949L;
   private final Component parent;
   private final IClientMessenger clientMessenger;
-  private final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave;
+  private final HeadlessAutoSaveType typeOfAutosave;
 
   public ChangeToAutosaveClientAction(final Component parent, final IClientMessenger clientMessenger,
-      final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave) {
+      final HeadlessAutoSaveType typeOfAutosave) {
     super("Change To " + typeOfAutosave.toString().toLowerCase());
     this.parent = JOptionPane.getFrameForComponent(parent);
     this.clientMessenger = clientMessenger;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -18,6 +18,7 @@ import javax.swing.SwingUtilities;
 import org.triplea.game.server.HeadlessGameServer;
 
 import games.strategy.engine.data.PlayerId;
+import games.strategy.engine.framework.AutoSaveFileUtils;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.mc.ClientModel;
@@ -26,7 +27,6 @@ import games.strategy.engine.framework.startup.mc.IClientChannel;
 import games.strategy.engine.framework.startup.mc.IObserverWaitingToJoin;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.message.ConnectionLostException;
 import games.strategy.engine.message.IChannelMessenger;
@@ -209,7 +209,7 @@ public class ServerLauncher extends AbstractLauncher {
             // if we do not do this, we can get into an infinite loop of launching a game,
             // then crashing out, then launching, etc.
             serverModel.setAllPlayersToNullNodes();
-            final File f1 = SaveGameFileChooser.getHeadlessAutoSaveFile();
+            final File f1 = AutoSaveFileUtils.getHeadlessAutoSaveFile();
             if (f1.exists()) {
               gameSelectorModel.load(f1);
             } else {
@@ -309,8 +309,8 @@ public class ServerLauncher extends AbstractLauncher {
   private void saveAndEndGame(final INode node) {
     // a hack, if headless save to the autosave to avoid polluting our savegames folder with a million saves
     final File f = headless
-        ? SaveGameFileChooser.getHeadlessAutoSaveFile()
-        : SaveGameFileChooser.getLostConnectionAutoSaveFile(LocalDateTime.now());
+        ? AutoSaveFileUtils.getHeadlessAutoSaveFile()
+        : AutoSaveFileUtils.getLostConnectionAutoSaveFile(LocalDateTime.now());
     try {
       serverGame.saveGame(f);
     } catch (final Exception e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -37,6 +37,7 @@ import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameState;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.network.ui.ChangeGameOptionsClientAction;
 import games.strategy.engine.framework.network.ui.ChangeGameToSaveGameClientAction;
@@ -47,7 +48,6 @@ import games.strategy.engine.framework.startup.launcher.IServerReady;
 import games.strategy.engine.framework.startup.login.ClientLogin;
 import games.strategy.engine.framework.startup.ui.ClientOptions;
 import games.strategy.engine.framework.startup.ui.PlayerType;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.framework.ui.background.WaitWindow;
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.IChannelMessenger;
@@ -450,7 +450,7 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   public Action getHostBotChangeToAutosaveClientAction(final Component parent,
-      final SaveGameFileChooser.AUTOSAVE_TYPE autosaveType) {
+      final HeadlessAutoSaveType autosaveType) {
     return new ChangeToAutosaveClientAction(parent, getMessenger(), autosaveType);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
@@ -2,8 +2,8 @@ package games.strategy.engine.framework.startup.mc;
 
 import java.util.Set;
 
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.message.PlayerListing;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.message.IRemote;
 import games.strategy.net.INode;
 
@@ -34,7 +34,7 @@ public interface IServerStartupRemote extends IRemote {
 
   void changeServerGameTo(final String gameName);
 
-  void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave);
+  void changeToLatestAutosave(final HeadlessAutoSaveType typeOfAutosave);
 
   void changeToGameSave(final byte[] bytes, final String fileName);
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -45,12 +45,12 @@ import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameState;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
 import games.strategy.engine.framework.startup.login.ClientLoginValidator;
 import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.engine.framework.startup.ui.ServerOptions;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
@@ -368,7 +368,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     }
 
     @Override
-    public void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE autoSaveType) {
+    public void changeToLatestAutosave(final HeadlessAutoSaveType autoSaveType) {
       final @Nullable HeadlessGameServer headlessGameServer = HeadlessGameServer.getInstance();
       if (headlessGameServer != null) {
         headlessGameServer.loadGameSave(autoSaveType.getFile());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -22,9 +22,9 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.chat.IChatPanel;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.IRemoteModelListener;
-import games.strategy.engine.framework.ui.SaveGameFileChooser.AUTOSAVE_TYPE;
 import games.strategy.ui.SwingAction;
 
 /**
@@ -251,14 +251,16 @@ public class ClientSetupPanel extends SetupPanel {
     actions.add(clientModel.getHostBotSetMapClientAction(this));
     actions.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
     actions.add(clientModel.getHostBotChangeGameToSaveGameClientAction());
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_ODD));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_EVEN));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_END_TURN));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_BEFORE_BATTLE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_AFTER_BATTLE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_AFTER_COMBAT_MOVE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, AUTOSAVE_TYPE.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_ODD));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_EVEN));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_END_TURN));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_BEFORE_BATTLE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_BATTLE));
+    actions.add(
+        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_COMBAT_MOVE));
+    actions.add(
+        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
     actions.add(clientModel.getHostBotGetGameSaveClientAction(this));
     return actions;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -23,6 +23,7 @@ import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -30,7 +31,6 @@ import games.strategy.engine.framework.startup.ui.FileBackedGamePropertiesCache;
 import games.strategy.engine.framework.startup.ui.IGamePropertiesCache;
 import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
 import swinglib.JButtonBuilder;
@@ -123,21 +123,21 @@ public class GameSelectorPanel extends JPanel implements Observer {
           final JPopupMenu menu = new JPopupMenu();
           menu.add(clientModelForHostBots.getHostBotChangeGameToSaveGameClientAction());
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE));
+              HeadlessAutoSaveType.AUTOSAVE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_ODD));
+              HeadlessAutoSaveType.AUTOSAVE_ODD));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN));
+              HeadlessAutoSaveType.AUTOSAVE_EVEN));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_END_TURN));
+              HeadlessAutoSaveType.AUTOSAVE_END_TURN));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_BEFORE_BATTLE));
+              HeadlessAutoSaveType.AUTOSAVE_BEFORE_BATTLE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_AFTER_BATTLE));
+              HeadlessAutoSaveType.AUTOSAVE_AFTER_BATTLE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_AFTER_COMBAT_MOVE));
+              HeadlessAutoSaveType.AUTOSAVE_AFTER_COMBAT_MOVE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
+              HeadlessAutoSaveType.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
           menu.add(clientModelForHostBots.getHostBotGetGameSaveClientAction(GameSelectorPanel.this));
           final Point point = loadSavedGame.getLocation();
           menu.show(GameSelectorPanel.this, point.x + loadSavedGame.getWidth(), point.y);

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -1,128 +1,20 @@
 package games.strategy.engine.framework.ui;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_HOSTED_BY;
-import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
-import static games.strategy.engine.framework.GameDataFileUtils.addExtension;
-import static games.strategy.util.StringUtils.capitalize;
-
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.triplea.settings.ClientSetting;
 
 /**
  * A file chooser for save games. Defaults to the user's configured save game folder.
- *
- * <p>
- * Also provides several methods for getting the names of auto-save files periodically generated during a game.
- * </p>
  */
 public final class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
 
   private static SaveGameFileChooser instance;
-
-  /**
-   * The available auto-saves that can be loaded by a headless game server.
-   */
-  public enum AUTOSAVE_TYPE {
-    AUTOSAVE(getHeadlessAutoSaveFile()),
-
-    /**
-     * A second auto-save that a headless game server will alternate between (the other being {@link #AUTOSAVE}).
-     *
-     * @deprecated No longer supported. If an old client happens to request this auto-save, it now forwards to the
-     *             same file as {@link #AUTOSAVE} instead of simply doing nothing. Remove upon next stable release (i.e.
-     *             once no stable client will ever request this auto-save).
-     */
-    @Deprecated
-    AUTOSAVE2(getHeadlessAutoSaveFile()),
-
-    AUTOSAVE_ODD(getOddRoundAutoSaveFile(true)),
-
-    AUTOSAVE_EVEN(getEvenRoundAutoSaveFile(true)),
-
-    AUTOSAVE_END_TURN(getBeforeStepAutoSaveFile("EndTurn", true)),
-
-    AUTOSAVE_BEFORE_BATTLE(getBeforeStepAutoSaveFile("Battle", true)),
-
-    AUTOSAVE_AFTER_BATTLE(getAfterStepAutoSaveFile("Battle", true)),
-
-    AUTOSAVE_AFTER_COMBAT_MOVE(getAfterStepAutoSaveFile("CombatMove", true)),
-
-    AUTOSAVE_AFTER_NON_COMBAT_MOVE(getAfterStepAutoSaveFile("NonCombatMove", true));
-
-    private final Path path;
-
-    AUTOSAVE_TYPE(final File file) {
-      path = file.toPath();
-    }
-
-    public File getFile() {
-      return path.toFile();
-    }
-  }
-
-  @VisibleForTesting
-  static File getAutoSaveFile(final String fileName) {
-    return ClientSetting.saveGamesFolderPath.getValueOrThrow().resolve(Paths.get("autoSave", fileName)).toFile();
-  }
-
-  private static File getAutoSaveFile(final String baseFileName, final boolean headless) {
-    return getAutoSaveFile(getAutoSaveFileName(baseFileName, headless));
-  }
-
-  @VisibleForTesting
-  static String getAutoSaveFileName(final String baseFileName, final boolean headless) {
-    if (headless) {
-      final String prefix = System.getProperty(TRIPLEA_NAME, System.getProperty(LOBBY_GAME_HOSTED_BY, ""));
-      if (!prefix.isEmpty()) {
-        return prefix + "_" + baseFileName;
-      }
-    }
-    return baseFileName;
-  }
-
-  public static File getHeadlessAutoSaveFile() {
-    return getAutoSaveFile(addExtension("autosave"), true);
-  }
-
-  public static File getOddRoundAutoSaveFile(final boolean headless) {
-    return getAutoSaveFile(addExtension("autosave_round_odd"), headless);
-  }
-
-  public static File getEvenRoundAutoSaveFile(final boolean headless) {
-    return getAutoSaveFile(addExtension("autosave_round_even"), headless);
-  }
-
-  public static File getLostConnectionAutoSaveFile(final LocalDateTime localDateTime) {
-    checkNotNull(localDateTime);
-
-    return getAutoSaveFile(
-        addExtension("connection_lost_on_" + DateTimeFormatter.ofPattern("MMM_dd_'at'_HH_mm").format(localDateTime)));
-  }
-
-  public static File getBeforeStepAutoSaveFile(final String stepName, final boolean headless) {
-    checkNotNull(stepName);
-
-    return getAutoSaveFile(addExtension("autosaveBefore" + capitalize(stepName)), headless);
-  }
-
-  public static File getAfterStepAutoSaveFile(final String stepName, final boolean headless) {
-    checkNotNull(stepName);
-
-    return getAutoSaveFile(addExtension("autosaveAfter" + capitalize(stepName)), headless);
-  }
 
   public static SaveGameFileChooser getInstance() {
     if (instance == null) {

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -18,8 +18,8 @@ import java.util.logging.Level;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.startup.mc.ServerModel;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.message.HubInvoke;
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteName;
@@ -269,7 +269,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   }
 
   @Override
-  public void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave) {
+  public void changeToLatestAutosave(final HeadlessAutoSaveType typeOfAutosave) {
     bareBonesSendMessageToServer("changeToLatestAutosave", typeOfAutosave);
   }
 

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -2,12 +2,12 @@ package games.strategy.net;
 
 import java.io.File;
 
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
+import games.strategy.engine.framework.HeadlessAutoSaveType;
 
 public interface IClientMessenger extends IMessenger {
   void changeServerGameTo(final String gameName);
 
-  void changeToLatestAutosave(final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave);
+  void changeToLatestAutosave(final HeadlessAutoSaveType typeOfAutosave);
 
   void changeToGameSave(final byte[] bytes, final String fileName);
 

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -33,6 +33,7 @@ import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.ArgParser;
+import games.strategy.engine.framework.AutoSaveFileUtils;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.headless.game.server.ArgValidationResult;
@@ -42,7 +43,6 @@ import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
 import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.sound.ClipPlayer;
@@ -269,7 +269,7 @@ public class HeadlessGameServer {
         new Thread(() -> {
           log.info("Remote Stop Game Initiated.");
           try {
-            serverGame.saveGame(SaveGameFileChooser.getHeadlessAutoSaveFile());
+            serverGame.saveGame(AutoSaveFileUtils.getHeadlessAutoSaveFile());
           } catch (final Exception e) {
             log.log(Level.SEVERE, "Failed to save game", e);
           }

--- a/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
@@ -1,10 +1,10 @@
-package games.strategy.engine.framework.ui;
+package games.strategy.engine.framework;
 
-import static games.strategy.engine.framework.ui.SaveGameFileChooser.getAfterStepAutoSaveFile;
-import static games.strategy.engine.framework.ui.SaveGameFileChooser.getAutoSaveFile;
-import static games.strategy.engine.framework.ui.SaveGameFileChooser.getAutoSaveFileName;
-import static games.strategy.engine.framework.ui.SaveGameFileChooser.getBeforeStepAutoSaveFile;
-import static games.strategy.engine.framework.ui.SaveGameFileChooser.getLostConnectionAutoSaveFile;
+import static games.strategy.engine.framework.AutoSaveFileUtils.getAfterStepAutoSaveFile;
+import static games.strategy.engine.framework.AutoSaveFileUtils.getAutoSaveFile;
+import static games.strategy.engine.framework.AutoSaveFileUtils.getAutoSaveFileName;
+import static games.strategy.engine.framework.AutoSaveFileUtils.getBeforeStepAutoSaveFile;
+import static games.strategy.engine.framework.AutoSaveFileUtils.getLostConnectionAutoSaveFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -15,11 +15,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import games.strategy.engine.framework.CliProperties;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 
-final class SaveGameFileChooserTest extends AbstractClientSettingTestCase {
+final class AutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   @Nested
   final class GetAutoSaveFileTest {
     @Test


### PR DESCRIPTION
## Overview

The original purpose of this PR was to fix violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in the `SaveGameFileChooser$AUTOSAVE_TYPE` enum.  However, I took it a bit further because I didn't think it made sense to define what is effectively auto-save file domain functionality within a UI-specific class.  Therefore, I extracted two new types to a non-UI package and moved the appropriate content from `SaveGameFileChooser` to the new types.

## Functional Changes

None.

## Refactoring Changes

* Moved `SaveGameFileChooser$AUTOSAVE_TYPE` to `g.s.engine.framework.HeadlessAutoSaveType`.
* Moved the auto-save file methods in `SaveGameFileChooser` to `g.s.engine.framework.AutoSaveFileUtils`.

## Manual Testing Performed

Verified a client from this branch could load various auto-saves on a headless server from this branch.