### PR TITLE
Checkstyle: Add missing Javadocs in g.s.triplea.ai

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -35,6 +35,10 @@ public class AiPoliticalUtils {
     return acceptableActions;
   }
 
+  /**
+   * Returns the non-war political actions considered acceptable for the specified player under the specified
+   * conditions.
+   */
   public static List<PoliticalActionAttachment> getPoliticalActionsOther(final PlayerId id,
       final Map<ICondition, Boolean> testedConditions, final GameData data) {
     final List<PoliticalActionAttachment> warActions = getPoliticalActionsTowardsWar(id, testedConditions, data);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProBattleResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProBattleResult.java
@@ -8,6 +8,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+/**
+ * The result of an AI battle analysis.
+ */
 @Getter
 @ToString
 @AllArgsConstructor

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProMyMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProMyMoveOptions.java
@@ -10,6 +10,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import lombok.Getter;
 
+/**
+ * The result of an AI movement analysis for its own possible moves.
+ */
 @Getter
 public class ProMyMoveOptions {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
@@ -15,6 +15,9 @@ import games.strategy.triplea.ai.pro.util.ProBattleUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
 import games.strategy.triplea.delegate.Matches;
 
+/**
+ * The result of an AI movement analysis for another player's possible moves.
+ */
 public class ProOtherMoveOptions {
 
   private final Map<Territory, ProTerritory> maxMoveMap;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPlaceTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPlaceTerritory.java
@@ -9,6 +9,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * The result of an AI placement analysis for a single territory.
+ */
 @EqualsAndHashCode(of = "territory")
 @Getter
 @Setter

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -24,6 +24,9 @@ import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import lombok.Getter;
 
+/**
+ * The result of an AI purchase analysis for a single production rule and unit type.
+ */
 public class ProPurchaseOption {
 
   @Getter
@@ -177,6 +180,9 @@ public class ProPurchaseOption {
     return calculateEfficiency(0.75, 1.25, supportAttackFactor, supportDefenseFactor, distanceFactor, data);
   }
 
+  /**
+   * Returns the sea defense efficiency for the specified units if this purchase option is selected.
+   */
   public double getSeaDefenseEfficiency(final GameData data, final List<Unit> ownedLocalUnits,
       final List<Unit> unitsToPlace, final boolean needDestroyer, final int unusedCarrierCapacity,
       final int unusedLocalCarrierCapacity) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -13,6 +13,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * The result of an AI purchase analysis for a single territory.
+ */
 @ToString
 public class ProPurchaseTerritory {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProResourceTracker.java
@@ -6,6 +6,9 @@ import games.strategy.engine.data.Resource;
 import games.strategy.triplea.Constants;
 import games.strategy.util.IntegerMap;
 
+/**
+ * Tracks available resources during an AI purchase analysis.
+ */
 public class ProResourceTracker {
 
   private final IntegerMap<Resource> resources;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -18,6 +18,9 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.util.CollectionUtils;
 
+/**
+ * The result of an AI territory analysis.
+ */
 public class ProTerritory {
 
   private final Territory territory;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTransport.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTransport.java
@@ -9,6 +9,9 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import lombok.Getter;
 
+/**
+ * The result of an AI amphibious movement analysis.
+ */
 @Getter
 public class ProTransport {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
@@ -19,6 +19,10 @@ import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 
+/**
+ * Dummy implementation of {@link IDelegateBridge} used during a battle simulation to capture all changes generated
+ * during the simulation.
+ */
 public class ProDummyDelegateBridge implements IDelegateBridge {
   private final PlainRandomSource randomSource = new PlainRandomSource();
   private final ITripleADisplay display = new HeadlessDisplay();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -40,7 +40,10 @@ import games.strategy.util.CollectionUtils;
  * Pro AI simulate turn utilities.
  */
 public class ProSimulateTurnUtils {
-
+  /**
+   * Simulates all pending battles in {@code data}. The simulation results are written as changes to
+   * {@code delegateBridge}.
+   */
   public static void simulateBattles(final GameData data, final PlayerId player, final IDelegateBridge delegateBridge,
       final ProOddsCalculator calc) {
 
@@ -92,6 +95,11 @@ public class ProSimulateTurnUtils {
     }
   }
 
+  /**
+   * Simulates the transfer of units between two territories for each entry in {@code moveMap}.
+   *
+   * @return A collection of the results for each simulated transfer.
+   */
   public static Map<Territory, ProTerritory> transferMoveMap(final Map<Territory, ProTerritory> moveMap,
       final GameData toData, final PlayerId player) {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -34,6 +34,10 @@ public class ProBattleUtils {
   public static final int SHORT_RANGE = 2;
   public static final int MEDIUM_RANGE = 3;
 
+  /**
+   * Return {@code true} if the specified battle would result in an overwhelming win for the attacker. An overwhelming
+   * win is defined as the ability to defeat the enemy without any losses or within a single round of combat.
+   */
   public static boolean checkForOverwhelmingWin(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits) {
     final GameData data = ProData.getData();
@@ -61,6 +65,12 @@ public class ProBattleUtils {
     return ((attackPower / data.getDiceSides()) >= totalDefenderHitPoints);
   }
 
+  /**
+   * Returns an estimate of the strength difference between the specified attacking and defending units.
+   *
+   * @return A value in the range [0,100]. 0 indicates absolute defender strength; 100 indicates absolute attacker
+   *         strength; 50 indicates equal attacker and defender strength.
+   */
   public static double estimateStrengthDifference(final Territory t, final List<Unit> attackingUnits,
       final List<Unit> defendingUnits) {
 
@@ -77,6 +87,11 @@ public class ProBattleUtils {
     return ((attackerStrength - defenderStrength) / Math.pow(defenderStrength, 0.85) * 50 + 50);
   }
 
+  /**
+   * Estimates the strength of {@code myUnits} relative to {@code enemyUnits}.
+   *
+   * @return The larger the result, the stronger {@code myUnits} are relative to {@code enemyUnits}.
+   */
   public static double estimateStrength(final Territory t, final List<Unit> myUnits, final List<Unit> enemyUnits,
       final boolean attacking) {
     final GameData data = ProData.getData();
@@ -111,6 +126,9 @@ public class ProBattleUtils {
     return territoryHasLocalLandSuperiority(t, distance, player, new HashMap<>());
   }
 
+  /**
+   * Returns {@code true} if {@code player} has land superiority within {@code distance} neighbors of {@code t}.
+   */
   public static boolean territoryHasLocalLandSuperiority(final Territory t, final int distance, final PlayerId player,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
 
@@ -157,6 +175,10 @@ public class ProBattleUtils {
     return true;
   }
 
+  /**
+   * Returns {@code true} if {@code player} has land superiority within {@code distance} neighbors of {@code t} after
+   * the specified moves are performed.
+   */
   public static boolean territoryHasLocalLandSuperiorityAfterMoves(final Territory t, final int distance,
       final PlayerId player, final Map<Territory, ProTerritory> moveMap) {
     final GameData data = ProData.getData();
@@ -188,6 +210,9 @@ public class ProBattleUtils {
     return strengthDifference <= 50;
   }
 
+  /**
+   * Returns {@code true} if {@code player} has naval superiority within at least 3 neighbors of {@code t}.
+   */
   public static boolean territoryHasLocalNavalSuperiority(final Territory t, final PlayerId player,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories, final List<Unit> unitsToPlace) {
     final GameData data = ProData.getData();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -28,7 +28,14 @@ import games.strategy.util.Tuple;
  * Pro AI move utilities.
  */
 public class ProMoveUtils {
-
+  /**
+   * Calculates normal movement routes (e.g. land, air, sea attack routes, not including amphibious, bombardment, or
+   * strategic bombing raid attack routes).
+   *
+   * @param moveUnits Receives the unit groups to move.
+   * @param moveRoutes Receives the routes for each unit group in {@code moveUnits}.
+   * @param attackMap Specifies the territories to be attacked.
+   */
   public static void calculateMoveRoutes(final PlayerId player, final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes, final Map<Territory, ProTerritory> attackMap, final boolean isCombatMove) {
 
@@ -109,6 +116,15 @@ public class ProMoveUtils {
     }
   }
 
+  /**
+   * Calculates amphibious movement routes.
+   *
+   * @param moveUnits Receives the unit groups to move.
+   * @param moveRoutes Receives the routes for each unit group in {@code moveUnits}.
+   * @param transportsToLoad Receives the transport groups for each unit group in {@code moveUnits}.
+   * @param attackMap Specifies the territories to be attacked. Will be updated to reflect any transports unloading in a
+   *        specific territory.
+   */
   public static void calculateAmphibRoutes(final PlayerId player, final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes, final List<Collection<Unit>> transportsToLoad,
       final Map<Territory, ProTerritory> attackMap, final boolean isCombatMove) {
@@ -233,6 +249,13 @@ public class ProMoveUtils {
     }
   }
 
+  /**
+   * Calculates bombardment movement routes.
+   *
+   * @param moveUnits Receives the unit groups to move.
+   * @param moveRoutes Receives the routes for each unit group in {@code moveUnits}.
+   * @param attackMap Specifies the territories to be attacked.
+   */
   public static void calculateBombardMoveRoutes(final PlayerId player, final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes, final Map<Territory, ProTerritory> attackMap) {
 
@@ -269,6 +292,13 @@ public class ProMoveUtils {
     }
   }
 
+  /**
+   * Calculates strategic bombing raid movement routes.
+   *
+   * @param moveUnits Receives the unit groups to move.
+   * @param moveRoutes Receives the routes for each unit group in {@code moveUnits}.
+   * @param attackMap Specifies the territories to be attacked.
+   */
   public static void calculateBombingRoutes(final PlayerId player, final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes, final Map<Territory, ProTerritory> attackMap) {
 
@@ -307,6 +337,9 @@ public class ProMoveUtils {
     doMove(moveUnits, moveRoutes, null, moveDel);
   }
 
+  /**
+   * Moves the specified groups of units along the specified routes, possibly using the specified transports.
+   */
   public static void doMove(final List<Collection<Unit>> moveUnits, final List<Route> moveRoutes,
       final List<Collection<Unit>> transportsToLoad, final IMoveDelegate moveDel) {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -39,6 +39,11 @@ public class ProOddsCalculator {
     isCanceled = true;
   }
 
+  /**
+   * Simulates the specified battle. Prior to the simulation, an estimate is made of the attacker's chance to win the
+   * battle. If the estimate indicates the attacker has almost no chance to win, the simulation is not performed, and
+   * an appropriate result indicating the defender's success is returned.
+   */
   public ProBattleResult estimateAttackBattleResults(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
 
@@ -55,6 +60,11 @@ public class ProOddsCalculator {
     return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits);
   }
 
+  /**
+   * Simulates the specified battle. Prior to the simulation, an estimate is made of the defender's chance to win the
+   * battle. If the estimate indicates the defender has almost no chance to win, the simulation is not performed, and
+   * an appropriate result indicating the attacker's success is returned.
+   */
   public ProBattleResult estimateDefendBattleResults(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
 
@@ -109,6 +119,9 @@ public class ProOddsCalculator {
     return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits, false);
   }
 
+  /**
+   * Simulates the specified battle.
+   */
   public ProBattleResult callBattleCalculator(final Territory t, final List<Unit> attackingUnits,
       final List<Unit> defendingUnits, final Set<Unit> bombardingUnits, final boolean retreatWhenOnlyAirLeft) {
     final GameData data = ProData.getData();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -102,6 +102,11 @@ public class ProPurchaseUtils {
         && units.stream().anyMatch(Matches.unitIsCarrier());
   }
 
+  /**
+   * Removes any invalid purchase options from {@code purchaseOptions}.
+   *
+   * @return TODO: Change return type to void; return value is never used.
+   */
   public static List<ProPurchaseOption> removeInvalidPurchaseOptions(final PlayerId player, final GameData data,
       final List<ProPurchaseOption> purchaseOptions, final ProResourceTracker resourceTracker,
       final int remainingUnitProduction, final List<Unit> unitsToPlace,
@@ -145,6 +150,11 @@ public class ProPurchaseUtils {
     return purchaseOptions;
   }
 
+  /**
+   * Randomly selects one of the specified purchase options of the specified type.
+   *
+   * @return The selected purchase option or empty if no purchase option of the specified type is available.
+   */
   public static Optional<ProPurchaseOption> randomizePurchaseOption(
       final Map<ProPurchaseOption, Double> purchaseEfficiencies, final String type) {
 
@@ -174,6 +184,10 @@ public class ProPurchaseUtils {
     return Optional.of(purchasePercentages.keySet().iterator().next());
   }
 
+  /**
+   * Returns the list of units to purchase that will maximize defense in the specified territory based on the specified
+   * purchase options.
+   */
   public static List<Unit> findMaxPurchaseDefenders(final PlayerId player, final Territory t,
       final List<ProPurchaseOption> landPurchaseOptions) {
 
@@ -249,6 +263,9 @@ public class ProPurchaseUtils {
     purchaseTerritories.values().forEach(ppt -> ppt.setUnitProduction(ppt.getUnitProduction() + 1));
   }
 
+  /**
+   * Returns all possible territories within which {@code player} can place purchased units.
+   */
   public static Map<Territory, ProPurchaseTerritory> findPurchaseTerritories(final PlayerId player) {
 
     ProLogger.info("Find all purchase territories");
@@ -361,6 +378,9 @@ public class ProPurchaseUtils {
     return null;
   }
 
+  /**
+   * Returns the list of units to place in the specified territory based on the specified purchases.
+   */
   public static List<Unit> getPlaceUnits(final Territory t,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -23,7 +23,10 @@ import games.strategy.triplea.delegate.UnitBattleComparator;
  * Pro AI attack options utilities.
  */
 public class ProSortMoveOptionsUtils {
-
+  /**
+   * Returns a copy of {@code unitAttackOptions} sorted by number of move options, then by cost of unit, then by unit
+   * type name.
+   */
   public static Map<Unit, Set<Territory>> sortUnitMoveOptions(final Map<Unit, Set<Territory>> unitAttackOptions) {
 
     final List<Map.Entry<Unit, Set<Territory>>> list = new ArrayList<>(unitAttackOptions.entrySet());
@@ -46,6 +49,11 @@ public class ProSortMoveOptionsUtils {
     return sortedUnitAttackOptions;
   }
 
+  /**
+   * Returns a copy of {@code unitAttackOptions} sorted by number of move options, then by cost of unit, then by unit
+   * type name. The number of move options are calculated based on pending battles which require additional units for
+   * the attacker to be successful.
+   */
   public static Map<Unit, Set<Territory>> sortUnitNeededOptions(final PlayerId player,
       final Map<Unit, Set<Territory>> unitAttackOptions, final Map<Territory, ProTerritory> attackMap,
       final ProOddsCalculator calc) {
@@ -95,6 +103,11 @@ public class ProSortMoveOptionsUtils {
     return sortedUnitAttackOptions;
   }
 
+  /**
+   * Returns a copy of {@code unitAttackOptions} sorted by number of move options, then by attack efficiency, then by
+   * air unit average movement distance, then by unit type name. The number of move options are calculated based on
+   * pending battles which require additional units for the attacker to be successful.
+   */
   public static Map<Unit, Set<Territory>> sortUnitNeededOptionsThenAttack(final PlayerId player,
       final Map<Unit, Set<Territory>> unitAttackOptions, final Map<Territory, ProTerritory> attackMap,
       final Map<Unit, Territory> unitTerritoryMap, final ProOddsCalculator calc) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -26,6 +26,9 @@ public class ProTerritoryValueUtils {
   private static final int MIN_FACTORY_CHECK_DISTANCE = 9;
   private static final int MAX_FACTORY_CHECK_DISTANCE = 30;
 
+  /**
+   * Returns the relative value of attacking the specified territory compared to other territories.
+   */
   public static double findTerritoryAttackValue(final PlayerId player, final Territory t) {
     final GameData data = ProData.getData();
     final int isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).test(t) ? 1 : 0;
@@ -49,6 +52,9 @@ public class ProTerritoryValueUtils {
         new HashSet<>(ProData.getData().getMap().getTerritories()));
   }
 
+  /**
+   * Returns the value of each territory in {@code territoriesToCheck}.
+   */
   public static Map<Territory, Double> findTerritoryValues(final PlayerId player,
       final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToAttack,
       final Set<Territory> territoriesToCheck) {
@@ -78,6 +84,9 @@ public class ProTerritoryValueUtils {
     return territoryValueMap;
   }
 
+  /**
+   * Returns the value of each sea territory in {@link ProData#getData()}.
+   */
   public static Map<Territory, Double> findSeaTerritoryValues(final PlayerId player,
       final List<Territory> territoriesThatCantBeHeld) {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -43,6 +43,9 @@ public class ProTransportUtils {
     return maxMovement;
   }
 
+  /**
+   * Returns the units to transport via {@code transport} whose land movement value does not exceed {@code value}.
+   */
   public static List<Unit> getUnitsToTransportThatCantMoveToHigherValue(final PlayerId player, final Unit transport,
       final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore,
       final Map<Territory, ProTerritory> moveMap, final Map<Unit, Set<Territory>> unitMoveMap, final double value) {
@@ -80,6 +83,9 @@ public class ProTransportUtils {
         ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, true));
   }
 
+  /**
+   * Returns the units to transport via {@code transport} that satisfy the specified predicate.
+   */
   // TODO: this needs fixed to consider whether a valid route exists to load all units
   public static List<Unit> getUnitsToTransportFromTerritories(final PlayerId player, final Unit transport,
       final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore,
@@ -244,6 +250,9 @@ public class ProTransportUtils {
     };
   }
 
+  /**
+   * Returns the air units in {@code units} that can't land on any carrier unit in {@code units}.
+   */
   public static List<Unit> getAirThatCantLandOnCarrier(final PlayerId player, final Territory t,
       final List<Unit> units) {
     final GameData data = ProData.getData();
@@ -265,6 +274,10 @@ public class ProTransportUtils {
     return airThatCantLand;
   }
 
+  /**
+   * Returns {@code true} if the carrier units in {@code existingUnits} have enough capacity to receive the air units in
+   * {@code existingUnits} in addition to {@code newUnit}.
+   */
   public static boolean validateCarrierCapacity(final PlayerId player, final Territory t,
       final List<Unit> existingUnits, final Unit newUnit) {
     final GameData data = ProData.getData();
@@ -283,6 +296,10 @@ public class ProTransportUtils {
     return capacity >= 0;
   }
 
+  /**
+   * Returns the unused capacity of all carrier units within 2 neighbors of {@code t} including any carrier units in
+   * {@code unitsToPlace}.
+   */
   public static int getUnusedLocalCarrierCapacity(final PlayerId player, final Territory t,
       final List<Unit> unitsToPlace) {
     final GameData data = ProData.getData();
@@ -314,6 +331,9 @@ public class ProTransportUtils {
     return capacity;
   }
 
+  /**
+   * Returns the unused capacity of all carrier units in {@code t} including any carrier units in {@code unitsToPlace}.
+   */
   public static int getUnusedCarrierCapacity(final PlayerId player, final Territory t, final List<Unit> unitsToPlace) {
     final List<Unit> units = new ArrayList<>(unitsToPlace);
     units.addAll(t.getUnits().getUnits());
@@ -329,6 +349,12 @@ public class ProTransportUtils {
     return capacity;
   }
 
+  /**
+   * Returns {@code units} sorted in such an order as to minimize losses during a battle involving carrier and air
+   * units. Carrier units are prioritized for loss if there is sufficient remaining carrier capacity or nearby land
+   * territories that can accommodate the remaining air units. Otherwise, air units are prioritized in order to ensure
+   * carrier capacity for the remaining air units.
+   */
   public static List<Unit> interleaveUnitsCarriersAndPlanes(final List<Unit> units,
       final int planesThatDontNeedToLand) {
     if (units.stream().noneMatch(Matches.unitIsCarrier())

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -41,6 +41,9 @@ public class ProUtils {
     return unitTerritoryMap;
   }
 
+  /**
+   * Returns a list of all players in turn order excluding {@code player}.
+   */
   public static List<PlayerId> getOtherPlayersInTurnOrder(final PlayerId player) {
     final GameData data = ProData.getData();
     final List<PlayerId> players = new ArrayList<>();
@@ -158,6 +161,11 @@ public class ProUtils {
     return capitals;
   }
 
+  /**
+   * Returns the distance to the closest enemy land territory to {@code t}.
+   *
+   * @return -1 if there is no enemy land territory within a distance of 10 of {@code t}.
+   */
   public static int getClosestEnemyLandTerritoryDistance(final GameData data, final PlayerId player,
       final Territory t) {
     final Set<Territory> landTerritories =
@@ -175,6 +183,11 @@ public class ProUtils {
     return (minDistance < 10) ? minDistance : -1;
   }
 
+  /**
+   * Returns the distance to the closest enemy or neutral land territory to {@code t}.
+   *
+   * @return -1 if there is no enemy or neutral land territory within a distance of 10 of {@code t}.
+   */
   public static int getClosestEnemyOrNeutralLandTerritoryDistance(final GameData data, final PlayerId player,
       final Territory t, final Map<Territory, Double> territoryValueMap) {
     final Set<Territory> landTerritories =
@@ -198,6 +211,13 @@ public class ProUtils {
     return (minDistance < 10) ? minDistance : -1;
   }
 
+  /**
+   * Returns the distance to the closest enemy land territory to {@code t} assuming movement only through water
+   * territories.
+   *
+   * @return -1 if there is no enemy land territory within a distance of 10 of {@code t} when moving only through water
+   *         territories.
+   */
   public static int getClosestEnemyLandTerritoryDistanceOverWater(final GameData data, final PlayerId player,
       final Territory t) {
     final Set<Territory> neighborTerritories = data.getMap().getNeighbors(t, 9);

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
@@ -14,6 +14,9 @@ import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 
+/**
+ * An AI implementation that takes no action except to purchase and place units according to very simple rules.
+ */
 public class DoesNothingAi extends AbstractAi {
 
   public DoesNothingAi(final String name) {


### PR DESCRIPTION
## Overview

Fixes violations of the Checkstyle JavadocType and JavadocMethod rules in types within the `g.s.triplea.ai` package by adding missing Javadocs, where required.

@ron-murhammer Requesting your review here to ensure I didn't totally misinterpret some of these AI methods.

## Functional Changes

None.

## Manual Testing Performed

None.  **This PR contains no code changes.**