### PR TITLE
Display Java version on main screen

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -13,14 +13,14 @@ import games.strategy.triplea.settings.ClientSetting;
  * Utility class containing swing logic to show a file prompt to user. Used for selecting saved games.
  */
 public final class GameFileSelector {
-  private GameFileSelector() {
-
-  }
+  private GameFileSelector() {}
 
   /**
    * Opens up a UI pop-up allowing user to select a game file. Returns nothing if user closes the pop-up.
    */
   public static Optional<File> selectGameFile() {
+    // For some strange reason, the only way to get a Mac OS X native-style file dialog
+    // is to use an AWT FileDialog instead of a Swing JDialog
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = GameRunner.newFileDialog();
       fileDialog.setMode(FileDialog.LOAD);
@@ -29,12 +29,10 @@ public final class GameFileSelector {
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();
       final String dirName = fileDialog.getDirectory();
-
-
       return Optional.ofNullable(fileName)
           .map(name -> new File(dirName, fileName));
     }
+
     return GameRunner.showSaveGameFileChooser();
   }
-
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -265,8 +265,6 @@ public final class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void selectSavedGameFile() {
-    // For some strange reason, the only way to get a Mac OS X native-style file dialog
-    // is to use an AWT FileDialog instead of a Swing JDialog
     GameFileSelector.selectGameFile()
         .ifPresent(file -> Interruptibles
             .await(() -> GameRunner.newBackgroundTaskRunner().runInBackground("Loading savegame...", () -> {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -29,6 +29,7 @@ import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.ui.FileBackedGamePropertiesCache;
 import games.strategy.engine.framework.startup.ui.IGamePropertiesCache;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.ui.SwingAction;
@@ -38,8 +39,9 @@ import swinglib.JButtonBuilder;
 /**
  * Left hand side panel of the launcher screen that has various info, like selected game and engine version.
  */
-public class GameSelectorPanel extends JPanel implements Observer {
+public final class GameSelectorPanel extends JPanel implements Observer {
   private static final long serialVersionUID = -4598107601238030020L;
+
   private final GameSelectorModel model;
   private final IGamePropertiesCache gamePropertiesCache = new FileBackedGamePropertiesCache();
   private final Map<String, Object> originalPropertiesMap = new HashMap<>();
@@ -71,37 +73,41 @@ public class GameSelectorPanel extends JPanel implements Observer {
     }
 
     setLayout(new GridBagLayout());
-    add(new JLabel("Engine Version:"), buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
-    add(new JLabel(ClientContext.engineVersion().getExactVersion()), buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
 
-    add(new JLabel("Map Name:"), buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
-    add(nameText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
+    add(new JLabel("Java Version:"), buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
+    add(new JLabel(SystemProperties.getJavaRuntimeVersion()), buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
 
-    add(new JLabel("Map Version:"), buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
-    add(versionText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
+    add(new JLabel("Engine Version:"), buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
+    add(new JLabel(ClientContext.engineVersion().getExactVersion()), buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
 
-    add(new JLabel("Game Round:"), buildGridCell(0, 3, new Insets(0, 10, 3, 5)));
-    add(roundText, buildGridCell(1, 3, new Insets(0, 0, 3, 0)));
+    add(new JLabel("Map Name:"), buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
+    add(nameText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
 
-    add(new JLabel("File Name:"), buildGridCell(0, 4, new Insets(20, 10, 3, 5)));
+    add(new JLabel("Map Version:"), buildGridCell(0, 3, new Insets(0, 10, 3, 5)));
+    add(versionText, buildGridCell(1, 3, new Insets(0, 0, 3, 0)));
 
-    add(fileNameText, buildGridRow(0, 5, new Insets(0, 10, 3, 5)));
+    add(new JLabel("Game Round:"), buildGridCell(0, 4, new Insets(0, 10, 3, 5)));
+    add(roundText, buildGridCell(1, 4, new Insets(0, 0, 3, 0)));
 
-    add(loadNewGame, buildGridRow(0, 6, new Insets(25, 10, 10, 10)));
+    add(new JLabel("File Name:"), buildGridCell(0, 5, new Insets(20, 10, 3, 5)));
 
-    add(loadSavedGame, buildGridRow(0, 7, new Insets(0, 10, 10, 10)));
+    add(fileNameText, buildGridRow(0, 6, new Insets(0, 10, 3, 5)));
+
+    add(loadNewGame, buildGridRow(0, 7, new Insets(25, 10, 10, 10)));
+
+    add(loadSavedGame, buildGridRow(0, 8, new Insets(0, 10, 10, 10)));
 
     final JButton downloadMapButton = JButtonBuilder.builder()
         .title("Download Maps")
         .toolTip("Click this button to install additional maps")
         .actionListener(DownloadMapsWindow::showDownloadMapsWindow)
         .build();
-    add(downloadMapButton, buildGridRow(0, 8, new Insets(0, 10, 10, 10)));
+    add(downloadMapButton, buildGridRow(0, 9, new Insets(0, 10, 10, 10)));
 
-    add(gameOptions, buildGridRow(0, 9, new Insets(25, 10, 10, 10)));
+    add(gameOptions, buildGridRow(0, 10, new Insets(25, 10, 10, 10)));
 
     // spacer
-    add(new JPanel(), new GridBagConstraints(0, 10, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+    add(new JPanel(), new GridBagConstraints(0, 11, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
         new Insets(0, 0, 0, 0), 0, 0));
 
     loadNewGame.addActionListener(e -> {

--- a/game-core/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/SystemProperties.java
@@ -27,6 +27,10 @@ public final class SystemProperties {
     return checkNotNull(System.getProperty("java.home"));
   }
 
+  public static String getJavaRuntimeVersion() {
+    return checkNotNull(System.getProperty("java.runtime.version"));
+  }
+
   private static String getOsName() {
     return checkNotNull(System.getProperty("os.name"));
   }


### PR DESCRIPTION
## Overview

Addresses https://github.com/triplea-game/triplea/issues/4358#issuecomment-440570057.

During the discussion on the problems we're experiencing with older bundled JREs, it was suggested to include the Java version on the main screen.  This PR does that by simply displaying it above the engine version.  Please feel free to suggest alternate placement of this information, including not at all if the team feels there's a better way to address the aforementioned linked suggestion.

## Functional Changes

The value of the `java.runtime.version` system property is now displayed on the main screen.

## Refactoring Changes

In the second commit, I moved a comment from `GameSelectorPanel` to `GameFileSelector` that appeared to have been left behind when the latter class was extracted.

## Manual Testing Performed

Verified the visual placement of the Java version displayed on the main screen.

## Screen Shots

![main-screen-java-version-after](https://user-images.githubusercontent.com/4826349/49526971-ea94fb00-f87e-11e8-8df6-ee84ad9e781e.png)

/cc: @panther2 