### PR TITLE
README reorder, condense header sections, update link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@
 
 ##  [TripleA Home Page](http://triplea-game.org/)
 
-TripleA is an open source gaming community, free to play, 100% open source and volunteer run
+TripleA is an open source gaming community, free to play, 100% open source and volunteer run.
+
+- ***Contact-us***: 
+  - [Forums: Questions & Help](https://forums.triplea-game.org/category/10/help-questions)
+  - [Bug Tracker](https://github.com/triplea-game/triplea/issues/new)
+  - [Gitter](https://gitter.im/triplea-game/social)
+- ***Technical Documentation***: 
+  - [Developer Setup](https://github.com/triplea-game/triplea/tree/master/docs/dev)
+  - [Project Documentation](https://github.com/triplea-game/triplea/tree/master/docs/)
+
+
+
+- ***Dashboards***
+  - [Is the lobby running?](https://stats.uptimerobot.com/14RYqsN5m)
 
  
 ## [Download and install TripleA](http://triplea-game.org/download/)
 ![screenshot from 2018-02-08 22-58-33](https://user-images.githubusercontent.com/12397753/36015523-a4e28a24-0d23-11e8-84c0-c4bd0ee19ce0.png)
-
-
-## Contact Us:
-- [Github Issues (Bug Reports)](https://github.com/triplea-game/triplea/issues/new)
-- [Gitter](https://gitter.im/triplea-game/social)
-
-## Is it Running? Availability Dashboards
-- [Lobby and Forums](https://stats.uptimerobot.com/14RYqsN5m)
-- [Game Hosting Bots](https://stats.uptimerobot.com/2WVgrCzO4)
-
-## Documentation Links
-- [Documentation Home](https://github.com/triplea-game/triplea/tree/master/docs/)
-- [Developer Getting-Started Documentation](https://github.com/triplea-game/triplea/tree/master/docs/dev)
 
 ## License
 


### PR DESCRIPTION
## Overview
- Instead of big section headers we can have smaller list headers to
organize the links

- The preview image is large, links underneath it are a bit buried. This
update keeps only the license information below the image and moves
everything else above.

- Link for bot availability page is dropped. It's too much to have
multiple pages to check, that level of detail is not really appropriate
outside of system admins.


## Functional Changes
Changes github project README

## Manual Testing Performed
- *after* screenshots from renderer below

## Before & After Screen Shots
### Before
note: documentation links and license are cut-off; just speaks to them being harder to find when viewing: https://github.com/triplea-game/triplea

![screenshot from 2019-01-10 13-15-15](https://user-images.githubusercontent.com/12397753/50997588-d37aa600-14d9-11e9-8ce6-6e9ad30fcdfc.png)

### After
note: only the license information is cut-off
![screenshot from 2019-01-10 13-08-18](https://user-images.githubusercontent.com/12397753/50997657-fd33cd00-14d9-11e9-9431-0c670cd9549d.png)
