### PR TITLE
Add offline lobby (un)mute

### DIFF
--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -157,7 +157,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public void notifyUsernameMutingOfPlayer(final String username, final Instant muteExpires) {
+  public void notifyUsernameMutingOfPlayer(final String username, final @Nullable Instant muteExpires) {
     synchronized (cachedListLock) {
       if (!liveMutedUsernames.contains(username)) {
         liveMutedUsernames.add(username);
@@ -177,7 +177,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public void notifyMacMutingOfPlayer(final String mac, final Instant muteExpires) {
+  public void notifyMacMutingOfPlayer(final String mac, final @Nullable Instant muteExpires) {
     synchronized (cachedListLock) {
       if (!liveMutedMacAddresses.contains(mac)) {
         liveMutedMacAddresses.add(mac);
@@ -383,7 +383,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public void notifyUsernameMiniBanningOfPlayer(final String username, final Instant expires) {
+  public void notifyUsernameMiniBanningOfPlayer(final String username, final @Nullable Instant expires) {
     synchronized (cachedListLock) {
       if (!miniBannedUsernames.contains(username)) {
         miniBannedUsernames.add(username);
@@ -418,7 +418,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public void notifyIpMiniBanningOfPlayer(final String ip, final Instant expires) {
+  public void notifyIpMiniBanningOfPlayer(final String ip, final @Nullable Instant expires) {
     synchronized (cachedListLock) {
       if (!miniBannedIpAddresses.contains(ip)) {
         miniBannedIpAddresses.add(ip);
@@ -442,7 +442,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public void notifyMacMiniBanningOfPlayer(final String mac, final Instant expires) {
+  public void notifyMacMiniBanningOfPlayer(final String mac, final @Nullable Instant expires) {
     synchronized (cachedListLock) {
       if (!miniBannedMacAddresses.contains(mac)) {
         miniBannedMacAddresses.add(mac);

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -1,7 +1,6 @@
 package games.strategy.net;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -12,6 +11,7 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -192,7 +192,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     final Timer unmuteUsernameTimer = new Timer("Username unmute timer");
     unmuteUsernameTimer.schedule(
         newUnmuteTimerTask(() -> isUsernameMutedInBackingStore(username), () -> liveMutedUsernames.remove(username)),
-        Math.max(0, MILLIS.between(Instant.now(), expires)));
+        millisBetweenNowAnd(expires));
   }
 
   /**
@@ -223,11 +223,15 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     };
   }
 
+  private static long millisBetweenNowAnd(final Instant end) {
+    return Math.max(0, ChronoUnit.MILLIS.between(Instant.now(), end));
+  }
+
   private void scheduleMacUnmuteAt(final String mac, final Instant expires) {
     final Timer unmuteMacTimer = new Timer("Mac unmute timer");
     unmuteMacTimer.schedule(
         newUnmuteTimerTask(() -> isMacMutedInBackingStore(mac), () -> liveMutedMacAddresses.remove(mac)),
-        Math.max(0, MILLIS.between(Instant.now(), expires)));
+        millisBetweenNowAnd(expires));
   }
 
   /**
@@ -392,7 +396,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
         final Timer unbanUsernameTimer = new Timer("Username unban timer");
         unbanUsernameTimer.schedule(
             newUnbanTimerTask(() -> miniBannedUsernames.remove(username)),
-            Math.max(0, MILLIS.between(Instant.now(), expires)));
+            millisBetweenNowAnd(expires));
       }
     }
   }
@@ -427,7 +431,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
         final Timer unbanIpTimer = new Timer("IP unban timer");
         unbanIpTimer.schedule(
             newUnbanTimerTask(() -> miniBannedIpAddresses.remove(ip)),
-            Math.max(0, MILLIS.between(Instant.now(), expires)));
+            millisBetweenNowAnd(expires));
       }
     }
   }
@@ -451,7 +455,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
         final Timer unbanMacTimer = new Timer("Mac unban timer");
         unbanMacTimer.schedule(
             newUnbanTimerTask(() -> miniBannedMacAddresses.remove(mac)),
-            Math.max(0, MILLIS.between(Instant.now(), expires)));
+            millisBetweenNowAnd(expires));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -1,6 +1,7 @@
 package games.strategy.net;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -11,7 +12,6 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -190,13 +190,16 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
 
   private void scheduleUsernameUnmuteAt(final String username, final Instant checkTime) {
     final Timer unmuteUsernameTimer = new Timer("Username unmute timer");
-    unmuteUsernameTimer.schedule(getUsernameUnmuteTask(username),
-        checkTime.toEpochMilli() - System.currentTimeMillis());
+    unmuteUsernameTimer.schedule(
+        getUsernameUnmuteTask(username),
+        Math.max(0, MILLIS.between(Instant.now(), checkTime)));
   }
 
   private void scheduleMacUnmuteAt(final String mac, final Instant checkTime) {
     final Timer unmuteMacTimer = new Timer("Mac unmute timer");
-    unmuteMacTimer.schedule(getMacUnmuteTask(mac), checkTime.toEpochMilli() - System.currentTimeMillis());
+    unmuteMacTimer.schedule(
+        getMacUnmuteTask(mac),
+        Math.max(0, MILLIS.between(Instant.now(), checkTime)));
   }
 
   /**
@@ -344,14 +347,16 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
       }
       if (expires != null) {
         final Timer unbanUsernameTimer = new Timer("Username unban timer");
-        unbanUsernameTimer.schedule(new TimerTask() {
-          @Override
-          public void run() {
-            synchronized (cachedListLock) {
-              miniBannedUsernames.remove(username);
-            }
-          }
-        }, expires.toEpochMilli() - System.currentTimeMillis());
+        unbanUsernameTimer.schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                synchronized (cachedListLock) {
+                  miniBannedUsernames.remove(username);
+                }
+              }
+            },
+            Math.max(0, MILLIS.between(Instant.now(), expires)));
       }
     }
   }
@@ -373,14 +378,16 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
       }
       if (expires != null) {
         final Timer unbanIpTimer = new Timer("IP unban timer");
-        unbanIpTimer.schedule(new TimerTask() {
-          @Override
-          public void run() {
-            synchronized (cachedListLock) {
-              miniBannedIpAddresses.remove(ip);
-            }
-          }
-        }, expires.toEpochMilli() - System.currentTimeMillis());
+        unbanIpTimer.schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                synchronized (cachedListLock) {
+                  miniBannedIpAddresses.remove(ip);
+                }
+              }
+            },
+            Math.max(0, MILLIS.between(Instant.now(), expires)));
       }
     }
   }
@@ -402,14 +409,16 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
       }
       if (expires != null) {
         final Timer unbanMacTimer = new Timer("Mac unban timer");
-        unbanMacTimer.schedule(new TimerTask() {
-          @Override
-          public void run() {
-            synchronized (cachedListLock) {
-              miniBannedMacAddresses.remove(mac);
-            }
-          }
-        }, Instant.now().until(expires, ChronoUnit.MILLIS));
+        unbanMacTimer.schedule(
+            new TimerTask() {
+              @Override
+              public void run() {
+                synchronized (cachedListLock) {
+                  miniBannedMacAddresses.remove(mac);
+                }
+              }
+            },
+            Math.max(0, MILLIS.between(Instant.now(), expires)));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -97,13 +97,13 @@ public class HeadlessServerMessenger implements IServerMessenger {
   }
 
   @Override
-  public void notifyIpMiniBanningOfPlayer(final String ip, final Instant expires) {}
+  public void notifyIpMiniBanningOfPlayer(final String ip, final @Nullable Instant expires) {}
 
   @Override
-  public void notifyMacMiniBanningOfPlayer(final String mac, final Instant expires) {}
+  public void notifyMacMiniBanningOfPlayer(final String mac, final @Nullable Instant expires) {}
 
   @Override
-  public void notifyUsernameMiniBanningOfPlayer(final String username, final Instant expires) {}
+  public void notifyUsernameMiniBanningOfPlayer(final String username, final @Nullable Instant expires) {}
 
   @Override
   public @Nullable String getPlayerMac(final String name) {
@@ -111,10 +111,10 @@ public class HeadlessServerMessenger implements IServerMessenger {
   }
 
   @Override
-  public void notifyUsernameMutingOfPlayer(final String username, final Instant muteExpires) {}
+  public void notifyUsernameMutingOfPlayer(final String username, final @Nullable Instant muteExpires) {}
 
   @Override
-  public void notifyMacMutingOfPlayer(final String mac, final Instant muteExpires) {}
+  public void notifyMacMutingOfPlayer(final String mac, final @Nullable Instant muteExpires) {}
 
   @Override
   public boolean isUsernameMiniBanned(final String username) {

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -39,11 +39,29 @@ public interface IServerMessenger extends IMessenger {
    */
   Set<INode> getNodes();
 
-  void notifyIpMiniBanningOfPlayer(String ip, Instant expires);
+  /**
+   * Notifies the server that the specified IP address has been banned until the specified instant.
+   *
+   * @param ip The IP address to ban.
+   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
+   */
+  void notifyIpMiniBanningOfPlayer(String ip, @Nullable Instant expires);
 
-  void notifyMacMiniBanningOfPlayer(String mac, Instant expires);
+  /**
+   * Notifies the server that the specified hashed MAC address has been banned until the specified instant.
+   *
+   * @param mac The hashed MAC address to ban.
+   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
+   */
+  void notifyMacMiniBanningOfPlayer(String mac, @Nullable Instant expires);
 
-  void notifyUsernameMiniBanningOfPlayer(String username, Instant expires);
+  /**
+   * Notifies the server that the specified username has been banned until the specified instant.
+   *
+   * @param username The username to ban.
+   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
+   */
+  void notifyUsernameMiniBanningOfPlayer(String username, @Nullable Instant expires);
 
   /**
    * Returns the hashed MAC address for the user with the specified name or {@code null} if unknown.
@@ -51,9 +69,21 @@ public interface IServerMessenger extends IMessenger {
   @Nullable
   String getPlayerMac(String name);
 
-  void notifyUsernameMutingOfPlayer(String username, Instant muteExpires);
+  /**
+   * Notifies the server that the specified username has been muted until the specified instant.
+   *
+   * @param username The username to mute.
+   * @param muteExpires The time at which the mute expires or {@code null} if the mute is indefinite.
+   */
+  void notifyUsernameMutingOfPlayer(String username, @Nullable Instant muteExpires);
 
-  void notifyMacMutingOfPlayer(String mac, Instant muteExpires);
+  /**
+   * Notifies the server that the specified hashed MAC address has been muted until the specified instant.
+   *
+   * @param mac The hashed MAC address to mute.
+   * @param muteExpires The time at which the mute expires or {@code null} if the mute is indefinite.
+   */
+  void notifyMacMutingOfPlayer(String mac, @Nullable Instant muteExpires);
 
   boolean isUsernameMiniBanned(String username);
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -86,13 +86,16 @@ public final class LobbyMenu extends JMenuBar {
     addDisplayPlayersInformationMenu(diagnostics);
   }
 
-  private void createToolboxMenu(final JMenu menuBar) {
-    final JMenu toolbox = new JMenu("Toolbox");
-    menuBar.add(toolbox);
-    addBanUsernameMenu(toolbox);
-    addBanMacAddressMenu(toolbox);
-    addUnbanUsernameMenu(toolbox);
-    addUnbanMacAddressMenu(toolbox);
+  private void createToolboxMenu(final JMenu parentMenu) {
+    final JMenu toolboxMenu = new JMenu("Toolbox");
+    parentMenu.add(toolboxMenu);
+    addBanUsernameMenuItem(toolboxMenu);
+    addBanMacAddressMenuItem(toolboxMenu);
+    addUnbanUsernameMenuItem(toolboxMenu);
+    addUnbanMacAddressMenuItem(toolboxMenu);
+    parentMenu.addSeparator();
+    addMuteUsernameMenuItem(toolboxMenu);
+    addUnmuteUsernameMenuItem(toolboxMenu);
   }
 
   private void addDisplayPlayersInformationMenu(final JMenu parentMenu) {
@@ -140,7 +143,7 @@ public final class LobbyMenu extends JMenuBar {
     parentMenu.add(menuItem);
   }
 
-  private void addBanUsernameMenu(final JMenu parentMenu) {
+  private void addBanUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Ban Username");
     menuItem.addActionListener(e -> {
       final @Nullable String username = showInputDialog(
@@ -188,7 +191,7 @@ public final class LobbyMenu extends JMenuBar {
     }
   }
 
-  private void addBanMacAddressMenu(final JMenu parentMenu) {
+  private void addBanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Ban Hashed Mac Address");
     menuItem.addActionListener(e -> {
       final @Nullable String hashedMacAddress = showInputDialog(
@@ -208,7 +211,7 @@ public final class LobbyMenu extends JMenuBar {
     parentMenu.add(menuItem);
   }
 
-  private void addUnbanUsernameMenu(final JMenu parentMenu) {
+  private void addUnbanUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unban Username");
     menuItem.addActionListener(e -> {
       final @Nullable String username = showInputDialog("Enter the username that you want to unban from the lobby.");
@@ -224,7 +227,7 @@ public final class LobbyMenu extends JMenuBar {
     parentMenu.add(menuItem);
   }
 
-  private void addUnbanMacAddressMenu(final JMenu parentMenu) {
+  private void addUnbanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unban Hashed Mac Address");
     menuItem.addActionListener(e -> {
       final @Nullable String hashedMacAddress = showInputDialog(
@@ -238,6 +241,42 @@ public final class LobbyMenu extends JMenuBar {
         return;
       }
       getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH));
+    });
+    parentMenu.add(menuItem);
+  }
+
+  private void addMuteUsernameMenuItem(final JMenu parentMenu) {
+    final JMenuItem menuItem = new JMenuItem("Mute Username");
+    menuItem.addActionListener(e -> {
+      final @Nullable String username = showInputDialog(
+          "Enter the username that you want to mute in the lobby.\n\n"
+              + "Note that this mute is effective on any username, registered or anonymous, online or offline.");
+      if (Strings.isNullOrEmpty(username)) {
+        return;
+      }
+      if (!DBUser.isValidUserName(username)) {
+        showErrorDialog("The username you entered is invalid.", "Invalid Username");
+        return;
+      }
+      showTimespanDialog(
+          "Please consult other admins before muting longer than 1 day.",
+          date -> getModeratorController().muteUsername(newDummyNode(username), date));
+    });
+    parentMenu.add(menuItem);
+  }
+
+  private void addUnmuteUsernameMenuItem(final JMenu parentMenu) {
+    final JMenuItem menuItem = new JMenuItem("Unmute Username");
+    menuItem.addActionListener(e -> {
+      final @Nullable String username = showInputDialog("Enter the username that you want to unmute in the lobby.");
+      if (Strings.isNullOrEmpty(username)) {
+        return;
+      }
+      if (!DBUser.isValidUserName(username)) {
+        showErrorDialog("The username you entered is invalid.", "Invalid Username");
+        return;
+      }
+      getModeratorController().muteUsername(newDummyNode(username), Date.from(Instant.EPOCH));
     });
     parentMenu.add(menuItem);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -204,18 +204,25 @@ public final class LobbyMenu extends JMenuBar {
       final @Nullable String hashedMacAddress = showInputDialog(
           "Enter the hashed Mac Address that you want to ban from the lobby.\n\n"
               + "Hashed Mac Addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
-      if (Strings.isNullOrEmpty(hashedMacAddress)) {
-        return;
+      if (validateHashedMacAddress(hashedMacAddress)) {
+        showTimespanDialog(
+            "Please consult other admins before banning longer than 1 day.",
+            date -> getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, date));
       }
-      if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
-        showErrorDialog("The hashed Mac Address you entered is invalid.", "Invalid Hashed Mac");
-        return;
-      }
-      showTimespanDialog(
-          "Please consult other admins before banning longer than 1 day.",
-          date -> getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, date));
     });
     parentMenu.add(menuItem);
+  }
+
+  private boolean validateHashedMacAddress(final @Nullable String hashedMacAddress) {
+    if (Strings.isNullOrEmpty(hashedMacAddress)) {
+      // user canceled operation
+      return false;
+    } else if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
+      showErrorDialog("The hashed Mac Address you entered is invalid.", "Invalid Hashed Mac");
+      return false;
+    }
+
+    return true;
   }
 
   private void addUnbanUsernameMenuItem(final JMenu parentMenu) {
@@ -235,14 +242,9 @@ public final class LobbyMenu extends JMenuBar {
       final @Nullable String hashedMacAddress = showInputDialog(
           "Enter the hashed Mac Address that you want to unban from the lobby.\n\n"
               + "Hashed Mac Addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
-      if (Strings.isNullOrEmpty(hashedMacAddress)) {
-        return;
+      if (validateHashedMacAddress(hashedMacAddress)) {
+        getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH));
       }
-      if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
-        showErrorDialog("The hashed Mac Address you entered is invalid.", "Invalid Hashed Mac");
-        return;
-      }
-      getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH));
     });
     parentMenu.add(menuItem);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -93,7 +93,7 @@ public final class LobbyMenu extends JMenuBar {
     addBanMacAddressMenuItem(toolboxMenu);
     addUnbanUsernameMenuItem(toolboxMenu);
     addUnbanMacAddressMenuItem(toolboxMenu);
-    parentMenu.addSeparator();
+    toolboxMenu.addSeparator();
     addMuteUsernameMenuItem(toolboxMenu);
     addUnmuteUsernameMenuItem(toolboxMenu);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -149,22 +149,29 @@ public final class LobbyMenu extends JMenuBar {
       final @Nullable String username = showInputDialog(
           "Enter the username that you want to ban from the lobby.\n\n"
               + "Note that this ban is effective on any username, registered or anonymous, online or offline.");
-      if (Strings.isNullOrEmpty(username)) {
-        return;
+      if (validateUsername(username)) {
+        showTimespanDialog(
+            "Please consult other admins before banning longer than 1 day.",
+            date -> getModeratorController().banUsername(newDummyNode(username), date));
       }
-      if (!DBUser.isValidUserName(username)) {
-        showErrorDialog("The username you entered is invalid.", "Invalid Username");
-        return;
-      }
-      showTimespanDialog(
-          "Please consult other admins before banning longer than 1 day.",
-          date -> getModeratorController().banUsername(newDummyNode(username), date));
     });
     parentMenu.add(menuItem);
   }
 
   private @Nullable String showInputDialog(final String message) {
     return JOptionPane.showInputDialog(lobbyFrame, message);
+  }
+
+  private boolean validateUsername(final @Nullable String username) {
+    if (Strings.isNullOrEmpty(username)) {
+      // user canceled operation
+      return false;
+    } else if (!DBUser.isValidUserName(username)) {
+      showErrorDialog("The username you entered is invalid.", "Invalid Username");
+      return false;
+    }
+
+    return true;
   }
 
   private void showErrorDialog(final String message, final String title) {
@@ -215,14 +222,9 @@ public final class LobbyMenu extends JMenuBar {
     final JMenuItem menuItem = new JMenuItem("Unban Username");
     menuItem.addActionListener(e -> {
       final @Nullable String username = showInputDialog("Enter the username that you want to unban from the lobby.");
-      if (Strings.isNullOrEmpty(username)) {
-        return;
+      if (validateUsername(username)) {
+        getModeratorController().banUsername(newDummyNode(username), Date.from(Instant.EPOCH));
       }
-      if (!DBUser.isValidUserName(username)) {
-        showErrorDialog("The username you entered is invalid.", "Invalid Username");
-        return;
-      }
-      getModeratorController().banUsername(newDummyNode(username), Date.from(Instant.EPOCH));
     });
     parentMenu.add(menuItem);
   }
@@ -251,16 +253,11 @@ public final class LobbyMenu extends JMenuBar {
       final @Nullable String username = showInputDialog(
           "Enter the username that you want to mute in the lobby.\n\n"
               + "Note that this mute is effective on any username, registered or anonymous, online or offline.");
-      if (Strings.isNullOrEmpty(username)) {
-        return;
+      if (validateUsername(username)) {
+        showTimespanDialog(
+            "Please consult other admins before muting longer than 1 day.",
+            date -> getModeratorController().muteUsername(newDummyNode(username), date));
       }
-      if (!DBUser.isValidUserName(username)) {
-        showErrorDialog("The username you entered is invalid.", "Invalid Username");
-        return;
-      }
-      showTimespanDialog(
-          "Please consult other admins before muting longer than 1 day.",
-          date -> getModeratorController().muteUsername(newDummyNode(username), date));
     });
     parentMenu.add(menuItem);
   }
@@ -269,14 +266,9 @@ public final class LobbyMenu extends JMenuBar {
     final JMenuItem menuItem = new JMenuItem("Unmute Username");
     menuItem.addActionListener(e -> {
       final @Nullable String username = showInputDialog("Enter the username that you want to unmute in the lobby.");
-      if (Strings.isNullOrEmpty(username)) {
-        return;
+      if (validateUsername(username)) {
+        getModeratorController().muteUsername(newDummyNode(username), Date.from(Instant.EPOCH));
       }
-      if (!DBUser.isValidUserName(username)) {
-        showErrorDialog("The username you entered is invalid.", "Invalid Username");
-        return;
-      }
-      getModeratorController().muteUsername(newDummyNode(username), Date.from(Instant.EPOCH));
     });
     parentMenu.add(menuItem);
   }


### PR DESCRIPTION
## Overview

Mods recently made a request to permit offline (un)mute (e.g. see [here](https://forums.triplea-game.org/post/19419)).  This PR adds (un)mute by username; (un)mute by MAC requires an RMI API change, which would break lobby compatibility.

The current lobby supports unmuting an online user by specifying a duration of zero when using the **Quick Mute** command from the context menu in the player panel.  Unfortunately, this feature will probably always result in an exception on the server due to the fact that computing `(now1 + 0) - now2` usually results in a negative value because `now1` and `now2` are evaluated at two different times on two different hosts.  I fixed this issue by rounding negative durations up to zero.

(**NOTE:** Specifying a duration of zero using the **Mute Player** command from the context menu in the player panel is not supported because the `SpinnerNumberModel` there specifies a minimum value of one.)

Doubly unfortunate, is that this bug may also prevent the new offline unmute feature from working with the current production lobby.  Therefore, until a new lobby is deployed, both online and offline unmute may only work intermittently.

## Functional Changes

* Added two new commands to the **Admin > Toolbox** menu: **Mute Username** and **Unmute Username**.  These work exactly like the corresponding ban commands except they (un)mute the user instead of (un)banning them.
* Fixed a bug in `AbstractServerMessenger` that throws an `IllegalArgumentException` when attempting to schedule an unmute task with a negative delay.  This usually occurs when specifying a mute duration <= 0 (that is how we specify any existing mute should be removed).

## Refactoring Changes

* Extracted helpers for validating the username and hashed MAC address entered in the (un)ban/(un)mute commands.
* Extracted helper for creating a `TimerTask` for unbanning a user.
* Inlined some existing helpers for creating a `TimerTask` for unmuting a user, as they were used in only one location each.
* Annotated `Instant` parameters that can be `null` related to banning/muting.

## Manual Testing Performed

* Test case 1
  * As mod, mute user while they are offline using new command.
  * Login as user and verify user is muted.
  * Logoff user.
  * As mod, unmute user while they are offline using new command.
  * Login as user and verify user is not muted.
* Test case 2
  * Login as user and verify user is unmuted.
  * As mod, mute user while they are online using new command.
  * Verify user is muted.
  * As mod, unmute user while they are online using new command.
  * Verify user is not muted.
* Test case 3
  * Login as user and verify user is unmuted.
  * As mod, mute user while they are online using **Quick Mute** command from player panel.
  * Verify user is muted.
  * As mod, unmute user while they are online using **Quick Mute** command from player panel using zero duration.
  * Verify user is not muted.

## Before & After Screen Shots

### Before

![admin-toolbox-before](https://user-images.githubusercontent.com/4826349/50554499-72f19a80-0c89-11e9-9775-028388f14bd6.png)

### After

![admin-toolbox-after](https://user-images.githubusercontent.com/4826349/50554500-77b64e80-0c89-11e9-9351-ff2d868ed023.png)

## Additional Review Notes

* Some methods were simply moved to conform to our method ordering conventions.  I'll note those so they can be ignored during review.
* Ignoring whitespace changes will remove a little bit of re-indentation noise.