### PR TITLE
Error Prone: Fix ThreadPriorityCheck violations in test code

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/game-core/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -46,7 +46,6 @@ public class VaultTest {
     final UnifiedMessenger clientUnifiedMessenger = new UnifiedMessenger(clientMessenger);
     serverVault = new Vault(new ChannelMessenger(serverUnifiedMessenger));
     clientVault = new Vault(new ChannelMessenger(clientUnifiedMessenger));
-    Thread.yield();
   }
 
   @AfterEach

--- a/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -160,12 +160,14 @@ public class MessengerIntegrationTest {
   @Test
   public void testMultipleMessages() throws Exception {
     final CountDownLatch testReadyLatch = new CountDownLatch(1);
-    final Thread t1 = new Thread(new MultipleMessageSender(serverMessenger, testReadyLatch));
-    final Thread t2 = new Thread(new MultipleMessageSender(client1Messenger, testReadyLatch));
-    final Thread t3 = new Thread(new MultipleMessageSender(client2Messenger, testReadyLatch));
+    final CountDownLatch workersReadyLatch = new CountDownLatch(3);
+    final Thread t1 = new Thread(new MultipleMessageSender(serverMessenger, testReadyLatch, workersReadyLatch));
+    final Thread t2 = new Thread(new MultipleMessageSender(client1Messenger, testReadyLatch, workersReadyLatch));
+    final Thread t3 = new Thread(new MultipleMessageSender(client2Messenger, testReadyLatch, workersReadyLatch));
     t1.start();
     t2.start();
     t3.start();
+    workersReadyLatch.await();
     testReadyLatch.countDown();
     t1.join();
     t2.join();
@@ -334,14 +336,20 @@ public class MessengerIntegrationTest {
   private static final class MultipleMessageSender implements Runnable {
     private final IMessenger messenger;
     private final CountDownLatch testReadyLatch;
+    private final CountDownLatch workersReadyLatch;
 
-    MultipleMessageSender(final IMessenger messenger, final CountDownLatch testReadyLatch) {
+    MultipleMessageSender(
+        final IMessenger messenger,
+        final CountDownLatch testReadyLatch,
+        final CountDownLatch workersReadyLatch) {
       this.messenger = messenger;
       this.testReadyLatch = testReadyLatch;
+      this.workersReadyLatch = workersReadyLatch;
     }
 
     @Override
     public void run() {
+      workersReadyLatch.countDown();
       Interruptibles.await(testReadyLatch);
       for (int i = 0; i < 100; i++) {
         messenger.broadcast(i);


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone ThreadPriorityCheck violations in test code.

The `Thread#yield()` call removed in the first commit seemed completely unnecessary.  Just in case there's some weird race condition lurking in there, I re-ran the Travis build five times.  This test didn't fail during those runs.  If some kind of intermittent failure appears in the future, I'll revisit the test at that time.

## Functional Changes

None.

## Manual Testing Performed

None.