### PR TITLE
Checkstyle: Add missing Javadocs

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
@@ -7,6 +7,9 @@ import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 
+/**
+ * A channel representing a remote client of a network game. Used by the server to notify clients of various events.
+ */
 public interface IClientChannel extends IChannelSubscribor {
   RemoteName CHANNEL_NAME =
       new RemoteName("games.strategy.engine.framework.ui.IClientChannel.CHANNEL", IClientChannel.class);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.framework.startup.mc;
 
+/**
+ * A listener that receives network game setup events from a remote node.
+ */
 public interface IRemoteModelListener {
   /**
    * The players available have changed.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
@@ -7,6 +7,9 @@ import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.message.IRemote;
 import games.strategy.net.INode;
 
+/**
+ * Allows client nodes to access various information from the server node during network game setup.
+ */
 public interface IServerStartupRemote extends IRemote {
   /**
    * Returns a listing of the players in the game.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -68,11 +68,17 @@ import games.strategy.util.Interruptibles;
 import games.strategy.util.Version;
 import lombok.extern.java.Log;
 
+/**
+ * Represents a network-aware game server to which multiple clients may connect.
+ */
 @Log
 public class ServerModel extends Observable implements IMessengerErrorListener, IConnectionChangeListener {
   public static final RemoteName SERVER_REMOTE_NAME =
       new RemoteName("games.strategy.engine.framework.ui.ServerStartup.SERVER_REMOTE", IServerStartupRemote.class);
 
+  /**
+   * Indicates the server is running in a headed or headless context.
+   */
   public enum InteractionMode {
     HEADLESS, SWING_CLIENT_UI
   }
@@ -607,6 +613,10 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     return localPlayerMappings;
   }
 
+  /**
+   * Returns the game launcher or empty if all players are not assigned to a node (e.g. if a player drops out before
+   * starting the game).
+   */
   public Optional<ServerLauncher> getLauncher() {
     synchronized (this) {
       disallowRemoveConnections();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -49,6 +49,9 @@ public class SetupPanelModel {
     setGameTypePanel(new PbemSetupPanel(gameSelectorModel));
   }
 
+  /**
+   * Starts the game server and displays the game start screen afterwards, awaiting remote game clients.
+   */
   public void showServer(final Component ui) {
     final ServerModel model = new ServerModel(gameSelectorModel, this);
     if (!model.createServerMessenger(ui)) {

--- a/game-core/src/main/java/games/strategy/engine/message/HubInvocationResults.java
+++ b/game-core/src/main/java/games/strategy/engine/message/HubInvocationResults.java
@@ -3,6 +3,9 @@ package games.strategy.engine.message;
 import games.strategy.engine.message.unifiedmessenger.InvocationResults;
 import games.strategy.net.GUID;
 
+/**
+ * The results of a remote method call invoked via {@link HubInvoke}.
+ */
 public class HubInvocationResults extends InvocationResults {
   private static final long serialVersionUID = -1769876896858969L;
 

--- a/game-core/src/main/java/games/strategy/engine/message/HubInvoke.java
+++ b/game-core/src/main/java/games/strategy/engine/message/HubInvoke.java
@@ -3,6 +3,10 @@ package games.strategy.engine.message;
 import games.strategy.engine.message.unifiedmessenger.Invoke;
 import games.strategy.net.GUID;
 
+/**
+ * A request to invoke a remote method on the hub node. All remote method invocations originate as an instance of this
+ * class.
+ */
 public class HubInvoke extends Invoke {
   private static final long serialVersionUID = -176987635348969L;
 

--- a/game-core/src/main/java/games/strategy/engine/message/SpokeInvocationResults.java
+++ b/game-core/src/main/java/games/strategy/engine/message/SpokeInvocationResults.java
@@ -3,6 +3,9 @@ package games.strategy.engine.message;
 import games.strategy.engine.message.unifiedmessenger.InvocationResults;
 import games.strategy.net.GUID;
 
+/**
+ * The results of a remote method call invoked via {@link SpokeInvoke}.
+ */
 public class SpokeInvocationResults extends InvocationResults {
   private static final long serialVersionUID = 8998965687635348969L;
 

--- a/game-core/src/main/java/games/strategy/engine/message/SpokeInvoke.java
+++ b/game-core/src/main/java/games/strategy/engine/message/SpokeInvoke.java
@@ -9,6 +9,11 @@ import games.strategy.net.GUID;
 import games.strategy.net.INode;
 import games.strategy.net.Node;
 
+/**
+ * A request forwarded by the hub node to invoke a remote method on a spoke node. Instances of this class should only be
+ * created by the messaging framework on the hub node. All remote method invocations should originate as an instance of
+ * {@link HubInvoke}.
+ */
 public class SpokeInvoke extends Invoke {
   private static final long serialVersionUID = -2007645463748969L;
   private INode invoker;

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -20,6 +20,9 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.util.Interruptibles;
 
+/**
+ * The hub node in a spoke-hub messaging architecture.
+ */
 public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeListener {
   private static final int NODE_IMPLEMENTATION_TIMEOUT = 200;
   private final UnifiedMessenger localUnified;

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/HasEndPointImplementor.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/HasEndPointImplementor.java
@@ -2,7 +2,9 @@ package games.strategy.engine.message.unifiedmessenger;
 
 import java.io.Serializable;
 
-// someone now has an implementor for an endpoint
+/**
+ * A message indicating someone now has an implementor for an end point.
+ */
 public class HasEndPointImplementor implements Serializable {
   private static final long serialVersionUID = 7607319129099694815L;
   public final String endPointName;

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/NoLongerHasEndPointImplementor.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/NoLongerHasEndPointImplementor.java
@@ -2,7 +2,9 @@ package games.strategy.engine.message.unifiedmessenger;
 
 import java.io.Serializable;
 
-// someone no longer has implementors for an endpoint
+/**
+ * A message indicating someone no longer has implementors for an end point.
+ */
 public class NoLongerHasEndPointImplementor implements Serializable {
   private static final long serialVersionUID = -4855990132007435355L;
   public final String endPointName;

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -179,6 +179,9 @@ public class UnifiedMessenger {
     }
   }
 
+  /**
+   * Removes the specified implementor for the end point with the specified name.
+   */
   public void removeImplementor(final String name, final Object implementor) {
     checkNotNull(implementor);
 
@@ -230,7 +233,9 @@ public class UnifiedMessenger {
     }
   }
 
-
+  /**
+   * Invoked when a message is received from a node (either a remote client or the server itself).
+   */
   public void messageReceived(final Serializable msg, final INode from) {
     if (msg instanceof SpokeInvoke) {
       // if this isn't the server, something is wrong

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -200,6 +200,11 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     unmuteMacTimer.schedule(getMacUnmuteTask(mac), checkTime.toEpochMilli() - System.currentTimeMillis());
   }
 
+  /**
+   * Invoked when the node with the specified unique name has successfully logged in. Note that {@code uniquePlayerName}
+   * is the node name and may not be identical to the name of the player associated with the node (see
+   * {@link #getUniqueName(String)}.
+   */
   public void notifyPlayerLogin(final String uniquePlayerName, final String mac) {
     synchronized (cachedListLock) {
       cachedMacAddresses.put(uniquePlayerName, mac);
@@ -441,6 +446,11 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
         .anyMatch(nodeName::equalsIgnoreCase);
   }
 
+  /**
+   * Returns a node name, based on the specified node name, that is unique across all nodes. The node name is made
+   * unique by adding a numbered suffix to the existing node name. For example, for the second node with the name "foo",
+   * this method will return "foo (1)".
+   */
   public String getUniqueName(final String name) {
     String currentName = name;
     if (currentName.length() > 50) {

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -30,6 +30,9 @@ import games.strategy.net.nio.QuarantineConversation;
 import games.strategy.util.Interruptibles;
 import lombok.extern.java.Log;
 
+/**
+ * Default implementation of {@link IClientMessenger}.
+ */
 @Log
 public class ClientMessenger implements IClientMessenger, NioSocketListener {
   private INode node;

--- a/game-core/src/main/java/games/strategy/net/DefaultObjectStreamFactory.java
+++ b/game-core/src/main/java/games/strategy/net/DefaultObjectStreamFactory.java
@@ -6,6 +6,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
+/**
+ * Default implementation of {@link IObjectStreamFactory} that uses {@link ObjectOutputStream} and
+ * {@link ObjectInputStream} for serialization and deserialization, respectively.
+ */
 public class DefaultObjectStreamFactory implements IObjectStreamFactory {
   @Override
   public ObjectInputStream create(final InputStream stream) throws IOException {

--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -8,6 +8,9 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+/**
+ * Implementation of {@link IServerMessenger} for a headless game server.
+ */
 public class HeadlessServerMessenger implements IServerMessenger {
 
   private final INode node;

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -4,6 +4,9 @@ import java.io.File;
 
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 
+/**
+ * A client messenger. Additional methods for selecting the game on the server.
+ */
 public interface IClientMessenger extends IMessenger {
   void changeServerGameTo(final String gameName);
 

--- a/game-core/src/main/java/games/strategy/net/IConnectionChangeListener.java
+++ b/game-core/src/main/java/games/strategy/net/IConnectionChangeListener.java
@@ -1,5 +1,8 @@
 package games.strategy.net;
 
+/**
+ * A listener that receives notifications when the connection list maintained by a {@link IServerMessenger} changes.
+ */
 public interface IConnectionChangeListener {
   /**
    * A connection has been added.

--- a/game-core/src/main/java/games/strategy/net/IMessageListener.java
+++ b/game-core/src/main/java/games/strategy/net/IMessageListener.java
@@ -2,6 +2,9 @@ package games.strategy.net;
 
 import java.io.Serializable;
 
+/**
+ * A listener that receives event notifications from a {@link IMessenger}.
+ */
 public interface IMessageListener {
   void messageReceived(Serializable msg, INode from);
 }

--- a/game-core/src/main/java/games/strategy/net/IMessengerErrorListener.java
+++ b/game-core/src/main/java/games/strategy/net/IMessengerErrorListener.java
@@ -1,9 +1,12 @@
 package games.strategy.net;
 
+/**
+ * A listener that receives error notifications from a {@link IMessenger}.
+ */
 public interface IMessengerErrorListener {
   /**
    * The messenger is no longer able to send or receive messages.
-   * This signals that an error has occured, will not be sent if the
+   * This signals that an error has occurred, will not be sent if the
    * node was shutdown.
    */
   void messengerInvalid(Throwable cause);

--- a/game-core/src/main/java/games/strategy/net/IObjectStreamFactory.java
+++ b/game-core/src/main/java/games/strategy/net/IObjectStreamFactory.java
@@ -6,6 +6,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 
+/**
+ * Factory for creating matching pairs of {@link ObjectInputStream} and {@link ObjectOutputStream}. The extra layer of
+ * indirection permits customizing the serialization and deserialization process for a particular object graph.
+ */
 public interface IObjectStreamFactory {
   ObjectInputStream create(InputStream stream) throws IOException;
 

--- a/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -2,8 +2,10 @@ package games.strategy.net;
 
 import java.io.Serializable;
 
-// written over the network very often, so make externalizable to
-// increase performance
+/**
+ * The envelope for a message consisting of both the header and payload. The header specifies the source and
+ * destination nodes of the message.
+ */
 public class MessageHeader {
   // if null, then a broadcast
   private final INode to;


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocType and JavadocMethod rules in various packages by adding missing Javadocs, where required.

## Functional Changes

None.

## Manual Testing Performed

None.  **This PR contains no code changes.**