### PR TITLE
Remove lobby maintenance mode

### DIFF
--- a/lobby/config/lobby/lobby.properties
+++ b/lobby/config/lobby/lobby.properties
@@ -3,7 +3,6 @@
 ## Available properties:
 ##
 ## Name              Type     Default  Description
-## maintenance_mode  Boolean  false    "true" to enable lobby maintenance mode or "false" to disable it.
 ## port              Integer  3304     The port on which the lobby will listen for connections.
 ##
 

--- a/lobby/src/main/java/org/triplea/lobby/server/config/LobbyConfiguration.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/config/LobbyConfiguration.java
@@ -42,16 +42,11 @@ public final class LobbyConfiguration {
     return propertyReader.readProperty(PropertyKeys.POSTGRES_USER);
   }
 
-  public boolean isMaintenanceMode() {
-    return propertyReader.readBooleanPropertyOrDefault(PropertyKeys.MAINTENANCE_MODE, DefaultValues.MAINTENANCE_MODE);
-  }
-
   /**
    * The valid lobby property keys.
    */
   @VisibleForTesting
   public interface PropertyKeys {
-    String MAINTENANCE_MODE = "maintenance_mode";
     String PORT = "port";
     String POSTGRES_DATABASE = "postgres_database";
     String POSTGRES_HOST = "postgres_host";
@@ -62,7 +57,6 @@ public final class LobbyConfiguration {
 
   @VisibleForTesting
   interface DefaultValues {
-    boolean MAINTENANCE_MODE = false;
     int PORT = 3304;
     String POSTGRES_DATABASE = "ta_users";
     String POSTGRES_HOST = "localhost";

--- a/lobby/src/test/java/org/triplea/lobby/server/config/LobbyConfigurationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/config/LobbyConfigurationTest.java
@@ -121,22 +121,4 @@ public final class LobbyConfigurationTest {
       assertThat(lobbyConfiguration.getPostgresUser(), is(emptyString()));
     }
   }
-
-  @Nested
-  public final class IsMaintenanceModeTest {
-    @Test
-    public void shouldReturnValueWhenPresent() {
-      final boolean value = !DefaultValues.MAINTENANCE_MODE;
-      memoryPropertyReader.setProperty(PropertyKeys.MAINTENANCE_MODE, String.valueOf(value));
-
-      assertThat(lobbyConfiguration.isMaintenanceMode(), is(value));
-    }
-
-    @Test
-    public void shouldReturnDefaultValueWhenAbsent() {
-      memoryPropertyReader.setProperty(PropertyKeys.MAINTENANCE_MODE, "");
-
-      assertThat(lobbyConfiguration.isMaintenanceMode(), is(DefaultValues.MAINTENANCE_MODE));
-    }
-  }
 }


### PR DESCRIPTION
## Overview

The lobby maintenance mode feature (added in #2628) predates the new automated infrastructure.  Not only was it never used prior to the new infrastructure, but, given the way the automated infrastructure works, it probably will not be useful in that context.

## Functional Changes

Removed support for placing the lobby in maintenance mode.

## Manual Testing Performed

None.