### PR TITLE
Fix potential NPE in ActionButtons#changeTo()

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -4,6 +4,7 @@ import java.awt.CardLayout;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -258,8 +259,8 @@ public class ActionButtons extends JPanel {
     return pickTerritoryAndUnitsPanel.waitForPickTerritoryAndUnits(territoryChoices, unitChoices, unitsPerPick);
   }
 
-  public @Nullable ActionPanel getCurrent() {
-    return actionPanel;
+  public Optional<ActionPanel> getCurrent() {
+    return Optional.ofNullable(actionPanel);
   }
 
   public BattlePanel getBattlePanel() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -43,7 +44,7 @@ public class ActionButtons extends JPanel {
   private TechPanel techPanel;
   private EndTurnPanel endTurnPanel;
   private MoveForumPosterPanel moveForumPosterPanel;
-  private ActionPanel actionPanel;
+  private @Nullable ActionPanel actionPanel;
   private PoliticsPanel politicsPanel;
   private UserActionPanel userActionPanel;
   private PickTerritoryAndUnitsPanel pickTerritoryAndUnitsPanel;
@@ -150,15 +151,18 @@ public class ActionButtons extends JPanel {
     changeTo(id, moveForumPosterPanel);
   }
 
-  private void changeTo(final PlayerId id, final ActionPanel newCurrent) {
-    actionPanel.setActive(false);
-    actionPanel = newCurrent;
-    // newCurrent might be null if we are shutting down
-    if (actionPanel == null) {
-      return;
+  private void changeTo(final PlayerId id, final @Nullable ActionPanel newCurrent) {
+    if (actionPanel != null) {
+      actionPanel.setActive(false);
     }
-    actionPanel.display(id);
-    SwingUtilities.invokeLater(() -> layout.show(ActionButtons.this, actionPanel.toString()));
+
+    actionPanel = newCurrent;
+
+    // newCurrent might be null if we are shutting down
+    if (actionPanel != null) {
+      actionPanel.display(id);
+      SwingUtilities.invokeLater(() -> layout.show(ActionButtons.this, actionPanel.toString()));
+    }
   }
 
   public void changeToPickTerritoryAndUnits(final PlayerId id) {
@@ -254,7 +258,7 @@ public class ActionButtons extends JPanel {
     return pickTerritoryAndUnitsPanel.waitForPickTerritoryAndUnits(territoryChoices, unitChoices, unitsPerPick);
   }
 
-  public ActionPanel getCurrent() {
+  public @Nullable ActionPanel getCurrent() {
     return actionPanel;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -428,10 +428,10 @@ public final class TripleAFrame extends JFrame {
         } finally {
           data.releaseReadLock();
         }
-        actionButtons.getCurrent().setActive(false);
+        actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(false));
         editPanel.display(player1);
       } else {
-        actionButtons.getCurrent().setActive(true);
+        actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(true));
         editPanel.setActive(false);
       }
     });
@@ -1178,9 +1178,7 @@ public final class TripleAFrame extends JFrame {
       });
       Interruptibles.await(latch2);
     }
-    if (actionButtons.getCurrent() != null) {
-      actionButtons.getCurrent().setActive(false);
-    }
+    actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(false));
     return territoryAndUnits;
   }
 
@@ -1835,9 +1833,7 @@ public final class TripleAFrame extends JFrame {
       if (getEditMode()) {
         tabsPanel.add("Edit", editPanel);
       }
-      if (actionButtons.getCurrent() != null) {
-        actionButtons.getCurrent().setActive(false);
-      }
+      actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(false));
       historyComponent.removeAll();
       historyComponent.setLayout(new BorderLayout());
       // create history tree context menu
@@ -1993,9 +1989,7 @@ public final class TripleAFrame extends JFrame {
       if (getEditMode()) {
         tabsPanel.add("Edit", editPanel);
       }
-      if (actionButtons.getCurrent() != null) {
-        actionButtons.getCurrent().setActive(true);
-      }
+      actionButtons.getCurrent().ifPresent(actionPanel -> actionPanel.setActive(true));
       gameMainPanel.removeAll();
       gameMainPanel.setLayout(new BorderLayout());
       gameMainPanel.add(gameCenterPanel, BorderLayout.CENTER);


### PR DESCRIPTION
## Overview

Fixes #3726.

I still can't reproduce the original NPE, but an inspection of the code reveals there are small windows in which `ActionButtons#actionPanel` can be `null` at times other than during shutdown.  To be safe, I simply check for a `null` `actionPanel` both before and after changing the reference in `changeTo()`.

## Functional Changes

None.

## Refactoring Changes

The second commit changes the return type of `ActionButtons#getCurrent()` from `@Nullable ActionPanel` to `Optional<ActionPanel>` to make it harder to trigger another NPE in downstream code.  There was some code in `TripleAFrame` that didn't always check the return value for `null`.

## Manual Testing Performed

None.