### PR TITLE
Rename "seperate" -> "separate"

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DelegateList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DelegateList.java
@@ -41,7 +41,7 @@ public class DelegateList extends GameDataComponent implements Iterable<IDelegat
   }
 
   private void writeObject(@SuppressWarnings("unused") final ObjectOutputStream out) {
-    // dont write since delegates should be handled seperatly.
+    // don't write since delegates should be handled separately.
   }
 
   private void readObject(@SuppressWarnings("unused") final ObjectInputStream in) {

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -188,7 +188,7 @@ public class PbemDiceRoller implements IRandomSource {
       }
       reRollButton.setEnabled(false);
       exitButton.setEnabled(false);
-      new Thread(this::rollInSeperateThread, "Triplea, roll in seperate thread").start();
+      new Thread(this::rollInSeparateThread, "Triplea, roll in separate thread").start();
     }
 
     private void closeAndReturn() {
@@ -205,7 +205,7 @@ public class PbemDiceRoller implements IRandomSource {
      * opening) will close the window and notify any waiting threads when completed successfully.
      * Before contacting Irony Dice Server, check if email has a reasonable valid syntax.
      */
-    private void rollInSeperateThread() throws IllegalStateException {
+    private void rollInSeparateThread() throws IllegalStateException {
       if (SwingUtilities.isEventDispatchThread()) {
         throw new IllegalStateException("Wrong thread");
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -753,7 +753,7 @@ public class AirBattle extends AbstractBattle {
       final DiceRoll dice, final PlayerId hitPlayer, final PlayerId firingPlayer, final CasualtyDetails details) {
     getDisplay(bridge).casualtyNotification(battleId, stepName, dice, hitPlayer, details.getKilled(),
         details.getDamaged(), Collections.emptyMap());
-    // execute in a seperate thread to allow either player to click continue first.
+    // execute in a separate thread to allow either player to click continue first.
     final Thread t = new Thread(() -> {
       try {
         getRemote(firingPlayer, bridge).confirmEnemyCasualties(battleId, "Press space to continue", hitPlayer);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -33,7 +33,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Triple;
@@ -136,7 +136,7 @@ public class BattleCalculator {
    */
   private static Tuple<List<List<Unit>>, List<Unit>> categorizeLowLuckAirUnits(final Collection<Unit> units,
       final int groupSize) {
-    final Collection<UnitCategory> categorizedAir = UnitSeperator.categorize(units, null, false, true);
+    final Collection<UnitCategory> categorizedAir = UnitSeparator.categorize(units, null, false, true);
     final List<List<Unit>> groupsOfSize = new ArrayList<>();
     final List<Unit> toRoll = new ArrayList<>();
     for (final UnitCategory uc : categorizedAir) {
@@ -865,14 +865,14 @@ public class BattleCalculator {
 
   /**
    * Checks if the given collections target are all of one category as defined
-   * by UnitSeperator.categorize and they are not two hit units.
+   * by UnitSeparator.categorize and they are not two hit units.
    *
    * @param targets a collection of target units
    * @param dependents map of depend units for target units
    */
   private static boolean allTargetsOneTypeOneHitPoint(final Collection<Unit> targets,
       final Map<Unit, Collection<Unit>> dependents) {
-    final Set<UnitCategory> categorized = UnitSeperator.categorize(targets, dependents, false, false);
+    final Set<UnitCategory> categorized = UnitSeparator.categorize(targets, dependents, false, false);
     if (categorized.size() == 1) {
       final UnitCategory unitCategory = categorized.iterator().next();
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -38,7 +38,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PredicateBuilder;
@@ -1112,11 +1112,11 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsTransportingSomeCategories(final Collection<Unit> units) {
-    final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(units);
+    final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(units);
     return unit -> {
       final Collection<Unit> transporting = TripleAUnit.get(unit).getTransporting();
       return transporting != null
-          && !Collections.disjoint(UnitSeperator.categorize(transporting), unitCategories);
+          && !Collections.disjoint(UnitSeparator.categorize(transporting), unitCategories);
     };
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -33,7 +33,7 @@ import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PredicateBuilder;
@@ -1150,7 +1150,7 @@ public class MoveValidator {
       }
       if (!unitsToTransports.keySet().containsAll(land)) {
         // some units didn't get mapped to a transport
-        final Collection<UnitCategory> unitsToLoadCategories = UnitSeperator.categorize(land);
+        final Collection<UnitCategory> unitsToLoadCategories = UnitSeparator.categorize(land);
         if (unitsToTransports.size() == 0 || unitsToLoadCategories.size() == 1) {
           // set all unmapped units as disallowed if there are no transports or only one unit category
           for (final Unit unit : land) {

--- a/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -282,7 +282,7 @@ public class MyFormatter {
    * In both cases, the objects will appear in the string in order by name.
    * </p>
    */
-  public static String defaultNamedToTextList(final Collection<? extends DefaultNamed> list, final String seperator,
+  public static String defaultNamedToTextList(final Collection<? extends DefaultNamed> list, final String separator,
       final boolean showQuantity) {
     final IntegerMap<DefaultNamed> map = new IntegerMap<>();
     for (final DefaultNamed unit : list) {
@@ -307,7 +307,7 @@ public class MyFormatter {
       }
       count--;
       if (count > 1) {
-        buf.append(seperator);
+        buf.append(separator);
       }
       if (count == 1) {
         buf.append(" and ");

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 
@@ -145,7 +145,7 @@ public class PlayerUnitsPanel extends JPanel {
     }
 
     // Populate units into each category then add any remaining categories (damaged units, etc)
-    final Set<UnitCategory> unitCategories = UnitSeperator.categorize(units);
+    final Set<UnitCategory> unitCategories = UnitSeparator.categorize(units);
     for (final UnitCategory category : categories) {
       for (final UnitCategory unitCategory : unitCategories) {
         if (category.equals(unitCategory)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -33,7 +33,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.AbstractUndoableMove;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 
 abstract class AbstractUndoableMovesPanel extends JPanel {
   private static final long serialVersionUID = 1910945925958952416L;
@@ -77,17 +77,17 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
       add(new JLabel((this instanceof UndoablePlacementsPanel) ? "Placements:" : "Moves:"), BorderLayout.NORTH);
     }
     int scrollIncrement = 10;
-    final Dimension seperatorSize = new Dimension(150, 20);
+    final Dimension separatorSize = new Dimension(150, 20);
     while (iter.hasNext()) {
       final AbstractUndoableMove item = iter.next();
       final JComponent moveComponent = createComponentForMove(item);
       scrollIncrement = moveComponent.getPreferredSize().height;
       items.add(moveComponent);
       if (iter.hasNext()) {
-        final JSeparator seperator = new JSeparator(SwingConstants.HORIZONTAL);
-        seperator.setPreferredSize(seperatorSize);
-        seperator.setMaximumSize(seperatorSize);
-        items.add(seperator);
+        final JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
+        separator.setPreferredSize(separatorSize);
+        separator.setMaximumSize(separatorSize);
+        items.add(separator);
       }
     }
     if (movePanel.getUndoableMoves() != null && movePanel.getUndoableMoves().size() > 1) {
@@ -96,7 +96,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
       items.add(undoAllButton);
     }
 
-    final int scrollIncrementFinal = scrollIncrement + seperatorSize.height;
+    final int scrollIncrementFinal = scrollIncrement + separatorSize.height;
     // JScrollPane scroll = new JScrollPane(items);
     scroll = new JScrollPane(items) {
       private static final long serialVersionUID = -1064967105431785533L;
@@ -124,7 +124,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
   private JComponent createComponentForMove(final AbstractUndoableMove move) {
     final Box unitsBox = new Box(BoxLayout.X_AXIS);
     unitsBox.add(new JLabel((move.getIndex() + 1) + ") "));
-    final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(move.getUnits());
+    final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(move.getUnits());
     final Dimension buttonSize = new Dimension(80, 22);
     for (final UnitCategory category : unitCategories) {
       final Optional<ImageIcon> icon =

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -66,7 +66,7 @@ import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitOwner;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.ui.Util;
@@ -189,7 +189,7 @@ public class BattleDisplay extends JPanel {
     for (final Collection<Unit> dependentCollection : dependentsMap.values()) {
       dependentUnitsReturned.addAll(dependentCollection);
     }
-    for (final UnitCategory category : UnitSeperator.categorize(killedUnits, dependentsMap, false, false)) {
+    for (final UnitCategory category : UnitSeparator.categorize(killedUnits, dependentsMap, false, false)) {
       final JPanel panel = new JPanel();
       JLabel unit = uiContext.createUnitImageJLabel(category.getType(), category.getOwner());
       panel.add(unit);
@@ -740,7 +740,7 @@ public class BattleDisplay extends JPanel {
         }
       }
       final int diceSides = gameData.getDiceSides();
-      final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(units, null, false, false, false);
+      final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(units, null, false, false, false);
       for (final UnitCategory category : unitCategories) {
         int strength;
         final UnitAttachment attachment = UnitAttachment.get(category.getType());
@@ -860,13 +860,13 @@ public class BattleDisplay extends JPanel {
       if (!killed.isEmpty()) {
         this.killed.add(new JLabel("Killed"));
       }
-      final Iterable<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false);
+      final Iterable<UnitCategory> killedIter = UnitSeparator.categorize(killed, dependents, false, false);
       categorizeUnits(killedIter, false, false);
       damaged.removeAll(killed);
       if (!damaged.isEmpty()) {
         this.damaged.add(new JLabel("Damaged"));
       }
-      final Iterable<UnitCategory> damagedIter = UnitSeperator.categorize(damaged, dependents, false, false);
+      final Iterable<UnitCategory> damagedIter = UnitSeparator.categorize(damaged, dependents, false, false);
       categorizeUnits(damagedIter, true, true);
       invalidate();
       validate();
@@ -877,7 +877,7 @@ public class BattleDisplay extends JPanel {
       if (!killed.isEmpty()) {
         this.killed.add(new JLabel("Killed"));
       }
-      final Iterable<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false);
+      final Iterable<UnitCategory> killedIter = UnitSeparator.categorize(killed, dependents, false, false);
       categorizeUnits(killedIter, false, false);
       invalidate();
       validate();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -61,7 +61,7 @@ import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.TuvUtils;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
@@ -144,9 +144,9 @@ class EditPanel extends ActionPanel {
           final List<Unit> allOfCorrectType = CollectionUtils.getMatches(allUnits,
               o -> selectedUnitTypes.contains(o.getType()));
           final int allCategories =
-              UnitSeperator.categorize(allOfCorrectType, mustMoveWithDetails.getMustMoveWith(), true, true).size();
+              UnitSeparator.categorize(allOfCorrectType, mustMoveWithDetails.getMustMoveWith(), true, true).size();
           final int selectedCategories =
-              UnitSeperator.categorize(selectedUnits, mustMoveWithDetails.getMustMoveWith(), true, true).size();
+              UnitSeparator.categorize(selectedUnits, mustMoveWithDetails.getMustMoveWith(), true, true).size();
           mustChoose = (allCategories != selectedCategories);
         }
         final Collection<Unit> bestUnits;

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -60,7 +60,7 @@ import games.strategy.triplea.ui.screen.UnitsDrawer;
 import games.strategy.triplea.ui.screen.drawable.IDrawable.OptionalExtraBorderLevel;
 import games.strategy.triplea.util.Stopwatch;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.ImageScrollerLargeView;
 import games.strategy.ui.Util;
@@ -630,7 +630,7 @@ public class MapPanel extends ImageScrollerLargeView {
     }
     if (highlightedUnits != null) {
       for (final List<Unit> value : highlightedUnits.values()) {
-        for (final UnitCategory category : UnitSeperator.categorize(value)) {
+        for (final UnitCategory category : UnitSeparator.categorize(value)) {
           final List<Unit> territoryUnitsOfSameCategory = category.getUnits();
           if (territoryUnitsOfSameCategory.isEmpty()) {
             continue;
@@ -800,7 +800,7 @@ public class MapPanel extends ImageScrollerLargeView {
       gameData.releaseReadLock();
     }
 
-    final Set<UnitCategory> categories = UnitSeperator.categorize(units);
+    final Set<UnitCategory> categories = UnitSeparator.categorize(units);
     final int iconWidth = uiContext.getUnitImageFactory().getUnitImageWidth();
     final int horizontalSpace = 5;
     final BufferedImage img = Util.createImage(categories.size() * (horizontalSpace + iconWidth),

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -46,7 +46,7 @@ import games.strategy.triplea.delegate.data.MoveValidationResult;
 import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.ObjectUtils;
@@ -195,7 +195,7 @@ public class MovePanel extends AbstractMovePanel {
 
     // Are the transports all of the same type and if they are, then don't ask
     final Collection<UnitCategory> categories =
-        UnitSeperator.categorize(candidateTransports, mustMoveWithDetails.getMustMoveWith(), true, false);
+        UnitSeparator.categorize(candidateTransports, mustMoveWithDetails.getMustMoveWith(), true, false);
     if (categories.size() == 1) {
       return unitsToUnload;
     }
@@ -234,11 +234,11 @@ public class MovePanel extends AbstractMovePanel {
           if (transporting == null) {
             continue;
           }
-          final Collection<UnitCategory> transCategories = UnitSeperator.categorize(transporting);
+          final Collection<UnitCategory> transCategories = UnitSeparator.categorize(transporting);
           final Iterator<Unit> unitIter = availableUnits.iterator();
           while (unitIter.hasNext()) {
             final Unit unit = unitIter.next();
-            final Collection<UnitCategory> unitCategory = UnitSeperator.categorize(Collections.singleton(unit));
+            final Collection<UnitCategory> unitCategory = UnitSeparator.categorize(Collections.singleton(unit));
 
             // Is one of the transported units of the same type we want to unload?
             if (!Collections.disjoint(transCategories, unitCategory)) {
@@ -663,7 +663,7 @@ public class MovePanel extends AbstractMovePanel {
         return candidateTransports;
       }
       // all the same type, dont ask unless we have more than 1 unit type
-      if (UnitSeperator.categorize(candidateTransports, endMustMoveWith.getMustMoveWith(), true, false).size() == 1
+      if (UnitSeparator.categorize(candidateTransports, endMustMoveWith.getMustMoveWith(), true, false).size() == 1
           && unitsToLoad.size() == 1) {
         return candidateTransports;
       }
@@ -1142,7 +1142,7 @@ public class MovePanel extends AbstractMovePanel {
     boolean mustQueryUser = initialMustQueryUser;
     if (!mustQueryUser) {
       final Set<UnitCategory> categories =
-          UnitSeperator.categorize(candidateUnits, mustMoveWithDetails.getMustMoveWith(), true, false);
+          UnitSeparator.categorize(candidateUnits, mustMoveWithDetails.getMustMoveWith(), true, false);
       for (final UnitCategory category1 : categories) {
         // we cant move these, dont bother to check
         if (category1.getMovement() == 0) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -25,7 +25,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.util.CollectionUtils;
 
 class PlacePanel extends AbstractMovePanel {
@@ -159,7 +159,7 @@ class PlacePanel extends AbstractMovePanel {
   }
 
   private void updateUnits() {
-    final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(getCurrentPlayer().getUnits().getUnits());
+    final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(getCurrentPlayer().getUnits().getUnits());
     unitsToPlace.setUnitsFromCategories(unitCategories);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -24,7 +24,7 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.IntegerMap;
@@ -82,7 +82,7 @@ public class PurchasePanel extends ActionPanel {
 
       getData().acquireReadLock();
       try {
-        purchasedPreviousRoundsUnits.setUnitsFromCategories(UnitSeperator.categorize(id.getUnits().getUnits()));
+        purchasedPreviousRoundsUnits.setUnitsFromCategories(UnitSeparator.categorize(id.getUnits().getUnits()));
         add(Box.createVerticalStrut(4));
         if (!id.getUnits().isEmpty()) {
           add(purchasedPreviousRoundsLabel);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -22,7 +22,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.odds.calculator.OddsCalculatorDialog;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.OverlayIcon;
 import games.strategy.ui.SwingComponents;
 
@@ -96,11 +96,11 @@ class TerritoryDetailPanel extends AbstractStatPanel {
     final JPanel panel = new JPanel();
     panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-    final List<UnitCategory> units = UnitSeperator.getSortedUnitCategories(territory, uiContext.getMapData());
+    final List<UnitCategory> units = UnitSeparator.getSortedUnitCategories(territory, uiContext.getMapData());
     @Nullable
     PlayerId currentPlayer = null;
     for (final UnitCategory item : units) {
-      // seperate players with a seperator
+      // separate players with a separator
       if (!item.getOwner().equals(currentPlayer)) {
         currentPlayer = item.getOwner();
         panel.add(Box.createVerticalStrut(15));

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -25,7 +25,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitOwner;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
 import games.strategy.util.IntegerMap;
@@ -162,9 +162,9 @@ final class UnitChooser extends JPanel {
       final boolean categorizeMovement, final boolean categorizeTransportCost,
       final Collection<Unit> defaultSelections) {
     final Collection<UnitCategory> categories =
-        UnitSeperator.categorize(units, dependent, categorizeMovement, categorizeTransportCost);
+        UnitSeparator.categorize(units, dependent, categorizeMovement, categorizeTransportCost);
     final Collection<UnitCategory> defaultSelectionsCategorized =
-        UnitSeperator.categorize(defaultSelections, dependent, categorizeMovement, categorizeTransportCost);
+        UnitSeparator.categorize(defaultSelections, dependent, categorizeMovement, categorizeTransportCost);
     final IntegerMap<UnitCategory> defaultValues = createDefaultSelectionsMap(defaultSelectionsCategorized);
     for (final UnitCategory category : categories) {
       addCategory(category, defaultValues.getInt(category));

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -23,7 +23,7 @@ import games.strategy.triplea.ui.DicePanel;
 import games.strategy.triplea.ui.MapPanel;
 import games.strategy.triplea.ui.SimpleUnitPanel;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 
 /**
  * A UI component that displays details about the currently-selected history node.
@@ -108,7 +108,7 @@ public class HistoryDetailsPanel extends JPanel {
   }
 
   private void renderUnits(final GridBagConstraints mainConstraints, final Collection<Unit> units) {
-    final Collection<UnitCategory> unitsCategories = UnitSeperator.categorize(units);
+    final Collection<UnitCategory> unitsCategories = UnitSeparator.categorize(units);
     final SimpleUnitPanel unitsPanel = new SimpleUnitPanel(mapPanel.getUiContext());
     unitsPanel.setUnitsFromCategories(unitsCategories);
     add(unitsPanel, mainConstraints);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -52,7 +52,7 @@ import games.strategy.triplea.ui.screen.drawable.TerritoryEffectDrawable;
 import games.strategy.triplea.ui.screen.drawable.TerritoryNameDrawable;
 import games.strategy.triplea.ui.screen.drawable.VcDrawable;
 import games.strategy.triplea.util.UnitCategory;
-import games.strategy.triplea.util.UnitSeperator;
+import games.strategy.triplea.util.UnitSeparator;
 import games.strategy.ui.Util;
 import games.strategy.util.Tuple;
 
@@ -341,7 +341,7 @@ public class TileManager {
     }
 
     Point lastPlace = null;
-    for (final UnitCategory category : UnitSeperator.getSortedUnitCategories(territory, mapData)) {
+    for (final UnitCategory category : UnitSeparator.getSortedUnitCategories(territory, mapData)) {
       final boolean overflow;
       if (placementPoints.hasNext()) {
         lastPlace = new Point(placementPoints.next());

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -164,8 +164,8 @@ public class TransportUtils {
     final List<Unit> totalLoad = new ArrayList<>();
 
     // Get a list of the unit categories
-    final Collection<UnitCategory> unitTypes = UnitSeperator.categorize(canBeTransported, null, false, true);
-    final Collection<UnitCategory> transportTypes = UnitSeperator.categorize(airTransports, null, false, false);
+    final Collection<UnitCategory> unitTypes = UnitSeparator.categorize(canBeTransported, null, false, true);
+    final Collection<UnitCategory> transportTypes = UnitSeparator.categorize(airTransports, null, false, false);
     for (final UnitCategory unitType : unitTypes) {
       final int transportCost = unitType.getTransportCost();
       for (final UnitCategory transportType : transportTypes) {

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -24,8 +24,8 @@ import games.strategy.triplea.ui.mapdata.MapData;
 /**
  * Separates a group of units into distinct categories.
  */
-public class UnitSeperator {
-  private UnitSeperator() {}
+public class UnitSeparator {
+  private UnitSeparator() {}
 
   /**
    * Finds unit categories, removes not displayed, and then sorts them into logical order to display based on:
@@ -35,7 +35,7 @@ public class UnitSeperator {
    */
   public static List<UnitCategory> getSortedUnitCategories(final Territory t, final MapData mapData) {
     final GameData data = t.getData();
-    final List<UnitCategory> categories = new ArrayList<>(UnitSeperator.categorize(t.getUnits().getUnits()));
+    final List<UnitCategory> categories = new ArrayList<>(UnitSeparator.categorize(t.getUnits().getUnits()));
     categories.removeIf(uc -> !mapData.shouldDrawUnit(uc.getType().getName()));
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -23,7 +23,7 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.xml.TestMapGameData;
 
 @ExtendWith(MockitoExtension.class)
-public class UnitSeperatorTest {
+public class UnitSeparatorTest {
 
   @Mock
   private MapData mockMapData;
@@ -48,7 +48,7 @@ public class UnitSeperatorTest {
     units.addAll(GameDataTestUtil.truck(data).create(1, germans));
     GameDataTestUtil.addTo(northernGermany, units);
     when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(true);
-    final List<UnitCategory> categories = UnitSeperator.getSortedUnitCategories(northernGermany, mockMapData);
+    final List<UnitCategory> categories = UnitSeparator.getSortedUnitCategories(northernGermany, mockMapData);
     final List<UnitCategory> expected = new ArrayList<>();
     expected.add(createUnitCategory("germanFactory", germans, data));
     expected.add(createUnitCategory("Truck", germans, data));
@@ -72,7 +72,7 @@ public class UnitSeperatorTest {
     units.addAll(GameDataTestUtil.italianInfantry(data).create(1, italians));
     GameDataTestUtil.addTo(northernGermany, units);
     when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(false);
-    final List<UnitCategory> categories = UnitSeperator.getSortedUnitCategories(northernGermany, mockMapData);
+    final List<UnitCategory> categories = UnitSeparator.getSortedUnitCategories(northernGermany, mockMapData);
     final List<UnitCategory> expected = new ArrayList<>();
     assertEquals(expected, categories);
   }


### PR DESCRIPTION
## Overview

Renames all misspellings of the root word _separate_.

## Functional Changes

None.

## Manual Testing Performed

None.