### PR TITLE
Upgrade version numberring to X.Y.<build>

### DIFF
--- a/config/triplea/schemas/lobby_server.json
+++ b/config/triplea/schemas/lobby_server.json
@@ -10,7 +10,7 @@
     "properties": {
       "version": {
         "description": "The lobby server engine version",
-        "type": "string",
+        "type": [ "string", "number" ],
         "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
       },
       "host": {

--- a/config/triplea/schemas/lobby_server.json
+++ b/config/triplea/schemas/lobby_server.json
@@ -10,8 +10,8 @@
     "properties": {
       "version": {
         "description": "The lobby server engine version",
-        "type": [ "string", "number" ],
-        "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+        "type": "string",
+        "pattern": "^\\d+(\\.\\d+){1,3}$"
       },
       "host": {
         "description": "The lobby server host",

--- a/game-core/src/main/java/games/strategy/engine/GameEngineVersion.java
+++ b/game-core/src/main/java/games/strategy/engine/GameEngineVersion.java
@@ -34,7 +34,7 @@ public final class GameEngineVersion {
   public boolean isCompatibleWithEngineVersion(final Version engineVersion) {
     checkNotNull(engineVersion);
 
-    return version.withMicro(0).equals(engineVersion.withMicro(0));
+    return version.withPoint(0).equals(engineVersion.withPoint(0));
   }
 
   /**
@@ -48,6 +48,6 @@ public final class GameEngineVersion {
   public boolean isCompatibleWithMapMinimumEngineVersion(final Version mapMinimumEngineVersion) {
     checkNotNull(mapMinimumEngineVersion);
 
-    return version.withMicro(0).isGreaterThanOrEqualTo(mapMinimumEngineVersion.withMicro(0));
+    return version.withPoint(0).isGreaterThanOrEqualTo(mapMinimumEngineVersion.withPoint(0));
   }
 }

--- a/game-core/src/main/java/games/strategy/util/Version.java
+++ b/game-core/src/main/java/games/strategy/util/Version.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 
 /**
  * Represents a version string.
- * versions are of the form major.minor.point.micro
+ * versions are of the form major.minor.point
  */
 public final class Version implements Serializable, Comparable<Version> {
   private static final long serialVersionUID = -4770210855326775333L;
@@ -25,14 +25,14 @@ public final class Version implements Serializable, Comparable<Version> {
   private final String exactVersion;
 
   /**
-   * Constructs a Version object without the point and micro version, defaults those to 0.
+   * Constructs a Version object without the point version, defaults those to 0.
    */
   public Version(final int major, final int minor) {
     this(major, minor, 0);
   }
 
   /**
-   * Constructs a Version object without the micro version, defaults to 0.
+   * Constructs a Version object with all three parts: major/minor/point.
    */
   public Version(final int major, final int minor, final int point) {
     this(major, minor, point, 0);
@@ -50,7 +50,7 @@ public final class Version implements Serializable, Comparable<Version> {
   }
 
   /**
-   * version must be of the from xx.xx.xx.xx or xx.xx.xx or xx.xx or xx where xx is a positive integer.
+   * version must be of the from xx.xx.xx or xx.xx or xx where xx is a positive integer.
    */
   public Version(final String version) {
     exactVersion = version;
@@ -75,9 +75,9 @@ public final class Version implements Serializable, Comparable<Version> {
    * Returns the exact and full version number.
    * For example, if we specify:
    * <code>
-   * new Version(1.2.3.4.5).getMicro == 4; // true
-   * new Version(1.2.3.4.5).toString().equals("1.2.3.4"); // true
-   * new Version(1.2.3.4.5).getExactVersion.equals("1.2.3.4.5"); // true
+   * new Version("1.2.3").getPoint == 3; // true
+   * new Version("1.2.3.4").toString().equals("1.2.3"); // true
+   * new Version("1.2.3.4").getExactVersion.equals("1.2.3.4"); // true
    * </code>
    */
   public String getExactVersion() {

--- a/game-core/src/main/java/games/strategy/util/Version.java
+++ b/game-core/src/main/java/games/strategy/util/Version.java
@@ -21,7 +21,6 @@ public final class Version implements Serializable, Comparable<Version> {
   private final int major;
   private final int minor;
   private final int point;
-  private final int micro;
   private final String exactVersion;
 
   /**
@@ -35,37 +34,29 @@ public final class Version implements Serializable, Comparable<Version> {
    * Constructs a Version object with all three parts: major/minor/point.
    */
   public Version(final int major, final int minor, final int point) {
-    this(major, minor, point, 0);
-  }
-
-  /**
-   * Constructs a Version object with all version values set.
-   */
-  public Version(final int major, final int minor, final int point, final int micro) {
     this.major = major;
     this.minor = minor;
     this.point = point;
-    this.micro = micro;
     exactVersion = toString();
   }
 
   /**
-   * version must be of the from xx.xx.xx or xx.xx or xx where xx is a positive integer.
+   * version must be of the from xx.xx.xx or
+   * xx.xx or xx where xx is a positive integer
    */
   public Version(final String version) {
     exactVersion = version;
 
-    final Matcher matcher = Pattern.compile("^(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(?:\\.((?:\\d+|dev)[^.]*))?)?)?")
+    final Matcher matcher = Pattern.compile("^(\\d+)(?:\\.(\\d+)(?:\\.((?:\\d+|dev)[^.]*))?)?")
         .matcher(version);
 
     if (matcher.find()) {
       major = Integer.parseInt(matcher.group(1));
       minor = Optional.ofNullable(matcher.group(2)).map(Integer::valueOf).orElse(0);
-      point = Optional.ofNullable(matcher.group(3)).map(Integer::valueOf).orElse(0);
-      final String microString = matcher.group(4);
-      micro = "dev".equals(microString)
+      final String pointString = matcher.group(3);
+      point = "dev".equals(pointString)
           ? Integer.MAX_VALUE
-          : Optional.ofNullable(microString).map(Integer::valueOf).orElse(0);
+          : Optional.ofNullable(pointString).map(Integer::valueOf).orElse(0);
       return;
     }
     throw new IllegalArgumentException("Invalid version String: " + version);
@@ -106,13 +97,6 @@ public final class Version implements Serializable, Comparable<Version> {
     return point;
   }
 
-  /**
-   * Returns the micro version number.
-   */
-  public int getMicro() {
-    return micro;
-  }
-
   @Override
   public boolean equals(final @Nullable Object o) {
     return o instanceof Version && compareTo((Version) o) == 0;
@@ -120,7 +104,7 @@ public final class Version implements Serializable, Comparable<Version> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(major, minor, point, micro);
+    return Objects.hash(major, minor, point);
   }
 
   @Override
@@ -130,7 +114,6 @@ public final class Version implements Serializable, Comparable<Version> {
     return Comparator.comparingInt(Version::getMajor)
         .thenComparingInt(Version::getMinor)
         .thenComparingInt(Version::getPoint)
-        .thenComparingInt(Version::getMicro)
         .compare(this, other);
   }
 
@@ -174,10 +157,10 @@ public final class Version implements Serializable, Comparable<Version> {
   }
 
   /**
-   * Returns a new version with the major, minor, and point versions from this instance and the specified micro version.
+   * Returns a new version with the major and minor versions from this instance and the specified point version.
    */
-  public Version withMicro(final int micro) {
-    return new Version(major, minor, point, micro);
+  public Version withPoint(final int point) {
+    return new Version(major, minor, point);
   }
 
   /**
@@ -188,12 +171,11 @@ public final class Version implements Serializable, Comparable<Version> {
         ".",
         String.valueOf(major),
         String.valueOf(minor),
-        String.valueOf(point),
-        (micro == Integer.MAX_VALUE) ? "dev" : String.valueOf(micro));
+        (point == Integer.MAX_VALUE) ? "dev" : String.valueOf(point));
   }
 
   @Override
   public String toString() {
-    return micro != 0 ? toStringFull() : major + "." + minor + (point != 0 ? "." + point : "");
+    return point != 0 ? toStringFull() : major + "." + minor;
   }
 }

--- a/game-core/src/main/java/games/strategy/util/Version.java
+++ b/game-core/src/main/java/games/strategy/util/Version.java
@@ -41,8 +41,7 @@ public final class Version implements Serializable, Comparable<Version> {
   }
 
   /**
-   * version must be of the from xx.xx.xx or
-   * xx.xx or xx where xx is a positive integer
+   * version must be of the from xx.xx.xx or xx.xx or xx where xx is a positive integer
    */
   public Version(final String version) {
     exactVersion = version;
@@ -66,9 +65,9 @@ public final class Version implements Serializable, Comparable<Version> {
    * Returns the exact and full version number.
    * For example, if we specify:
    * <code>
-   * new Version("1.2.3").getPoint == 3; // true
+   * new Version("1.2.3").getPoint() == 3; // true
    * new Version("1.2.3.4").toString().equals("1.2.3"); // true
-   * new Version("1.2.3.4").getExactVersion.equals("1.2.3.4"); // true
+   * new Version("1.2.3.4").getExactVersion().equals("1.2.3.4"); // true
    * </code>
    */
   public String getExactVersion() {

--- a/game-core/src/main/resources/META-INF/triplea/product.properties
+++ b/game-core/src/main/resources/META-INF/triplea/product.properties
@@ -1,1 +1,1 @@
-version = 1.10.0.0.@buildId@
+version = 1.10.@buildId@

--- a/game-core/src/test/java/games/strategy/engine/GameEngineVersionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/GameEngineVersionTest.java
@@ -17,25 +17,23 @@ final class GameEngineVersionTest {
     @Test
     void shouldReturnTrueWhenOtherVersionIsCompatible() {
       Arrays.asList(
-          Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
-          Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
-          Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"))
+          Tuple.of(new Version(1, 2, 3), "equal versions should be compatible"),
+          Tuple.of(new Version(1, 2, 0), "smaller point version should be compatible"),
+          Tuple.of(new Version(1, 2, 9), "larger point version should be compatible"))
           .forEach(t -> assertTrue(
-              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
+              GameEngineVersion.of(new Version(1, 2, 3)).isCompatibleWithEngineVersion(t.getFirst()),
               t.getSecond()));
     }
 
     @Test
     void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
       Arrays.asList(
-          Tuple.of(new Version(1, 2, 0, 4), "smaller point version should not be compatible"),
-          Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
-          Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should not be compatible"),
-          Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
-          Tuple.of(new Version(0, 2, 3, 4), "smaller major version should not be compatible"),
-          Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
+          Tuple.of(new Version(1, 0, 3), "smaller minor version should not be compatible"),
+          Tuple.of(new Version(1, 9, 3), "larger minor version should not be compatible"),
+          Tuple.of(new Version(0, 2, 3), "smaller major version should not be compatible"),
+          Tuple.of(new Version(9, 2, 3), "larger major version should not be compatible"))
           .forEach(t -> assertFalse(
-              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithEngineVersion(t.getFirst()),
+              GameEngineVersion.of(new Version(1, 2, 3)).isCompatibleWithEngineVersion(t.getFirst()),
               t.getSecond()));
     }
   }
@@ -45,25 +43,23 @@ final class GameEngineVersionTest {
     @Test
     void shouldReturnTrueWhenOtherVersionIsCompatible() {
       Arrays.asList(
-          Tuple.of(new Version(1, 2, 3, 4), "equal versions should be compatible"),
-          Tuple.of(new Version(1, 2, 3, 0), "smaller micro version should be compatible"),
-          Tuple.of(new Version(1, 2, 3, 9), "larger micro version should be compatible"),
-          Tuple.of(new Version(1, 2, 0, 4), "smaller point version should be compatible"),
-          Tuple.of(new Version(1, 0, 3, 4), "smaller minor version should be compatible"),
-          Tuple.of(new Version(0, 2, 3, 4), "smaller major version should be compatible"))
+          Tuple.of(new Version(1, 2, 3), "equal versions should be compatible"),
+          Tuple.of(new Version(1, 2, 0), "smaller point version should be compatible"),
+          Tuple.of(new Version(1, 2, 9), "larger point version should be compatible"),
+          Tuple.of(new Version(1, 0, 3), "smaller minor version should be compatible"),
+          Tuple.of(new Version(0, 2, 3), "smaller major version should be compatible"))
           .forEach(t -> assertTrue(
-              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
+              GameEngineVersion.of(new Version(1, 2, 3)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
               t.getSecond()));
     }
 
     @Test
     void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
       Arrays.asList(
-          Tuple.of(new Version(1, 2, 9, 4), "larger point version should not be compatible"),
-          Tuple.of(new Version(1, 9, 3, 4), "larger minor version should not be compatible"),
-          Tuple.of(new Version(9, 2, 3, 4), "larger major version should not be compatible"))
+          Tuple.of(new Version(1, 9, 3), "larger minor version should not be compatible"),
+          Tuple.of(new Version(9, 2, 3), "larger major version should not be compatible"))
           .forEach(t -> assertFalse(
-              GameEngineVersion.of(new Version(1, 2, 3, 4)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
+              GameEngineVersion.of(new Version(1, 2, 3)).isCompatibleWithMapMinimumEngineVersion(t.getFirst()),
               t.getSecond()));
     }
   }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -48,7 +48,7 @@ public class GameSelectorModelTest extends AbstractClientSettingTestCase {
     assertThat(objectToCheck.getGameVersion(), is(fakeGameVersion));
   }
 
-  private static final String fakeGameVersion = "12.34.56.78";
+  private static final String fakeGameVersion = "12.34.56";
   private static final String fakeGameRound = "3";
   private static final String fakeGameName = "_fakeGameName_";
   private static final String fakeFileName = "/hack/and/slash";

--- a/game-core/src/test/java/games/strategy/util/VersionTest.java
+++ b/game-core/src/test/java/games/strategy/util/VersionTest.java
@@ -55,6 +55,11 @@ public class VersionTest {
         Tuple.of(new Version("0.0.dev"), new Version(0, 0, 0)))
         .forEach(t -> assertThat(t.getFirst().compareTo(t.getSecond()), is(greaterThan(0))));
   }
+  
+  @Test
+  public void testWithPoint() {
+    assertEquals(new Version(1, 2, 999), new Version(1, 2, 3).withPoint(999));
+  }
 
   @Test
   public void testIsGreaterThan() {

--- a/game-core/src/test/java/games/strategy/util/VersionTest.java
+++ b/game-core/src/test/java/games/strategy/util/VersionTest.java
@@ -29,33 +29,30 @@ public class VersionTest {
   @Test
   public void compareTo_ShouldReturnNegativeIntegerWhenFirstIsLessThanSecond() {
     Arrays.asList(
-        Tuple.of(new Version(1, 0, 0, 0), new Version(2, 0, 0, 0)),
-        Tuple.of(new Version(0, 1, 0, 0), new Version(0, 2, 0, 0)),
-        Tuple.of(new Version(0, 0, 1, 0), new Version(0, 0, 2, 0)),
-        Tuple.of(new Version(0, 0, 0, 1), new Version(0, 0, 0, 2)),
-        Tuple.of(new Version(0, 0, 0, 0), new Version("0.0.0.dev")))
+        Tuple.of(new Version(1, 0, 0), new Version(2, 0, 0)),
+        Tuple.of(new Version(0, 1, 0), new Version(0, 2, 0)),
+        Tuple.of(new Version(0, 0, 1), new Version(0, 0, 2)),
+        Tuple.of(new Version(0, 0, 0), new Version("0.0.dev")))
         .forEach(t -> assertThat(t.getFirst().compareTo(t.getSecond()), is(lessThan(0))));
   }
 
   @Test
   public void compareTo_ShouldReturnZeroWhenFirstIsEqualToSecond() {
     Arrays.asList(
-        Tuple.of(new Version(1, 0, 0, 0), new Version(1, 0, 0, 0)),
-        Tuple.of(new Version(0, 1, 0, 0), new Version(0, 1, 0, 0)),
-        Tuple.of(new Version(0, 0, 1, 0), new Version(0, 0, 1, 0)),
-        Tuple.of(new Version(0, 0, 0, 1), new Version(0, 0, 0, 1)),
-        Tuple.of(new Version("0.0.0.dev"), new Version("0.0.0.dev")))
+        Tuple.of(new Version(1, 0, 0), new Version(1, 0, 0)),
+        Tuple.of(new Version(0, 1, 0), new Version(0, 1, 0)),
+        Tuple.of(new Version(0, 0, 1), new Version(0, 0, 1)),
+        Tuple.of(new Version("0.0.dev"), new Version("0.0.dev")))
         .forEach(t -> assertThat(t.getFirst().compareTo(t.getSecond()), is(0)));
   }
 
   @Test
   public void compareTo_ShouldReturnPositiveIntegerWhenFirstIsGreaterThanSecond() {
     Arrays.asList(
-        Tuple.of(new Version(2, 0, 0, 0), new Version(1, 0, 0, 0)),
-        Tuple.of(new Version(0, 2, 0, 0), new Version(0, 1, 0, 0)),
-        Tuple.of(new Version(0, 0, 2, 0), new Version(0, 0, 1, 0)),
-        Tuple.of(new Version(0, 0, 0, 2), new Version(0, 0, 0, 1)),
-        Tuple.of(new Version("0.0.0.dev"), new Version(0, 0, 0, 0)))
+        Tuple.of(new Version(2, 0, 0), new Version(1, 0, 0)),
+        Tuple.of(new Version(0, 2, 0), new Version(0, 1, 0)),
+        Tuple.of(new Version(0, 0, 2), new Version(0, 0, 1)),
+        Tuple.of(new Version("0.0.dev"), new Version(0, 0, 0)))
         .forEach(t -> assertThat(t.getFirst().compareTo(t.getSecond()), is(greaterThan(0))));
   }
 
@@ -81,27 +78,22 @@ public class VersionTest {
   }
 
   @Test
-  public void testWithMicro() {
-    assertEquals(new Version(1, 2, 3, 999), new Version(1, 2, 3, 4).withMicro(999));
-  }
-
-  @Test
   public void testToString() {
     assertEquals("1.2.3", new Version("1.2.3").toString());
     assertEquals("1.2", new Version("1.2").toString());
     assertEquals("1.2", new Version("1.2.0").toString());
-    assertEquals("1.2.3.dev", new Version("1.2.3.dev").toString());
+    assertEquals("1.2.dev", new Version("1.2.dev").toString());
   }
 
   @Test
   public void testToStringFull() {
-    assertEquals("1.2.3.dev", new Version("1.2.3.dev").toStringFull());
+    assertEquals("1.2.dev", new Version("1.2.dev").toStringFull());
   }
 
   @Test
   public void testGetExactVersion() {
-    assertEquals("1.2.3.4", new Version(1, 2, 3, 4).getExactVersion());
-    assertEquals("1.2.3.4.5", new Version("1.2.3.4.5").getExactVersion());
+    assertEquals("1.2.3", new Version(1, 2, 3).getExactVersion());
+    assertEquals("1.2.3.4", new Version("1.2.3.4").getExactVersion());
     assertEquals("1.2.3.4.something weird", new Version("1.2.3.4.something weird").getExactVersion());
   }
 
@@ -115,6 +107,6 @@ public class VersionTest {
     assertThrows(IllegalArgumentException.class, () -> new Version("a.b.c.12.34"));
     assertThrows(IllegalArgumentException.class, () -> new Version("a:b:c.12.34.56"));
     assertThrows(IllegalArgumentException.class, () -> new Version("a;b;c.12.34.56.78"));
-    assertThrows(IllegalArgumentException.class, () -> new Version("1.2.3.4 wrong syntax"));
+    assertThrows(IllegalArgumentException.class, () -> new Version("1.2.3 wrong syntax"));
   }
 }

--- a/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
+++ b/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationIntegrationTest.java
@@ -14,6 +14,6 @@ final class ProductConfigurationIntegrationTest {
   void shouldReadPropertiesFromResource() {
     assertThat(
         productConfiguration.getVersion().getExactVersion(),
-        matchesPattern("1\\.10\\.0\\.0\\.(@buildId@|dev|\\d+)"));
+        matchesPattern("1\\.10\\.(@buildId@|dev|\\d+)"));
   }
 }

--- a/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationTest.java
+++ b/game-core/src/test/java/org/triplea/common/config/product/ProductConfigurationTest.java
@@ -15,8 +15,8 @@ final class ProductConfigurationTest {
 
   @Test
   void getVersion() {
-    memoryPropertyReader.setProperty(PropertyKeys.VERSION, "1.0.1.3.buildId");
+    memoryPropertyReader.setProperty(PropertyKeys.VERSION, "1.6.buildId");
 
-    assertThat(productConfiguration.getVersion(), is(new Version(1, 0, 1, 3)));
+    assertThat(productConfiguration.getVersion(), is(new Version(1, 6)));
   }
 }

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -18,7 +18,7 @@
     Join the TripleA ranked ladder by posting here:
     https://forums.triplea-game.org/topic/1068/invitation-requests-to-the-new-ladder-and-tournament-site
   error_message:
-- version: 1.10
+- version: "1.10"
   host: lobby.triplea-game.org
   port: 3304
   message: |

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -18,7 +18,7 @@
     Join the TripleA ranked ladder by posting here:
     https://forums.triplea-game.org/topic/1068/invitation-requests-to-the-new-ladder-and-tournament-site
   error_message:
-- version: 1.10.0.0
+- version: 1.10
   host: lobby.triplea-game.org
   port: 3304
   message: |


### PR DESCRIPTION
## Overview
The discussed change to version numbering.

## Functional Changes
Removes unnecessary double zero in the version numbering. This also allows Triple-A to know what build it was and if something is older or newer.

## Manual Testing Performed
- .. Games are able to be started, saved and loaded. Can't load old version games.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Refer to #4234.

Re-created because it picked up a bunch of unrelated changes.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
