### PR TITLE
Use look and feel display name in client settings UI

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -6,10 +6,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -62,25 +60,20 @@ public final class LookAndFeel {
     return Services.tryLoadAny(SubstanceLookAndFeelManager.class);
   }
 
-  /**
-   * Returns a collection of the available Look-And-Feels.
-   */
-  public static List<String> getLookAndFeelAvailableList() {
-    final List<String> lookAndFeelClassNames = new ArrayList<>();
-    lookAndFeelClassNames.addAll(getInstalledLookAndFeelClassNames());
-    lookAndFeelClassNames.addAll(getSubstanceLookAndFeelClassNames());
-    return lookAndFeelClassNames;
+  public static Collection<UIManager.LookAndFeelInfo> getAvailableLookAndFeels() {
+    final Collection<UIManager.LookAndFeelInfo> lookAndFeels = new ArrayList<>();
+    lookAndFeels.addAll(getSystemLookAndFeels());
+    lookAndFeels.addAll(getSubstanceLookAndFeels());
+    return lookAndFeels;
   }
 
-  private static Collection<String> getInstalledLookAndFeelClassNames() {
-    return Arrays.stream(UIManager.getInstalledLookAndFeels())
-        .map(UIManager.LookAndFeelInfo::getClassName)
-        .collect(Collectors.toList());
+  private static Collection<UIManager.LookAndFeelInfo> getSystemLookAndFeels() {
+    return Arrays.asList(UIManager.getInstalledLookAndFeels());
   }
 
-  private static Collection<String> getSubstanceLookAndFeelClassNames() {
+  private static Collection<UIManager.LookAndFeelInfo> getSubstanceLookAndFeels() {
     return getSubstanceLookAndFeelManager()
-        .map(SubstanceLookAndFeelManager::getInstalledLookAndFeelClassNames)
+        .map(SubstanceLookAndFeelManager::getInstalledLookAndFeels)
         .orElseGet(Collections::emptyList);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -8,7 +8,10 @@ import static games.strategy.triplea.settings.SelectionComponentFactory.proxySet
 import static games.strategy.triplea.settings.SelectionComponentFactory.selectionBox;
 import static games.strategy.triplea.settings.SelectionComponentFactory.textField;
 
+import java.util.Collection;
+
 import javax.swing.JComponent;
+import javax.swing.UIManager;
 
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import lombok.AllArgsConstructor;
@@ -108,11 +111,16 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
           + "WARNING: restart all running TripleA instances after changing this setting to avoid system instability.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
+      final Collection<UIManager.LookAndFeelInfo> lookAndFeels = LookAndFeel.getAvailableLookAndFeels();
       return selectionBox(
           ClientSetting.lookAndFeel,
-          LookAndFeel.getLookAndFeelAvailableList(),
-          ClientSetting.lookAndFeel.getValueOrThrow(),
-          s -> s.replaceFirst(".*\\.", "").replaceFirst("LookAndFeel$", ""));
+          UIManager.LookAndFeelInfo.class,
+          lookAndFeels,
+          lookAndFeelClassName -> lookAndFeels.stream()
+              .filter(lookAndFeel -> lookAndFeel.getClassName().equals(lookAndFeelClassName))
+              .findAny(),
+          UIManager.LookAndFeelInfo::getClassName,
+          UIManager.LookAndFeelInfo::getName);
     }
   },
 

--- a/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
+++ b/game-core/src/main/java/org/triplea/game/client/ui/swing/laf/SubstanceLookAndFeelManager.java
@@ -2,6 +2,8 @@ package org.triplea.game.client.ui.swing.laf;
 
 import java.util.Collection;
 
+import javax.swing.UIManager;
+
 /**
  * A service for managing the Substance look and feel library.
  */
@@ -12,9 +14,9 @@ public interface SubstanceLookAndFeelManager {
   String getDefaultLookAndFeelClassName();
 
   /**
-   * Returns a collection of class names for all installed Substance look and feels.
+   * Returns a collection of all installed Substance look and feels.
    */
-  Collection<String> getInstalledLookAndFeelClassNames();
+  Collection<UIManager.LookAndFeelInfo> getInstalledLookAndFeels();
 
   /**
    * Initializes the Substance look and feel library. Should be called before any Substance look and feel is created.

--- a/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/swing/laf/DefaultSubstanceLookAndFeelManager.java
@@ -3,7 +3,10 @@ package org.triplea.game.client.ui.swing.laf;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import javax.swing.UIManager;
+
 import org.pushingpixels.substance.api.SubstanceCortex;
+import org.pushingpixels.substance.api.skin.SkinInfo;
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
 /**
@@ -16,14 +19,16 @@ public final class DefaultSubstanceLookAndFeelManager implements SubstanceLookAn
   }
 
   @Override
-  public Collection<String> getInstalledLookAndFeelClassNames() {
+  public Collection<UIManager.LookAndFeelInfo> getInstalledLookAndFeels() {
     return SubstanceCortex.GlobalScope.getAllSkins().values().stream()
-        .map(skinInfo -> getLookAndFeelClassNameForSkinClassName(skinInfo.getClassName()))
+        .map(DefaultSubstanceLookAndFeelManager::newLookAndFeelInfoForSkin)
         .collect(Collectors.toList());
   }
 
-  private static String getLookAndFeelClassNameForSkinClassName(final String skinClassName) {
-    return skinClassName.replaceFirst("(?<=\\.)(\\w+)Skin$", "Substance$1LookAndFeel");
+  private static UIManager.LookAndFeelInfo newLookAndFeelInfoForSkin(final SkinInfo skinInfo) {
+    return new UIManager.LookAndFeelInfo(
+        "Substance " + skinInfo.getDisplayName(),
+        skinInfo.getClassName().replaceFirst("(?<=\\.)(\\w+)Skin$", "Substance$1LookAndFeel"));
   }
 
   @Override


### PR DESCRIPTION
## Overview

We currently parse the L&F class name to display it in the client settings UI.  However, every look and feel has an associated display name that could be used instead.  This PR adjusts the client settings UI to use this display name instead of a partial class name.

## Functional Changes

None.

## Refactoring Changes

* Changed the `LookAndFeel` class to return a collection of `LookAndFeelInfo` instead of the look and feel class name alone.
* Changed `SelectionComponentFactory#selectionBox()` so that the combo box item type and client setting value type can be totally arbitrary and different.  It uses conversion functions to translate between the two.

## Before & After Screen Shots

### Before

![ui-theme-client-settings-before](https://user-images.githubusercontent.com/4826349/48881404-4a04fc80-ede3-11e8-9b88-eab12514dd87.png)

### After

![ui-theme-client-settings-after](https://user-images.githubusercontent.com/4826349/48881406-4d988380-ede3-11e8-807e-8dae0d9e049d.png)

## Manual Testing Performed

Verified the L&F setting tab works as expected.