### PR TITLE
DocumentListenerBuilder

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -16,6 +16,7 @@ import games.strategy.engine.random.IRemoteDiceServer;
 import games.strategy.engine.random.PbemDiceRoller;
 import games.strategy.engine.random.PropertiesDiceRoller;
 import games.strategy.util.Util;
+import swinglib.DocumentListenerBuilder;
 
 /**
  * A class to configure a Dice Server for the game.
@@ -71,9 +72,9 @@ public class DiceServerEditor extends EditorPanel {
       final PbemDiceRoller random = new PbemDiceRoller(newDiceServer());
       random.test();
     });
-    toAddress.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
-    ccAddress.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
-    gameId.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
+    DocumentListenerBuilder.attachDocumentListener(toAddress, this::checkFieldsAndNotify);
+    DocumentListenerBuilder.attachDocumentListener(ccAddress, this::checkFieldsAndNotify);
+    DocumentListenerBuilder.attachDocumentListener(gameId, this::checkFieldsAndNotify);
   }
 
   private void checkFieldsAndNotify() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
@@ -6,8 +6,6 @@ import java.awt.GridBagLayout;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 
 /**
  * Helper Base class for Editors, that provides a basic collection of useful operations.
@@ -46,31 +44,5 @@ abstract class EditorPanel extends JPanel {
   boolean setLabelValid(final boolean valid, final JLabel label) {
     label.setForeground(valid ? labelColor : Color.RED);
     return valid;
-  }
-
-  /**
-   * Wrapper class to add input changed listeners to JTextFields with ease.
-   */
-  static class TextFieldInputListenerWrapper implements DocumentListener {
-    private final Runnable runnable;
-
-    TextFieldInputListenerWrapper(final Runnable runnable) {
-      this.runnable = runnable;
-    }
-
-    @Override
-    public void changedUpdate(final DocumentEvent e) {
-      runnable.run();
-    }
-
-    @Override
-    public void insertUpdate(final DocumentEvent e) {
-      runnable.run();
-    }
-
-    @Override
-    public void removeUpdate(final DocumentEvent e) {
-      runnable.run();
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -26,6 +26,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.ProgressWindow;
 import games.strategy.util.Util;
 import lombok.extern.java.Log;
+import swinglib.DocumentListenerBuilder;
 
 /**
  * An editor for modifying email senders.
@@ -62,8 +63,8 @@ public class EmailSenderEditor extends EditorPanel {
     row++;
     add(alsoPostAfterCombatMove, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, 0), 0, 0));
-    subject.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
-    toAddress.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
+    DocumentListenerBuilder.attachDocumentListener(subject, this::checkFieldsAndNotify);
+    DocumentListenerBuilder.attachDocumentListener(toAddress, this::checkFieldsAndNotify);
   }
 
   private void checkFieldsAndNotify() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -29,6 +29,7 @@ import games.strategy.ui.ProgressWindow;
 import games.strategy.util.TimeManager;
 import games.strategy.util.Util;
 import lombok.extern.java.Log;
+import swinglib.DocumentListenerBuilder;
 
 /**
  * A class for selecting which Forum poster to use.
@@ -89,7 +90,7 @@ public class ForumPosterEditor extends EditorPanel {
     viewPosts.addActionListener(e -> newForumPoster().viewPosted());
     testForum.addActionListener(e -> testForum());
     forums.addItemListener(e -> checkFieldsAndNotify());
-    topicIdField.getDocument().addDocumentListener(new TextFieldInputListenerWrapper(this::checkFieldsAndNotify));
+    DocumentListenerBuilder.attachDocumentListener(topicIdField, this::checkFieldsAndNotify);
 
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -18,8 +18,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -35,11 +33,12 @@ import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.util.CollectionUtils;
 import games.strategy.util.Tuple;
+import swinglib.DocumentListenerBuilder;
 
 /**
  * Order of loss panel, helps user create an order of loss string that is used to choose casualty order.
  */
-public class OrderOfLossesInputPanel extends JPanel {
+class OrderOfLossesInputPanel extends JPanel {
   private static final long serialVersionUID = 8815617685388156219L;
   private static final char OOL_SEPARATOR = ';';
   private static final char OOL_AMOUNT_DESCRIPTOR = '^';
@@ -56,7 +55,9 @@ public class OrderOfLossesInputPanel extends JPanel {
   private final JButton clear;
   private final boolean land;
 
-  public OrderOfLossesInputPanel(final String attackerOrder, final String defenderOrder,
+
+
+  OrderOfLossesInputPanel(final String attackerOrder, final String defenderOrder,
       final List<UnitCategory> attackerCategories, final List<UnitCategory> defenderCategories, final boolean land,
       final UiContext uiContext, final GameData data) {
     this.data = data;
@@ -65,63 +66,13 @@ public class OrderOfLossesInputPanel extends JPanel {
     this.attackerCategories = attackerCategories;
     this.defenderCategories = defenderCategories;
     attackerTextField = new JTextField(attackerOrder == null ? "" : attackerOrder);
-    attackerTextField.getDocument().addDocumentListener(new DocumentListener() {
-      @Override
-      public void insertUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(attackerTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          attackerLabel.setForeground(Color.red);
-        } else {
-          attackerLabel.setForeground(null);
-        }
-      }
+    DocumentListenerBuilder.attachDocumentListener(attackerTextField,
+        () -> turnToRedIfNotValidOrderOfLoss(attackerTextField));
 
-      @Override
-      public void removeUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(attackerTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          attackerLabel.setForeground(Color.red);
-        } else {
-          attackerLabel.setForeground(null);
-        }
-      }
-
-      @Override
-      public void changedUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(attackerTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          attackerLabel.setForeground(Color.red);
-        } else {
-          attackerLabel.setForeground(null);
-        }
-      }
-    });
     defenderTextField = new JTextField(defenderOrder == null ? "" : defenderOrder);
-    defenderTextField.getDocument().addDocumentListener(new DocumentListener() {
-      @Override
-      public void insertUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(defenderTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          defenderLabel.setForeground(Color.red);
-        } else {
-          defenderLabel.setForeground(null);
-        }
-      }
+    DocumentListenerBuilder.attachDocumentListener(defenderTextField,
+        () -> turnToRedIfNotValidOrderOfLoss(defenderTextField));
 
-      @Override
-      public void removeUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(defenderTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          defenderLabel.setForeground(Color.red);
-        } else {
-          defenderLabel.setForeground(null);
-        }
-      }
-
-      @Override
-      public void changedUpdate(final DocumentEvent e) {
-        if (!isValidOrderOfLoss(defenderTextField.getText(), OrderOfLossesInputPanel.this.data)) {
-          defenderLabel.setForeground(Color.red);
-        } else {
-          defenderLabel.setForeground(null);
-        }
-      }
-    });
     clear = new JButton("Clear");
     clear.addActionListener(e -> {
       attackerTextField.setText("");
@@ -130,10 +81,17 @@ public class OrderOfLossesInputPanel extends JPanel {
     layoutComponents();
   }
 
+  private void turnToRedIfNotValidOrderOfLoss(final JTextField textField) {
+    textField.setForeground(
+        isValidOrderOfLoss(textField.getText(), data)
+            ? null
+            : Color.red);
+  }
+
   /**
    * Validates if a given string can be parsed for order of losses.
    */
-  public static boolean isValidOrderOfLoss(final String orderOfLoss, final GameData data) {
+  static boolean isValidOrderOfLoss(final String orderOfLoss, final GameData data) {
     if (orderOfLoss == null || orderOfLoss.trim().length() == 0) {
       return true;
     }
@@ -183,7 +141,7 @@ public class OrderOfLossesInputPanel extends JPanel {
   /**
    * Returns units in the same ordering as the 'order of loss' string passed in.
    */
-  public static List<Unit> getUnitListByOrderOfLoss(final String ool, final Collection<Unit> units,
+  static List<Unit> getUnitListByOrderOfLoss(final String ool, final Collection<Unit> units,
       final GameData data) {
     if (ool == null || ool.trim().length() == 0) {
       return null;
@@ -292,11 +250,11 @@ public class OrderOfLossesInputPanel extends JPanel {
     return panel;
   }
 
-  public String getAttackerOrder() {
+  String getAttackerOrder() {
     return attackerTextField.getText();
   }
 
-  public String getDefenderOrder() {
+  String getDefenderOrder() {
     return defenderTextField.getText();
   }
 }

--- a/game-core/src/main/java/swinglib/DocumentListenerBuilder.java
+++ b/game-core/src/main/java/swinglib/DocumentListenerBuilder.java
@@ -1,0 +1,42 @@
+package swinglib;
+
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.JTextComponent;
+
+
+/**
+ * Helper to create a 'DocumentListener', which is a way to listen to text events on text fields
+ * and text areas. An action listener on text fields only fires on a keypressed 'enter' event and
+ * a key listener does not fire when text is copy-pasted into the field. The document listener
+ * should reliably trigger when text is changed.
+ */
+public final class DocumentListenerBuilder {
+
+  /**
+   * Attaches a given (add/remove/changed) text change action to a {@code JTextComponent}.
+   *
+   * @param textComponent Will receive a new document listener
+   * @param listenerAction The action to call.
+   */
+  public static void attachDocumentListener(
+      final JTextComponent textComponent, final Runnable listenerAction) {
+    textComponent.getDocument().addDocumentListener(
+        new DocumentListener() {
+          @Override
+          public void insertUpdate(final DocumentEvent e) {
+            listenerAction.run();
+          }
+
+          @Override
+          public void removeUpdate(final DocumentEvent e) {
+            listenerAction.run();
+          }
+
+          @Override
+          public void changedUpdate(final DocumentEvent e) {
+            listenerAction.run();
+          }
+        });
+  }
+}

--- a/game-core/src/main/java/swinglib/JButtonBuilder.java
+++ b/game-core/src/main/java/swinglib/JButtonBuilder.java
@@ -6,7 +6,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.Component;
 import java.awt.Font;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import javax.swing.JButton;
 import javax.swing.UIManager;
@@ -27,10 +27,10 @@ public class JButtonBuilder {
   private String title;
   private String toolTip;
   private String componentName;
-  private Function<Component, Runnable> clickAction;
+  private Consumer<Component> clickAction;
   private boolean enabled = true;
-  private boolean selected = false;
-  private int biggerFont = 0;
+  private boolean selected;
+  private int biggerFont;
 
   private JButtonBuilder() {}
 
@@ -47,7 +47,7 @@ public class JButtonBuilder {
 
     final JButton button = new JButton(title);
     Optional.ofNullable(clickAction)
-        .ifPresent(listener -> button.addActionListener(e -> clickAction.apply(button).run()));
+        .ifPresent(listener -> button.addActionListener(e -> clickAction.accept(button)));
     Optional.ofNullable(componentName).ifPresent(button::setName);
     Optional.ofNullable(toolTip).ifPresent(button::setToolTipText);
 
@@ -138,7 +138,7 @@ public class JButtonBuilder {
    */
   public JButtonBuilder actionListener(final Runnable actionListener) {
     checkNotNull(actionListener);
-    return actionListener(c -> actionListener);
+    return actionListener(c -> actionListener.run());
   }
 
 
@@ -149,10 +149,10 @@ public class JButtonBuilder {
    * that should be located above the button. Since we do not have a button reference yet while
    * constructing the button, this method can be used in that situation.
    *
-   * @param clickAction The action listener to invoke when the button is clicked, this listener will be evaluated
-   *        and attached to the button when the button is constructed (ie: {@code #build}.
+   * @param clickAction The action listener to invoke when the button is clicked, the parameter to the listener
+   *        is the button that was clicked (so it can be enabled/disabled, or text updated).
    */
-  public JButtonBuilder actionListener(final Function<Component, Runnable> clickAction) {
+  public JButtonBuilder actionListener(final Consumer<Component> clickAction) {
     this.clickAction = checkNotNull(clickAction);
     return this;
   }

--- a/game-core/src/main/java/swinglib/JTextFieldBuilder.java
+++ b/game-core/src/main/java/swinglib/JTextFieldBuilder.java
@@ -10,6 +10,7 @@ import java.util.function.Consumer;
 import javax.swing.JTextField;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.JTextComponent;
 import javax.swing.text.PlainDocument;
 
 import com.google.common.base.Preconditions;
@@ -44,7 +45,7 @@ public class JTextFieldBuilder {
   private Integer maxLength;
   private String componentName;
 
-  private Consumer<String> textEnteredAction;
+  private Consumer<JTextComponent> textEnteredAction;
   private boolean enabled = true;
   private boolean readOnly;
   private Consumer<JTextField> onFocusAction;
@@ -59,8 +60,11 @@ public class JTextFieldBuilder {
     Optional.ofNullable(columns)
         .ifPresent(textField::setColumns);
 
+
     Optional.ofNullable(textEnteredAction)
-        .ifPresent(action -> textField.addActionListener(e -> action.accept(textField.getText())));
+        .ifPresent(
+            action ->
+                DocumentListenerBuilder.attachDocumentListener(textField, () -> textEnteredAction.accept(textField)));
 
     Optional.ofNullable(maxLength)
         .map(JTextFieldLimit::new)
@@ -166,7 +170,7 @@ public class JTextFieldBuilder {
    * @param textEnteredAction Action to fire on 'enter', input value is the current value of the
    *        text field.
    */
-  public JTextFieldBuilder actionListener(final Consumer<String> textEnteredAction) {
+  public JTextFieldBuilder actionListener(final Consumer<JTextComponent> textEnteredAction) {
     Preconditions.checkNotNull(textEnteredAction);
     this.textEnteredAction = textEnteredAction;
     return this;

--- a/game-core/src/test/java/swinglib/JTextFieldBuilderTest.java
+++ b/game-core/src/test/java/swinglib/JTextFieldBuilderTest.java
@@ -64,8 +64,8 @@ class JTextFieldBuilderTest {
     JTextFieldBuilder.builder()
         .actionListener(fieldValue -> value.incrementAndGet())
         .build()
-        // and then fire the action!
-        .getActionListeners()[0].actionPerformed(null);
+        .setText("text");
+
     MatcherAssert.assertThat(
         "action expected to have been called and incremented our value from 0 to 1",
         value.get(), Is.is(1));


### PR DESCRIPTION
## Overview
Extracts helper code for creating DocumentListener instances and
attaching those instances to a text field or text area. DocumentListener
is useful as it is fired whenever text is updated (text pasted events
are not triggered by action or key listeners)


## Functional Changes

- One subtle change the error handling of OOL menu is updated so that the text field
*text* turns red instead of the text field label.

## Manual Testing Performed
- Launched game, did smoke testing.

## Before & After Screen Shots
### Before

Note the red "Attacker Units" text:
![screenshot from 2019-01-10 18-04-30](https://user-images.githubusercontent.com/12397753/51013140-b9f74f80-1515-11e9-93be-e87c7a471c9d.png)

### After

![screenshot from 2019-01-10 18-03-33](https://user-images.githubusercontent.com/12397753/51013146-bf549a00-1515-11e9-8de8-4bb81b1c7941.png)

