### PR TITLE
Auto Kill logic looking at attack value rather than defense

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1155,7 +1155,7 @@ public class BattleTracker implements Serializable {
       final List<Unit> defenders = new ArrayList<>(battle.getDefendingUnits());
       final List<Unit> sortedUnitsList = getSortedDefendingUnits(bridge, gameData, territory, defenders);
       if (getDependentOn(battle).isEmpty() && DiceRoll.getTotalPower(
-          DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, false, gameData,
+          DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, true, gameData,
               territory, TerritoryEffectHelper.getEffects(territory), false, null),
           gameData) == 0) {
         battle.fight(bridge);
@@ -1171,8 +1171,8 @@ public class BattleTracker implements Serializable {
   private static List<Unit> getSortedDefendingUnits(final IDelegateBridge bridge, final GameData gameData,
       final Territory territory, final List<Unit> defenders) {
     final List<Unit> sortedUnitsList = new ArrayList<>(CollectionUtils.getMatches(defenders,
-        Matches.unitCanBeInBattle(true, !territory.isWater(), 1, false, true, true)));
-    sortedUnitsList.sort(new UnitBattleComparator(false, TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
+        Matches.unitCanBeInBattle(false, !territory.isWater(), 1, false, true, true)));
+    sortedUnitsList.sort(new UnitBattleComparator(true, TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
         TerritoryEffectHelper.getEffects(territory), gameData, false, false));
     Collections.reverse(sortedUnitsList);
     return sortedUnitsList;


### PR DESCRIPTION
## Overview
Shouldn't fight transports automatically on the basis that they're defenseless when they are attack-less.

Thought I'd fixed this bug over a year ago. Perhaps it was lost, perhaps never merged, perhaps re-introduced.

## Functional Changes
Was looking at attack value rather than defense value to find if a unit should be automatically fought on the basis that it is defenseless. Now looks at defense value, which is correct.


## Manual Testing Performed
- .. Tested that auto combats were no longer triggered on Classic.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
