### PR TITLE
Error Prone: Fix EqualsGetClass violations in DefaultAttachment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ subprojects {
             '-Xep:CatchAndPrintStackTrace:ERROR',
             '-Xep:ClassCanBeStatic:ERROR',
             '-Xep:DefaultCharset:ERROR',
+            '-Xep:EqualsGetClass:ERROR',
             '-Xep:EqualsIncompatibleType:ERROR',
             '-Xep:EqualsUnsafeCast:ERROR',
             '-Xep:FutureReturnValueIgnored:ERROR',

--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -134,20 +134,21 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return Objects.hash(attachedTo, name);
   }
 
   @Override
-  public boolean equals(final Object obj) {
+  public final boolean equals(final Object obj) {
     if (this == obj) {
       return true;
-    }
-    if (obj == null || getClass() != obj.getClass()) {
+    } else if (!(obj instanceof DefaultAttachment)) {
       return false;
     }
+
     final DefaultAttachment other = (DefaultAttachment) obj;
-    return Objects.equals(Objects.toString(attachedTo, null), Objects.toString(other.attachedTo, null))
+    return getClass().equals(other.getClass())
+        && Objects.equals(Objects.toString(attachedTo, null), Objects.toString(other.attachedTo, null))
         && (Objects.equals(name, other.name) || this.toString().equals(other.toString()));
   }
 }


### PR DESCRIPTION
## Overview

Fixes violations of the Error Prone EqualsGetClass rule in the `DefaultAttachment` class.

Unfortunately, the fix employed in this PR is a bit redundant using both `instanceof` and `getClass()` comparisons, but that was the only way I could get rid of the violation without suppressing it.  I can go back to just a `getClass()` comparison if a `@SuppressWarnings` is acceptable.

## Functional Changes

None.

## Manual Testing Performed

None.  There are existing unit tests for `DefaultAttachment#equals()` that provide 100% line and branch coverage.  Those tests continue to pass after this change with no reduction in coverage.