### PR TITLE
Add check for sea units to enemySurfaceExclusionTerritories

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -983,9 +983,10 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         case "enemy": // any enemy units in the territory
           allUnits.retainAll(CollectionUtils.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)));
           break;
-        case "enemy_surface": // any enemy units (not trn/sub) in the territory
+        case "enemy_surface": // any enemy sea units (not trn/sub) in the territory
           allUnits.retainAll(
               CollectionUtils.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)
+                  .and(Matches.unitIsSea())
                   .and(Matches.unitIsNotSub())
                   .and(Matches.unitIsNotTransportButCouldBeCombatTransport())));
           break;


### PR DESCRIPTION
## Overview
Fixes #4347 

## Functional Changes
- Adds check for only sea units to enemySurfaceExclusionTerritories (so it doesn't consider land or air units) in addition to filtering out subs and non-combat transports

