### PR TITLE
Run DialogBuilder#showDialog on AWT

### DIFF
--- a/game-core/src/main/java/swinglib/DialogBuilder.java
+++ b/game-core/src/main/java/swinglib/DialogBuilder.java
@@ -157,16 +157,24 @@ public class DialogBuilder {
         return;
       }
 
-      final int result = JOptionPane.showConfirmDialog(
-          withConfirmActionBuilder.withMessageBuilder.withTitleBuilder.withParentBuilder.parent,
-          withConfirmActionBuilder.withMessageBuilder.message,
-          withConfirmActionBuilder.withMessageBuilder.withTitleBuilder.title,
-          JOptionPane.YES_NO_OPTION,
-          JOptionPane.QUESTION_MESSAGE);
+      SwingAction.invokeNowOrLater(
+          () -> {
+            final int result =
+                JOptionPane.showConfirmDialog(
+                    withConfirmActionBuilder
+                        .withMessageBuilder
+                        .withTitleBuilder
+                        .withParentBuilder
+                        .parent,
+                    withConfirmActionBuilder.withMessageBuilder.message,
+                    withConfirmActionBuilder.withMessageBuilder.withTitleBuilder.title,
+                    JOptionPane.YES_NO_OPTION,
+                    JOptionPane.QUESTION_MESSAGE);
 
-      if (result == JOptionPane.YES_OPTION) {
-        withConfirmActionBuilder.confirmAction.run();
-      }
+            if (result == JOptionPane.YES_OPTION) {
+              withConfirmActionBuilder.confirmAction.run();
+            }
+          });
     }
   }
 }


### PR DESCRIPTION
## Overview
To avoid callers needing to know about AWT threading detail,
this update changes DialogBuilder to always show dialog on AWT thread.
This avoids AWT threading error when clients are not already on AWT
thread.


## Additional Review Notes
- most changes are whitespace, this is roughly a one line change
