### PR TITLE
Error Prone: Fix equals unsafe cast violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ subprojects {
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
             '-Xep:EqualsIncompatibleType:ERROR',
+            '-Xep:EqualsUnsafeCast:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',
             '-Xep:ImmutableEnumChecker:ERROR',
             '-Xep:InconsistentCapitalization:ERROR',

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -106,9 +106,12 @@ public class Route implements Serializable, Iterable<Territory> {
 
   @Override
   public boolean equals(final Object o) {
-    if (o == null) {
+    if (o == this) {
+      return true;
+    } else if (!(o instanceof Route)) {
       return false;
     }
+
     final Route other = (Route) o;
     if (!(other.numberOfSteps() == this.numberOfSteps())) {
       return false;

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -15,6 +15,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
+
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
@@ -43,7 +45,7 @@ public class Route implements Serializable, Iterable<Territory> {
   private static final List<Territory> EMPTY_TERRITORY_LIST = Collections.emptyList();
 
   private final List<Territory> steps = new ArrayList<>();
-  private Territory start;
+  private @Nullable Territory start;
 
   public Route() {}
 
@@ -114,7 +116,7 @@ public class Route implements Serializable, Iterable<Territory> {
 
     final Route other = (Route) o;
     return (numberOfSteps() == other.numberOfSteps())
-        && getStart().equals(other.getStart())
+        && Objects.equals(getStart(), other.getStart())
         && getAllTerritories().equals(other.getAllTerritories());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -107,7 +107,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   @Override
-  public boolean equals(final Object o) {
+  public final boolean equals(final Object o) {
     if (o == this) {
       return true;
     } else if (!(o instanceof Route)) {
@@ -121,7 +121,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(start, getSteps());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -113,10 +113,9 @@ public class Route implements Serializable, Iterable<Territory> {
     }
 
     final Route other = (Route) o;
-    if (!(other.numberOfSteps() == this.numberOfSteps())) {
-      return false;
-    }
-    return other.getStart().equals(this.getStart()) && other.getAllTerritories().equals(this.getAllTerritories());
+    return (numberOfSteps() == other.numberOfSteps())
+        && getStart().equals(other.getStart())
+        && getAllTerritories().equals(other.getAllTerritories());
   }
 
   @Override

--- a/game-core/src/test/java/games/strategy/engine/data/RouteTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RouteTest.java
@@ -1,0 +1,60 @@
+package games.strategy.engine.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class RouteTest {
+  @Nested
+  final class EqualsTest {
+    private final GameData gameData = new GameData();
+    private final Territory territory1 = new Territory("territory1", gameData);
+    private final Territory territory2 = new Territory("territory2", gameData);
+    private final Route reference = new Route(territory1, territory2);
+
+    @Test
+    void shouldReturnTrueWhenOtherIsSameInstance() {
+      assertThat(reference.equals(reference), is(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenOtherIsEqual() {
+      final Route other = new Route(territory1, territory2);
+
+      assertThat(reference.equals(other), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNull() {
+      assertThat(reference.equals(null), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNotInstanceOfRoute() {
+      assertThat(reference.equals(new Object()), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasDifferentStepCount() {
+      final Route other = new Route(territory1);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasSameStepCountButHasDifferentStartTerritory() {
+      final Route other = new Route(territory2, territory1);
+
+      assertThat(reference.equals(other), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasSameStepCountAndHasSameStartTerritoryButHasDifferentTerritoryList() {
+      final Route other = new Route(territory1, new Territory("territory3", gameData));
+
+      assertThat(reference.equals(other), is(false));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/RouteTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RouteTest.java
@@ -27,6 +27,14 @@ final class RouteTest {
     }
 
     @Test
+    void shouldReturnTrueWhenReferenceAndOtherAreEmpty() {
+      final Route reference = new Route();
+      final Route other = new Route();
+
+      assertThat(reference.equals(other), is(true));
+    }
+
+    @Test
     void shouldReturnFalseWhenOtherIsNull() {
       assertThat(reference.equals(null), is(false));
     }

--- a/game-core/src/test/java/games/strategy/triplea/ui/MapRouteDrawerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/MapRouteDrawerTest.java
@@ -28,7 +28,7 @@ import games.strategy.triplea.image.ResourceImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.IntegerMap;
 
-public class RouteTest {
+final class MapRouteDrawerTest {
   private final Point[] dummyPoints = new Point[] {new Point(0, 0), new Point(100, 0), new Point(0, 100)};
   private final MapData dummyMapData = mock(MapData.class);
   private final MapRouteDrawer spyRouteDrawer = spy(new MapRouteDrawer(mock(MapPanel.class), dummyMapData));


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsUnsafeCast rule.

The actual fix is in the second commit.

## Functional Changes

None.

## Refactoring Changes

* Renamed the existing `RouteTest` class to `MapRouteDrawerTest` because it really tests the `MapRouteDrawer` class and to avoid confusion with the new `RouteTest` fixture I introduced in this PR.
* Simplified the `Route#equals()` implementation after adding characterization tests.
* Made `Route#equals()` and `hashCode()` final to avoid surprises in the future if someone thinks it's a good idea to redefine them in a subclass.

## Manual Testing Performed

None.