### PR TITLE
Update production dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
         jbcryptVersion = '0.4'
         junitJupiterVersion = '5.3.2'
         mockitoVersion = '2.23.4'
-        postgresqlVersion = '42.2.2'
+        postgresqlVersion = '42.2.5'
         sonatypeGoodiesPrefsVersion = '2.2.5'
     }
 
@@ -64,7 +64,7 @@ subprojects {
     dependencies {
         errorprone 'com.google.errorprone:error_prone_core:2.3.1'
 
-        implementation 'com.google.guava:guava:24.1-jre'
+        implementation 'com.google.guava:guava:27.0.1-jre'
 
         testImplementation 'com.github.npathai:hamcrest-optional:2.0.0'
         testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.0.3'

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -3,14 +3,14 @@ import org.apache.tools.ant.filters.ReplaceTokens
 description = 'TripleA core library containing code shared between headed and headless versions'
 
 ext {
-    apacheHttpComponentsVersion = '4.5.5'
+    apacheHttpComponentsVersion = '4.5.6'
 }
 
 dependencies {
     implementation project(':http-client')
     implementation 'com.github.openjson:openjson:1.0.10'
     implementation 'com.googlecode.soundlibs:jlayer:1.0.1.4'
-    implementation 'com.sun.mail:javax.mail:1.6.1'
+    implementation 'com.sun.mail:javax.mail:1.6.2'
     implementation 'com.yuvimasory:orange-extensions:1.3.0'
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'commons-codec:commons-codec:1.11'
@@ -19,7 +19,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
     implementation "org.mindrot:jbcrypt:$jbcryptVersion"
-    implementation 'org.yaml:snakeyaml:1.19'
+    implementation 'org.yaml:snakeyaml:1.23'
 
     testImplementation project(':test-common')
     testImplementation "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -8,8 +8,8 @@ mainClassName = 'org.triplea.server.http.spark.SparkServer'
 
 dependencies {
     implementation project(':http-client')
-    implementation 'com.sparkjava:spark-core:2.3'
-    implementation 'com.google.code.gson:gson:2.7'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.sparkjava:spark-core:2.8.0'
 
     testImplementation project(':test-common')
     testImplementation 'uk.co.datumedge:hamcrest-json:0.2'


### PR DESCRIPTION
## Overview

Updates all production dependencies to the latest version.

The only risky production update here is Guava.  I reviewed the release notes for all releases between 24.1 and 27.0.1.  I didn't see any breaking changes.

All other updates are either bug fix releases or are feature releases for dependencies of the new HTTP server component.  Since that component is not yet in production, the risk of a breaking change is minimal.

## Functional Changes

None.

## Manual Testing Performed

* Smoke tested a local game from both an IDE build and a locally-built artifact.
* Verified lobby connectivity from both an IDE build and a locally-built artifact.
* Verified I could download a map from an IDE build.