### PR TITLE
Refactor delegate normal battle classes

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -1,7 +1,11 @@
 package games.strategy.triplea.delegate;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
@@ -14,24 +18,36 @@ import games.strategy.engine.data.Unit;
  */
 public abstract class DependentBattle extends AbstractBattle {
   private static final long serialVersionUID = 9119442509652443015L;
+  protected Map<Territory, Collection<Unit>> attackingFromMap;
+  protected Set<Territory> attackingFrom;
+  private Collection<Territory> amphibiousAttackFrom;
 
   DependentBattle(final Territory battleSite, final PlayerId attacker, final BattleTracker battleTracker,
       final GameData data) {
     super(battleSite, attacker, battleTracker, false, BattleType.NORMAL, data);
+    attackingFromMap = new HashMap<>();
+    attackingFrom = new HashSet<>();
+    amphibiousAttackFrom = new ArrayList<>();
   }
 
   /**
    * Return attacking from Collection.
    */
-  public abstract Collection<Territory> getAttackingFrom();
+  public Collection<Territory> getAttackingFrom() {
+    return attackingFrom;
+  }
 
   /**
    * Return attacking from Map.
    */
-  public abstract Map<Territory, Collection<Unit>> getAttackingFromMap();
+  public Map<Territory, Collection<Unit>> getAttackingFromMap() {
+    return attackingFromMap;
+  }
 
   /**
    * Returns territories where there are amphibious attacks.
    */
-  public abstract Collection<Territory> getAmphibiousAttackTerritories();
+  public Collection<Territory> getAmphibiousAttackTerritories() {
+    return amphibiousAttackFrom;
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -88,10 +88,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private static final long serialVersionUID = 5879502298361231540L;
 
   // maps Territory-> units (stores a collection of who is attacking from where, needed for undoing moves)
-  private Map<Territory, Collection<Unit>> attackingFromMap = new HashMap<>();
   private final Collection<Unit> attackingWaitingToDie = new ArrayList<>();
-  private Set<Territory> attackingFrom = new HashSet<>();
-  private final Collection<Territory> amphibiousAttackFrom = new ArrayList<>();
   private final Collection<Unit> defendingWaitingToDie = new ArrayList<>();
   // keep track of all the units that die in the battle to show in the history window
   private final Collection<Unit> killed = new ArrayList<>();
@@ -2705,21 +2702,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       battleTracker.removeBattle(this, gameData);
     }
-  }
-
-  @Override
-  public Collection<Territory> getAttackingFrom() {
-    return attackingFrom;
-  }
-
-  @Override
-  public Map<Territory, Collection<Unit>> getAttackingFromMap() {
-    return attackingFromMap;
-  }
-
-  @Override
-  public Collection<Territory> getAmphibiousAttackTerritories() {
-    return amphibiousAttackFrom;
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.delegate;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,16 +28,9 @@ import games.strategy.util.CollectionUtils;
 public class NonFightingBattle extends DependentBattle {
   private static final long serialVersionUID = -1699534010648145123L;
 
-  private final Set<Territory> attackingFrom;
-  private final Collection<Territory> amphibiousAttackFrom;
-  private final Map<Territory, Collection<Unit>> attackingFromMap;
-
   public NonFightingBattle(final Territory battleSite, final PlayerId attacker, final BattleTracker battleTracker,
       final GameData data) {
     super(battleSite, attacker, battleTracker, data);
-    attackingFromMap = new HashMap<>();
-    attackingFrom = new HashSet<>();
-    amphibiousAttackFrom = new ArrayList<>();
   }
 
   @Override
@@ -159,20 +150,5 @@ public class NonFightingBattle extends DependentBattle {
     for (final Map.Entry<Unit, Collection<Unit>> entry : dependencies.entrySet()) {
       dependentUnits.computeIfAbsent(entry.getKey(), k -> new LinkedHashSet<>()).addAll(entry.getValue());
     }
-  }
-
-  @Override
-  public Collection<Territory> getAttackingFrom() {
-    return attackingFrom;
-  }
-
-  @Override
-  public Map<Territory, Collection<Unit>> getAttackingFromMap() {
-    return attackingFromMap;
-  }
-
-  @Override
-  public Collection<Territory> getAmphibiousAttackTerritories() {
-    return amphibiousAttackFrom;
   }
 }


### PR DESCRIPTION
## Overview
Could not be done on 1.9 because it broke serialisation. 

## Functional Changes
None. Just refactored the code line.

## Manual Testing Performed
- .. Saved mid-battle in classic. Re-loaded ok.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Was attempted in #1583 but did in fact break serialisation for save games but not networked games.

Can be done properly now.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
