### PR TITLE
Fix last used host property null handling

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -78,10 +78,7 @@ public final class LobbyServerPropertiesFetcher {
       return fromHostedFile;
     }
 
-    return Optional.of(LobbyServerProperties.builder()
-        .host(ClientSetting.lobbyLastUsedHost.getValueOrThrow())
-        .port(ClientSetting.lobbyLastUsedPort.getValueOrThrow())
-        .build());
+    return getLastUsedProperties();
   }
 
   private static Optional<LobbyServerProperties> getTestOverrideProperties() {
@@ -118,6 +115,17 @@ public final class LobbyServerPropertiesFetcher {
     });
 
     return lobbyProps;
+  }
+
+  private Optional<LobbyServerProperties> getLastUsedProperties() {
+    return ClientSetting.lobbyLastUsedHost
+        .getValue()
+        .map(
+            host ->
+                ClientSetting.lobbyLastUsedPort
+                    .getValue()
+                    .map(port -> LobbyServerProperties.builder().host(host).port(port).build())
+                    .orElse(null));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -117,7 +117,7 @@ public final class LobbyServerPropertiesFetcher {
     return lobbyProps;
   }
 
-  private Optional<LobbyServerProperties> getLastUsedProperties() {
+  private static Optional<LobbyServerProperties> getLastUsedProperties() {
     return ClientSetting.lobbyLastUsedHost
         .getValue()
         .map(


### PR DESCRIPTION
## Overview
`ClientSetting.lobbyLastUsed*` is not set on a completely new OS and
install. This update takes into account the 'lastUsed' client setting
can be empty.

## Functional Changes
Technically a bug fix, fixes mistake in recent updates

