### PR TITLE
Fix Substance color chooser crash

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -13,6 +13,9 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
+import org.triplea.common.util.Services;
+import org.triplea.game.client.ui.swing.laf.SubstanceLookAndFeelManager;
+
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.SettingsWindow;
@@ -39,6 +42,7 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void initialize() {
+    Services.loadAny(SubstanceLookAndFeelManager.class).initialize();
     ClientSetting.lookAndFeel.addListener(gameSetting -> {
       setupLookAndFeel(gameSetting.getValueOrThrow());
       SettingsWindow.updateLookAndFeel();

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -42,7 +42,7 @@ public final class LookAndFeel {
    * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void initialize() {
-    Services.loadAny(SubstanceLookAndFeelManager.class).initialize();
+    getSubstanceLookAndFeelManager().initialize();
     ClientSetting.lookAndFeel.addListener(gameSetting -> {
       setupLookAndFeel(gameSetting.getValueOrThrow());
       SettingsWindow.updateLookAndFeel();
@@ -56,13 +56,17 @@ public final class LookAndFeel {
     setupLookAndFeel(ClientSetting.lookAndFeel.getValueOrThrow());
   }
 
+  private static SubstanceLookAndFeelManager getSubstanceLookAndFeelManager() {
+    return Services.loadAny(SubstanceLookAndFeelManager.class);
+  }
+
   /**
    * Returns a collection of the available Look-And-Feels.
    */
   public static List<String> getLookAndFeelAvailableList() {
     final List<String> lookAndFeelClassNames = new ArrayList<>();
     lookAndFeelClassNames.addAll(getInstalledLookAndFeelClassNames());
-    lookAndFeelClassNames.addAll(getSubstanceLookAndFeelClassNames());
+    lookAndFeelClassNames.addAll(getSubstanceLookAndFeelManager().getInstalledLookAndFeelClassNames());
     return lookAndFeelClassNames;
   }
 
@@ -72,46 +76,10 @@ public final class LookAndFeel {
         .collect(Collectors.toList());
   }
 
-  private static Collection<String> getSubstanceLookAndFeelClassNames() {
-    return Arrays.asList(
-        "Autumn",
-        "BusinessBlackSteel",
-        "BusinessBlueSteel",
-        "Business",
-        "Cerulean",
-        "CremeCoffee",
-        "Creme",
-        "DustCoffee",
-        "Dust",
-        "Gemini",
-        "GraphiteAqua",
-        "GraphiteChalk",
-        "GraphiteGlass",
-        "GraphiteGold",
-        "Graphite",
-        "Magellan",
-        "Mariner",
-        "MistAqua",
-        "MistSilver",
-        "Moderate",
-        "NebulaBrickWall",
-        "Nebula",
-        "OfficeBlack2007",
-        "OfficeBlue2007",
-        "OfficeSilver2007",
-        "Raven",
-        "Sahara",
-        "Twilight").stream()
-        .map(LookAndFeel::substance)
-        .collect(Collectors.toList());
-  }
-
-  private static String substance(final String baseName) {
-    return "org.pushingpixels.substance.api.skin.Substance" + baseName + "LookAndFeel";
-  }
-
   public static String getDefaultLookAndFeelClassName() {
-    return SystemProperties.isMac() ? UIManager.getSystemLookAndFeelClassName() : substance("Graphite");
+    return SystemProperties.isMac()
+        ? UIManager.getSystemLookAndFeelClassName()
+        : getSubstanceLookAndFeelManager().getDefaultLookAndFeelClassName();
   }
 
   private static void setupLookAndFeel(final String lookAndFeelName) {

--- a/game-core/src/main/java/org/triplea/common/util/Services.java
+++ b/game-core/src/main/java/org/triplea/common/util/Services.java
@@ -3,6 +3,7 @@ package org.triplea.common.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 /**
@@ -19,11 +20,17 @@ public final class Services {
   public static <T> T loadAny(final Class<T> type) {
     checkNotNull(type);
 
-    final Iterator<T> iterator = ServiceLoader.load(type).iterator();
-    if (!iterator.hasNext()) {
-      throw new ServiceNotAvailableException(type);
-    }
+    return tryLoadAny(type).orElseThrow(() -> new ServiceNotAvailableException(type));
+  }
 
-    return iterator.next();
+  /**
+   * Returns any available provider of the service of the specified type or empty if there are no service providers of
+   * the specified type available.
+   */
+  public static <T> Optional<T> tryLoadAny(final Class<T> type) {
+    checkNotNull(type);
+
+    final Iterator<T> iterator = ServiceLoader.load(type).iterator();
+    return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
   }
 }

--- a/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
+++ b/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
@@ -1,9 +1,21 @@
 package org.triplea.game.client.ui.swing.laf;
 
+import java.util.Collection;
+
 /**
  * A service for managing the Substance look and feel library.
  */
 public interface SubstanceLookAndFeelManager {
+  /**
+   * Returns the class name of the default Substance look and feel.
+   */
+  String getDefaultLookAndFeelClassName();
+
+  /**
+   * Returns a collection of class names for all installed Substance look and feels.
+   */
+  Collection<String> getInstalledLookAndFeelClassNames();
+
   /**
    * Initializes the Substance look and feel library. Should be called before any Substance look and feel is created.
    */

--- a/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
+++ b/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
@@ -1,0 +1,11 @@
+package org.triplea.game.client.ui.swing.laf;
+
+/**
+ * A service for managing the Substance look and feel library.
+ */
+public interface SubstanceLookAndFeelManager {
+  /**
+   * Initializes the Substance look and feel library. Should be called before any Substance look and feel is created.
+   */
+  void initialize();
+}

--- a/game-core/src/test/java/org/triplea/common/util/ServicesTest.java
+++ b/game-core/src/test/java/org/triplea/common/util/ServicesTest.java
@@ -1,16 +1,19 @@
 package org.triplea.common.util;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.triplea.common.util.Services.loadAny;
+import static org.triplea.common.util.Services.tryLoadAny;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public final class ServicesTest {
+final class ServicesTest {
   @Nested
   final class LoadAnyTest {
     @Test
@@ -22,6 +25,19 @@ public final class ServicesTest {
     void shouldThrowExceptionWhenServiceNotAvailable() {
       final Exception e = assertThrows(ServiceNotAvailableException.class, () -> loadAny(UnknownService.class));
       assertThat(e.getMessage(), containsString(UnknownService.class.getName()));
+    }
+  }
+
+  @Nested
+  final class TryLoadAnyTest {
+    @Test
+    void shouldReturnServiceWhenServiceIsAvailable() {
+      assertThat(tryLoadAny(KnownService.class), isPresentAnd(is(instanceOf(KnownServiceImpl.class))));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenServiceNotAvailable() {
+      assertThat(tryLoadAny(UnknownService.class), isEmpty());
     }
   }
 

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -21,8 +21,7 @@ dependencies {
     }
 
     implementation project(':game-core')
-
-    runtimeOnly 'org.pushing-pixels:radiance-substance:1.0.0'
+    implementation 'org.pushing-pixels:radiance-substance:1.0.2'
 
     if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
         testCompileOnly remoteLib(javaFxRuntimeUrl)

--- a/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
@@ -1,10 +1,10 @@
 package org.triplea.game.client.ui.swing.laf;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.pushingpixels.substance.api.SubstanceCortex;
+import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
 /**
  * Default implementation of the {@link SubstanceLookAndFeelManager} service.
@@ -12,46 +12,18 @@ import org.pushingpixels.substance.api.SubstanceCortex;
 public final class DefaultSubstanceLookAndFeelManager implements SubstanceLookAndFeelManager {
   @Override
   public String getDefaultLookAndFeelClassName() {
-    return getClassNameForSkin("Graphite");
-  }
-
-  private static String getClassNameForSkin(final String skinName) {
-    return "org.pushingpixels.substance.api.skin.Substance" + skinName + "LookAndFeel";
+    return SubstanceGraphiteLookAndFeel.class.getName();
   }
 
   @Override
   public Collection<String> getInstalledLookAndFeelClassNames() {
-    return Arrays.asList(
-        "Autumn",
-        "BusinessBlackSteel",
-        "BusinessBlueSteel",
-        "Business",
-        "Cerulean",
-        "CremeCoffee",
-        "Creme",
-        "DustCoffee",
-        "Dust",
-        "Gemini",
-        "GraphiteAqua",
-        "GraphiteChalk",
-        "GraphiteGlass",
-        "GraphiteGold",
-        "Graphite",
-        "Magellan",
-        "Mariner",
-        "MistAqua",
-        "MistSilver",
-        "Moderate",
-        "NebulaBrickWall",
-        "Nebula",
-        "OfficeBlack2007",
-        "OfficeBlue2007",
-        "OfficeSilver2007",
-        "Raven",
-        "Sahara",
-        "Twilight").stream()
-        .map(DefaultSubstanceLookAndFeelManager::getClassNameForSkin)
+    return SubstanceCortex.GlobalScope.getAllSkins().values().stream()
+        .map(skinInfo -> getLookAndFeelClassNameForSkinClassName(skinInfo.getClassName()))
         .collect(Collectors.toList());
+  }
+
+  private static String getLookAndFeelClassNameForSkinClassName(final String skinClassName) {
+    return skinClassName.replaceFirst("(?<=\\.)(\\w+)Skin$", "Substance$1LookAndFeel");
   }
 
   @Override

--- a/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
@@ -1,11 +1,59 @@
 package org.triplea.game.client.ui.swing.laf;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.pushingpixels.substance.api.SubstanceCortex;
 
 /**
  * Default implementation of the {@link SubstanceLookAndFeelManager} service.
  */
 public final class DefaultSubstanceLookAndFeelManager implements SubstanceLookAndFeelManager {
+  @Override
+  public String getDefaultLookAndFeelClassName() {
+    return getClassNameForSkin("Graphite");
+  }
+
+  private static String getClassNameForSkin(final String skinName) {
+    return "org.pushingpixels.substance.api.skin.Substance" + skinName + "LookAndFeel";
+  }
+
+  @Override
+  public Collection<String> getInstalledLookAndFeelClassNames() {
+    return Arrays.asList(
+        "Autumn",
+        "BusinessBlackSteel",
+        "BusinessBlueSteel",
+        "Business",
+        "Cerulean",
+        "CremeCoffee",
+        "Creme",
+        "DustCoffee",
+        "Dust",
+        "Gemini",
+        "GraphiteAqua",
+        "GraphiteChalk",
+        "GraphiteGlass",
+        "GraphiteGold",
+        "Graphite",
+        "Magellan",
+        "Mariner",
+        "MistAqua",
+        "MistSilver",
+        "Moderate",
+        "NebulaBrickWall",
+        "Nebula",
+        "OfficeBlack2007",
+        "OfficeBlue2007",
+        "OfficeSilver2007",
+        "Raven",
+        "Sahara",
+        "Twilight").stream()
+        .map(DefaultSubstanceLookAndFeelManager::getClassNameForSkin)
+        .collect(Collectors.toList());
+  }
+
   @Override
   public void initialize() {
     // workaround for https://github.com/kirill-grouchnikov/radiance/issues/102; remove when upgrading to Substance 1.5+

--- a/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
@@ -1,0 +1,14 @@
+package org.triplea.game.client.ui.swing.laf;
+
+import org.pushingpixels.substance.api.SubstanceCortex;
+
+/**
+ * Default implementation of the {@link SubstanceLookAndFeelManager} service.
+ */
+public final class DefaultSubstanceLookAndFeelManager implements SubstanceLookAndFeelManager {
+  @Override
+  public void initialize() {
+    // workaround for https://github.com/kirill-grouchnikov/radiance/issues/102; remove when upgrading to Substance 1.5+
+    SubstanceCortex.GlobalScope.setUseDefaultColorChooser();
+  }
+}

--- a/game-headed/src/main/resources/META-INF/services/org.triplea.game.client.ui.swing.laf.SubstanceLookAndFeelManager
+++ b/game-headed/src/main/resources/META-INF/services/org.triplea.game.client.ui.swing.laf.SubstanceLookAndFeelManager
@@ -1,0 +1,1 @@
+org.triplea.game.client.ui.swing.laf.DefaultSubstanceLookAndFeelManager


### PR DESCRIPTION
## Overview

Showing a `JColorChooser` dialog on Linux when a Substance L&F is active crashes the JVM.  The gory details of this issue are described in kirill-grouchnikov/radiance#102.

As described in the above issue, Substance has been modified to remove the Java code that exploits the native code bug that ultimately crashes the JVM.  However, that fix will not be available until Substance 1.5 is released.  In the meantime, this PR implements the workaround recommended by the Substance maintainer.

## Functional Changes

Use the default Java color chooser dialog in all Substance L&Fs instead of the custom Substance color chooser dialog.

## Refactoring Changes

I had to introduce a new service to avoid adding a compile-time dependency on Substance in `game-core`.  Since I had to add this new service anyway, I moved all the Substance-specific L&F logic from `LookAndFeel` in `game-core` to `DefaultSubstanceLookAndFeelManager` in `game-headed`.  This also allowed using the Substance API to dynamically determine the available L&Fs instead of hard-coding them (neither the L&F nor skin classes are loaded to populate this list, so we are still good at not loading unused, and potentially expensive, classes).

## Manual Testing Performed

* Ran the Map Properties Maker map tool and verified editing a player color brought up the color chooser dialog instead of crashing the JVM.
* Verified the Substance L&Fs are included in the list of available L&Fs in the client settings UI and that I could switch between them, including the default (Graphite).