### PR TITLE
Add HomePage Link to README and shorten it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,8 @@ TripleA is an open source gaming community, free to play, 100% open source and v
 ## Documentation Links
 - [Documentation Home](https://github.com/triplea-game/triplea/tree/master/docs/)
 - [Developer Getting-Started Documentation](https://github.com/triplea-game/triplea/tree/master/docs/dev)
-- [License](docs/license.md)
+
+## License
+
+This project is licensed under the terms of the 
+[GNU General Public License v3.0 with additional permissions](/docs/license.md).

--- a/README.md
+++ b/README.md
@@ -4,48 +4,25 @@
 [![codecov](https://img.shields.io/codecov/c/github/triplea-game/triplea/master.svg?style=flat-square)](https://codecov.io/gh/triplea-game/triplea)
 [![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)
 
+
+##  [TripleA Home Page](http://triplea-game.org/)
+
 TripleA is an open source gaming community, free to play, 100% open source and volunteer run
 
+ 
 ## [Download and install TripleA](http://triplea-game.org/download/)
-
 ![screenshot from 2018-02-08 22-58-33](https://user-images.githubusercontent.com/12397753/36015523-a4e28a24-0d23-11e8-84c0-c4bd0ee19ce0.png)
 
-- Online lobby, find and join live games
-- Play by email
-- Play vs AI
-- Many community created maps available for in-game download, you can create your own with your own rule set!
 
-## Contact Us
-- [Bug report](https://github.com/triplea-game/triplea/issues/new)
-- [Feature requests](https://forums.triplea-game.org/category/42/feature-requests-and-ideas)
+## Contact Us:
+- [Github Issues (Bug Reports)](https://github.com/triplea-game/triplea/issues/new)
 - [Gitter](https://gitter.im/triplea-game/social)
 
-## Up-Time Reports
+## Is it Running? Availability Dashboards
 - [Lobby and Forums](https://stats.uptimerobot.com/14RYqsN5m)
 - [Game Hosting Bots](https://stats.uptimerobot.com/2WVgrCzO4)
 
 ## Documentation Links
-- Developer, getting started: https://github.com/triplea-game/triplea/tree/master/docs/dev
-- Moderator, how-to: https://forums.triplea-game.org/ (secret admin section)
-- Setting up Linode servers: https://github.com/triplea-game/lobby#adding-linode-servers
-- Lobby+Bot Ops (install, check status, restart): https://github.com/triplea-game/lobby
-- Forums Ops: https://github.com/triplea-game/triplea/tree/master/docs/admin#nodebb-forums
-- Dice Server (TODO): https://github.com/triplea-game/triplea/tree/master/docs/admin#the-dice-server
-
-## License
-
-Copyright (C) 2001-2019 TripleA contributors.
-
-This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with this program; if not, see http://www.gnu.org/licenses.
-
-#### Additional permission under GNU GPL version 3 section 7
-
-If you modify this Program, or any covered work, by linking or combining it with any of the following libraries (or a modified version of those libraries), containing parts covered by the terms of the library's associated license, the licensors of this Program grant you additional permission to convey the resulting work.
-
-Library | Group ID | Artifact ID | SPDX License ID
-:-- | :-- | :-- | :--
-JavaMail | com.sun.mail | javax.mail | GPL-2.0-only
+- [Documentation Home](https://github.com/triplea-game/triplea/tree/master/docs/)
+- [Developer Getting-Started Documentation](https://github.com/triplea-game/triplea/tree/master/docs/dev)
+- [License](docs/license.md)

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,22 @@
+[Full license](https://github.com/triplea-game/triplea/blob/master/LICENSE)
+
+
+## License
+
+Copyright (C) 2001-2019 TripleA contributors.
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, see http://www.gnu.org/licenses.
+
+#### Additional permission under GNU GPL version 3 section 7
+
+If you modify this Program, or any covered work, by linking or combining it with any of the following libraries (or a modified version of those libraries), containing parts covered by the terms of the library's associated license, the licensors of this Program grant you additional permission to convey the resulting work.
+
+Library | Group ID | Artifact ID | SPDX License ID
+:-- | :-- | :-- | :--
+JavaMail | com.sun.mail | javax.mail | GPL-2.0-only
+
+

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,7 +1,6 @@
-[Full license](https://github.com/triplea-game/triplea/blob/master/LICENSE)
-
-
 ## License
+
+[GNU GENERAL PUBLIC LICENSE Version 3](https://github.com/triplea-game/triplea/blob/master/LICENSE)
 
 Copyright (C) 2001-2019 TripleA contributors.
 
@@ -18,5 +17,8 @@ If you modify this Program, or any covered work, by linking or combining it with
 Library | Group ID | Artifact ID | SPDX License ID
 :-- | :-- | :-- | :--
 JavaMail | com.sun.mail | javax.mail | GPL-2.0-only
+
+
+
 
 


### PR DESCRIPTION
## Overview

There is a bit too much information on the README page that turns it
into mostly noise. The updates here are to clarify the headers and
remove content.

The license block was large and simply extracted, the game description
list is removed as we go over that on the homepage. The page beginning
with a link to download did not 100% make sense and made scanning a bit
difficult. Instead we now start with a link to the homepage.

Last, the availaibility report title was updated to make it more obvious
what it is.



## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![screenshot from 2019-01-05 12-23-09](https://user-images.githubusercontent.com/12397753/50728818-b9f5ea80-10e4-11e9-80c5-cd053fbd07d8.png)

### After
![screenshot from 2019-01-05 12-22-54](https://user-images.githubusercontent.com/12397753/50728823-beba9e80-10e4-11e9-9c6b-a1eda44daa14.png)


