### PR TITLE
Docs: create legacy folder, move 'engine_code_overview.md'

### DIFF
--- a/docs/dev/legacy/engine_code_overview.md
+++ b/docs/dev/legacy/engine_code_overview.md
@@ -148,7 +148,7 @@ the game goes through in the gamePlay tag.
 
 
 ```xml
-<delegate name="battle&quot" javaClass="BattleDelegate"/>
+ <delegate name="battle" javaClass="BattleDelegate"/>
 <delegate name="move" javaClass="MoveDelegate"/>
 
 <step name="usMove" delegate="move" player="bush"/>

--- a/docs/dev/legacy/engine_code_overview.md
+++ b/docs/dev/legacy/engine_code_overview.md
@@ -1,3 +1,7 @@
+```
+This is the original design document published with Triplea.
+It is quite old, potentially out of date, left intact for historical reference.
+```
 
 ## Design Goals
 
@@ -143,7 +147,7 @@ the game goes through in the gamePlay tag.
 
 
 
-```
+```xml
 <delegate name="battle&quot" javaClass="BattleDelegate"/>
 <delegate name="move" javaClass="MoveDelegate"/>
 
@@ -193,9 +197,8 @@ style="mso-spacerun: yes">  A game player can be anything from a GUI to
 an AI to a PBEM interface.
 
 A GamePlayer sends messages to the current game delegate
-saying what moves the player would like to make.<span style="mso-spacerun:
-yes">  The Delegate will then validate the move, and if the move is
-valid, alter the GameData.
+saying what moves the player would like to make. The Delegate will then
+validate the move, and if the move is valid, alter the GameData.
 
 
 ##
@@ -213,12 +216,10 @@ start method returns.
 
 
 Because delegates and game players may not be on the same
-machine, communication is done through Bridges.<span style="mso-spacerun:
-yes">  
+machine, communication is done through Bridges.
 
 A delegate can send a message to a player through its
-delegateBridge using the sendMessage(..) functions.<span style="mso-spacerun:
-yes">  
+delegateBridge using the sendMessage(..) functions.
 
 A GamePlayer can only send a message to the games current
 delegate. The message is sent using the


### PR DESCRIPTION
## Overview
- engine_code_overview.md is a very old document, one of the originals.
The only reason to keep it around and not update it is for historical
reference. A note was added to the top of the documentation that it is
historical/legacy and the documentation file was moved to a new
'legacy/' folder.

- despite the header saying 'left intact', a few left-over HTML characters that were missed during cleanup/migration were cleaned up


## Functional Changes
- documentation updates only


## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![screenshot from 2019-01-10 13-29-34](https://user-images.githubusercontent.com/12397753/50998288-cced2e00-14db-11e9-8221-74f59ace8880.png)

### After
Note: the documentation file is moved to a 'legacy' folder and now has a header on it:
![screenshot from 2019-01-10 13-25-54](https://user-images.githubusercontent.com/12397753/50998221-a7f8bb00-14db-11e9-9327-6b00278e0efd.png)

