### PR TITLE
Improve route finding to consider friendly and requiresUnits

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1714,6 +1714,12 @@ public final class Matches {
     };
   }
 
+  static Predicate<Territory> territoryHasRequiredUnitsToMove(final Collection<Unit> units, final GameData data) {
+    return t -> {
+      return units.stream().allMatch(unitHasRequiredUnitsToMove(t, data));
+    };
+  }
+
   static Predicate<Territory> territoryIsBlockadeZone() {
     return t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1521,23 +1521,23 @@ public class MoveValidator {
         .and(Matches.territoryWasFoughOver(AbstractMoveDelegate.getBattleTracker(data)).negate());
     final Predicate<Territory> noEnemyUnits = Matches.territoryHasNoEnemyUnits(player, data);
     final Predicate<Territory> noAa = Matches.territoryHasEnemyAaForFlyOver(player, data).negate();
-    final List<Predicate<Territory>> tests = new ArrayList<>(Arrays.asList(
+    final List<Predicate<Territory>> prioritizedMovePreferences = new ArrayList<>(Arrays.asList(
         hasRequiredUnitsToMove.and(notEnemyOwned).and(noEnemyUnits),
         hasRequiredUnitsToMove.and(noEnemyUnits),
         hasRequiredUnitsToMove.and(noAa),
         notEnemyOwned.and(noEnemyUnits),
         noEnemyUnits,
         noAa));
-    for (final Predicate<Territory> t : tests) {
-      final Predicate<Territory> testMatch;
+    for (final Predicate<Territory> movePreference : prioritizedMovePreferences) {
+      final Predicate<Territory> moveCondition;
       if (mustGoLand) {
-        testMatch = t.and(Matches.territoryIsLand()).and(noImpassableOrRestrictedOrNeutral);
+        moveCondition = movePreference.and(Matches.territoryIsLand()).and(noImpassableOrRestrictedOrNeutral);
       } else if (mustGoSea) {
-        testMatch = t.and(Matches.territoryIsWater()).and(noImpassableOrRestrictedOrNeutral);
+        moveCondition = movePreference.and(Matches.territoryIsWater()).and(noImpassableOrRestrictedOrNeutral);
       } else {
-        testMatch = t.and(noImpassableOrRestrictedOrNeutral);
+        moveCondition = movePreference.and(noImpassableOrRestrictedOrNeutral);
       }
-      final Route testRoute = data.getMap().getRouteIgnoreEndValidatingCanals(start, end, testMatch, units, player);
+      final Route testRoute = data.getMap().getRouteIgnoreEndValidatingCanals(start, end, moveCondition, units, player);
       if ((testRoute != null) && (testRoute.numberOfSteps() <= defaultRoute.numberOfSteps())) {
         return testRoute;
       }


### PR DESCRIPTION
## Overview
- Addresses a portion of #4477 related to improving route finding preferences for equal distance routes

## Functional Changes
- Route finding now prefers routes that have the needed requiredUnitsToMove (rails, etc) and are not enemy owned

## Manual Testing Performed
- Tested a bunch of different routing finding options and used this TWW test game which made Austria UK owned to move German units around it: 
[test.zip](https://github.com/triplea-game/triplea/files/2725913/test.zip)

## Additional Review Notes
- Did some minor refactoring as well to clean up the route finding code