### PR TITLE
Update FinishedBattle to clear transportedBy

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -47,12 +47,14 @@ public class FinishedBattle extends AbstractBattle {
 
   @Override
   public void fight(final IDelegateBridge bridge) {
-    if (!headless) {
-      battleTracker.getBattleRecords().addResultToBattle(attacker, battleId, defender, attackerLostTuv,
-          defenderLostTuv, battleResultDescription, new BattleResults(this, gameData));
-    }
-    battleTracker.removeBattle(this, bridge.getData());
     isOver = true;
+    battleTracker.removeBattle(this, bridge.getData());
+    if (headless) {
+      return;
+    }
+    clearTransportedBy(bridge);
+    battleTracker.getBattleRecords().addResultToBattle(attacker, battleId, defender, attackerLostTuv, defenderLostTuv,
+        battleResultDescription, new BattleResults(this, gameData));
   }
 
   @Override


### PR DESCRIPTION
## Overview
- Fixes #4446 

## Functional Changes
- Add logic to clear `transportedBy` unit field when `FinishedBattle` is completed to avoid any amphib units believing they are still on the transport and not being able to be edited out

## Manual Testing Performed
- Tested to ensure after the combat in this save game that amphib units could be edited out without an error: 
[test_after_cm.zip](https://github.com/triplea-game/triplea/files/2719619/test_after_cm.zip)

## Additional Review Notes
- Did some refactoring to consolidate logic to clear transportedBy into AbstractBattle as its used by both MustFightBattle and FinishedBattle
- A few small clean ups around headless parameter where some code paths weren't possible
