### PR TITLE
Fix raw type warning

### DIFF
--- a/http-server/src/main/java/org/triplea/server/EnvironmentVariable.java
+++ b/http-server/src/main/java/org/triplea/server/EnvironmentVariable.java
@@ -18,7 +18,7 @@ public enum EnvironmentVariable {
   static {
     final Collection<String> missingVariables =
         stream(EnvironmentVariable.values())
-            .map(Enum::name)
+            .map(EnvironmentVariable::name)
             .filter(name -> System.getenv(name) == null)
             .collect(Collectors.toList());
 


### PR DESCRIPTION
## Overview

Fixes the following raw type warning emitted by the compiler:

```
/home/travis/build/triplea-game/triplea/http-server/src/main/java/org/triplea/server/EnvironmentVariable.java:21: warning: [rawtypes] found raw type: Enum
            .map(Enum::name)
                 ^
  missing type arguments for generic class Enum<E>
  where E is a type-variable:
    E extends Enum<E> declared in class Enum
```

## Functional Changes

None.

## Manual Testing Performed

None.