### PR TITLE
Use primitive int instead of @Nonnull Integer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -24,7 +24,7 @@ import lombok.Getter;
 @Builder
 @Getter
 @EqualsAndHashCode
-public class LobbyServerProperties {
+public final class LobbyServerProperties {
   /** The host address of the lobby, typically an IP address. */
   @Nonnull private final String host;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -29,7 +29,7 @@ public final class LobbyServerProperties {
   @Nonnull private final String host;
 
   /** The port the lobby is listening on. */
-  @Nonnull private final Integer port;
+  private final int port;
 
   /** URI for the http lobby server. */
   @Nullable private final URI httpServerUri;

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesTest.java
@@ -1,0 +1,16 @@
+package games.strategy.engine.lobby.client.login;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+final class LobbyServerPropertiesTest {
+  @Nested
+  final class EqualsAndHashCodeTest {
+    @Test
+    void shouldBeEquatableAndHashable() {
+      EqualsVerifier.forClass(LobbyServerProperties.class).verify();
+    }
+  }
+}


### PR DESCRIPTION
## Overview

I missed asking about this in a previous code review.  It seems that there's no reason to use a boxed type if it can't be `null`.

## Functional Changes

None.

## Manual Testing Performed

None.