### PR TITLE
Allow check-in of IDEA run configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .classpath
 .gradle
-.idea
+.idea/*
+!.idea/runConfigurations
 .project
 .remote-libs/
 .settings

--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
+    <module name="game-headed_main" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="org.triplea.game.client.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/LobbyRunner.xml
+++ b/.idea/runConfigurations/LobbyRunner.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LobbyRunner" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="org.triplea.lobby.server.LobbyRunner" />
+    <module name="lobby_main" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/lobby" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="org.triplea.lobby.server.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
## Overview


Included are two initial run configurations files.
Yet to be included would be a third for bot, that is left out of scope
for now.

Changes:
1. Unignore .idea/runConfigurations folder
2. Check-in launchers for: headed runner and lobby

To unignore the '.idea/runConfigurations' folder we must first ignore the children of the '.idea' folder and not the '.idea' folder itself. From the [git-documentation](https://git-scm.com/docs/gitignore)

> "It is not possible to re-include a file if a parent directory of that
file is excluded."

Next, we add a "re-include" rule to add back anything in the
'.idea/runConfigurations' folder, which is where IDEA places its shared
run configuration files. FWIW: It does not seem there is a way to change this
location (which is perhaps just as well as run configurations have not
changed that often after being checked in)

Discussion:
- While an IDEA plugin can be used to read eclipse launcher files, we do
not have a lot of launchers, it's cheap to create the run
configurations, and the plugin is not necessarily seemless to use and
adds extra overhead compared to checking in run-configurations every now
and then. In other words, I've found it's quite a bit easier to manually re-create run
configurations than it is to wire up the plugin. At that rate we would
just as well check in these files.



## Functional Changes

- None to game
- Should be transparent to developers using eclipse
- Developers using IDEA will gain pre-configured launchers

## Manual Testing Performed
- Run configurations work. The lobby run configuration out of the box does not work, it needs a working path set to 'triplea/lobby' 

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

Just a hovertext, no run configurations
![screenshot from 2018-12-03 23-17-09](https://user-images.githubusercontent.com/12397753/49425144-95a79680-f751-11e8-8d19-9d1978b35a7e.png)

### After

Run configuration drop-down has two entries in it:
![screenshot from 2018-12-03 23-15-55](https://user-images.githubusercontent.com/12397753/49425094-790b5e80-f751-11e8-939c-2b949b5a477a.png)
