### PR TITLE
Error Prone: Fix EqualsGetClass violations in effectively final classes

### DIFF
--- a/game-core/src/main/java/games/strategy/util/Triple.java
+++ b/game-core/src/main/java/games/strategy/util/Triple.java
@@ -1,9 +1,10 @@
 package games.strategy.util;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
+
+import lombok.EqualsAndHashCode;
 
 /**
  * A heterogeneous container of three values.
@@ -12,7 +13,8 @@ import com.google.common.base.MoreObjects;
  * @param <S> The type of the second value.
  * @param <T> The type of the third value.
  */
-public class Triple<F, S, T> implements Serializable {
+@EqualsAndHashCode
+public final class Triple<F, S, T> implements Serializable {
   private static final long serialVersionUID = -8188046743232005918L;
   private final Tuple<F, S> tuple;
   private final T third;
@@ -64,25 +66,5 @@ public class Triple<F, S, T> implements Serializable {
         .add("second", getSecond())
         .add("third", getThird())
         .toString();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tuple, third);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-
-    final Triple<?, ?, ?> other = (Triple<?, ?, ?>) obj;
-    return Objects.equals(tuple, other.tuple)
-        && Objects.equals(getThird(), other.getThird());
   }
 }

--- a/game-core/src/main/java/games/strategy/util/Tuple.java
+++ b/game-core/src/main/java/games/strategy/util/Tuple.java
@@ -1,9 +1,10 @@
 package games.strategy.util;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
+
+import lombok.EqualsAndHashCode;
 
 /**
  * A heterogeneous container of two values.
@@ -11,11 +12,11 @@ import com.google.common.base.MoreObjects;
  * @param <T> The type of the first value.
  * @param <S> The type of the second value.
  */
-public class Tuple<T, S> implements Serializable {
+@EqualsAndHashCode
+public final class Tuple<T, S> implements Serializable {
   private static final long serialVersionUID = -5091545494950868125L;
   private final T first;
   private final S second;
-
 
   /**
    * Static creation method to create a new instance of a tuple with the parameters provided.
@@ -59,26 +60,5 @@ public class Tuple<T, S> implements Serializable {
         .add("first", getFirst())
         .add("second", getSecond())
         .toString();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(first, second);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-
-    // ignore parameterization, just perform equals-check on components
-    final Tuple<?, ?> other = (Tuple<?, ?>) obj;
-    return Objects.equals(getFirst(), other.getFirst())
-        && Objects.equals(getSecond(), other.getSecond());
   }
 }

--- a/game-core/src/test/java/games/strategy/util/TripleTest.java
+++ b/game-core/src/test/java/games/strategy/util/TripleTest.java
@@ -1,0 +1,16 @@
+package games.strategy.util;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class TripleTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(Triple.class).verify();
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/util/TupleTest.java
+++ b/game-core/src/test/java/games/strategy/util/TupleTest.java
@@ -5,34 +5,19 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Map;
-
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Maps;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class TupleTest {
-  Tuple<String, Integer> testObj = Tuple.of("hi", 123);
+  private final Tuple<String, Integer> testObj = Tuple.of("hi", 123);
 
   @Test
   public void basicUsage() {
     assertThat(testObj.getFirst(), is("hi"));
     assertThat(testObj.getSecond(), is(123));
-  }
-
-  @Test
-  public void verifyEquality() {
-    assertThat(testObj, is(testObj));
-
-    final Tuple<String, Integer> copyObj = Tuple.of(testObj.getFirst(), testObj.getSecond());
-    assertThat(testObj, is(copyObj));
-    assertThat(copyObj, is(testObj));
-
-    assertThat("check equals against null case",
-        copyObj.equals(null), is(false));
   }
 
   @Test
@@ -50,16 +35,11 @@ public class TupleTest {
     assertThat(nullTuple, not(Tuple.of("something else", (String) null)));
   }
 
-  @Test
-  public void checkUsingTupleAsMapKey() {
-    final Map<Tuple<String, String>, String> map = Maps.newHashMap();
-    final Tuple<String, String> tuple = Tuple.of("This is a bad idea using tuples this much", "another value");
-    final String value = "some value";
-
-    assertFalse(map.containsKey(tuple));
-
-    map.put(tuple, value);
-    assertTrue(map.containsKey(tuple));
-    assertThat(map.get(tuple), is(value));
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(Tuple.class).verify();
+    }
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsGetClass rule in classes that are effectively `final`.

The fixes here were to simply make the classes `final` and use Lombok to generate appropriate `equals()` and `hashCode()` methods.  I added characterization tests for `equals()` and `hashCode()` prior to making any changes.  I also removed some tests that overlapped the EqualsVerifier tests.

## Functional Changes

None.

## Manual Testing Performed

None.