### PR TITLE
Remove unused field

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -14,14 +14,11 @@ import org.apache.http.impl.client.HttpClients;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
-import lombok.extern.java.Log;
-
 /**
  * Provides methods to download files via HTTP.
  *
  * @deprecated Use either {@code ContentReader} or {@code DownloadLengthReader} instead.
  */
-@Log
 @Deprecated
 // TODO: testing, break up DownloadUtilsTest to test this component individually from DownloadUtils.
 public final class DownloadUtils {


### PR DESCRIPTION
## Overview

Removes the unused `Logger` field from `DownloadUtils`.

## Functional Changes

None.

## Manual Testing Performed

None.