### PR TITLE
Add aa support

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -229,7 +229,7 @@ public class ProPurchaseOption {
     units.addAll(unitType.create(1, player, true));
     final Set<List<UnitSupportAttachment>> supportsAvailable = new HashSet<>();
     final IntegerMap<UnitSupportAttachment> supportLeft = new IntegerMap<>();
-    DiceRoll.getSupport(units, supportsAvailable, supportLeft, new HashMap<>(), data, defense, true);
+    DiceRoll.getSortedSupport(units, supportsAvailable, supportLeft, new HashMap<>(), data, defense, true);
     double totalSupportFactor = 0;
     for (final UnitSupportAttachment usa : unitSupportAttachments) {
       for (final List<UnitSupportAttachment> bonusType : supportsAvailable) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -54,7 +54,7 @@ public class ProBattleUtils {
         new UnitBattleComparator(false, ProData.unitValueMap, TerritoryEffectHelper.getEffects(t), data, false, false));
     Collections.reverse(sortedUnitsList);
     final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
-        defendingUnits, false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+        defendingUnits, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     final List<Unit> defendersWithHitPoints =
         CollectionUtils.getMatches(defendingUnits, Matches.unitIsInfrastructure().negate());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
@@ -103,7 +103,7 @@ public class ProBattleUtils {
         TerritoryEffectHelper.getEffects(t), data, false, false));
     Collections.reverse(sortedUnitsList);
     final int myPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
-        enemyUnits, !attacking, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+        enemyUnits, !attacking, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     return (myPower * 6.0 / data.getDiceSides());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -144,13 +144,13 @@ public class ProSortMoveOptionsUtils {
           Collections.reverse(sortedUnitsList);
           final int powerWithout =
               DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
-                  false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                  false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
           sortedUnitsList.add(o1.getKey());
           sortedUnitsList.sort(new UnitBattleComparator(false, ProData.unitValueMap,
               TerritoryEffectHelper.getEffects(t), data, false, false));
           Collections.reverse(sortedUnitsList);
           final int powerWith = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
-              defendingUnits, false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+              defendingUnits, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
           final int power = powerWith - powerWithout;
           if (power < minPower1) {
             minPower1 = power;
@@ -172,13 +172,13 @@ public class ProSortMoveOptionsUtils {
           Collections.reverse(sortedUnitsList);
           final int powerWithout =
               DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
-                  false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                  false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
           sortedUnitsList.add(o2.getKey());
           sortedUnitsList.sort(new UnitBattleComparator(false, ProData.unitValueMap,
               TerritoryEffectHelper.getEffects(t), data, false, false));
           Collections.reverse(sortedUnitsList);
           final int powerWith = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList,
-              defendingUnits, false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+              defendingUnits, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
           final int power = powerWith - powerWithout;
           if (power < minPower2) {
             minPower2 = power;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2852,7 +2852,8 @@ public class UnitAttachment extends DefaultAttachment {
         final String text = String.valueOf(support.getBonus())
             + (moreThanOneSupportType ? " " + support.getBonusType() : "")
             + " "
-            + (support.getDice() == null ? ""
+            + (support.getDice() == null
+                ? ""
                 : support.getDice().replace(":", " & ").replace("AAroll", "Targeted Roll")
                     .replace("AAstrength", "Targeted Power").replace("roll", "Roll").replace("strength", "Power"))
             + " to " + support.getNumber()

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2851,9 +2851,10 @@ public class UnitAttachment extends DefaultAttachment {
                 : (support.getOffence() ? "Attack" : "Defense"));
         final String text = String.valueOf(support.getBonus())
             + (moreThanOneSupportType ? " " + support.getBonusType() : "")
-            + (support.getStrength() && support.getRoll()
-                ? " Power & Rolls"
-                : (support.getStrength() ? " Power" : " Rolls"))
+            + " "
+            + (support.getDice() == null ? ""
+                : support.getDice().replace(":", " & ").replace("AAroll", "Targeted Roll")
+                    .replace("AAstrength", "Targeted Power").replace("roll", "Roll").replace("strength", "Power"))
             + " to " + support.getNumber()
             + (support.getAllied() && support.getEnemy()
                 ? " Allied & Enemy "

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -173,7 +173,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
   }
 
-  private String getDice() {
+  String getDice() {
     return dice;
   }
 
@@ -393,6 +393,8 @@ public class UnitSupportAttachment extends DefaultAttachment {
         .put("defence", MutableProperty.ofReadOnly(this::getDefence))
         .put("roll", MutableProperty.ofReadOnly(this::getRoll))
         .put("strength", MutableProperty.ofReadOnly(this::getStrength))
+        .put("aaRoll", MutableProperty.ofReadOnly(this::getAaRoll))
+        .put("aaStrength", MutableProperty.ofReadOnly(this::getAaStrength))
         .put("bonus",
             MutableProperty.of(
                 this::setBonus,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -29,6 +29,8 @@ public class UnitSupportAttachment extends DefaultAttachment {
   private boolean defence = false;
   private boolean roll = false;
   private boolean strength = false;
+  private boolean aaRoll = false;
+  private boolean aaStrength = false;
   private int bonus = 0;
   private int number = 0;
   private boolean allied = false;
@@ -37,7 +39,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   private List<PlayerId> players = new ArrayList<>();
   private boolean impArtTech = false;
   // strings
-  // roll or strength
+  // roll or strength or AAroll or AAstrength
   private String dice;
   // offence or defence
   private String side;
@@ -151,22 +153,24 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   private void setDice(final String dice) throws GameParseException {
+    resetDice();
     if (dice == null) {
-      resetDice();
       return;
     }
-    roll = false;
-    strength = false;
+    this.dice = dice;
     for (final String element : splitOnColon(dice)) {
       if (element.equalsIgnoreCase("roll")) {
         roll = true;
       } else if (element.equalsIgnoreCase("strength")) {
         strength = true;
+      } else if (element.equalsIgnoreCase("AAroll")) {
+        aaRoll = true;
+      } else if (element.equalsIgnoreCase("AAstrength")) {
+        aaStrength = true;
       } else {
-        throw new GameParseException(dice + " dice must be roll or strength" + thisErrorMsg());
+        throw new GameParseException(dice + " dice must be roll, strength, AAroll, or AAstrength: " + thisErrorMsg());
       }
     }
-    this.dice = dice;
   }
 
   private String getDice() {
@@ -177,6 +181,8 @@ public class UnitSupportAttachment extends DefaultAttachment {
     dice = null;
     roll = false;
     strength = false;
+    aaRoll = false;
+    aaStrength = false;
   }
 
   private void setBonus(final String bonus) {
@@ -272,6 +278,14 @@ public class UnitSupportAttachment extends DefaultAttachment {
 
   public boolean getStrength() {
     return strength;
+  }
+
+  public boolean getAaRoll() {
+    return aaRoll;
+  }
+
+  public boolean getAaStrength() {
+    return aaStrength;
   }
 
   public boolean getDefence() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -116,8 +116,8 @@ class AaInMoveUtil implements Serializable {
           // get rid of units already killed, so we don't target them twice
           validTargetedUnitsForThisRoll.removeAll(casualties);
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
-            dice[0] = DiceRoll.rollAa(validTargetedUnitsForThisRoll, currentPossibleAa, AaInMoveUtil.this.bridge,
-                territory, true);
+            dice[0] = DiceRoll.rollSbrOrFlyOverAa(validTargetedUnitsForThisRoll, currentPossibleAa,
+                AaInMoveUtil.this.bridge, territory, true);
           }
         }
       };

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -705,7 +705,7 @@ public class BattleCalculator {
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<>();
     final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<>();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(
-        sortedUnitsList, new ArrayList<>(enemyUnits), defending, false, data, battlesite,
+        sortedUnitsList, new ArrayList<>(enemyUnits), defending, data, battlesite,
         territoryEffects, amphibious, amphibiousLandAttackers, unitSupportPowerMap, unitSupportRollsMap);
     // Sort units starting with weakest for finding the worst units
     Collections.reverse(sortedUnitsList);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -26,7 +26,6 @@ import games.strategy.net.GUID;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.weak.WeakAi;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
@@ -900,74 +899,6 @@ public class BattleCalculator {
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;
     }
     return false;
-  }
-
-  private static int getRolls(final Collection<Unit> units, final PlayerId id,
-      final boolean defend, final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
-      final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
-      final Set<List<UnitSupportAttachment>> supportRulesEnemy,
-      final IntegerMap<UnitSupportAttachment> supportLeftEnemyCopy,
-      final Collection<TerritoryEffect> territoryEffects) {
-    int count = 0;
-    for (final Unit unit : units) {
-      final int unitRoll = getRolls(unit, id, defend, bombing, supportRulesFriendly, supportLeftFriendlyCopy,
-          supportRulesEnemy, supportLeftEnemyCopy, territoryEffects);
-      count += unitRoll;
-    }
-    return count;
-  }
-
-  static int getRolls(final Collection<Unit> units, final PlayerId id, final boolean defend,
-      final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
-    return getRolls(units, id, defend, bombing, new HashSet<>(),
-        new IntegerMap<>(), new HashSet<>(),
-        new IntegerMap<>(), territoryEffects);
-  }
-
-  private static int getRolls(final Unit unit, final PlayerId id, final boolean defend,
-      final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
-      final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
-      final Set<List<UnitSupportAttachment>> supportRulesEnemy,
-      final IntegerMap<UnitSupportAttachment> supportLeftEnemyCopy,
-      final Collection<TerritoryEffect> territoryEffects) {
-    final UnitAttachment unitAttachment = UnitAttachment.get(unit.getType());
-    int rolls;
-    if (defend) {
-      rolls = unitAttachment.getDefenseRolls(id);
-    } else {
-      rolls = unitAttachment.getAttackRolls(id);
-    }
-    final Map<UnitSupportAttachment, IntegerMap<Unit>> dummyEmptyMap =
-        new HashMap<>();
-    rolls += DiceRoll.getSupport(unit, supportRulesFriendly, supportLeftFriendlyCopy, dummyEmptyMap, null, false, true);
-    rolls += DiceRoll.getSupport(unit, supportRulesEnemy, supportLeftEnemyCopy, dummyEmptyMap, null, false, true);
-    rolls = Math.max(0, rolls);
-    // if we are strategic bombing, we do not care what the strength of the unit is...
-    if (bombing) {
-      return rolls;
-    }
-    int strength;
-    if (defend) {
-      strength = unitAttachment.getDefense(unit.getOwner());
-    } else {
-      strength = unitAttachment.getAttack(unit.getOwner());
-    }
-    // TODO: we should add in isMarine bonus too...
-    strength +=
-        DiceRoll.getSupport(unit, supportRulesFriendly, supportLeftFriendlyCopy, dummyEmptyMap, null, true, false);
-    strength += DiceRoll.getSupport(unit, supportRulesEnemy, supportLeftEnemyCopy, dummyEmptyMap, null, true, false);
-    strength += TerritoryEffectHelper.getTerritoryCombatBonus(unit.getType(), territoryEffects, defend);
-    if (strength <= 0) {
-      rolls = 0;
-    }
-    return rolls;
-  }
-
-  static int getRolls(final Unit unit, final PlayerId id, final boolean defend,
-      final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
-    return getRolls(unit, id, defend, bombing, new HashSet<>(),
-        new IntegerMap<>(), new HashSet<>(),
-        new IntegerMap<>(), territoryEffects);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -379,7 +379,7 @@ public class BattleCalculator {
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
         DiceRoll.getAaUnitPowerAndRollsForNormalBattles(defendingAa, allEnemyUnits, allFriendlyUnits, defending,
             bridge.getData());
-    if (DiceRoll.getTotalAAattacks(unitPowerAndRollsMap, planes) != planeHitPoints) {
+    if (DiceRoll.getTotalAaAttacks(unitPowerAndRollsMap, planes) != planeHitPoints) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Triple<Integer, Integer, Boolean> triple =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -159,18 +159,7 @@ public class BattleCalculator {
   private static CasualtyDetails getLowLuckAaCasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> defendingAa, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
-    {
-      final Set<Unit> duplicatesCheckSet1 = new HashSet<>(planes);
-      if (planes.size() != duplicatesCheckSet1.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + planes + "  HashSet:" + duplicatesCheckSet1);
-      }
-      final Set<Unit> duplicatesCheckSet2 = new HashSet<>(defendingAa);
-      if (defendingAa.size() != duplicatesCheckSet2.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + defendingAa + "  HashSet:" + duplicatesCheckSet2);
-      }
-    }
+
     int hitsLeft = dice.getHits();
     if (hitsLeft <= 0) {
       return new CasualtyDetails();
@@ -179,7 +168,7 @@ public class BattleCalculator {
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
     final GameData data = bridge.getData();
     final Tuple<Integer, Integer> attackThenDiceSides =
-        DiceRoll.getAAattackAndMaxDiceSides(defendingAa, data, !defending);
+        DiceRoll.getMaxAaAttackAndDiceSides(defendingAa, data, !defending);
     final int highestAttack = attackThenDiceSides.getFirst();
     if (highestAttack < 1) {
       return new CasualtyDetails();
@@ -327,13 +316,7 @@ public class BattleCalculator {
    */
   public static CasualtyDetails randomAaCasualties(final Collection<Unit> planes, final DiceRoll dice,
       final IDelegateBridge bridge, final boolean allowMultipleHitsPerUnit) {
-    {
-      final Set<Unit> duplicatesCheckSet1 = new HashSet<>(planes);
-      if (planes.size() != duplicatesCheckSet1.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + planes + "  HashSet:" + duplicatesCheckSet1);
-      }
-    }
+
     final int hitsLeft = dice.getHits();
     if (hitsLeft <= 0) {
       return new CasualtyDetails();
@@ -403,7 +386,7 @@ public class BattleCalculator {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Tuple<Integer, Integer> attackThenDiceSides =
-        DiceRoll.getAAattackAndMaxDiceSides(defendingAa, bridge.getData(), !defending);
+        DiceRoll.getMaxAaAttackAndDiceSides(defendingAa, bridge.getData(), !defending);
     final int highestAttack = attackThenDiceSides.getFirst();
     // int chosenDiceSize = attackThenDiceSides[1];
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -389,9 +389,7 @@ public class BattleCalculator {
     if (!allSameAttackPower) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
-    final Tuple<Integer, Integer> attackThenDiceSides =
-        DiceRoll.getMaxAaAttackAndDiceSides(defendingAa, bridge.getData(), !defending);
-    final int highestAttack = attackThenDiceSides.getFirst();
+    final int highestAttack = DiceRoll.getMaxAaAttackAndDiceSides(defendingAa, bridge.getData(), !defending).getFirst();
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
     final int hits = dice.getHits();
     final List<Unit> planesList = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -161,20 +161,19 @@ public class BattleCalculator {
 
   private static CasualtyDetails getLowLuckAaCasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> defendingAa, final Collection<Unit> allEnemyUnits, final Collection<Unit> allFriendlyUnits,
-      final DiceRoll dice, final IDelegateBridge bridge,
-      final boolean allowMultipleHitsPerUnit) {
+      final DiceRoll dice, final IDelegateBridge bridge, final boolean allowMultipleHitsPerUnit) {
 
     int hitsLeft = dice.getHits();
     if (hitsLeft <= 0) {
       return new CasualtyDetails();
     }
 
+    final GameData data = bridge.getData();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
-        DiceRoll.getAaUnitPowerAndRollsForNormalBattles(defendingAa, allEnemyUnits, allFriendlyUnits, defending, null);
+        DiceRoll.getAaUnitPowerAndRollsForNormalBattles(defendingAa, allEnemyUnits, allFriendlyUnits, !defending, data);
 
     // if we can damage units, do it now
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
-    final GameData data = bridge.getData();
     final Tuple<Integer, Integer> attackThenDiceSides =
         DiceRoll.getMaxAaAttackAndDiceSides(defendingAa, data, !defending, unitPowerAndRollsMap);
     final int highestAttack = attackThenDiceSides.getFirst();
@@ -371,14 +370,15 @@ public class BattleCalculator {
    */
   private static CasualtyDetails individuallyFiredAaCasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> defendingAa, final Collection<Unit> allEnemyUnits, final Collection<Unit> allFriendlyUnits,
-      final DiceRoll dice, final IDelegateBridge bridge,
-      final boolean allowMultipleHitsPerUnit) {
+      final DiceRoll dice, final IDelegateBridge bridge, final boolean allowMultipleHitsPerUnit) {
+
     // if we have aa guns that are not infinite, then we need to randomly decide the aa casualties since there are not
     // enough rolls to have a single roll for each aircraft, or too many rolls normal behavior is instant kill, which
     // means planes.size()
     final int planeHitPoints = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
-        DiceRoll.getAaUnitPowerAndRollsForNormalBattles(defendingAa, allEnemyUnits, allFriendlyUnits, defending, null);
+        DiceRoll.getAaUnitPowerAndRollsForNormalBattles(defendingAa, allEnemyUnits, allFriendlyUnits, defending,
+            bridge.getData());
     if (DiceRoll.getTotalAAattacks(unitPowerAndRollsMap, planes) != planeHitPoints) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -81,9 +81,8 @@ public class BattleTracker implements Serializable {
   private BattleRecords battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
-  private final Collection<
-      Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>>> relationshipChangesThisTurn =
-          new ArrayList<>();
+  private final Collection<Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>>> relationshipChangesThisTurn =
+      new ArrayList<>();
 
   /**
    * Indicates whether a battle is to be fought in the given territory.
@@ -160,8 +159,7 @@ public class BattleTracker implements Serializable {
   private boolean didThesePlayersJustGoToWarThisTurn(final PlayerId p1, final PlayerId p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
-    for (final Tuple<Tuple<PlayerId, PlayerId>,
-        Tuple<RelationshipType, RelationshipType>> t : relationshipChangesThisTurn) {
+    for (final Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>> t : relationshipChangesThisTurn) {
       final Tuple<PlayerId, PlayerId> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
         if (!players.getSecond().equals(p2)) {
@@ -1151,7 +1149,7 @@ public class BattleTracker implements Serializable {
       final List<Unit> defenders = new ArrayList<>(battle.getDefendingUnits());
       final List<Unit> sortedUnitsList = getSortedDefendingUnits(bridge, gameData, territory, defenders);
       if (getDependentOn(battle).isEmpty() && DiceRoll.getTotalPower(
-          DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, false, false, gameData,
+          DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, false, gameData,
               territory, TerritoryEffectHelper.getEffects(territory), false, null),
           gameData) == 0) {
         battle.fight(bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -81,8 +81,9 @@ public class BattleTracker implements Serializable {
   private BattleRecords battleRecords = null;
   // to keep track of all relationships that have changed this turn
   // (so we can validate things like transports loading in newly created hostile zones)
-  private final Collection<Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>>> relationshipChangesThisTurn =
-      new ArrayList<>();
+  private final Collection<
+      Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>>> relationshipChangesThisTurn =
+          new ArrayList<>();
 
   /**
    * Indicates whether a battle is to be fought in the given territory.
@@ -159,7 +160,8 @@ public class BattleTracker implements Serializable {
   private boolean didThesePlayersJustGoToWarThisTurn(final PlayerId p1, final PlayerId p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
-    for (final Tuple<Tuple<PlayerId, PlayerId>, Tuple<RelationshipType, RelationshipType>> t : relationshipChangesThisTurn) {
+    for (final Tuple<Tuple<PlayerId, PlayerId>,
+        Tuple<RelationshipType, RelationshipType>> t : relationshipChangesThisTurn) {
       final Tuple<PlayerId, PlayerId> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
         if (!players.getSecond().equals(p2)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -76,9 +76,6 @@ public class DiceRoll implements Externalizable {
     for (final Unit u : aaUnits) {
       final UnitAttachment ua = UnitAttachment.get(u.getType());
       int uaDiceSides = defending ? ua.getAttackAaMaxDieSides() : ua.getOffensiveAttackAaMaxDieSides();
-      if (unitPowerAndRollsMap.containsKey(u)) {
-        uaDiceSides = unitPowerAndRollsMap.get(u).getSecond();
-      }
       if (uaDiceSides < 1) {
         uaDiceSides = diceSize;
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -130,12 +130,14 @@ public class DiceRoll implements Externalizable {
   }
 
   static DiceRoll rollAa(final Collection<Unit> validTargets, final Collection<Unit> aaUnits,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
+      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final IDelegateBridge bridge, final Territory location, final boolean defending) {
 
+    final GameData data = bridge.getData();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
         getAaUnitPowerAndRollsForNormalBattles(aaUnits, allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie, defending, null);
+            allFriendlyUnitsAliveOrWaitingToDie, defending, data);
 
     // Check that there are valid AA and targets to roll for
     final int totalAaAttacks = getTotalAAattacks(unitPowerAndRollsMap, validTargets);
@@ -144,7 +146,6 @@ public class DiceRoll implements Externalizable {
     }
 
     // Determine dice sides (doesn't handle the possibility of different dice sides within the same typeAA)
-    final GameData data = bridge.getData();
     final int diceSides = getMaxAaAttackAndDiceSides(aaUnits, data, defending, unitPowerAndRollsMap).getSecond();
 
     // Roll AA dice for LL or regular

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -544,13 +544,6 @@ public class DiceRoll implements Externalizable {
       final IDelegateBridge bridge, final IBattle battle, final String annotation,
       final Collection<TerritoryEffect> territoryEffects, final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
     final List<Unit> units = new ArrayList<>(unitsList);
-    {
-      final Set<Unit> duplicatesCheckSet = new HashSet<>(unitsList);
-      if (units.size() != duplicatesCheckSet.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + units + "  HashSet:" + duplicatesCheckSet);
-      }
-    }
     final GameData data = bridge.getData();
     final Territory location = battle.getTerritory();
     final boolean isAmphibiousBattle = battle.isAmphibious();
@@ -802,13 +795,7 @@ public class DiceRoll implements Externalizable {
 
   static DiceRoll airBattle(final List<Unit> unitsList, final boolean defending, final PlayerId player,
       final IDelegateBridge bridge, final String annotation) {
-    {
-      final Set<Unit> duplicatesCheckSet1 = new HashSet<>(unitsList);
-      if (unitsList.size() != duplicatesCheckSet1.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + unitsList + "  HashSet:" + duplicatesCheckSet1);
-      }
-    }
+
     final GameData data = bridge.getData();
     final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
     final List<Unit> units = new ArrayList<>(unitsList);
@@ -911,13 +898,6 @@ public class DiceRoll implements Externalizable {
       final IDelegateBridge bridge, final IBattle battle, final String annotation,
       final Collection<TerritoryEffect> territoryEffects, final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
     final List<Unit> units = new ArrayList<>(unitsList);
-    {
-      final Set<Unit> duplicatesCheckSet = new HashSet<>(unitsList);
-      if (units.size() != duplicatesCheckSet.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + units + "  HashSet:" + duplicatesCheckSet);
-      }
-    }
     final GameData data = bridge.getData();
     sortByStrength(units, defending);
     final Territory location = battle.getTerritory();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2055,31 +2055,47 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if ((defending && !canFireDefendingAa()) || (!defending && !canFireOffensiveAa())) {
         return;
       }
-      for (final String currentTypeAa : (defending ? defendingAaTypes : offensiveAaTypes)) {
-        final Collection<Unit> currentAaUnits = CollectionUtils
-            .getMatches((defending ? defendingAa : offensiveAa), Matches.unitIsAaOfTypeAa(currentTypeAa));
-        final List<Collection<Unit>> firingGroups = createFiringUnitGroups(currentAaUnits);
-        for (final Collection<Unit> currentPossibleAa : firingGroups) {
-          final Set<UnitType> targetUnitTypesForThisTypeAa =
-              UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAa(gameData);
-          final Set<UnitType> airborneTypesTargettedToo =
-              defending ? TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData).get(currentTypeAa)
+
+      // Find all friendly and enemy units that could potentially provide support
+      final List<Unit> allFriendlyUnitsAliveOrWaitingToDie = new ArrayList<>();
+      final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
+      if (defending) {
+        allFriendlyUnitsAliveOrWaitingToDie.addAll(defendingUnits);
+        allFriendlyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
+        allEnemyUnitsAliveOrWaitingToDie.addAll(attackingUnits);
+        allEnemyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
+      } else {
+        allFriendlyUnitsAliveOrWaitingToDie.addAll(attackingUnits);
+        allFriendlyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
+        allEnemyUnitsAliveOrWaitingToDie.addAll(defendingUnits);
+        allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
+      }
+
+      // Loop through each type of AA and break into firing groups based on suicideOnHit
+      for (final String aaType : (defending ? defendingAaTypes : offensiveAaTypes)) {
+        final Collection<Unit> aaTypeUnits = CollectionUtils.getMatches((defending ? defendingAa : offensiveAa),
+            Matches.unitIsAaOfTypeAa(aaType));
+        final List<Collection<Unit>> firingGroups = createFiringUnitGroups(aaTypeUnits);
+        for (final Collection<Unit> firingGroup : firingGroups) {
+          final Set<UnitType> validTargetTypes =
+              UnitAttachment.get(firingGroup.iterator().next().getType()).getTargetsAa(gameData);
+          final Set<UnitType> airborneTypesTargeted =
+              defending ? TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData).get(aaType)
                   : new HashSet<>();
-          final Collection<Unit> validAttackingUnitsForThisRoll = CollectionUtils.getMatches(
-              (defending ? attackingUnits : defendingUnits), Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa)
-                  .or(Matches.unitIsAirborne().and(Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+          final Collection<Unit> validTargets = CollectionUtils
+              .getMatches((defending ? attackingUnits : defendingUnits), Matches.unitIsOfTypes(validTargetTypes)
+                  .or(Matches.unitIsAirborne().and(Matches.unitIsOfTypes(airborneTypesTargeted))));
           final IExecutable rollDice = new IExecutable() {
             private static final long serialVersionUID = 6435935558879109347L;
 
             @Override
             public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              validAttackingUnitsForThisRoll.removeAll(casualtiesSoFar);
-              if (!validAttackingUnitsForThisRoll.isEmpty()) {
-                dice =
-                    DiceRoll.rollAa(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, battleSite,
-                        defending);
+              validTargets.removeAll(casualtiesSoFar);
+              if (!validTargets.isEmpty()) {
+                dice = DiceRoll.rollAa(validTargets, firingGroup, allEnemyUnitsAliveOrWaitingToDie,
+                    allFriendlyUnitsAliveOrWaitingToDie, bridge, battleSite, defending);
                 if (!headless) {
-                  if (currentTypeAa.equals("AA")) {
+                  if (aaType.equals("AA")) {
                     if (dice.getHits() > 0) {
                       bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
                           (defending ? defender : attacker));
@@ -2090,11 +2106,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                   } else {
                     if (dice.getHits() > 0) {
                       bridge.getSoundChannelBroadcaster().playSoundForAll(
-                          SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                          SoundPath.CLIP_BATTLE_X_PREFIX + aaType.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                           (defending ? defender : attacker));
                     } else {
                       bridge.getSoundChannelBroadcaster().playSoundForAll(
-                          SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
+                          SoundPath.CLIP_BATTLE_X_PREFIX + aaType.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
                           (defending ? defender : attacker));
                     }
                   }
@@ -2107,9 +2123,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
             @Override
             public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              if (!validAttackingUnitsForThisRoll.isEmpty()) {
-                final CasualtyDetails details =
-                    selectCasualties(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, currentTypeAa);
+              if (!validTargets.isEmpty()) {
+                final CasualtyDetails details = selectCasualties(validTargets, firingGroup, bridge, aaType);
                 markDamaged(details.getDamaged(), bridge);
                 casualties = details;
                 casualtiesSoFar.addAll(details.getKilled());
@@ -2121,10 +2136,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
             @Override
             public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              if (!validAttackingUnitsForThisRoll.isEmpty()) {
-                notifyCasualtiesAa(bridge, currentTypeAa);
+              if (!validTargets.isEmpty()) {
+                notifyCasualtiesAa(bridge, aaType);
                 removeCasualties(casualties.getKilled(), ReturnFire.ALL, !defending, bridge);
-                removeSuicideOnHitCasualties(currentPossibleAa, dice.getHits(), defending, bridge);
+                removeSuicideOnHitCasualties(firingGroup, dice.getHits(), defending, bridge);
               }
             }
           };

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -363,7 +363,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              dice = DiceRoll.rollAa(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, battleSite, true);
+              dice = DiceRoll.rollSbrOrFlyOverAa(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, battleSite,
+                  true);
               if (currentTypeAa.equals("AA")) {
                 if (dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT, defender);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -13,6 +13,8 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
@@ -554,7 +556,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             "Duplicate Units Detected: Original List:" + attackingUnits + "  HashSet:" + duplicatesCheckSet1);
       }
 
-      final int rollCount = BattleCalculator.getRolls(attackingUnits, attacker, false, true, territoryEffects);
+      final int rollCount = getSbrRolls(attackingUnits, attacker);
       if (rollCount == 0) {
         dice = null;
         return;
@@ -583,7 +585,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             int i = 0;
             final int diceSides = gameData.getDiceSides();
             for (final Unit u : attackingUnits) {
-              final int rolls = BattleCalculator.getRolls(u, attacker, false, true, territoryEffects);
+              final int rolls = getSbrRolls(u, attacker);
               if (rolls < 1) {
                 continue;
               }
@@ -616,7 +618,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           int i = 0;
           final int diceSides = gameData.getDiceSides();
           for (final Unit u : attackingUnits) {
-            final int rolls = BattleCalculator.getRolls(u, attacker, false, true, territoryEffects);
+            final int rolls = getSbrRolls(u, attacker);
             if (rolls < 1) {
               continue;
             }
@@ -688,8 +690,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       // limit to maxDamage
       for (final Unit attacker : attackingUnits) {
         final UnitAttachment ua = UnitAttachment.get(attacker.getType());
-        final int rolls = BattleCalculator.getRolls(attacker, StrategicBombingRaidBattle.this.attacker, false, true,
-            territoryEffects);
+        final int rolls = getSbrRolls(attacker, StrategicBombingRaidBattle.this.attacker);
         int costThisUnit = 0;
         if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
           // LHTR means we select the best Dice roll for the unit
@@ -807,6 +808,19 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       }
       bombingRaidTotal = cost;
     }
+  }
+
+  private static int getSbrRolls(final Collection<Unit> units, final PlayerId id) {
+    int count = 0;
+    for (final Unit unit : units) {
+      count += getSbrRolls(unit, id);
+    }
+    return count;
+  }
+
+  @VisibleForTesting
+  static int getSbrRolls(final Unit unit, final PlayerId id) {
+    return UnitAttachment.get(unit.getType()).getAttackRolls(id);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -550,11 +550,6 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
 
     private void rollDice(final IDelegateBridge bridge) {
-      final Set<Unit> duplicatesCheckSet1 = new HashSet<>(attackingUnits);
-      if (attackingUnits.size() != duplicatesCheckSet1.size()) {
-        throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + attackingUnits + "  HashSet:" + duplicatesCheckSet1);
-      }
 
       final int rollCount = getSbrRolls(attackingUnits, attacker);
       if (rollCount == 0) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -697,13 +697,13 @@ class OddsCalculatorPanel extends JPanel {
       attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data, false, false));
       Collections.reverse(attackers);
       final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers, defenders,
-          false, false, data, location, territoryEffects, isAmphibiousBattle,
+          false, data, location, territoryEffects, isAmphibiousBattle,
           (isAmphibiousBattle ? attackers : new ArrayList<>())), data);
       // defender is never amphibious
       final int defensePower =
           DiceRoll
               .getTotalPower(
-                  DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, attackers, true, false,
+                  DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, attackers, true,
                       data, location, territoryEffects, isAmphibiousBattle, new ArrayList<>()),
                   data);
       attackerUnitsTotalPower.setText("Power: " + attackPower);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -735,7 +735,7 @@ public class BattleDisplay extends JPanel {
         gameData.acquireReadLock();
         try {
           unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units,
-              new ArrayList<>(enemyBattleModel.getUnits()), !attack, false, gameData, location,
+              new ArrayList<>(enemyBattleModel.getUnits()), !attack, gameData, location,
               territoryEffects, isAmphibious, amphibiousLandAttackers);
         } finally {
           gameData.releaseReadLock();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -114,7 +114,8 @@ public class BattleCalculatorTest {
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(2, casualties.size());
@@ -140,7 +141,8 @@ public class BattleCalculatorTest {
         .thenAnswer(withValues(1, 1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
@@ -167,7 +169,8 @@ public class BattleCalculatorTest {
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
@@ -193,7 +196,8 @@ public class BattleCalculatorTest {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
@@ -221,7 +225,8 @@ public class BattleCalculatorTest {
         .thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -253,7 +258,8 @@ public class BattleCalculatorTest {
     final DiceRoll roll = DiceRoll
         .rollAa(CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-            defendingAa, bridge, territory("Germany", data), true);
+            defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+            true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -279,7 +285,8 @@ public class BattleCalculatorTest {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, bridge, territory("Germany", data), true);
+        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -431,22 +431,20 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testDiceRollCount() {
+  public void testSbrRolls() {
     final PlayerId british = GameDataTestUtil.british(gameData);
-    final Territory location = gameData.getMap().getTerritory("United Kingdom");
-    final Unit bombers =
+    final Unit bomber =
         gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber()).get(0);
-    final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(location);
     // default 1 roll
-    assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(1));
-    assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(1));
+    assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(1));
+    assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(1));
     // hb, for revised 2 on attack, 1 on defence
     final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // lhtr hb, 2 for both
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(2));
-    assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(2));
+    assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
+    assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -226,10 +226,10 @@ public class DiceRollTest {
         .thenAnswer(withValues(1)); // aa misses at 1 (0 based)
     // aa hits
     final DiceRoll hit =
-        DiceRoll.rollAa(bomber(gameData).create(1, british(gameData)), aaGunList, bridge, westRussia, true);
+        DiceRoll.rollAa(bombers, aaGunList, bombers, aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
     // aa misses
-    final DiceRoll miss = DiceRoll.rollAa(bombers, aaGunList, bridge, westRussia, true);
+    final DiceRoll miss = DiceRoll.rollAa(bombers, aaGunList, bombers, aaGunList, bridge, westRussia, true);
     assertThat(miss.getHits(), is(0));
   }
 
@@ -251,18 +251,18 @@ public class DiceRollTest {
     // aa hits
     final DiceRoll hit = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, westRussia, true);
+        aaGunList, fighterList, aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, westRussia, true);
+        aaGunList, fighterList, aaGunList, bridge, westRussia, true);
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
     final DiceRoll hitNoRoll = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, westRussia, true);
+        aaGunList, fighterList, aaGunList, bridge, westRussia, true);
     assertThat(hitNoRoll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -283,7 +283,7 @@ public class DiceRollTest {
     // aa hits at 0 (0 based)
     final DiceRoll hit = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, westRussia, true);
+        aaGunList, fighterList, aaGunList, bridge, westRussia, true);
     assertThat(hit.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -308,18 +308,18 @@ public class DiceRollTest {
     // aa radar hits
     final DiceRoll hit = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, finnland, true);
+        aaGunList, fighterList, aaGunList, bridge, finnland, true);
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, finnland, true);
+        aaGunList, fighterList, aaGunList, bridge, finnland, true);
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
     final DiceRoll hitNoRoll = DiceRoll.rollAa(CollectionUtils.getMatches(fighterList,
         Matches.unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAa(gameData))),
-        aaGunList, bridge, finnland, true);
+        aaGunList, fighterList, aaGunList, bridge, finnland, true);
     assertThat(hitNoRoll.getHits(), is(2));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -322,6 +323,73 @@ public class DiceRollTest {
         aaGunList, fighterList, aaGunList, bridge, finnland, true);
     assertThat(hitNoRoll.getHits(), is(2));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
+  }
+
+  @Test
+  public void testAaSupport() throws Exception {
+    gameData = TestMapGameData.TWW.getGameData();
+    GameDataTestUtil.makeGameLowLuck(gameData);
+
+    final PlayerId usa = GameDataTestUtil.usa(gameData);
+    final PlayerId germany = GameDataTestUtil.germany(gameData);
+    final Territory westernFrance = territory("Western France", gameData);
+    final List<Unit> atGuns = GameDataTestUtil.germanAntiTankGun(gameData).create(1, germany);
+    GameDataTestUtil.addTo(westernFrance, atGuns);
+    final List<Unit> targets = GameDataTestUtil.americanTank(gameData).create(1, usa);
+
+    final IDelegateBridge bridge = newDelegateBridge(usa);
+    whenGetRandom(bridge)
+        .thenAnswer(withValues(1)) // at hits at 1 (0 based)
+        .thenAnswer(withValues(2)) // at misses at 2 (0 based)
+        .thenAnswer(withValues(3)) // at hits at 3 with support (0 based)
+        .thenAnswer(withValues(4)) // at misses at 4 with support (0 based)
+        .thenAnswer(withValues(7)) // at hits at 7 with 2 AT + support (0 based)
+        .thenAnswer(withValues(8)) // at misses at 8 with 2 AT + support (0 based)
+        .thenAnswer(withValues(1)) // at hits at 1 with 4 AT + support + counter support (0 based)
+        .thenAnswer(withValues(2)); // at misses at 2 with 4 AT + support + counter support (0 based)
+
+    // 1 AT gun
+    final DiceRoll hit = DiceRoll.rollAa(targets, atGuns, targets, atGuns, bridge, westernFrance, true);
+    assertThat(hit.getHits(), is(1));
+    final DiceRoll miss = DiceRoll.rollAa(targets, atGuns, targets, atGuns, bridge, westernFrance, true);
+    assertThat(miss.getHits(), is(0));
+
+    // 1 AT gun + 1 AT support (AT support is a unit that provides +2 AA strength for 3 units)
+    final List<Unit> supportUnits = GameDataTestUtil.germanAtSupport(gameData).create(1, germany);
+    final DiceRoll hitWithSupport =
+        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+    assertThat(hitWithSupport.getHits(), is(1));
+    final DiceRoll missWithSupport =
+        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+    assertThat(missWithSupport.getHits(), is(0));
+
+    // 2 AT guns + 1 AT support
+    atGuns.addAll(GameDataTestUtil.germanAntiTankGun(gameData).create(1, germany));
+    final DiceRoll hitWith2AtAndSupport =
+        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+    assertThat(hitWith2AtAndSupport.getHits(), is(1));
+    final DiceRoll missWith2AtAndSupport =
+        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+    assertThat(missWith2AtAndSupport.getHits(), is(0));
+
+    // 2 AT guns + 1 AT support + 1 enemy AT counter (AT counter is a unit that provides -10 AA strength for 3 units)
+    // Doesn't even roll any dice since strength ends up being 0 for both AT guns
+    final List<Unit> enemySupportUnits = GameDataTestUtil.americanAtCounter(gameData).create(1, usa);
+    final DiceRoll missWith2AtAndSupportAndEnemySupport =
+        DiceRoll.rollAa(targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+    assertThat(missWith2AtAndSupportAndEnemySupport.getHits(), is(0));
+
+    // 4 AT guns + 1 AT support + 1 enemy AT counter
+    // Enemy AT counter zeroes out 3 AT guns and AT support so just 1 AT gun fires
+    atGuns.addAll(GameDataTestUtil.germanAntiTankGun(gameData).create(2, germany));
+    final DiceRoll hitWith4AtAndSupportAndEnemySupport =
+        DiceRoll.rollAa(targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+    assertThat(hitWith4AtAndSupportAndEnemySupport.getHits(), is(1));
+    final DiceRoll missWith4AtAndSupportAndEnemySupport =
+        DiceRoll.rollAa(targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+    assertThat(missWith4AtAndSupportAndEnemySupport.getHits(), is(0));
+
+    thenGetRandomShouldHaveBeenCalled(bridge, times(8));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -304,6 +304,34 @@ public final class GameDataTestUtil {
   }
 
   /**
+   * Returns a germanAntiTankGun UnitType object for the specified GameData object.
+   */
+  public static UnitType germanAntiTankGun(final GameData data) {
+    return unitType("germanAntiTankGun", data);
+  }
+
+  /**
+   * Returns a germanATSupport UnitType object for the specified GameData object.
+   */
+  public static UnitType germanAtSupport(final GameData data) {
+    return unitType("germanATSupport", data);
+  }
+
+  /**
+   * Returns a americanTank UnitType object for the specified GameData object.
+   */
+  public static UnitType americanAtCounter(final GameData data) {
+    return unitType("americanATCounter", data);
+  }
+
+  /**
+   * Returns a americanTank UnitType object for the specified GameData object.
+   */
+  public static UnitType americanTank(final GameData data) {
+    return unitType("americanTank", data);
+  }
+
+  /**
    * Returns a americanCruiser UnitType object for the specified GameData object.
    */
   public static UnitType americanCruiser(final GameData data) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -168,7 +168,8 @@ public class WW2V3Year41Test {
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, bridge, territory("Germany", gameData), true);
+        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        territory("Germany", gameData), true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(2, casualties.size());
@@ -198,7 +199,8 @@ public class WW2V3Year41Test {
         .thenAnswer(withValues(1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, bridge, territory("Germany", gameData), true);
+        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        territory("Germany", gameData), true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -231,7 +233,8 @@ public class WW2V3Year41Test {
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, bridge, territory("Germany", gameData), true);
+        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        territory("Germany", gameData), true);
     assertEquals(2, roll.getHits());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));

--- a/game-core/src/test/resources/Total_World_War_Dec1941.xml
+++ b/game-core/src/test/resources/Total_World_War_Dec1941.xml
@@ -1921,6 +1921,7 @@
     <unit name="germanAdvancedSubmarine"/>
     <unit name="germanAntiAirGun"/>
     <unit name="germanAntiTankGun"/>
+    <unit name="germanATSupport"/>
     <unit name="germanDestroyer"/>
     <unit name="germanHeavyDestroyer"/>
     <unit name="germanCruiser"/>
@@ -1993,6 +1994,7 @@
     <unit name="americanAdvancedSubmarine"/>
     <unit name="americanAntiAirGun"/>
     <unit name="americanAntiTankGun"/>
+    <unit name="americanATCounter"/>
     <unit name="americanDestroyer"/>
     <unit name="americanHeavyDestroyer"/>
     <unit name="americanCruiser"/>
@@ -7773,6 +7775,20 @@
       <option name="canBeGivenByTerritoryTo" value="Germany"/>
       <option name="damageableAA" value="true"/>
       <option name="canInvadeOnlyFrom" value="none"/>
+    </attachment>
+    <attachment name="unitAttachment" attachTo="germanATSupport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="movement" value="1"/>
+      <option name="attack" value="1"/>
+      <option name="defense" value="3"/>
+      <option name="transportCost" value="2"/>
+      <option name="isInfantry" value="true"/>
+    </attachment>
+    <attachment name="unitAttachment" attachTo="americanATCounter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+      <option name="movement" value="1"/>
+      <option name="attack" value="1"/>
+      <option name="defense" value="3"/>
+      <option name="transportCost" value="2"/>
+      <option name="isInfantry" value="true"/>
     </attachment>
     <attachment name="unitAttachment" attachTo="germanTank" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
       <option name="movement" value="2"/>
@@ -16688,6 +16704,28 @@
       <option name="bonusType" value="ArtilleryBonus"/>
       <option name="impArtTech" value="false"/>
       <option name="players" value="Germany"/>
+    </attachment>
+    <attachment name="supportAttachmentATSupportgerman" attachTo="germanATSupport" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+      <option name="unitType" value="germanAntiTankGun"/>
+      <option name="faction" value="allied"/>
+      <option name="side" value="defence"/>
+      <option name="dice" value="AAstrength"/>
+      <option name="bonus" value="2"/>
+      <option name="number" value="3"/>
+      <option name="bonusType" value="ATBonus"/>
+      <option name="impArtTech" value="false"/>
+      <option name="players" value="Germany"/>
+    </attachment>
+    <attachment name="supportAttachmentATCounterAmerican" attachTo="americanATCounter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+      <option name="unitType" value="germanAntiTankGun"/>
+      <option name="faction" value="enemy"/>
+      <option name="side" value="offence"/>
+      <option name="dice" value="AAstrength"/>
+      <option name="bonus" value="-10"/>
+      <option name="number" value="3"/>
+      <option name="bonusType" value="ATBonus"/>
+      <option name="impArtTech" value="false"/>
+      <option name="players" value="Usa"/>
     </attachment>
     <attachment name="supportAttachmentTacBombgerman" attachTo="germanTacticalBomber" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
       <option name="unitType" value="germanTank:germanHeavyTank"/>


### PR DESCRIPTION
## Overview
- Addresses https://forums.triplea-game.org/topic/915/support-for-aa-attacks

## Functional Changes
- Add new UnitSupportAttachment options for the `dice` parameter to specify AA support
```
<option name="dice" value="AAstrength"/>
<option name="dice" value="AAroll"/>
```
- Update battle logic to take into account these support values
- Remove old duplicate unit checks
- Update unit tooltips
- Simplify SBR roll logic

## Manual Testing Performed
- Tested existing AA functionality on revised, global, and Battle for Arda

## XML Examples
AT Support
```
    <attachment name="supportAttachmentATSupportgerman" attachTo="germanATSupport" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
      <option name="unitType" value="germanAntiTankGun"/>
      <option name="faction" value="allied"/>
      <option name="side" value="defence"/>
      <option name="dice" value="AAstrength"/>
      <option name="bonus" value="2"/>
      <option name="number" value="3"/>
      <option name="bonusType" value="ATBonus"/>
      <option name="impArtTech" value="false"/>
      <option name="players" value="Germany"/>
    </attachment>
```
AT Counter Support
```
    <attachment name="supportAttachmentATCounterAmerican" attachTo="americanATCounter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
      <option name="unitType" value="germanAntiTankGun"/>
      <option name="faction" value="enemy"/>
      <option name="side" value="offence"/>
      <option name="dice" value="AAstrength"/>
      <option name="bonus" value="-10"/>
      <option name="number" value="3"/>
      <option name="bonusType" value="ATBonus"/>
      <option name="impArtTech" value="false"/>
      <option name="players" value="Usa"/>
    </attachment>
```
