### PR TITLE
Reduce unchecked conversion warnings in MapProperty

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -6,37 +6,35 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import javax.swing.JComponent;
 
 /**
  * Basically creates a map of other properties.
  *
- * @param <T> String or something with a valid toString()
- * @param <U> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
+ * @param <V> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
-public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
+public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
   private static final long serialVersionUID = -8021039503574228146L;
 
-  private Map<T, U> map;
+  private Map<String, V> map;
   private final List<IEditableProperty<?>> properties = new ArrayList<>();
 
-  public MapProperty(final String name, final String description, final Map<T, U> map) {
+  public MapProperty(final String name, final String description, final Map<String, V> map) {
     super(name, description);
     this.map = map;
     resetProperties(map, properties, name, description);
   }
 
   private void resetProperties(
-      final Map<T, U> map,
+      final Map<String, V> map,
       final List<IEditableProperty<?>> properties,
       final String name,
       final String description) {
     properties.clear();
-    for (final Entry<T, U> entry : map.entrySet()) {
-      final String key = (String) entry.getKey();
-      final U value = entry.getValue();
+    for (final Map.Entry<String, V> entry : map.entrySet()) {
+      final String key = entry.getKey();
+      final V value = entry.getValue();
       if (value instanceof Boolean) {
         properties.add(new BooleanProperty(key, description, ((Boolean) value)));
       } else if (value instanceof Color) {
@@ -64,14 +62,14 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
   }
 
   @Override
-  public Map<T, U> getValue() {
+  public Map<String, V> getValue() {
     return map;
   }
 
   @Override
-  public void setValue(final Map<T, U> value) {
+  public void setValue(final Map<String, V> value) {
     map = value;
-    resetProperties(map, properties, this.getName(), this.getDescription());
+    resetProperties(map, properties, getName(), getDescription());
   }
 
   @Override
@@ -89,11 +87,11 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
     if (value instanceof Map) {
       try {
         @SuppressWarnings("unchecked")
-        final Map<T, U> test = (Map<T, U>) value;
+        final Map<String, V> test = (Map<String, V>) value;
         if (map != null && !map.isEmpty() && !test.isEmpty()) {
-          T key = null;
-          U val = null;
-          for (final Entry<T, U> entry : map.entrySet()) {
+          String key = null;
+          V val = null;
+          for (final Map.Entry<String, V> entry : map.entrySet()) {
             if (entry.getValue() != null && entry.getKey() != null) {
               key = entry.getKey();
               val = entry.getValue();
@@ -101,7 +99,7 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
             }
           }
           if (key != null) {
-            for (final Entry<T, U> entry : test.entrySet()) {
+            for (final Map.Entry<String, V> entry : test.entrySet()) {
               if (entry.getKey() != null && entry.getValue() != null
                   && (!entry.getKey().getClass().isAssignableFrom(key.getClass())
                       || !entry.getValue().getClass().isAssignableFrom(val.getClass()))) {
@@ -110,7 +108,7 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
             }
           }
         }
-        resetProperties(test, new ArrayList<>(), this.getName(), this.getDescription());
+        resetProperties(test, new ArrayList<>(), getName(), getDescription());
       } catch (final Exception e) {
         return false;
       }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -20,7 +20,7 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
   private static final long serialVersionUID = -8021039503574228146L;
 
   private Map<T, U> map;
-  final List<IEditableProperty<U>> properties = new ArrayList<>();
+  private final List<IEditableProperty<?>> properties = new ArrayList<>();
 
   public MapProperty(final String name, final String description, final Map<T, U> map) {
     super(name, description);
@@ -28,29 +28,29 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
     resetProperties(map, properties, name, description);
   }
 
-  @SuppressWarnings("unchecked")
-  private void resetProperties(final Map<T, U> map, final List<IEditableProperty<U>> properties, final String name,
+  private void resetProperties(
+      final Map<T, U> map,
+      final List<IEditableProperty<?>> properties,
+      final String name,
       final String description) {
     properties.clear();
     for (final Entry<T, U> entry : map.entrySet()) {
       final String key = (String) entry.getKey();
       final U value = entry.getValue();
       if (value instanceof Boolean) {
-        properties.add((IEditableProperty<U>) new BooleanProperty(key, description, ((Boolean) value)));
+        properties.add(new BooleanProperty(key, description, ((Boolean) value)));
       } else if (value instanceof Color) {
-        properties.add((IEditableProperty<U>) new ColorProperty(key, description, ((Color) value)));
+        properties.add(new ColorProperty(key, description, ((Color) value)));
       } else if (value instanceof File) {
-        properties.add((IEditableProperty<U>) new FileProperty(key, description, ((File) value)));
+        properties.add(new FileProperty(key, description, ((File) value)));
       } else if (value instanceof String) {
-        properties.add((IEditableProperty<U>) new StringProperty(key, description, ((String) value)));
+        properties.add(new StringProperty(key, description, ((String) value)));
       } else if (value instanceof Collection) {
-        properties.add((IEditableProperty<U>) new CollectionProperty<>(name, description, ((Collection<U>) value)));
+        properties.add(new CollectionProperty<>(name, description, ((Collection<?>) value)));
       } else if (value instanceof Integer) {
-        properties.add((IEditableProperty<U>) new NumberProperty(key, description,
-            Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) value)));
+        properties.add(new NumberProperty(key, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) value)));
       } else if (value instanceof Double) {
-        properties.add((IEditableProperty<U>) new DoubleProperty(key, description,
-            Double.MAX_VALUE, Double.MIN_VALUE, ((Double) value), 5));
+        properties.add(new DoubleProperty(key, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) value), 5));
       } else {
         throw new IllegalArgumentException(
             "Cannot instantiate MapProperty with: " + value.getClass().getCanonicalName());
@@ -110,8 +110,7 @@ public class MapProperty<T, U> extends AbstractEditableProperty<Map<T, U>> {
             }
           }
         }
-        final List<IEditableProperty<U>> testProps = new ArrayList<>();
-        resetProperties(test, testProps, this.getName(), this.getDescription());
+        resetProperties(test, new ArrayList<>(), this.getName(), this.getDescription());
       } catch (final Exception e) {
         return false;
       }

--- a/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/game-core/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -64,7 +64,7 @@ public class MapPropertyWrapper<T> extends AbstractEditableProperty<T> {
     } else if (defaultValue instanceof Collection) {
       property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
     } else if (defaultValue instanceof Map) {
-      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
+      property = new MapProperty<>(name, description, ((Map<String, ?>) defaultValue));
     } else if (defaultValue instanceof Integer) {
       property = new NumberProperty(name, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
     } else if (defaultValue instanceof Double) {


### PR DESCRIPTION
## Overview

Reduces the need to suppress some unchecked conversion warnings in the `MapProperty` class.  It also locks down the key type of `MapProperty` to `String`, as that is required by the implementation.

## Functional Changes

None.

## Refactoring Changes

* Changed the `properties` field type to `IEditableProperty<?>` to avoid the need for unchecked casts.  Since callers only use `IEditableProperty<?>`, and not `IEditableProperty<U>`, there is no loss of fidelity here.
* Locked down the key type to `String`.  The implementation of `resetProperties()` unconditionally casts each map key to `String`, so if it was anything else, a `ClassCastException` would have occurred.

## Manual Testing Performed

Used the Map Properties Maker to edit the player color properties (this is the only property that results in the creation of a `MapProperty` instance).

**NOTE:** I had to run the above test with a non-Substance L&F active.  With a Substance L&F active, my JVM crashed every time the Color Chooser dialog was opened.  I verified this behavior occurs on `master`, as well.  In 1.9.0.0.12226, the Color Chooser dialog is displayed, but it locks up the EDT, and I had to kill the process.  I will investigate this issue separately and open a Substance issue, if required.