### PR TITLE
Move game setting display sensitivity concern to UI layer

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -113,16 +113,12 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
   public static final ClientSetting<String> loggingVerbosity =
       new StringClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
-  public static final ClientSetting<String> emailServerHost =
-      new StringClientSetting("EMAIL_SERVER_HOST");
-  public static final ClientSetting<Integer> emailServerPort =
-      new IntegerClientSetting("EMAIL_SERVER_PORT");
+  public static final ClientSetting<String> emailServerHost = new StringClientSetting("EMAIL_SERVER_HOST");
+  public static final ClientSetting<Integer> emailServerPort = new IntegerClientSetting("EMAIL_SERVER_PORT");
   public static final ClientSetting<Boolean> emailServerSecurity =
       new BooleanClientSetting("EMAIL_SERVER_SECURITY", true);
-  public static final ClientSetting<char[]> emailUsername =
-      new ProtectedStringClientSetting("EMAIL_USERNAME", false);
-  public static final ClientSetting<char[]> emailPassword =
-      new ProtectedStringClientSetting("EMAIL_PASSWORD", true);
+  public static final ClientSetting<char[]> emailUsername = new ProtectedStringClientSetting("EMAIL_USERNAME");
+  public static final ClientSetting<char[]> emailPassword = new ProtectedStringClientSetting("EMAIL_PASSWORD");
 
   private static final AtomicReference<Preferences> preferencesRef = new AtomicReference<>();
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -61,10 +60,4 @@ public interface GameSetting<T> {
    * Unregisters {@code listener} to no longer receive a notification whenever the setting value has changed.
    */
   void removeListener(Consumer<GameSetting<T>> listener);
-
-
-
-  default String getDisplayValue() {
-    return Objects.toString(getValue().orElse(null));
-  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ProtectedStringClientSetting.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.Arrays;
-
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.security.CredentialManager;
@@ -12,12 +10,8 @@ import games.strategy.util.function.ThrowingBiFunction;
  * ClientSetting to store encrypted versions of potentially sensitive Strings.
  */
 final class ProtectedStringClientSetting extends ClientSetting<char[]> {
-
-  private final boolean sensitive;
-
-  ProtectedStringClientSetting(final String name, final boolean sensitive) {
+  ProtectedStringClientSetting(final String name) {
     super(char[].class, name);
-    this.sensitive = sensitive;
   }
 
   @Override
@@ -59,14 +53,5 @@ final class ProtectedStringClientSetting extends ClientSetting<char[]> {
     } catch (final CredentialManagerException e) {
       throw new ValueEncodingException("Error while trying to unprotect string '" + encodedValue + "'", e);
     }
-  }
-
-  @Override
-  public String getDisplayValue() {
-    final char[] string = getValue().orElse(new char[0]);
-    if (sensitive) {
-      Arrays.fill(string, '*');
-    }
-    return new String(string);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -35,12 +35,41 @@ public interface SelectionComponent<T> {
    */
   interface SaveContext {
     /**
-     * Sets the value for the specified game setting. Selection components must call this method to change a setting
-     * value and must not call {@link GameSetting#setValue(Object)} directly.
+     * Sets the insensitive value for the specified game setting. Selection components must call this method to change a
+     * setting value and must not call {@link GameSetting#setValue(Object)} directly.
      *
      * @param gameSetting The game setting whose value is to be set.
      * @param value The new setting value or {@code null} to clear the setting value.
      */
-    <T> void setValue(GameSetting<T> gameSetting, @Nullable T value);
+    default <T> void setValue(GameSetting<T> gameSetting, @Nullable T value) {
+      setValue(gameSetting, value, ValueSensitivity.INSENSITIVE);
+    }
+
+    /**
+     * Sets the value with the specified sensitivity for the specified game setting. Selection components must call this
+     * method to change a setting value and must not call {@link GameSetting#setValue(Object)} directly.
+     *
+     * @param gameSetting The game setting whose value is to be set.
+     * @param value The new setting value or {@code null} to clear the setting value.
+     * @param valueSensitivity The sensitivity of the new setting value to disclosure. Use
+     *        {@link ValueSensitivity#INSENSITIVE} if the value can be displayed to the user in the UI; otherwise use
+     *        {@link ValueSensitivity#SENSITIVE} if the value should be masked before it is displayed to the user.
+     */
+    <T> void setValue(GameSetting<T> gameSetting, @Nullable T value, ValueSensitivity valueSensitivity);
+
+    /**
+     * The sensitivity of a value to disclosure in the UI.
+     */
+    enum ValueSensitivity {
+      /**
+       * The value is not sensitive and may be displayed in the UI.
+       */
+      INSENSITIVE,
+
+      /**
+       * The value is sensitive and will be masked when displayed in the UI.
+       */
+      SENSITIVE;
+    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -542,7 +542,10 @@ final class SelectionComponentFactory {
         context.setValue(usernameSetting, username.isEmpty() ? null : username.toCharArray());
         withSensitiveArray(
             passwordField::getPassword,
-            password -> context.setValue(passwordSetting, (password.length == 0) ? null : password));
+            password -> context.setValue(
+                passwordSetting,
+                (password.length == 0) ? null : password,
+                SaveContext.ValueSensitivity.SENSITIVE));
       }
 
       @Override

--- a/game-core/src/test/java/games/strategy/triplea/settings/ProtectedStringClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ProtectedStringClientSettingTest.java
@@ -15,23 +15,7 @@ import games.strategy.security.CredentialManager;
 import games.strategy.security.CredentialManagerException;
 
 final class ProtectedStringClientSettingTest {
-  private final ProtectedStringClientSetting clientSetting = new ProtectedStringClientSetting("name", false);
-
-  @Nested
-  final class GetDisplayValueTest extends AbstractClientSettingTestCase {
-    @Test
-    void shouldReturnUnmaskedValueWhenNotSensitive() {
-      clientSetting.setValue("$eCrEt".toCharArray());
-      assertThat(clientSetting.getDisplayValue(), is("$eCrEt"));
-    }
-
-    @Test
-    void shouldReturnMaskedValueWhenSensitive() {
-      final ProtectedStringClientSetting clientSetting = new ProtectedStringClientSetting("name", true);
-      clientSetting.setValue("$eCrEt".toCharArray());
-      assertThat(clientSetting.getDisplayValue(), is("******"));
-    }
-  }
+  private final ProtectedStringClientSetting clientSetting = new ProtectedStringClientSetting("name");
 
   @Nested
   final class EncodeValueTest {

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -1,5 +1,8 @@
 package games.strategy.triplea.settings;
 
+import static games.strategy.triplea.settings.SaveFunction.toDisplayString;
+import static games.strategy.triplea.settings.SelectionComponent.SaveContext.ValueSensitivity.INSENSITIVE;
+import static games.strategy.triplea.settings.SelectionComponent.SaveContext.ValueSensitivity.SENSITIVE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
@@ -18,6 +21,7 @@ import java.util.function.Consumer;
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,90 +29,172 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.util.concurrent.Runnables;
 
-@ExtendWith(MockitoExtension.class)
 final class SaveFunctionTest {
-  @Mock
-  private SelectionComponent<JComponent> mockSelectionComponent;
-  @Mock
-  private SelectionComponent<JComponent> mockSelectionComponent2;
-  @Mock
-  private GameSetting<String> mockSetting;
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class SaveSettingsTest {
+    @Mock
+    private SelectionComponent<JComponent> mockSelectionComponent;
+    @Mock
+    private SelectionComponent<JComponent> mockSelectionComponent2;
+    @Mock
+    private GameSetting<String> mockSetting;
 
-  @Test
-  void messageOnValidIsInformation() {
-    givenValidationResults(true, true);
+    @Test
+    void messageOnValidIsInformation() {
+      givenValidationResults(true, true);
 
-    final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
+      final SaveFunction.SaveResult result = SaveFunction.saveSettings(
+          Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
-    assertThat("There will always be a message back to the user", result.message, is(not(emptyString())));
-    assertThat("All valid, message type should informational", result.dialogType, is(JOptionPane.INFORMATION_MESSAGE));
-  }
-
-  private void givenValidationResults(final boolean first, final boolean second) {
-    when(mockSelectionComponent.isValid()).thenReturn(first);
-    whenSelectionComponentSave(mockSelectionComponent, context -> context.setValue(mockSetting, TestData.fakeValue));
-    if (first) {
-      when(mockSetting.getValue()).thenReturn(Optional.empty());
+      assertThat("There will always be a message back to the user", result.message, is(not(emptyString())));
+      assertThat("All valid, message type should informational", result.dialogType,
+          is(JOptionPane.INFORMATION_MESSAGE));
     }
 
-    when(mockSelectionComponent2.isValid()).thenReturn(second);
-    whenSelectionComponentSave(mockSelectionComponent2, context -> context.setValue(mockSetting, "abc"));
+    private void givenValidationResults(final boolean first, final boolean second) {
+      when(mockSelectionComponent.isValid()).thenReturn(first);
+      whenSelectionComponentSave(mockSelectionComponent, context -> context.setValue(mockSetting, TestData.fakeValue));
+      if (first) {
+        when(mockSetting.getValue()).thenReturn(Optional.empty());
+      }
+
+      when(mockSelectionComponent2.isValid()).thenReturn(second);
+      whenSelectionComponentSave(mockSelectionComponent2, context -> context.setValue(mockSetting, "abc"));
+    }
+
+    private void whenSelectionComponentSave(
+        final SelectionComponent<?> selectionComponent,
+        final Consumer<SelectionComponent.SaveContext> action) {
+      doAnswer(invocation -> {
+        final SelectionComponent.SaveContext context = (SelectionComponent.SaveContext) invocation.getArgument(0);
+        action.accept(context);
+        return null;
+      }).when(selectionComponent).save(any(SelectionComponent.SaveContext.class));
+    }
+
+    @Test
+    void messageOnNotValidResultIsWarning() {
+      givenValidationResults(false, false);
+
+      final SaveFunction.SaveResult result = SaveFunction.saveSettings(
+          Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
+
+      assertThat(result.message, is(not(emptyString())));
+      assertThat(result.dialogType, is(JOptionPane.WARNING_MESSAGE));
+    }
+
+    @Test
+    void messageOnMixedResultIsWarning() {
+      givenValidationResults(true, false);
+
+      final SaveFunction.SaveResult result = SaveFunction.saveSettings(
+          Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
+
+      assertThat(result.message, is(not(emptyString())));
+      assertThat("At least one value was not updated, should be warning message type",
+          result.dialogType, is(JOptionPane.WARNING_MESSAGE));
+    }
+
+    @Test
+    void valueSavedWhenValid(@Mock final Runnable flushSettingsAction) {
+      when(mockSelectionComponent.isValid()).thenReturn(true);
+      whenSelectionComponentSave(mockSelectionComponent, context -> context.setValue(mockSetting, TestData.fakeValue));
+      when(mockSetting.getValue()).thenReturn(Optional.empty());
+      when(mockSelectionComponent2.isValid()).thenReturn(false);
+
+      SaveFunction.saveSettings(Arrays.asList(mockSelectionComponent, mockSelectionComponent2), flushSettingsAction);
+
+      verify(flushSettingsAction).run();
+      verify(mockSetting).setValue(TestData.fakeValue);
+    }
+
+    @Test
+    void noSettingsSavedIfAllInvalid(@Mock final Runnable flushSettingsAction) {
+      when(mockSelectionComponent.isValid()).thenReturn(false);
+
+      SaveFunction.saveSettings(Collections.singletonList(mockSelectionComponent), flushSettingsAction);
+
+      verify(flushSettingsAction, never()).run();
+    }
   }
 
-  private static void whenSelectionComponentSave(
-      final SelectionComponent<?> selectionComponent,
-      final Consumer<SelectionComponent.SaveContext> action) {
-    doAnswer(invocation -> {
-      final SelectionComponent.SaveContext context = (SelectionComponent.SaveContext) invocation.getArgument(0);
-      action.accept(context);
-      return null;
-    }).when(selectionComponent).save(any(SelectionComponent.SaveContext.class));
-  }
+  @Nested
+  final class ToDisplayStringTest {
+    @Nested
+    final class WhenValueIsNull {
+      @Test
+      void shouldReturnDefaultValueWhenInsensitiveAndDefaultValueIsNotNull() {
+        assertThat(toDisplayString(null, "value", INSENSITIVE), is("<default> (value)"));
+      }
 
-  @Test
-  void messageOnNotValidResultIsWarning() {
-    givenValidationResults(false, false);
+      @Test
+      void shouldReturnUnsetWhenInsensitiveAndDefaultValueIsNull() {
+        assertThat(toDisplayString(null, null, INSENSITIVE), is("<unset>"));
+      }
 
-    final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
+      @Test
+      void shouldReturnMaskedDefaultValueWhenSenstiveAndDefaultValueIsNotNull() {
+        assertThat(toDisplayString(null, "value", SENSITIVE), is("<default> (*****)"));
+      }
 
-    assertThat(result.message, is(not(emptyString())));
-    assertThat(result.dialogType, is(JOptionPane.WARNING_MESSAGE));
-  }
+      @Test
+      void shouldReturnUnsetWhenSensitiveAndDefaultValueIsNull() {
+        assertThat(toDisplayString(null, null, SENSITIVE), is("<unset>"));
+      }
+    }
 
-  @Test
-  void messageOnMixedResultIsWarning() {
-    givenValidationResults(true, false);
+    @Nested
+    final class WhenValueEqualsDefaultValue {
+      @Test
+      void shouldReturnDefaultValueWhenInsensitive() {
+        assertThat(toDisplayString("value", "value", INSENSITIVE), is("<default> (value)"));
+      }
 
-    final SaveFunction.SaveResult result = SaveFunction.saveSettings(
-        Arrays.asList(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
+      @Test
+      void shouldReturnMaskedDefaultValueWhenSenstive() {
+        assertThat(toDisplayString("value", "value", SENSITIVE), is("<default> (*****)"));
+      }
+    }
 
-    assertThat(result.message, is(not(emptyString())));
-    assertThat("At least one value was not updated, should be warning message type",
-        result.dialogType, is(JOptionPane.WARNING_MESSAGE));
-  }
+    @Nested
+    final class WhenValueTypeIsString {
+      @Test
+      void shouldReturnValueWhenInsensitive() {
+        assertThat(toDisplayString("value", null, INSENSITIVE), is("value"));
+      }
 
-  @Test
-  void valueSavedWhenValid(@Mock final Runnable flushSettingsAction) {
-    when(mockSelectionComponent.isValid()).thenReturn(true);
-    whenSelectionComponentSave(mockSelectionComponent, context -> context.setValue(mockSetting, TestData.fakeValue));
-    when(mockSetting.getValue()).thenReturn(Optional.empty());
-    when(mockSelectionComponent2.isValid()).thenReturn(false);
+      @Test
+      void shouldReturnMaskedValueWhenSenstive() {
+        assertThat(toDisplayString("value", null, SENSITIVE), is("*****"));
+      }
+    }
 
-    SaveFunction.saveSettings(Arrays.asList(mockSelectionComponent, mockSelectionComponent2), flushSettingsAction);
+    @Nested
+    final class WhenValueTypeIsCharArray {
+      @Test
+      void shouldReturnValueWhenInsensitive() {
+        assertThat(toDisplayString(new char[] {'v', 'a', 'l', 'u', 'e'}, null, INSENSITIVE), is("value"));
+      }
 
-    verify(flushSettingsAction).run();
-    verify(mockSetting).setValue(TestData.fakeValue);
-  }
+      @Test
+      void shouldReturnMaskedValueWhenSenstive() {
+        assertThat(toDisplayString(new char[] {'v', 'a', 'l', 'u', 'e'}, null, SENSITIVE), is("*****"));
+      }
+    }
 
-  @Test
-  void noSettingsSavedIfAllInvalid(@Mock final Runnable flushSettingsAction) {
-    when(mockSelectionComponent.isValid()).thenReturn(false);
+    @Nested
+    final class WhenValueTypeIsOther {
+      @Test
+      void shouldReturnValueWhenInsensitive() {
+        assertThat(toDisplayString(42, null, INSENSITIVE), is("42"));
+      }
 
-    SaveFunction.saveSettings(Collections.singletonList(mockSelectionComponent), flushSettingsAction);
-
-    verify(flushSettingsAction, never()).run();
+      @Test
+      void shouldReturnMaskedValueWhenSenstive() {
+        assertThat(toDisplayString(42, null, SENSITIVE), is("**"));
+      }
+    }
   }
 
   private interface TestData {

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -121,7 +121,10 @@ class SettingsPane extends StackPane {
   private void save() {
     final SelectionComponent.SaveContext context = new SelectionComponent.SaveContext() {
       @Override
-      public <T> void setValue(final GameSetting<T> gameSetting, final @Nullable T value) {
+      public <T> void setValue(
+          final GameSetting<T> gameSetting,
+          final @Nullable T value,
+          final SelectionComponent.SaveContext.ValueSensitivity valueSensitivity) {
         gameSetting.setValue(value);
       }
     };


### PR DESCRIPTION
## Overview

Moves the `GameSetting` display sensitivity concern from `GameSetting` itself to the UI layer, as discussed in https://github.com/triplea-game/triplea/pull/4349#discussion_r234394519.  Also improves the UI to better indicate when a setting is reset to the default value, including the case where there is no default value and the value is effectively unset.

## Functional Changes

* When resetting a setting with a default value, the confirmation message now indicates this with a `<default>` label.
* When resetting a setting without a default value, the confirmation message now says `<unset>` instead of `null` or an empty string.

See the screenshots below for examples.  Happy to entertain changes to the format strings.  The `<default>` label may be overkill and possibly information overload for the user.

## Refactoring Changes

* Removed the `GameSetting#getDisplayValue()` method.
* Added a new parameter to `SelectionComponent$SaveContext#setValue()` that indicates whether the value is sensitive or not.

## Manual Testing Performed

Smoke tested setting and resetting various settings in the Engine Preferences dialog.

## Before & After Screen Shots

### Before

![settings-lobby-reset-before](https://user-images.githubusercontent.com/4826349/49389068-737f2b80-f6f3-11e8-86c6-4579baf47ca7.png)

![settings-pbem-reset-before](https://user-images.githubusercontent.com/4826349/49389062-6f530e00-f6f3-11e8-9825-9e2ba63ca57b.png)

![settings-saves-reset-before](https://user-images.githubusercontent.com/4826349/49389083-79750c80-f6f3-11e8-8355-46274992b073.png)

### After

![settings-lobby-reset-after](https://user-images.githubusercontent.com/4826349/49389091-7ed25700-f6f3-11e8-9d52-d8a05950b3b2.png)

![settings-pbem-reset-after](https://user-images.githubusercontent.com/4826349/49389100-81cd4780-f6f3-11e8-9b70-9440c471e192.png)

![settings-saves-reset-after](https://user-images.githubusercontent.com/4826349/49389110-84c83800-f6f3-11e8-931e-92dc164edd32.png)

## Additional Review Notes

Please view with whitespace changes ignored as there were some indentation changes in `SaveFunctionTest`.