### PR TITLE
Simplification to construct http clients with URI

### DIFF
--- a/http-client/src/main/java/org/triplea/http/client/HttpClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/HttpClient.java
@@ -3,6 +3,7 @@ package org.triplea.http.client;
 import java.net.URI;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
@@ -19,15 +20,15 @@ import lombok.RequiredArgsConstructor;
 // TODO: verify testing.
 @RequiredArgsConstructor
 public class HttpClient<ClientTypeT, RequestT, ResponseT>
-    implements BiFunction<URI, RequestT, ServiceResponse<ResponseT>> {
+    implements Function<RequestT, ServiceResponse<ResponseT>> {
 
   private final Consumer<RequestT> rateLimiter = new RateLimiter<>();
   private final Class<ClientTypeT> classType;
   private final BiFunction<ClientTypeT, RequestT, ResponseT> sendFunction;
+  private final URI hostUri;
 
   @Override
   public ServiceResponse<ResponseT> apply(
-      final URI hostUri,
       final RequestT requestToSend) {
     try {
       rateLimiter.accept(requestToSend);

--- a/http-client/src/main/java/org/triplea/http/client/ServiceClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/ServiceClient.java
@@ -1,7 +1,6 @@
 package org.triplea.http.client;
 
-import java.net.URI;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,15 +12,14 @@ import lombok.RequiredArgsConstructor;
  */
 @RequiredArgsConstructor
 public class ServiceClient<RequestT, ResponseT>
-    implements BiFunction<URI, RequestT, ServiceResponse<ResponseT>> {
+    implements Function<RequestT, ServiceResponse<ResponseT>> {
 
   private final HttpClient<?, RequestT, ResponseT> client;
 
   @Override
   public ServiceResponse<ResponseT> apply(
-      final URI hostUri,
       final RequestT requestToSend) {
 
-    return client.apply(hostUri, requestToSend);
+    return client.apply(requestToSend);
   }
 }

--- a/http-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClientFactory.java
+++ b/http-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClientFactory.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.error.report;
 
+import java.net.URI;
+
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.error.report.create.ErrorReport;
@@ -13,9 +15,10 @@ public class ErrorReportClientFactory {
   /**
    * Creates an error report uploader clients, sends error reports and gets a response back.
    */
-  public static ServiceClient<ErrorReport, ErrorReportResponse> newErrorUploader() {
+  public static ServiceClient<ErrorReport, ErrorReportResponse> newErrorUploader(final URI uri) {
     return new ServiceClient<>(new HttpClient<>(
         ErrorReportClient.class,
-        ErrorReportClient::sendErrorReport));
+        ErrorReportClient::sendErrorReport,
+        uri));
   }
 }

--- a/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
+++ b/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.github.issues;
 
+import java.net.URI;
+
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.github.issues.create.CreateIssueRequest;
@@ -20,8 +22,12 @@ public class GithubIssueClientFactory {
   public ServiceClient<CreateIssueRequest, CreateIssueResponse> newGithubIssueCreator(
       final String authToken,
       final String githubOrg,
-      final String githubRepo) {
-    return new ServiceClient<>(new HttpClient<>(GithubIssueClient.class,
-        (client, request) -> client.newIssue(authToken, githubOrg, githubRepo, request)));
+      final String githubRepo,
+      final URI uri) {
+    return new ServiceClient<>(
+        new HttpClient<>(
+            GithubIssueClient.class,
+            (client, request) -> client.newIssue(authToken, githubOrg, githubRepo, request),
+            uri));
   }
 }

--- a/http-client/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -89,8 +89,8 @@ class ErrorReportClientTest {
   private static ServiceResponse<ErrorReportResponse> doServiceCall(final WireMockServer wireMockServer) {
     WireMock.configureFor("localhost", wireMockServer.port());
     final URI hostUri = URI.create(wireMockServer.url(""));
-    return ErrorReportClientFactory.newErrorUploader()
-        .apply(hostUri, new ErrorReport(ErrorReportDetails.builder()
+    return ErrorReportClientFactory.newErrorUploader(hostUri)
+        .apply(new ErrorReport(ErrorReportDetails.builder()
             .title(MESSAGE_FROM_USER)
             .gameVersion(GAME_VERSION)
             .logRecord(logRecord)

--- a/http-server/src/main/java/org/triplea/server/reporting/error/upload/ErrorUploadConfiguration.java
+++ b/http-server/src/main/java/org/triplea/server/reporting/error/upload/ErrorUploadConfiguration.java
@@ -24,10 +24,10 @@ public class ErrorUploadConfiguration {
         new GithubIssueClientFactory().newGithubIssueCreator(
             environmentConfiguration.getGithubAuthToken(),
             environmentConfiguration.getGithubOrg(),
-            environmentConfiguration.getGithubRepo());
+            environmentConfiguration.getGithubRepo(),
+            environmentConfiguration.getGithubHost());
 
     return ErrorUploadStrategy.builder()
-        .hostUri(environmentConfiguration.getGithubHost())
         .createIssueClient(createIssueClient)
         .requestAdapter(new ErrorReportRequestAdapter())
         .responseAdapter(new ErrorReportResponseAdapter())

--- a/http-server/src/main/java/org/triplea/server/reporting/error/upload/ErrorUploadStrategy.java
+++ b/http-server/src/main/java/org/triplea/server/reporting/error/upload/ErrorUploadStrategy.java
@@ -1,6 +1,5 @@
 package org.triplea.server.reporting.error.upload;
 
-import java.net.URI;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
@@ -25,14 +24,12 @@ public class ErrorUploadStrategy implements Function<ErrorReport, ErrorReportRes
   private final Function<ServiceResponse<CreateIssueResponse>, ErrorReportResponse> responseAdapter;
   @Nonnull
   private final ServiceClient<CreateIssueRequest, CreateIssueResponse> createIssueClient;
-  @Nonnull
-  private final URI hostUri;
 
   @Override
   public ErrorReportResponse apply(final ErrorReport errorReport) {
     final CreateIssueRequest createIssueRequest = requestAdapter.apply(errorReport);
     // TODO: have we done the appropriate filtering to not create bad requests?
-    final ServiceResponse<CreateIssueResponse> response = createIssueClient.apply(hostUri, createIssueRequest);
+    final ServiceResponse<CreateIssueResponse> response = createIssueClient.apply(createIssueRequest);
     return responseAdapter.apply(response);
   }
 }

--- a/http-server/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
+++ b/http-server/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
@@ -67,7 +67,7 @@ class SparkServerSystemTest {
   @Test
   void errorReportEndpont() {
     final ServiceClient<ErrorReport, ErrorReportResponse> client =
-        ErrorReportClientFactory.newErrorUploader();
+        ErrorReportClientFactory.newErrorUploader(LOCAL_HOST);
 
     when(errorUploadStrategy.apply(ERROR_REPORT))
         .thenReturn(ErrorReportResponse.builder()
@@ -75,7 +75,7 @@ class SparkServerSystemTest {
             .build());
 
     final ServiceResponse<ErrorReportResponse> response =
-        client.apply(LOCAL_HOST, ERROR_REPORT);
+        client.apply(ERROR_REPORT);
 
     assertThat(response.getSendResult(), is(SendResult.SENT));
     assertThat(response.getPayload(), isPresent());

--- a/http-server/src/test/java/org/triplea/server/reporting/error/upload/ErrorUploaderTest.java
+++ b/http-server/src/test/java/org/triplea/server/reporting/error/upload/ErrorUploaderTest.java
@@ -3,7 +3,6 @@ package org.triplea.server.reporting.error.upload;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
 import java.util.function.Function;
 
 import org.hamcrest.core.IsSame;
@@ -21,8 +20,6 @@ import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ErrorUploaderTest {
-
-  private static final URI SAMPLE_URI = URI.create("https://example");
 
   @Mock
   private ServiceClient<CreateIssueRequest, CreateIssueResponse> serviceClient;
@@ -47,7 +44,6 @@ class ErrorUploaderTest {
     errorUploader = ErrorUploadStrategy.builder()
         .responseAdapter(responseAdapter)
         .requestAdapter(requestAdapter)
-        .hostUri(SAMPLE_URI)
         .createIssueClient(serviceClient)
         .build();
   }
@@ -55,7 +51,7 @@ class ErrorUploaderTest {
   @Test
   void apply() {
     when(requestAdapter.apply(errorReport)).thenReturn(createIssueRequest);
-    when(serviceClient.apply(SAMPLE_URI, createIssueRequest)).thenReturn(serviceResponse);
+    when(serviceClient.apply(createIssueRequest)).thenReturn(serviceResponse);
     when(responseAdapter.apply(serviceResponse)).thenReturn(errorReportResponse);
 
     final ErrorReportResponse response = errorUploader.apply(errorReport);


### PR DESCRIPTION
## Overview
Previously we would pass host URI as part of method call. By
constructing http clients with URI we can simplify their usage.


## Functional Changes
none


## Manual Testing Performed
none

