### PR TITLE
Replace two-param log() calls with one- or three-param versions

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.CodeSource;
-import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
@@ -116,7 +115,7 @@ public final class ClientFileSystemHelper {
       mapsFolder.mkdirs();
     }
     if (!mapsFolder.exists()) {
-      log.log(Level.SEVERE, "Error, downloaded maps folder does not exist: " + mapsFolder.getAbsolutePath());
+      log.severe("Error, downloaded maps folder does not exist: " + mapsFolder.getAbsolutePath());
     }
     return mapsFolder;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -161,9 +161,8 @@ public final class GameParser {
     // see if we have any SAX errors we need to show
     if (!errorsSax.isEmpty()) {
       for (final SAXParseException error : errorsSax) {
-        log.log(Level.SEVERE,
-            "SAXParseException: game: " + (data.getGameName() == null ? "?" : data.getGameName()) + ", line: " + error
-                .getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage());
+        log.severe("SAXParseException: game: " + (data.getGameName() == null ? "?" : data.getGameName()) + ", line: "
+            + error.getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage());
       }
     }
     parseDiceSides(getSingleChild("diceSides", root, true));

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
@@ -136,7 +135,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     private static void printError(final String errorMessage) {
       if (!shownError) {
         shownError = true;
-        log.log(Level.SEVERE, errorMessage);
+        log.severe(errorMessage);
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -137,7 +137,7 @@ public class ClientGame extends AbstractGame {
           }
           i++;
           if (i > 300 && !shownErrorMessage) {
-            log.log(Level.SEVERE, "Waited more than 30 seconds for step to update. Something wrong.");
+            log.severe("Waited more than 30 seconds for step to update. Something wrong.");
             shownErrorMessage = true;
             // TODO: should we throw an illegal state error? or just return? or a game over exception? should we
             // request the server to send the step update again or something?

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -295,7 +295,7 @@ public class ServerGame extends AbstractGame {
    */
   public void stopGame() {
     if (isGameOver) {
-      log.log(Level.WARNING, "Game previously stopped, cannot stop again.");
+      log.warning("Game previously stopped, cannot stop again.");
       return;
     }
 
@@ -313,7 +313,7 @@ public class ServerGame extends AbstractGame {
         log.warning("Could not stop delegate execution.");
         // Try one more time
         if (!delegateExecutionManager.blockDelegateExecution(16000)) {
-          log.log(Level.SEVERE, "Exiting...");
+          log.severe("Exiting...");
           ExitStatus.FAILURE.exit();
         }
       }
@@ -375,7 +375,7 @@ public class ServerGame extends AbstractGame {
       if (!delegateExecutionManager.blockDelegateExecution(6000)) {
         // try again
         if (!delegateExecutionManager.blockDelegateExecution(6000)) {
-          log.log(Level.SEVERE, errorMessage + " could not lock delegate execution");
+          log.severe(errorMessage + " could not lock delegate execution");
           return;
         }
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -237,7 +237,7 @@ public class InGameLobbyWatcher {
                 + "See 'How To Host...' in the help menu, at the top of the lobby screen.\n"
                 + "The server tried to connect to your external ip: " + addressUsed;
             if (HeadlessGameServer.headless()) {
-              log.log(Level.SEVERE, message);
+              log.severe(message);
               ExitStatus.FAILURE.exit();
             }
             final Frame parentComponent = JOptionPane.getFrameForComponent(parent);

--- a/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/HistoryWriter.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.history;
 
 import java.io.Serializable;
-import java.util.logging.Level;
 
 import javax.swing.SwingUtilities;
 
@@ -143,8 +142,7 @@ public class HistoryWriter implements Serializable {
   public void addChildToEvent(final EventChild node) {
     assertCorrectThread();
     if (!isCurrentEvent()) {
-      log.log(Level.SEVERE,
-          "Not in an event, but trying to add child: " + node + ". Current history node is: " + current);
+      log.severe("Not in an event, but trying to add child: " + node + ". Current history node is: " + current);
       startEvent("Filler event for child: " + node);
     }
     addToCurrent(node);
@@ -156,7 +154,7 @@ public class HistoryWriter implements Serializable {
   public void addChange(final Change change) {
     assertCorrectThread();
     if (!isCurrentEvent() && !isCurrentStep()) {
-      log.log(Level.SEVERE,
+      log.severe(
           "Not in an event or step, but trying to add change: " + change + ". Current history node is: " + current);
       startEvent("Filler event for change: " + change);
     }
@@ -169,8 +167,7 @@ public class HistoryWriter implements Serializable {
   public void setRenderingData(final Object details) {
     assertCorrectThread();
     if (!isCurrentEvent()) {
-      log.log(Level.SEVERE,
-          "Not in an event, but trying to set details: " + details + ". Current history node is: " + current);
+      log.severe("Not in an event, but trying to set details: " + details + ". Current history node is: " + current);
       startEvent("Filler event for details: " + details);
     }
     history.getGameData().acquireWriteLock();

--- a/game-core/src/main/java/games/strategy/thread/LockUtil.java
+++ b/game-core/src/main/java/games/strategy/thread/LockUtil.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
-import java.util.logging.Level;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -113,9 +112,7 @@ public enum LockUtil {
   private static final class DefaultErrorReporter implements ErrorReporter {
     @Override
     public void reportError(final Lock from, final Lock to) {
-      log.log(
-          Level.SEVERE,
-          "Invalid lock ordering at, from:" + from + " to:" + to + " stack trace:" + getStackTrace());
+      log.severe("Invalid lock ordering at, from:" + from + " to:" + to + " stack trace:" + getStackTrace());
     }
 
     private static String getStackTrace() {

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -195,10 +195,10 @@ public class ResourceLoader implements Closeable {
     for (int i = 0; i < paths.length; i++) {
       final File f = new File(paths[i]);
       if (!f.exists()) {
-        log.log(Level.SEVERE, f + " does not exist");
+        log.severe(f + " does not exist");
       }
       if (!f.isDirectory() && !f.getName().endsWith(".zip")) {
-        log.log(Level.SEVERE, f + " is not a directory or a zip file");
+        log.severe(f + " is not a directory or a zip file");
       }
       try {
         urls[i] = f.toURI().toURL();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -70,8 +70,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     final PlayerId player = data.getPlayerList().getPlayerId(playerName);
     if (player == null) {
       // could be an old map, or an old save, so we don't want to stop the game from running.
-      log.log(Level.SEVERE,
-          "When trying to find condition: " + conditionName + ", player does not exist: " + playerName);
+      log.severe("When trying to find condition: " + conditionName + ", player does not exist: " + playerName);
       return null;
     }
     final Collection<PlayerId> allPlayers = data.getPlayerList().getPlayers();
@@ -85,11 +84,9 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       } else if (conditionName.contains(Constants.POLITICALACTION_ATTACHMENT_PREFIX)) {
         attachment = PoliticalActionAttachment.get(player, conditionName, allPlayers);
       } else {
-        log.log(
-            Level.SEVERE,
-            conditionName + " attachment must begin with: " + Constants.RULES_OBJECTIVE_PREFIX
-                + " or " + Constants.RULES_CONDITION_PREFIX + " or " + Constants.TRIGGER_ATTACHMENT_PREFIX + " or "
-                + Constants.POLITICALACTION_ATTACHMENT_PREFIX);
+        log.severe(conditionName + " attachment must begin with: " + Constants.RULES_OBJECTIVE_PREFIX
+            + " or " + Constants.RULES_CONDITION_PREFIX + " or " + Constants.TRIGGER_ATTACHMENT_PREFIX + " or "
+            + Constants.POLITICALACTION_ATTACHMENT_PREFIX);
         return null;
       }
     } catch (final Exception e) {
@@ -98,7 +95,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       return null;
     }
     if (attachment == null) {
-      log.log(Level.SEVERE, "Condition attachment does not exist: " + conditionName);
+      log.severe("Condition attachment does not exist: " + conditionName);
       return null;
     }
     return attachment;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -441,7 +441,7 @@ public class AirBattle extends AbstractBattle {
     final Territory retreatTo =
         getRemote(retreatingPlayer, bridge).retreatQuery(battleId, false, battleSite, availableTerritories, text);
     if (retreatTo != null && !availableTerritories.contains(retreatTo)) {
-      log.log(Level.SEVERE, "Invalid retreat selection :" + retreatTo + " not in "
+      log.severe("Invalid retreat selection :" + retreatTo + " not in "
           + MyFormatter.defaultNamedToTextList(availableTerritories));
       return;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
@@ -528,12 +527,10 @@ public class BattleCalculator {
         && !(numhits + damaged.size() == (hitsRemaining > totalHitpoints ? totalHitpoints : hitsRemaining))) {
       tripleaPlayer.reportError("Wrong number of casualties selected");
       if (headLess) {
-        log.log(
-            Level.SEVERE,
-            "Possible Infinite Loop: Wrong number of casualties selected: number of hits on units "
-                + (numhits + damaged.size()) + " != number of hits to take "
-                + (hitsRemaining > totalHitpoints ? totalHitpoints : hitsRemaining) + ", for "
-                + casualtySelection.toString());
+        log.severe("Possible Infinite Loop: Wrong number of casualties selected: number of hits on units "
+            + (numhits + damaged.size()) + " != number of hits to take "
+            + (hitsRemaining > totalHitpoints ? totalHitpoints : hitsRemaining) + ", for "
+            + casualtySelection.toString());
       }
       return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
@@ -543,10 +540,8 @@ public class BattleCalculator {
     if (!sortedTargetsToPickFrom.containsAll(killed) || !sortedTargetsToPickFrom.containsAll(damaged)) {
       tripleaPlayer.reportError("Cannot remove enough units of those types");
       if (headLess) {
-        log.log(
-            Level.SEVERE,
-            "Possible Infinite Loop: Cannot remove enough units of those types: targets "
-                + MyFormatter.unitsToTextNoOwner(sortedTargetsToPickFrom) + ", for " + casualtySelection.toString());
+        log.severe("Possible Infinite Loop: Cannot remove enough units of those types: targets "
+            + MyFormatter.unitsToTextNoOwner(sortedTargetsToPickFrom) + ", for " + casualtySelection.toString());
       }
       return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -12,7 +12,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -552,7 +551,7 @@ public class BattleTracker implements Serializable {
         bridge.getHistoryWriter().addChildToEvent(id.getName() + " loses " + -puChargeReal + " "
             + MyFormatter.pluralize("PU", -puChargeReal) + " for violating " + territory.getName() + "s neutrality.");
       } else {
-        log.log(Level.SEVERE, "Player, " + id.getName() + " attacks a Neutral territory, and should have had to pay "
+        log.severe("Player, " + id.getName() + " attacks a Neutral territory, and should have had to pay "
             + puChargeIdeal + ", but did not have enough PUs to pay! This is a bug.");
         bridge.getHistoryWriter()
             .addChildToEvent(id.getName() + " loses " + -puChargeReal + " " + MyFormatter.pluralize("PU", -puChargeReal)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -141,7 +141,8 @@ public class InitializationDelegate extends BaseTripleADelegate {
                   Level.SEVERE,
                   "You can only edit add transports+units after the initialization delegate of the game is finished.  "
                       + "If this error came up and you have not used Edit Mode to add units + transports, then please "
-                      + "report this as a bug:\n" + e.getMessage());
+                      + "report this as a bug.",
+                  e);
             }
             found = true;
             break;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Sets;
@@ -1322,7 +1321,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Territory retreatTo = getRemote(retreatingPlayer, bridge).retreatQuery(battleId,
         (submerge || canDefendingSubsSubmergeOrRetreat), battleSite, availableTerritories, text);
     if (retreatTo != null && !availableTerritories.contains(retreatTo) && !subs) {
-      log.log(Level.SEVERE, "Invalid retreat selection :" + retreatTo + " not in "
+      log.severe("Invalid retreat selection :" + retreatTo + " not in "
           + MyFormatter.defaultNamedToTextList(availableTerritories));
       return;
     }

--- a/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.player;
 
-import java.util.logging.Level;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.player.IGamePlayer;
@@ -62,13 +60,13 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
         Interruptibles.sleep(100);
         i++;
         if (i == 30) {
-          log.log(Level.SEVERE, "Start step: " + stepName + " does not match player bridge step: " + bridgeStep
+          log.severe("Start step: " + stepName + " does not match player bridge step: " + bridgeStep
               + ". Player Bridge GameOver=" + getPlayerBridge().isGameOver() + ", PlayerId: " + getPlayerId().getName()
               + ", Game: " + getGameData().getGameName()
               + ". Something wrong or very laggy. Will keep trying for 30 more seconds. ");
         }
         if (i > 310) {
-          log.log(Level.SEVERE, "Start step: " + stepName + " still does not match player bridge step: " + bridgeStep
+          log.severe("Start step: " + stepName + " still does not match player bridge step: " + bridgeStep
               + " even after waiting more than 30 seconds. This will probably result in a ClassCastException very "
               + "soon. Player Bridge GameOver=" + getPlayerBridge().isGameOver()
               + ", PlayerId: " + getPlayerId().getName() + ", Game: " + getGameData().getGameName());

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -140,7 +139,7 @@ public class ObjectivePanel extends AbstractStatPanel {
         final List<String> key = Splitter.on(';').splitToList(fileKey.substring(gameName.length()));
         final String value = (String) entry.getValue();
         if (key.size() != 2) {
-          log.log(Level.SEVERE, "objective.properties keys must be 2 parts: <game_name>."
+          log.severe("objective.properties keys must be 2 parts: <game_name>."
               + ObjectiveProperties.GROUP_PROPERTY + ".<#>;player  OR  <game_name>.player;attachmentName");
           continue;
         }
@@ -172,9 +171,8 @@ public class ObjectivePanel extends AbstractStatPanel {
         final List<String> key = Splitter.on(';').splitToList(fileKey.substring(gameName.length()));
         final String value = (String) entry.getValue();
         if (key.size() != 2) {
-          log.log(Level.SEVERE,
-              "objective.properties keys must be 2 parts: <game_name>."
-                  + ObjectiveProperties.GROUP_PROPERTY + ".<#>;player  OR  <game_name>.player;attachmentName");
+          log.severe("objective.properties keys must be 2 parts: <game_name>."
+              + ObjectiveProperties.GROUP_PROPERTY + ".<#>;player  OR  <game_name>.player;attachmentName");
           continue;
         }
         if (key.get(0).startsWith(ObjectiveProperties.GROUP_PROPERTY)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -12,7 +12,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -130,7 +129,7 @@ public class HistoryLog extends JFrame {
       }
       printRemainingTurn(turnStartNode, verbose, data.getDiceSides(), players);
     } else {
-      log.log(Level.SEVERE, "No step node found in!");
+      log.severe("No step node found in!");
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -213,7 +213,7 @@ final class ViewMenu extends JMenu {
       }
     }
     if (!matchFound) {
-      log.log(Level.SEVERE, "default unit size does not match any menu item");
+      log.severe("default unit size does not match any menu item");
     }
     unitSizeMenu.add(radioItem125);
     unitSizeMenu.add(radioItem100);

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -11,7 +11,6 @@ import java.awt.geom.AffineTransform;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.logging.Level;
 import java.util.prefs.Preferences;
 
 import games.strategy.engine.data.GameData;
@@ -112,7 +111,7 @@ public class UnitsDrawer implements IDrawable {
         uiContext.getUnitImageFactory().getImage(type, owner, damaged > 0 || bombingUnitDamage > 0, disabled);
 
     if (!img.isPresent() && !uiContext.isShutDown()) {
-      log.log(Level.SEVERE, "MISSING IMAGE (this unit or image will be invisible): " + type);
+      log.severe("MISSING IMAGE (this unit or image will be invisible): " + type);
     }
 
     if (img.isPresent() && enabledFlags) {

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -3,7 +3,6 @@ package games.strategy.util;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -83,11 +82,11 @@ public class LocalizeHtml {
           URL replacementUrl = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
 
           if (replacementUrl == null || replacementUrl.toString().length() == 0) {
-            log.log(Level.SEVERE, "Could not find: " + mapNameDir + "/" + ASSET_IMAGE_FOLDER + imageFileName);
+            log.severe("Could not find: " + mapNameDir + "/" + ASSET_IMAGE_FOLDER + imageFileName);
             replacementUrl = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
           }
           if (replacementUrl == null || replacementUrl.toString().length() == 0) {
-            log.log(Level.SEVERE, "Could not find: " + ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
+            log.severe("Could not find: " + ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
             continue;
           }
           localizedHtmlText = localizedHtmlText.replaceAll(link, replacementUrl.toString());

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -593,13 +593,12 @@ public class HeadlessGameServer {
   public static void start(final String[] args) {
     final ArgValidationResult validation = HeadlessGameServerCliParam.validateArgs(args);
     if (!validation.isValid()) {
-      log.log(Level.SEVERE,
-          String.format("Failed to start, improper args: %s\n"
-              + "Errors:\n- %s\n"
-              + "Example usage: %s",
-              Arrays.toString(args),
-              String.join("\n- ", validation.getErrorMessages()),
-              HeadlessGameServerCliParam.exampleUsage()));
+      log.severe(String.format("Failed to start, improper args: %s\n"
+          + "Errors:\n- %s\n"
+          + "Example usage: %s",
+          Arrays.toString(args),
+          String.join("\n- ", validation.getErrorMessages()),
+          HeadlessGameServerCliParam.exampleUsage()));
       return;
     }
 

--- a/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-core/src/main/java/tools/image/CenterPicker.java
@@ -143,7 +143,7 @@ public final class CenterPicker {
         try (InputStream is = new FileInputStream(file.getPath())) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          log.log(Level.SEVERE, "Something wrong with your Polygons file: " + file.getAbsolutePath());
+          log.severe("Something wrong with your Polygons file: " + file.getAbsolutePath());
           throw e;
         }
       } else {
@@ -152,7 +152,7 @@ public final class CenterPicker {
           try (InputStream is = new FileInputStream(polyPath)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(is);
           } catch (final IOException e) {
-            log.log(Level.SEVERE, "Something wrong with your Polygons file: " + polyPath);
+            log.severe("Something wrong with your Polygons file: " + polyPath);
             throw e;
           }
         }

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -222,7 +222,7 @@ public final class DecorationPlacer {
           log.info("Centers : " + fileCenters.getPath());
           centers = PointFileReaderWriter.readOneToOne(is);
         } catch (final IOException e) {
-          log.log(Level.SEVERE, "Something wrong with Centers file");
+          log.severe("Something wrong with Centers file");
           throw e;
         }
       } else {
@@ -240,7 +240,7 @@ public final class DecorationPlacer {
             throw new IOException("no centers file specified");
           }
         } catch (final IOException e) {
-          log.log(Level.SEVERE, "Something wrong with Centers file");
+          log.severe("Something wrong with Centers file");
           throw e;
         }
       }
@@ -259,7 +259,7 @@ public final class DecorationPlacer {
           log.info("Polygons : " + filePoly.getPath());
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          log.log(Level.SEVERE, "Something wrong with your Polygons file: " + filePoly.getAbsolutePath());
+          log.severe("Something wrong with your Polygons file: " + filePoly.getAbsolutePath());
           throw e;
         }
       } else {
@@ -270,7 +270,7 @@ public final class DecorationPlacer {
           try (InputStream is = new FileInputStream(polyPath)) {
             polygons = PointFileReaderWriter.readOneToManyPolygons(is);
           } catch (final IOException e) {
-            log.log(Level.SEVERE, "Something wrong with your Polygons file: " + polyPath);
+            log.severe("Something wrong with your Polygons file: " + polyPath);
             throw e;
           }
         } else {

--- a/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -288,7 +288,7 @@ public final class PlacementPicker {
           log.info("Polygons : " + file.getPath());
           polygons = PointFileReaderWriter.readOneToManyPolygons(is);
         } catch (final IOException e) {
-          log.log(Level.SEVERE, "Failed to load polygons: " + file.getAbsolutePath());
+          log.severe("Failed to load polygons: " + file.getAbsolutePath());
           throw e;
         }
       } else {


### PR DESCRIPTION
## Overview

Replaces calls to `Logger#log(Level, String)` with an equivalent call:

1. In most cases, the replacement was one of the one-parameter named level methods (e.g. `Logger#severe(String)`).
1. In one case, an exception message was being printed as part of the log message, so I converted the call to `Logger#log(Level, String, Throwable)` to capture the full stack trace of the exception.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

Viewing with whitespace changes ignored will hide some indentation changes.