### PR TITLE
Fix requiresUnits carrier placement bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1307,7 +1307,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * Returns a predicate that indicates whether the territory contains one of the required combos of units
-   * (and if 'doNotCountNeighbors' is false, and unit is Sea unit, will return true if an adjacent land
+   * (and if 'doNotCountNeighbors' is false, and territory is water, will return true if an adjacent land
    * territory has one of the required combos as well).
    *
    * @param to - Territory we are testing for required units
@@ -1325,15 +1325,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
           .test(unitWhichRequiresUnits)) {
         return true;
       }
-      if (!doNotCountNeighbors) {
-        if (Matches.unitIsSea().test(unitWhichRequiresUnits)) {
-          for (final Territory current : getAllProducers(to, player,
-              Collections.singletonList(unitWhichRequiresUnits), true)) {
-            final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
-            if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
-                .test(unitWhichRequiresUnits)) {
-              return true;
-            }
+      if (!doNotCountNeighbors && to.isWater()) {
+        for (final Territory current : getAllProducers(to, player,
+            Collections.singletonList(unitWhichRequiresUnits), true)) {
+          final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
+          if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
+              .test(unitWhichRequiresUnits)) {
+            return true;
           }
         }
       }


### PR DESCRIPTION
Fixes issue reported here: https://forums.triplea-game.org/topic/986/red-sun-over-china-rsoc-official-thread/107

Addresses issue where fighters can't be placed on carriers if using "requiresUnits" property for a map. Now checks if the territory is sea rather than the unit for checking adjacent factories.