### PR TITLE
Refactor: DownloadUtils split into two classes

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -1,0 +1,98 @@
+package games.strategy.engine.framework.map.download;
+// TODO: move to package games.strategy.engine.framework.map.download
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.system.HttpProxy;
+import lombok.AllArgsConstructor;
+import lombok.extern.java.Log;
+
+/** Provides methods to download files via HTTP. */
+@Log
+@AllArgsConstructor
+// TODO: testing, break up DownloadUtilsTest to test this component individually from DownloadUtils.
+final class ContentReader {
+  private final Supplier<CloseableHttpClient> httpClientFactory;
+
+  /**
+   * Creates a temp file, downloads the contents of a target uri to that file, returns the file.
+   *
+   * @param uri The URI whose contents will be downloaded
+   */
+  DownloadUtils.FileDownloadResult downloadToFile(final String uri) {
+    final File file = ClientFileSystemHelper.createTempFile();
+    file.deleteOnExit();
+    try {
+      downloadToFile(uri, file);
+      return DownloadUtils.FileDownloadResult.success(file);
+    } catch (final IOException e) {
+      log.log(
+          Level.SEVERE,
+          "Failed to download: "
+              + uri
+              + ", will attempt to use backup values where available. "
+              + "Please check your network connection.",
+          e);
+      return DownloadUtils.FileDownloadResult.FAILURE;
+    }
+  }
+
+  /**
+   * Downloads the resource at the specified URI to the specified file.
+   *
+   * @param uri The resource URI; must not be {@code null}.
+   * @param file The file that will receive the resource; must not be {@code null}.
+   * @throws IOException If an error occurs during the download.
+   */
+  void downloadToFile(final String uri, final File file) throws IOException {
+    checkNotNull(uri);
+    checkNotNull(file);
+
+    try (FileOutputStream os = new FileOutputStream(file);
+        CloseableHttpClient client = httpClientFactory.get()) {
+      downloadToFile(uri, os, client);
+    }
+  }
+
+  @VisibleForTesting
+  static void downloadToFile(
+      final String uri, final FileOutputStream os, final CloseableHttpClient client)
+      throws IOException {
+    try (CloseableHttpResponse response = client.execute(newHttpGetRequest(uri))) {
+      final int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        throw new IOException(String.format("unexpected status code (%d)", statusCode));
+      }
+
+      final HttpEntity entity = response.getEntity();
+      if (entity == null) {
+        throw new IOException("entity is missing");
+      }
+
+      os.getChannel().transferFrom(Channels.newChannel(entity.getContent()), 0L, Long.MAX_VALUE);
+    }
+  }
+
+  private static HttpRequestBase newHttpGetRequest(final String uri) {
+    final HttpGet request = new HttpGet(uri);
+    HttpProxy.addProxy(request);
+    return request;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -1,5 +1,5 @@
 package games.strategy.engine.framework.map.download;
-// TODO: move to package games.strategy.engine.framework.map.download
+// TODO: move to package games.strategy.engine.framework.map.download.client
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
@@ -1,0 +1,103 @@
+package games.strategy.engine.framework.map.download;
+// TODO: move to package games.strategy.engine.framework.map.download
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import games.strategy.engine.framework.system.HttpProxy;
+import lombok.AllArgsConstructor;
+import lombok.extern.java.Log;
+
+/** Can execute an http head request to determine the size of a file download from URI. */
+@Log
+@AllArgsConstructor
+// TODO: testing, break up DownloadUtilsTest to test this component individually from DownloadUtils.
+final class DownloadLengthReader {
+
+  private final Supplier<CloseableHttpClient> httpClientFactory;
+
+  @VisibleForTesting
+  final ConcurrentMap<String, Long> downloadLengthsByUri = new ConcurrentHashMap<>();
+
+  /**
+   * Gets the download length for the resource at the specified URI.
+   *
+   * <p>This method is thread safe.
+   *
+   * @param uri The resource URI; must not be {@code null}.
+   * @return The download length (in bytes) or empty if unknown; never {@code null}.
+   */
+  Optional<Long> getDownloadLength(final String uri) {
+    return getDownloadLengthFromCache(uri, this::getDownloadLengthFromHost);
+  }
+
+  @VisibleForTesting
+  Optional<Long> getDownloadLengthFromCache(
+      final String uri, final DownloadLengthSupplier supplier) {
+    return Optional.ofNullable(
+        downloadLengthsByUri.computeIfAbsent(uri, k -> supplier.get(k).orElse(null)));
+  }
+
+  @VisibleForTesting
+  interface DownloadLengthSupplier {
+    Optional<Long> get(String uri);
+  }
+
+  private Optional<Long> getDownloadLengthFromHost(final String uri) {
+    try (CloseableHttpClient client = httpClientFactory.get()) {
+      return getDownloadLengthFromHost(uri, client);
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, String.format("failed to get download length for '%s'", uri), e);
+      return Optional.empty();
+    }
+  }
+
+  @VisibleForTesting
+  static Optional<Long> getDownloadLengthFromHost(
+      final String uri, final CloseableHttpClient client) throws IOException {
+    try (CloseableHttpResponse response = client.execute(newHttpHeadRequest(uri))) {
+      final int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        throw new IOException(String.format("unexpected status code (%d)", statusCode));
+      }
+
+      final Header header = response.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
+      // NB: it is legal for a server to respond with "Transfer-Encoding: chunked" instead of
+      // Content-Length
+      if (header == null) {
+        return Optional.empty();
+      }
+
+      final String encodedLength = header.getValue();
+      if (encodedLength == null) {
+        throw new IOException("content length header value is absent");
+      }
+
+      try {
+        return Optional.of(Long.parseLong(encodedLength));
+      } catch (final NumberFormatException e) {
+        throw new IOException(e);
+      }
+    }
+  }
+
+  private static HttpRequestBase newHttpHeadRequest(final String uri) {
+    final HttpHead request = new HttpHead(uri);
+    HttpProxy.addProxy(request);
+    return request;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
@@ -1,5 +1,5 @@
 package games.strategy.engine.framework.map.download;
-// TODO: move to package games.strategy.engine.framework.map.download
+// TODO: move to package games.strategy.engine.framework.map.download.client
 
 import java.io.IOException;
 import java.util.Optional;

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -1,115 +1,53 @@
 package games.strategy.engine.framework.map.download;
+// TODO: move to package games.strategy.engine.framework.map.download
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.channels.Channels;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
+import java.util.function.Supplier;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.system.HttpProxy;
 import lombok.extern.java.Log;
 
 /**
  * Provides methods to download files via HTTP.
+ *
+ * @deprecated Use either {@code ContentReader} or {@code DownloadLengthReader} instead.
  */
 @Log
+@Deprecated
+// TODO: testing, break up DownloadUtilsTest to test this component individually from DownloadUtils.
 public final class DownloadUtils {
-  @VisibleForTesting
-  static final ConcurrentMap<String, Long> downloadLengthsByUri = new ConcurrentHashMap<>();
+
+  @VisibleForTesting static ContentReader contentReader;
+  @VisibleForTesting static DownloadLengthReader downloadLengthReader;
+
+  static {
+    final Supplier<CloseableHttpClient> httpClientSupplier =
+        () -> HttpClients.custom().disableCookieManagement().build();
+    contentReader = new ContentReader(httpClientSupplier);
+    downloadLengthReader = new DownloadLengthReader(httpClientSupplier);
+  }
 
   private DownloadUtils() {}
 
   /**
    * Gets the download length for the resource at the specified URI.
    *
-   * <p>
-   * This method is thread safe.
-   * </p>
+   * <p>This method is thread safe.
    *
    * @param uri The resource URI; must not be {@code null}.
-   *
    * @return The download length (in bytes) or empty if unknown; never {@code null}.
    */
   static Optional<Long> getDownloadLength(final String uri) {
-    return getDownloadLengthFromCache(uri, DownloadUtils::getDownloadLengthFromHost);
-  }
-
-  @VisibleForTesting
-  static Optional<Long> getDownloadLengthFromCache(final String uri, final DownloadLengthSupplier supplier) {
-    return Optional.ofNullable(downloadLengthsByUri.computeIfAbsent(uri, k -> supplier.get(k).orElse(null)));
-  }
-
-  @VisibleForTesting
-  interface DownloadLengthSupplier {
-    Optional<Long> get(String uri);
-  }
-
-  private static Optional<Long> getDownloadLengthFromHost(final String uri) {
-    try (CloseableHttpClient client = newHttpClient()) {
-      return getDownloadLengthFromHost(uri, client);
-    } catch (final IOException e) {
-      log.log(Level.SEVERE, String.format("failed to get download length for '%s'", uri), e);
-      return Optional.empty();
-    }
-  }
-
-  @VisibleForTesting
-  static Optional<Long> getDownloadLengthFromHost(
-      final String uri,
-      final CloseableHttpClient client) throws IOException {
-    try (CloseableHttpResponse response = client.execute(newHttpHeadRequest(uri))) {
-      final int statusCode = response.getStatusLine().getStatusCode();
-      if (statusCode != HttpStatus.SC_OK) {
-        throw new IOException(String.format("unexpected status code (%d)", statusCode));
-      }
-
-      final Header header = response.getFirstHeader(HttpHeaders.CONTENT_LENGTH);
-      // NB: it is legal for a server to respond with "Transfer-Encoding: chunked" instead of Content-Length
-      if (header == null) {
-        return Optional.empty();
-      }
-
-      final String encodedLength = header.getValue();
-      if (encodedLength == null) {
-        throw new IOException("content length header value is absent");
-      }
-
-      try {
-        return Optional.of(Long.parseLong(encodedLength));
-      } catch (final NumberFormatException e) {
-        throw new IOException(e);
-      }
-    }
-  }
-
-  private static CloseableHttpClient newHttpClient() {
-    return HttpClients.custom().disableCookieManagement().build();
-  }
-
-  private static HttpRequestBase newHttpHeadRequest(final String uri) {
-    final HttpHead request = new HttpHead(uri);
-    HttpProxy.addProxy(request);
-    return request;
+    return downloadLengthReader.getDownloadLength(uri);
   }
 
   /**
@@ -118,21 +56,10 @@ public final class DownloadUtils {
    * @param uri The URI whose contents will be downloaded
    */
   public static FileDownloadResult downloadToFile(final String uri) {
-    final File file = ClientFileSystemHelper.createTempFile();
-    file.deleteOnExit();
-    try {
-      downloadToFile(uri, file);
-      return FileDownloadResult.success(file);
-    } catch (final IOException e) {
-      log.log(Level.SEVERE, "Failed to download: " + uri + ", will attempt to use backup values where available. "
-          + "Please check your network connection.", e);
-      return FileDownloadResult.FAILURE;
-    }
+    return contentReader.downloadToFile(uri);
   }
 
-  /**
-   * The result of a file download request.
-   */
+  /** The result of a file download request. */
   public static class FileDownloadResult {
     public final boolean wasSuccess;
     public final File downloadedFile;
@@ -150,7 +77,8 @@ public final class DownloadUtils {
 
     private FileDownloadResult(final File downloadedFile) {
       Preconditions.checkState(
-          downloadedFile.exists(), "Error, file does not exist: " + downloadedFile.getAbsolutePath());
+          downloadedFile.exists(),
+          "Error, file does not exist: " + downloadedFile.getAbsolutePath());
       this.downloadedFile = downloadedFile;
       this.wasSuccess = true;
     }
@@ -161,42 +89,11 @@ public final class DownloadUtils {
    *
    * @param uri The resource URI; must not be {@code null}.
    * @param file The file that will receive the resource; must not be {@code null}.
-   *
    * @throws IOException If an error occurs during the download.
    */
-  public static void downloadToFile(final String uri, final File file) throws IOException {
+  static void downloadToFile(final String uri, final File file) throws IOException {
     checkNotNull(uri);
     checkNotNull(file);
-
-    try (FileOutputStream os = new FileOutputStream(file);
-        CloseableHttpClient client = newHttpClient()) {
-      downloadToFile(uri, os, client);
-    }
-  }
-
-  @VisibleForTesting
-  static void downloadToFile(
-      final String uri,
-      final FileOutputStream os,
-      final CloseableHttpClient client) throws IOException {
-    try (CloseableHttpResponse response = client.execute(newHttpGetRequest(uri))) {
-      final int statusCode = response.getStatusLine().getStatusCode();
-      if (statusCode != HttpStatus.SC_OK) {
-        throw new IOException(String.format("unexpected status code (%d)", statusCode));
-      }
-
-      final HttpEntity entity = response.getEntity();
-      if (entity == null) {
-        throw new IOException("entity is missing");
-      }
-
-      os.getChannel().transferFrom(Channels.newChannel(entity.getContent()), 0L, Long.MAX_VALUE);
-    }
-  }
-
-  private static HttpRequestBase newHttpGetRequest(final String uri) {
-    final HttpGet request = new HttpGet(uri);
-    HttpProxy.addProxy(request);
-    return request;
+    contentReader.downloadToFile(uri, file);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -1,5 +1,5 @@
 package games.strategy.engine.framework.map.download;
-// TODO: move to package games.strategy.engine.framework.map.download
+// TODO: move to package games.strategy.engine.framework.map.download.client
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTest.java
@@ -38,7 +38,6 @@ import org.junitpioneer.jupiter.TempDirectory.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
@@ -88,7 +87,7 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
 
     private void downloadToFile() throws Exception {
       try (FileOutputStream os = new FileOutputStream(file)) {
-        DownloadUtils.downloadToFile(URI, os, client);
+        DownloadUtils.contentReader.downloadToFile(URI, os, client);
       }
     }
 
@@ -120,16 +119,16 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
   @Nested
   public final class GetDownloadLengthFromCacheTest {
     @Mock
-    private DownloadLengthSupplier downloadLengthSupplier;
+    private DownloadLengthReader.DownloadLengthSupplier downloadLengthSupplier;
 
     @BeforeEach
     public void setUp() {
-      DownloadUtils.downloadLengthsByUri.clear();
+      DownloadUtils.downloadLengthReader.downloadLengthsByUri.clear();
     }
 
     @AfterEach
     public void tearDown() {
-      DownloadUtils.downloadLengthsByUri.clear();
+      DownloadUtils.downloadLengthReader.downloadLengthsByUri.clear();
     }
 
     @Test
@@ -143,12 +142,12 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
     }
 
     private Optional<Long> getDownloadLengthFromCache() {
-      return DownloadUtils.getDownloadLengthFromCache(URI, downloadLengthSupplier);
+      return DownloadUtils.downloadLengthReader.getDownloadLengthFromCache(URI, downloadLengthSupplier);
     }
 
     @Test
     public void shouldUseCacheWhenUriPresentInCache() {
-      DownloadUtils.downloadLengthsByUri.put(URI, 42L);
+      DownloadUtils.downloadLengthReader.downloadLengthsByUri.put(URI, 42L);
 
       final Optional<Long> downloadLength = getDownloadLengthFromCache();
 
@@ -163,7 +162,7 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
       final Optional<Long> downloadLength = getDownloadLengthFromCache();
 
       assertThat(downloadLength, is(Optional.empty()));
-      assertThat(DownloadUtils.downloadLengthsByUri, is(anEmptyMap()));
+      assertThat(DownloadUtils.downloadLengthReader.downloadLengthsByUri, is(anEmptyMap()));
     }
   }
 
@@ -204,7 +203,7 @@ public final class DownloadUtilsTest extends AbstractClientSettingTestCase {
     }
 
     private Optional<Long> getDownloadLengthFromHost() throws Exception {
-      return DownloadUtils.getDownloadLengthFromHost(URI, client);
+      return DownloadUtils.downloadLengthReader.getDownloadLengthFromHost(URI, client);
     }
 
     @Test


### PR DESCRIPTION
## Overview

This refactor is a preliminary step to making DownloadUtils stateful and
slitting up its API. In this change we introduce two new objects that
will eventually be used directly by clients and replace DownloadUtils.
As a stepping stone to this we first create the objects and move the
implementation of DownloadUtils to these objects, and then have
DownloadUtils simply delegate to these new objects.


## Functional Changes
- none

## Manual Testing Performed
- none


## Additional Review Notes

This PR just moves code and adds some TODOs. The green code is what we have split off from DownloadUtils. Tests are not yet modified intentionally to show we are still maintaining existing behavior.