### PR TITLE
Checkstyle: Add missing Javadocs

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -22,6 +22,9 @@ import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.util.Interruptibles;
 import lombok.extern.java.Log;
 
+/**
+ * Implementation of {@link IGame} for a network client node.
+ */
 @Log
 public class ClientGame extends AbstractGame {
   public static RemoteName getRemoteStepAdvancerName(final INode node) {
@@ -161,6 +164,10 @@ public class ClientGame extends AbstractGame {
     }
   }
 
+  /**
+   * Shuts down this client node. May or may not affect the server depending on the role of the player associated with
+   * this node.
+   */
   public void shutDown() {
     if (isGameOver) {
       return;

--- a/game-core/src/main/java/games/strategy/engine/framework/GameObjectStreamFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameObjectStreamFactory.java
@@ -11,6 +11,12 @@ import games.strategy.engine.data.GameObjectInputStream;
 import games.strategy.engine.data.GameObjectOutputStream;
 import games.strategy.net.IObjectStreamFactory;
 
+/**
+ * Implementation of {@link IObjectStreamFactory} that uses {@link GameObjectOutputStream} and
+ * {@link GameObjectInputStream} for serialization and deserialization, respectively. These streams ensure referential
+ * identity among various game data components to prevent unwanted copies from being made during the serialization and
+ * deserialization process.
+ */
 public class GameObjectStreamFactory implements IObjectStreamFactory {
   private GameData gameData;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/LocalPlayers.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/LocalPlayers.java
@@ -7,6 +7,10 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.player.IGamePlayer;
 import games.strategy.triplea.player.AbstractHumanPlayer;
 
+/**
+ * A collection of {@link IGamePlayer}s that are local to the current node. For example, in a network game, the human
+ * at a single node may be responsible for managing multiple game players, such as all member nations of the Allies.
+ */
 public class LocalPlayers {
   protected final Set<IGamePlayer> localPlayers;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -57,8 +57,7 @@ import games.strategy.util.Interruptibles;
 import lombok.extern.java.Log;
 
 /**
- * Represents a running game.
- * Lookups to get a GamePlayer from PlayerId and the current Delegate.
+ * Implementation of {@link IGame} for a network server node.
  */
 @Log
 public class ServerGame extends AbstractGame {
@@ -185,6 +184,9 @@ public class ServerGame extends AbstractGame {
     }
   }
 
+  /**
+   * Adds a new observer (non-participant) node to this server game.
+   */
   public void addObserver(final IObserverWaitingToJoin blockingObserver,
       final IObserverWaitingToJoin nonBlockingObserver, final INode newNode) {
     try {
@@ -297,6 +299,10 @@ public class ServerGame extends AbstractGame {
     }
   }
 
+  /**
+   * Stops the game on this server node, subsequently stopping all client nodes. This server node will then be shut
+   * down.
+   */
   public void stopGame() {
     if (isGameOver) {
       log.log(Level.WARNING, "Game previously stopped, cannot stop again.");

--- a/game-core/src/main/java/games/strategy/engine/framework/VerifiedRandomNumbers.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/VerifiedRandomNumbers.java
@@ -3,6 +3,9 @@ package games.strategy.engine.framework;
 import games.strategy.triplea.formatter.MyFormatter;
 import lombok.Getter;
 
+/**
+ * A collection of generated random numbers that have been verified as being untampered from a remote random source.
+ */
 @Getter
 public class VerifiedRandomNumbers {
   private final int[] values;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ILauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ILauncher.java
@@ -2,6 +2,9 @@ package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
 
+/**
+ * Responsible for starting the game UI and beginning game play.
+ */
 public interface ILauncher {
   void launch(Component parent);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -20,7 +20,7 @@ import games.strategy.util.Interruptibles;
 import lombok.extern.java.Log;
 
 /**
- * Launcher for a local or a client game. A launcher will start the game UI and begin game play.
+ * Implementation of {@link ILauncher} for a headed local or network client game.
  */
 @Log
 public class LocalLauncher extends AbstractLauncher {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
@@ -1,5 +1,9 @@
 package games.strategy.engine.framework.startup.launcher;
 
+/**
+ * An unchecked exception indicating the map associated with a save game was not found and must be installed before game
+ * play can begin.
+ */
 public class MapNotFoundException extends IllegalStateException {
   private static final long serialVersionUID = -1027460394367073991L;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -42,6 +42,9 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.util.Interruptibles;
 import lombok.extern.java.Log;
 
+/**
+ * Implementation of {@link ILauncher} for a headed or headless network server game.
+ */
 @Log
 public class ServerLauncher extends AbstractLauncher {
   private final int clientCount;
@@ -271,6 +274,11 @@ public class ServerLauncher extends AbstractLauncher {
     serverGame.addObserver(blockingObserver, nonBlockingObserver, newNode);
   }
 
+  /**
+   * Invoked when the connection to the specified node has been lost. Updates the game state appropriately depending on
+   * the role of the player associated with the specified node. For example, a disconnected participant will cause the
+   * game to be stopped, while a disconnected observer will have no effect.
+   */
   public void connectionLost(final INode node) {
     if (isLaunching) {
       // this is expected, we told the observer

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -28,6 +28,9 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.util.LocalizeHtml;
 
+/**
+ * A modal dialog that prompts the user to select a game (map) from the list of installed games (maps).
+ */
 public class GameChooser extends JDialog {
   private static final long serialVersionUID = -3223711652118741132L;
 
@@ -90,6 +93,9 @@ public class GameChooser extends JDialog {
     infoPanel.add(notesScroll, BorderLayout.CENTER);
   }
 
+  /**
+   * Displays the Game Chooser dialog and returns the game selected by the user or {@code null} if no game was selected.
+   */
   public static GameChooserEntry chooseGame(final Frame parent, final String defaultGameName)
       throws InterruptedException {
     final GameChooserModel gameChooserModel =

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -15,6 +15,9 @@ import games.strategy.triplea.Constants;
 import games.strategy.util.UrlStreams;
 import lombok.extern.java.Log;
 
+/**
+ * An installed game (map) that is selectable by the user from the Game Chooser dialog.
+ */
 @Log
 public class GameChooserEntry implements Comparable<GameChooserEntry> {
   private final URI url;
@@ -38,6 +41,9 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
     }
   }
 
+  /**
+   * Returns a {@link GameData} instance resulting from fully parsing the XML associated with this game.
+   */
   public GameData fullyParseGameData() throws GameParseException {
     // TODO: We should be setting this in the the constructor. At this point, you have to call methods in the
     // correct order for things to work, and that is bads.

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -36,6 +36,14 @@ import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.ui.display.TripleADisplay;
 
+/**
+ * Default implementation of {@link IGameLoader}.
+ *
+ * <p>
+ * TODO: As there are no longer different game loader specializations, this class should be renamed to
+ * {@code DefaultGameLoader} and moved to the {@code g.s.engine.data} package.
+ * </p>
+ */
 public class TripleA implements IGameLoader {
   private static final long serialVersionUID = -8374315848374732436L;
 

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -202,6 +202,10 @@ public class TripleAUnit extends Unit {
     return Math.max(0, UnitAttachment.get(getType()).getMovement(getOwner()) + bonusMovement - alreadyMoved);
   }
 
+  /**
+   * Returns a tuple whose first element indicates the minimum movement remaining for the specified collection of units,
+   * and whose second element indicates the maximum movement remaining for the specified collection of units.
+   */
   public static Tuple<Integer, Integer> getMinAndMaxMovementLeft(final Collection<Unit> units) {
     int min = 100000;
     int max = 0;
@@ -380,6 +384,13 @@ public class TripleAUnit extends Unit {
         data, accountForDamage, mathMaxZero);
   }
 
+  /**
+   * Returns the unit from the specified collection that has the largest production capacity within the specified
+   * territory.
+   *
+   * @param accountForDamage {@code true} if the production capacity should account for unit damage; otherwise
+   *        {@code false}.
+   */
   public static Unit getBiggestProducer(final Collection<Unit> units, final Territory producer, final PlayerId player,
       final GameData data, final boolean accountForDamage) {
     final Predicate<Unit> factoryMatch = Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player)
@@ -405,6 +416,14 @@ public class TripleAUnit extends Unit {
     return highestUnit;
   }
 
+  /**
+   * Returns the production capacity for the specified unit within the specified territory.
+   *
+   * @param accountForDamage {@code true} if the production capacity should account for unit damage; otherwise
+   *        {@code false}.
+   * @param mathMaxZero {@code true} if a negative production capacity should be rounded to zero; {@code false} to allow
+   *        a negative production capacity.
+   */
   public static int getHowMuchCanUnitProduce(final Unit u, final Territory producer, final PlayerId player,
       final GameData data, final boolean accountForDamage, final boolean mathMaxZero) {
     if (u == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/AbstractMoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/AbstractMoveDescription.java
@@ -5,6 +5,9 @@ import java.util.Collection;
 
 import games.strategy.engine.data.Unit;
 
+/**
+ * Superclass for any action that describes the movement or placement of units.
+ */
 public abstract class AbstractMoveDescription implements Serializable {
   private static final long serialVersionUID = -6615899716448836002L;
   private final Collection<Unit> units;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
@@ -14,7 +14,9 @@ import games.strategy.triplea.delegate.IBattle.BattleType;
  * in order to use it for conditions and other things later.
  */
 public class BattleRecord implements Serializable {
-
+  /**
+   * A summary description of the possible results of a battle.
+   */
   public enum BattleResultDescription {
     /** conquered without a fight. */
     BLITZED,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
@@ -86,6 +86,9 @@ public class BattleRecords implements Serializable {
     return playerRecords;
   }
 
+  /**
+   * Returns the amount of TUV lost by either the attacker or defender for all the specified battles.
+   */
   public static int getLostTuvForBattleRecords(final Collection<BattleRecord> brs, final boolean attackerLostTuv,
       final boolean includeNullPlayer) {
     int lostTuv = 0;
@@ -103,6 +106,9 @@ public class BattleRecords implements Serializable {
     return lostTuv;
   }
 
+  /**
+   * Indicates there was a battle in any of the specified territories matching the specified criteria.
+   */
   public static boolean getWereThereBattlesInTerritoriesMatching(final Collection<BattleRecord> brs,
       final PlayerId attacker, final PlayerId defender, final String battleType,
       final Collection<Territory> anyOfTheseTerritories) {
@@ -127,6 +133,9 @@ public class BattleRecords implements Serializable {
     return false;
   }
 
+  /**
+   * Removes the battle with the specified ID from this list of battles.
+   */
   public void removeBattle(final PlayerId currentPlayer, final GUID battleId) {
     final Map<GUID, BattleRecord> current = records.get(currentPlayer);
     // we can't count on this being the current player. If we created a battle using edit mode, then the battle might be
@@ -144,6 +153,9 @@ public class BattleRecords implements Serializable {
     current.remove(battleId);
   }
 
+  /**
+   * Adds the specified battles to this list of battles.
+   */
   public void addRecord(final BattleRecords other) {
     for (final PlayerId p : other.records.keySet()) {
       final Map<GUID, BattleRecord> currentRecord = records.get(p);
@@ -168,6 +180,9 @@ public class BattleRecords implements Serializable {
     }
   }
 
+  /**
+   * Removes the specified battles from this list of battles.
+   */
   public void removeRecord(final BattleRecords other) {
     for (final PlayerId p : other.records.keySet()) {
       final Map<GUID, BattleRecord> currentRecord = records.get(p);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
@@ -4,12 +4,15 @@ import java.util.List;
 
 import games.strategy.engine.data.Unit;
 
+/**
+ * A casualty list that also tracks whether or not casualties should be automatically calculated.
+ */
 public class CasualtyDetails extends CasualtyList {
   private static final long serialVersionUID = 2261683015991514918L;
   private final boolean autoCalculated;
 
   /**
-   * Creates new SelectCasualtyMessage.
+   * Creates new CasualtyDetails.
    *
    * @param killed killed units
    * @param damaged damaged units (Can have multiple of the same unit, to show multiple hits to that unit.)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyList.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyList.java
@@ -9,6 +9,9 @@ import java.util.List;
 
 import games.strategy.engine.data.Unit;
 
+/**
+ * A collection of units either killed or damaged during a battle.
+ */
 public class CasualtyList implements Serializable {
   private static final long serialVersionUID = 6501752134047891398L;
   private final List<Unit> killed;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/FightBattleDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/FightBattleDetails.java
@@ -7,6 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * Information about a pending battle that must be fought.
+ */
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
@@ -10,6 +10,9 @@ import java.util.Map.Entry;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
 
+/**
+ * Describes an action that moves one or more units along a specific route.
+ */
 public class MoveDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = 2199608152808948043L;
   private final Route route;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 import games.strategy.engine.data.Unit;
 
+/**
+ * The result of validating a unit movement action. For an invalid movement action, provides details on which units are
+ * not permitted to perform the movement.
+ */
 public class MoveValidationResult implements Serializable, Comparable<MoveValidationResult> {
   private static final long serialVersionUID = 6648363112533514955L;
   private String error = null;
@@ -45,6 +49,9 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
     unresolvedUnits.add(unit);
   }
 
+  /**
+   * Removes the specified unit from the list of unresolved units associated with the specified warning.
+   */
   public boolean removeUnresolvedUnit(final String warning, final Unit unit) {
     final int index = unresolvedUnitWarnings.indexOf(warning);
     if (index == -1) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/PlaceableUnits.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/PlaceableUnits.java
@@ -5,6 +5,9 @@ import java.util.Collection;
 
 import games.strategy.engine.data.Unit;
 
+/**
+ * The result of validating a unit placement action.
+ */
 public class PlaceableUnits implements Serializable {
   private static final long serialVersionUID = 6572719978603199091L;
   private String errorMessage;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/PlacementDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/PlacementDescription.java
@@ -5,6 +5,9 @@ import java.util.Collection;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
+/**
+ * Describes an action that places one or more units within a territory.
+ */
 public class PlacementDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = -3141153168992624631L;
   private final Territory territory;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/TechResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/TechResults.java
@@ -3,6 +3,9 @@ package games.strategy.triplea.delegate.data;
 import java.io.Serializable;
 import java.util.List;
 
+/**
+ * The result of spending tech tokens.
+ */
 public class TechResults implements Serializable {
   private static final long serialVersionUID = 5574673305892105782L;
   private final int[] rolls;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractForumPosterDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractForumPosterDelegate.java
@@ -4,6 +4,10 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.pbem.PbemMessagePoster;
 
+/**
+ * Logic for posting a save game to a forum. Supplements other game logic at points where it makes sense to record a
+ * save game (e.g. at the end of a game turn).
+ */
 public interface IAbstractForumPosterDelegate extends IRemote, IDelegate {
   boolean postTurnSummary(final PbemMessagePoster poster, final String title, final boolean includeSaveGame);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -7,9 +7,12 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.UndoablePlacement;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 
+/**
+ * Logic for placing units within a territory.
+ */
 public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePlacement> {
   /**
-   * Places the specified units in the specified territry.
+   * Places the specified units in the specified territory.
    *
    * @param units units to place.
    * @param at territory to place
@@ -21,6 +24,9 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
     return placeUnits(units, at, BidMode.NOT_BID);
   }
 
+  /**
+   * Indicates whether or not bidding is enabled during placement.
+   */
   enum BidMode {
     BID, NOT_BID
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -7,6 +7,9 @@ import games.strategy.triplea.delegate.IBattle;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.delegate.data.BattleListing;
 
+/**
+ * Logic for querying and fighting pending battles.
+ */
 public interface IBattleDelegate extends IRemote, IDelegate {
   /**
    * Returns the battles currently waiting to be fought.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPoliticsDelegate.java
@@ -6,6 +6,9 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 
+/**
+ * Logic for performing political actions.
+ */
 public interface IPoliticsDelegate extends IRemote, IDelegate {
   void attemptAction(PoliticalActionAttachment actionChoice);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -9,6 +9,9 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.message.IRemote;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Logic for purchasing and repairing units.
+ */
 public interface IPurchaseDelegate extends IRemote, IDelegate {
   /**
    * Purchases the specified units.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/ITechDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/ITechDelegate.java
@@ -7,6 +7,9 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Logic for spending tech tokens.
+ */
 public interface ITechDelegate extends IRemote, IDelegate {
   /**
    * Rolls for the specified tech.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IUserActionDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IUserActionDelegate.java
@@ -6,6 +6,9 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.attachments.UserActionAttachment;
 
+/**
+ * Logic for performing user actions.
+ */
 public interface IUserActionDelegate extends IRemote, IDelegate {
   void attemptAction(UserActionAttachment actionChoice);
 


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocType and JavadocMethod rules in various packages by adding missing Javadocs, where required.

## Functional Changes

None.

## Manual Testing Performed

None.  **This PR contains no code changes.**