### PR TITLE
Remove "m_" field support from MapPropertyWrapper

### DIFF
--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -42,9 +42,9 @@ import lombok.extern.java.Log;
 @Log
 public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
   private static final long serialVersionUID = 6406798101396215624L;
+
   private final IEditableProperty<T> property;
   private final Method setter;
-
 
   @SuppressWarnings("unchecked")
   private MapPropertyWrapper(final String name, final String description, final T defaultValue, final Method setter) {
@@ -156,7 +156,6 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
     return property.validate(value);
   }
 
-
   private static Field getFieldIncludingFromSuperClasses(final Class<?> c, final String name,
       final boolean justFromSuper) {
     if (!justFromSuper) {
@@ -189,10 +188,6 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
    */
   @VisibleForTesting
   static Field getPropertyField(final String propertyName, final Class<?> type) {
-    try {
-      return getFieldIncludingFromSuperClasses(type, "m_" + propertyName, false);
-    } catch (final IllegalStateException ignored) {
-      return getFieldIncludingFromSuperClasses(type, propertyName, false);
-    }
+    return getFieldIncludingFromSuperClasses(type, propertyName, false);
   }
 }

--- a/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
+++ b/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
@@ -13,19 +13,11 @@ import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.xml.TestAttachment;
 
-public final class MapPropertyWrapperTest {
+final class MapPropertyWrapperTest {
   @Nested
-  public final class GetPropertyFieldTest {
+  final class GetPropertyFieldTest {
     @Test
-    public void shouldReturnFieldWhenFieldWithEmUnderscorePrefixExistsInTargetClass() {
-      final Field field = MapPropertyWrapper.getPropertyField("intValue", ExampleEmUnderscoreParentAttachment.class);
-
-      assertThat(field.getName(), is("m_intValue"));
-      assertThat(field.getDeclaringClass(), is(ExampleEmUnderscoreParentAttachment.class));
-    }
-
-    @Test
-    public void shouldReturnFieldWhenFieldWithoutEmUnderscorePrefixExistsInTargetClass() {
+    void shouldReturnFieldWhenFieldExistsInTargetClass() {
       final Field field = MapPropertyWrapper.getPropertyField("doubleValue", ExampleChildAttachment.class);
 
       assertThat(field.getName(), is("doubleValue"));
@@ -33,15 +25,7 @@ public final class MapPropertyWrapperTest {
     }
 
     @Test
-    public void shouldReturnFieldWhenFieldWithEmUnderscorePrefixExistsInAncestorClass() {
-      final Field field = MapPropertyWrapper.getPropertyField("intValue", ExampleEmUnderscoreChildAttachment.class);
-
-      assertThat(field.getName(), is("m_intValue"));
-      assertThat(field.getDeclaringClass(), is(ExampleEmUnderscoreParentAttachment.class));
-    }
-
-    @Test
-    public void shouldReturnFieldWhenFieldWithoutEmUnderscorePrefixExistsInAncestorClass() {
+    void shouldReturnFieldWhenFieldExistsInAncestorClass() {
       final Field field = MapPropertyWrapper.getPropertyField("intValue", ExampleChildAttachment.class);
 
       assertThat(field.getName(), is("intValue"));
@@ -49,27 +33,8 @@ public final class MapPropertyWrapperTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenFieldDoesNotExist() {
+    void shouldThrowExceptionWhenFieldDoesNotExist() {
       assertThrows(IllegalStateException.class, () -> MapPropertyWrapper.getPropertyField("xxx", TestAttachment.class));
-    }
-  }
-
-  static class ExampleEmUnderscoreParentAttachment extends TestAttachment {
-    private static final long serialVersionUID = 4140595034027616571L;
-
-    @SuppressWarnings("checkstyle:MemberName") // "m_" prefix required for test
-    int m_intValue;
-
-    ExampleEmUnderscoreParentAttachment(final String name, final Attachable attachable, final GameData gameData) {
-      super(name, attachable, gameData);
-    }
-  }
-
-  static class ExampleEmUnderscoreChildAttachment extends ExampleEmUnderscoreParentAttachment {
-    private static final long serialVersionUID = -2515485990895802645L;
-
-    ExampleEmUnderscoreChildAttachment(final String name, final Attachable attachable, final GameData gameData) {
-      super(name, attachable, gameData);
     }
   }
 


### PR DESCRIPTION
## Overview

All `m_` fields in the codebase have been renamed, and this prefix no longer exists.  Therefore, it is no longer necessary for `MapPropertyWrapper` to check for such fields via reflection.

## Functional Changes

* Removed support for `m_` fields from `MapPropertyWrapper`.

## Manual Testing Performed

None.