### PR TITLE
Reduce ignored loader tag log level

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -515,7 +515,7 @@ public final class GameParser {
 
   private static void parseGameLoader(final Node loader) {
     if (loader != null) {
-      log.info("Loader tag is being ignored");
+      log.fine("Loader tag is being ignored");
     }
   }
 


### PR DESCRIPTION
## Overview

Resolves #4063.

Now that we can enable logs below `INFO` level, it seems appropriate to reduce the log level for the `GameParser` "Loader tag is being ignored" message, as suggested in #4063.

The original issue recommends using "debug" level, but `Level` supports no such named value.  The named level immediately below `INFO` is `CONFIG`, but the description of that level doesn't seem appropriate for this message.  Levels `FINE`, `FINER`, and `FINEST` all represent debug traces, so I simply chose `FINE`. as it is the least verbose debug trace level.

## Functional Changes

Changed log level of the `GameParser` "Loader tag is being ignored" message from `INFO` to `FINE`.

## Manual Testing Performed

Verified this message is only displayed when the "All Messages" log level is selected in the console.