### PR TITLE
Rename IChannelSubscribor -> IChannelSubscriber

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -78,7 +78,7 @@ public class Chat {
     // this all seems a lot more involved than it needs to be.
     final IChatController controller = (IChatController) messengers.getRemoteMessenger()
         .getRemote(ChatController.getChatControlerRemoteName(chatName));
-    messengers.getChannelMessenger().registerChannelSubscriber(chatChannelSubscribor,
+    messengers.getChannelMessenger().registerChannelSubscriber(chatChannelSubscriber,
         new RemoteName(chatChannelName, IChatChannel.class));
     final Tuple<Map<INode, Tag>, Long> init = controller.joinChat();
     final Map<INode, Tag> chatters = init.getFirst();
@@ -172,7 +172,7 @@ public class Chat {
    * Stop receiving events from the messenger.
    */
   public void shutdown() {
-    messengers.getChannelMessenger().unregisterChannelSubscriber(chatChannelSubscribor,
+    messengers.getChannelMessenger().unregisterChannelSubscriber(chatChannelSubscriber,
         new RemoteName(chatChannelName, IChatChannel.class));
     if (messengers.getMessenger().isConnected()) {
       final RemoteName chatControllerName = ChatController.getChatControlerRemoteName(chatName);
@@ -229,7 +229,7 @@ public class Chat {
     return new ArrayList<>(nodes);
   }
 
-  private final IChatChannel chatChannelSubscribor = new IChatChannel() {
+  private final IChatChannel chatChannelSubscriber = new IChatChannel() {
     private void assertMessageFromServer() {
       final INode senderNode = MessageContext.getSender();
       final INode serverNode = messengers.getMessenger().getServerNode();

--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -184,13 +184,13 @@ public class Chat {
 
   void sendSlap(final String playerName) {
     final IChatChannel remote = (IChatChannel) messengers.getChannelMessenger()
-        .getChannelBroadcastor(new RemoteName(chatChannelName, IChatChannel.class));
+        .getChannelBroadcaster(new RemoteName(chatChannelName, IChatChannel.class));
     remote.slapOccured(playerName);
   }
 
   public void sendMessage(final String message, final boolean meMessage) {
     final IChatChannel remote = (IChatChannel) messengers.getChannelMessenger()
-        .getChannelBroadcastor(new RemoteName(chatChannelName, IChatChannel.class));
+        .getChannelBroadcaster(new RemoteName(chatChannelName, IChatChannel.class));
     if (meMessage) {
       remote.meMessageOccured(message);
     } else {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -102,7 +102,7 @@ public class ChatController implements IChatController {
   }
 
   private IChatChannel getChatBroadcaster() {
-    return (IChatChannel) channelMessenger.getChannelBroadcastor(new RemoteName(chatChannel, IChatChannel.class));
+    return (IChatChannel) channelMessenger.getChannelBroadcaster(new RemoteName(chatChannel, IChatChannel.class));
   }
 
   // a player has joined

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.chat.IChatController.Tag;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.net.INode;
 
 /**
@@ -10,7 +10,7 @@ import games.strategy.net.INode;
  * RMI warning: the ordering of methods cannot be changed, these methods will be invoked by method order number
  * </p>
  */
-public interface IChatChannel extends IChannelSubscribor {
+public interface IChatChannel extends IChannelSubscriber {
   // we get the sender from MessageContext
   void chatOccured(final String message);
 

--- a/game-core/src/main/java/games/strategy/engine/chat/IStatusChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IStatusChannel.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.chat;
 
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 
 /**
  * A channel through which a chat participant's status is communicated.
  */
-public interface IStatusChannel extends IChannelSubscribor {
+public interface IStatusChannel extends IChannelSubscriber {
   RemoteName STATUS_CHANNEL =
       new RemoteName(IStatusChannel.class.getName() + ".STATUS", IStatusChannel.class);
 

--- a/game-core/src/main/java/games/strategy/engine/chat/StatusController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/StatusController.java
@@ -32,7 +32,7 @@ class StatusController implements IStatusController {
       status.remove(to);
     }
     final IStatusChannel channel =
-        (IStatusChannel) messengers.getChannelMessenger().getChannelBroadcastor(IStatusChannel.STATUS_CHANNEL);
+        (IStatusChannel) messengers.getChannelMessenger().getChannelBroadcaster(IStatusChannel.STATUS_CHANNEL);
     channel.statusChanged(to, null);
   }
 
@@ -50,7 +50,7 @@ class StatusController implements IStatusController {
       status.put(node, newStatus);
     }
     final IStatusChannel channel =
-        (IStatusChannel) messengers.getChannelMessenger().getChannelBroadcastor(IStatusChannel.STATUS_CHANNEL);
+        (IStatusChannel) messengers.getChannelMessenger().getChannelBroadcaster(IStatusChannel.STATUS_CHANNEL);
     channel.statusChanged(node, newStatus);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/StatusManager.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/StatusManager.java
@@ -16,11 +16,11 @@ public class StatusManager {
   private final Map<INode, String> status = new HashMap<>();
   private final Messengers messengers;
   private final Object mutex = new Object();
-  private final IStatusChannel statusChannelSubscribor;
+  private final IStatusChannel statusChannelSubscriber;
 
   public StatusManager(final Messengers messengers) {
     this.messengers = messengers;
-    statusChannelSubscribor = (node, status1) -> {
+    statusChannelSubscriber = (node, status1) -> {
       synchronized (mutex) {
         if (status1 == null) {
           StatusManager.this.status.remove(node);
@@ -35,7 +35,7 @@ public class StatusManager {
       final StatusController controller = new StatusController(messengers);
       messengers.getRemoteMessenger().registerRemote(controller, IStatusController.STATUS_CONTROLLER);
     }
-    this.messengers.getChannelMessenger().registerChannelSubscriber(statusChannelSubscribor,
+    this.messengers.getChannelMessenger().registerChannelSubscriber(statusChannelSubscriber,
         IStatusChannel.STATUS_CHANNEL);
     final IStatusController controller =
         (IStatusController) this.messengers.getRemoteMessenger().getRemote(IStatusController.STATUS_CONTROLLER);
@@ -48,7 +48,7 @@ public class StatusManager {
   }
 
   public void shutDown() {
-    messengers.getChannelMessenger().unregisterChannelSubscriber(statusChannelSubscribor,
+    messengers.getChannelMessenger().unregisterChannelSubscriber(statusChannelSubscriber,
         IStatusChannel.STATUS_CHANNEL);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -119,13 +119,13 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public IDisplay getDisplayChannelBroadcaster() {
     final Object implementor =
-        game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getDisplayChannel(gameData));
+        game.getChannelMessenger().getChannelBroadcaster(AbstractGame.getDisplayChannel(gameData));
     return (IDisplay) getOutbound(implementor);
   }
 
   @Override
   public ISound getSoundChannelBroadcaster() {
-    final Object implementor = game.getChannelMessenger().getChannelBroadcastor(AbstractGame.getSoundChannel(gameData));
+    final Object implementor = game.getChannelMessenger().getChannelBroadcaster(AbstractGame.getSoundChannel(gameData));
     return (ISound) getOutbound(implementor);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
+++ b/game-core/src/main/java/games/strategy/engine/display/IDisplay.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.display;
 
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 
 /**
  * A Display is a view of the game.
  * Displays listen on the display channel for game events. There may be many displays
  * on a single vm, and conversely a display may interact with many IGamePlayers
  */
-public interface IDisplay extends IChannelSubscribor {
+public interface IDisplay extends IChannelSubscriber {
   void shutDown();
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -12,7 +12,7 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.startup.ui.PlayerType;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.player.IGamePlayer;
 
@@ -38,11 +38,11 @@ public interface IGameLoader extends Serializable {
   /**
    * Get the type of the display.
    *
-   * @return an interface that extends IChannelSubscribor
+   * @return an interface that extends IChannelSubscriber
    */
-  Class<? extends IChannelSubscribor> getDisplayType();
+  Class<? extends IChannelSubscriber> getDisplayType();
 
-  Class<? extends IChannelSubscribor> getSoundType();
+  Class<? extends IChannelSubscriber> getSoundType();
 
   /**
    * Get the type of the GamePlayer.

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
@@ -2,12 +2,12 @@ package games.strategy.engine.framework;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.PlayerId;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 
 /**
  * All changes to game data (Changes and History events) can be tracked through this channel.
  */
-public interface IGameModifiedChannel extends IChannelSubscribor {
+public interface IGameModifiedChannel extends IChannelSubscriber {
   void gameDataChanged(final Change change);
 
   void startHistoryEvent(final String event, final Object renderingData);

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -603,7 +603,7 @@ public class ServerGame extends AbstractGame {
   }
 
   private IGameModifiedChannel getGameModifiedBroadcaster() {
-    return (IGameModifiedChannel) channelMessenger.getChannelBroadcastor(IGame.GAME_MODIFICATION_CHANNEL);
+    return (IGameModifiedChannel) channelMessenger.getChannelBroadcaster(IGame.GAME_MODIFICATION_CHANNEL);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -127,7 +127,7 @@ public class ServerLauncher extends AbstractLauncher {
         HeadlessGameServer.setServerGame(serverGame);
       }
       // tell the clients to start, later we will wait for them to all signal that they are ready.
-      ((IClientChannel) channelMessenger.getChannelBroadcastor(IClientChannel.CHANNEL_NAME))
+      ((IClientChannel) channelMessenger.getChannelBroadcaster(IClientChannel.CHANNEL_NAME))
           .doneSelectingPlayers(gameDataAsBytes, serverGame.getPlayerManager().getPlayerMapping());
 
       final boolean useSecureRandomSource = !remotePlayers.isEmpty();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
@@ -3,14 +3,14 @@ package games.strategy.engine.framework.startup.mc;
 import java.util.Map;
 
 import games.strategy.engine.framework.message.PlayerListing;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.INode;
 
 /**
  * A channel representing a remote client of a network game. Used by the server to notify clients of various events.
  */
-public interface IClientChannel extends IChannelSubscribor {
+public interface IClientChannel extends IChannelSubscriber {
   RemoteName CHANNEL_NAME =
       new RemoteName("games.strategy.engine.framework.ui.IClientChannel.CHANNEL", IClientChannel.class);
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -480,7 +480,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     Optional.ofNullable(channelMessenger)
         .ifPresent(messenger -> {
           final IClientChannel channel =
-              (IClientChannel) messenger.getChannelBroadcastor(IClientChannel.CHANNEL_NAME);
+              (IClientChannel) messenger.getChannelBroadcaster(IClientChannel.CHANNEL_NAME);
           channel.playerListingChanged(getPlayerListingInternal());
         });
   }
@@ -643,7 +643,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
   public void newGame() {
     serverMessenger.setAcceptNewConnections(true);
     final IClientChannel channel =
-        (IClientChannel) channelMessenger.getChannelBroadcastor(IClientChannel.CHANNEL_NAME);
+        (IClientChannel) channelMessenger.getChannelBroadcaster(IClientChannel.CHANNEL_NAME);
     notifyChanellPlayersChanged();
     channel.gameReset();
   }

--- a/game-core/src/main/java/games/strategy/engine/history/DelegateHistoryWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/DelegateHistoryWriter.java
@@ -13,7 +13,7 @@ public class DelegateHistoryWriter implements IDelegateHistoryWriter {
   private final IGameModifiedChannel channel;
 
   public DelegateHistoryWriter(final IChannelMessenger messenger) {
-    channel = (IGameModifiedChannel) messenger.getChannelBroadcastor(IGame.GAME_MODIFICATION_CHANNEL);
+    channel = (IGameModifiedChannel) messenger.getChannelBroadcaster(IGame.GAME_MODIFICATION_CHANNEL);
   }
 
   public DelegateHistoryWriter(final IGameModifiedChannel channel) {

--- a/game-core/src/main/java/games/strategy/engine/message/ChannelMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/ChannelMessenger.java
@@ -21,17 +21,17 @@ public class ChannelMessenger implements IChannelMessenger {
   }
 
   @Override
-  public IChannelSubscribor getChannelBroadcastor(final RemoteName channelName) {
+  public IChannelSubscriber getChannelBroadcastor(final RemoteName channelName) {
     final InvocationHandler ih =
         new UnifiedInvocationHandler(unifiedMessenger, channelName.getName(), true, channelName.getClazz());
-    return (IChannelSubscribor) Proxy
+    return (IChannelSubscriber) Proxy
         .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class<?>[] {channelName.getClazz()}, ih);
   }
 
   @Override
   public void registerChannelSubscriber(final Object implementor, final RemoteName channelName) {
-    if (!IChannelSubscribor.class.isAssignableFrom(channelName.getClazz())) {
-      throw new IllegalStateException(channelName.getClazz() + " is not a channel subscribor");
+    if (!IChannelSubscriber.class.isAssignableFrom(channelName.getClazz())) {
+      throw new IllegalStateException(channelName.getClazz() + " is not a channel subscriber");
     }
     unifiedMessenger.addImplementor(channelName, implementor, true);
   }

--- a/game-core/src/main/java/games/strategy/engine/message/ChannelMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/ChannelMessenger.java
@@ -21,7 +21,7 @@ public class ChannelMessenger implements IChannelMessenger {
   }
 
   @Override
-  public IChannelSubscriber getChannelBroadcastor(final RemoteName channelName) {
+  public IChannelSubscriber getChannelBroadcaster(final RemoteName channelName) {
     final InvocationHandler ih =
         new UnifiedInvocationHandler(unifiedMessenger, channelName.getName(), true, channelName.getClazz());
     return (IChannelSubscriber) Proxy

--- a/game-core/src/main/java/games/strategy/engine/message/IChannelMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/IChannelMessenger.java
@@ -27,7 +27,7 @@ import games.strategy.net.INode;
  * <pre>
  * IFoo anotherFoo = new Foo();
  * anotherChannelMessenger.registerChannelSubscriber(anotherFoo, FOO);
- * IFoo multicastFoo = (IFoo) anotherChannelMessenger.getChannelBroadcastor(FOO);
+ * IFoo multicastFoo = (IFoo) anotherChannelMessenger.getChannelBroadcaster(FOO);
  * multicastFoo.fee();
  * </pre>
  *
@@ -67,7 +67,7 @@ public interface IChannelMessenger {
   /**
    * Get a reference such that methods called on it will be multicast to all subscribers of the channel.
    */
-  IChannelSubscriber getChannelBroadcastor(RemoteName channelName);
+  IChannelSubscriber getChannelBroadcaster(RemoteName channelName);
 
   /**
    * register a subscriber to a channel.

--- a/game-core/src/main/java/games/strategy/engine/message/IChannelMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/IChannelMessenger.java
@@ -17,7 +17,7 @@ import games.strategy.net.INode;
  * <pre>
  * RemoteName FOO = new RemoteName(&quot;Foo&quot;, IFoo.class);
  * IFoo aFoo = new Foo();
- * someChannelMessenger.registerChannelSubscribor(aFoo, FOO);
+ * someChannelMessenger.registerChannelSubscriber(aFoo, FOO);
  * </pre>
  *
  * <p>
@@ -26,7 +26,7 @@ import games.strategy.net.INode;
  *
  * <pre>
  * IFoo anotherFoo = new Foo();
- * anotherChannelMessenger.registerChannelSubscribor(anotherFoo, FOO);
+ * anotherChannelMessenger.registerChannelSubscriber(anotherFoo, FOO);
  * IFoo multicastFoo = (IFoo) anotherChannelMessenger.getChannelBroadcastor(FOO);
  * multicastFoo.fee();
  * </pre>
@@ -67,7 +67,7 @@ public interface IChannelMessenger {
   /**
    * Get a reference such that methods called on it will be multicast to all subscribers of the channel.
    */
-  IChannelSubscribor getChannelBroadcastor(RemoteName channelName);
+  IChannelSubscriber getChannelBroadcastor(RemoteName channelName);
 
   /**
    * register a subscriber to a channel.

--- a/game-core/src/main/java/games/strategy/engine/message/IChannelSubscriber.java
+++ b/game-core/src/main/java/games/strategy/engine/message/IChannelSubscriber.java
@@ -6,9 +6,8 @@ package games.strategy.engine.message;
  * may be called by a remote VM.
  * Return values of an IChannelSubscriber will be ignored.
  * Exceptions thrown by methods of an IChannelSubscriber will be printed to standard error, but otherwise ignored.
- * Arguments to the methods of IChannelSubscribor should not be modified
+ * Arguments to the methods of IChannelSubscriber should not be modified
  * in any way. The values may be used in method calls to other subscribers.
  */
-// TODO: fix typo in Subscribor, should be 'Subscriber'
-public interface IChannelSubscribor {
+public interface IChannelSubscriber {
 }

--- a/game-core/src/main/java/games/strategy/engine/message/MessageContext.java
+++ b/game-core/src/main/java/games/strategy/engine/message/MessageContext.java
@@ -20,7 +20,7 @@ public class MessageContext {
    *
    * <p>
    * Will return null if the current thread is not currently executing a remote method of an IRemote or
-   * IChannelSubscribor.
+   * IChannelSubscriber.
    * </p>
    *
    * <p>

--- a/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
+++ b/game-core/src/main/java/games/strategy/engine/message/MessengerException.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.message;
 
 /**
- * All methods called on an IRemote or an IChannelSubscribor may throw one of these exceptions.
+ * All methods called on an IRemote or an IChannelSubscriber may throw one of these exceptions.
  */
 public class MessengerException extends RuntimeException {
   private static final long serialVersionUID = 1058615494612307887L;

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -92,7 +92,7 @@ public class Vault {
   }
 
   private IRemoteVault getRemoteBroadcaster() {
-    return (IRemoteVault) channelMessenger.getChannelBroadcastor(VAULT_CHANNEL);
+    return (IRemoteVault) channelMessenger.getChannelBroadcaster(VAULT_CHANNEL);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -16,7 +16,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESKeySpec;
 
 import games.strategy.engine.message.IChannelMessenger;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteName;
 
 /**
@@ -328,7 +328,7 @@ public class Vault {
     }
   }
 
-  interface IRemoteVault extends IChannelSubscribor {
+  interface IRemoteVault extends IChannelSubscriber {
     void addLockedValue(VaultId id, byte[] data);
 
     void unlock(VaultId id, byte[] secretKeyBytes);

--- a/game-core/src/main/java/games/strategy/sound/ISound.java
+++ b/game-core/src/main/java/games/strategy/sound/ISound.java
@@ -3,13 +3,13 @@ package games.strategy.sound;
 import java.util.Collection;
 
 import games.strategy.engine.data.PlayerId;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 
 /**
  * A sound channel allowing sounds normally played on the server (for example: in a delegate, such as a the move
  * delegate) to also be played on clients.
  */
-public interface ISound extends IChannelSubscribor {
+public interface ISound extends IChannelSubscriber {
 
   /**
    * You will want to call this from things that the server only runs (like delegates), and not call this from user

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -19,7 +19,7 @@ import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
 import games.strategy.engine.framework.startup.ui.PlayerType;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.player.IGamePlayer;
 import games.strategy.sound.ClipPlayer;
@@ -138,12 +138,12 @@ public class TripleA implements IGameLoader {
   }
 
   @Override
-  public Class<? extends IChannelSubscribor> getDisplayType() {
+  public Class<? extends IChannelSubscriber> getDisplayType() {
     return ITripleADisplay.class;
   }
 
   @Override
-  public Class<? extends IChannelSubscribor> getSoundType() {
+  public Class<? extends IChannelSubscriber> getSoundType() {
     return ISound.class;
   }
 

--- a/game-core/src/main/java/org/triplea/lobby/common/ILobbyGameBroadcaster.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/ILobbyGameBroadcaster.java
@@ -1,14 +1,14 @@
 package org.triplea.lobby.common;
 
 import games.strategy.engine.lobby.server.GameDescription;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.GUID;
 
 /**
  * A service that notifies nodes of lobby game state changes (e.g. when games are added to or removed from the lobby).
  */
-public interface ILobbyGameBroadcaster extends IChannelSubscribor {
+public interface ILobbyGameBroadcaster extends IChannelSubscriber {
   RemoteName REMOTE_NAME =
       new RemoteName("games.strategy.engine.lobby.server.IGameBroadcaster.CHANNEL", ILobbyGameBroadcaster.class);
 

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -52,7 +52,7 @@ public class ChannelMessengerTest {
   public void testLocalCall() {
     final RemoteName descriptor = new RemoteName("testLocalCall", IChannelBase.class);
     serverChannelMessenger.registerChannelSubscriber(new ChannelSubscriber(), descriptor);
-    final IChannelBase subscriber = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(descriptor);
+    final IChannelBase subscriber = (IChannelBase) serverChannelMessenger.getChannelBroadcaster(descriptor);
     subscriber.testNoParams();
     subscriber.testPrimitives(1, (short) 0, 1, (byte) 1, true, (float) 1.0);
     subscriber.testString("a");
@@ -64,7 +64,7 @@ public class ChannelMessengerTest {
     final ChannelSubscriber subscriber1 = new ChannelSubscriber();
     serverChannelMessenger.registerChannelSubscriber(subscriber1, testRemote);
     assertHasChannel(testRemote, unifiedMessengerHub);
-    final IChannelBase channelTest = (IChannelBase) clientChannelMessenger.getChannelBroadcastor(testRemote);
+    final IChannelBase channelTest = (IChannelBase) clientChannelMessenger.getChannelBroadcaster(testRemote);
     channelTest.testNoParams();
     assertCallCountIs(subscriber1, 1);
     channelTest.testString("a");
@@ -87,7 +87,7 @@ public class ChannelMessengerTest {
     final String mac = MacFinder.getHashedMacAddress();
     final ClientMessenger clientMessenger2 = new ClientMessenger("localhost", serverPort, "client2", mac);
     final ChannelMessenger client2 = new ChannelMessenger(new UnifiedMessenger(clientMessenger2));
-    ((IChannelBase) client2.getChannelBroadcastor(test)).testString("a");
+    ((IChannelBase) client2.getChannelBroadcaster(test)).testString("a");
     assertCallCountIs(client1Subscriber, 1);
   }
 
@@ -101,10 +101,10 @@ public class ChannelMessengerTest {
     clientChannelMessenger.registerChannelSubscriber(subscriber3, testRemote3);
     assertHasChannel(testRemote2, unifiedMessengerHub);
     assertHasChannel(testRemote3, unifiedMessengerHub);
-    final IChannelBase channelTest2 = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(testRemote2);
+    final IChannelBase channelTest2 = (IChannelBase) serverChannelMessenger.getChannelBroadcaster(testRemote2);
     channelTest2.testNoParams();
     assertCallCountIs(subscriber2, 1);
-    final IChannelBase channelTest3 = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(testRemote3);
+    final IChannelBase channelTest3 = (IChannelBase) serverChannelMessenger.getChannelBroadcaster(testRemote3);
     channelTest3.testNoParams();
     assertCallCountIs(subscriber3, 1);
   }

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import games.strategy.engine.message.ChannelMessenger;
-import games.strategy.engine.message.IChannelSubscribor;
+import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.engine.message.UnifiedMessengerHub;
 import games.strategy.net.ClientMessenger;
@@ -51,36 +51,36 @@ public class ChannelMessengerTest {
   @Test
   public void testLocalCall() {
     final RemoteName descriptor = new RemoteName("testLocalCall", IChannelBase.class);
-    serverChannelMessenger.registerChannelSubscriber(new ChannelSubscribor(), descriptor);
-    final IChannelBase subscribor = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(descriptor);
-    subscribor.testNoParams();
-    subscribor.testPrimitives(1, (short) 0, 1, (byte) 1, true, (float) 1.0);
-    subscribor.testString("a");
+    serverChannelMessenger.registerChannelSubscriber(new ChannelSubscriber(), descriptor);
+    final IChannelBase subscriber = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(descriptor);
+    subscriber.testNoParams();
+    subscriber.testPrimitives(1, (short) 0, 1, (byte) 1, true, (float) 1.0);
+    subscriber.testString("a");
   }
 
   @Test
   public void testRemoteCall() {
     final RemoteName testRemote = new RemoteName("testRemote", IChannelBase.class);
-    final ChannelSubscribor subscribor1 = new ChannelSubscribor();
-    serverChannelMessenger.registerChannelSubscriber(subscribor1, testRemote);
+    final ChannelSubscriber subscriber1 = new ChannelSubscriber();
+    serverChannelMessenger.registerChannelSubscriber(subscriber1, testRemote);
     assertHasChannel(testRemote, unifiedMessengerHub);
     final IChannelBase channelTest = (IChannelBase) clientChannelMessenger.getChannelBroadcastor(testRemote);
     channelTest.testNoParams();
-    assertCallCountIs(subscribor1, 1);
+    assertCallCountIs(subscriber1, 1);
     channelTest.testString("a");
-    assertCallCountIs(subscribor1, 2);
+    assertCallCountIs(subscriber1, 2);
     channelTest.testPrimitives(1, (short) 0, 1, (byte) 1, true, (float) 1.0);
-    assertCallCountIs(subscribor1, 3);
+    assertCallCountIs(subscriber1, 3);
     channelTest.testArray(null, null, null, null, null, null);
-    assertCallCountIs(subscribor1, 4);
+    assertCallCountIs(subscriber1, 4);
   }
 
   @Test
   public void testMultipleClients() throws Exception {
     // set up the client and server so that the client has 1 subscriber, and the server knows about it
     final RemoteName test = new RemoteName("test", IChannelBase.class);
-    final ChannelSubscribor client1Subscribor = new ChannelSubscribor();
-    clientChannelMessenger.registerChannelSubscriber(client1Subscribor, test);
+    final ChannelSubscriber client1Subscriber = new ChannelSubscriber();
+    clientChannelMessenger.registerChannelSubscriber(client1Subscriber, test);
     assertHasChannel(test, unifiedMessengerHub);
     assertEquals(1, clientChannelMessenger.getUnifiedMessenger().getLocalEndPointCount(test));
     // add a new client
@@ -88,25 +88,25 @@ public class ChannelMessengerTest {
     final ClientMessenger clientMessenger2 = new ClientMessenger("localhost", serverPort, "client2", mac);
     final ChannelMessenger client2 = new ChannelMessenger(new UnifiedMessenger(clientMessenger2));
     ((IChannelBase) client2.getChannelBroadcastor(test)).testString("a");
-    assertCallCountIs(client1Subscribor, 1);
+    assertCallCountIs(client1Subscriber, 1);
   }
 
   @Test
   public void testMultipleChannels() {
     final RemoteName testRemote2 = new RemoteName("testRemote2", IChannelBase.class);
     final RemoteName testRemote3 = new RemoteName("testRemote3", IChannelBase.class);
-    final ChannelSubscribor subscribor2 = new ChannelSubscribor();
-    clientChannelMessenger.registerChannelSubscriber(subscribor2, testRemote2);
-    final ChannelSubscribor subscribor3 = new ChannelSubscribor();
-    clientChannelMessenger.registerChannelSubscriber(subscribor3, testRemote3);
+    final ChannelSubscriber subscriber2 = new ChannelSubscriber();
+    clientChannelMessenger.registerChannelSubscriber(subscriber2, testRemote2);
+    final ChannelSubscriber subscriber3 = new ChannelSubscriber();
+    clientChannelMessenger.registerChannelSubscriber(subscriber3, testRemote3);
     assertHasChannel(testRemote2, unifiedMessengerHub);
     assertHasChannel(testRemote3, unifiedMessengerHub);
     final IChannelBase channelTest2 = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(testRemote2);
     channelTest2.testNoParams();
-    assertCallCountIs(subscribor2, 1);
+    assertCallCountIs(subscriber2, 1);
     final IChannelBase channelTest3 = (IChannelBase) serverChannelMessenger.getChannelBroadcastor(testRemote3);
     channelTest3.testNoParams();
-    assertCallCountIs(subscribor3, 1);
+    assertCallCountIs(subscriber3, 1);
   }
 
   private static void assertHasChannel(final RemoteName descriptor, final UnifiedMessengerHub hub) {
@@ -118,17 +118,17 @@ public class ChannelMessengerTest {
     assertTrue(hub.hasImplementors(descriptor.getName()));
   }
 
-  private static void assertCallCountIs(final ChannelSubscribor subscribor, final int expected) {
+  private static void assertCallCountIs(final ChannelSubscriber subscriber, final int expected) {
     // since the method call happens in a separate thread, wait for the call to go through, but don't wait too long
     int waitCount = 0;
-    while (waitCount < 20 && expected != subscribor.getCallCount()) {
+    while (waitCount < 20 && expected != subscriber.getCallCount()) {
       Interruptibles.sleep(50);
       waitCount++;
     }
-    assertEquals(expected, subscribor.getCallCount());
+    assertEquals(expected, subscriber.getCallCount());
   }
 
-  private interface IChannelBase extends IChannelSubscribor {
+  private interface IChannelBase extends IChannelSubscriber {
     void testNoParams();
 
     void testPrimitives(int a, short b, long c, byte d, boolean e, float f);
@@ -138,7 +138,7 @@ public class ChannelMessengerTest {
     void testArray(int[] ints, short[] shorts, byte[] bytes, boolean[] bools, float[] floats, Object[] objects);
   }
 
-  private static class ChannelSubscribor implements IChannelBase {
+  private static class ChannelSubscriber implements IChannelBase {
     private int callCount = 0;
 
     private synchronized void incrementCount() {

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
@@ -51,7 +51,7 @@ public final class LobbyServer {
     new StatusManager(messengers).shutDown();
 
     final LobbyGameController controller = new LobbyGameController((ILobbyGameBroadcaster) messengers
-        .getChannelMessenger().getChannelBroadcastor(ILobbyGameBroadcaster.REMOTE_NAME), server);
+        .getChannelMessenger().getChannelBroadcaster(ILobbyGameBroadcaster.REMOTE_NAME), server);
     controller.register(messengers.getRemoteMessenger());
 
     // now we are open for business


### PR DESCRIPTION
## Overview

Renames "subscribor" to "subscriber" and "broadcastor" to "broadcaster".

## Functional Changes

None.

## Manual Testing Performed

Verified that a lobby client from this branch can connect to a 1.9 lobby server and subsequently chat and join a 1.10 bot.  (That is, this change does not appear to break lobby compatibility.)