### PR TITLE
Error report window, do not send empty

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
@@ -38,6 +38,15 @@ class ErrorReportUploadAction implements BiConsumer<JFrame, UserErrorReport> {
   }
 
   private void sendErrorReport(final JFrame frame, final ErrorReport errorReport) {
+    if(errorReport.isEmpty()) {
+      DialogBuilder.builder()
+          .parent(frame)
+          .title("Error: Missing data")
+          .errorMessage("please fill in both a title and description of the problem.")
+          .showDialog();
+      return;
+    }
+
     final ServiceResponse<ErrorReportResponse> response = serviceClient.apply(errorReport);
     final URI githubLink =
         response.getPayload().map(pay -> pay.getGithubIssueLink().orElse(null)).orElse(null);

--- a/http-client/src/main/java/org/triplea/http/client/error/report/create/ErrorReport.java
+++ b/http-client/src/main/java/org/triplea/http/client/error/report/create/ErrorReport.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import com.google.common.base.Strings;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -59,4 +60,7 @@ public class ErrorReport {
         .orElse("");
   }
 
+  public boolean isEmpty() {
+    return (Strings.emptyToNull(title) == null) || (Strings.emptyToNull(description) == null);
+  }
 }


### PR DESCRIPTION
## Overview
If either error description or title are empty, do not attempt to send an
error report and instead prompt user.

![screenshot from 2019-01-04 17-27-02](https://user-images.githubusercontent.com/12397753/50718614-430a1480-1046-11e9-9fa7-9b85aa3acae5.png)
