### PR TITLE
Improve exception contract between ClientSetting and its subclasses

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -6,12 +6,12 @@ final class BooleanClientSetting extends ClientSetting<Boolean> {
   }
 
   @Override
-  protected String formatValue(final Boolean value) {
+  protected String encodeValue(final Boolean value) {
     return value.toString();
   }
 
   @Override
-  protected Boolean parseValue(final String encodedValue) {
+  protected Boolean decodeValue(final String encodedValue) {
     return Boolean.valueOf(encodedValue);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/EnumClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/EnumClientSetting.java
@@ -6,12 +6,16 @@ final class EnumClientSetting<E extends Enum<E>> extends ClientSetting<E> {
   }
 
   @Override
-  protected String formatValue(final E value) {
+  protected String encodeValue(final E value) {
     return value.toString();
   }
 
   @Override
-  protected E parseValue(final String encodedValue) {
-    return Enum.valueOf(getType(), encodedValue);
+  protected E decodeValue(final String encodedValue) throws ValueEncodingException {
+    try {
+      return Enum.valueOf(getType(), encodedValue);
+    } catch (final IllegalArgumentException e) {
+      throw new ValueEncodingException(e);
+    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
@@ -10,12 +10,16 @@ final class IntegerClientSetting extends ClientSetting<Integer> {
   }
 
   @Override
-  protected String formatValue(final Integer value) {
+  protected String encodeValue(final Integer value) {
     return value.toString();
   }
 
   @Override
-  protected Integer parseValue(final String encodedValue) {
-    return Integer.valueOf(encodedValue);
+  protected Integer decodeValue(final String encodedValue) throws ValueEncodingException {
+    try {
+      return Integer.valueOf(encodedValue);
+    } catch (final NumberFormatException e) {
+      throw new ValueEncodingException(e);
+    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
@@ -13,12 +13,12 @@ final class PathClientSetting extends ClientSetting<Path> {
   }
 
   @Override
-  protected String formatValue(final Path value) {
+  protected String encodeValue(final Path value) {
     return value.toString();
   }
 
   @Override
-  protected Path parseValue(final String encodedValue) {
+  protected Path decodeValue(final String encodedValue) {
     return Paths.get(encodedValue);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
@@ -2,13 +2,16 @@ package games.strategy.triplea.settings;
 
 import java.util.Arrays;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.security.CredentialManager;
 import games.strategy.security.CredentialManagerException;
+import games.strategy.util.function.ThrowingBiFunction;
 
 /**
  * ClientSetting to store encrypted versions of potentially sensitive Strings.
  */
-class ProtectedStringClientSetting extends ClientSetting<char[]> {
+final class ProtectedStringClientSetting extends ClientSetting<char[]> {
 
   private final boolean sensitive;
 
@@ -17,26 +20,49 @@ class ProtectedStringClientSetting extends ClientSetting<char[]> {
     this.sensitive = sensitive;
   }
 
+  @Override
+  protected String encodeValue(final char[] value) throws ValueEncodingException {
+    return withCredentialManager(value, ProtectedStringClientSetting::encodeValue);
+  }
+
   /**
    * Protects the given char array and cleans the content afterwards.
    */
-  @Override
-  protected String formatValue(final char[] value) {
-    try (CredentialManager manager = CredentialManager.newInstance()) {
-      return manager.protect(value);
+  @VisibleForTesting
+  static String encodeValue(final char[] value, final CredentialManager credentialManager)
+      throws ValueEncodingException {
+    try {
+      return credentialManager.protect(value);
     } catch (final CredentialManagerException e) {
-      throw new IllegalStateException("Error while trying to protect String.", e);
+      throw new ValueEncodingException("Error while trying to protect string", e);
     } finally {
       Arrays.fill(value, '\0');
     }
   }
 
-  @Override
-  protected char[] parseValue(final String encodedValue) {
-    try (CredentialManager manager = CredentialManager.newInstance()) {
-      return manager.unprotect(encodedValue);
+  private static <T, R> R withCredentialManager(
+      final T value,
+      final ThrowingBiFunction<T, CredentialManager, R, ValueEncodingException> function)
+      throws ValueEncodingException {
+    try (CredentialManager credentialManager = CredentialManager.newInstance()) {
+      return function.apply(value, credentialManager);
     } catch (final CredentialManagerException e) {
-      throw new IllegalArgumentException("Error while trying to unprotect string '" + encodedValue + "'.", e);
+      throw new ValueEncodingException("Failed to create credential manager", e);
+    }
+  }
+
+  @Override
+  protected char[] decodeValue(final String encodedValue) throws ValueEncodingException {
+    return withCredentialManager(encodedValue, ProtectedStringClientSetting::decodeValue);
+  }
+
+  @VisibleForTesting
+  static char[] decodeValue(final String encodedValue, final CredentialManager credentialManager)
+      throws ValueEncodingException {
+    try {
+      return credentialManager.unprotect(encodedValue);
+    } catch (final CredentialManagerException e) {
+      throw new ValueEncodingException("Error while trying to unprotect string '" + encodedValue + "'", e);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/StringClientSetting.java
@@ -10,12 +10,12 @@ final class StringClientSetting extends ClientSetting<String> {
   }
 
   @Override
-  protected String formatValue(final String value) {
+  protected String encodeValue(final String value) {
     return value;
   }
 
   @Override
-  protected String parseValue(final String encodedValue) {
+  protected String decodeValue(final String encodedValue) {
     return encodedValue;
   }
 }

--- a/game-core/src/main/java/games/strategy/util/function/ThrowingBiFunction.java
+++ b/game-core/src/main/java/games/strategy/util/function/ThrowingBiFunction.java
@@ -1,0 +1,24 @@
+package games.strategy.util.function;
+
+/**
+ * A function that accepts two arguments, produces a result, and may throw a checked exception.
+ *
+ * @param <T> The type of the first argument to the function.
+ * @param <U> The type of the second argument to the function.
+ * @param <R> The type of the result of the function.
+ * @param <E> The type of exception that may be thrown by the function.
+ */
+@FunctionalInterface
+public interface ThrowingBiFunction<T, U, R, E extends Throwable> {
+  /**
+   * Applies the function to the given arguments.
+   *
+   * @param t The first function argument.
+   * @param u The second function argument.
+   *
+   * @return The function result.
+   *
+   * @throws E If an error occurs while applying the function.
+   */
+  R apply(T t, U u) throws E;
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/BooleanClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/BooleanClientSettingTest.java
@@ -10,28 +10,28 @@ final class BooleanClientSettingTest {
   private final BooleanClientSetting clientSetting = new BooleanClientSetting("name", false);
 
   @Nested
-  final class FormatValueTest {
+  final class EncodeValueTest {
     @Test
     void shouldReturnEncodedValue() {
-      assertThat(clientSetting.formatValue(false), is("false"));
-      assertThat(clientSetting.formatValue(true), is("true"));
+      assertThat(clientSetting.encodeValue(false), is("false"));
+      assertThat(clientSetting.encodeValue(true), is("true"));
     }
   }
 
   @Nested
-  final class ParseValueTest {
+  final class DecodeValueTest {
     @Test
     void shouldReturnTrueWhenEncodedValueIsCaseInsensitiveTrue() {
-      assertThat(clientSetting.parseValue("true"), is(true));
-      assertThat(clientSetting.parseValue("TRUE"), is(true));
+      assertThat(clientSetting.decodeValue("true"), is(true));
+      assertThat(clientSetting.decodeValue("TRUE"), is(true));
     }
 
     @Test
     void shouldReturnFalseWhenEncodedValueIsNotCaseInsensitiveTrue() {
-      assertThat(clientSetting.parseValue(""), is(false));
-      assertThat(clientSetting.parseValue("false"), is(false));
-      assertThat(clientSetting.parseValue("FALSE"), is(false));
-      assertThat(clientSetting.parseValue("yes"), is(false));
+      assertThat(clientSetting.decodeValue(""), is(false));
+      assertThat(clientSetting.decodeValue("false"), is(false));
+      assertThat(clientSetting.decodeValue("FALSE"), is(false));
+      assertThat(clientSetting.decodeValue("yes"), is(false));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
@@ -34,12 +34,12 @@ final class ClientSettingAsGameSettingTest extends AbstractGameSettingTestCase {
     }
 
     @Override
-    protected String formatValue(final Integer value) {
+    protected String encodeValue(final Integer value) {
       return value.toString();
     }
 
     @Override
-    protected Integer parseValue(final String encodedValue) {
+    protected Integer decodeValue(final String encodedValue) {
       return Integer.valueOf(encodedValue);
     }
   }

--- a/game-core/src/test/java/games/strategy/triplea/settings/EnumClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/EnumClientSettingTest.java
@@ -14,27 +14,27 @@ final class EnumClientSettingTest {
       new EnumClientSetting<>(FakeEnum.class, "name", FakeEnum.ONE);
 
   @Nested
-  final class FormatValueTest {
+  final class EncodeValueTest {
     @Test
     void shouldReturnEnumConstantName() {
       Arrays.stream(FakeEnum.values()).forEach(value -> {
-        assertThat(clientSetting.formatValue(value), is(value.toString()));
+        assertThat(clientSetting.encodeValue(value), is(value.toString()));
       });
     }
   }
 
   @Nested
-  final class ParseValueTest {
+  final class DecodeValueTest {
     @Test
-    void shouldReturnAssociatedEnumConstantWhenEncodedValueIsLegal() {
-      Arrays.stream(FakeEnum.values()).forEach(value -> {
-        assertThat(clientSetting.parseValue(value.toString()), is(value));
-      });
+    void shouldReturnAssociatedEnumConstantWhenEncodedValueIsLegal() throws Exception {
+      for (final FakeEnum value : FakeEnum.values()) {
+        assertThat(clientSetting.decodeValue(value.toString()), is(value));
+      }
     }
 
     @Test
     void shouldThrowExceptionWhenEncodedValueIsIllegal() {
-      assertThrows(IllegalArgumentException.class, () -> clientSetting.parseValue("__unknown__"));
+      assertThrows(ClientSetting.ValueEncodingException.class, () -> clientSetting.decodeValue("__unknown__"));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
@@ -11,32 +11,32 @@ final class IntegerClientSettingTest {
   private final IntegerClientSetting clientSetting = new IntegerClientSetting("name", 0);
 
   @Nested
-  final class FormatValueTest {
+  final class EncodeValueTest {
     @Test
     void shouldReturnEncodedValue() {
-      assertThat(clientSetting.formatValue(Integer.MIN_VALUE), is("-2147483648"));
-      assertThat(clientSetting.formatValue(-1), is("-1"));
-      assertThat(clientSetting.formatValue(0), is("0"));
-      assertThat(clientSetting.formatValue(1), is("1"));
-      assertThat(clientSetting.formatValue(Integer.MAX_VALUE), is("2147483647"));
+      assertThat(clientSetting.encodeValue(Integer.MIN_VALUE), is("-2147483648"));
+      assertThat(clientSetting.encodeValue(-1), is("-1"));
+      assertThat(clientSetting.encodeValue(0), is("0"));
+      assertThat(clientSetting.encodeValue(1), is("1"));
+      assertThat(clientSetting.encodeValue(Integer.MAX_VALUE), is("2147483647"));
     }
   }
 
   @Nested
-  final class ParseValueTest {
+  final class DecodeValueTest {
     @Test
-    void shouldReturnIntegerWhenEncodedValueIsLegal() {
-      assertThat(clientSetting.parseValue("-2147483648"), is(Integer.MIN_VALUE));
-      assertThat(clientSetting.parseValue("-1"), is(-1));
-      assertThat(clientSetting.parseValue("0"), is(0));
-      assertThat(clientSetting.parseValue("1"), is(1));
-      assertThat(clientSetting.parseValue("2147483647"), is(Integer.MAX_VALUE));
+    void shouldReturnIntegerWhenEncodedValueIsLegal() throws Exception {
+      assertThat(clientSetting.decodeValue("-2147483648"), is(Integer.MIN_VALUE));
+      assertThat(clientSetting.decodeValue("-1"), is(-1));
+      assertThat(clientSetting.decodeValue("0"), is(0));
+      assertThat(clientSetting.decodeValue("1"), is(1));
+      assertThat(clientSetting.decodeValue("2147483647"), is(Integer.MAX_VALUE));
     }
 
     @Test
     void shouldThrowExceptionWhenEncodedValueIsIllegal() {
-      assertThrows(NumberFormatException.class, () -> clientSetting.parseValue(""));
-      assertThrows(NumberFormatException.class, () -> clientSetting.parseValue("a123"));
+      assertThrows(ClientSetting.ValueEncodingException.class, () -> clientSetting.decodeValue(""));
+      assertThrows(ClientSetting.ValueEncodingException.class, () -> clientSetting.decodeValue("a123"));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/PathClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/PathClientSettingTest.java
@@ -12,20 +12,20 @@ final class PathClientSettingTest {
   private final PathClientSetting clientSetting = new PathClientSetting("name", Paths.get("/path", "to", "file"));
 
   @Nested
-  final class FormatValueTest {
+  final class EncodeValueTest {
     @Test
     void shouldReturnEncodedValue() {
-      assertThat(clientSetting.formatValue(Paths.get("/absolute", "path", "to", "file")), is("/absolute/path/to/file"));
-      assertThat(clientSetting.formatValue(Paths.get("relative", "path", "to", "file")), is("relative/path/to/file"));
+      assertThat(clientSetting.encodeValue(Paths.get("/absolute", "path", "to", "file")), is("/absolute/path/to/file"));
+      assertThat(clientSetting.encodeValue(Paths.get("relative", "path", "to", "file")), is("relative/path/to/file"));
     }
   }
 
   @Nested
-  final class ParseValueTest {
+  final class DecodeValueTest {
     @Test
     void shouldReturnPath() {
-      assertThat(clientSetting.parseValue("/absolute/path/to/file"), is(Paths.get("/absolute", "path", "to", "file")));
-      assertThat(clientSetting.parseValue("relative/path/to/file"), is(Paths.get("relative", "path", "to", "file")));
+      assertThat(clientSetting.decodeValue("/absolute/path/to/file"), is(Paths.get("/absolute", "path", "to", "file")));
+      assertThat(clientSetting.decodeValue("relative/path/to/file"), is(Paths.get("relative", "path", "to", "file")));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/StringClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/StringClientSettingTest.java
@@ -10,18 +10,18 @@ final class StringClientSettingTest {
   private final StringClientSetting clientSetting = new StringClientSetting("name");
 
   @Nested
-  final class FormatValueTest {
+  final class EncodeValueTest {
     @Test
     void shouldReturnValueUnchanged() {
-      assertThat(clientSetting.formatValue("value"), is("value"));
+      assertThat(clientSetting.encodeValue("value"), is("value"));
     }
   }
 
   @Nested
-  final class ParseValueTest {
+  final class DecodeValueTest {
     @Test
     void shouldReturnEncodedValueUnchanged() {
-      assertThat(clientSetting.parseValue("encodedValue"), is("encodedValue"));
+      assertThat(clientSetting.decodeValue("encodedValue"), is("encodedValue"));
     }
   }
 }


### PR DESCRIPTION
## Overview

While the `ClientSetting#parseValue()` method specifies subclasses should throw `IllegalArgumentException` if they can't parse an encoded value, it makes no provision for subclasses to throw a specific exception from `formatValue()` if they can't encode a value (e.g. as can happen in `ProtectedStringClientSetting` if there is an encryption error).

This PR introduces a dedicated checked exception that subclasses may throw if they can't encode/decode a value.  `ClientSetting` handles exceptions of this type in an appropriate manner depending on the context.

## Functional Changes

* When calling `setValue()`, if an error occurs while encoding the value as a string, the error will be logged, but the client setting will be left unchanged instead of throwing an unchecked exception.  This is symmetric with the behavior of `getValue()` in that, if the encoded value cannot be decoded, no exception is thrown, but rather the error is logged and the default value is returned.

## Refactoring Changes

* Changed the signatures of the methods used to encode/decode a value to permit them to throw a dedicated checked exception (`ClientSetting$ValueEncodingException`) to indicate a failure.
* Renamed the `formatValue()` and `parseValue()` methods to `encodeValue()` and `decodeValue()`, respectively, because it seemed more consistent after introducing the new custom exception.

## Manual Testing Performed

Verified the new PBEM/PBF settings behave as expected due to the changes in `ProtectedStringClientSetting`.

## Additional Review Notes

Because of the method renames, several files were affected outside the core change.  The core change is mostly in `ClientSetting`, `EnumClientSetting`, `IntegerClientSetting`, `ProtectedStringClientSetting`, `ClientSettingTest`, and `ProtectedStringClientSettingTest`.