### PR TITLE
Simplify MapProperty#validate()

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -13,11 +13,14 @@ import java.util.Objects;
 
 import javax.swing.JComponent;
 
+import lombok.extern.java.Log;
+
 /**
  * Basically creates a map of other properties.
  *
  * @param <V> parameters can be: Boolean, String, Integer, Double, Color, File, Collection, Map
  */
+@Log
 public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
   private static final long serialVersionUID = -8021039503574228146L;
 
@@ -55,8 +58,8 @@ public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
       } else if (value instanceof Double) {
         properties.add(new DoubleProperty(key, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) value), 5));
       } else {
-        throw new IllegalArgumentException(
-            "Cannot instantiate MapProperty with: " + value.getClass().getCanonicalName());
+        final String valueTypeName = (value != null) ? value.getClass().getCanonicalName() : "<null>";
+        throw new IllegalArgumentException("cannot instantiate MapProperty with value type: " + valueTypeName);
       }
     });
   }
@@ -107,6 +110,7 @@ public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
       final Map<String, ?> typedOtherMap = (Map<String, ?>) otherMap;
       resetProperties(typedOtherMap, new ArrayList<>(), getName(), getDescription());
     } catch (final IllegalArgumentException e) {
+      log.warning("Validation failed: " + e.getMessage());
       return false;
     }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/MapProperty.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.properties;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.Color;
 import java.io.File;
 import java.util.ArrayList;
@@ -22,6 +24,9 @@ public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
 
   public MapProperty(final String name, final String description, final Map<String, V> map) {
     super(name, description);
+
+    checkNotNull(map);
+
     this.map = map;
     resetProperties(map, properties, name, description);
   }
@@ -68,6 +73,8 @@ public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
 
   @Override
   public void setValue(final Map<String, V> value) {
+    checkNotNull(value);
+
     map = value;
     resetProperties(map, properties, getName(), getDescription());
   }
@@ -88,7 +95,7 @@ public class MapProperty<V> extends AbstractEditableProperty<Map<String, V>> {
       try {
         @SuppressWarnings("unchecked")
         final Map<String, V> test = (Map<String, V>) value;
-        if (map != null && !map.isEmpty() && !test.isEmpty()) {
+        if (!map.isEmpty() && !test.isEmpty()) {
           String key = null;
           V val = null;
           for (final Map.Entry<String, V> entry : map.entrySet()) {

--- a/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
@@ -34,7 +34,7 @@ final class MapPropertyTest {
     void shouldReturnTrueWhenValueIsMapAndPropertyMapContainsNullKey() {
       final MapProperty<Integer> mapProperty = newMapProperty(Collections.singletonMap(null, 42));
 
-      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, "11", KEY_2, "22")), is(true));
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, 11, KEY_2, 22)), is(true));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
@@ -1,0 +1,73 @@
+package games.strategy.engine.data.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+final class MapPropertyTest {
+  @Nested
+  final class ValidateTest {
+    private static final String KEY_1 = "key1";
+    private static final String KEY_2 = "key2";
+
+    private final MapProperty<Integer> mapProperty = newMapProperty(ImmutableMap.of(KEY_1, 42));
+
+    private <T> MapProperty<T> newMapProperty(final Map<String, T> map) {
+      return new MapProperty<>("name", "description", map);
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsMapAndPropertyMapIsEmpty() {
+      final MapProperty<Integer> mapProperty = newMapProperty(ImmutableMap.of());
+
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, "11", KEY_2, "22")), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsMapAndPropertyMapContainsNullKey() {
+      final MapProperty<Integer> mapProperty = newMapProperty(Collections.singletonMap(null, 42));
+
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, "11", KEY_2, "22")), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsMapAndEmpty() {
+      assertThat(mapProperty.validate(ImmutableMap.of()), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenValueIsMapAndKeysAreCompatibleAndValuesAreCompatible() {
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, 11, KEY_2, 22)), is(true));
+      assertThat(mapProperty.validate(Collections.singletonMap(null, 33)), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsNotMap() {
+      assertThat(mapProperty.validate(new Object()), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsMapAndValuesAreCompatibleButKeysAreNotCompatible() {
+      assertThat(mapProperty.validate(ImmutableMap.of(1, 11, 2, 22)), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsMapAndKeysAreCompatibleButValuesAreNotCompatible() {
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, "11", KEY_2, "22")), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenValueIsMapAndValuesAreCompatibleButValueTypeIsNotSupported() {
+      final MapProperty<Integer> mapProperty = newMapProperty(ImmutableMap.of());
+
+      assertThat(mapProperty.validate(ImmutableMap.of(KEY_1, Long.MAX_VALUE)), is(false));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/MapPropertyTest.java
@@ -54,6 +54,11 @@ final class MapPropertyTest {
     }
 
     @Test
+    void shouldReturnFalseWhenValueIsMapAndContainsNullValue() {
+      assertThat(mapProperty.validate(Collections.singletonMap(KEY_1, null)), is(false));
+    }
+
+    @Test
     void shouldReturnFalseWhenValueIsMapAndValuesAreCompatibleButKeysAreNotCompatible() {
       assertThat(mapProperty.validate(ImmutableMap.of(1, 11, 2, 22)), is(false));
     }


### PR DESCRIPTION
## Overview

This originally started as a simple potential NPE fix in `MapProperty#validate()`, as identified by my static analyzer.  Based on the suggestion in https://github.com/triplea-game/triplea/pull/4356#discussion_r233567780, I ended up simplifying the method implementation.

## Functional Changes

None.

## Manual Testing Performed

None.  Characterization tests were added before the refactoring was performed.

## Additional Review Notes

I ended up not using `Collections#checkedMap()`, as originally suggested, because it required several additional unchecked casts due to not having access to a `Class<V>` instance.  The current solution has a single unchecked cast to `Map<String, ?>`, which is guaranteed to be safe due to the prior checks.