### PR TITLE
Remove unnecessary Optional

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -9,6 +9,7 @@ import javax.swing.JFrame;
 import org.triplea.http.client.error.report.ErrorReportClientFactory;
 
 import games.strategy.engine.lobby.client.login.LobbyPropertyFetcherConfiguration;
+import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.settings.ClientSetting;
 
 class ErrorReportConfiguration {
@@ -20,8 +21,7 @@ class ErrorReportConfiguration {
    */
   static BiConsumer<JFrame, UserErrorReport> newReportHandler() {
     return newFromUserOverride()
-        .orElseGet(
-            () -> newFromRemoteProperties().orElse(ErrorReportUploadAction.OFFLINE_STRATEGY));
+        .orElseGet(ErrorReportConfiguration::newFromRemoteProperties);
   }
 
   private static Optional<BiConsumer<JFrame, UserErrorReport>> newFromUserOverride() {
@@ -32,12 +32,9 @@ class ErrorReportConfiguration {
         .map(ErrorReportUploadAction::new);
   }
 
-  private static Optional<BiConsumer<JFrame, UserErrorReport>> newFromRemoteProperties() {
-    return LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
-        .fetchLobbyServerProperties()
-        .map(
-            props ->
-                new ErrorReportUploadAction(
-                    ErrorReportClientFactory.newErrorUploader(props.getHttpServerUri())));
+  private static BiConsumer<JFrame, UserErrorReport> newFromRemoteProperties() {
+    final LobbyServerProperties props =
+        LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher().fetchLobbyServerProperties();
+    return new ErrorReportUploadAction(ErrorReportClientFactory.newErrorUploader(props.getHttpServerUri()));
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
@@ -17,17 +17,6 @@ import swinglib.DialogBuilder;
 
 @AllArgsConstructor
 class ErrorReportUploadAction implements BiConsumer<JFrame, UserErrorReport> {
-
-  static final BiConsumer<JFrame, UserErrorReport> OFFLINE_STRATEGY =
-      (frame, report) ->
-          DialogBuilder.builder()
-              .parent(frame)
-              .title("Unable to connect to server")
-              .errorMessage(
-                  "TripleA is unable to get the servers network adddress, please restart "
-                      + "Triplea and try again, if this problem keeps happening please contact Triplea")
-              .showDialog();
-
   private final ServiceClient<ErrorReport, ErrorReportResponse> serviceClient;
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -19,6 +19,7 @@ import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.ScreenChangeListener;
 import games.strategy.engine.lobby.client.login.LobbyLogin;
 import games.strategy.engine.lobby.client.login.LobbyPropertyFetcherConfiguration;
+import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -105,18 +106,15 @@ public class SetupPanelModel {
    * @param uiParent Used to center pop-up's prompting user for their lobby credentials.
    */
   public void login(final Component uiParent) {
-    LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher().fetchLobbyServerProperties()
-        .ifPresent(lobbyServerProperties -> {
-          final LobbyLogin login =
-              new LobbyLogin(JOptionPane.getFrameForComponent(uiParent), lobbyServerProperties);
-
-          Optional.ofNullable(login.login())
-              .ifPresent(
-                  lobbyClient -> {
-                    final LobbyFrame lobbyFrame = new LobbyFrame(lobbyClient, lobbyServerProperties);
-                    GameRunner.hideMainFrame();
-                    lobbyFrame.setVisible(true);
-                  });
-        });
+    final LobbyServerProperties lobbyServerProperties =
+        LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher().fetchLobbyServerProperties();
+    final LobbyLogin login = new LobbyLogin(JOptionPane.getFrameForComponent(uiParent), lobbyServerProperties);
+    Optional.ofNullable(login.login())
+        .ifPresent(
+            lobbyClient -> {
+              final LobbyFrame lobbyFrame = new LobbyFrame(lobbyClient, lobbyServerProperties);
+              GameRunner.hideMainFrame();
+              lobbyFrame.setVisible(true);
+            });
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -59,29 +59,28 @@ public final class LobbyServerPropertiesFetcher {
    * @return LobbyServerProperties as fetched and parsed from github hosted remote URL.
    *         Otherwise backup values from client config.
    */
-  public Optional<LobbyServerProperties> fetchLobbyServerProperties() {
+  public LobbyServerProperties fetchLobbyServerProperties() {
     if (lobbyServerProperties == null) {
-      final Optional<LobbyServerProperties> props = fetchProperties();
-      props.ifPresent(lobbyProps -> lobbyServerProperties = lobbyProps);
+      lobbyServerProperties = fetchProperties();
     }
-    return Optional.ofNullable(lobbyServerProperties);
+    return lobbyServerProperties;
   }
   
-  private Optional<LobbyServerProperties> fetchProperties() {
+  private LobbyServerProperties fetchProperties() {
     final Optional<LobbyServerProperties> userOverride = getTestOverrideProperties();
     if (userOverride.isPresent()) {
-      return userOverride;
+      return userOverride.get();
     }
 
     final Optional<LobbyServerProperties> fromHostedFile = getRemoteProperties();
     if (fromHostedFile.isPresent()) {
-      return fromHostedFile;
+      return fromHostedFile.get();
     }
 
-    return Optional.of(LobbyServerProperties.builder()
+    return LobbyServerProperties.builder()
         .host(ClientSetting.lobbyLastUsedHost.getValueOrThrow())
         .port(ClientSetting.lobbyLastUsedPort.getValueOrThrow())
-        .build());
+        .build();
   }
 
   private static Optional<LobbyServerProperties> getTestOverrideProperties() {


### PR DESCRIPTION
## Overview

As noted in https://github.com/triplea-game/triplea/pull/4503#discussion_r245343281, `LobbyServerPropertiesFetcher#fetchProperties()` always returns a non-empty `Optional<LobbyServerProperties>`, so that all callers are guaranteed to receive a non-`null` `LobbyServerProperties` instance.  I continued pulling that thread up the call stack to remove related `Optional` usage as far as possible.

## Functional Changes

None.

## Manual Testing Performed

None.

## Additional Review Notes

Please view with whitespace changes ignored.