### PR TITLE
Remove deprecated HeadlessAutoSaveType enum constant

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
@@ -7,21 +7,21 @@ import java.nio.file.Path;
  * The types of auto-saves that can be loaded by a headless game server.
  */
 public enum HeadlessAutoSaveType {
-  AUTOSAVE(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
+  DEFAULT(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
 
-  AUTOSAVE_ODD(AutoSaveFileUtils.getOddRoundAutoSaveFile(true)),
+  ODD_ROUND(AutoSaveFileUtils.getOddRoundAutoSaveFile(true)),
 
-  AUTOSAVE_EVEN(AutoSaveFileUtils.getEvenRoundAutoSaveFile(true)),
+  EVEN_ROUND(AutoSaveFileUtils.getEvenRoundAutoSaveFile(true)),
 
-  AUTOSAVE_END_TURN(AutoSaveFileUtils.getBeforeStepAutoSaveFile("EndTurn", true)),
+  END_TURN(AutoSaveFileUtils.getBeforeStepAutoSaveFile("EndTurn", true)),
 
-  AUTOSAVE_BEFORE_BATTLE(AutoSaveFileUtils.getBeforeStepAutoSaveFile("Battle", true)),
+  BEFORE_BATTLE(AutoSaveFileUtils.getBeforeStepAutoSaveFile("Battle", true)),
 
-  AUTOSAVE_AFTER_BATTLE(AutoSaveFileUtils.getAfterStepAutoSaveFile("Battle", true)),
+  AFTER_BATTLE(AutoSaveFileUtils.getAfterStepAutoSaveFile("Battle", true)),
 
-  AUTOSAVE_AFTER_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("CombatMove", true)),
+  AFTER_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("CombatMove", true)),
 
-  AUTOSAVE_AFTER_NON_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("NonCombatMove", true));
+  AFTER_NON_COMBAT_MOVE(AutoSaveFileUtils.getAfterStepAutoSaveFile("NonCombatMove", true));
 
   private final Path path;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveType.java
@@ -9,16 +9,6 @@ import java.nio.file.Path;
 public enum HeadlessAutoSaveType {
   AUTOSAVE(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
 
-  /**
-   * A second auto-save that a headless game server will alternate between (the other being {@link #AUTOSAVE}).
-   *
-   * @deprecated No longer supported. If an old client happens to request this auto-save, it now forwards to the
-   *             same file as {@link #AUTOSAVE} instead of simply doing nothing. Remove upon next stable release (i.e.
-   *             once no stable client will ever request this auto-save).
-   */
-  @Deprecated
-  AUTOSAVE2(AutoSaveFileUtils.getHeadlessAutoSaveFile()),
-
   AUTOSAVE_ODD(AutoSaveFileUtils.getOddRoundAutoSaveFile(true)),
 
   AUTOSAVE_EVEN(AutoSaveFileUtils.getEvenRoundAutoSaveFile(true)),

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -251,16 +251,14 @@ public class ClientSetupPanel extends SetupPanel {
     actions.add(clientModel.getHostBotSetMapClientAction(this));
     actions.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
     actions.add(clientModel.getHostBotChangeGameToSaveGameClientAction());
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_ODD));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_EVEN));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_END_TURN));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_BEFORE_BATTLE));
-    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_BATTLE));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_COMBAT_MOVE));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.DEFAULT));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.ODD_ROUND));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.EVEN_ROUND));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.END_TURN));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.BEFORE_BATTLE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AFTER_BATTLE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AFTER_COMBAT_MOVE));
+    actions.add(clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.AFTER_NON_COMBAT_MOVE));
     actions.add(clientModel.getHostBotGetGameSaveClientAction(this));
     return actions;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -123,21 +123,21 @@ public class GameSelectorPanel extends JPanel implements Observer {
           final JPopupMenu menu = new JPopupMenu();
           menu.add(clientModelForHostBots.getHostBotChangeGameToSaveGameClientAction());
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE));
+              HeadlessAutoSaveType.DEFAULT));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_ODD));
+              HeadlessAutoSaveType.ODD_ROUND));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_EVEN));
+              HeadlessAutoSaveType.EVEN_ROUND));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_END_TURN));
+              HeadlessAutoSaveType.END_TURN));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_BEFORE_BATTLE));
+              HeadlessAutoSaveType.BEFORE_BATTLE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_AFTER_BATTLE));
+              HeadlessAutoSaveType.AFTER_BATTLE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_AFTER_COMBAT_MOVE));
+              HeadlessAutoSaveType.AFTER_COMBAT_MOVE));
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
-              HeadlessAutoSaveType.AUTOSAVE_AFTER_NON_COMBAT_MOVE));
+              HeadlessAutoSaveType.AFTER_NON_COMBAT_MOVE));
           menu.add(clientModelForHostBots.getHostBotGetGameSaveClientAction(GameSelectorPanel.this));
           final Point point = loadSavedGame.getLocation();
           menu.show(GameSelectorPanel.this, point.x + loadSavedGame.getWidth(), point.y);


### PR DESCRIPTION
## Overview

We are free to remove the deprecated `HeadlessAutoSaveType#AUTOSAVE2` enum constant in the incompatible 1.10 release because no compatible client will ever request it from a headless server.

## Functional Changes

None.

## Refactoring Changes

In addition to removing the deprecated enum constant, I removed the redundant `AUTOSAVE_` prefix from the `HeadlessAutoSaveType` enum constants.  I simply renamed the `AUTOSAVE` enum constant to `DEFAULT`.

## Manual Testing Performed

None.