### PR TITLE
Error Prone: Fix EqualsGetClass violations in DownloadFileDescription

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -12,7 +12,7 @@ import games.strategy.util.Version;
  * This class represents the essential data for downloading a TripleA map. Where to get it, where to install it,
  * version, etc..
  */
-public class DownloadFileDescription {
+public final class DownloadFileDescription {
   private final String url;
   private final String description;
   private final String mapName;
@@ -21,11 +21,9 @@ public class DownloadFileDescription {
   private final MapCategory mapCategory;
   private final String img;
 
-
   enum DownloadType {
     MAP, MAP_SKIN, MAP_TOOL
   }
-
 
   enum MapCategory {
     BEST("High Quality"),
@@ -38,7 +36,6 @@ public class DownloadFileDescription {
 
     final String outputLabel;
 
-
     MapCategory(final String label) {
       outputLabel = label;
     }
@@ -47,7 +44,6 @@ public class DownloadFileDescription {
     public String toString() {
       return outputLabel;
     }
-
   }
 
   DownloadFileDescription(final String url, final String description, final String mapName,
@@ -125,7 +121,6 @@ public class DownloadFileDescription {
     text += getDescription();
     return text;
   }
-
 
   @Override
   public boolean equals(final Object rhs) {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -1,18 +1,20 @@
 package games.strategy.engine.framework.map.download;
 
 import java.io.File;
-import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.util.Version;
+import lombok.EqualsAndHashCode;
 
 /**
  * This class represents the essential data for downloading a TripleA map. Where to get it, where to install it,
  * version, etc..
  */
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public final class DownloadFileDescription {
+  @EqualsAndHashCode.Include
   private final String url;
   private final String description;
   private final String mapName;
@@ -120,19 +122,5 @@ public final class DownloadFileDescription {
     }
     text += getDescription();
     return text;
-  }
-
-  @Override
-  public boolean equals(final Object rhs) {
-    if (rhs == null || getClass() != rhs.getClass()) {
-      return false;
-    }
-    final DownloadFileDescription other = (DownloadFileDescription) rhs;
-    return Objects.equals(this.url, other.url);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(url);
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -5,14 +5,15 @@ import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.util.Version;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
-
   @Test
   public void testIsMap() {
     final DownloadFileDescription testObj = new DownloadFileDescription("", "", "", new Version(0, 0),
@@ -32,7 +33,6 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription testObj = new DownloadFileDescription("", "", "", new Version(0, 0),
         DownloadFileDescription.DownloadType.MAP_TOOL, DownloadFileDescription.MapCategory.EXPERIMENTAL);
     assertThat(testObj.isMapTool(), is(true));
-
   }
 
   @Test
@@ -52,7 +52,6 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
     assertThat(testObj.getMapCategory(), is(DownloadFileDescription.MapCategory.BEST));
   }
 
-
   @Test
   public void testGetMapFileName() {
     final String expectedFileName = "world_war_ii_revised.zip";
@@ -68,7 +67,6 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
     inputUrl = "abc.zip";
     testObj = testObjFromUrl(inputUrl);
     assertThat("Unable to parse a url, no last '/' character, return empty.", testObj.getMapZipFileName(), is(""));
-
   }
 
   private static DownloadFileDescription testObjFromUrl(final String inputUrl) {
@@ -95,5 +93,15 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
         DownloadFileDescription.DownloadType.MAP, DownloadFileDescription.MapCategory.EXPERIMENTAL);
 
     assertThat(testObj.getInstallLocation().getAbsolutePath(), is(expected.getAbsolutePath()));
+  }
+
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    final void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(DownloadFileDescription.class)
+          .withOnlyTheseFields("url")
+          .verify();
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -5,20 +5,21 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
+import games.strategy.util.Version;
 
-@ExtendWith(MockitoExtension.class)
 public class FileDownloadTest {
-  @Mock
-  private DownloadFileDescription mockDownload;
-
   @Test
   public void testBasicStartCancel() {
-    final DownloadFile testObj = new DownloadFile(mockDownload, mock(DownloadListener.class));
+    final DownloadFileDescription downloadFileDescription = new DownloadFileDescription(
+        "url",
+        "description",
+        "mapName",
+        new Version(0, 0),
+        DownloadFileDescription.DownloadType.MAP,
+        DownloadFileDescription.MapCategory.BEST);
+    final DownloadFile testObj = new DownloadFile(downloadFileDescription, mock(DownloadListener.class));
     assertThat(testObj.getDownloadState(), is(DownloadState.NOT_STARTED));
 
     testObj.startAsyncDownload();


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsGetClass rule in `DownloadFileDescription`.

The fix was to make the class `final` and use Lombok to generate appropriate `equals()` and `hashCode()` methods.  I added appropriate characterization tests before changing the `equals()` and `hashCode()` implementations.

One existing test had to be changed.  It was mocking `DownloadFileDescription`, which is no longer possible now that the class is `final`.  `DownloadFileDescription` is a value type, and the mocking wasn't really necessary--it just seemed to be a lazy way to create an instance without having to specify a long list of constructor arguments.

## Functional Changes

None.

## Manual Testing Performed

None.