### PR TITLE
Add extension to disable headed tests in headless graphics environment

### DIFF
--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowAcceptanceTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowAcceptanceTest.java
@@ -1,12 +1,10 @@
 package games.strategy.debug.error.reporting;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.awt.GraphicsEnvironment;
 import java.util.function.BiConsumer;
 
 import javax.swing.JButton;
@@ -19,30 +17,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.test.common.swing.DisabledInHeadlessGraphicsEnvironment;
 import org.triplea.test.common.swing.SwingComponentWrapper;
 
 import swinglib.DialogBuilder;
-
 
 /**
  * Set up a window, enter in data for the user input text fields, click the submit button and verify
  * we have that data sent to the {@code reportHandler}.
  */
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({DisabledInHeadlessGraphicsEnvironment.class, MockitoExtension.class})
 class ErrorReportWindowAcceptanceTest {
-
   private static final String TITLE = "addis informacio";
-
   private static final String DESCRIPTION = "errus descriptus";
 
   @BeforeAll
   static void disableSwingPopups() {
     DialogBuilder.suppressDialog();
-  }
-
-  @BeforeAll
-  static void skipIfHeadless() {
-    assumeFalse(GraphicsEnvironment.isHeadless());
   }
 
   @Mock

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowAcceptanceTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowAcceptanceTest.java
@@ -26,7 +26,8 @@ import swinglib.DialogBuilder;
  * Set up a window, enter in data for the user input text fields, click the submit button and verify
  * we have that data sent to the {@code reportHandler}.
  */
-@ExtendWith({DisabledInHeadlessGraphicsEnvironment.class, MockitoExtension.class})
+@ExtendWith(DisabledInHeadlessGraphicsEnvironment.class)
+@ExtendWith(MockitoExtension.class)
 class ErrorReportWindowAcceptanceTest {
   private static final String TITLE = "addis informacio";
   private static final String DESCRIPTION = "errus descriptus";

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportWindowTest.java
@@ -1,25 +1,14 @@
 package games.strategy.debug.error.reporting;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
-import java.awt.GraphicsEnvironment;
 import java.util.Arrays;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.test.common.swing.DisabledInHeadlessGraphicsEnvironment;
 import org.triplea.test.common.swing.SwingComponentWrapper;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(DisabledInHeadlessGraphicsEnvironment.class)
 class ErrorReportWindowTest {
-
-  @BeforeAll
-  static void skipIfHeadless() {
-    assumeFalse(GraphicsEnvironment.isHeadless());
-    assumeFalse(Boolean.valueOf(System.getProperty("java.awt.headless", "false")));
-  }
-
   /**
    * Verify that all expected components have been added.
    */

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/PreviewWindowTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/PreviewWindowTest.java
@@ -3,34 +3,23 @@ package games.strategy.debug.error.reporting;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
-import java.awt.GraphicsEnvironment;
 
 import javax.swing.JFrame;
 import javax.swing.JTextArea;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.test.common.swing.DisabledInHeadlessGraphicsEnvironment;
 import org.triplea.test.common.swing.SwingComponentWrapper;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith(DisabledInHeadlessGraphicsEnvironment.class)
 class PreviewWindowTest {
-
   private static final String TITLE = "Lixas velum in antenna!";
   private static final String DESCRIPTION = "Barbatus mons superbe talems gluten est.";
-
   private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
       .title(TITLE)
       .description(DESCRIPTION)
       .build();
-
-  @BeforeAll
-  static void skipIfHeadless() {
-    assumeFalse(GraphicsEnvironment.isHeadless());
-  }
 
   /**
    * Just check that we have rendered at least the user supplied info to the window in a text

--- a/game-core/src/test/java/swinglib/JFrameBuilderTest.java
+++ b/game-core/src/test/java/swinglib/JFrameBuilderTest.java
@@ -4,33 +4,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.test.common.swing.DisabledInHeadlessGraphicsEnvironment;
 import org.triplea.test.common.swing.SwingComponentWrapper;
 
+@ExtendWith(DisabledInHeadlessGraphicsEnvironment.class)
 class JFrameBuilderTest {
-
   private static final String TITLE = "A falsis, finis secundus quadra.";
   private static final int WIDTH = 100;
   private static final int HEIGHT = 1000;
 
-  @BeforeAll
-  static void skipIfHeadless() {
-    assumeFalse(GraphicsEnvironment.isHeadless());
-  }
-
   @Test
   void title() {
-
     final JFrame frame = JFrameBuilder.builder()
         .title(TITLE)
         .build();
@@ -59,7 +52,6 @@ class JFrameBuilderTest {
 
     assertThat(minSize.width, is(WIDTH));
     assertThat(minSize.height, is(HEIGHT));
-
   }
 
   @Test
@@ -97,7 +89,6 @@ class JFrameBuilderTest {
         defaultLocation,
         not(equalTo(relativeLocation)));
   }
-
 
   @Test
   void addComponents() {

--- a/test-common/src/main/java/org/triplea/test/common/swing/DisabledInHeadlessGraphicsEnvironment.java
+++ b/test-common/src/main/java/org/triplea/test/common/swing/DisabledInHeadlessGraphicsEnvironment.java
@@ -1,0 +1,26 @@
+package org.triplea.test.common.swing;
+
+import java.awt.GraphicsEnvironment;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * An extension that disables tests when run in a headless graphics environment.
+ */
+public final class DisabledInHeadlessGraphicsEnvironment implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+    return evaluateExecutionCondition(GraphicsEnvironment.isHeadless());
+  }
+
+  @VisibleForTesting
+  static ConditionEvaluationResult evaluateExecutionCondition(final boolean headless) {
+    return headless
+        ? ConditionEvaluationResult.disabled("Test disabled in headless graphics environment")
+        : ConditionEvaluationResult.enabled(null);
+  }
+}

--- a/test-common/src/test/java/org/triplea/test/common/swing/DisabledInHeadlessGraphicsEnvironmentTest.java
+++ b/test-common/src/test/java/org/triplea/test/common/swing/DisabledInHeadlessGraphicsEnvironmentTest.java
@@ -1,0 +1,32 @@
+package org.triplea.test.common.swing;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.triplea.test.common.swing.DisabledInHeadlessGraphicsEnvironment.evaluateExecutionCondition;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+
+final class DisabledInHeadlessGraphicsEnvironmentTest {
+  @Nested
+  final class EvaluateExecutionConditionTest {
+    @Test
+    void shouldReturnDisabledWhenGraphicsEnvironmentIsHeadless() {
+      final ConditionEvaluationResult result = evaluateExecutionCondition(true);
+
+      assertThat(result.isDisabled(), is(true));
+      assertThat(result.getReason(), isPresentAndIs("Test disabled in headless graphics environment"));
+    }
+
+    @Test
+    void shouldReturnEnabledWhenGraphicsEnvironmentIsHeaded() {
+      final ConditionEvaluationResult result = evaluateExecutionCondition(false);
+
+      assertThat(result.isDisabled(), is(false));
+      assertThat(result.getReason(), isEmpty());
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Adds a JUnit extension to disable headed tests when run in a headless graphics environment.  Removes some duplicate code that does the same thing in each such test.

## Functional Changes

None.

## Manual Testing Performed

None.