### PR TITLE
IDEA Launcher config, allow multiple HeadedGameRunner instances

### DIFF
--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" nameIsGenerated="true">
+  <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" singleton="false" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
     <module name="game-headed_main" />
     <extension name="coverage">


### PR DESCRIPTION
## Overview

Simple flip of a configuration for IDEA HeadedGameRunner that allows for
multiple instances to be run.


## Functional Changes
- None

## Manual Testing Performed
- Launcher runs
