### PR TITLE
Fix deprecation in java 10

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -55,7 +55,7 @@ final class FileMenu extends JMenu {
     }));
     menuFileSave.setMnemonic(KeyEvent.VK_S);
     menuFileSave.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
     return menuFileSave;
   }
 
@@ -81,7 +81,7 @@ final class FileMenu extends JMenu {
     }));
     menuPbem.setMnemonic(KeyEvent.VK_P);
     menuPbem.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
     return menuPbem;
   }
 
@@ -92,10 +92,10 @@ final class FileMenu extends JMenu {
     if (isMac) { // On Mac OS X, the command-Q is reserved for the Quit action,
       // so set the command-L key combo for the Leave Game action
       leaveGameMenuExit.setAccelerator(
-          KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+          KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
     } else { // On non-Mac operating systems, set the Ctrl-Q key combo for the Leave Game action
       leaveGameMenuExit.setAccelerator(
-          KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+          KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
     }
     add(leaveGameMenuExit);
     // Mac OS X automatically creates a Quit menu item under the TripleA menu,

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -80,7 +80,7 @@ final class GameMenu extends JMenu {
     final JMenuItem gameMenuItem = add(action);
     gameMenuItem.setMnemonic(keyCode);
     gameMenuItem.setAccelerator(
-        KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(keyCode, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
   }
 
   private void addEditMode() {
@@ -89,7 +89,7 @@ final class GameMenu extends JMenu {
     final JMenuItem editMenuItem = add(editMode);
     editMenuItem.setMnemonic(KeyEvent.VK_E);
     editMenuItem.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
   }
 
   private void addShowVerifiedDice() {
@@ -132,7 +132,7 @@ final class GameMenu extends JMenu {
     }));
     politicsMenuItem.setMnemonic(KeyEvent.VK_P);
     politicsMenuItem.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
   }
 
   private void addNotificationSettings() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -238,7 +238,7 @@ public final class HelpMenu extends JMenu {
     }));
     unitMenuItem.setMnemonic(KeyEvent.VK_U);
     unitMenuItem.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
   }
 
   public static final JEditorPane gameNotesPane = new JEditorPane();


### PR DESCRIPTION
## Overview
This changes a method that get's deprecated in Java 10.
I was successfully able to compile TripleA in IntelliJ using JDK 11, and checked the deprecation warnings.
The only thing left to change to get rid of all the deprecations is to migrate away from the Observer-pattern i.e. replace Observable and Observer with something equivalent. (Partly already done in  #4454 )

There's also another thing I noticed with Java 11:
![Screenshot](https://user-images.githubusercontent.com/8350879/50541457-a14a7980-0ba6-11e9-8d18-36f6877814ad.png)
I really thinks it speaks for itself. The map looks awful and I don't really know why.
I might play around with the settings and hopefully find the root cause.

## Functional Changes
None.

## Manual Testing Performed
Tested the Shortcut, they still work.