### PR TITLE
Do not store ClientSetting default value in preferences

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.settings;
 
+import static games.strategy.util.Util.not;
+
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
@@ -215,7 +217,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
 
   @Override
   public final void setValue(final @Nullable T value) {
-    setStringValue(Optional.ofNullable(value).map(this::formatValue).orElse(null));
+    setStringValue(Optional.ofNullable(value)
+        .filter(not(this::isDefaultValue))
+        .map(this::formatValue)
+        .orElse(null));
   }
 
   private void setStringValue(final @Nullable String value) {
@@ -226,6 +231,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
     }
 
     listeners.forEach(listener -> listener.accept(this));
+  }
+
+  private boolean isDefaultValue(final T value) {
+    return value.equals(defaultValue);
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/triplea/settings/AbstractClientSettingTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/AbstractClientSettingTestCase.java
@@ -1,8 +1,13 @@
 package games.strategy.triplea.settings;
 
+import java.util.prefs.Preferences;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+
+import lombok.AccessLevel;
+import lombok.Getter;
 
 /**
  * Superclass for test fixtures that directly or indirectly interact with instances of {@link ClientSetting}.
@@ -13,12 +18,14 @@ import org.sonatype.goodies.prefs.memory.MemoryPreferences;
  * </p>
  */
 public abstract class AbstractClientSettingTestCase {
+  @Getter(AccessLevel.PROTECTED)
+  private final Preferences preferences = new MemoryPreferences();
+
   protected AbstractClientSettingTestCase() {}
 
   @BeforeEach
-  @SuppressWarnings("static-method")
   public final void initializeClientSettingPreferences() {
-    ClientSetting.setPreferences(new MemoryPreferences());
+    ClientSetting.setPreferences(preferences);
   }
 
   @AfterEach

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.settings;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -47,6 +48,21 @@ final class ClientSettingTest {
       clientSetting.setValue("otherValue");
 
       assertThat(clientSetting.getValue(), isPresentAndIs(defaultValue));
+    }
+  }
+
+  @Nested
+  final class SetValueTest extends AbstractClientSettingTestCase {
+    @Test
+    void shouldClearPreferenceWhenValueEqualsDefaultValue() {
+      final String name = "name";
+      final String defaultValue = "defaultValue";
+      final ClientSetting<String> clientSetting = new FakeClientSetting(name, defaultValue);
+      clientSetting.setValue("otherValue");
+
+      clientSetting.setValue(defaultValue);
+
+      assertThat(getPreferences().get(name, null), is(nullValue()));
     }
   }
 


### PR DESCRIPTION
## Overview

Currently, if the default value of a `ClientSetting` is passed to `setValue()`, the underlying preference is set to the encoded value.  Not only is this redundant, but the behavior is slightly different from the case where the user never changed the value from the default in the first place.  Specifically, if we ever change the default value in the future, a user who simply clicked **Reset to Default** in the UI won't pick up the new default, while a user who never changed the value will pick up the new default value.

This PR changes the behavior of `ClientSetting#setValue()` such that if an attempt is made to set the  value to the default value, we no longer save the default value in the preference store.  Instead, the preference is cleared so that the default value will be returned upon the next read.

## Functional Changes

If the default value is passed to `ClientSetting#setValue()`, the underlying preference will be cleared instead of set to the corresponding encoded value.

## Manual Testing Performed

Verified that if I explicitly set a client setting to its default value in the UI and save the settings, the underlying preference is removed from the backing store.