### PR TITLE
Display map size downloaded so far when total map size is unknown

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
 
+import org.apache.commons.io.FileUtils;
+
 import games.strategy.util.OptionalUtils;
 
 /**
@@ -36,6 +38,7 @@ final class MapDownloadProgressListener {
 
     progressBar.setMinimum(MIN_PROGRESS_VALUE);
     progressBar.setMaximum(MAX_PROGRESS_VALUE);
+    progressBar.setStringPainted(true);
   }
 
   private void requestDownloadLength() {
@@ -44,22 +47,22 @@ final class MapDownloadProgressListener {
   }
 
   void downloadStarted() {
-    updateProgressBar("Pending...");
+    updateProgressBarWithCurrentLength("Pending...", 0L);
   }
 
-  private void updateProgressBar(final String toolTipText) {
+  private void updateProgressBarWithCurrentLength(final String toolTipText, final long currentLength) {
     SwingUtilities.invokeLater(() -> {
       progressBar.setIndeterminate(true);
-      progressBar.setStringPainted(false);
+      progressBar.setString(FileUtils.byteCountToDisplaySize(currentLength));
       progressBar.setToolTipText(toolTipText);
     });
   }
 
-  private void updateProgressBar(final String toolTipText, final int value) {
+  private void updateProgressBarWithPercentComplete(final String toolTipText, final int percentComplete) {
     SwingUtilities.invokeLater(() -> {
       progressBar.setIndeterminate(false);
-      progressBar.setValue(value);
-      progressBar.setStringPainted(true);
+      progressBar.setString(null);
+      progressBar.setValue(percentComplete);
       progressBar.setToolTipText(toolTipText);
     });
   }
@@ -67,8 +70,8 @@ final class MapDownloadProgressListener {
   void downloadUpdated(final long currentLength) {
     final String toolTipText = String.format("Installing to: %s", download.getInstallLocation());
     OptionalUtils.ifPresentOrElse(downloadLength,
-        totalLength -> updateProgressBar(toolTipText, percentComplete(currentLength, totalLength)),
-        () -> updateProgressBar(toolTipText));
+        totalLength -> updateProgressBarWithPercentComplete(toolTipText, percentComplete(currentLength, totalLength)),
+        () -> updateProgressBarWithCurrentLength(toolTipText, currentLength));
   }
 
   private static int percentComplete(final long currentLength, final long totalLength) {
@@ -76,6 +79,8 @@ final class MapDownloadProgressListener {
   }
 
   void downloadCompleted() {
-    updateProgressBar(String.format("Installed to: %s", download.getInstallLocation()), MAX_PROGRESS_VALUE);
+    updateProgressBarWithPercentComplete(
+        String.format("Installed to: %s", download.getInstallLocation()),
+        MAX_PROGRESS_VALUE);
   }
 }


### PR DESCRIPTION
## Overview

Resolves #4482.

As discussed in that issue, we can't really fix the issue because GitHub is simply not sending us a `Content-Length` header.  This PR implements the workaround suggested in https://github.com/triplea-game/triplea/issues/4482#issuecomment-451290018.  Basically, as long as we don't know the total download size, we report the size downloaded so far while continuing to display an indeterminate progress bar.  If the total download size is received before the download completes, we switch to a determinate progress bar and display the percent complete (the current behavior).

## Functional Changes

* When total map download size is unknown, display a human-friendly representation of the total number of bytes downloaded so far.  I'm using the Apache Commons I/O `FileUtils#byteCountToDisplaySize()` method to format the byte count.  It's not perfect in the sense that it truncates to whole values.  For example, if 1.9 MiB have been downloaded so far, it reports 1 MiB--until it rolls over to 2 MiB.

## Manual Testing Performed

* Downloaded a map from GitHub for which no `Content-Length` header is returned and ensured the current number of bytes downloaded is displayed until the download is complete, at which time the progress bar reports 100%.
* Downloaded a map from a custom URI for which a `Content-Length` header is returned and ensured the percent complete is displayed until the download is complete.

## Screencasts

### Map with Known Total Size

[download-map-known-total-size.zip](https://github.com/triplea-game/triplea/files/2729245/download-map-known-total-size.zip)

### Map with Unknown Total Size

[download-map-unknown-total-size.zip](https://github.com/triplea-game/triplea/files/2729244/download-map-unknown-total-size.zip)