### PR TITLE
Decouple Headless and Headed ServerSetupPanelModel

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -83,7 +83,7 @@ public class SetupPanelModel {
     }
   }
 
-  protected void setGameTypePanel(final ISetupPanel panel) {
+  public void setGameTypePanel(final ISetupPanel panel) {
     if (this.panel != null) {
       this.panel.cancel();
     }

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -40,9 +40,7 @@ import games.strategy.engine.framework.headless.game.server.ArgValidationResult;
 import games.strategy.engine.framework.headless.game.server.HeadlessGameServerCliParam;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
-import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
-import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.sound.ClipPlayer;
@@ -509,7 +507,7 @@ public class HeadlessGameServer {
         }
         if (setupPanelModel.getPanel() != null
             && setupPanelModel.getPanel().canGameStart()) {
-          final boolean started = startHeadlessGame(setupPanelModel);
+          final boolean started = startHeadlessGame(setupPanelModel, gameSelectorModel);
           if (!started) {
             log.warning("Error in launcher, going back to waiting.");
           } else {
@@ -521,11 +519,12 @@ public class HeadlessGameServer {
     }, "Headless Server Waiting For Users To Connect And Start").start();
   }
 
-  private static synchronized boolean startHeadlessGame(final SetupPanelModel setupPanelModel) {
+  private static synchronized boolean startHeadlessGame(
+      final HeadlessServerSetupPanelModel setupPanelModel, final GameSelectorModel gameSelectorModel) {
     try {
       if (setupPanelModel != null && setupPanelModel.getPanel() != null && setupPanelModel.getPanel().canGameStart()) {
-        log.info("Starting Game: " + setupPanelModel.getGameSelectorModel().getGameData().getGameName()
-            + ", Round: " + setupPanelModel.getGameSelectorModel().getGameData().getSequence().getRound());
+        log.info("Starting Game: " + gameSelectorModel.getGameData().getGameName()
+            + ", Round: " + gameSelectorModel.getGameData().getSequence().getRound());
 
         final boolean launched = setupPanelModel.getPanel().getLauncher()
             .map(launcher -> {
@@ -556,20 +555,11 @@ public class HeadlessGameServer {
     return getServerModel(setupPanelModel);
   }
 
-  private static ServerModel getServerModel(final SetupPanelModel setupPanelModel) {
-    if (setupPanelModel == null) {
-      return null;
-    }
-    final ISetupPanel setup = setupPanelModel.getPanel();
-    if (setup == null) {
-      return null;
-    }
-    if (setup instanceof ServerSetupPanel) {
-      return ((ServerSetupPanel) setup).getModel();
-    } else if (setup instanceof HeadlessServerSetup) {
-      return ((HeadlessServerSetup) setup).getModel();
-    }
-    return null;
+  private static ServerModel getServerModel(final HeadlessServerSetupPanelModel setupPanelModel) {
+    return Optional.ofNullable(setupPanelModel)
+        .map(HeadlessServerSetupPanelModel::getPanel)
+        .map(HeadlessServerSetup::getModel)
+        .orElse(null);
   }
 
   /**

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
@@ -1,39 +1,34 @@
 package org.triplea.game.server;
 
+import java.util.Optional;
+
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
-import games.strategy.engine.framework.startup.mc.SetupPanelModel;
-import games.strategy.engine.framework.startup.ui.ISetupPanel;
 
 /**
  * Setup panel model for headless server.
  */
-class HeadlessServerSetupPanelModel extends SetupPanelModel {
+public class HeadlessServerSetupPanelModel {
+
+  private final GameSelectorModel gameSelectorModel;
+  private HeadlessServerSetup headlessServerSetup;
+
   HeadlessServerSetupPanelModel(final GameSelectorModel gameSelectorModel) {
-    super(gameSelectorModel);
+    this.gameSelectorModel = gameSelectorModel;
   }
 
-  @Override
   public void showSelectType() {
-    final ServerModel model = new ServerModel(gameSelectorModel, this, ServerModel.InteractionMode.HEADLESS);
+    final ServerModel model = new ServerModel(gameSelectorModel, this);
     if (!model.createServerMessenger(null)) {
       model.cancel();
       return;
     }
-    setGameTypePanel(new HeadlessServerSetup(model, gameSelectorModel));
+
+    Optional.ofNullable(headlessServerSetup).ifPresent(HeadlessServerSetup::cancel);
+    headlessServerSetup = new HeadlessServerSetup(model, gameSelectorModel);
   }
 
-  @Override
-  protected void setGameTypePanel(final ISetupPanel panel) {
-    if (panel == null || panel instanceof HeadlessServerSetup) {
-      super.setGameTypePanel(panel);
-    } else {
-      throw new IllegalArgumentException("Invalid panel of type " + panel.getClass());
-    }
-  }
-
-  @Override
   public HeadlessServerSetup getPanel() {
-    return (HeadlessServerSetup) super.getPanel();
+    return headlessServerSetup;
   }
 }


### PR DESCRIPTION
## Overview

In this refactor we remove the 'extends SetupPanelModel' from
HeadlessServerSetupPanel. This is a setp towards decoupling headed
vs headless panel models.

Note: HeadlessServerSetupPanelModel did not use 'SetupPanelModel' for
all that much in the end, most notably as a 'holder' for a ISetupPanel
reference, which is easily extracted into the child class to then break
the inheritance relationship.

## Functional Changes
None

## Manual Testing Performed
None
