### PR TITLE
Error Prone: Fix EqualsGetClass violations in GameChooserEntry

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -221,7 +221,7 @@ public class GameSelectorModel extends Observable {
       // game model list
       try {
         final URI defaultUri = new URI(userPreferredDefaultGameUri);
-        selectedGame = new GameChooserEntry(defaultUri);
+        selectedGame = GameChooserEntry.newInstance(defaultUri);
       } catch (final Exception e) {
         resetToFactoryDefault();
         selectedGame = selectByName();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
@@ -1,0 +1,132 @@
+package games.strategy.engine.framework.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+
+import games.strategy.engine.data.EngineVersionException;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameParseException;
+import games.strategy.engine.data.GameParser;
+import games.strategy.triplea.Constants;
+import games.strategy.util.UrlStreams;
+import lombok.extern.java.Log;
+
+@Log
+final class DefaultGameChooserEntry implements GameChooserEntry {
+  private final URI url;
+  private GameData gameData;
+  private boolean gameDataFullyLoaded = false;
+  private final String gameNameAndMapNameProperty;
+
+  DefaultGameChooserEntry(final URI uri) throws IOException, GameParseException, EngineVersionException {
+    url = uri;
+
+    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
+    if (!inputStream.isPresent()) {
+      gameNameAndMapNameProperty = "";
+      // this means the map was deleted out from under us.
+      return;
+    }
+
+    try (InputStream input = inputStream.get()) {
+      gameData = GameParser.parseShallow(uri.toString(), input);
+      gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
+    }
+  }
+
+  @Override
+  public GameData fullyParseGameData() throws GameParseException {
+    // TODO: We should be setting this in the the constructor. At this point, you have to call methods in the
+    // correct order for things to work, and that is bads.
+    gameData = null;
+
+    final Optional<InputStream> inputStream = UrlStreams.openStream(url);
+    if (!inputStream.isPresent()) {
+      return gameData;
+    }
+
+    try (InputStream input = inputStream.get()) {
+      gameData = GameParser.parse(url.toString(), input);
+      gameDataFullyLoaded = true;
+    } catch (final EngineVersionException e) {
+      log.log(Level.SEVERE, "Game engine not compatible with: " + url, e);
+      throw new GameParseException(e);
+    } catch (final GameParseException e) {
+      log.log(Level.SEVERE, "Could not parse:" + url, e);
+      throw e;
+    } catch (final Exception e) {
+      log.log(Level.SEVERE, "Could not parse:" + url, e);
+      throw new GameParseException(e);
+    }
+    return gameData;
+  }
+
+  @Override
+  public boolean isGameDataLoaded() {
+    return gameDataFullyLoaded;
+  }
+
+  @Override
+  public String getGameName() {
+    return gameData.getGameName();
+  }
+
+  // the user may have selected a map skin instead of this map folder, so don't use this for anything except our
+  // equals/hashcode below
+  private String getMapNameProperty() {
+    final String mapName = (String) gameData.getProperties().get(Constants.MAP_NAME);
+    if (mapName == null || mapName.trim().length() == 0) {
+      throw new IllegalStateException("Map name property not set on game");
+    }
+    return mapName;
+  }
+
+  @Override
+  public String toString() {
+    return getGameName();
+  }
+
+  @Override
+  public GameData getGameData() {
+    return gameData;
+  }
+
+  @Override
+  public URI getUri() {
+    return url;
+  }
+
+  @Override
+  public String getLocation() {
+    return url.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(gameNameAndMapNameProperty);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof DefaultGameChooserEntry)) {
+      return false;
+    }
+
+    final DefaultGameChooserEntry other = (DefaultGameChooserEntry) obj;
+    if (gameData == null && other.gameData != null) {
+      return false;
+    }
+    return other.gameData != null && this.gameNameAndMapNameProperty.equals(other.gameNameAndMapNameProperty);
+  }
+
+  @Override
+  public int compareTo(final GameChooserEntry o) {
+    return getGameName().compareToIgnoreCase(o.getGameName());
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserEntry.java
@@ -1,105 +1,28 @@
 package games.strategy.engine.framework.ui;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.logging.Level;
 
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
-import games.strategy.engine.data.GameParser;
-import games.strategy.triplea.Constants;
-import games.strategy.util.UrlStreams;
-import lombok.extern.java.Log;
 
 /**
  * An installed game (map) that is selectable by the user from the Game Chooser dialog.
  */
-@Log
-public class GameChooserEntry implements Comparable<GameChooserEntry> {
-  private final URI url;
-  private GameData gameData;
-  private boolean gameDataFullyLoaded = false;
-  private final String gameNameAndMapNameProperty;
-
-  public GameChooserEntry(final URI uri) throws IOException, GameParseException, EngineVersionException {
-    url = uri;
-
-    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
-    if (!inputStream.isPresent()) {
-      gameNameAndMapNameProperty = "";
-      // this means the map was deleted out from under us.
-      return;
-    }
-
-    try (InputStream input = inputStream.get()) {
-      gameData = GameParser.parseShallow(uri.toString(), input);
-      gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
-    }
-  }
-
+public interface GameChooserEntry extends Comparable<GameChooserEntry> {
   /**
    * Returns a {@link GameData} instance resulting from fully parsing the XML associated with this game.
    */
-  public GameData fullyParseGameData() throws GameParseException {
-    // TODO: We should be setting this in the the constructor. At this point, you have to call methods in the
-    // correct order for things to work, and that is bads.
-    gameData = null;
+  GameData fullyParseGameData() throws GameParseException;
 
-    final Optional<InputStream> inputStream = UrlStreams.openStream(url);
-    if (!inputStream.isPresent()) {
-      return gameData;
-    }
+  boolean isGameDataLoaded();
 
-    try (InputStream input = inputStream.get()) {
-      gameData = GameParser.parse(url.toString(), input);
-      gameDataFullyLoaded = true;
-    } catch (final EngineVersionException e) {
-      log.log(Level.SEVERE, "Game engine not compatible with: " + url, e);
-      throw new GameParseException(e);
-    } catch (final GameParseException e) {
-      log.log(Level.SEVERE, "Could not parse:" + url, e);
-      throw e;
-    } catch (final Exception e) {
-      log.log(Level.SEVERE, "Could not parse:" + url, e);
-      throw new GameParseException(e);
-    }
-    return gameData;
-  }
+  String getGameName();
 
-  public boolean isGameDataLoaded() {
-    return gameDataFullyLoaded;
-  }
+  GameData getGameData();
 
-  public String getGameName() {
-    return gameData.getGameName();
-  }
-
-  // the user may have selected a map skin instead of this map folder, so don't use this for anything except our
-  // equals/hashcode below
-  private String getMapNameProperty() {
-    final String mapName = (String) gameData.getProperties().get(Constants.MAP_NAME);
-    if (mapName == null || mapName.trim().length() == 0) {
-      throw new IllegalStateException("Map name property not set on game");
-    }
-    return mapName;
-  }
-
-  @Override
-  public String toString() {
-    return getGameName();
-  }
-
-  public GameData getGameData() {
-    return gameData;
-  }
-
-  public URI getUri() {
-    return url;
-  }
+  URI getUri();
 
   /**
    * Returns the location of the game file.
@@ -108,37 +31,11 @@ public class GameChooserEntry implements Comparable<GameChooserEntry> {
    * The "location" is actually a URI in string form.
    * </p>
    *
-   * @return The location of the game file; never {@code null}.
+   * @return The location of the game file.
    */
-  public String getLocation() {
-    return url.toString();
-  }
+  String getLocation();
 
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(gameNameAndMapNameProperty);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final GameChooserEntry other = (GameChooserEntry) obj;
-    if (gameData == null && other.gameData != null) {
-      return false;
-    }
-    return other.gameData != null && this.gameNameAndMapNameProperty.equals(other.gameNameAndMapNameProperty);
-  }
-
-  @Override
-  public int compareTo(final GameChooserEntry o) {
-    return getGameName().compareToIgnoreCase(o.getGameName());
+  static GameChooserEntry newInstance(final URI uri) throws IOException, GameParseException, EngineVersionException {
+    return new DefaultGameChooserEntry(uri);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -19,7 +19,6 @@ import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.io.FileUtils;
 import games.strategy.ui.SwingAction;
@@ -144,7 +143,7 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
    */
   private static Optional<GameChooserEntry> createGameChooserEntry(final URI uri) {
     try {
-      return Optional.of(createEntry(uri));
+      return Optional.of(GameChooserEntry.newInstance(uri));
     } catch (final EngineVersionException e) {
       log.log(Level.SEVERE, "Engine version problem:" + uri, e);
     } catch (final Exception e) {
@@ -161,11 +160,6 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
         .mapToObj(this::get)
         .filter(e -> e.getGameData().getGameName().equals(name))
         .findAny();
-  }
-
-  private static GameChooserEntry createEntry(final URI uri)
-      throws IOException, GameParseException, EngineVersionException {
-    return new GameChooserEntry(uri);
   }
 
   private static Set<GameChooserEntry> populateFromDirectory(final File mapDir) {


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsGetClass rule in the `GameChooserEntry` class.

`GameChooserEntry` has deep integration with other subsystems, which explains why there are unit tests that mock it to avoid the integration dependencies (NB: those unit tests don't have a dependency on any of the existing `GameChooserEntry` implementation; they simply stub method return values for the benefit of other code).  That's kind of a smell, so I transformed `GameChooserEntry` into an interface and extracted the existing implementation into the new `DefaultGameChooserEntry` class.  The unit tests then are just mocking an interface rather than a concrete class.

Once that was complete, it was a simple matter to fix the `equals()` implementation to conform to the Error Prone rule.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested the Game Chooser dialog.