### PR TITLE
Remove unused dice server options

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -10,7 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -68,7 +67,6 @@ import games.strategy.util.Version;
  */
 public class GameData implements Serializable {
   private static final long serialVersionUID = -2612710634080125728L;
-  public static final String GAME_UUID = "GAME_UUID";
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private transient LockUtil lockUtil = LockUtil.INSTANCE;
   private transient volatile boolean forceInSwingEventThread = false;
@@ -104,7 +102,6 @@ public class GameData implements Serializable {
 
   public GameData() {
     delegateList = new DelegateList(this);
-    properties.set(GAME_UUID, UUID.randomUUID().toString());
   }
 
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -336,8 +336,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     LocalBeanCache.INSTANCE.storeSerializable(server.getDisplayName(), server);
     LocalBeanCache.INSTANCE.writeToDisk();
     // create local launcher
-    final String gameUuid = (String) gameSelectorModel.getGameData().getProperties().get(GameData.GAME_UUID);
-    final PbemDiceRoller randomSource = new PbemDiceRoller((IRemoteDiceServer) diceServerEditor.getBean(), gameUuid);
+    final PbemDiceRoller randomSource = new PbemDiceRoller((IRemoteDiceServer) diceServerEditor.getBean());
     final Map<String, PlayerType> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
     for (final PlayerSelectorRow player : this.playerTypes) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -68,7 +68,7 @@ public class DiceServerEditor extends EditorPanel {
    */
   private void setupListeners() {
     testDiceyButton.addActionListener(e -> {
-      final PbemDiceRoller random = new PbemDiceRoller(getDiceServer(), null);
+      final PbemDiceRoller random = new PbemDiceRoller(getDiceServer());
       random.test();
     });
     final DocumentListener docListener = new EditorChangedFiringDocumentListener();

--- a/game-core/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
@@ -13,8 +13,7 @@ public interface IRemoteDiceServer extends IBean {
   /**
    * Post a request to the dice server, and return the resulting html page as a string.
    */
-  String postRequest(int max, int numDice, String subjectMessage, String gameId, String gameUuid)
-      throws IOException;
+  String postRequest(int max, int numDice, String subjectMessage, String gameId) throws IOException;
 
   /**
    * Given the html page returned from postRequest, return the dice []

--- a/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/game-core/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -26,8 +26,7 @@ public final class InternalDiceServer implements IRemoteDiceServer {
   }
 
   @Override
-  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
-      final String gameUuid) {
+  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId) {
     // the interface is rather stupid, you have to return a string here, which is then passed back in getDice()
     final int[] ints = randomSource.getRandom(max, numDice, "Internal Dice Server");
     final StringBuilder sb = new StringBuilder();

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -31,7 +31,6 @@ import games.strategy.util.Interruptibles;
  * before returning.
  */
 public class PbemDiceRoller implements IRandomSource {
-  private final String gameUuid;
   private final IRemoteDiceServer remoteDiceServer;
   private static Frame focusWindow;
 
@@ -44,9 +43,8 @@ public class PbemDiceRoller implements IRandomSource {
     focusWindow = w;
   }
 
-  public PbemDiceRoller(final IRemoteDiceServer diceServer, final String gameUuid) {
+  public PbemDiceRoller(final IRemoteDiceServer diceServer) {
     remoteDiceServer = diceServer;
-    this.gameUuid = gameUuid;
   }
 
   /**
@@ -55,7 +53,7 @@ public class PbemDiceRoller implements IRandomSource {
   public void test() {
     // TODO: do a test based on data.getDiceSides()
     final HttpDiceRollerDialog dialog =
-        new HttpDiceRollerDialog(getFocusedFrame(), 6, 1, "Test", remoteDiceServer, "test-roll");
+        new HttpDiceRollerDialog(getFocusedFrame(), 6, 1, "Test", remoteDiceServer);
     dialog.setTest();
     dialog.roll();
   }
@@ -64,7 +62,7 @@ public class PbemDiceRoller implements IRandomSource {
   public int[] getRandom(final int max, final int count, final String annotation) throws IllegalStateException {
     final Supplier<int[]> action = () -> {
       final HttpDiceRollerDialog dialog =
-          new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer, gameUuid);
+          new HttpDiceRollerDialog(getFocusedFrame(), max, count, annotation, remoteDiceServer);
       dialog.roll();
       return dialog.getDiceRoll();
     };
@@ -107,7 +105,6 @@ public class PbemDiceRoller implements IRandomSource {
     private final String subjectMessage;
     private final String gameId;
     private final IRemoteDiceServer diceServer;
-    private final String gameUuid;
     private boolean test = false;
     private final JPanel buttons = new JPanel();
     private Window owner;
@@ -120,10 +117,9 @@ public class PbemDiceRoller implements IRandomSource {
      * @param count the number of dice rolled
      * @param subjectMessage the subject for the email the dice roller will send (if it sends emails)
      * @param diceServer the dice server implementation
-     * @param gameUuid the TripleA game UUID or null
      */
     HttpDiceRollerDialog(final Frame owner, final int sides, final int count, final String subjectMessage,
-        final IRemoteDiceServer diceServer, final String gameUuid) {
+        final IRemoteDiceServer diceServer) {
       super(owner, "Dice roller", true);
       this.owner = owner;
       this.sides = sides;
@@ -131,7 +127,6 @@ public class PbemDiceRoller implements IRandomSource {
       this.subjectMessage = subjectMessage;
       gameId = diceServer.getGameId() == null ? "" : diceServer.getGameId();
       this.diceServer = diceServer;
-      this.gameUuid = gameUuid;
       setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
       exitButton.addActionListener(e -> ExitStatus.FAILURE.exit());
       exitButton.setEnabled(false);
@@ -216,7 +211,7 @@ public class PbemDiceRoller implements IRandomSource {
       appendText("Contacting  " + diceServer.getDisplayName() + "\n");
       String text = null;
       try {
-        text = diceServer.postRequest(sides, count, subjectMessage, gameId, gameUuid);
+        text = diceServer.postRequest(sides, count, subjectMessage, gameId);
         if (text.length() == 0) {
           appendText("Nothing could be read from dice server\n");
           appendText("Please check your firewall settings");

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -119,8 +119,8 @@ public final class PropertiesDiceRoller implements IRemoteDiceServer {
   }
 
   @Override
-  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
-      final String gameUuid) throws IOException {
+  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId)
+      throws IOException {
     final String normalizedGameId = gameId.trim().isEmpty() ? "TripleA" : gameId;
     String message = normalizedGameId + ":" + subjectMessage;
     final int maxLength = Integer.valueOf(props.getProperty("message.maxlength"));
@@ -131,19 +131,13 @@ public final class PropertiesDiceRoller implements IRemoteDiceServer {
         HttpClientBuilder.create().setRedirectStrategy(new AdvancedRedirectStrategy()).build()) {
       final HttpPost httpPost = new HttpPost(props.getProperty("path"));
       final List<NameValuePair> params = ImmutableList.of(
-          new BasicNameValuePair("numdice", "" + numDice),
-          new BasicNameValuePair("numsides", "" + max),
-          new BasicNameValuePair("modroll", "No"),
-          new BasicNameValuePair("numroll", "" + 1),
+          new BasicNameValuePair("numdice", String.valueOf(numDice)),
+          new BasicNameValuePair("numsides", String.valueOf(max)),
           new BasicNameValuePair("subject", message),
           new BasicNameValuePair("roller", getToAddress()),
-          new BasicNameValuePair("gm", getCcAddress()),
-          new BasicNameValuePair("send", "true"));
+          new BasicNameValuePair("gm", getCcAddress()));
       httpPost.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
       httpPost.addHeader("User-Agent", "triplea/" + ClientContext.engineVersion());
-      // this is to allow a dice server to allow the user to request the emails for the game
-      // rather than sending out email for each roll
-      httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = props.getProperty("host");
       final int port = Integer.parseInt(props.getProperty("port", "-1"));
       final String scheme = props.getProperty("scheme", "http");

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -2,9 +2,6 @@ package games.strategy.triplea.ui.menubar;
 
 import java.awt.BorderLayout;
 import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -32,7 +29,6 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JSpinner;
-import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.MenuEvent;
@@ -91,7 +87,6 @@ final class ViewMenu extends JMenu {
     addChatTimeMenu();
     addShowCommentLog();
     addTabbedProduction();
-    addShowGameUuid();
     addSeparator();
     addFindTerritory();
 
@@ -110,22 +105,6 @@ final class ViewMenu extends JMenu {
     tabbedProduction.setSelected(PurchasePanel.isTabbedProduction());
     tabbedProduction.addActionListener(e -> PurchasePanel.setTabbedProduction(tabbedProduction.isSelected()));
     add(tabbedProduction);
-  }
-
-  private void addShowGameUuid() {
-    add(SwingAction.of("Game UUID", e -> {
-      final String id = (String) gameData.getProperties().get(GameData.GAME_UUID);
-      final JTextField text = new JTextField();
-      text.setText(id);
-      final JPanel panel = new JPanel();
-      panel.setLayout(new GridBagLayout());
-      panel.add(new JLabel("Game UUID:"), new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-      panel.add(text, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.BOTH,
-          new Insets(0, 0, 0, 0), 0, 0));
-      JOptionPane.showOptionDialog(JOptionPane.getFrameForComponent(this), panel, "Game UUID",
-          JOptionPane.YES_NO_OPTION, JOptionPane.INFORMATION_MESSAGE, null, new String[] {"OK"}, "OK");
-    })).setMnemonic(KeyEvent.VK_U);
   }
 
   private void addZoomMenu() {

--- a/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -16,11 +16,11 @@ final class GameDataManagerTest {
   @Nested
   final class RoundTripTest {
     @Test
-    void shouldPreserveGameUuid() throws Exception {
+    void shouldPreserveGameName() throws Exception {
       final GameData data = new GameData();
       final byte[] bytes = IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data));
       final GameData loaded = IoUtils.readFromMemory(bytes, GameDataManager::loadGame);
-      assertEquals(loaded.getProperties().get(GameData.GAME_UUID), data.getProperties().get(GameData.GAME_UUID));
+      assertEquals(loaded.getGameName(), data.getGameName());
     }
   }
 


### PR DESCRIPTION
## Overview
During recent conversations I decided to dig through the dice server client-side code and found a couple of options I never heard of. Turns out they are ignored by MARTI:
https://github.com/triplea-game/dice-server/blob/bb07730886f904c24328ad478fd3c6b7f7214f8d/src/MARTI.php#L15-L19

## Functional Changes
None really. The only thing that might be noticed is that there's now a Game UUID button in the view menu missing. It really did nothing, so why bother keeping that to fill savegame space?

## Manual Testing Performed
I verified a normal game could be played.