### PR TITLE
Add option for logging all application-specific messages

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/Console.java
+++ b/game-core/src/main/java/games/strategy/debug/Console.java
@@ -1,167 +1,27 @@
 package games.strategy.debug;
 
-import java.awt.BorderLayout;
-import java.awt.Toolkit;
-import java.awt.datatransfer.StringSelection;
-import java.awt.event.ItemEvent;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-
-import javax.swing.AbstractButton;
-import javax.swing.Action;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JRadioButtonMenuItem;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
-import javax.swing.JToggleButton;
-import javax.swing.JToolBar;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
-import javax.swing.event.PopupMenuEvent;
-import javax.swing.event.PopupMenuListener;
-
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
-
-import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
-import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.ui.SwingAction;
-import games.strategy.ui.SwingComponents;
-import lombok.AllArgsConstructor;
-import lombok.extern.java.Log;
-
 /**
  * A 'console' window to display log messages to users.
  */
-@Log
-public final class Console {
-  private static final ImmutableCollection<LogLevelItem> LOG_LEVEL_ITEMS = ImmutableList.of(
-      new LogLevelItem("Errors and Warnings", Level.WARNING),
-      new LogLevelItem("All Messages", Level.ALL));
+public interface Console {
+  /**
+   * Shows or hides the console window.
+   */
+  void setVisible(boolean visible);
 
-  private final JTextArea textArea = new JTextArea(20, 50);
-  private final JFrame frame = new JFrame("TripleA Console");
-  private Level logLevel = Level.WARNING;
+  /**
+   * Appends the specified string to the end of the console window without a trailing newline.
+   */
+  void append(String s);
 
-  public Console() {
-    setLogLevel(getDefaultLogLevel());
-
-    ClientSetting.showConsole.addListener(gameSetting -> {
-      if (gameSetting.getValueOrThrow()) {
-        SwingUtilities.invokeLater(() -> setVisible(true));
-      }
-    });
-
-    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.setValueAndFlush(false));
-    LookAndFeelSwingFrameListener.register(frame);
-    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-    frame.getContentPane().setLayout(new BorderLayout());
-    textArea.setLineWrap(true);
-    textArea.setWrapStyleWord(true);
-    frame.getContentPane().add(new JScrollPane(textArea), BorderLayout.CENTER);
-    final JToolBar actions = new JToolBar(SwingConstants.HORIZONTAL);
-    frame.getContentPane().add(actions, BorderLayout.SOUTH);
-    actions.setFloatable(false);
-    final Action threadDiagnoseAction =
-        SwingAction.of("Enumerate Threads", e -> log.info(DebugUtils.getThreadDumps()));
-    actions.add(threadDiagnoseAction);
-    actions.add(SwingAction.of("Memory", e -> append(DebugUtils.getMemory())));
-    actions.add(SwingAction.of("Properties", e -> append(DebugUtils.getProperties())));
-    actions.add(SwingAction.of("Copy to clipboard", e -> {
-      final String text = textArea.getText();
-      final StringSelection select = new StringSelection(text);
-      Toolkit.getDefaultToolkit().getSystemClipboard().setContents(select, select);
-    }));
-    actions.add(SwingAction.of("Clear", e -> textArea.setText("")));
-    actions.add(newLogLevelButton());
-    SwingUtilities.invokeLater(frame::pack);
-
-    if (ClientSetting.showConsole.getValueOrThrow()) {
-      SwingUtilities.invokeLater(() -> setVisible(true));
-    }
-  }
-
-  private static Level getDefaultLogLevel() {
-    final String logLevelName = ClientSetting.loggingVerbosity.getValueOrThrow();
-    try {
-      return Level.parse(logLevelName);
-    } catch (final IllegalArgumentException e) {
-      log.warning("Client setting " + ClientSetting.loggingVerbosity + " contains malformed log level ("
-          + logLevelName + "); defaulting to WARNING");
-      return Level.WARNING;
-    }
-  }
-
-  private void setLogLevel(final Level level) {
-    logLevel = level;
-    LogManager.getLogManager().getLogger("").setLevel(attenuateLogLevel(level));
-  }
-
-  private static Level attenuateLogLevel(final Level level) {
-    return (level.intValue() < Level.INFO.intValue()) ? Level.INFO : level;
-  }
-
-  private AbstractButton newLogLevelButton() {
-    final JToggleButton button = new JToggleButton("Log Level ▼");
-    button.addItemListener(e -> {
-      if (e.getStateChange() == ItemEvent.SELECTED) {
-        createAndShowLogLevelMenu((JComponent) e.getSource(), button);
-      }
-    });
-    return button;
-  }
-
-  private void createAndShowLogLevelMenu(final JComponent component, final AbstractButton button) {
-    final JPopupMenu menu = new JPopupMenu();
-    menu.addPopupMenuListener(new PopupMenuListener() {
-      @Override
-      public void popupMenuWillBecomeVisible(final PopupMenuEvent e) {}
-
-      @Override
-      public void popupMenuWillBecomeInvisible(final PopupMenuEvent e) {
-        button.setSelected(false);
-      }
-
-      @Override
-      public void popupMenuCanceled(final PopupMenuEvent e) {
-        button.setSelected(false);
-      }
-    });
-    LOG_LEVEL_ITEMS.forEach(item -> {
-      final JMenuItem menuItem = new JRadioButtonMenuItem(item.label, item.level.equals(logLevel));
-      menuItem.addActionListener(e -> {
-        setLogLevel(item.level);
-        setDefaultLogLevel(item.level);
-        appendLn("Log level updated to: " + item.level);
-      });
-      menu.add(menuItem);
-    });
-    menu.show(component, 0, component.getHeight());
-  }
-
-  private static void setDefaultLogLevel(final Level level) {
-    ClientSetting.loggingVerbosity.setValueAndFlush(level.getName());
-  }
-
-  public void setVisible(final boolean visible) {
-    frame.setVisible(visible);
-  }
-
-  public void append(final String s) {
-    SwingUtilities.invokeLater(() -> textArea.append(s));
-  }
-
-  public void appendLn(final String s) {
+  /**
+   * Appends the specified string to the end of the console window with a trailing newline.
+   */
+  default void appendLn(final String s) {
     append(s + "\n");
   }
 
-  @AllArgsConstructor
-  private static final class LogLevelItem {
-    final String label;
-    final Level level;
+  static Console newInstance() {
+    return new DefaultConsole();
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/ConsoleHandler.java
+++ b/game-core/src/main/java/games/strategy/debug/ConsoleHandler.java
@@ -1,17 +1,17 @@
 package games.strategy.debug;
 
-import java.util.function.Consumer;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
-
-import lombok.AllArgsConstructor;
+import java.util.logging.SimpleFormatter;
 
 /**
- * A {@link Handler} that publishes log records to an injected log handler. This can be wired up to send log messages
- * to a UI console.
+ * A {@link Handler} that publishes log records to an instance of {@link Console}.
+ *
  * <p>
- * Configuration: This handler does not currently support configuration through the {@link LogManager}.
+ * <strong>Configuration:</strong> This handler does not currently support configuration through the {@link LogManager}.
  * It always uses the following default configuration:
  * </p>
  * <ul>
@@ -21,31 +21,27 @@ import lombok.AllArgsConstructor;
  * <li>Encoding: default platform encoding</li>
  * </ul>
  */
-@AllArgsConstructor
 public final class ConsoleHandler extends Handler {
+  private final Console console;
 
-  private final Consumer<LogRecord> msgReceiver;
+  public ConsoleHandler(final Console console) {
+    checkNotNull(console);
 
-  @Override
-  public void close() {
-    // no-op
+    this.console = console;
+
+    setFormatter(new SimpleFormatter());
   }
 
   @Override
-  public void flush() {
-    // no-op
-  }
+  public void close() {}
 
   @Override
-  public void publish(final LogRecord record) {
-    if (!isLoggable(record)) {
-      return;
+  public void flush() {}
+
+  @Override
+  public synchronized void publish(final LogRecord record) {
+    if (isLoggable(record)) {
+      console.append(getFormatter().format(record));
     }
-    msgReceiver.accept(record);
-  }
-
-  @Override
-  public boolean isLoggable(final LogRecord record) {
-    return (record != null) && super.isLoggable(record);
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/DefaultConsole.java
+++ b/game-core/src/main/java/games/strategy/debug/DefaultConsole.java
@@ -1,0 +1,158 @@
+package games.strategy.debug;
+
+import java.awt.BorderLayout;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ItemEvent;
+import java.util.logging.Level;
+
+import javax.swing.AbstractButton;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JToggleButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+
+import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener;
+import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.ui.SwingAction;
+import games.strategy.ui.SwingComponents;
+import lombok.AllArgsConstructor;
+import lombok.extern.java.Log;
+
+@Log
+final class DefaultConsole implements Console {
+  private static final ImmutableCollection<LogLevelItem> LOG_LEVEL_ITEMS = ImmutableList.of(
+      new LogLevelItem("Errors and Warnings", Level.WARNING),
+      new LogLevelItem("Errors, Warnings and Informational Messages", Level.INFO),
+      new LogLevelItem("All Messages", Level.ALL));
+
+  private final JTextArea textArea = new JTextArea(20, 50);
+  private final JFrame frame = new JFrame("TripleA Console");
+  private Level logLevel = Level.WARNING;
+
+  DefaultConsole() {
+    setLogLevel(getDefaultLogLevel());
+
+    ClientSetting.showConsole.addListener(gameSetting -> {
+      if (gameSetting.getValueOrThrow()) {
+        SwingUtilities.invokeLater(() -> setVisible(true));
+      }
+    });
+
+    SwingComponents.addWindowClosedListener(frame, () -> ClientSetting.showConsole.setValueAndFlush(false));
+    LookAndFeelSwingFrameListener.register(frame);
+    frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+    frame.getContentPane().setLayout(new BorderLayout());
+    textArea.setLineWrap(true);
+    textArea.setWrapStyleWord(true);
+    frame.getContentPane().add(new JScrollPane(textArea), BorderLayout.CENTER);
+    final JToolBar actions = new JToolBar(SwingConstants.HORIZONTAL);
+    frame.getContentPane().add(actions, BorderLayout.SOUTH);
+    actions.setFloatable(false);
+    final Action threadDiagnoseAction =
+        SwingAction.of("Enumerate Threads", e -> log.info(DebugUtils.getThreadDumps()));
+    actions.add(threadDiagnoseAction);
+    actions.add(SwingAction.of("Memory", e -> append(DebugUtils.getMemory())));
+    actions.add(SwingAction.of("Properties", e -> append(DebugUtils.getProperties())));
+    actions.add(SwingAction.of("Copy to clipboard", e -> {
+      final String text = textArea.getText();
+      final StringSelection select = new StringSelection(text);
+      Toolkit.getDefaultToolkit().getSystemClipboard().setContents(select, select);
+    }));
+    actions.add(SwingAction.of("Clear", e -> textArea.setText("")));
+    actions.add(newLogLevelButton());
+    SwingUtilities.invokeLater(frame::pack);
+
+    if (ClientSetting.showConsole.getValueOrThrow()) {
+      SwingUtilities.invokeLater(() -> setVisible(true));
+    }
+  }
+
+  private static Level getDefaultLogLevel() {
+    final String logLevelName = ClientSetting.loggingVerbosity.getValueOrThrow();
+    try {
+      return Level.parse(logLevelName);
+    } catch (final IllegalArgumentException e) {
+      log.warning("Client setting " + ClientSetting.loggingVerbosity + " contains malformed log level ("
+          + logLevelName + "); defaulting to WARNING");
+      return Level.WARNING;
+    }
+  }
+
+  private void setLogLevel(final Level level) {
+    logLevel = level;
+    LoggerManager.setLogLevel(level);
+  }
+
+  private AbstractButton newLogLevelButton() {
+    final JToggleButton button = new JToggleButton("Log Level ▼");
+    button.addItemListener(e -> {
+      if (e.getStateChange() == ItemEvent.SELECTED) {
+        createAndShowLogLevelMenu((JComponent) e.getSource(), button);
+      }
+    });
+    return button;
+  }
+
+  private void createAndShowLogLevelMenu(final JComponent component, final AbstractButton button) {
+    final JPopupMenu menu = new JPopupMenu();
+    menu.addPopupMenuListener(new PopupMenuListener() {
+      @Override
+      public void popupMenuWillBecomeVisible(final PopupMenuEvent e) {}
+
+      @Override
+      public void popupMenuWillBecomeInvisible(final PopupMenuEvent e) {
+        button.setSelected(false);
+      }
+
+      @Override
+      public void popupMenuCanceled(final PopupMenuEvent e) {
+        button.setSelected(false);
+      }
+    });
+    LOG_LEVEL_ITEMS.forEach(item -> {
+      final JMenuItem menuItem = new JRadioButtonMenuItem(item.label, item.level.equals(logLevel));
+      menuItem.addActionListener(e -> {
+        setLogLevel(item.level);
+        setDefaultLogLevel(item.level);
+        appendLn("Log level updated to: " + item.level);
+      });
+      menu.add(menuItem);
+    });
+    menu.show(component, 0, component.getHeight());
+  }
+
+  private static void setDefaultLogLevel(final Level level) {
+    ClientSetting.loggingVerbosity.setValueAndFlush(level.getName());
+  }
+
+  @Override
+  public void setVisible(final boolean visible) {
+    frame.setVisible(visible);
+  }
+
+  @Override
+  public void append(final String s) {
+    SwingUtilities.invokeLater(() -> textArea.append(s));
+  }
+
+  @AllArgsConstructor
+  private static final class LogLevelItem {
+    final String label;
+    final Level level;
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessageHandler.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessageHandler.java
@@ -1,0 +1,47 @@
+package games.strategy.debug;
+
+import java.util.function.Consumer;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A {@link Handler} that displays an error message dialog if any log record with a level equal to or greater than
+ * {@link Level#WARNING} is published.
+ *
+ * <p>
+ * <strong>Configuration:</strong> This handler does not currently support configuration through the {@link LogManager}.
+ * It always uses the following default configuration:
+ * </p>
+ * <ul>
+ * <li>Level: {@code Level.ALL}</li>
+ * <li>Filter: No {@code Filter}</li>
+ * <li>Formatter: No {@code Formatter}</li>
+ * <li>Encoding: default platform encoding</li>
+ * </ul>
+ */
+public final class ErrorMessageHandler extends Handler {
+  @VisibleForTesting
+  static final int THRESHOLD_LEVEL_VALUE = Level.WARNING.intValue();
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public synchronized void publish(final LogRecord record) {
+    publish(record, ErrorMessage::show);
+  }
+
+  @VisibleForTesting
+  void publish(final LogRecord record, final Consumer<LogRecord> consumer) {
+    if (isLoggable(record) && (record.getLevel().intValue() >= THRESHOLD_LEVEL_VALUE)) {
+      consumer.accept(record);
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/LoggerManager.java
+++ b/game-core/src/main/java/games/strategy/debug/LoggerManager.java
@@ -1,0 +1,34 @@
+package games.strategy.debug;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Manages all application-specific loggers and provides convenience methods for configuring them.
+ */
+final class LoggerManager {
+  /**
+   * Stores strong references to application-specific loggers so they aren't GCed after being configured.
+   */
+  private static final ImmutableCollection<Logger> loggers = getLoggers();
+
+  private LoggerManager() {}
+
+  private static ImmutableCollection<Logger> getLoggers() {
+    return Arrays.asList("games.strategy", "org.triplea", "swinglib", "tools").stream()
+        .map(Logger::getLogger)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  static void setLogLevel(final Level level) {
+    checkNotNull(level);
+
+    loggers.forEach(logger -> logger.setLevel(level));
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
-import java.util.logging.SimpleFormatter;
+import java.util.logging.Logger;
 
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -51,6 +51,7 @@ import org.triplea.game.client.ui.javafx.JavaFxClientRunner;
 import games.strategy.debug.Console;
 import games.strategy.debug.ConsoleHandler;
 import games.strategy.debug.ErrorMessage;
+import games.strategy.debug.ErrorMessageHandler;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.GameEngineVersion;
 import games.strategy.engine.auto.health.check.LocalSystemChecker;
@@ -116,15 +117,7 @@ public final class GameRunner {
     if (!ClientSetting.useExperimentalJavaFxUi.getValueOrThrow()) {
       Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
         LookAndFeel.initialize();
-        final Console console = new Console();
-        final SimpleFormatter formatter = new SimpleFormatter();
-        LogManager.getLogManager().getLogger("").addHandler(new ConsoleHandler(
-            logMsg -> {
-              if (logMsg.getLevel().intValue() > Level.INFO.intValue()) {
-                ErrorMessage.show(logMsg);
-              }
-              console.append(formatter.format(logMsg));
-            }));
+        initializeLogManager(Console.newInstance());
         ErrorMessage.enable();
       }));
     }
@@ -159,6 +152,12 @@ public final class GameRunner {
       LocalSystemChecker.launch();
       UpdateChecks.launch();
     }
+  }
+
+  private static void initializeLogManager(final Console console) {
+    final Logger defaultLogger = LogManager.getLogManager().getLogger("");
+    defaultLogger.addHandler(new ErrorMessageHandler());
+    defaultLogger.addHandler(new ConsoleHandler(console));
   }
 
   private static JFrame newMainFrame() {

--- a/game-core/src/test/java/games/strategy/debug/ErrorMessageHandlerTest.java
+++ b/game-core/src/test/java/games/strategy/debug/ErrorMessageHandlerTest.java
@@ -1,0 +1,72 @@
+package games.strategy.debug;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+final class ErrorMessageHandlerTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class PublishTest {
+    @Mock
+    private Consumer<LogRecord> consumer;
+    private final ErrorMessageHandler errorMessageHandler = new ErrorMessageHandler();
+
+    private LogRecord newLogRecord(final int levelValue) {
+      final Level level = new Level("name", levelValue) {
+        private static final long serialVersionUID = 1L;
+      };
+      return new LogRecord(level, "message");
+    }
+
+    @Test
+    void shouldInvokeConsumerWhenRecordIsLoggableAndLogLevelIsEqualToThreshold() {
+      final LogRecord record = newLogRecord(ErrorMessageHandler.THRESHOLD_LEVEL_VALUE);
+
+      errorMessageHandler.publish(record, consumer);
+
+      verify(consumer).accept(record);
+    }
+
+    @Test
+    void shouldInvokeConsumerWhenRecordIsLoggableAndLogLevelIsGreaterThanThreshold() {
+      final LogRecord record = newLogRecord(ErrorMessageHandler.THRESHOLD_LEVEL_VALUE + 1);
+
+      errorMessageHandler.publish(record, consumer);
+
+      verify(consumer).accept(record);
+    }
+
+    @Test
+    void shouldNotInvokeConsumerWhenRecordIsNotLoggable(@Mock final Filter filter) {
+      final LogRecord record = newLogRecord(ErrorMessageHandler.THRESHOLD_LEVEL_VALUE);
+      when(filter.isLoggable(record)).thenReturn(false);
+      errorMessageHandler.setFilter(filter);
+
+      errorMessageHandler.publish(record, consumer);
+
+      verify(consumer, never()).accept(any());
+    }
+
+    @Test
+    void shouldNotInvokeConsumerWhenLogLevelIsBelowThreshold() {
+      final LogRecord record = newLogRecord(ErrorMessageHandler.THRESHOLD_LEVEL_VALUE - 1);
+
+      errorMessageHandler.publish(record, consumer);
+
+      verify(consumer, never()).accept(any());
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Even when selecting the "All Messages" log level in the console, the logging subsystem currently drops all records with a level lower than `INFO`.  I believe this decision was made because we're setting the level on the default (global) logger, and using a verbose log level results in _every subsystem_ in the JVM flooding the console with messages, which renders the application unusable.

On several occasions (most recently [here](https://forums.triplea-game.org/post/18428)), we've needed to capture logs that are output below `INFO` level.  The only way we can currently do this is by sending the user a custom properties file and asking them to run the application with specific CLI arguments to enable the desired logs (see https://github.com/triplea-game/triplea/issues/3539#issuecomment-406364665).

This PR is an attempt to make enabling verbose log levels a bit easier by supporting such a configuration directly via the UI.  It does this via three primary changes:

1. Add a third option to the log level dropdown in the console so that the three options now correspond to levels `WARNING`, `INFO`, and `ALL`.
1. Remove the artificial attenuation, and thus allow logs below `INFO` to be displayed.
1. Only configure TripleA-specific loggers rather than the global logger.  This bypasses the problem of enabling verbose logs for every logger in the JVM.

Regarding change (3).  My assertion is that we really should only be changing the verbosity of our own loggers and leave those loggers outside the purview of TripleA in their default configuration.  In only rare cases should we need to enable more verbose logs outside of TripleA.  In those cases, the properties file approach outlined above should be sufficient (and provides finer control versus simply bumping verbosity _everywhere_).

However, if (3) is a questionable change, in addition to configuring the application-specific loggers, I can add back the global logger configuration with the log level attenuation.  This would really only be necessary if we absolutely do not want `INFO` level logs coming from the rest of the JVM when the user has selected "Errors and Warnings".  (I've never seen any, but that doesn't mean there aren't any lurking out there.)

## Functional Changes

* Added the option "Errors, Warnings and Informational Messages" to the log level dropdown in the console.  This option corresponds to log level `INFO`.
* When selecting a new log level in the console, only TripleA-specific loggers are configured with the new log level.  These loggers include:
    * `games.strategy`
    * `org.triplea`
    * `swinglib`
    * `tools`
(We probably want to consider moving `swinglib` and `tools` under `org.triplea` in the future.)
* Selecting log level "All Messages" in the console will now report logs from `ALL` levels instead of only `INFO` and above.

## Refactoring Changes

* Encapsulated the `Console` and `ErrorMessage` log handler logic in their own classes so it wasn't blasted in the middle of the `GameRunner` code.
    * I broke this logic into two separate handlers because it seemed `Console` and `ErrorMessage` are  orthogonal concerns.
* Transformed `Console` into an interface to make some testing easier.

## Manual Testing Performed

* Ran a local game against the AI at log level `ALL` to ensure there wasn't a flood of unexpected logs.
* Manually triggered both `SEVERE` and `WARNING` logs to ensure the `ErrorMessage` dialog continues to operate as expected.

## Before & After Screen Shots

### Before

![log-levels-before](https://user-images.githubusercontent.com/4826349/50378394-8a80b180-05ff-11e9-85f8-bd5534a3f285.png)

### After

![log-levels-after](https://user-images.githubusercontent.com/4826349/50378396-8fddfc00-05ff-11e9-8c6c-3e5bc7eea67f.png)