### PR TITLE
Rename some GameSetting methods

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -50,7 +50,7 @@ public final class Console {
   public Console() {
     setLogLevel(getDefaultLogLevel());
 
-    ClientSetting.showConsole.addSaveListener(gameSetting -> {
+    ClientSetting.showConsole.addListener(gameSetting -> {
       if (gameSetting.getValueOrThrow()) {
         SwingUtilities.invokeLater(() -> setVisible(true));
       }

--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -56,7 +56,7 @@ public final class Console {
       }
     });
 
-    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.saveAndFlush(false));
+    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.setValueAndFlush(false));
     LookAndFeelSwingFrameListener.register(frame);
     frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     frame.getContentPane().setLayout(new BorderLayout());
@@ -144,7 +144,7 @@ public final class Console {
   }
 
   private static void setDefaultLogLevel(final Level level) {
-    ClientSetting.loggingVerbosity.saveAndFlush(level.getName());
+    ClientSetting.loggingVerbosity.setValueAndFlush(level.getName());
   }
 
   public void setVisible(final boolean visible) {

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -74,7 +74,7 @@ public enum ErrorMessage {
                 .toolTip("Shows the error console window with full error details.")
                 .actionListener(() -> {
                   hide();
-                  ClientSetting.showConsole.saveAndFlush(true);
+                  ClientSetting.showConsole.setValueAndFlush(true);
                 })
                 .build())
             .addHorizontalGlue()

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -63,7 +63,7 @@ final class EngineVersionCheck {
       return false;
     }
 
-    updateCheckDateSetting.save(formatUpdateCheckDate(now));
+    updateCheckDateSetting.setValue(formatUpdateCheckDate(now));
     flushSetting.run();
     return true;
   }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -32,7 +32,7 @@ final class UpdatedMapsCheck {
       return false;
     }
 
-    updateCheckDateSetting.save(formatUpdateCheckDate(now));
+    updateCheckDateSetting.setValue(formatUpdateCheckDate(now));
     flushSetting.run();
     return true;
   }

--- a/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/config/client/LobbyServerPropertiesFetcher.java
@@ -82,8 +82,8 @@ public final class LobbyServerPropertiesFetcher {
     try {
       final LobbyServerProperties downloadedProps = downloadAndParseRemoteFile(lobbyPropsUrl, currentVersion,
           LobbyPropertyFileParser::parse);
-      ClientSetting.lobbyLastUsedHost.save(downloadedProps.host);
-      ClientSetting.lobbyLastUsedPort.save(downloadedProps.port);
+      ClientSetting.lobbyLastUsedHost.setValue(downloadedProps.host);
+      ClientSetting.lobbyLastUsedPort.setValue(downloadedProps.port);
       ClientSetting.flush();
       return downloadedProps;
     } catch (final IOException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -43,7 +43,7 @@ public final class ArgParser {
 
   private static void setSystemPropertyOrClientSetting(final String key, final String value) {
     if (CliProperties.MAP_FOLDER.equals(key)) {
-      ClientSetting.mapFolderOverride.saveAndFlush(Paths.get(value));
+      ClientSetting.mapFolderOverride.setValueAndFlush(Paths.get(value));
     } else {
       System.setProperty(key, value);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -39,7 +39,7 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void initialize() {
-    ClientSetting.lookAndFeel.addSaveListener(gameSetting -> {
+    ClientSetting.lookAndFeel.addListener(gameSetting -> {
       setupLookAndFeel(gameSetting.getValueOrThrow());
       SettingsWindow.updateLookAndFeel();
       JOptionPane.showMessageDialog(

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
@@ -31,9 +31,8 @@ public final class LookAndFeelSwingFrameListener implements Consumer<GameSetting
    */
   public static void register(final JFrame component) {
     final Consumer<GameSetting<String>> listener = new LookAndFeelSwingFrameListener(component);
-    ClientSetting.lookAndFeel.addSaveListener(listener);
-    SwingComponents.addWindowClosingListener(component,
-        () -> ClientSetting.lookAndFeel.removeSaveListener(listener));
+    ClientSetting.lookAndFeel.addListener(listener);
+    SwingComponents.addWindowClosingListener(component, () -> ClientSetting.lookAndFeel.removeListener(listener));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -133,7 +133,7 @@ public class MapDownloadController {
     return new TutorialMapPreferences() {
       @Override
       public void preventPromptToDownload() {
-        ClientSetting.promptToDownloadTutorialMap.save(false);
+        ClientSetting.promptToDownloadTutorialMap.setValue(false);
         ClientSetting.flush();
       }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -208,7 +208,7 @@ public class ClientModel implements IMessengerErrorListener {
     }
     final String name = props.getName();
     log.fine("Client playing as:" + name);
-    ClientSetting.playerName.save(name);
+    ClientSetting.playerName.setValue(name);
     ClientSetting.flush();
     final int port = props.getPort();
     if (port >= 65536 || port <= 0) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -56,9 +56,9 @@ public class GameSelectorModel extends Observable {
     fileName = entry.getLocation();
     setGameData(entry.getGameData());
     if (entry.getGameData() != null) {
-      ClientSetting.defaultGameName.save(entry.getGameData().getGameName());
+      ClientSetting.defaultGameName.setValue(entry.getGameData().getGameName());
     }
-    ClientSetting.defaultGameUri.save(entry.getUri().toString());
+    ClientSetting.defaultGameUri.setValue(entry.getUri().toString());
     ClientSetting.flush();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -195,7 +195,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
           }
           final String name = options.getName();
           log.fine("Server playing as:" + name);
-          ClientSetting.playerName.save(name);
+          ClientSetting.playerName.setValue(name);
           ClientSetting.flush();
           final int port = options.getPort();
           if (port >= 65536 || port == 0) {

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -52,8 +52,8 @@ public class HttpProxy {
       port = host.isEmpty() ? null : address.get().getPort();
     }
 
-    ClientSetting.proxyHost.save(host);
-    ClientSetting.proxyPort.save(port);
+    ClientSetting.proxyHost.setValue(host);
+    ClientSetting.proxyPort.setValue(port);
     ClientSetting.flush();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -118,7 +118,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   private final Class<T> type;
   private final String name;
   private final @Nullable T defaultValue;
-  private final Collection<Consumer<GameSetting<T>>> onSaveActions = new CopyOnWriteArrayList<>();
+  private final Collection<Consumer<GameSetting<T>>> listeners = new CopyOnWriteArrayList<>();
 
   /**
    * Initializes a new instance of {@code ClientSetting} with no default value.
@@ -162,14 +162,14 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   }
 
   @Override
-  public final void addSaveListener(final Consumer<GameSetting<T>> saveListener) {
-    Preconditions.checkNotNull(saveListener);
-    onSaveActions.add(saveListener);
+  public final void addListener(final Consumer<GameSetting<T>> listener) {
+    Preconditions.checkNotNull(listener);
+    listeners.add(listener);
   }
 
   @Override
-  public final void removeSaveListener(final Consumer<GameSetting<T>> saveListener) {
-    onSaveActions.remove(saveListener);
+  public final void removeListener(final Consumer<GameSetting<T>> listener) {
+    listeners.remove(listener);
   }
 
   public static void showSettingsWindow() {
@@ -225,7 +225,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       getPreferences().put(name, value);
     }
 
-    onSaveActions.forEach(saveAction -> saveAction.accept(this));
+    listeners.forEach(listener -> listener.accept(this));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -62,7 +62,13 @@ public interface GameSetting<T> {
    */
   void resetValue();
 
-  void addSaveListener(Consumer<GameSetting<T>> listener);
+  /**
+   * Registers {@code listener} to receive a notification whenever the setting value has changed.
+   */
+  void addListener(Consumer<GameSetting<T>> listener);
 
-  void removeSaveListener(Consumer<GameSetting<T>> listener);
+  /**
+   * Unregisters {@code listener} to no longer receive a notification whenever the setting value has changed.
+   */
+  void removeListener(Consumer<GameSetting<T>> listener);
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -21,22 +21,22 @@ public interface GameSetting<T> {
   /**
    * Sets the current value of the setting using an untyped value.
    *
-   * @param newValue The new setting value or {@code null} to clear the setting value. Clearing the setting value will
+   * @param value The new setting value or {@code null} to clear the setting value. Clearing the setting value will
    *        result in the default value being returned on future reads of the setting value. If no default value is
    *        defined for the setting, future reads will return an empty result.
    *
-   * @throws ClassCastException If the type of of {@code newValue} is incompatible with the setting value type.
+   * @throws ClassCastException If the type of of {@code value} is incompatible with the setting value type.
    */
-  void saveObject(@Nullable Object newValue);
+  void setObjectValue(@Nullable Object value);
 
   /**
    * Sets the current value of the setting.
    *
-   * @param newValue The new setting value or {@code null} to clear the setting value. Clearing the setting value will
+   * @param value The new setting value or {@code null} to clear the setting value. Clearing the setting value will
    *        result in the default value being returned on future reads of the setting value. If no default value is
    *        defined for the setting, future reads will return an empty result.
    */
-  void save(@Nullable T newValue);
+  void setValue(@Nullable T value);
 
   /**
    * Returns the default value of the setting or empty if the setting has no default value.

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -36,7 +36,7 @@ final class SaveFunction {
             .stream()
             .filter(entry -> !entry.getKey().getValue().equals(Optional.ofNullable(entry.getValue())))
             .forEach(entry -> {
-              entry.getKey().saveObject(entry.getValue());
+              entry.getKey().setObjectValue(entry.getValue());
               successMsg.append(String.format("%s was updated to: %s\n", entry.getKey(), entry.getValue()));
             });
       } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -26,7 +26,7 @@ final class DebugMenu extends JMenu {
       add(SwingAction.of("Show Hard AI Logs", e -> ProAi.showSettingsWindow())).setMnemonic(KeyEvent.VK_X);
     }
 
-    add(SwingAction.of("Show Console", e -> ClientSetting.showConsole.saveAndFlush(true)))
+    add(SwingAction.of("Show Console", e -> ClientSetting.showConsole.setValueAndFlush(true)))
         .setMnemonic(KeyEvent.VK_C);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
@@ -91,7 +91,7 @@ final class EngineVersionCheckTest {
       givenFirstRun();
 
       assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-      verify(updateCheckDateSetting).save(formatUpdateCheckDate(now));
+      verify(updateCheckDateSetting).setValue(formatUpdateCheckDate(now));
       verify(flushSetting).run();
     }
 
@@ -125,7 +125,7 @@ final class EngineVersionCheckTest {
       givenEngineUpdateCheckLastRunRelativeToNow(0, ChronoUnit.DAYS);
 
       assertThat(whenIsEngineUpdateCheckRequired(), is(false));
-      verify(updateCheckDateSetting, never()).save(anyString());
+      verify(updateCheckDateSetting, never()).setValue(anyString());
       verify(flushSetting, never()).run();
     }
   }

--- a/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -71,7 +71,7 @@ final class UpdatedMapsCheckTest {
       givenMapUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.YEARS);
 
       assertThat(whenIsMapUpdateCheckRequired(), is(true));
-      verify(updateCheckDateSetting).save(formatUpdateCheckDate(now));
+      verify(updateCheckDateSetting).setValue(formatUpdateCheckDate(now));
       verify(flushSetting).run();
     }
 
@@ -94,7 +94,7 @@ final class UpdatedMapsCheckTest {
       givenMapUpdateCheckLastRunRelativeToNow(0, ChronoUnit.MONTHS);
 
       assertThat(whenIsMapUpdateCheckRequired(), is(false));
-      verify(updateCheckDateSetting, never()).save(anyString());
+      verify(updateCheckDateSetting, never()).setValue(anyString());
       verify(flushSetting, never()).run();
     }
   }

--- a/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -73,7 +73,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void mapFolderOverrideClientSettingIsSetWhenSpecified() {
-    ClientSetting.mapFolderOverride.save(Paths.get("some", "path"));
+    ClientSetting.mapFolderOverride.setValue(Paths.get("some", "path"));
     final Path mapFolder = Paths.get("/path", "to", "maps");
 
     ArgParser
@@ -84,7 +84,7 @@ public class ArgParserTest extends AbstractClientSettingTestCase {
 
   @Test
   public void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
-    ClientSetting.mapFolderOverride.save(Paths.get("some", "path"));
+    ClientSetting.mapFolderOverride.setValue(Paths.get("some", "path"));
 
     ArgParser.handleCommandLineArgs();
 

--- a/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
@@ -23,7 +23,7 @@ final class AutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   final class GetAutoSaveFileTest {
     @Test
     void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.saveGamesFolderPath.save(Paths.get("path", "to", "saves"));
+      ClientSetting.saveGamesFolderPath.setValue(Paths.get("path", "to", "saves"));
 
       final String fileName = "savegame.tsvg";
       assertThat(getAutoSaveFile(fileName), is(Paths.get("path", "to", "saves", "autoSave", fileName).toFile()));

--- a/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
@@ -136,7 +136,7 @@ public abstract class AbstractGameSettingTestCase {
   }
 
   @Nested
-  final class SaveObjectTest {
+  final class SetObjectValueTest {
     @Test
     void shouldResetValueWhenValueIsNull() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);

--- a/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
@@ -141,7 +141,7 @@ public abstract class AbstractGameSettingTestCase {
     void shouldResetValueWhenValueIsNull() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
 
-      gameSetting.saveObject(NO_VALUE);
+      gameSetting.setObjectValue(NO_VALUE);
 
       assertThat(gameSetting.getValue(), isPresentAndIs(DEFAULT_VALUE));
     }
@@ -150,7 +150,7 @@ public abstract class AbstractGameSettingTestCase {
     void shouldSetValueWhenValueIsNonNullAndHasCorrectType() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
 
-      gameSetting.saveObject(OTHER_VALUE);
+      gameSetting.setObjectValue(OTHER_VALUE);
 
       assertThat(gameSetting.getValue(), isPresentAndIs(OTHER_VALUE));
     }
@@ -159,7 +159,7 @@ public abstract class AbstractGameSettingTestCase {
     void shouldThrowExceptionWhenValueIsNonNullAndHasWrongType() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
 
-      assertThrows(ClassCastException.class, () -> gameSetting.saveObject("2112"));
+      assertThrows(ClassCastException.class, () -> gameSetting.setObjectValue("2112"));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
@@ -11,7 +11,7 @@ final class ClientSettingAsGameSettingTest extends AbstractGameSettingTestCase {
   protected GameSetting<Integer> newGameSetting(final @Nullable Integer value, final @Nullable Integer defaultValue) {
     final TestClientSetting clientSetting = new TestClientSetting(defaultValue);
     if (value != null) {
-      clientSetting.save(value);
+      clientSetting.setValue(value);
     }
     return clientSetting;
   }

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -52,36 +52,36 @@ final class ClientSettingTest {
 
   @ExtendWith(MockitoExtension.class)
   @Nested
-  final class SaveListenerTest extends AbstractClientSettingTestCase {
+  final class ListenerTest extends AbstractClientSettingTestCase {
     private static final String TEST_VALUE = "value";
 
     @Mock
-    private Consumer<GameSetting<String>> mockSaveListener;
+    private Consumer<GameSetting<String>> listener;
     private final ClientSetting<String> clientSetting = new FakeClientSetting("TEST_SETTING");
 
     @Test
-    void saveListenerIsCalled() {
+    void listenerShouldBeCalled() {
       doAnswer(invocation -> {
         @SuppressWarnings("unchecked")
         final GameSetting<String> gameSetting = (GameSetting<String>) invocation.getArgument(0);
         assertThat(gameSetting.getValue(), isPresentAndIs(TEST_VALUE));
         return null;
-      }).when(mockSaveListener).accept(clientSetting);
-      clientSetting.addSaveListener(mockSaveListener);
+      }).when(listener).accept(clientSetting);
+      clientSetting.addListener(listener);
 
       clientSetting.setValue(TEST_VALUE);
 
-      verify(mockSaveListener).accept(clientSetting);
+      verify(listener).accept(clientSetting);
     }
 
     @Test
-    void verifyRemovedSavedListenersAreNotCalled() {
-      clientSetting.addSaveListener(mockSaveListener);
-      clientSetting.removeSaveListener(mockSaveListener);
+    void removedListenerShouldNotBeCalled() {
+      clientSetting.addListener(listener);
+      clientSetting.removeListener(listener);
 
       clientSetting.setValue(TEST_VALUE);
 
-      verify(mockSaveListener, never()).accept(clientSetting);
+      verify(listener, never()).accept(clientSetting);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -44,7 +44,7 @@ final class ClientSettingTest {
           throw new IllegalArgumentException();
         }
       };
-      clientSetting.save("otherValue");
+      clientSetting.setValue("otherValue");
 
       assertThat(clientSetting.getValue(), isPresentAndIs(defaultValue));
     }
@@ -69,7 +69,7 @@ final class ClientSettingTest {
       }).when(mockSaveListener).accept(clientSetting);
       clientSetting.addSaveListener(mockSaveListener);
 
-      clientSetting.save(TEST_VALUE);
+      clientSetting.setValue(TEST_VALUE);
 
       verify(mockSaveListener).accept(clientSetting);
     }
@@ -79,7 +79,7 @@ final class ClientSettingTest {
       clientSetting.addSaveListener(mockSaveListener);
       clientSetting.removeSaveListener(mockSaveListener);
 
-      clientSetting.save(TEST_VALUE);
+      clientSetting.setValue(TEST_VALUE);
 
       verify(mockSaveListener, never()).accept(clientSetting);
     }

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -95,7 +95,7 @@ public class SaveFunctionTest {
         + "which should only happen when settings were successfully saved.",
         callCount.get(), is(1));
 
-    Mockito.verify(mockSetting).saveObject(TestData.fakeValue);
+    Mockito.verify(mockSetting).setObjectValue(TestData.fakeValue);
   }
 
   @Test

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -121,7 +121,7 @@ class SettingsPane extends StackPane {
         .map(SelectionComponent::readValues)
         .map(Map::entrySet)
         .flatMap(Collection::stream)
-        .forEach(entry -> entry.getKey().saveObject(entry.getValue()));
+        .forEach(entry -> entry.getKey().setObjectValue(entry.getValue()));
     // TODO visual feedback
   }
 


### PR DESCRIPTION
## Overview

After the recent refactoring in `GameSetting` and `ClientSetting`, some of the method names seemed to no longer be consistent.  For example, the `save()` method would probably be better named `setValue()` given the `getValue()` and `isSet()` accessors in the API.  This PR simply renames a few methods to keep the API method names consistent.

## Functional Changes

None.

## Refactoring Changes

* Renamed `GameSetting#save()` -> `setValue()`
* Renamed `GameSetting#saveObject()` -> `setObjectValue()`
* Renamed `ClientSetting#saveAndFlush()` -> `setValueAndFlush()`
* Renamed `GameSetting#addSaveListener()` -> `addListener()`
* Renamed `GameSetting#removeSaveListener()` -> `removeListener()`

## Manual Testing Performed

None.