### PR TITLE
Automatically add hashed MAC address prefix if needed

### DIFF
--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -301,19 +301,4 @@ public final class MacFinder {
       return false;
     }
   }
-
-  /**
-   * Removes the prefix from the specified hashed MAC address.
-   *
-   * @param hashedMacAddress The hashed MAC address whose prefix is to be removed.
-   *
-   * @return The hashed MAC address without its prefix.
-   *
-   * @throws IllegalArgumentException If {@code hashedMacAddress} is not a valid hashed MAC address.
-   */
-  public static String trimHashedMacAddressPrefix(final String hashedMacAddress) {
-    checkNotNull(hashedMacAddress);
-
-    return Md5Crypt.getHash(hashedMacAddress);
-  }
 }

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -301,4 +301,18 @@ public final class MacFinder {
       return false;
     }
   }
+
+  /**
+   * Returns {@code value} with a hashed MAC address prefix if one is not already present.
+   *
+   * @return The returned value may not be a valid hashed MAC address and should be validated using
+   *         {@link #isValidHashedMacAddress(String)}.
+   */
+  public static String withPrefix(final String value) {
+    checkNotNull(value);
+
+    return isValidHashedMacAddress(value)
+        ? value
+        : Md5Crypt.fromSaltAndHash(HASHED_MAC_ADDRESS_SALT, value);
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -7,6 +7,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
@@ -146,35 +147,30 @@ public final class LobbyMenu extends JMenuBar {
   private void addBanUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Ban Username");
     menuItem.addActionListener(e -> {
-      final @Nullable String username = showInputDialog(
-          "Enter the username that you want to ban from the lobby.\n\n"
-              + "Note that this ban is effective on any username, registered or anonymous, online or offline.");
-      if (validateUsername(username)) {
-        showTimespanDialog(
-            "Please consult other admins before banning longer than 1 day.",
-            date -> getModeratorController().banUsername(newDummyNode(username), date));
-      }
+      final String message = "Enter the username that you want to ban from the lobby.\n"
+          + "\n"
+          + "Note that this ban is effective on any username, registered or anonymous, online or offline.";
+      showInputDialog(message)
+          .filter(this::validateUsername)
+          .ifPresent(username -> showTimespanDialog(
+              "Please consult other admins before banning longer than 1 day.",
+              date -> getModeratorController().banUsername(newDummyNode(username), date)));
     });
     parentMenu.add(menuItem);
   }
 
-  private @Nullable String showInputDialog(final String message) {
-    return JOptionPane.showInputDialog(lobbyFrame, message);
+  private Optional<String> showInputDialog(final String message) {
+    final @Nullable String result = JOptionPane.showInputDialog(lobbyFrame, message);
+    return Strings.isNullOrEmpty(result) ? Optional.empty() : Optional.of(result);
   }
 
   private boolean validateUsername(final @Nullable String username) {
-    if (wasInputDialogCanceled(username)) {
-      return false;
-    } else if (!DBUser.isValidUserName(username)) {
+    if (!DBUser.isValidUserName(username)) {
       showErrorDialog("The username you entered is invalid.", "Invalid Username");
       return false;
     }
 
     return true;
-  }
-
-  private static boolean wasInputDialogCanceled(final @Nullable String result) {
-    return Strings.isNullOrEmpty(result);
   }
 
   private void showErrorDialog(final String message, final String title) {
@@ -204,30 +200,24 @@ public final class LobbyMenu extends JMenuBar {
   private void addBanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Ban Hashed Mac Address");
     menuItem.addActionListener(e -> {
-      final @Nullable String hashedMacAddress =
-          showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to ban from the lobby.");
-      if (validateHashedMacAddress(hashedMacAddress)) {
-        showTimespanDialog(
-            "Please consult other admins before banning longer than 1 day.",
-            date -> getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, date));
-      }
+      showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to ban from the lobby.")
+          .filter(this::validateHashedMacAddress)
+          .ifPresent(hashedMacAddress -> showTimespanDialog(
+              "Please consult other admins before banning longer than 1 day.",
+              date -> getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, date)));
     });
     parentMenu.add(menuItem);
   }
 
-  private @Nullable String showHashedMacAddressInputDialog(final String message) {
-    final @Nullable String hashedMacAddress = showInputDialog(message + "\n"
+  private Optional<String> showHashedMacAddressInputDialog(final String message) {
+    final String completeMessage = message + "\n"
         + "\n"
-        + "Hashed Mac addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
-    return wasInputDialogCanceled(hashedMacAddress)
-        ? hashedMacAddress
-        : MacFinder.withPrefix(hashedMacAddress);
+        + "Hashed Mac addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3";
+    return showInputDialog(completeMessage).map(MacFinder::withPrefix);
   }
 
   private boolean validateHashedMacAddress(final @Nullable String hashedMacAddress) {
-    if (wasInputDialogCanceled(hashedMacAddress)) {
-      return false;
-    } else if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
+    if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
       showErrorDialog("The hashed Mac Address you entered is invalid.", "Invalid Hashed Mac");
       return false;
     }
@@ -238,10 +228,10 @@ public final class LobbyMenu extends JMenuBar {
   private void addUnbanUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unban Username");
     menuItem.addActionListener(e -> {
-      final @Nullable String username = showInputDialog("Enter the username that you want to unban from the lobby.");
-      if (validateUsername(username)) {
-        getModeratorController().banUsername(newDummyNode(username), Date.from(Instant.EPOCH));
-      }
+      showInputDialog("Enter the username that you want to unban from the lobby.")
+          .filter(this::validateUsername)
+          .ifPresent(username -> getModeratorController()
+              .banUsername(newDummyNode(username), Date.from(Instant.EPOCH)));
     });
     parentMenu.add(menuItem);
   }
@@ -249,11 +239,10 @@ public final class LobbyMenu extends JMenuBar {
   private void addUnbanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unban Hashed Mac Address");
     menuItem.addActionListener(e -> {
-      final @Nullable String hashedMacAddress =
-          showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to unban from the lobby.");
-      if (validateHashedMacAddress(hashedMacAddress)) {
-        getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH));
-      }
+      showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to unban from the lobby.")
+          .filter(this::validateHashedMacAddress)
+          .ifPresent(hashedMacAddress -> getModeratorController()
+              .banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH)));
     });
     parentMenu.add(menuItem);
   }
