### PR TITLE
Checkstyle: Add missing Javadocs in g.s.triplea.attachments

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -300,6 +300,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return chanceDecrementOnSuccess;
   }
 
+  /**
+   * Adjusts the chance to hit for this condition.
+   *
+   * @param success {@code true} to decrement the chance to hit for successful conditions; {@code false} to increment
+   *        the chance to hit for failed conditions.
+   */
   public void changeChanceDecrementOrIncrementOnSuccessOrFailure(final IDelegateBridge delegateBridge,
       final boolean success,
       final boolean historyChild) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -22,6 +22,13 @@ import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Tuple;
 
+/**
+ * Superclass for all attachments that trigger an action based on an event.
+ *
+ * <p>
+ * TODO: Merge with {@link TriggerAttachment}, as that is the only subclass.
+ * </p>
+ */
 public abstract class AbstractTriggerAttachment extends AbstractConditionsAttachment {
   private static final long serialVersionUID = 5866039180681962697L;
 
@@ -40,6 +47,10 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
     super(name, attachable, gameData);
   }
 
+  /**
+   * Returns a new change that marks all trigger attachments for the specified player has having been used this round.
+   * If any trigger attachment has already been marked as used, it will not be modified.
+   */
   public static CompositeChange triggerSetUsedForThisRound(final PlayerId player) {
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -19,6 +19,10 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
 
+/**
+ * An attachment for instances of {@link Territory} that defines a canal through which certain land units may pass from
+ * one bordering territory to another.
+ */
 public class CanalAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -1991066817386812634L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -24,6 +24,10 @@ import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Triple;
 
+/**
+ * An attachment for instances of {@link PlayerId} that defines properties unrelated to rules (see the class
+ * description of {@link AbstractPlayerRulesAttachment}).
+ */
 public class PlayerAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 1880755875866426270L;
 
@@ -196,6 +200,10 @@ public class PlayerAttachment extends DefaultAttachment {
     attackingLimit = new HashSet<>();
   }
 
+  /**
+   * Returns {@code true} if the specified units can move into the specified territory without violating the specified
+   * stacking limit (movement, attack, or placement).
+   */
   public static boolean getCanTheseUnitsMoveWithoutViolatingStackingLimit(final String limitType,
       final Collection<Unit> unitsMoving, final Territory toMoveInto, final PlayerId owner, final GameData data) {
     final PlayerAttachment pa = PlayerAttachment.get(owner);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -12,6 +12,9 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.triplea.Constants;
 
+/**
+ * An attachment for instances of {@link RelationshipType}.
+ */
 public class RelationshipTypeAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -4367286684249791984L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -41,6 +41,10 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Tuple;
 
+/**
+ * An attachment for instances of {@link PlayerId} that defines various conditions for enabling certain rules (see the
+ * class description of {@link AbstractPlayerRulesAttachment}).
+ */
 public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private static final long serialVersionUID = 7301965634079412516L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -663,6 +663,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneTargettedByAa;
   }
 
+  /**
+   * Returns a map of the air unit types that can be targeted by each type of AA fire. The key is the type of AA fire.
+   * The value is the collection of air unit types that can be targeted by the key.
+   */
   public static Map<String, Set<UnitType>> getAirborneTargettedByAa(final PlayerId player,
       final GameData data) {
     final Map<String, Set<UnitType>> airborneTargettedByAa = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -14,6 +14,9 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 
+/**
+ * An attachment for instances of {@link PlayerId} that defines properties related to technology advances.
+ */
 public class TechAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -8780929085456199961L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -33,6 +33,9 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+/**
+ * An attachment for instances of {@link Territory}.
+ */
 public class TerritoryAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 9102862080104655281L;
 
@@ -616,6 +619,10 @@ public class TerritoryAttachment extends DefaultAttachment {
     blockadeZone = false;
   }
 
+  /**
+   * Returns the collection of territories that make up the convoy route containing the specified territory or
+   * {@code null} if the specified territory is not part of a convoy route.
+   */
   public static Set<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(final Territory t, final GameData data) {
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta == null || !ta.getConvoyRoute()) {
@@ -634,6 +641,9 @@ public class TerritoryAttachment extends DefaultAttachment {
     return territories;
   }
 
+  /**
+   * Returns a string suitable for display describing the territory to which this attachment is attached.
+   */
   public String toStringForInfo(final boolean useHtml, final boolean includeAttachedToName) {
     final StringBuilder sb = new StringBuilder();
     final String br = (useHtml ? "<br>" : ", ");

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -18,6 +18,9 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.util.IntegerMap;
 
+/**
+ * An attachment for instances of {@link TerritoryEffect}.
+ */
 public class TerritoryEffectAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 6379810228136325991L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -55,6 +55,9 @@ import games.strategy.util.ObjectUtils;
 import games.strategy.util.Tuple;
 import lombok.extern.java.Log;
 
+/**
+ * An attachment for instances of {@link PlayerId} that defines actions to be triggered upon various events.
+ */
 @Log
 public class TriggerAttachment extends AbstractTriggerAttachment {
   private static final long serialVersionUID = -3327739180569606093L;
@@ -1341,6 +1344,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   // default location for
   // when 'when' is not used.
   // Should be void.
+
+  /**
+   * Triggers all notifications associated with {@code satisfiedTriggers}.
+   */
   public static void triggerNotifications(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -1390,6 +1397,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all player property changes associated with {@code satisfiedTriggers}. Only player property changes
+   * associated with the following attachments will be triggered: {@link PlayerAttachment}, {@link RulesAttachment},
+   * {@link TriggerAttachment}, {@link TechAttachment}, {@link PoliticalActionAttachment}, and
+   * {@link UserActionAttachment}.
+   */
   public static void triggerPlayerPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1536,6 +1549,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all relationship type property changes associated with {@code satisfiedTriggers}. Only relationship type
+   * property changes associated with the following attachments will be triggered: {@link RelationshipTypeAttachment}.
+   */
   public static void triggerRelationshipTypePropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1590,6 +1607,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all territory property changes associated with {@code satisfiedTriggers}. Only territory property changes
+   * associated with the following attachments will be triggered: {@link TerritoryAttachment} and
+   * {@link CanalAttachment}.
+   */
   public static void triggerTerritoryPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1669,6 +1691,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all territory effect property changes associated with {@code satisfiedTriggers}. Only territory effect
+   * property changes associated with the following attachments will be triggered: {@link TerritoryEffectAttachment}.
+   */
   public static void triggerTerritoryEffectPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1723,6 +1749,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all unit property changes associated with {@code satisfiedTriggers}. Only unit property changes associated
+   * with the following attachments will be triggered: {@link UnitAttachment} and {@link UnitSupportAttachment}.
+   */
   public static void triggerUnitPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1792,6 +1822,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all relationship changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerRelationshipChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1846,6 +1879,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all available technology advance changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerAvailableTechChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1887,6 +1923,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all technology advance changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerTechChange(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -1918,6 +1957,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all production changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerProductionChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1947,6 +1989,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all production frontier edit changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerProductionFrontierEditChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -1996,6 +2041,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all unit support changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerSupportChange(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -2051,6 +2099,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all territory ownership changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerChangeOwnership(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
@@ -2104,6 +2155,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all purchase changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerPurchase(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -2140,6 +2194,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all unit removal changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerUnitRemoval(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -2168,6 +2225,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all unit placement changes associated with {@code satisfiedTriggers}.
+   */
   public static void triggerUnitPlacement(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
@@ -2261,6 +2321,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return resources;
   }
 
+  /**
+   * Triggers all trigger activations associated with {@code satisfiedTriggers}.
+   */
   public static void triggerActivateTriggerOther(final Map<ICondition, Boolean> testedConditionsSoFar,
       final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge, final String beforeOrAfter,
       final String stepName, final boolean useUses, final boolean testUses, final boolean testChance,
@@ -2323,6 +2386,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+  /**
+   * Triggers all victory notifications associated with {@code satisfiedTriggers}.
+   */
   public static void triggerVictory(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1005,6 +1005,10 @@ public class UnitAttachment extends DefaultAttachment {
     return map;
   }
 
+  /**
+   * Returns the subset of {@code units} that will receive the ability {@code filterForAbility} when they are with,
+   * or on the same route as, another unit.
+   */
   public static Collection<Unit> getUnitsWhichReceivesAbilityWhenWith(final Collection<Unit> units,
       final String filterForAbility, final GameData data) {
     if (units.stream().noneMatch(Matches.unitCanReceiveAbilityWhenWith())) {
@@ -2383,6 +2387,12 @@ public class UnitAttachment extends DefaultAttachment {
     tuv = -1;
   }
 
+  /**
+   * Returns the maximum number of units of the specified type that can be placed in the specified territory according
+   * to the specified stacking limit (movement, attack, or placement).
+   *
+   * @return {@link Integer#MAX_VALUE} if there is no stacking limit for the specified conditions.
+   */
   public static int getMaximumNumberOfThisUnitTypeToReachStackingLimit(final String limitType, final UnitType ut,
       final Territory t, final PlayerId owner, final GameData data) {
     final UnitAttachment ua = UnitAttachment.get(ut);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -21,6 +21,9 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 
+/**
+ * An attachment for instances of {@link UnitType} that defines properties for unit types that support other units.
+ */
 public class UnitSupportAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -3015679930172496082L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
@@ -6,6 +6,21 @@ import java.util.Comparator;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.Matches;
 
+/**
+ * A comparator that sorts unit types in a meaningful order.
+ *
+ * <p>
+ * The order is based on the following attributes of the unit type:
+ * </p>
+ * <ul>
+ * <li>infrastructure</li>
+ * <li>anti-aircraft</li>
+ * <li>air</li>
+ * <li>sea</li>
+ * <li>attack power</li>
+ * <li>name</li>
+ * </ul>
+ */
 public class UnitTypeComparator implements Comparator<UnitType>, Serializable {
   private static final long serialVersionUID = -7065456161376169082L;
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -97,6 +97,10 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     activateTrigger = new ArrayList<>();
   }
 
+  /**
+   * Fires all trigger attachments associated with the specified user action attachment that satisfy the specified
+   * conditions.
+   */
   public static void fireTriggers(final UserActionAttachment actionAttachment,
       final Map<ICondition, Boolean> testedConditionsSoFar, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocType and JavadocMethod rules in types within the `g.s.triplea.attachments` package by adding missing Javadocs, where required.

## Functional Changes

None.

## Manual Testing Performed

None.  **This PR contains no code changes.**