### PR TITLE
Rename installer tasks

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -51,7 +51,7 @@ jar {
     }
 }
 
-task downloadInstallerAssets(group: 'release') {
+task downloadPlatformInstallerAssets(group: 'release') {
     doLast {
         [
             'icons/triplea_icon_16_16.png',
@@ -73,10 +73,10 @@ task downloadInstallerAssets(group: 'release') {
     }
 }
 
-task headedGameInstallers(
+task platformInstallers(
         type: com.install4j.gradle.Install4jTask,
         group: 'release',
-        dependsOn: [shadowJar, downloadInstallerAssets]) {
+        dependsOn: [shadowJar, downloadPlatformInstallerAssets]) {
     projectFile = file('build.install4j')
     release = version
 
@@ -85,7 +85,7 @@ task headedGameInstallers(
     }
 }
 
-task headedGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
+task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
     from file('.triplea-root')
     from(file('assets')) {
         into 'assets'
@@ -98,9 +98,9 @@ task headedGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     }
 }
 
-task release(group: 'release', dependsOn: [headedGameArchive, headedGameInstallers]) {
+task release(group: 'release', dependsOn: [portableInstaller, platformInstallers]) {
     doLast {
-        publishArtifacts(headedGameArchive.outputs.files + [
+        publishArtifacts(portableInstaller.outputs.files + [
             file("$releasesDir/TripleA_${version}_macos.dmg"),
             file("$releasesDir/TripleA_${version}_unix.sh"),
             file("$releasesDir/TripleA_${version}_windows-32bit.exe"),

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -20,7 +20,7 @@ jar {
     }
 }
 
-task headlessGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
+task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
     from file('.triplea-root')
     from file('scripts/run_bot')
     from(file('scripts/run_bot.bat')) {
@@ -32,8 +32,8 @@ task headlessGameArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     }
 }
 
-task release(group: 'release', dependsOn: headlessGameArchive) {
+task release(group: 'release', dependsOn: portableInstaller) {
     doLast {
-        publishArtifacts(headlessGameArchive.outputs.files)
+        publishArtifacts(portableInstaller.outputs.files)
     }
 }

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -21,14 +21,14 @@ jar {
     }
 }
 
-task httpServerArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
+task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
     from(shadowJar.outputs) {
         into 'bin'
     }
 }
 
-task release(group: 'release', dependsOn: httpServerArchive) {
+task release(group: 'release', dependsOn: portableInstaller) {
     doLast {
-        publishArtifacts(httpServerArchive.outputs.files)
+        publishArtifacts(portableInstaller.outputs.files)
     }
 }

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -16,16 +16,14 @@ flyway {
     password = 'postgres'
 }
 
-task lobbyDbMigrationScripts(type: Zip, group: 'release') {
+task portableInstaller(type: Zip, group: 'release') {
     from 'src/main/resources/db/migration'
     include '*.sql'
     archiveName 'migrations.zip'
 }
 
-task release(group: 'release', dependsOn: lobbyDbMigrationScripts) {
+task release(group: 'release', dependsOn: portableInstaller) {
     doLast {
-        publishArtifacts([
-            file("$distsDir/migrations.zip")
-        ])
+        publishArtifacts(portableInstaller.outputs.files)
     }
 }

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -22,7 +22,7 @@ jar {
     }
 }
 
-task lobbyArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
+task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
     from('config') {
         into 'config'
     }
@@ -31,8 +31,8 @@ task lobbyArchive(type: Zip, group: 'release', dependsOn: shadowJar) {
     }
 }
 
-task release(group: 'release', dependsOn: lobbyArchive) {
+task release(group: 'release', dependsOn: portableInstaller) {
     doLast {
-        publishArtifacts(lobbyArchive.outputs.files)
+        publishArtifacts(portableInstaller.outputs.files)
     }
 }


### PR DESCRIPTION
## Overview

Renames the Gradle installer-related tasks to remove some redundancy and for consistency across projects.

For example, to build the headed game install4j installers previously, one would run the `:game-headed:headedGameInstallers` task.  The task basically repeats the project name and is redundant.  Now one will run the `:game-headed:platformInstallers` task.

The task for each project's portable installer was previously named `[project]Archive` (or something close to that).  These are all now named just `portableInstaller` for consistency.  For example, where one would have previously run the `:game-headed:headedGameArchive` task to build the headed game portable installer, one will now run the `:game-headed:portableInstaller` task.

## Functional Changes

None.

## Manual Testing Performed

Ran the `release` task locally and verified all expected project artifacts were built with the correct name.