### PR TITLE
ProtectedStringClientSetting: Require owner to scrub char array

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -221,11 +221,6 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   }
 
   @Override
-  public final void setObjectValue(final @Nullable Object value) {
-    setValue(type.cast(value));
-  }
-
-  @Override
   public final void setValue(final @Nullable T value) {
     setEncodedValue(Optional.ofNullable(value)
         .filter(not(this::isDefaultValue))

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -20,17 +20,6 @@ public interface GameSetting<T> {
   boolean isSet();
 
   /**
-   * Sets the current value of the setting using an untyped value.
-   *
-   * @param value The new setting value or {@code null} to clear the setting value. Clearing the setting value will
-   *        result in the default value being returned on future reads of the setting value. If no default value is
-   *        defined for the setting, future reads will return an empty result.
-   *
-   * @throws ClassCastException If the type of of {@code value} is incompatible with the setting value type.
-   */
-  void setObjectValue(@Nullable Object value);
-
-  /**
    * Sets the current value of the setting.
    *
    * @param value The new setting value or {@code null} to clear the setting value. Clearing the setting value will

--- a/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
@@ -25,9 +25,6 @@ final class ProtectedStringClientSetting extends ClientSetting<char[]> {
     return withCredentialManager(value, ProtectedStringClientSetting::encodeValue);
   }
 
-  /**
-   * Protects the given char array and cleans the content afterwards.
-   */
   @VisibleForTesting
   static String encodeValue(final char[] value, final CredentialManager credentialManager)
       throws ValueEncodingException {
@@ -35,8 +32,6 @@ final class ProtectedStringClientSetting extends ClientSetting<char[]> {
       return credentialManager.protect(value);
     } catch (final CredentialManagerException e) {
       throw new ValueEncodingException("Error while trying to protect string", e);
-    } finally {
-      Arrays.fill(value, '\0');
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -38,8 +38,7 @@ final class SaveFunction {
             .forEach(entry -> {
               final GameSetting<?> setting = entry.getKey();
               setting.setObjectValue(entry.getValue());
-              successMsg.append(String
-                  .format("%s was updated to: %s\n", setting, setting.getDisplayValue()));
+              successMsg.append(String.format("%s was updated to: %s\n", setting, setting.getDisplayValue()));
             });
       } else {
         selectionComponent.readValues().forEach((key, value) -> failMsg.append(

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -29,21 +29,23 @@ final class SaveFunction {
 
     // save all the values, save stuff that is valid and that was updated
     selectionComponents.forEach(selectionComponent -> {
-      if (selectionComponent.isValid()) {
-        // read and save all settings
-        selectionComponent.readValues()
-            .entrySet()
-            .stream()
-            .filter(entry -> doesNewSettingDiffer(entry.getKey(), entry.getValue()))
-            .forEach(entry -> {
-              final GameSetting<?> setting = entry.getKey();
-              setting.setObjectValue(entry.getValue());
-              successMsg.append(String.format("%s was updated to: %s\n", setting, setting.getDisplayValue()));
-            });
-      } else {
-        selectionComponent.readValues().forEach((key, value) -> failMsg.append(
-            String.format("Could not set %s to %s, %s\n", key, value, selectionComponent.validValueDescription())));
-      }
+      final SelectionComponent.SaveContext context = new SelectionComponent.SaveContext() {
+        private final boolean selectionComponentValid = selectionComponent.isValid();
+
+        @Override
+        public <T> void setValue(final GameSetting<T> gameSetting, final T value) {
+          if (selectionComponentValid) {
+            if (doesNewSettingDiffer(gameSetting, value)) {
+              gameSetting.setValue(value);
+              successMsg.append(String.format("%s was updated to: %s\n", gameSetting, gameSetting.getDisplayValue()));
+            }
+          } else {
+            failMsg.append(String.format("Could not set %s to %s, %s\n",
+                gameSetting, value, selectionComponent.validValueDescription()));
+          }
+        }
+      };
+      selectionComponent.save(context);
     });
 
     final String success = successMsg.toString();

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -1,6 +1,6 @@
 package games.strategy.triplea.settings;
 
-import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A SelectionComponent represents a UI component that a user can use to update the value of a ClientSetting.
@@ -19,11 +19,9 @@ public interface SelectionComponent<T> {
   String validValueDescription();
 
   /**
-   * Reads values stored in the UI components, returns a map of preference keys and the value represented in
-   * the corresponding UI component. A {@code null} value in the map indicates the value should be reset to its default
-   * value.
+   * Saves values stored in the UI components to the underlying game settings.
    */
-  Map<GameSetting<?>, /* @Nullable */ Object> readValues();
+  void save(SaveContext context);
 
   void resetToDefault();
 
@@ -31,4 +29,18 @@ public interface SelectionComponent<T> {
    * Reset any settings that are bound, and reset the UI.
    */
   void reset();
+
+  /**
+   * The execution context for the {@link SelectionComponent#save(SaveContext)} method.
+   */
+  interface SaveContext {
+    /**
+     * Sets the value for the specified game setting. Selection components must call this method to change a setting
+     * value and must not call {@link GameSetting#setValue(Object)} directly.
+     *
+     * @param gameSetting The game setting whose value is to be set.
+     * @param value The new setting value or {@code null} to clear the setting value.
+     */
+    <T> void setValue(GameSetting<T> gameSetting, @Nullable T value);
+  }
 }

--- a/game-core/src/main/java/org/triplea/common/util/Arrays.java
+++ b/game-core/src/main/java/org/triplea/common/util/Arrays.java
@@ -3,6 +3,7 @@ package org.triplea.common.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.fill;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -13,10 +14,24 @@ public final class Arrays {
   private Arrays() {}
 
   /**
+   * Executes {@code consumer} with the sensitive character array produced by {@code supplier}. The character array will
+   * be scrubbed before this method returns.
+   */
+  public static void withSensitiveArray(final Supplier<char[]> supplier, final Consumer<char[]> consumer) {
+    checkNotNull(supplier);
+    checkNotNull(consumer);
+
+    withSensitiveArrayAndReturn(supplier, array -> {
+      consumer.accept(array);
+      return null;
+    });
+  }
+
+  /**
    * Executes {@code function} with the sensitive character array produced by {@code supplier} and returns the result.
    * The character array will be scrubbed before this method returns.
    */
-  public static <R> R withSensitiveArray(final Supplier<char[]> supplier, final Function<char[], R> function) {
+  public static <R> R withSensitiveArrayAndReturn(final Supplier<char[]> supplier, final Function<char[], R> function) {
     checkNotNull(supplier);
     checkNotNull(function);
 

--- a/game-core/src/main/java/org/triplea/common/util/Arrays.java
+++ b/game-core/src/main/java/org/triplea/common/util/Arrays.java
@@ -1,0 +1,30 @@
+package org.triplea.common.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Arrays.fill;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A collection of useful methods for working with arrays.
+ */
+public final class Arrays {
+  private Arrays() {}
+
+  /**
+   * Executes {@code function} with the sensitive character array produced by {@code supplier} and returns the result.
+   * The character array will be scrubbed before this method returns.
+   */
+  public static <R> R withSensitiveArray(final Supplier<char[]> supplier, final Function<char[], R> function) {
+    checkNotNull(supplier);
+    checkNotNull(function);
+
+    final char[] array = supplier.get();
+    try {
+      return function.apply(array);
+    } finally {
+      fill(array, '\0');
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/AbstractGameSettingTestCase.java
@@ -136,30 +136,23 @@ public abstract class AbstractGameSettingTestCase {
   }
 
   @Nested
-  final class SetObjectValueTest {
+  final class SetValueTest {
     @Test
     void shouldResetValueWhenValueIsNull() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
 
-      gameSetting.setObjectValue(NO_VALUE);
+      gameSetting.setValue(NO_VALUE);
 
       assertThat(gameSetting.getValue(), isPresentAndIs(DEFAULT_VALUE));
     }
 
     @Test
-    void shouldSetValueWhenValueIsNonNullAndHasCorrectType() {
+    void shouldSetValueWhenValueIsNonNull() {
       final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
 
-      gameSetting.setObjectValue(OTHER_VALUE);
+      gameSetting.setValue(OTHER_VALUE);
 
       assertThat(gameSetting.getValue(), isPresentAndIs(OTHER_VALUE));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenValueIsNonNullAndHasWrongType() {
-      final GameSetting<Integer> gameSetting = newGameSetting(VALUE, DEFAULT_VALUE);
-
-      assertThrows(ClassCastException.class, () -> gameSetting.setObjectValue("2112"));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/settings/ProtectedStringClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ProtectedStringClientSettingTest.java
@@ -43,7 +43,6 @@ final class ProtectedStringClientSettingTest {
         final String encodedValue = ProtectedStringClientSetting.encodeValue(value, credentialManager);
 
         assertThat(credentialManager.unprotectToString(encodedValue), is("value"));
-        assertThat("value was scrubbed", value, is(new char[] {0, 0, 0, 0, 0}));
       }
     }
 

--- a/game-core/src/test/java/org/triplea/common/util/ArraysTest.java
+++ b/game-core/src/test/java/org/triplea/common/util/ArraysTest.java
@@ -1,0 +1,29 @@
+package org.triplea.common.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.triplea.common.util.Arrays.withSensitiveArray;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class ArraysTest {
+  @Nested
+  final class WithSensitiveArrayTest {
+    @Test
+    void shouldReturnFunctionResult() {
+      assertThat(withSensitiveArray(() -> new char[0], it -> 42), is(42));
+    }
+
+    @Test
+    void shouldScrubArray() {
+      final char[] array = new char[] {'B', 'a', 'r'};
+
+      withSensitiveArray(() -> array, Function.identity());
+
+      assertThat(array, is(new char[] {'\0', '\0', '\0'}));
+    }
+  }
+}

--- a/game-core/src/test/java/org/triplea/common/util/ArraysTest.java
+++ b/game-core/src/test/java/org/triplea/common/util/ArraysTest.java
@@ -2,26 +2,59 @@ package org.triplea.common.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.triplea.common.util.Arrays.withSensitiveArray;
+import static org.triplea.common.util.Arrays.withSensitiveArrayAndReturn;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 final class ArraysTest {
   @Nested
   final class WithSensitiveArrayTest {
+    private final char[] array = new char[] {'B', 'a', 'r'};
+
     @Test
-    void shouldReturnFunctionResult() {
-      assertThat(withSensitiveArray(() -> new char[0], it -> 42), is(42));
+    void shouldInvokeConsumer(@Mock final Consumer<char[]> consumer) {
+      withSensitiveArray(() -> array, consumer);
+
+      verify(consumer).accept(array);
     }
 
     @Test
     void shouldScrubArray() {
-      final char[] array = new char[] {'B', 'a', 'r'};
+      withSensitiveArray(() -> array, it -> {
+      });
 
-      withSensitiveArray(() -> array, Function.identity());
+      assertThat(array, is(new char[] {'\0', '\0', '\0'}));
+    }
+  }
+
+  @Nested
+  final class WithSensitiveArrayAndReturnTest {
+    private final char[] array = new char[] {'B', 'a', 'r'};
+
+    @Test
+    void shouldReturnFunctionResult(@Mock final Function<char[], Integer> function) {
+      when(function.apply(array)).thenReturn(42);
+
+      final Integer result = withSensitiveArrayAndReturn(() -> array, function);
+
+      assertThat(result, is(42));
+      verify(function).apply(array);
+    }
+
+    @Test
+    void shouldScrubArray() {
+      withSensitiveArrayAndReturn(() -> array, Function.identity());
 
       assertThat(array, is(new char[] {'\0', '\0', '\0'}));
     }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -2,16 +2,18 @@ package org.triplea.game.client.ui.javafx;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.triplea.game.client.ui.javafx.util.ClientSettingJavaFxUiBinding;
 import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
+import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SettingType;
 import javafx.fxml.FXML;
@@ -117,11 +119,13 @@ class SettingsPane extends StackPane {
 
   @FXML
   private void save() {
-    selectionComponentsBySetting.values().stream()
-        .map(SelectionComponent::readValues)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
-        .forEach(entry -> entry.getKey().setObjectValue(entry.getValue()));
+    final SelectionComponent.SaveContext context = new SelectionComponent.SaveContext() {
+      @Override
+      public <T> void setValue(final GameSetting<T> gameSetting, final @Nullable T value) {
+        gameSetting.setValue(value);
+      }
+    };
+    selectionComponentsBySetting.values().forEach(selectionComponent -> selectionComponent.save(context));
     // TODO visual feedback
   }
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/JavaFxSelectionComponentFactory.java
@@ -2,9 +2,6 @@ package org.triplea.game.client.ui.javafx.util;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -14,7 +11,6 @@ import com.google.common.base.Strings;
 
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SelectionComponentUiUtils;
 import javafx.beans.binding.Bindings;
@@ -89,10 +85,10 @@ final class JavaFxSelectionComponentFactory {
       }
 
       @Override
-      public Map<GameSetting<?>, Object> readValues() {
+      public void save(final SaveContext context) {
         final Integer spinnerValue = spinner.getValue();
         final @Nullable Integer value = (allowUnset && spinnerValue.equals(unsetValue())) ? null : spinnerValue;
-        return Collections.singletonMap(clientSetting, value);
+        context.setValue(clientSetting, value);
       }
 
       @Override
@@ -133,8 +129,8 @@ final class JavaFxSelectionComponentFactory {
       }
 
       @Override
-      public Map<GameSetting<?>, Object> readValues() {
-        return Collections.singletonMap(clientSetting, checkBox.selectedProperty().get());
+      public void save(final SaveContext context) {
+        context.setValue(clientSetting, checkBox.selectedProperty().get());
       }
 
       @Override
@@ -175,9 +171,9 @@ final class JavaFxSelectionComponentFactory {
       }
 
       @Override
-      public Map<GameSetting<?>, Object> readValues() {
+      public void save(final SaveContext context) {
         final String value = textField.getText();
-        return Collections.singletonMap(clientSetting, value.isEmpty() ? null : value);
+        context.setValue(clientSetting, value.isEmpty() ? null : value);
       }
 
       @Override
@@ -249,8 +245,8 @@ final class JavaFxSelectionComponentFactory {
     }
 
     @Override
-    public Map<GameSetting<?>, Object> readValues() {
-      return Collections.singletonMap(clientSetting, selectedPath);
+    public void save(final SaveContext context) {
+      context.setValue(clientSetting, selectedPath);
     }
 
     @Override
@@ -331,25 +327,21 @@ final class JavaFxSelectionComponentFactory {
     }
 
     @Override
-    public Map<GameSetting<?>, Object> readValues() {
-      final Map<GameSetting<?>, Object> values = new HashMap<>();
-
+    public void save(final SaveContext context) {
       if (noneButton.isSelected()) {
-        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.NONE);
+        context.setValue(proxyChoiceClientSetting, HttpProxy.ProxyChoice.NONE);
       } else if (systemButton.isSelected()) {
-        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS);
+        context.setValue(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_SYSTEM_SETTINGS);
         HttpProxy.updateSystemProxy();
       } else {
-        values.put(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
+        context.setValue(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_USER_PREFERENCES);
       }
 
       final String host = hostText.getText().trim();
-      values.put(proxyHostClientSetting, host.isEmpty() ? null : host);
+      context.setValue(proxyHostClientSetting, host.isEmpty() ? null : host);
 
       final String encodedPort = portText.getText().trim();
-      values.put(proxyPortClientSetting, encodedPort.isEmpty() ? null : Integer.valueOf(encodedPort));
-
-      return values;
+      context.setValue(proxyPortClientSetting, encodedPort.isEmpty() ? null : Integer.valueOf(encodedPort));
     }
 
     @Override


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/triplea-game/triplea/pull/4349#discussion_r234394727.

Having `ProtectedStringClientSetting#setValue()` scrub its argument may lead to surprises because nothing in the `GameSetting#setValue()` method contract states that the argument will be modified by the implementation.  If a caller wishes to make additional use of the argument, they either need to make a copy or rearrange code to ensure all usage occurs before the call to `setValue()`.  This could lead to hard-to-track-down bugs.

## Functional Changes

`ProtectedStringClientSetting#setValue()` no longer scrubs the new value.  It is now the responsibility of the character array's owner to scrub it at the appropriate time.

## Refactoring Changes

The `SelectionComponent#readValues()` method wasn't amenable to scrubing sensitive values because `SaveFunction` pulls the values out of `SelectionComponent`, which forces the owner to give up ownership to `SaveFunction`, which doesn't know that one of the values may need to be scrubbed.

I addressed this by inverting the dependency so that `SaveFunction` passes an abstraction to `SelectionComponent` through which the setting value can be set.  This has the following benefits:

* The scope of the new setting values are completely within the new `SelectionComponent#save()` method so that they can be properly scrubbed if they happen to contain sensitive values.
* New setting values can now be set in a type-safe manner due to no longer needing to store all values in a heterogeneous map.

## Manual Testing Performed

Smoke tested the client settings UI in both the Swing and JFX clients.