### PR TITLE
Remove unnecessary @SuppressWarnings in CustomMatcher

### DIFF
--- a/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
+++ b/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
@@ -39,9 +39,9 @@ public class CustomMatcher<T> extends BaseMatcher<T> {
   private final String description;
   @Nonnull
   private final Predicate<T> checkCondition;
-  @SuppressWarnings("FieldMayBeFinal")
   @Builder.Default
-  private Function<T, String> debug = Object::toString;
+  @Nonnull
+  private final Function<T, String> debug = Object::toString;
 
   @SuppressWarnings("unchecked")
   @Override

--- a/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
+++ b/test-common/src/main/java/org/triplea/test/common/CustomMatcher.java
@@ -5,8 +5,8 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
-import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
 
 import lombok.Builder;
 
@@ -34,7 +34,7 @@ import lombok.Builder;
  *        value, then this would be of type 'HashMap'
  */
 @Builder
-public class CustomMatcher<T> extends BaseMatcher<T> {
+public final class CustomMatcher<T> extends TypeSafeMatcher<T> {
   @Nonnull
   private final String description;
   @Nonnull
@@ -43,16 +43,14 @@ public class CustomMatcher<T> extends BaseMatcher<T> {
   @Nonnull
   private final Function<T, String> debug = Object::toString;
 
-  @SuppressWarnings("unchecked")
   @Override
-  public boolean matches(final Object item) {
-    return checkCondition.test((T) item);
+  protected boolean matchesSafely(final T item) {
+    return checkCondition.test(item);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public void describeMismatch(final Object item, final Description description) {
-    description.appendText(debug.apply((T) item));
+  protected void describeMismatchSafely(final T item, final Description mismatchDescription) {
+    mismatchDescription.appendText(debug.apply(item));
   }
 
   @Override

--- a/test-common/src/test/java/org/triplea/test/common/CustomMatcherTest.java
+++ b/test-common/src/test/java/org/triplea/test/common/CustomMatcherTest.java
@@ -1,28 +1,30 @@
 package org.triplea.test.common;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.regex.Pattern;
+
 import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
 class CustomMatcherTest {
-
-
   /**
    * Example output using a matcher with a failure injected.:
    *
    * <pre>
-   *       MatcherAssert.assertThat(500, numberIsEqualToExampleMatcher(3));
-   java.lang.AssertionError:
-   Expected: Test value should have been equal to: 3
-   but: 500
+   * MatcherAssert.assertThat(500, numberIsEqualToExampleMatcher(3));
+   *
+   * java.lang.AssertionError:
+   * Expected: Test value should have been equal to: 3
+   *      but: 500
    * </pre>
    */
   @Test
   void exampleWithDefaultBehavior() {
-    MatcherAssert.assertThat(0, numberIsEqualToExampleMatcher(0));
-    MatcherAssert.assertThat(5, numberIsEqualToExampleMatcher(5));
+    assertThat(0, numberIsEqualToExampleMatcher(0));
+    assertThat(5, numberIsEqualToExampleMatcher(5));
   }
 
   private static Matcher<Integer> numberIsEqualToExampleMatcher(final int expected) {
@@ -34,47 +36,51 @@ class CustomMatcherTest {
 
   @Test
   void basicMismatchCase() {
-    assertThrows(AssertionError.class, () -> MatcherAssert.assertThat(0, numberIsEqualToExampleMatcher(100)));
+    assertThrows(AssertionError.class, () -> assertThat(0, numberIsEqualToExampleMatcher(100)));
   }
-
-
 
   /**
    * Example output using a matcher with a failure injected.:
    *
    * <pre>
-   *       MatcherAssert.assertThat(
-   *         "Hashcode values are expected to match between 'abc' and 'abc'",
-   *         "abc",
-   *         hashCodesMatch("abc"));
-   java.lang.AssertionError: In this example, if there is a failure, the ..[shortened]... get the #toString of 'abc'
-   Expected: Expected hashcode: 2987023 (hashed from: abc1)
-   but: Hashcode value is: 96354
+   * MatcherAssert.assertThat(
+   *     "Hashcode values are expected to match between 'abc' and 'abc'",
+   *     "abc",
+   *     hashCodesMatch("abc"));
+   *
+   * java.lang.AssertionError: In this example, if there is a failure, the ..[shortened]... get the #toString of 'abc'
+   * Expected: Expected hashcode: 2987023 (hashed from: abc1)
+   *      but: Hashcode value is: 96354
    * </pre>
    */
   @Test
-  public void exampleWithTestValueDebug() {
-    MatcherAssert.assertThat(
+  void exampleWithTestValueDebug() {
+    assertThat(
         "Hashcode values are expected to match between 'abc' and 'abc'",
         "abc",
         hashCodesMatch("abc"));
 
-    assertThrows(
+    final Throwable e = assertThrows(
         AssertionError.class,
-        () -> MatcherAssert.assertThat(
+        () -> assertThat(
             "The hashcodes of different strings do not match, so we'll expect an exception here."
                 + "This test can be used as an example to demo the debug messaging we get on a a failure by "
                 + "commenting out the assertThrows",
             "123",
             hashCodesMatch("abc")));
+    assertThat(e.getMessage(), matchesPattern(line("Expected: Expected hash code: \\d+ \\(hashed from: abc\\)")));
+    assertThat(e.getMessage(), matchesPattern(line("     but: Hash code value is: \\d+")));
   }
 
-  private static Matcher<String> hashCodesMatch(final String stringWithHashToMatch) {
+  private static Matcher<String> hashCodesMatch(final String value) {
     return CustomMatcher.<String>builder()
-        .description(
-            "Expected hashcode: " + stringWithHashToMatch.hashCode() + " ( hashed from: " + stringWithHashToMatch + ")")
-        .checkCondition(testValue -> testValue.hashCode() == stringWithHashToMatch.hashCode())
-        .debug(testValue -> "Hashcode value is: " + testValue.hashCode())
+        .description("Expected hash code: " + value.hashCode() + " (hashed from: " + value + ")")
+        .checkCondition(testValue -> testValue.hashCode() == value.hashCode())
+        .debug(testValue -> "Hash code value is: " + testValue.hashCode())
         .build();
+  }
+
+  private static Pattern line(final String regex) {
+    return Pattern.compile(".*^" + regex + "$.*", Pattern.DOTALL | Pattern.MULTILINE);
   }
 }


### PR DESCRIPTION
## Overview

There are a few `@SuppressWarnings` in the `CustomMatcher` class whose underlying causes can be easily fixed.  This PR does so.

## Functional Changes

None.

## Refactoring Changes

* Removed the `FieldMayBeFinal` warning suppression on the `debug` field by making the field final.
    * There doesn't seem to be anything precluding this field from being final.  Lombok seems to handle it just fine.  The warning suppression has been there since this class was introduced, so I'm not sure what the reasoning was for making this field non-final at the time.
* Removed the `unchecked` warning suppressions by inheriting from `TypeSafeMatcher` instead of `BaseMatcher`.
* Improved unit tests by adding assertions for the behavior of the `debug()` method.
* Reformatted examples in unit test Javadocs.

## Manual Testing Performed

None.