@@ -261,14 +250,14 @@ public final class LobbyMenu extends JMenuBar {
   private void addMuteUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Mute Username");
     menuItem.addActionListener(e -> {
-      final @Nullable String username = showInputDialog(
-          "Enter the username that you want to mute in the lobby.\n\n"
-              + "Note that this mute is effective on any username, registered or anonymous, online or offline.");
-      if (validateUsername(username)) {
-        showTimespanDialog(
-            "Please consult other admins before muting longer than 1 day.",
-            date -> getModeratorController().muteUsername(newDummyNode(username), date));
-      }
+      final String message = "Enter the username that you want to mute in the lobby.\n"
+          + "\n"
+          + "Note that this mute is effective on any username, registered or anonymous, online or offline.";
+      showInputDialog(message)
+          .filter(this::validateUsername)
+          .ifPresent(username -> showTimespanDialog(
+              "Please consult other admins before muting longer than 1 day.",
+              date -> getModeratorController().muteUsername(newDummyNode(username), date)));
     });
     parentMenu.add(menuItem);
   }
@@ -276,10 +265,10 @@ public final class LobbyMenu extends JMenuBar {
   private void addUnmuteUsernameMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unmute Username");
     menuItem.addActionListener(e -> {
-      final @Nullable String username = showInputDialog("Enter the username that you want to unmute in the lobby.");
-      if (validateUsername(username)) {
-        getModeratorController().muteUsername(newDummyNode(username), Date.from(Instant.EPOCH));
-      }
+      showInputDialog("Enter the username that you want to unmute in the lobby.")
+          .filter(this::validateUsername)
+          .ifPresent(username -> getModeratorController()
+              .muteUsername(newDummyNode(username), Date.from(Instant.EPOCH)));
     });
     parentMenu.add(menuItem);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -163,8 +163,7 @@ public final class LobbyMenu extends JMenuBar {
   }
 
   private boolean validateUsername(final @Nullable String username) {
-    if (Strings.isNullOrEmpty(username)) {
-      // user canceled operation
+    if (wasInputDialogCanceled(username)) {
       return false;
     } else if (!DBUser.isValidUserName(username)) {
       showErrorDialog("The username you entered is invalid.", "Invalid Username");
@@ -172,6 +171,10 @@ public final class LobbyMenu extends JMenuBar {
     }
 
     return true;
+  }
+
+  private static boolean wasInputDialogCanceled(final @Nullable String result) {
+    return Strings.isNullOrEmpty(result);
   }
 
   private void showErrorDialog(final String message, final String title) {
@@ -201,9 +204,8 @@ public final class LobbyMenu extends JMenuBar {
   private void addBanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Ban Hashed Mac Address");
     menuItem.addActionListener(e -> {
-      final @Nullable String hashedMacAddress = showInputDialog(
-          "Enter the hashed Mac Address that you want to ban from the lobby.\n\n"
-              + "Hashed Mac Addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
+      final @Nullable String hashedMacAddress =
+          showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to ban from the lobby.");
       if (validateHashedMacAddress(hashedMacAddress)) {
         showTimespanDialog(
             "Please consult other admins before banning longer than 1 day.",
@@ -213,9 +215,17 @@ public final class LobbyMenu extends JMenuBar {
     parentMenu.add(menuItem);
   }
 
+  private @Nullable String showHashedMacAddressInputDialog(final String message) {
+    final @Nullable String hashedMacAddress = showInputDialog(message + "\n"
+        + "\n"
+        + "Hashed Mac addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
+    return wasInputDialogCanceled(hashedMacAddress)
+        ? hashedMacAddress
+        : MacFinder.withPrefix(hashedMacAddress);
+  }
+
   private boolean validateHashedMacAddress(final @Nullable String hashedMacAddress) {
-    if (Strings.isNullOrEmpty(hashedMacAddress)) {
-      // user canceled operation
+    if (wasInputDialogCanceled(hashedMacAddress)) {
       return false;
     } else if (!MacFinder.isValidHashedMacAddress(hashedMacAddress)) {
       showErrorDialog("The hashed Mac Address you entered is invalid.", "Invalid Hashed Mac");
@@ -239,9 +249,8 @@ public final class LobbyMenu extends JMenuBar {
   private void addUnbanMacAddressMenuItem(final JMenu parentMenu) {
     final JMenuItem menuItem = new JMenuItem("Unban Hashed Mac Address");
     menuItem.addActionListener(e -> {
-      final @Nullable String hashedMacAddress = showInputDialog(
-          "Enter the hashed Mac Address that you want to unban from the lobby.\n\n"
-              + "Hashed Mac Addresses should be entered in this format: $1$MH$345ntXD4G3AKpAeHZdaGe3");
+      final @Nullable String hashedMacAddress =
+          showHashedMacAddressInputDialog("Enter the hashed Mac address that you want to unban from the lobby.");
       if (validateHashedMacAddress(hashedMacAddress)) {
         getModeratorController().banMac(newDummyNode("__unknown__"), hashedMacAddress, Date.from(Instant.EPOCH));
       }

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -82,24 +82,6 @@ public final class Md5Crypt {
   }
 
   /**
-   * Gets the hash for the specified hashed value.
-   *
-   * @param hashedValue The hashed value from a previous call to {@link #hash(String, String)} whose hash is to be
-   *        returned.
-   *
-   * @return The hash for the specified hashed value.
-   *
-   * @throws IllegalArgumentException If {@code hashedValue} is not an MD5-crypt hashed value.
-   */
-  public static String getHash(final String hashedValue) {
-    checkNotNull(hashedValue);
-
-    final Matcher matcher = HASHED_VALUE_PATTERN.matcher(hashedValue);
-    checkArgument(matcher.matches(), "'" + hashedValue + "' is not an MD5-crypt hashed value");
-    return matcher.group(2);
-  }
-
-  /**
    * Gets the salt for the specified hashed value.
    *
    * @param hashedValue The hashed value from a previous call to {@link #hash(String, String)} whose salt is to be

--- a/game-core/src/main/java/games/strategy/util/Md5Crypt.java
+++ b/game-core/src/main/java/games/strategy/util/Md5Crypt.java
@@ -111,4 +111,17 @@ public final class Md5Crypt {
 
     return HASHED_VALUE_PATTERN.matcher(value).matches();
   }
+
+  /**
+   * Creates a new hashed value from the specified salt and hash components.
+   *
+   * @return The returned value may not be a legal MD5-crypt hashed value if either {@code salt} or {@code hash} are
+   *         illegal and should be validated using {@link #isLegalHashedValue(String)}.
+   */
+  public static String fromSaltAndHash(final String salt, final String hash) {
+    checkNotNull(salt);
+    checkNotNull(hash);
+
+    return String.format("%s%s$%s", MAGIC, salt, hash);
+  }
 }

--- a/game-core/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/game-core/src/test/java/games/strategy/net/MacFinderTest.java
@@ -50,17 +50,4 @@ final class MacFinderTest {
       assertThat(MacFinder.isValidHashedMacAddress("$1$SALT$ABCDWXYZabcdwxyz0189./"), is(false));
     }
   }
-
-  @Nested
-  final class TrimHashedMacAddressPrefixTest {
-    @Test
-    void shouldReturnHashedMacAddressWithoutPrefixWhenValid() {
-      assertThat(MacFinder.trimHashedMacAddressPrefix("$1$MH$ABCDWXYZabcdwxyz0189./"), is("ABCDWXYZabcdwxyz0189./"));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenInvalid() {
-      assertThrows(IllegalArgumentException.class, () -> MacFinder.trimHashedMacAddressPrefix("invalid"));
-    }
-  }
 }

--- a/game-core/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/game-core/src/test/java/games/strategy/net/MacFinderTest.java
@@ -50,4 +50,17 @@ final class MacFinderTest {
       assertThat(MacFinder.isValidHashedMacAddress("$1$SALT$ABCDWXYZabcdwxyz0189./"), is(false));
     }
   }
+
+  @Nested
+  final class WithPrefixTest {
+    @Test
+    void shouldReturnValueUnchangedWhenPrefixPresent() {
+      assertThat(MacFinder.withPrefix("$1$MH$ABCDWXYZabcdwxyz0189./"), is("$1$MH$ABCDWXYZabcdwxyz0189./"));
+    }
+
+    @Test
+    void shouldReturnValueWithPrefixWhenPrefixAbsent() {
+      assertThat(MacFinder.withPrefix("ABCDWXYZabcdwxyz0189./"), is("$1$MH$ABCDWXYZabcdwxyz0189./"));
+    }
+  }
 }

--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -1,5 +1,6 @@
 package games.strategy.util;
 
+import static games.strategy.util.Md5Crypt.fromSaltAndHash;
 import static games.strategy.util.Md5Crypt.getSalt;
 import static games.strategy.util.Md5Crypt.hash;
 import static games.strategy.util.Md5Crypt.hashPassword;
@@ -130,6 +131,14 @@ public final class Md5CryptTest {
                 isLegalHashedValue(value),
                 is(false));
           });
+    }
+  }
+
+  @Nested
+  final class FromSaltAndHashTest {
+    @Test
+    void shouldReturnHashedValue() {
+      assertThat(fromSaltAndHash("salt", "hash"), is("$1$salt$hash"));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
+++ b/game-core/src/test/java/games/strategy/util/Md5CryptTest.java
@@ -1,6 +1,5 @@
 package games.strategy.util;
 
-import static games.strategy.util.Md5Crypt.getHash;
 import static games.strategy.util.Md5Crypt.getSalt;
 import static games.strategy.util.Md5Crypt.hash;
 import static games.strategy.util.Md5Crypt.hashPassword;
@@ -71,19 +70,6 @@ public final class Md5CryptTest {
     @Test
     public void shouldSilentlyReplaceIllegalCharactersInSaltWithPeriod() {
       assertThat(hash("value", "ABC!@DEF"), is(hash("value", "ABC..DEF")));
-    }
-  }
-
-  @Nested
-  public final class GetHashTest {
-    @Test
-    public void shouldReturnHashWhenHashedValueIsLegal() {
-      assertThat(getHash("$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"), is("KsXRew.PuhVQTNMKSXQZx0"));
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenHashedValueIsIllegal() {
-      assertThrows(IllegalArgumentException.class, () -> getHash("1$A$KnCRC85Rudn6P3cpfe3LR/"));
     }
   }
 

--- a/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
@@ -350,10 +350,11 @@ final class ModeratorController implements IModeratorController {
     builder.append("\r\nHashed Mac: ");
     if (UNKNOWN_HASHED_MAC_ADDRESS.equals(mac)) {
       builder.append("(Unknown)");
-    } else if (MacFinder.isValidHashedMacAddress(mac)) {
-      builder.append(MacFinder.trimHashedMacAddressPrefix(mac));
     } else {
-      builder.append(mac).append(" (Invalid)");
+      builder.append(mac);
+      if (!MacFinder.isValidHashedMacAddress(mac)) {
+        builder.append(" (Invalid)");
+      }
     }
     builder.append("\r\nAliases: ").append(getAliasesFor(node));
     return builder.toString();


### PR DESCRIPTION
## Overview

Addresses a mod request from [here](https://forums.triplea-game.org/post/19362) to be more lenient when accepting hashed MAC addresses for (un)ban.  Namely, that the hashed MAC prefix `$1$MH$` should be automatically added if not specified by the user.

## Functional Changes

* When prompting user for a hashed MAC address to (un)ban, automatically add the `$1$MH$` prefix if it is not specified.
* No longer strip the `$1$MH$` prefix when displaying hashed MAC addresses in the **Show player information** window.

## Refactoring Changes

* Changed `LobbyServer#showInputDialog()` (and variants) to use an empty `Optional` to indicate the user canceled the dialog rather than a `null` or empty string.  Note that this accounts for the majority of changes in `LobbyServer`.

## Manual Testing Performed

* Verified no error was reported when attempting to unban the following hashed MAC addresses:
  * `$1$MH$ABCDWXYZabcdwxyz0189./`
  * `ABCDWXYZabcdwxyz0189./`
* Verified an error was reported when attempting to unban the following hashed MAC addresses:
  * `$1$something$ABCDWXYZabcdwxyz0189./`
* Smoke tested (un)ban by username, (un)ban by MAC, and (un)mute by username.