### PR TITLE
Move UnifiedMessengerHub#waitForNodesToImplement() to test code 

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.23'
 
     testImplementation project(':test-common')
+    testImplementation 'org.awaitility:awaitility:3.1.3'
     testImplementation "org.sonatype.goodies:goodies-prefs:$sonatypeGoodiesPrefsVersion"
 }
 

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import games.strategy.engine.message.unifiedmessenger.HasEndPointImplementor;
 import games.strategy.engine.message.unifiedmessenger.NoLongerHasEndPointImplementor;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
@@ -18,13 +16,11 @@ import games.strategy.net.IMessageListener;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
-import games.strategy.util.Interruptibles;
 
 /**
  * The hub node in a spoke-hub messaging architecture.
  */
 public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeListener {
-  private static final int NODE_IMPLEMENTATION_TIMEOUT = 200;
   private final UnifiedMessenger localUnified;
   // the messenger we are based on
   private final IMessenger messenger;
@@ -136,22 +132,6 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
         new SpokeInvoke(hubInvoke.methodCallId, hubInvoke.needReturnValues, hubInvoke.call, from);
     for (final INode node : remote) {
       send(invoke, node);
-    }
-  }
-
-  /**
-   * Wait for the messenger to know about the given endpoint.
-   *
-   * @deprecated testing code smell, should not be dependent upon wall clock timing, try to remove this method.
-   */
-  @VisibleForTesting
-  @Deprecated
-  public void waitForNodesToImplement(final String endPointName) {
-    final long endTime = NODE_IMPLEMENTATION_TIMEOUT + System.currentTimeMillis();
-    while (System.currentTimeMillis() < endTime && !hasImplementors(endPointName)) {
-      if (!Interruptibles.sleep(50)) {
-        return;
-      }
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -211,13 +211,23 @@ public class RemoteMessengerTest {
       final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
       final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
       clientRemoteMessenger.registerRemote(new TestRemote(), test);
-      serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
+      waitForNodesToImplement(serverUnifiedMessenger, test.getName());
       assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
       client.shutDown();
       Interruptibles.sleep(200);
       assertTrue(!serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
     } finally {
       shutdownServerAndClient(server, client);
+    }
+  }
+
+  private static void waitForNodesToImplement(final UnifiedMessenger unifiedMessenger, final String endPointName) {
+    final long timeoutInMilliseconds = 200L;
+    final long endTime = timeoutInMilliseconds + System.currentTimeMillis();
+    while (System.currentTimeMillis() < endTime && !unifiedMessenger.getHub().hasImplementors(endPointName)) {
+      if (!Interruptibles.sleep(50)) {
+        return;
+      }
     }
   }
 
@@ -244,7 +254,7 @@ public class RemoteMessengerTest {
         Interruptibles.await(testCompleteSignal);
       };
       clientRemoteMessenger.registerRemote(foo, test);
-      serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
+      waitForNodesToImplement(serverUnifiedMessenger, test.getName());
       assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
       final CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
         final IFoo remoteFoo = (IFoo) serverRemoteMessenger.getRemote(test);


### PR DESCRIPTION
## Overview

The `UnifiedMessengerHub#waitForNodesToImplement()` method is only used by test code.  So the primary purpose of this PR is to move it to the test source set because it doesn't need to be part of the `UnififiedMessengerHub` API.

Now that the method is in test code, I removed the `@Deprecated` annotation.  While it would be preferable to react to an event rather than polling the system, we poll in many other places of test code, such that deprecating this one (now private) method would be inconsistent.

The second commit goes a step further and introduces the [Awaitility](https://github.com/awaitility/awaitility) library to replace the custom polling code previously part of `waitForNodesToImplement()`.  There are plenty of other places in test code where we have such polling code, and Awaitility seems to be perfectly suited for this purpose.  If taking on a new test dependency at this time is undesirable, I can revert the second commit, as the first commit fulfills the purpose of this PR.

## Functional Changes

None.


## Manual Testing Performed

None.

## Additional Review Notes

I removed the 200 ms timeout while waiting for the end point to be implemented.  It seemed rather arbitrary, there is no timing requirement under test, and it just made the code noisier to read.  Awaitility uses a default 10 second timeout.  I figured that as long as the test fails if the timeout is exceeded, that's all that really matters.