### PR TITLE
Send headless game server error/warning logs to chat

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -264,7 +264,9 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   private void addChatMessage(final String originalMessage, final String from, final boolean thirdperson) {
-    final String message = Ascii.truncate(originalMessage, 200, "...");
+    final String message = from.equals(chat.getServerNode().getName())
+        ? originalMessage
+        : Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";
     final Document doc = text.getDocument();
     try {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -264,6 +264,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   private void addChatMessage(final String originalMessage, final String from, final boolean thirdperson) {
+    // we don't want to truncate messages from the server as those may be logs with accompanying stack traces
     final String message = from.equals(chat.getServerNode().getName())
         ? originalMessage
         : Ascii.truncate(originalMessage, 200, "...");

--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -13,7 +13,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.logging.Level;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -30,12 +29,10 @@ import games.strategy.triplea.UrlConstants;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
 import games.strategy.util.Version;
-import lombok.extern.java.Log;
 
 /**
  * Responsible for loading saved games, new games from xml, and saving games.
  */
-@Log
 public final class GameDataManager {
   private static final String DELEGATE_START = "<DelegateStart>";
   private static final String DELEGATE_DATA_NEXT = "<DelegateData>";
@@ -79,14 +76,6 @@ public final class GameDataManager {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
       if (!GameEngineVersion.of(ClientContext.engineVersion()).isCompatibleWithEngineVersion(readVersion)) {
-        // a hack for now, but a headless server should not try to open any savegame that is not its version
-        if (headless) {
-          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion()
-              + "  Trying to load game created with: " + readVersion;
-          HeadlessGameServer.sendChat(message);
-          log.log(Level.SEVERE, message);
-          return null;
-        }
         final String error = "Incompatible engine versions. We are: "
             + ClientContext.engineVersion() + " . Trying to load game created with: " + readVersion
             + "\nTo download the latest version of TripleA, Please visit "

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -191,12 +191,9 @@ public class ServerLauncher extends AbstractLauncher {
           });
           stopGame();
         } catch (final RuntimeException e) {
-          final String errorMessage = "Unrecognized error occurred: " + e.getMessage() + ", if this is a repeatable "
-              + "error please make a copy of this savegame and report to:\n" + UrlConstants.GITHUB_ISSUES;
+          final String errorMessage = "Unrecognized error occurred. If this is a repeatable error, "
+              + "please make a copy of this savegame and report to:\n" + UrlConstants.GITHUB_ISSUES;
           log.log(Level.SEVERE, errorMessage, e);
-          if (headless) {
-            HeadlessGameServer.sendChat(errorMessage);
-          }
           stopGame();
         }
         // having an oddball issue with the zip stream being closed while parsing to load default game. might be

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -84,10 +84,7 @@ public class GameSelectorModel extends Observable {
         setGameData(newData);
       }
     } catch (final Exception e) {
-      log.log(Level.SEVERE,
-          String.format("Error loading game file: %s, %s",
-              file.getAbsolutePath(), e.getMessage()),
-          e);
+      log.log(Level.SEVERE, "Error loading game file: " + file.getAbsolutePath(), e);
     }
   }
 

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -232,23 +232,6 @@ public class HeadlessGameServer {
     }
   }
 
-  /**
-   * Sends a chat message to all nodes except the originating node.
-   */
-  public static synchronized void sendChat(final String chatString) {
-    final HeadlessGameServer instance = getInstance();
-    if (instance != null) {
-      final Chat chat = instance.getChat();
-      if (chat != null) {
-        try {
-          chat.sendMessage(chatString, false);
-        } catch (final Exception e) {
-          log.log(Level.SEVERE, "Failed to send chat", e);
-        }
-      }
-    }
-  }
-
   public String getSalt() {
     return BCrypt.gensalt();
   }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,5 +1,9 @@
 package org.triplea.game.server;
 
+import java.util.logging.LogManager;
+
+import org.triplea.game.server.debug.ChatHandler;
+
 /**
  * Runs a headless game server.
  */
@@ -11,6 +15,11 @@ public final class HeadlessGameRunner {
    * the headless game server is shut down via administrative command.
    */
   public static void main(final String[] args) {
+    initializeLogManager();
     HeadlessGameServer.start(args);
+  }
+
+  private static void initializeLogManager() {
+    LogManager.getLogManager().getLogger("").addHandler(new ChatHandler());
   }
 }

--- a/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
+++ b/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
@@ -1,0 +1,81 @@
+package org.triplea.game.server.debug;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.triplea.game.server.HeadlessGameServer;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A {@link Handler} that publishes log records to the chat subsystem. This allows a headless game server to report its
+ * own logs to other game clients via the chat window.
+ *
+ * <p>
+ * <strong>Configuration:</strong> This handler does not currently support configuration through the {@link LogManager}.
+ * It always uses the following default configuration:
+ * </p>
+ * <ul>
+ * <li>Level: {@code Level.WARNING}</li>
+ * <li>Filter: No {@code Filter}</li>
+ * <li>Formatter: {@code java.util.logging.SimpleFormatter}</li>
+ * <li>Encoding: default platform encoding</li>
+ * </ul>
+ */
+@ThreadSafe
+public final class ChatHandler extends Handler {
+  @GuardedBy("this")
+  private boolean enabled = true;
+
+  public ChatHandler() {
+    setLevel(Level.WARNING);
+    setFormatter(new SimpleFormatter());
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public synchronized void publish(final LogRecord record) {
+    publish(record, ChatHandler::sendChatMessage);
+  }
+
+  @GuardedBy("this")
+  @VisibleForTesting
+  void publish(final LogRecord record, final Consumer<String> sendChatMessage) {
+    assert Thread.holdsLock(this);
+
+    // guard against infinite recursion if sendChatMessage also logs
+    if (isLoggable(record) && enabled) {
+      enabled = false;
+      try {
+        sendChatMessage.accept(formatChatMessage(record));
+      } finally {
+        enabled = true;
+      }
+    }
+  }
+
+  private static void sendChatMessage(final String message) {
+    Optional.ofNullable(HeadlessGameServer.getInstance())
+        .map(HeadlessGameServer::getChat)
+        .ifPresent(chat -> chat.sendMessage(message, false));
+  }
+
+  private String formatChatMessage(final LogRecord record) {
+    return getFormatter()
+        .format(record)
+        .trim();
+  }
+}

--- a/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
+++ b/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
@@ -1,0 +1,76 @@
+package org.triplea.game.server.debug;
+
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+final class ChatHandlerTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class PublishTest {
+    private final ChatHandler chatHandler = new ChatHandler();
+    @Mock
+    private Consumer<String> sendChatMessage;
+
+    private LogRecord newLoggableLogRecord() {
+      return new LogRecord(Level.WARNING, "message");
+    }
+
+    private LogRecord newUnloggableLogRecord() {
+      return new LogRecord(Level.FINEST, "message");
+    }
+
+    private void publish(final LogRecord record) {
+      synchronized (chatHandler) {
+        chatHandler.publish(record, sendChatMessage);
+      }
+    }
+
+    @Test
+    void shouldSendChatMessageWhenRecordIsLoggable() {
+      publish(newLoggableLogRecord());
+
+      verify(sendChatMessage).accept(anyString());
+    }
+
+    @Test
+    void shouldNotSendChatMessageWhenRecordIsNotLoggable() {
+      publish(newUnloggableLogRecord());
+
+      verify(sendChatMessage, never()).accept(anyString());
+    }
+
+    @Test
+    void shouldNotIncludeTrailingNewlineInChatMessage() {
+      publish(newLoggableLogRecord());
+
+      verify(sendChatMessage).accept(not(endsWith("\n")));
+    }
+
+    @Test
+    void shouldNotSendChatMessageWhenRecordIsLoggableAndCallIsReentrant() {
+      doAnswer(invocation -> {
+        publish(newLoggableLogRecord());
+        return null;
+      }).when(sendChatMessage).accept(anyString());
+
+      publish(newLoggableLogRecord());
+
+      verify(sendChatMessage, times(1)).accept(anyString());
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This is part of the continuing effort to move as much headless game server code as possible to the `game-headless` project.  To that end, this PR focuses on removing calls to `HeadlessGameServer#sendChat()` that report errors on the bot to clients via the chat subsystem.  In all such cases (a total of two), the message sent via `sendChat()` was also being logged.  Therefore, this PR employs a solution whereby all error/warning logs are reported to clients via the chat subsystem, similar to what we did for the headed client by sending logs to the error console.

**NOTE:** The proposal put forth in this PR is questionable because it increases the verbosity of bot error messages observed by the end user.  That may be considered undesirable by some.

## Functional Changes

* The headless game server registers a new log handler (`ChatHandler`) that sends all error/warning logs to the chat subsystem.

## Manual Testing Performed

* Manually triggered errors on the two code paths affected by this change.  Verified that the errors were reported in chat, as expected.
* Played a game using a bot and verified no unexpected messages appeared in chat during the game.

## Before & After Screen Shots

Loading a save game on a bot that is incompatible with the bot's engine:

### Before

![headless-game-server-error-report-before](https://user-images.githubusercontent.com/4826349/50235762-aaf20700-0386-11e9-9834-ef3baf7d7b20.png)

### After

![headless-game-server-error-report-after](https://user-images.githubusercontent.com/4826349/50235774-afb6bb00-0386-11e9-97d2-899f0fde3b53.png)