### PR TITLE
Return Optionals on LobbyServerProperties & Enforce Port to Be Set

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -18,7 +18,6 @@ import games.strategy.net.ClientMessenger;
 import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.IMessenger;
 import games.strategy.net.MacFinder;
-import games.strategy.triplea.UrlConstants;
 
 /**
  * The client side of the lobby authentication protocol.
@@ -48,13 +47,6 @@ public class LobbyLogin {
   public @Nullable LobbyClient login() {
     if (lobbyServerProperties.getServerErrorMessage().isPresent()) {
       showError("Could not connect to server", lobbyServerProperties.getServerErrorMessage().get());
-      return null;
-    }
-    if (lobbyServerProperties.getPort() == -1) {
-      showError("Could not connect to server",
-          "<html>Could not find lobby server for this version of TripleA, <br>"
-              + "Please make sure you are using the latest version: " + UrlConstants.LATEST_GAME_DOWNLOAD_WEBSITE
-              + "</html>");
       return null;
     }
     return loginToServer();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -46,8 +46,8 @@ public class LobbyLogin {
    * </p>
    */
   public @Nullable LobbyClient login() {
-    if (!lobbyServerProperties.isServerAvailable()) {
-      showError("Could not connect to server", lobbyServerProperties.getServerErrorMessage());
+    if (lobbyServerProperties.getServerErrorMessage().isPresent()) {
+      showError("Could not connect to server", lobbyServerProperties.getServerErrorMessage().get());
       return null;
     }
     if (lobbyServerProperties.getPort() == -1) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
@@ -1,12 +1,14 @@
 package games.strategy.engine.lobby.client.login;
 
+import games.strategy.engine.framework.map.download.DownloadConfiguration;
+
 /**
  * Responsible for constructing a {@code LobbyServerPropertiesFetcher}.
  */
 public class LobbyPropertyFetcherConfiguration {
 
   private static final LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher =
-      new LobbyServerPropertiesFetcher();
+      new LobbyServerPropertiesFetcher(url -> DownloadConfiguration.contentReader().downloadToFile(url));
 
   public static LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher() {
     return lobbyServerPropertiesFetcher;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.yaml.snakeyaml.Yaml;
 
@@ -42,10 +41,7 @@ class LobbyPropertyFileParser {
         .port((Integer) yamlProps.get("port"))
         .serverMessage((String) yamlProps.get("message"))
         .serverErrorMessage((String) yamlProps.get("error_message"))
-        .httpServerUri(
-            Optional.ofNullable((String) yamlProps.get(YAML_HTTP_SERVER_URI))
-                .map(URI::create)
-                .orElse(null))
+        .httpServerUri(URI.create((String) yamlProps.get(YAML_HTTP_SERVER_URI)))
         .build();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -33,7 +33,7 @@ public final class LobbyServerProperties {
   @Nonnull private final Integer port;
 
   /** URI for the http lobby server. */
-  @Nullable private final URI httpServerUri;
+  @Nonnull private final URI httpServerUri;
 
   @Nullable private final String serverErrorMessage;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.lobby.client.login;
 
 import java.net.URI;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -29,7 +30,7 @@ public final class LobbyServerProperties {
   @Nonnull private final String host;
 
   /** The port the lobby is listening on. */
-  private final int port;
+  @Nonnull private final Integer port;
 
   /** URI for the http lobby server. */
   @Nullable private final URI httpServerUri;
@@ -41,16 +42,11 @@ public final class LobbyServerProperties {
    */
   @Nullable private final String serverMessage;
 
-  public String getServerMessage() {
-    return Strings.nullToEmpty(serverMessage);
+  public Optional<String> getServerMessage() {
+    return Optional.ofNullable(Strings.emptyToNull(serverMessage));
   }
 
-  public String getServerErrorMessage() {
-    return Strings.nullToEmpty(serverErrorMessage);
-  }
-
-  /** Returns true if the server is available. If not then see <code>serverErrorMessage</code> */
-  public boolean isServerAvailable() {
-    return Strings.nullToEmpty(serverErrorMessage).isEmpty();
+  public Optional<String> getServerErrorMessage() {
+    return Optional.ofNullable(Strings.emptyToNull(serverErrorMessage));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -62,7 +62,7 @@ public class LobbyFrame extends JFrame {
     final Chat chat = new Chat(this.client.getMessenger(), LobbyConstants.LOBBY_CHAT,
         this.client.getChannelMessenger(), this.client.getRemoteMessenger(), Chat.ChatSoundProfile.LOBBY_CHATROOM);
     chatMessagePanel = new ChatMessagePanel(chat);
-    showServerMessage(lobbyServerProperties);
+    lobbyServerProperties.getServerMessage().ifPresent(chatMessagePanel::addServerMessage);
     chatMessagePanel.setShowTime(true);
     final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(null);
     chatPlayers.addHiddenPlayerName(LobbyConstants.ADMIN_USERNAME);
@@ -97,12 +97,6 @@ public class LobbyFrame extends JFrame {
 
   public ChatMessagePanel getChatMessagePanel() {
     return chatMessagePanel;
-  }
-
-  private void showServerMessage(final LobbyServerProperties props) {
-    if (!props.getServerMessage().isEmpty()) {
-      chatMessagePanel.addServerMessage(props.getServerMessage());
-    }
   }
 
   private List<Action> newAdminActions(final INode clickedOn) {

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -71,6 +71,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
   public static final ClientSetting<String> lobbyLastUsedHost = new StringClientSetting("LOBBY_LAST_USED_HOST");
   public static final ClientSetting<Integer> lobbyLastUsedPort = new IntegerClientSetting("LOBBY_LAST_USED_PORT");
+  public static final ClientSetting<String> lobbyLastUsedHttpHostUri =
+      new StringClientSetting("LOBBY_LAST_USED_HTTP_HOST");
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
   public static final ClientSetting<Integer> mapEdgeScrollSpeed = new IntegerClientSetting("MAP_EDGE_SCROLL_SPEED", 30);

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.lobby.client.login;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -61,8 +63,8 @@ class LobbyPropertyFileParserTest {
     assertThat(result.getHost(), is(TestData.host));
     assertThat(result.getPort(), is(Integer.valueOf(TestData.port)));
     assertThat(result.getHttpServerUri(), is(TestData.httpHostUri));
-    assertThat(result.getServerMessage(), is(TestData.message));
-    assertThat(result.getServerErrorMessage(), is(TestData.errorMessage));
+    assertThat(result.getServerMessage(), isPresentAndIs(TestData.message));
+    assertThat(result.getServerErrorMessage(), isPresentAndIs(TestData.errorMessage));
   }
 
   private static String newYaml(final TestProps... testProps) {
@@ -84,8 +86,8 @@ class LobbyPropertyFileParserTest {
 
     assertThat(result.getHost(), is(TestData.hostOther));
     assertThat(result.getPort(), is(Integer.valueOf(TestData.portOther)));
-    assertThat(result.getServerMessage(), is(""));
-    assertThat(result.getServerErrorMessage(), is(""));
+    assertThat(result.getServerMessage(), isEmpty());
+    assertThat(result.getServerErrorMessage(), isEmpty());
   }
 
   private interface TestData {

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -22,6 +22,7 @@ class LobbyPropertyFileParserTest {
     testProps1.errorMessage = TestData.errorMessage;
     testProps1.message = TestData.message;
     testProps1.version = TestData.version0;
+    testProps1.httpHostUri = TestData.httpHostUri;
 
     final TestProps testProps2 = new TestProps();
     testProps2.host = TestData.host;
@@ -29,6 +30,7 @@ class LobbyPropertyFileParserTest {
     testProps2.errorMessage = TestData.errorMessage;
     testProps2.message = TestData.message;
     testProps2.version = TestData.version1;
+    testProps2.httpHostUri = TestData.httpHostUri;
 
     final TestProps testPropsMatch = new TestProps();
     testPropsMatch.host = TestData.hostOther;
@@ -36,6 +38,7 @@ class LobbyPropertyFileParserTest {
     testPropsMatch.errorMessage = "";
     testPropsMatch.message = "";
     testPropsMatch.version = TestData.clientCurrentVersion;
+    testPropsMatch.httpHostUri = TestData.httpHostUri;
 
     return new TestProps[] {
         testProps1, testProps2, testPropsMatch

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherIntegrationTest.java
@@ -13,7 +13,7 @@ class LobbyServerPropertiesFetcherIntegrationTest extends AbstractClientSettingT
   @Test
   void remoteLobbyUrlReaderWorks() {
 
-    final LobbyServerPropertiesFetcher testObj = new LobbyServerPropertiesFetcher();
+    final LobbyServerPropertiesFetcher testObj = LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher();
 
     assertThat("verify fetch to get current lobby properties",
         testObj.fetchLobbyServerProperties(), notNullValue());

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -74,6 +75,9 @@ class LobbyServerPropertiesFetcherTest {
     @Mock
     private GameSetting<Integer> testLobbyPortSetting;
 
+    @Mock
+    private GameSetting<String> testLobbyHttpUriSetting;
+
     private Optional<LobbyServerProperties> result;
 
     private void givenTestLobbyHostIsNotSet() {
@@ -82,6 +86,11 @@ class LobbyServerPropertiesFetcherTest {
 
     private void givenTestLobbyHostIsSet() {
       when(testLobbyHostSetting.isSet()).thenReturn(true);
+    }
+
+    private void givenTestLobbyHttpUriIsSet() {
+      when(testLobbyHttpUriSetting.isSet()).thenReturn(true);
+      when(testLobbyHttpUriSetting.getValueOrThrow()).thenReturn("http://uri");
     }
 
     private void givenTestLobbyHostIsSetTo(final String host) {
@@ -99,7 +108,9 @@ class LobbyServerPropertiesFetcherTest {
     }
 
     private void whenGetTestOverrideProperties() {
-      result = LobbyServerPropertiesFetcher.getTestOverrideProperties(testLobbyHostSetting, testLobbyPortSetting);
+      result =
+          LobbyServerPropertiesFetcher.getTestOverrideProperties(
+              testLobbyHostSetting, testLobbyPortSetting, testLobbyHttpUriSetting);
     }
 
     private void thenResultIsEmpty() {
@@ -148,6 +159,7 @@ class LobbyServerPropertiesFetcherTest {
     void shouldReturnPropertiesWhenHostSetAndPortSet() {
       givenTestLobbyHostIsSetTo("foo");
       givenTestLobbyPortIsSetTo(4242);
+      givenTestLobbyHttpUriIsSet();
 
       whenGetTestOverrideProperties();
 
@@ -159,6 +171,10 @@ class LobbyServerPropertiesFetcherTest {
     Version version = new Version("0.0.0.0");
     String url = "someUrl";
     LobbyServerProperties lobbyServerProperties =
-        LobbyServerProperties.builder().host("host").port(123).build();
+        LobbyServerProperties.builder()
+            .host("host")
+            .port(123)
+            .httpServerUri(URI.create("http://demo"))
+            .build();
   }
 }

--- a/http-client/src/main/java/org/triplea/http/client/HttpClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/HttpClient.java
@@ -5,10 +5,10 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
-
-import javax.annotation.Nonnull;
 
 /**
  * Wrapper around feign clients to do provide universal http send/receive functionality.

--- a/http-client/src/main/java/org/triplea/http/client/HttpClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/HttpClient.java
@@ -8,6 +8,8 @@ import java.util.function.Function;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nonnull;
+
 /**
  * Wrapper around feign clients to do provide universal http send/receive functionality.
  * Notably this class provides a unified interface for throttling, for interpretting errors/exceptions
@@ -23,9 +25,9 @@ public class HttpClient<ClientTypeT, RequestT, ResponseT>
     implements Function<RequestT, ServiceResponse<ResponseT>> {
 
   private final Consumer<RequestT> rateLimiter = new RateLimiter<>();
-  private final Class<ClientTypeT> classType;
-  private final BiFunction<ClientTypeT, RequestT, ResponseT> sendFunction;
-  private final URI hostUri;
+  @Nonnull private final Class<ClientTypeT> classType;
+  @Nonnull private final BiFunction<ClientTypeT, RequestT, ResponseT> sendFunction;
+  @Nonnull private final URI hostUri;
 
   @Override
   public ServiceResponse<ResponseT> apply(

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -1,7 +1,7 @@
 - version: 1.9.0.0
   host: lobby.triplea-game.org
   port: 3304
-  http_server_uri: ""
+  http_server_uri: "http://prerelease.triplea-game.org:4567"
   message: |
     Welcome to TripleA 1.9 - Got a question, please visit the forums: https://forums.triplea-game.org/
     No talking politics in the lobby! Take your political comments to a private game!


### PR DESCRIPTION
## Overview

- Update LobbyServerProperties API to return `Optional<String>` when
data is not set rather than return an empty string. A 'set' error
message is now the indicator if server is not available rather than
there being a specific method for it.

- 'int' -> 'Integer' is to allow the '@Nonnull' annotation to be applied
and force the property to be set as part of builder construction. Otherwise
we could omit the 'port' from the construction and '#getPort' would then return
'0', a silent error.

## Functional Changes
- One functionality change is that a `LobbyServerProperties` object can no longer be constructed without a 'port'. In all case we were already doing that, so in effect there is no change and this is a straight refactor.

## Manual Testing
- Verified could connect to lobby in the headed game.