### PR TITLE
Error Prone: Fix EqualsGetClass violations in IBean implementations

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/IBean.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/IBean.java
@@ -2,6 +2,8 @@ package games.strategy.engine.framework.startup.ui.editors;
 
 import java.io.Serializable;
 
+import javax.annotation.Nullable;
+
 /**
  * An interface specifying that this component is a bean that can provide an editor
  * Beans must have a default constructor.
@@ -27,4 +29,10 @@ public interface IBean extends Serializable {
    * @return the help text
    */
   String getHelpText();
+
+  /**
+   * Returns {@code true} if this bean is the same type as {@code other}. Note that this doesn't necessarily mean type
+   * in the sense of a Java class, but it may. This method is used to select a bean within a list of beans in the UI.
+   */
+  boolean isSameType(@Nullable IBean other);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
@@ -8,9 +8,9 @@ import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -174,13 +174,13 @@ public class SelectAndViewEditor extends EditorPanel {
    *
    * @param bean the bean
    */
-  public void setSelectedBean(final IBean bean) {
+  public void setSelectedBean(final @Nullable IBean bean) {
     final MutableComboBoxModel<IBean> model = (MutableComboBoxModel<IBean>) selector.getModel();
     final DefaultComboBoxModel<IBean> newModel = new DefaultComboBoxModel<>();
     boolean found = false;
     for (int i = 0; i < model.getSize(); i++) {
-      final IBean candidate = model.getElementAt(i);
-      if (Objects.equals(candidate, bean)) {
+      final @Nullable IBean candidate = model.getElementAt(i);
+      if (((candidate == null) && (bean == null)) || ((candidate != null) && candidate.isSameType(bean))) {
         found = true;
         newModel.addElement(bean);
       } else {

--- a/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -186,12 +186,13 @@ public abstract class AbstractForumPoster implements IForumPoster {
   }
 
   @Override
-  public boolean equals(final Object other) {
+  @SuppressWarnings("EqualsGetClass") // all concrete subclasses are equal to each other regardless of state
+  public final boolean equals(final Object other) {
     return other != null && getClass().equals(other.getClass());
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hashCode(getClass());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -4,11 +4,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Objects;
 import java.util.logging.Level;
+
+import javax.annotation.Nullable;
 
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.ForumPosterEditor;
+import games.strategy.engine.framework.startup.ui.editors.IBean;
 import games.strategy.security.CredentialManager;
 import games.strategy.security.CredentialManagerException;
 import lombok.extern.java.Log;
@@ -186,13 +188,7 @@ public abstract class AbstractForumPoster implements IForumPoster {
   }
 
   @Override
-  @SuppressWarnings("EqualsGetClass") // all concrete subclasses are equal to each other regardless of state
-  public final boolean equals(final Object other) {
+  public final boolean isSameType(final @Nullable IBean other) {
     return other != null && getClass().equals(other.getClass());
-  }
-
-  @Override
-  public final int hashCode() {
-    return Objects.hashCode(getClass());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -392,12 +392,13 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   @Override
-  public boolean equals(final Object other) {
+  @SuppressWarnings("EqualsGetClass") // all concrete subclasses are equal to each other regardless of state
+  public final boolean equals(final Object other) {
     return other != null && getClass().equals(other.getClass());
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hashCode(getClass());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -7,13 +7,13 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
+import javax.annotation.Nullable;
 import javax.mail.BodyPart;
 import javax.mail.Message;
 import javax.mail.MessagingException;
@@ -30,6 +30,7 @@ import com.google.common.base.Splitter;
 
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.EmailSenderEditor;
+import games.strategy.engine.framework.startup.ui.editors.IBean;
 import games.strategy.security.CredentialManager;
 import games.strategy.security.CredentialManagerException;
 import games.strategy.triplea.help.HelpSupport;
@@ -392,13 +393,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   @Override
-  @SuppressWarnings("EqualsGetClass") // all concrete subclasses are equal to each other regardless of state
-  public final boolean equals(final Object other) {
+  public final boolean isSameType(final @Nullable IBean other) {
     return other != null && getClass().equals(other.getClass());
-  }
-
-  @Override
-  public final int hashCode() {
-    return Objects.hashCode(getClass());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -13,7 +13,7 @@ import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
  * the dice.
  * Because DiceServers must be serializable read resolve must be implemented
  */
-public class InternalDiceServer implements IRemoteDiceServer {
+public final class InternalDiceServer implements IRemoteDiceServer {
   private static final long serialVersionUID = -8369097763085658445L;
   private static final char DICE_SEPARATOR = ',';
 
@@ -82,7 +82,8 @@ public class InternalDiceServer implements IRemoteDiceServer {
    *
    * @return a new InternalDiceServer
    */
-  public Object readResolve() {
+  @SuppressWarnings("static-method")
+  private Object readResolve() {
     return new InternalDiceServer();
   }
 
@@ -106,7 +107,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
 
   @Override
   public boolean equals(final Object other) {
-    return other != null && getClass().equals(other.getClass());
+    return other instanceof InternalDiceServer;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -1,11 +1,12 @@
 package games.strategy.engine.random;
 
-import java.util.Objects;
+import javax.annotation.Nullable;
 
 import com.google.common.base.Splitter;
 
 import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
+import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
  * This is not actually a dice server, it just uses the normal TripleA PlainRandomSource for dice roll
@@ -106,12 +107,7 @@ public final class InternalDiceServer implements IRemoteDiceServer {
   }
 
   @Override
-  public boolean equals(final Object other) {
+  public boolean isSameType(final @Nullable IBean other) {
     return other instanceof InternalDiceServer;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(getClass());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.random;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -14,6 +16,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
+
+import javax.annotation.Nonnull;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -35,6 +39,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
@@ -51,7 +56,7 @@ import lombok.extern.java.Log;
  * A pbem dice roller that reads its configuration from a properties file.
  */
 @Log
-public class PropertiesDiceRoller implements IRemoteDiceServer {
+public final class PropertiesDiceRoller implements IRemoteDiceServer {
   private static final long serialVersionUID = 6481409417543119539L;
 
   /**
@@ -86,18 +91,20 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
     return rollers;
   }
 
-  private final Properties props;
+  private final @Nonnull Properties props;
   private String toAddress;
   private String ccAddress;
   private String gameId;
 
-  public PropertiesDiceRoller(final Properties props) {
+  private PropertiesDiceRoller(final Properties props) {
+    checkNotNull(props);
+
     this.props = props;
   }
 
   @Override
   public String getDisplayName() {
-    return props.getProperty("name");
+    return props.getProperty(PropertyKeys.NAME);
   }
 
   @Override
@@ -256,6 +263,11 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
   @Override
   public int hashCode() {
     return Objects.hashCode(getDisplayName());
+  }
+
+  @VisibleForTesting
+  interface PropertyKeys {
+    String NAME = "name";
   }
 
   private static class AdvancedRedirectStrategy extends LaxRedirectStrategy {

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.random;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -17,7 +15,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -91,20 +89,19 @@ public final class PropertiesDiceRoller implements IRemoteDiceServer {
     return rollers;
   }
 
-  private final @Nonnull Properties props;
+  private final Properties props;
   private String toAddress;
   private String ccAddress;
   private String gameId;
 
-  private PropertiesDiceRoller(final Properties props) {
-    checkNotNull(props);
-
+  @VisibleForTesting
+  PropertiesDiceRoller(final Properties props) {
     this.props = props;
   }
 
   @Override
   public String getDisplayName() {
-    return props.getProperty(PropertyKeys.NAME);
+    return props.getProperty(PropertyKeys.DISPLAY_NAME);
   }
 
   @Override
@@ -256,18 +253,13 @@ public final class PropertiesDiceRoller implements IRemoteDiceServer {
   }
 
   @Override
-  public boolean equals(final Object other) {
-    return other instanceof PropertiesDiceRoller && Objects.equals(getDisplayName(), ((IBean) other).getDisplayName());
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(getDisplayName());
+  public boolean isSameType(final @Nullable IBean other) {
+    return other instanceof PropertiesDiceRoller && Objects.equals(getDisplayName(), other.getDisplayName());
   }
 
   @VisibleForTesting
   interface PropertyKeys {
-    String NAME = "name";
+    String DISPLAY_NAME = "name";
   }
 
   private static class AdvancedRedirectStrategy extends LaxRedirectStrategy {

--- a/game-core/src/test/java/games/strategy/engine/pbem/AbstractForumPosterTest.java
+++ b/game-core/src/test/java/games/strategy/engine/pbem/AbstractForumPosterTest.java
@@ -1,0 +1,26 @@
+package games.strategy.engine.pbem;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class AbstractForumPosterTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(AbstractForumPoster.class)
+          .usingGetClass()
+          .withIgnoredFields(
+              "alsoPostAfterCombatMove",
+              "credentialsProtected",
+              "credentialsSaved",
+              "includeSaveGame",
+              "password",
+              "topicId",
+              "username")
+          .verify();
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/pbem/AbstractForumPosterTest.java
+++ b/game-core/src/test/java/games/strategy/engine/pbem/AbstractForumPosterTest.java
@@ -1,26 +1,67 @@
 package games.strategy.engine.pbem;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-
 final class AbstractForumPosterTest {
   @Nested
-  final class EqualsAndHashCodeTest {
+  final class IsSameTypeTest {
+    private final AbstractForumPoster reference = new ConcreteForumPoster();
+
     @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(AbstractForumPoster.class)
-          .usingGetClass()
-          .withIgnoredFields(
-              "alsoPostAfterCombatMove",
-              "credentialsProtected",
-              "credentialsSaved",
-              "includeSaveGame",
-              "password",
-              "topicId",
-              "username")
-          .verify();
+    void shouldReturnTrueWhenOtherHasSameClass() {
+      assertThat(reference.isSameType(new ConcreteForumPoster()), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasDifferentClass() {
+      assertThat(reference.isSameType(mock(AbstractForumPoster.class)), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNull() {
+      assertThat(reference.isSameType(null), is(false));
+    }
+
+    private final class ConcreteForumPoster extends AbstractForumPoster {
+      private static final long serialVersionUID = -6649241125894154214L;
+
+      @Override
+      public boolean postTurnSummary(final String summary, final String subject) {
+        return false;
+      }
+
+      @Override
+      public IForumPoster doClone() {
+        return null;
+      }
+
+      @Override
+      public boolean supportsSaveGame() {
+        return false;
+      }
+
+      @Override
+      public String getDisplayName() {
+        return null;
+      }
+
+      @Override
+      public void viewPosted() {}
+
+      @Override
+      public String getTestMessage() {
+        return null;
+      }
+
+      @Override
+      public String getHelpText() {
+        return null;
+      }
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/pbem/GenericEmailSenderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/pbem/GenericEmailSenderTest.java
@@ -1,30 +1,34 @@
 package games.strategy.engine.pbem;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-
 final class GenericEmailSenderTest {
   @Nested
-  final class EqualsAndHashCodeTest {
+  final class IsSameTypeTest {
+    private final GenericEmailSender reference = new ConcreteEmailSender();
+
     @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(GenericEmailSender.class)
-          .usingGetClass()
-          .withIgnoredFields(
-              "alsoPostAfterCombatMove",
-              "credentialsProtected",
-              "credentialsSaved",
-              "encryption",
-              "host",
-              "password",
-              "port",
-              "subjectPrefix",
-              "timeout",
-              "toAddress",
-              "username")
-          .verify();
+    void shouldReturnTrueWhenOtherHasSameClass() {
+      assertThat(reference.isSameType(new ConcreteEmailSender()), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasDifferentClass() {
+      assertThat(reference.isSameType(mock(GenericEmailSender.class)), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNull() {
+      assertThat(reference.isSameType(null), is(false));
+    }
+
+    private final class ConcreteEmailSender extends GenericEmailSender {
+      private static final long serialVersionUID = 9167992793666878829L;
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/pbem/GenericEmailSenderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/pbem/GenericEmailSenderTest.java
@@ -1,0 +1,30 @@
+package games.strategy.engine.pbem;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class GenericEmailSenderTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(GenericEmailSender.class)
+          .usingGetClass()
+          .withIgnoredFields(
+              "alsoPostAfterCombatMove",
+              "credentialsProtected",
+              "credentialsSaved",
+              "encryption",
+              "host",
+              "password",
+              "port",
+              "subjectPrefix",
+              "timeout",
+              "toAddress",
+              "username")
+          .verify();
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
@@ -4,27 +4,40 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 final class InternalDiceServerTest {
-  private final InternalDiceServer internalDiceServer = new InternalDiceServer();
-
   @Nested
-  final class EqualsAndHashCodeTest {
+  final class IsSameTypeTest {
+    private final InternalDiceServer reference = new InternalDiceServer();
+
     @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(InternalDiceServer.class).verify();
+    void shouldReturnTrueWhenOtherHasSameClass() {
+      assertThat(reference.isSameType(new InternalDiceServer()), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasDifferentClass() {
+      assertThat(reference.isSameType(mock(IBean.class)), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNull() {
+      assertThat(reference.isSameType(null), is(false));
     }
   }
 
   @Nested
   final class GetDiceTest {
+    private final InternalDiceServer internalDiceServer = new InternalDiceServer();
+
     private Integer[] getDice(final String string) {
       final int ignoredCount = -1;
       return Arrays.stream(internalDiceServer.getDice(string, ignoredCount)).boxed().toArray(Integer[]::new);

--- a/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/InternalDiceServerTest.java
@@ -10,8 +10,18 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 final class InternalDiceServerTest {
   private final InternalDiceServer internalDiceServer = new InternalDiceServer();
+
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(InternalDiceServer.class).verify();
+    }
+  }
 
   @Nested
   final class GetDiceTest {

--- a/game-core/src/test/java/games/strategy/engine/random/PropertiesDiceRollerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/PropertiesDiceRollerTest.java
@@ -1,27 +1,45 @@
 package games.strategy.engine.random;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
 import java.util.Properties;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 final class PropertiesDiceRollerTest {
   @Nested
-  final class EqualsAndHashCodeTest {
-    @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(PropertiesDiceRoller.class)
-          .withOnlyTheseFields("props")
-          .withPrefabValues(Properties.class, newProperties("red"), newProperties("black"))
-          .verify();
-    }
-    
-    private Properties newProperties(final String name) {
+  final class IsSameTypeTest {
+    private final PropertiesDiceRoller reference = new PropertiesDiceRoller(newProperties("name1"));
+
+    private Properties newProperties(final String displayName) {
       final Properties properties = new Properties();
-      properties.put(PropertiesDiceRoller.PropertyKeys.NAME, name);
+      properties.put(PropertiesDiceRoller.PropertyKeys.DISPLAY_NAME, displayName);
       return properties;
+    }
+
+    @Test
+    void shouldReturnTrueWhenOtherHasSameClassAndDisplayName() {
+      assertThat(reference.isSameType(new PropertiesDiceRoller(newProperties("name1"))), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasSameClassButDifferentDisplayName() {
+      assertThat(reference.isSameType(new PropertiesDiceRoller(newProperties("name2"))), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherHasDifferentClass() {
+      assertThat(reference.isSameType(mock(IBean.class)), is(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOtherIsNull() {
+      assertThat(reference.isSameType(null), is(false));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/random/PropertiesDiceRollerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/random/PropertiesDiceRollerTest.java
@@ -1,0 +1,27 @@
+package games.strategy.engine.random;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class PropertiesDiceRollerTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(PropertiesDiceRoller.class)
+          .withOnlyTheseFields("props")
+          .withPrefabValues(Properties.class, newProperties("red"), newProperties("black"))
+          .verify();
+    }
+    
+    private Properties newProperties(final String name) {
+      final Properties properties = new Properties();
+      properties.put(PropertiesDiceRoller.PropertyKeys.NAME, name);
+      return properties;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsGetClass rule in `IBean` implementations.

**Note that there are two solutions proposed in this PR.**

The first commit is the straightforward fix of the `equals()` implementation.  However, this required suppressing two of the violations in abstract base classes because using `getClass()` was the right thing to do to achieve the desired `equals()` contract.  In order to add unit tests, I had to introduce some EqualsVerifier smells to accommodate our definition of `equals()` in `AbstractForumPoster` and `GenericEmailSender`.

The second commit (how this PR is proposed for merge) partially reverts #2526 and re-introduces a dedicated method on `IBean` to answer the question "is this bean the same _type_ as another?"  This results in cleaner tests and there is no longer a need to suppress any Error Prone warnings because we're not subverting the LSP in the `equals()` contract.

In the end, I don't think it really matters which solution we go with since `IBean` is slated for removal.  So, I'm happy to revert the second commit if the first is preferable in the short-term.

## Functional Changes

None.

## Manual Testing Performed

Verified re-loading a saved PBEM/PBF game correctly restored the previously selected dice server, forum poster, and email sender.  I did this with various combinations including the disabled forum/email poster/sender.