### PR TITLE
Put LobbyServerProperties behind cache

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -18,7 +18,7 @@ import games.strategy.engine.framework.startup.ui.PbemSetupPanel;
 import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.ScreenChangeListener;
 import games.strategy.engine.lobby.client.login.LobbyLogin;
-import games.strategy.engine.lobby.client.login.LobbyServerPropertiesFetcher;
+import games.strategy.engine.lobby.client.login.LobbyPropertyFetcherConfiguration;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -105,7 +105,7 @@ public class SetupPanelModel {
    * @param uiParent Used to center pop-up's prompting user for their lobby credentials.
    */
   public void login(final Component uiParent) {
-    new LobbyServerPropertiesFetcher().fetchLobbyServerProperties()
+    LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher().fetchLobbyServerProperties()
         .ifPresent(lobbyServerProperties -> {
           final LobbyLogin login =
               new LobbyLogin(JOptionPane.getFrameForComponent(uiParent), lobbyServerProperties);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
@@ -1,0 +1,14 @@
+package games.strategy.engine.lobby.client.login;
+
+/**
+ * Responsible for constructing a {@code LobbyServerPropertiesFetcher}.
+ */
+public class LobbyPropertyFetcherConfiguration {
+
+  private static final LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher =
+      new LobbyServerPropertiesFetcher();
+
+  public static LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher() {
+    return lobbyServerPropertiesFetcher;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -9,6 +9,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
+
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.engine.ClientContext;
@@ -25,6 +27,8 @@ import lombok.extern.java.Log;
 @Log
 public final class LobbyServerPropertiesFetcher {
   private final Function<String, Optional<File>> fileDownloader;
+  @Nullable private LobbyServerProperties lobbyServerProperties;
+
 
   /**
    * Default constructor with default (prod) dependencies.
@@ -56,6 +60,14 @@ public final class LobbyServerPropertiesFetcher {
    *         Otherwise backup values from client config.
    */
   public Optional<LobbyServerProperties> fetchLobbyServerProperties() {
+    if (lobbyServerProperties == null) {
+      final Optional<LobbyServerProperties> props = fetchProperties();
+      props.ifPresent(lobbyProps -> lobbyServerProperties = lobbyProps);
+    }
+    return Optional.ofNullable(lobbyServerProperties);
+  }
+  
+  private Optional<LobbyServerProperties> fetchProperties() {
     final Optional<LobbyServerProperties> userOverride = getTestOverrideProperties();
     if (userOverride.isPresent()) {
       return userOverride;


### PR DESCRIPTION
## Overview

- Here we add a transparent cache to LobbyServerPropertiesFetcher, this
way if we invoke the fetch from multiple places we will not be doing a
remote network call each time.
- Introduce a configuration object to construct our
LobbyServerPropertiesFetcher and to keep hold of a singleton instance

## Functional Changes
- LobbyServerProperties will return cached version of LobbyServerProperties after fetching it once

## Manual Testing Performed
- smoke tested that can connect to lobby, close lobby and connect back again
