### PR TITLE
Restore focus when closing history view

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1997,6 +1997,7 @@ public final class TripleAFrame extends JFrame {
       getContentPane().removeAll();
       getContentPane().add(gameMainPanel, BorderLayout.CENTER);
       validate();
+      requestWindowFocus();
     });
     mapPanel.setRoute(null);
   }


### PR DESCRIPTION
## Overview

Fixes #4458.

I couldn't find a better solution to the problem than simply restoring focus to `TripleAFrame`.  That will subsequently transfer focus to the appropriate child view, which, in this case, is `MapPanel`.

## Functional Changes

Transfer focus to `MapPanel` when closing the history view.  (In general, the focus will be transferred when calling `TripleAFrame#showGame()`.)

## Manual Testing Performed

* Start a local game.
* Verify navigation keys work.
* Open history view via <kbd>Ctrl</kbd>+<kbd>H</kbd>.
* Close history view via <kbd>Ctrl</kbd>+<kbd>G</kbd> (i.e. **Show current game**).
* Verify navigation keys work without any additional mouse/keyboard input.