### PR TITLE
Move TestAttachment/TestDelegate to test source set

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/data/GameSequenceTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameSequenceTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.delegate.IDelegate;
-import games.strategy.engine.xml.TestDelegate;
+import games.strategy.triplea.delegate.TestDelegate;
 
 final class GameSequenceTest {
   @Nested

--- a/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
+++ b/game-core/src/test/java/games/strategy/engine/data/TestAttachment.java
@@ -1,21 +1,11 @@
-package games.strategy.engine.xml;
+package games.strategy.engine.data;
 
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 
-import games.strategy.engine.data.Attachable;
-import games.strategy.engine.data.DefaultAttachment;
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.MutableProperty;
-
 /**
  * Fake attachment used for testing.
- *
- * <p>
- * Although this attachment is only ever used by test code, it is located in production code because it must be
- * available to the game parser.
- * </p>
  */
 public class TestAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 4886924951201479496L;

--- a/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -20,6 +20,7 @@ import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.ResourceList;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.TestAttachment;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitAttachment;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameStepPropertiesHelperTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameStepPropertiesHelperTest.java
@@ -20,7 +20,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.delegate.IDelegate;
-import games.strategy.engine.xml.TestDelegate;
 
 final class GameStepPropertiesHelperTest {
   private final GameData gameData = new GameData();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/TestDelegate.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/TestDelegate.java
@@ -1,9 +1,8 @@
-package games.strategy.engine.xml;
+package games.strategy.triplea.delegate;
 
 import java.io.Serializable;
 
 import games.strategy.engine.message.IRemote;
-import games.strategy.triplea.delegate.AbstractDelegate;
 
 /**
  * A simple dumb delegate, don't actually call these methods.

--- a/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -3,9 +3,13 @@ package games.strategy.triplea.xml;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
+import games.strategy.engine.data.TestAttachment;
+import games.strategy.engine.data.gameparser.XmlGameElementMapper;
+import games.strategy.triplea.delegate.TestDelegate;
 
 /**
  * The available maps for use during testing.
@@ -59,7 +63,9 @@ public enum TestMapGameData {
    */
   public GameData getGameData() throws Exception {
     try (InputStream is = new FileInputStream(Paths.get("src", "test", "resources", fileName).toFile())) {
-      return GameParser.parse("game name", is);
+      return GameParser.parse("game name", is, new XmlGameElementMapper(
+          Collections.singletonMap("TestDelegate", TestDelegate::new),
+          Collections.singletonMap("TestAttachment", TestAttachment::new)));
     }
   }
 }

--- a/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
+++ b/game-core/src/test/java/tools/map/making/MapPropertyWrapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.xml.TestAttachment;
+import games.strategy.engine.data.TestAttachment;
 
 final class MapPropertyWrapperTest {
   @Nested

--- a/game-core/src/test/resources/GameExample.xml
+++ b/game-core/src/test/resources/GameExample.xml
@@ -29,8 +29,8 @@
         <unit name="inf"/>
     </unitList>
     <gamePlay>
-        <delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
-        <delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <delegate name="battle" javaClass="TestDelegate"/>
+        <delegate name="move" javaClass="TestDelegate"/>
         <sequence>
             <step name="noPlayer" delegate="move" />
             <step name="usMove" delegate="move" player="bush"/>
@@ -68,13 +68,13 @@
         <attachment name="unitAttachment" attachTo="inf" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
             <option name="transportCost" value="1"/>
         </attachment>
-        <attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
+        <attachment name="resourceAttachment" attachTo="gold" javaClass="TestAttachment" type="resource">
             <option name="value" value="gold"/>
         </attachment>
-        <attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
+        <attachment name="territoryAttachment" attachTo="us" javaClass="TestAttachment" type="territory">
             <option name="value" value="us of a"/>
         </attachment>
-        <attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
+        <attachment name="playerAttachment" attachTo="chretian" javaClass="TestAttachment" type="player">
             <option name="value" value="liberal"/>
         </attachment>
     </attachmentList>

--- a/game-core/src/test/resources/Test.xml
+++ b/game-core/src/test/resources/Test.xml
@@ -27,8 +27,8 @@
         <unit name="inf"/>
     </unitList>
     <gamePlay>
-        <delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
-        <delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <delegate name="battle" javaClass="TestDelegate"/>
+        <delegate name="move" javaClass="TestDelegate"/>
         <sequence>
             <step name="noPlayer" delegate="move" />
             <step name="usMove" delegate="move" player="bush"/>
@@ -67,13 +67,13 @@
         <attachment name="unitAttachment" attachTo="inf" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
             <option name="movement" value="1"/>
         </attachment>
-        <attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
+        <attachment name="resourceAttachment" attachTo="gold" javaClass="TestAttachment" type="resource">
             <option name="value" value="gold"/>
         </attachment>
-        <attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
+        <attachment name="territoryAttachment" attachTo="us" javaClass="TestAttachment" type="territory">
             <option name="value" value="us of a"/>
         </attachment>
-        <attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
+        <attachment name="playerAttachment" attachTo="chretian" javaClass="TestAttachment" type="player">
             <option name="value" value="liberal"/>
         </attachment>
     </attachmentList>


### PR DESCRIPTION
## Overview

The `TestAttachment` and `TestDelegate` classes are only used by test code, but, due to the way `XmlGameElementMapper` is implemented, they need to be available to production code.  This PR changes the implementation of `XmlGameElementMapper` to allow tests to register fixture-specific attachments and delegates.

## Functional Changes

* Moved `TestAttachment` and `TestDelegate` to the test source set, thus they are no longer available to production code.
    * A search of the `triplea-maps` repo shows no maps use these types.

## Refactoring Changes

* Added a test-specific constructor to `XmlGameElementMapper` that allows test fixtures to register custom attachments and delegates to be instantiated by `GameParser`.
* Added a test-specific constructor to `GameParser` to allow it to accept a custom `XmlGameElementMapper` instance.
* Renamed `XmlGameElementMapper#getAttachment()` and `getDelegate()` to `newAttachment()` and `newDelegate()`, respectively, to better reflect that they are factory methods and return a new instance upon each call.
* Replaced the need for `XmlGameElementMapper$AttachmentData` with a functional interface that matches the signature of all attachment constructors.

## Manual Testing Performed

Started a headless game server and let it parse the 15 or so maps I currently have downloaded.