### PR TITLE
Fix potential NPE in BattleDisplay

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -730,7 +730,7 @@ public class BattleDisplay extends JPanel {
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap;
       final boolean isAirPreBattleOrPreRaid = battleType.isAirPreBattleOrPreRaid();
       if (isAirPreBattleOrPreRaid) {
-        unitPowerAndRollsMap = null;
+        unitPowerAndRollsMap = Collections.emptyMap();
       } else {
         gameData.acquireReadLock();
         try {


### PR DESCRIPTION
## Overview

My static analyzer was flagging a potential NPE on usage of the `unitPowerAndRollsMap` local variable within the `BattleDisplay$BattleModel#refresh()` method.  A manual analysis revealed there really is no potential for an NPE in the current code because `unitPowerAndRollsMap` is only accessed when `isAirPreBattleOrPreRaid` is `false`, and `unitPowerAndRollsMap` is `null` only when `isAirPreBattleOrPreRaid` is `true`.

However, an NPE could easily be introduced if this code were changed such that `unitPowerAndRollsMap` was accessed irrespective of `isAirPreBattleOrPreRaid`.  So I went ahead and just initialized it to an empty map.  The other alternative is to add an `assert unitPowerAndRollsMap != null` immediately before line 759 to document that `unitPowerAndRollsMap` should only be accessed when `isAirPreBattleOrPreRaid` is `true`. But I wasn't sure that would be very helpful.

## Functional Changes

None.

## Manual Testing Performed

None.