### PR TITLE
Fix Land Scramble Error by preventing a route to/from the same territory

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -996,8 +996,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           historyText =
               "Moving scrambled unit from " + t.getName() + " back to originating territory: " + landingTerr.getName();
         }
-        // if null, we leave it to die
-        if (landingTerr != null) {
+        if (landingTerr != null && !landingTerr.equals(t)) {
           change.add(ChangeFactory.moveUnits(t, landingTerr, Collections.singletonList(u)));
           change.add(Route.getFuelChanges(Collections.singleton(u), new Route(t, landingTerr), u.getOwner(), data));
         }


### PR DESCRIPTION
## Overview
- Fixes #4469

## Functional Changes
- Add check to avoid a route from/to same territory which causes a crash

## Manual Testing Performed
- Tested with this save game by scrambling UK fighters which then lose their starting territory: 
[test.zip](https://github.com/triplea-game/triplea/files/2725329/test.zip)
