### PR TITLE
Wire up Error Report Http Client

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -1,6 +1,7 @@
 package games.strategy.debug.error.reporting;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import javax.swing.JFrame;
@@ -18,19 +19,26 @@ class ErrorReportConfiguration {
    * dialog and sending error report data to the remote http server.
    */
   static BiConsumer<JFrame, UserErrorReport> newReportHandler() {
-    if (ClientSetting.httpLobbyUriOverride.isSet()) {
-      return new ErrorReportUploadAction(
-          ErrorReportClientFactory.newErrorUploader(
-              URI.create(ClientSetting.httpLobbyUriOverride.getValueOrThrow())));
-    }
+    return newFromUserOverride()
+        .orElseGet(
+            () -> newFromRemoteProperties().orElse(ErrorReportUploadAction.OFFLINE_STRATEGY));
+  }
 
+  private static Optional<BiConsumer<JFrame, UserErrorReport>> newFromUserOverride() {
+    return ClientSetting.httpLobbyUriOverride
+        .getValue()
+        .map(URI::create)
+        .map(ErrorReportClientFactory::newErrorUploader)
+        .map(ErrorReportUploadAction::new);
+  }
+
+  private static Optional<BiConsumer<JFrame, UserErrorReport>> newFromRemoteProperties() {
     return LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
         .fetchLobbyServerProperties()
         .<BiConsumer<JFrame, UserErrorReport>>map(
             lobbyServerProperties ->
                 new ErrorReportUploadAction(
                     ErrorReportClientFactory.newErrorUploader(
-                        lobbyServerProperties.getHttpServerUri())))
-        .orElse(ErrorReportUploadAction.OFFLINE_STRATEGY);
+                        lobbyServerProperties.getHttpServerUri())));
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -35,10 +35,9 @@ class ErrorReportConfiguration {
   private static Optional<BiConsumer<JFrame, UserErrorReport>> newFromRemoteProperties() {
     return LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
         .fetchLobbyServerProperties()
-        .<BiConsumer<JFrame, UserErrorReport>>map(
-            lobbyServerProperties ->
+        .map(
+            props ->
                 new ErrorReportUploadAction(
-                    ErrorReportClientFactory.newErrorUploader(
-                        lobbyServerProperties.getHttpServerUri())));
+                    ErrorReportClientFactory.newErrorUploader(props.getHttpServerUri())));
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -1,0 +1,36 @@
+package games.strategy.debug.error.reporting;
+
+import java.net.URI;
+import java.util.function.BiConsumer;
+
+import javax.swing.JFrame;
+
+import org.triplea.http.client.error.report.ErrorReportClientFactory;
+
+import games.strategy.engine.lobby.client.login.LobbyPropertyFetcherConfiguration;
+import games.strategy.triplea.settings.ClientSetting;
+
+class ErrorReportConfiguration {
+
+  /**
+   * Creates a 'report handler', this is the component invoked when we have collected all data from
+   * user and wish to then send that data. The report handler is responsible for showing a waiting
+   * dialog and sending error report data to the remote http server.
+   */
+  static BiConsumer<JFrame, UserErrorReport> newReportHandler() {
+    if (ClientSetting.httpLobbyUriOverride.isSet()) {
+      return new ErrorReportUploadAction(
+          ErrorReportClientFactory.newErrorUploader(
+              URI.create(ClientSetting.httpLobbyUriOverride.getValueOrThrow())));
+    }
+
+    return LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
+        .fetchLobbyServerProperties()
+        .<BiConsumer<JFrame, UserErrorReport>>map(
+            lobbyServerProperties ->
+                new ErrorReportUploadAction(
+                    ErrorReportClientFactory.newErrorUploader(
+                        lobbyServerProperties.getHttpServerUri())))
+        .orElse(ErrorReportUploadAction.OFFLINE_STRATEGY);
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
@@ -1,0 +1,73 @@
+package games.strategy.debug.error.reporting;
+
+import java.net.URI;
+import java.util.function.BiConsumer;
+
+import javax.swing.JFrame;
+
+import org.triplea.http.client.SendResult;
+import org.triplea.http.client.ServiceClient;
+import org.triplea.http.client.ServiceResponse;
+import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.create.ErrorReportResponse;
+
+import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
+import lombok.AllArgsConstructor;
+import swinglib.DialogBuilder;
+
+@AllArgsConstructor
+class ErrorReportUploadAction implements BiConsumer<JFrame, UserErrorReport> {
+
+  static final BiConsumer<JFrame, UserErrorReport> OFFLINE_STRATEGY =
+      (frame, report) ->
+          DialogBuilder.builder()
+              .parent(frame)
+              .title("Unable to connect to server")
+              .errorMessage(
+                  "TripleA is unable to get the servers network adddress, please restart "
+                      + "Triplea and try again, if this problem keeps happening please contact Triplea")
+              .showDialog();
+
+  private final ServiceClient<ErrorReport, ErrorReportResponse> serviceClient;
+
+  @Override
+  public void accept(final JFrame frame, final UserErrorReport errorReport) {
+    new BackgroundTaskRunner(frame)
+        .awaitRunInBackground(
+            "Sending report...", () -> sendErrorReport(frame, errorReport.toErrorReport()));
+  }
+
+  private void sendErrorReport(final JFrame frame, final ErrorReport errorReport) {
+    final ServiceResponse<ErrorReportResponse> response = serviceClient.apply(errorReport);
+    final URI githubLink =
+        response.getPayload().map(pay -> pay.getGithubIssueLink().orElse(null)).orElse(null);
+
+    if ((response.getSendResult() == SendResult.SENT) && (githubLink != null)) {
+      DialogBuilder.builder()
+          .parent(frame)
+          .title("Report sent successfully")
+          .infoMessage(
+              "Upload success, report created: "
+                  + response.getPayload().map(pay -> pay.getGithubIssueLink().orElse(null)))
+          .showDialog();
+      frame.dispose();
+    } else {
+      DialogBuilder.builder()
+          .parent(frame)
+          .title("Report upload failed")
+          .errorMessage(errorMessage(response))
+          .showDialog();
+      // We close the frame on success, but not on failure.
+      // This is so the user can recover any data they have typed.
+    }
+  }
+
+  private static String errorMessage(final ServiceResponse<ErrorReportResponse> response) {
+    return String.format(
+        "<html>Failure uploading report, please try again or contact support. <br/>"
+            + "Send result: %s<br />"
+            + "Error: %s"
+            + "</html>",
+        response.getSendResult(), response.getExceptionMessage());
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ReportWindowController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ReportWindowController.java
@@ -1,7 +1,6 @@
 package games.strategy.debug.error.reporting;
 
 import java.awt.Component;
-import java.util.function.BiConsumer;
 import java.util.logging.LogRecord;
 
 import javax.swing.JFrame;
@@ -14,16 +13,12 @@ public final class ReportWindowController {
 
   private ReportWindowController() {}
 
-  // TODO: replace no-op report handler with 'new ReportUploadProcess()'
-  private static final BiConsumer<JFrame, UserErrorReport> reportHandler = (frame, report) -> {
-  };
-
   public static void showWindow(final Component parent) {
     showWindow(parent, null);
   }
 
   public static void showWindow(final Component parent, final LogRecord logRecord) {
-    final JFrame frame = new ErrorReportWindow(reportHandler)
+    final JFrame frame = new ErrorReportWindow(ErrorReportConfiguration.newReportHandler())
         .buildWindow(parent, logRecord);
     frame.setVisible(true);
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -33,7 +33,6 @@ import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.GameChooser;
 import games.strategy.engine.framework.ui.GameChooserEntry;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.Interruptibles;
 import swinglib.JButtonBuilder;
 
 /**
@@ -266,11 +265,11 @@ public final class GameSelectorPanel extends JPanel implements Observer {
 
   private void selectSavedGameFile() {
     GameFileSelector.selectGameFile()
-        .ifPresent(file -> Interruptibles
-            .await(() -> GameRunner.newBackgroundTaskRunner().runInBackground("Loading savegame...", () -> {
+        .ifPresent(
+            file -> GameRunner.newBackgroundTaskRunner().awaitRunInBackground("Loading savegame...", () -> {
               model.load(file);
               setOriginalPropertiesMap(model.getGameData());
-            })));
+            }));
   }
 
   private void selectGameFile() {

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -14,6 +14,7 @@ import javax.swing.SwingWorker;
 
 import com.google.common.base.Throwables;
 
+import games.strategy.util.Interruptibles;
 import games.strategy.util.function.ThrowingSupplier;
 
 /**
@@ -50,6 +51,13 @@ public final class BackgroundTaskRunner {
       backgroundAction.run();
       return null;
     });
+  }
+
+  /**
+   * Similar to 'runInBackground' except uses Interruptibles#await to suppress the {@code InterruptedException}.
+   */
+  public void awaitRunInBackground(final String message, final Runnable backgroundAction) {
+    Interruptibles.await(() -> runInBackground(message, backgroundAction));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -95,6 +95,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE", false);
   public static final ClientSetting<String> testLobbyHost = new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort = new IntegerClientSetting("TEST_LOBBY_PORT");
+  public static final ClientSetting<String> httpLobbyUriOverride = new StringClientSetting("TEST_HTTP_LOBBY_URI");
   public static final ClientSetting<Boolean> firstTimeThisVersion =
       new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<String> lastCheckForEngineUpdate =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -228,6 +228,16 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
+  TEST_HTTP_LOBBY_URI(
+      "Http Lobby URI",
+      SettingType.TESTING,
+      "Specifies host and port for connecting to a test http lobby.") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return textField(ClientSetting.httpLobbyUriOverride);
+    }
+  },
+
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
       "Show First Time Prompts",
       SettingType.GAME,

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -229,9 +229,9 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
   },
 
   TEST_HTTP_LOBBY_URI(
-      "Http Lobby URI",
+      "HTTP Lobby URI",
       SettingType.TESTING,
-      "Specifies host and port for connecting to a test http lobby.") {
+      "Specifies host and port for connecting to a test HTTP lobby.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
       return textField(ClientSetting.httpLobbyUriOverride);


### PR DESCRIPTION
## Overview
- Wire up the error report upload client
  - Add configuration to instantiate the client
  - Add a 'handler' class "ErrorReportUploadAction" that will invoke the
    client and show a progress spinner while the upload is in-progress.
    The 'handler' is responsible for looking at the result and showing
    a success or error message.
- Add a user setting option to override http server URI
- Add convenience method to BackGroundTaskRunner that does not throw
InterruptedException

## Screeshot
![screenshot from 2019-01-04 02-12-30](https://user-images.githubusercontent.com/12397753/50683249-3ba32680-0fc6-11e9-963f-7c1e95140088.png)


## Functional Changes
- Sending reports with the send window will now do something and try to send the error report to our http server

## Manual Testing Performed
- turned on test-feature flag in settings, sent some reports. They failed, but they failed on the server and not due to any client issue.

## Reviewer Notes
Still quite a bit to do as follow-up:
- resolve server issues that prevent upload
- do a better job of wiring server error message back to client
- keep improving error handling on client side
- client side validation to disallow empty data from being sent
