### PR TITLE
Error report dialog improvements, clickable links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,10 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 plugins {
     id 'java'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'io.franzbecker.gradle-lombok' version '1.14' apply false
-    id 'net.ltgt.errorprone' version '0.0.16' apply false
+    id 'net.ltgt.errorprone' version '0.6.1' apply false
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
@@ -64,6 +66,10 @@ subprojects {
     dependencies {
         errorprone 'com.google.errorprone:error_prone_core:2.3.2'
 
+        if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
+            errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
+        }
+
         implementation 'com.google.guava:guava:27.0.1-jre'
 
         testImplementation 'com.github.npathai:hamcrest-optional:2.0.0'
@@ -81,34 +87,36 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.compilerArgs += [
-            '-Xep:ByteBufferBackingArray:ERROR',
-            '-Xep:CatchAndPrintStackTrace:ERROR',
-            '-Xep:ClassCanBeStatic:ERROR',
-            '-Xep:DefaultCharset:ERROR',
-            '-Xep:EqualsGetClass:ERROR',
-            '-Xep:EqualsIncompatibleType:ERROR',
-            '-Xep:EqualsUnsafeCast:ERROR',
-            '-Xep:FutureReturnValueIgnored:ERROR',
-            '-Xep:ImmutableEnumChecker:ERROR',
-            '-Xep:InconsistentCapitalization:ERROR',
-            '-Xep:JdkObsolete:ERROR',
-            '-Xep:MissingOverride:ERROR',
-            '-Xep:MutableConstantField:ERROR',
-            '-Xep:NonAtomicVolatileUpdate:ERROR',
-            '-Xep:OperatorPrecedence:ERROR',
-            '-Xep:ParameterName:OFF', // workaround for https://github.com/google/error-prone/issues/780
-            '-Xep:ReferenceEquality:ERROR',
-            '-Xep:StringSplitter:ERROR',
-            '-Xep:ThreadPriorityCheck:ERROR',
-            '-Xep:UndefinedEquals:ERROR',
-            '-Xep:UnnecessaryParentheses:ERROR',
-            '-Xep:UnsafeReflectiveConstructionCast:ERROR',
-            '-Xep:UnsynchronizedOverridesSynchronized:ERROR',
-            '-Xep:WaitNotInLoop:ERROR',
             '-Xlint:all,-processing',
             '-Xmaxwarns', '1000'
         ]
         options.encoding = 'UTF-8'
+        options.errorprone {
+            check 'ByteBufferBackingArray', CheckSeverity.ERROR
+            check 'CatchAndPrintStackTrace', CheckSeverity.ERROR
+            check 'ClassCanBeStatic', CheckSeverity.ERROR
+            check 'DefaultCharset', CheckSeverity.ERROR
+            check 'EqualsGetClass', CheckSeverity.ERROR
+            check 'EqualsIncompatibleType', CheckSeverity.ERROR
+            check 'EqualsUnsafeCast', CheckSeverity.ERROR
+            check 'FutureReturnValueIgnored', CheckSeverity.ERROR
+            check 'ImmutableEnumChecker', CheckSeverity.ERROR
+            check 'InconsistentCapitalization', CheckSeverity.ERROR
+            check 'JdkObsolete', CheckSeverity.ERROR
+            check 'MissingOverride', CheckSeverity.ERROR
+            check 'MutableConstantField', CheckSeverity.ERROR
+            check 'NonAtomicVolatileUpdate', CheckSeverity.ERROR
+            check 'OperatorPrecedence', CheckSeverity.ERROR
+            check 'ParameterName', CheckSeverity.OFF // workaround for https://github.com/google/error-prone/issues/780
+            check 'ReferenceEquality', CheckSeverity.ERROR
+            check 'StringSplitter', CheckSeverity.ERROR
+            check 'ThreadPriorityCheck', CheckSeverity.ERROR
+            check 'UndefinedEquals', CheckSeverity.ERROR
+            check 'UnnecessaryParentheses', CheckSeverity.ERROR
+            check 'UnsafeReflectiveConstructionCast', CheckSeverity.ERROR
+            check 'UnsynchronizedOverridesSynchronized', CheckSeverity.ERROR
+            check 'WaitNotInLoop', CheckSeverity.ERROR
+        }
         options.incremental = true
 
         // workaround for https://github.com/gradle/gradle/issues/2510
@@ -144,7 +152,9 @@ subprojects {
     }
 
     compileTestJava {
-        options.compilerArgs += ['-Xep:ClassCanBeStatic:OFF']
+        options.errorprone {
+            check 'ClassCanBeStatic', CheckSeverity.OFF
+        }
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ subprojects {
         testImplementation 'org.junit-pioneer:junit-pioneer:0.3.0'
         testImplementation "org.mockito:mockito-core:$mockitoVersion"
         testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"
 
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.3.2'

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -22,7 +22,7 @@ import swinglib.JPanelBuilder;
  */
 // Not static to allow for mock verifications.
 @SuppressWarnings("MethodMayBeStatic")
-final class ConfirmationDialogController {
+class ConfirmationDialogController {
 
 
   void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -20,12 +20,9 @@ import swinglib.JPanelBuilder;
  * This controller is responsible for showing success/failure confirmation dialogs
  * after an error report has been submitted.
  */
-// Not static to allow for mock verifications.
-@SuppressWarnings("MethodMayBeStatic")
 class ConfirmationDialogController {
 
-
-  void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
+  static void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
     SwingUtilities.invokeLater(() -> doShowFailureConfirmation(response));
   }
 
@@ -59,7 +56,7 @@ class ConfirmationDialogController {
     JOptionPane.showMessageDialog(null, messageToShow, "Report Upload Failed", JOptionPane.ERROR_MESSAGE);
   }
 
-  void showSuccessConfirmation(final URI reportLinkCreated) {
+  static void showSuccessConfirmation(final URI reportLinkCreated) {
     SwingUtilities.invokeLater(() -> doShowSuccessConfirmation(reportLinkCreated));
   }
 

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -1,0 +1,86 @@
+package games.strategy.debug.error.reporting;
+
+import java.net.URI;
+
+import javax.swing.JEditorPane;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.HyperlinkEvent;
+
+import org.triplea.http.client.ServiceResponse;
+import org.triplea.http.client.error.report.create.ErrorReportResponse;
+
+import games.strategy.net.OpenFileUtility;
+import games.strategy.triplea.UrlConstants;
+import swinglib.JPanelBuilder;
+
+/**
+ * This controller is responsible for showing success/failure confirmation dialogs
+ * after an error report has been submitted.
+ */
+// Not static to allow for mock verifications.
+@SuppressWarnings("MethodMayBeStatic")
+final class ConfirmationDialogController {
+
+
+  void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
+    SwingUtilities.invokeLater(() -> doShowFailureConfirmation(response));
+  }
+
+  private static void doShowFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
+    final JEditorPane editorPane = new JEditorPane("text/html",
+        "Failure uploading report, please try again or <a href='" + UrlConstants.GITHUB_ISSUES
+            + "'>contact support</a>.<br/><br/>"
+            + "Send status: "
+            + response.getSendResult() + "<br/>"
+            + response.getExceptionMessage()
+                .map(error -> "Errors reported: " + error)
+                .orElseGet(() -> response.getPayload()
+                    .map(ErrorReportResponse::getError)
+                    .map(e -> "<br/>Error reported from server:<br/>" + e)
+                    .orElse("")));
+    editorPane.setEditable(false);
+    editorPane.setOpaque(false);
+    editorPane.setBorder(new EmptyBorder(10, 0, 20, 0));
+    editorPane.addHyperlinkListener(e -> {
+      if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+        OpenFileUtility.openUrl(e.getURL().toString());
+      }
+    });
+
+    final JPanel messageToShow = JPanelBuilder.builder()
+        .borderEmpty(10)
+        .add(editorPane)
+        .build();
+
+    // parentComponent == null to avoid pop-up from appearing behind other windows
+    JOptionPane.showMessageDialog(null, messageToShow, "Report Upload Failed", JOptionPane.ERROR_MESSAGE);
+  }
+
+  void showSuccessConfirmation(final URI reportLinkCreated) {
+    SwingUtilities.invokeLater(() -> doShowSuccessConfirmation(reportLinkCreated));
+  }
+
+  private static void doShowSuccessConfirmation(final URI reportLinkCreated) {
+    final JEditorPane editorPane = new JEditorPane("text/html",
+        String.format("Upload success, report created:<br/><br/><a href='%s'>%s</a>",
+            reportLinkCreated, reportLinkCreated));
+    editorPane.setEditable(false);
+    editorPane.setOpaque(false);
+    editorPane.addHyperlinkListener(e -> {
+      if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+        OpenFileUtility.openUrl(e.getURL().toString());
+      }
+    });
+
+    final JPanel messageToShow = JPanelBuilder.builder()
+        .borderEmpty(10)
+        .add(editorPane)
+        .build();
+
+    // parentComponent == null to avoid pop-up from appearing behind other windows
+    JOptionPane.showMessageDialog(null, messageToShow, "Report Uploaded Successfully", JOptionPane.INFORMATION_MESSAGE);
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -58,8 +58,11 @@ class ErrorReportConfiguration {
    * Instantiate the object that will send an error report.
    */
   private static BiConsumer<JFrame, UserErrorReport> uploadAction(final URI uri) {
-    return new ErrorReportUploadAction(
-        ErrorReportClientFactory.newErrorUploader(uri),
-        new ConfirmationDialogController());
+    return ErrorReportUploadAction.builder()
+        .serviceClient(
+            ErrorReportClientFactory.newErrorUploader(uri))
+        .successConfirmation(ConfirmationDialogController::showSuccessConfirmation)
+        .failureConfirmation(ConfirmationDialogController::showFailureConfirmation)
+        .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
@@ -11,7 +11,6 @@ import org.triplea.http.client.ServiceResponse;
 import org.triplea.http.client.error.report.create.ErrorReport;
 import org.triplea.http.client.error.report.create.ErrorReportResponse;
 
-import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import lombok.RequiredArgsConstructor;
 import swinglib.DialogBuilder;
 
@@ -32,14 +31,8 @@ class ErrorReportUploadAction implements BiConsumer<JFrame, UserErrorReport> {
   private final ConfirmationDialogController dialogController;
 
   @Override
-  public void accept(final JFrame uploadReportWindow, final UserErrorReport errorReport) {
-    new BackgroundTaskRunner(uploadReportWindow)
-        .awaitRunInBackground(
-            "Sending report...", () -> sendErrorReport(uploadReportWindow, errorReport.toErrorReport()));
-  }
-
-  private void sendErrorReport(final JFrame frame, final ErrorReport errorReport) {
-    final ServiceResponse<ErrorReportResponse> response = serviceClient.apply(errorReport);
+  public void accept(final JFrame frame, final UserErrorReport errorReport) {
+    final ServiceResponse<ErrorReportResponse> response = serviceClient.apply(errorReport.toErrorReport());
     final URI githubLink =
         response.getPayload().map(pay -> pay.getGithubIssueLink().orElse(null)).orElse(null);
 

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
@@ -3,18 +3,16 @@ package games.strategy.debug.error.reporting;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 import org.triplea.test.common.Integration;
 
-import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 
 @Integration
-class ErrorReportConfigurationTest {
+class ErrorReportConfigurationTest extends AbstractClientSettingTestCase {
 
   @Test
   void verifyConstructionIsWithoutError() {
-    ClientSetting.setPreferences(new MemoryPreferences());
     ErrorReportConfiguration.newReportHandler();
     ErrorReportConfiguration.newReportHandler(Optional::empty);
     ErrorReportConfiguration.newReportHandler(() -> Optional.of("http://sample.uri"));

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
@@ -1,0 +1,22 @@
+package games.strategy.debug.error.reporting;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.sonatype.goodies.prefs.memory.MemoryPreferences;
+import org.triplea.test.common.Integration;
+
+import games.strategy.triplea.settings.ClientSetting;
+
+
+@Integration
+class ErrorReportConfigurationTest {
+
+  @Test
+  void verifyConstructionIsWithoutError() {
+    ClientSetting.setPreferences(new MemoryPreferences());
+    ErrorReportConfiguration.newReportHandler();
+    ErrorReportConfiguration.newReportHandler(Optional::empty);
+    ErrorReportConfiguration.newReportHandler(() -> Optional.of("http://sample.uri"));
+  }
+}

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -69,6 +69,7 @@ class ErrorReportUploadActionTest {
     verify(successConfirmation, never()).accept(any());
   }
 
+  @SuppressWarnings("unused") // Used by @MethodSource via reflection
   private static Collection<ServiceResponse<ErrorReportResponse>> withNonSuccessSendResults() {
     // Create ServiceResponses with each of the 'SendResult' values except for the successful SendResult value: 'SENT'
     return stream(SendResult.values())
@@ -95,6 +96,7 @@ class ErrorReportUploadActionTest {
     verify(successConfirmation, never()).accept(any());
   }
 
+  @SuppressWarnings("unused") // Used by @MethodSource via reflection
   private static Collection<ServiceResponse<ErrorReportResponse>> withMissingIssueLinkResult() {
     return asList(
         ServiceResponse.<ErrorReportResponse>builder()

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.when;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import javax.swing.JFrame;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,6 +35,9 @@ class ErrorReportUploadActionTest {
   @InjectMocks
   private ErrorReportUploadAction errorReportUploadAction;
 
+
+  @Mock
+  private JFrame jFrame;
 
   private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
       .build();
@@ -114,7 +119,7 @@ class ErrorReportUploadActionTest {
     when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
         .thenReturn(successCase);
 
-    errorReportUploadAction.accept(null, USER_ERROR_REPORT);
+    errorReportUploadAction.accept(jFrame, USER_ERROR_REPORT);
 
     verify(dialogController).showSuccessConfirmation(successCase.getPayload().get().getGithubIssueLink().get());
   }

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -4,7 +4,6 @@ import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +17,8 @@ import javax.swing.JFrame;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.SendResult;
@@ -56,20 +57,16 @@ class ErrorReportUploadActionTest {
       .build();
 
 
-  @Test
-  void nonSuccessSends() {
-    withNonSuccessSendResults()
-        .forEach(notSuccessfulSend -> {
-          when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
-              .thenReturn(notSuccessfulSend);
+  @ParameterizedTest
+  @MethodSource("withNonSuccessSendResults")
+  void nonSuccessSends(final ServiceResponse<ErrorReportResponse> notSuccessfulSend) {
+    when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
+        .thenReturn(notSuccessfulSend);
 
-          errorReportUploadAction.accept(null, USER_ERROR_REPORT);
+    errorReportUploadAction.accept(null, USER_ERROR_REPORT);
 
-          verify(failureConfirmation).accept(notSuccessfulSend);
-          verify(successConfirmation, never()).accept(any());
-
-          reset(serviceClient, failureConfirmation, successConfirmation);
-        });
+    verify(failureConfirmation).accept(notSuccessfulSend);
+    verify(successConfirmation, never()).accept(any());
   }
 
   private static Collection<ServiceResponse<ErrorReportResponse>> withNonSuccessSendResults() {
@@ -86,21 +83,16 @@ class ErrorReportUploadActionTest {
         .build();
   }
 
-  @Test
-  void missingIssueLinkInPaylaod() {
-    withMissingIssueLinkResult()
-        .forEach(missingLinkResult -> {
+  @ParameterizedTest
+  @MethodSource("withMissingIssueLinkResult")
+  void missingIssueLinkInPaylaod(final ServiceResponse<ErrorReportResponse> missingLinkResult) {
+    when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
+        .thenReturn(missingLinkResult);
 
-          when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
-              .thenReturn(missingLinkResult);
+    errorReportUploadAction.accept(null, USER_ERROR_REPORT);
 
-          errorReportUploadAction.accept(null, USER_ERROR_REPORT);
-
-          verify(failureConfirmation).accept(missingLinkResult);
-          verify(successConfirmation, never()).accept(any());
-
-          reset(serviceClient, failureConfirmation, successConfirmation);
-        });
+    verify(failureConfirmation).accept(missingLinkResult);
+    verify(successConfirmation, never()).accept(any());
   }
 
   private static Collection<ServiceResponse<ErrorReportResponse>> withMissingIssueLinkResult() {

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -1,0 +1,130 @@
+package games.strategy.debug.error.reporting;
+
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.SendResult;
+import org.triplea.http.client.ServiceClient;
+import org.triplea.http.client.ServiceResponse;
+import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.create.ErrorReportResponse;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorReportUploadActionTest {
+
+
+  @Mock
+  private ServiceClient<ErrorReport, ErrorReportResponse> serviceClient;
+
+  @Mock
+  private ConfirmationDialogController dialogController;
+
+  @InjectMocks
+  private ErrorReportUploadAction errorReportUploadAction;
+
+
+  private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
+      .build();
+
+
+  @Test
+  void nonSuccessSends() {
+    withNonSuccessSendResults()
+        .forEach(notSuccessfulSend -> {
+          when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
+              .thenReturn(notSuccessfulSend);
+
+          errorReportUploadAction.accept(null, USER_ERROR_REPORT);
+
+          verify(dialogController).showFailureConfirmation(notSuccessfulSend);
+
+          reset(serviceClient, dialogController);
+        });
+  }
+
+  private Collection<ServiceResponse<ErrorReportResponse>> withNonSuccessSendResults() {
+    // Create ServiceResponses with each of the 'SendResult' values except for the successful SendResult value: 'SENT'
+    return stream(SendResult.values())
+        .filter(sendResult -> sendResult != SendResult.SENT)
+        .map(ErrorReportUploadActionTest::serviceResponseWithSendResult)
+        .collect(Collectors.toSet());
+  }
+
+  private static ServiceResponse<ErrorReportResponse> serviceResponseWithSendResult(final SendResult sendResult) {
+    return ServiceResponse.<ErrorReportResponse>builder()
+        .sendResult(sendResult)
+        .build();
+  }
+
+  @Test
+  void missingIssueLinkInPaylaod() {
+    withMissingIssueLinkResult()
+        .forEach(missingLinkResult -> {
+
+          when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
+              .thenReturn(missingLinkResult);
+
+          errorReportUploadAction.accept(null, USER_ERROR_REPORT);
+
+          verify(dialogController).showFailureConfirmation(missingLinkResult);
+
+          reset(serviceClient, dialogController);
+        });
+  }
+
+  private static Collection<ServiceResponse<ErrorReportResponse>> withMissingIssueLinkResult() {
+    return asList(
+        ServiceResponse.<ErrorReportResponse>builder()
+            .sendResult(SendResult.SENT)
+            .build(),
+        ServiceResponse.<ErrorReportResponse>builder()
+            .sendResult(SendResult.SENT)
+            .payload(ErrorReportResponse.builder()
+                .build())
+            .build(),
+        ServiceResponse.<ErrorReportResponse>builder()
+            .sendResult(SendResult.SENT)
+            .payload(ErrorReportResponse.builder()
+                .error("simulated error")
+                .build())
+            .build(),
+        ServiceResponse.<ErrorReportResponse>builder()
+            .sendResult(SendResult.SENT)
+            .payload(ErrorReportResponse.builder()
+                .githubIssueLink("")
+                .build())
+            .build());
+  }
+
+  @Test
+  void successCase() {
+    final ServiceResponse<ErrorReportResponse> successCase = withSuccessfulSend();
+
+    when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
+        .thenReturn(successCase);
+
+    errorReportUploadAction.accept(null, USER_ERROR_REPORT);
+
+    verify(dialogController).showSuccessConfirmation(successCase.getPayload().get().getGithubIssueLink().get());
+  }
+
+  private static ServiceResponse<ErrorReportResponse> withSuccessfulSend() {
+    return ServiceResponse.<ErrorReportResponse>builder()
+        .sendResult(SendResult.SENT)
+        .payload(ErrorReportResponse.builder()
+            .githubIssueLink("http://successful.send")
+            .build())
+        .build();
+  }
+}

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -37,7 +37,7 @@ class ErrorReportUploadActionTest {
 
 
   @Mock
-  private JFrame jFrame;
+  private JFrame frame;
 
   private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
       .build();
@@ -119,7 +119,7 @@ class ErrorReportUploadActionTest {
     when(serviceClient.apply(USER_ERROR_REPORT.toErrorReport()))
         .thenReturn(successCase);
 
-    errorReportUploadAction.accept(jFrame, USER_ERROR_REPORT);
+    errorReportUploadAction.accept(frame, USER_ERROR_REPORT);
 
     verify(dialogController).showSuccessConfirmation(successCase.getPayload().get().getGithubIssueLink().get());
   }

--- a/http-client/src/main/java/org/triplea/http/client/ServiceResponse.java
+++ b/http-client/src/main/java/org/triplea/http/client/ServiceResponse.java
@@ -43,10 +43,9 @@ public class ServiceResponse<T> {
    *
    * @return An empty string if no exception is present, otherwise the exception message is returned.
    */
-  public String getExceptionMessage() {
+  public Optional<String> getExceptionMessage() {
     return Optional.ofNullable(thrown)
-        .map(Throwable::getMessage)
-        .orElse("");
+        .map(Throwable::getMessage);
   }
 
   /**

--- a/http-client/src/test/java/org/triplea/http/client/ServiceResponseTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/ServiceResponseTest.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
@@ -37,7 +39,7 @@ class ServiceResponseTest {
             .sendResult(SendResult.SERVER_ERROR)
             .build()
             .getExceptionMessage(),
-        is(""));
+        isEmpty());
 
     assertThat(
         ServiceResponse.<String>builder()
@@ -45,6 +47,6 @@ class ServiceResponseTest {
             .thrown(new IllegalStateException(SAMPLE_MESSGE))
             .build()
             .getExceptionMessage(),
-        is(SAMPLE_MESSGE));
+        isPresentAndIs(SAMPLE_MESSGE));
   }
 }

--- a/http-client/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-client/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -12,9 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -114,7 +112,7 @@ class ErrorReportClientTest {
 
     assertThat(response.getPayload(), isEmpty());
     assertThat(response.getThrown(), isPresent());
-    assertThat(response.getExceptionMessage(), not(emptyOrNullString()));
+    assertThat(response.getExceptionMessage(), isPresent());
   }
 
   private static void givenFaultyConnection(final WireMockServer wireMockServer, final Fault fault) {
@@ -135,7 +133,7 @@ class ErrorReportClientTest {
 
     assertThat(response.getPayload(), isEmpty());
     assertThat(response.getThrown(), isPresent());
-    assertThat(response.getExceptionMessage(), not(emptyOrNullString()));
+    assertThat(response.getExceptionMessage(), isPresent());
   }
 
   private static void givenServer500(final WireMockServer wireMockServer) {


### PR DESCRIPTION
## Overview
Various improvements to the result dialog after submitting an error
report:
- error report link is now clickable
- errors encountered will have better messaging and a clickable 'contact
support' link
- error message is updated to return server error message if there is
one, otherwise we will be grabbing error message from any exceptions we
encounter
- refactor: simplify constructor configuration
- refactor: move dialog creation responsibility from upload action class to new confirmation dialog controller.

## Functional Changes
- Clickable links on error upload confirmation window
- Better error messaging on confirmation window when something fails.

## Manual Testing Performed
- Custom launch individual windows to tweak their UI padding/settings.
- Went through various error/success use cases,  screenshots attached
- Injected an exception in the upload background task to make sure it was displayed and we did not have an infinite background task spinner.

## Screen Shots

### Error Case 1: Client -> Server Connection Error
Ran the client with no http server listening

![screenshot from 2019-01-08 12-16-02](https://user-images.githubusercontent.com/12397753/50856897-c1b1cb00-1340-11e9-8b9c-aa9f56717acf.png)

### Error Case 2: Server -> Github API Error
Sending empty data goes on to have a validation error from github API, generated on the http server and send back to the client;

![screenshot from 2019-01-08 12-15-14](https://user-images.githubusercontent.com/12397753/50856894-c1193480-1340-11e9-90e0-59e7f8757bfa.png)

### Success Case: Client -> Server -> Github API
![screenshot from 2019-01-08 12-15-32](https://user-images.githubusercontent.com/12397753/50856896-c1193480-1340-11e9-9bf1-d75e0271d465.png)