### PR TITLE
Checkstyle: Add missing Javadocs in g.s.triplea.delegate

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -363,6 +363,9 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     return getProduction(territories, getData());
   }
 
+  /**
+   * Returns the total production value of the specified territories.
+   */
   public static int getProduction(final Collection<Territory> territories, final GameData data) {
     int value = 0;
     for (final Territory current : territories) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -27,6 +27,9 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   // if we are in the process of doing a move. this instance will allow us to resume the move
   protected MovePerformer tempMovePerformer;
 
+  /**
+   * The type of move.
+   */
   public enum MoveType {
     DEFAULT, SPECIAL
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -721,6 +721,10 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     return null;
   }
 
+  /**
+   * Returns {@code null} if the specified units can be placed in the specified territory; otherwise returns an error
+   * message explaining why the units cannot be placed in the territory.
+   */
   public String canUnitsBePlaced(final Territory to, final Collection<Unit> units, final PlayerId player) {
     final Collection<Unit> allowedUnits = getUnitsToBePlaced(to, units, player);
     if (allowedUnits == null || !allowedUnits.containsAll(units)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -10,6 +10,13 @@ import games.strategy.engine.history.Step;
 import games.strategy.engine.player.IRemotePlayer;
 import games.strategy.triplea.Constants;
 
+/**
+ * Superclass for all logic that runs in edit mode.
+ *
+ * <p>
+ * TODO: Merge this class with EditDelegate, as it has no other subclasses.
+ * </p>
+ */
 public abstract class BaseEditDelegate extends BasePersistentDelegate {
   private static final String EDITMODE_ON = "Turning on Edit Mode";
   private static final String EDITMODE_OFF = "Turning off Edit Mode";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -927,6 +927,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
   }
 
+  /**
+   * Returns the maximum number of units that can scramble from the specified air bases.
+   *
+   * @return {@link Integer#MAX_VALUE} if any air base can scramble an infinite number of units.
+   */
   public static int getMaxScrambleCount(final Collection<Unit> airbases) {
     if (airbases.isEmpty()
         || !airbases.stream().allMatch(Matches.unitIsAirBase().and(Matches.unitIsNotDisabled()))) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleResults.java
@@ -8,6 +8,9 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.IBattle.WhoWon;
 import games.strategy.util.CollectionUtils;
 
+/**
+ * The results of an in-progress or complete battle.
+ */
 public class BattleResults extends GameDataComponent {
   private static final long serialVersionUID = 1381361441940258702L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -471,6 +471,10 @@ public class BattleTracker implements Serializable {
     // TODO: else what?
   }
 
+  /**
+   * Changes ownership of the specified territory to the specified player as a result of the territory being taken over
+   * after a battle.
+   */
   public void takeOver(final Territory territory, final PlayerId id, final IDelegateBridge bridge,
       final UndoableMove changeTracker, final Collection<Unit> arrivingUnits) {
     // This could be NULL if unowned water

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -15,6 +15,9 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Logic for unit placement when bid mode is active.
+ */
 public class BidPlaceDelegate extends AbstractPlaceDelegate {
   public BidPlaceDelegate() {}
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -14,6 +14,9 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Constants;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Logic for purchasing units when bid mode is active.
+ */
 public class BidPurchaseDelegate extends PurchaseDelegate {
   private int bid;
   private int spent;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DelegateFinder.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DelegateFinder.java
@@ -3,6 +3,9 @@ package games.strategy.triplea.delegate;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
 
+/**
+ * A collection of methods for obtaining various types of delegate instances from the game data.
+ */
 public class DelegateFinder {
   private static IDelegate findDelegate(final GameData data, final String delegateName) {
     final IDelegate delegate = data.getDelegateList().getDelegate(delegateName);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -704,6 +704,12 @@ public class DiceRoll implements Externalizable {
     return givenSupport;
   }
 
+  /**
+   * Sorts the specified collection of units in ascending order of their attack or defense strength.
+   *
+   * @param defending {@code true} if the units should be sorted by their defense strength; otherwise the units will be
+   *        sorted by their attack strength.
+   */
   public static void sortByStrength(final List<Unit> units, final boolean defending) {
     final Comparator<Unit> comp = (u1, u2) -> {
       final int v1;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -9,6 +9,9 @@ import java.util.Objects;
 public class Die implements Serializable {
   private static final long serialVersionUID = 8766753280669636980L;
 
+  /**
+   * The type of the die roll.
+   */
   public enum DieType {
     MISS, HIT, IGNORED
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -19,6 +19,9 @@ import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.Interruptibles;
 
+/**
+ * Maintains the state of a group of units firing during a {@link MustFightBattle}.
+ */
 public class Fire implements IExecutable {
 
   private static final long serialVersionUID = -3687054738070722403L;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GenericTechAdvance.java
@@ -5,6 +5,10 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.TechAttachment;
 
+/**
+ * A proxy for another {@link TechAdvance}. Delegates all operations to the proxied instance. If no instance to proxy is
+ * specified, an instance of this class will provide a suitable Null Object implementation.
+ */
 public class GenericTechAdvance extends TechAdvance {
   private static final long serialVersionUID = -5985281030083508185L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -19,10 +19,16 @@ import games.strategy.triplea.delegate.data.BattleRecord.BattleResultDescription
  * Represents a battle.
  */
 public interface IBattle extends Serializable {
+  /**
+   * Identifies the winner of a battle.
+   */
   enum WhoWon {
     NOTFINISHED, DRAW, ATTACKER, DEFENDER
   }
 
+  /**
+   * The type of a battle.
+   */
   enum BattleType {
     NORMAL("Battle"), AIR_BATTLE("Air Battle"), AIR_RAID("Air Raid"), BOMBING_RAID("Bombing Raid");
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/IExecutable.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/IExecutable.java
@@ -4,6 +4,11 @@ import java.io.Serializable;
 
 import games.strategy.engine.delegate.IDelegateBridge;
 
+/**
+ * A persistable action executed by a delegate.
+ *
+ * @see ExecutionStack
+ */
 public interface IExecutable extends Serializable {
   /**
    * See the documentation to IExecutionStack.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -61,6 +61,9 @@ public class MoveValidator {
       "Transport cannot both load AND unload after being in combat";
   public static final String NOT_ALL_UNITS_CAN_BLITZ = "Not all units can blitz";
 
+  /**
+   * Validates the specified move.
+   */
   public static MoveValidationResult validateMove(final Collection<Unit> units, final Route route,
       final PlayerId player, final Collection<Unit> transportsToLoad, final Map<Unit, Collection<Unit>> newDependents,
       final boolean isNonCombat, final List<UndoableMove> undoableMoves, final GameData data) {
@@ -868,6 +871,10 @@ public class MoveValidator {
     return false;
   }
 
+  /**
+   * Returns {@code true} if moving the specified units along the specified route requires them to be loaded/unloaded
+   * on/off a transport.
+   */
   // TODO KEV revise these to include paratroop load/unload
   public static boolean isLoad(final Collection<Unit> units, final Map<Unit, Collection<Unit>> newDependents,
       final Route route, final GameData data, final PlayerId player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -63,12 +63,24 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     DEFAULT, SUBS, PLANES, PARTIAL_AMPHIB
   }
 
-  // this class exists for testing
+  /**
+   * An action representing attacking subs firing during a battle.
+   *
+   * <p>
+   * NOTE: This type exists solely for tests to interrogate the execution stack looking for an action of this type.
+   * </p>
+   */
   public abstract static class AttackSubs implements IExecutable {
     private static final long serialVersionUID = 4872551667582174716L;
   }
 
-  // this class exists for testing
+  /**
+   * An action representing defending subs firing during a battle.
+   *
+   * <p>
+   * NOTE: This type exists solely for tests to interrogate the execution stack looking for an action of this type.
+   * </p>
+   */
   public abstract static class DefendSubs implements IExecutable {
     private static final long serialVersionUID = 3768066729336520095L;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -53,6 +53,9 @@ public class OriginalOwnerTracker implements Serializable {
     return ta.getOriginalOwner();
   }
 
+  /**
+   * Returns the territories originally owned by the specified player.
+   */
   public static Collection<Territory> getOriginallyOwned(final GameData data, final PlayerId player) {
     final Collection<Territory> territories = new ArrayList<>();
     for (final Territory t : data.getMap()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -42,6 +42,9 @@ import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Interruptibles;
 
+/**
+ * A strategic bombing raid (SBR) battle.
+ */
 public class StrategicBombingRaidBattle extends AbstractBattle implements BattleStepStrings {
   private static final long serialVersionUID = 8490171037606078890L;
   private static final String RAID = "Strategic bombing raid";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -20,6 +20,9 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.util.Tuple;
 
+/**
+ * Superclass for all technology advances.
+ */
 public abstract class TechAdvance extends NamedAttachable {
   private static final long serialVersionUID = -1076712297024403156L;
   private static final Class<?>[] preDefinedTechConstructorParameter = new Class<?>[] {GameData.class};
@@ -160,6 +163,15 @@ public abstract class TechAdvance extends NamedAttachable {
     }
   }
 
+  /**
+   * Creates and returns an instance of the well-known technology advance with the specified class name.
+   *
+   * @param s The fully-qualified name of the technology advance class.
+   * @param data
+   *
+   * @throws IllegalArgumentException If {@code s} is not a well-known technology advance.
+   * @throws IllegalStateException If an error occurs while creating the new technology advance instance.
+   */
   public static TechAdvance findDefinedAdvanceAndCreateAdvance(final String s, final GameData data) {
     final Class<? extends TechAdvance> clazz = ALL_PREDEFINED_TECHNOLOGIES.get(s);
     if (clazz == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -12,7 +12,11 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.util.IntegerMap;
 
-// TODO: make the Comparator be serializable. To get there all cass members need to be serializable or removed.
+// TODO: make the Comparator be serializable. To get there all class members need to be serializable or removed.
+
+/**
+ * A comparator that sorts units in order from most likely to least likely to be chosen as a battle loss.
+ */
 public class UnitBattleComparator implements Comparator<Unit> {
   private final boolean defending;
   private final IntegerMap<UnitType> costs;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -13,6 +13,9 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.TransportUtils;
 
+/**
+ * A collection of comparators for sorting units based on various heuristics.
+ */
 public class UnitComparator {
   static Comparator<Unit> getLowestToHighestMovementComparator() {
     return Comparator.comparing(TripleAUnit::get,


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocType and JavadocMethod rules in types within the `g.s.triplea.delegate` package by adding missing Javadocs, where required.

## Functional Changes

None.

## Manual Testing Performed

None.  **This PR contains no code changes.**