### PR TITLE
Improve 0 attack/defense check to consider support and territory effects

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -794,13 +794,20 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           checkForUnitsThatCanRollLeft(bridge, false);
           endBattle(bridge);
           attackerWins(bridge);
-        } else if (shouldEndBattleDueToMaxRounds()
-            || (!attackingUnits.isEmpty()
-                && attackingUnits.stream().allMatch(Matches.unitHasAttackValueOfAtLeast(1).negate())
-                && !defendingUnits.isEmpty()
-                && defendingUnits.stream().allMatch(Matches.unitHasDefendValueOfAtLeast(1).negate()))) {
+        } else if (shouldEndBattleDueToMaxRounds()) {
           endBattle(bridge);
           nobodyWins(bridge);
+        } else {
+          final int attackPower =
+              DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackingUnits, defendingUnits,
+                  false, gameData, battleSite, territoryEffects, isAmphibious, amphibiousLandAttackers), gameData);
+          final int defensePower =
+              DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(defendingUnits, attackingUnits,
+                  true, gameData, battleSite, territoryEffects, isAmphibious, amphibiousLandAttackers), gameData);
+          if (attackPower == 0 && defensePower == 0) {
+            endBattle(bridge);
+            nobodyWins(bridge);
+          }
         }
       }
     });


### PR DESCRIPTION
## Overview
- Fixes #4408

## Functional Changes
- Improve 0 attack/defense check to call the same method the actual battles and battle calc use to determine attack/defense strength instead of just checking each unit's strength

## Manual Testing Performed
- Tested a few combinations on TWW that lead to 0 attack/defense
- Tested the save game where the AI freezes on a battle on Celebes between 2 inf vs 1 strat/1 air transport

