### PR TITLE
Fix New Fighters On Old Carriers To Ignore Allied/Enemy Carriers

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -861,7 +861,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
           && allProducedUnits.stream().anyMatch(Matches.unitIsCarrier()))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
-              && to.getUnits().anyMatch(Matches.unitIsCarrier()))) {
+              && to.getUnits().anyMatch(Matches.unitIsCarrier().and(Matches
+                  .unitIsOwnedByOfAnyOfThesePlayers(GameStepPropertiesHelper.getCombinedTurns(getData(), player)))))) {
         placeableUnits
             .addAll(CollectionUtils.getMatches(units, Matches.unitIsAir().and(Matches.unitCanLandOnCarrier())));
       }


### PR DESCRIPTION
## Overview
- Fixes #4480

## Functional Changes
- Add check for "Produce new fighters on old carriers" that carriers are owned by player or combined turns player (not allies or enemies)

## Manual Testing Performed
- Updated test Global 40 XML to add combinedTurns to UK_Pacific place:
```
      <step name="UK_PacificPlace" delegate="place" player="UK_Pacific">
        <stepProperty name="combinedTurns" value="British:UK_Pacific"/>
      </step>
```
- Tested adding fighter to owned carrier (yes), combined turn carrier (yes), allied carrier (no), and enemy carrier (no) 
