### PR TITLE
Switch JDK9 build to JDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
   - jdk: oraclejdk8
     env: TRIPLEA_RELEASE=true
-  - jdk: oraclejdk9
+  - jdk: oraclejdk11
     env: TRIPLEA_RELEASE=false
 addons:
   postgresql: "9.5"

--- a/game-core/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/RemoteInterfaceHelperTest.java
@@ -3,41 +3,64 @@ package games.strategy.engine.message;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.PrintStream;
 import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
-public class RemoteInterfaceHelperTest {
-
+class RemoteInterfaceHelperTest {
   @Test
-  public void testSimple() {
-    assertEquals("compare", RemoteInterfaceHelper.getMethod(0, Comparator.class).getName());
-    assertEquals("add", RemoteInterfaceHelper.getMethod(0, Collection.class).getName());
-    assertEquals(0, RemoteInterfaceHelper.getNumber("add", new Class<?>[] {Object.class}, Collection.class));
-    assertEquals(2, RemoteInterfaceHelper.getNumber("clear", new Class<?>[] {}, Collection.class));
+  void testSimple() {
+    assertEquals("baz", RemoteInterfaceHelper.getMethod(5, FakeRemoteInterface.class).getName());
+    assertEquals("qux", RemoteInterfaceHelper.getMethod(8, FakeRemoteInterface.class).getName());
+    assertEquals(5, RemoteInterfaceHelper.getNumber("baz", new Class<?>[] {Object.class}, FakeRemoteInterface.class));
+    assertEquals(8, RemoteInterfaceHelper.getNumber("qux", new Class<?>[] {Object.class}, FakeRemoteInterface.class));
   }
 
-
   @Test
-  public void testCorrectOverloadOrder() {
-    checkMethodMatches("printf", new Class<?>[] {Locale.class, String.class, Object[].class},
-        RemoteInterfaceHelper.getMethod(26, PrintStream.class));
-    checkMethodMatches("println", new Class<?>[] {char[].class},
-        RemoteInterfaceHelper.getMethod(28, PrintStream.class));
-    checkMethodMatches("println", new Class<?>[] {boolean.class},
-        RemoteInterfaceHelper.getMethod(29, PrintStream.class));
-    checkMethodMatches("println", new Class<?>[] {char.class}, RemoteInterfaceHelper.getMethod(30, PrintStream.class));
+  void testCorrectOverloadOrder() {
+    checkMethodMatches(
+        "foo",
+        new Class<?>[] {String.class, Object[].class},
+        RemoteInterfaceHelper.getMethod(7, FakeRemoteInterface.class));
+    checkMethodMatches(
+        "bar",
+        new Class<?>[] {char[].class},
+        RemoteInterfaceHelper.getMethod(1, FakeRemoteInterface.class));
+    checkMethodMatches(
+        "bar",
+        new Class<?>[] {boolean.class},
+        RemoteInterfaceHelper.getMethod(2, FakeRemoteInterface.class));
+    checkMethodMatches(
+        "bar",
+        new Class<?>[] {char.class},
+        RemoteInterfaceHelper.getMethod(3, FakeRemoteInterface.class));
 
-    assertEquals(27, RemoteInterfaceHelper.getNumber("println", new Class<?>[] {}, PrintStream.class));
-    assertEquals(34, RemoteInterfaceHelper.getNumber("println", new Class<?>[] {Object.class}, PrintStream.class));
+    assertEquals(0, RemoteInterfaceHelper.getNumber("bar", new Class<?>[] {}, FakeRemoteInterface.class));
+    assertEquals(4, RemoteInterfaceHelper.getNumber("bar", new Class<?>[] {Object.class}, FakeRemoteInterface.class));
   }
 
   private static void checkMethodMatches(final String name, final Class<?>[] parameterTypes, final Method method) {
     assertEquals(name, method.getName());
     assertArrayEquals(parameterTypes, method.getParameterTypes());
+  }
+
+  private interface FakeRemoteInterface {
+    void foo(String arg1);
+
+    void foo(String arg1, Object... arg2);
+
+    void bar();
+
+    void bar(char[] arg1);
+
+    void bar(boolean arg1);
+
+    void bar(char arg1);
+
+    void bar(Object arg1);
+
+    int baz(Object arg1);
+
+    boolean qux(Object arg1);
   }
 }


### PR DESCRIPTION
## Overview

Replaces the current Travis JDK9 build with a JDK11 build.

## Functional Changes

None.

## Manual Testing Performed

In addition to the Travis build, I ran the `release` target locally under JDK11 to sanity check it, since we haven't traditionally run that task for the JDK9 build. I smoke tested a local game using the resulting headed game portable build under both Java 8 and Java 11.