### PR TITLE
Add uptime report dashboard links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ TripleA is an open source gaming community, free to play, 100% open source and v
 - [Feature requests](https://forums.triplea-game.org/category/42/feature-requests-and-ideas)
 - [Gitter](https://gitter.im/triplea-game/social)
 
+## Up-Time Reports
+- [Lobby and Forums](https://stats.uptimerobot.com/14RYqsN5m)
+- [Game Hosting Bots](https://stats.uptimerobot.com/2WVgrCzO4)
 
 ## Documentation Links
 - Developer, getting started: https://github.com/triplea-game/triplea/tree/master/docs/dev


### PR DESCRIPTION
## Overview
- Signed up for [uptime robot](http://uptimerobot.com/) with the shared
[triplea builder bot account](https://github.com/tripleabuilderbot)
- Added monitors for  Triple lobby, prerelease, forums and bot URLs+ports
- From this created two public dashboards in uptime robot and added
those links to README


## Functional Changes
- none

## Manual Testing Performed
- verified links work

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![screenshot from 2018-12-11 01-05-10](https://user-images.githubusercontent.com/12397753/49789440-dcad0300-fce0-11e8-918b-a75b26222038.png)

### After
![screenshot from 2018-12-11 01-05-42](https://user-images.githubusercontent.com/12397753/49789457-e9315b80-fce0-11e8-8cd1-1ceebc15b1d3.png)

