### PR TITLE
Refactor LobbyServerProperties data responsibilities

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -47,10 +47,10 @@ public class LobbyLogin {
    */
   public @Nullable LobbyClient login() {
     if (!lobbyServerProperties.isServerAvailable()) {
-      showError("Could not connect to server", lobbyServerProperties.serverErrorMessage);
+      showError("Could not connect to server", lobbyServerProperties.getServerErrorMessage());
       return null;
     }
-    if (lobbyServerProperties.port == -1) {
+    if (lobbyServerProperties.getPort() == -1) {
       showError("Could not connect to server",
           "<html>Could not find lobby server for this version of TripleA, <br>"
               + "Please make sure you are using the latest version: " + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE
@@ -83,8 +83,8 @@ public class LobbyLogin {
   private IMessenger login(final String userName, final String password, final boolean anonymousLogin)
       throws IOException {
     return new ClientMessenger(
-        lobbyServerProperties.host,
-        lobbyServerProperties.port,
+        lobbyServerProperties.getHost(),
+        lobbyServerProperties.getPort(),
         userName,
         MacFinder.getHashedMacAddress(),
         challenge -> {
@@ -159,8 +159,8 @@ public class LobbyLogin {
   private IMessenger createAccount(final String userName, final String password, final String email)
       throws IOException {
     return new ClientMessenger(
-        lobbyServerProperties.host,
-        lobbyServerProperties.port,
+        lobbyServerProperties.getHost(),
+        lobbyServerProperties.getPort(),
         userName,
         MacFinder.getHashedMacAddress(),
         challenge -> {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 
 import org.yaml.snakeyaml.Yaml;
 
@@ -26,7 +27,15 @@ class LobbyPropertyFileParser {
 
   public static LobbyServerProperties parse(final File file, final Version currentVersion) {
     try {
-      return new LobbyServerProperties(OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(file), currentVersion)));
+      final Map<String, Object> yamlProps =
+          OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(file), currentVersion));
+
+      return LobbyServerProperties.builder()
+          .host((String) yamlProps.get("host"))
+          .port((Integer) yamlProps.get("port"))
+          .serverMessage((String) yamlProps.get("message"))
+          .serverErrorMessage((String) yamlProps.get("error_message"))
+          .build();
     } catch (final IOException e) {
       throw new RuntimeException("Failed loading file: " + file.getAbsolutePath() + ", please try again, if the "
           + "problem does not go away please report a bug: " + UrlConstants.GITHUB_ISSUES);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -1,61 +1,51 @@
 package games.strategy.engine.lobby.client.login;
 
-import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.base.Strings;
+
+import lombok.Builder;
+import lombok.Getter;
 
 /**
  * Server properties.
  *
- * <p>
- * Generally there is one lobby server, but that server may move.
- * </p>
+ * <p>Generally there is one lobby server, but that server may move.
  *
- * <p>
- * To keep track of this, we always have a properties file in a constant location that points to the current lobby
- * server.
- * </p>
+ * <p>To keep track of this, we always have a properties file in a constant location that points to
+ * the current lobby server.
  *
- * <p>
- * The properties file may indicate that the server is not available using the ERROR_MESSAGE key.
- * </p>
+ * <p>The properties file may indicate that the server is not available using the ERROR_MESSAGE key.
  */
+@Builder
+@Getter
 public class LobbyServerProperties {
-  public final String host;
-  public final int port;
-  public final String serverErrorMessage;
-  public final String serverMessage;
+  /** The host address of the lobby, typically an IP address. */
+  @Nonnull private final String host;
+
+  /** The port the lobby is listening on. */
+  @Nonnull private final Integer port;
+
+  @Nullable private final String version;
+
+  @Nullable private final String serverErrorMessage;
 
   /**
-   * Inits a bare-bones object without server message.
-   *
-   * @param host The host address of the lobby, typically an IP address
-   * @param port The port the lobby is listening on
+   * Message from lobby, eg: "welcome, lobby rules are: xyz".
    */
-  LobbyServerProperties(final String host, final int port) {
-    this.host = host;
-    this.port = port;
-    this.serverErrorMessage = "";
-    this.serverMessage = "";
+  @Nullable private final String serverMessage;
+
+  public String getServerMessage() {
+    return Strings.nullToEmpty(serverMessage);
   }
 
-  /**
-   * Typical constructor for lobby properties based on a yaml object. Parses lobby
-   * host, port, message, and an error message used to indicate potential down times to the user.
-   *
-   * @param yamlProps Yaml object with lobby properties from the point of view of the game client.
-   */
-  LobbyServerProperties(final Map<String, Object> yamlProps) {
-    this.host = (String) yamlProps.get("host");
-    this.port = (Integer) yamlProps.get("port");
-    this.serverMessage = Strings.nullToEmpty((String) yamlProps.get("message"));
-    this.serverErrorMessage = Strings.nullToEmpty((String) yamlProps.get("error_message"));
+  public String getServerErrorMessage() {
+    return Strings.nullToEmpty(serverErrorMessage);
   }
 
-  /**
-   * Returns true if the server is available. If not then see <code>serverErrorMessage</code>
-   */
+  /** Returns true if the server is available. If not then see <code>serverErrorMessage</code> */
   public boolean isServerAvailable() {
-    return serverErrorMessage.isEmpty();
+    return Strings.nullToEmpty(serverErrorMessage).isEmpty();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -65,9 +65,11 @@ public final class LobbyServerPropertiesFetcher {
       final GameSetting<String> testLobbyHostSetting,
       final GameSetting<Integer> testLobbyPortSetting) {
     if (testLobbyHostSetting.isSet() && testLobbyPortSetting.isSet()) {
-      return Optional.of(new LobbyServerProperties(
-          testLobbyHostSetting.getValueOrThrow(),
-          testLobbyPortSetting.getValueOrThrow()));
+      return Optional.of(
+          LobbyServerProperties.builder()
+              .host(testLobbyHostSetting.getValueOrThrow())
+              .port(testLobbyPortSetting.getValueOrThrow())
+              .build());
     }
 
     return Optional.empty();
@@ -81,8 +83,8 @@ public final class LobbyServerPropertiesFetcher {
     try {
       final LobbyServerProperties downloadedProps = downloadAndParseRemoteFile(lobbyPropsUrl, currentVersion,
           LobbyPropertyFileParser::parse);
-      ClientSetting.lobbyLastUsedHost.setValue(downloadedProps.host);
-      ClientSetting.lobbyLastUsedPort.setValue(downloadedProps.port);
+      ClientSetting.lobbyLastUsedHost.setValue(downloadedProps.getHost());
+      ClientSetting.lobbyLastUsedPort.setValue(downloadedProps.getPort());
       ClientSetting.flush();
       return downloadedProps;
     } catch (final IOException e) {
@@ -99,9 +101,10 @@ public final class LobbyServerPropertiesFetcher {
       log.log(Level.SEVERE, "Encountered an error while downloading lobby property file: " + lobbyPropsUrl
           + ", will attempt to connect to the lobby at its last known address. If this problem keeps happening, "
           + "you may be seeing network troubles, or the lobby may not be available.", e);
-      return new LobbyServerProperties(
-          ClientSetting.lobbyLastUsedHost.getValueOrThrow(),
-          ClientSetting.lobbyLastUsedPort.getValueOrThrow());
+      return LobbyServerProperties.builder()
+          .host(ClientSetting.lobbyLastUsedHost.getValueOrThrow())
+          .port(ClientSetting.lobbyLastUsedPort.getValueOrThrow())
+          .build();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -100,8 +100,8 @@ public class LobbyFrame extends JFrame {
   }
 
   private void showServerMessage(final LobbyServerProperties props) {
-    if (!props.serverMessage.isEmpty()) {
-      chatMessagePanel.addServerMessage(props.serverMessage);
+    if (!props.getServerMessage().isEmpty()) {
+      chatMessagePanel.addServerMessage(props.getServerMessage());
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -59,10 +59,10 @@ class LobbyPropertyFileParserTest {
 
     final LobbyServerProperties result =
         LobbyPropertyFileParser.parse(testFile, new Version(TestData.clientCurrentVersion));
-    assertThat(result.host, is(TestData.host));
-    assertThat(result.port, is(Integer.valueOf(TestData.port)));
-    assertThat(result.serverMessage, is(TestData.message));
-    assertThat(result.serverErrorMessage, is(TestData.errorMessage));
+    assertThat(result.getHost(), is(TestData.host));
+    assertThat(result.getPort(), is(Integer.valueOf(TestData.port)));
+    assertThat(result.getServerMessage(), is(TestData.message));
+    assertThat(result.getServerErrorMessage(), is(TestData.errorMessage));
   }
 
   private static File newTempFile(final TestProps... testProps) throws Exception {
@@ -87,10 +87,10 @@ class LobbyPropertyFileParserTest {
     final LobbyServerProperties result =
         LobbyPropertyFileParser.parse(testFile, new Version(TestData.clientCurrentVersion));
 
-    assertThat(result.host, is(TestData.hostOther));
-    assertThat(result.port, is(Integer.valueOf(TestData.portOther)));
-    assertThat(result.serverMessage, is(""));
-    assertThat(result.serverErrorMessage, is(""));
+    assertThat(result.getHost(), is(TestData.hostOther));
+    assertThat(result.getPort(), is(Integer.valueOf(TestData.portOther)));
+    assertThat(result.getServerMessage(), is(""));
+    assertThat(result.getServerErrorMessage(), is(""));
   }
 
   private interface TestData {

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -112,8 +112,8 @@ class LobbyServerPropertiesFetcherTest {
       OptionalUtils.ifPresentOrElse(
           result,
           it -> {
-            assertThat(it.host, is(host));
-            assertThat(it.port, is(port));
+            assertThat(it.getHost(), is(host));
+            assertThat(it.getPort(), is(port));
           },
           () -> fail("expected non-empty properties, but was empty"));
     }
@@ -160,6 +160,7 @@ class LobbyServerPropertiesFetcherTest {
   private interface TestData {
     Version version = new Version("0.0.0.0");
     String url = "someUrl";
-    LobbyServerProperties lobbyServerProperties = new LobbyServerProperties("host", 123);
+    LobbyServerProperties lobbyServerProperties =
+        LobbyServerProperties.builder().host("host").port(123).build();
   }
 }


### PR DESCRIPTION
## Overview

- Use a `@Builder` instead of constructor
- Remove "yaml property" constructor and move the YAML
  property mapping responsibility out from LobbyServerProperties
- Remove public access variables in favor of getters
- Update data contract so that we accept nulls and would return empty
string



## Functional Changes
- none

## Manual Testing Performed
- 
