### PR TITLE
Group Lobby Login classes together

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -9,7 +9,6 @@ import javax.swing.SwingUtilities;
 
 import com.google.common.base.Preconditions;
 
-import games.strategy.engine.config.client.LobbyServerPropertiesFetcher;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.ClientSetupPanel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
@@ -20,6 +19,7 @@ import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.ScreenChangeListener;
 import games.strategy.engine.lobby.client.login.LobbyLogin;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
+import games.strategy.engine.lobby.client.login.LobbyServerPropertiesFetcher;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLocationFileDownloader.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLocationFileDownloader.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -13,7 +13,6 @@ import org.yaml.snakeyaml.Yaml;
 import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
 
-import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.util.OpenJsonUtils;
 import games.strategy.util.Version;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -32,7 +32,7 @@ public class LobbyServerProperties {
    * @param host The host address of the lobby, typically an IP address
    * @param port The port the lobby is listening on
    */
-  public LobbyServerProperties(final String host, final int port) {
+  LobbyServerProperties(final String host, final int port) {
     this.host = host;
     this.port = port;
     this.serverErrorMessage = "";
@@ -45,7 +45,7 @@ public class LobbyServerProperties {
    *
    * @param yamlProps Yaml object with lobby properties from the point of view of the game client.
    */
-  public LobbyServerProperties(final Map<String, Object> yamlProps) {
+  LobbyServerProperties(final Map<String, Object> yamlProps) {
     this.host = (String) yamlProps.get("host");
     this.port = (Integer) yamlProps.get("port");
     this.serverMessage = Strings.nullToEmpty((String) yamlProps.get("message"));

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,7 +10,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.map.download.DownloadUtils;
-import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSetting;

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,10 +11,9 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.util.Version;
 
-public class LobbyPropertyFileParserTest {
+class LobbyPropertyFileParserTest {
 
   private static TestProps[] testDataSet() {
     final TestProps testProps1 = new TestProps();
@@ -48,7 +47,7 @@ public class LobbyPropertyFileParserTest {
    * straight forward 1:1
    */
   @Test
-  public void parseWithSimpleCase() throws Exception {
+  void parseWithSimpleCase() throws Exception {
     final TestProps testProps = new TestProps();
     testProps.host = TestData.host;
     testProps.port = TestData.port;
@@ -82,7 +81,7 @@ public class LobbyPropertyFileParserTest {
    * line up and we get the expected lobby config back.
    */
   @Test
-  public void checkVersionSelection() throws Exception {
+  void checkVersionSelection() throws Exception {
     final File testFile = createTempFile(testDataSet());
 
     final LobbyServerProperties result =

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherIntegrationTest.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -9,9 +9,9 @@ import org.triplea.test.common.Integration;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 @Integration
-public class LobbyServerPropertiesFetcherIntegrationTest extends AbstractClientSettingTestCase {
+class LobbyServerPropertiesFetcherIntegrationTest extends AbstractClientSettingTestCase {
   @Test
-  public void remoteLobbyUrlReaderWorks() {
+  void remoteLobbyUrlReaderWorks() {
 
     final LobbyServerPropertiesFetcher testObj = new LobbyServerPropertiesFetcher();
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.config.client;
+package games.strategy.engine.lobby.client.login;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -19,31 +19,30 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import games.strategy.engine.framework.map.download.DownloadUtils;
-import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.settings.GameSetting;
 import games.strategy.util.OptionalUtils;
 import games.strategy.util.Version;
 
 @ExtendWith(MockitoExtension.class)
-public class LobbyServerPropertiesFetcherTest {
+class LobbyServerPropertiesFetcherTest {
   @Mock
   private LobbyLocationFileDownloader mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     testObj = new LobbyServerPropertiesFetcher(mockFileDownloader);
   }
 
   @ExtendWith(MockitoExtension.class)
   @Nested
-  public final class DownloadAndParseRemoteFileTest {
+  final class DownloadAndParseRemoteFileTest {
     /**
      * Happy case test path, download file, parse it, return values parsed.
      */
     @Test
-    public void happyCase() throws Exception {
+    void happyCase() throws Exception {
       givenHappyCase();
 
       final LobbyServerProperties result = testObj.downloadAndParseRemoteFile(TestData.url,
@@ -59,7 +58,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     @Test
-    public void throwsOnDownloadFailure() {
+    void throwsOnDownloadFailure() {
       assertThrows(IOException.class, () -> {
         when(mockFileDownloader.download(TestData.url)).thenReturn(DownloadUtils.FileDownloadResult.FAILURE);
 
@@ -70,7 +69,7 @@ public class LobbyServerPropertiesFetcherTest {
 
   @ExtendWith(MockitoExtension.class)
   @Nested
-  public final class GetTestOverridePropertiesTest {
+  final class GetTestOverridePropertiesTest {
     @Mock
     private GameSetting<String> testLobbyHostSetting;
 
@@ -120,7 +119,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     @Test
-    public void shouldReturnEmptyWhenHostNotSetAndPortNotSet() {
+    void shouldReturnEmptyWhenHostNotSetAndPortNotSet() {
       givenTestLobbyHostIsNotSet();
 
       whenGetTestOverrideProperties();
@@ -129,7 +128,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     @Test
-    public void shouldReturnEmptyWhenHostSetAndPortNotSet() {
+    void shouldReturnEmptyWhenHostSetAndPortNotSet() {
       givenTestLobbyHostIsSet();
       givenTestLobbyPortIsNotSet();
 
@@ -139,7 +138,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     @Test
-    public void shouldReturnEmptyWhenHostNotSetAndPortSet() {
+    void shouldReturnEmptyWhenHostNotSetAndPortSet() {
       givenTestLobbyHostIsNotSet();
 
       whenGetTestOverrideProperties();
@@ -148,7 +147,7 @@ public class LobbyServerPropertiesFetcherTest {
     }
 
     @Test
-    public void shouldReturnPropertiesWhenHostSetAndPortSet() {
+    void shouldReturnPropertiesWhenHostSetAndPortSet() {
       givenTestLobbyHostIsSetTo("foo");
       givenTestLobbyPortIsSetTo(4242);
 


### PR DESCRIPTION
## Overview
Moving all files from package 'games/strategy/engine/config/client/' to
'games/strategy/engine/lobby/client/login'


## Functional Changes
- none

## Manual Testing Performed
- could launch headed game and connect to lobby

## Additional Review Notes
- Just file moves to group related classes together. Further refactoring will build on this, first want to get the file moves out of the way.