### PR TITLE
Decouple ServerGame from HeadlessGameServer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -14,8 +14,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import org.triplea.game.server.HeadlessGameServer;
-
 import games.strategy.engine.GameOverException;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -73,6 +71,7 @@ public class ServerGame extends AbstractGame {
   private final DelegateExecutionManager delegateExecutionManager = new DelegateExecutionManager();
   private InGameLobbyWatcherWrapper inGameLobbyWatcher;
   private boolean needToInitialize = true;
+  private final boolean headless;
   /**
    * When the delegate execution is stopped, we countdown on this latch to prevent the startgame(...) method from
    * returning.
@@ -83,9 +82,14 @@ public class ServerGame extends AbstractGame {
    */
   private volatile boolean delegateExecutionStopped = false;
 
-  public ServerGame(final GameData data, final Set<IGamePlayer> localPlayers,
-      final Map<String, INode> remotePlayerMapping, final Messengers messengers) {
+  public ServerGame(
+      final GameData data,
+      final Set<IGamePlayer> localPlayers,
+      final Map<String, INode> remotePlayerMapping,
+      final Messengers messengers,
+      final boolean headless) {
     super(data, localPlayers, remotePlayerMapping, messengers);
+    this.headless = headless;
     gameModifiedChannel = new IGameModifiedChannel() {
       @Override
       public void gameDataChanged(final Change change) {
@@ -348,7 +352,7 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSaveBefore(final IDelegate delegate) {
-    saveGame(AutoSaveFileUtils.getBeforeStepAutoSaveFile(delegate.getName(), HeadlessGameServer.headless()));
+    saveGame(AutoSaveFileUtils.getBeforeStepAutoSaveFile(delegate.getName(), headless));
   }
 
   @Override
@@ -424,7 +428,6 @@ public class ServerGame extends AbstractGame {
     // otherwise, the delegate will execute again.
     final boolean autoSaveThisDelegate = currentDelegate.getClass().isAnnotationPresent(AutoSave.class)
         && currentDelegate.getClass().getAnnotation(AutoSave.class).afterStepEnd();
-    final boolean headless = HeadlessGameServer.headless();
     if (autoSaveThisDelegate && currentStep.getName().endsWith("Move")) {
       final String stepName = currentStep.getName();
       // If we are headless we don't want to include the nation in the save game because that would make it too

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -55,7 +55,7 @@ public class LocalLauncher extends AbstractLauncher {
       final Messengers messengers = new Messengers(new HeadlessServerMessenger());
       final Set<IGamePlayer> gamePlayers =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap());
-      final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers);
+      final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers, headless);
       game.setRandomSource(randomSource);
       gameData.getGameLoader().startGame(game, gamePlayers, headless, null);
       return Optional.of(game);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -121,7 +121,7 @@ public class ServerLauncher extends AbstractLauncher {
       final Set<IGamePlayer> localPlayerSet =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap());
       final Messengers messengers = new Messengers(messenger, remoteMessenger, channelMessenger);
-      serverGame = new ServerGame(gameData, localPlayerSet, remotePlayers, messengers);
+      serverGame = new ServerGame(gameData, localPlayerSet, remotePlayers, messengers, headless);
       serverGame.setInGameLobbyWatcher(inGameLobbyWatcher);
       if (headless) {
         HeadlessGameServer.setServerGame(serverGame);


### PR DESCRIPTION
## Overview

Decouples `ServerGame` from the `HeadlessGameServer#headless()` method.  All creators of `ServerGame` instances know at the time of creation whether they are running headless or not, so this information can be passed via the `ServerGame` constructor.

## Functional Changes

None.

## Manual Testing Performed

* Smoke tested a local game and verified `ServerGame#headless` is `false`.
* Smoke tested a bot game and verified `ServerGame#headless` on the bot is `true`, while `ServerGame#headless` on the client is `false`.