### PR TITLE
Checkstyle: Disallow redundant imports

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -207,6 +207,7 @@
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
         </module>
+        <module name="RedundantImport"/>
         <module name="UnusedImports"/>
         <module name="MethodParamPad"/>
         <module name="ParenPad"/>

--- a/http-server/src/test/java/org/triplea/server/reporting/error/ErrorReportResponseAdapterTest.java
+++ b/http-server/src/test/java/org/triplea/server/reporting/error/ErrorReportResponseAdapterTest.java
@@ -14,7 +14,6 @@ import org.triplea.http.client.SendResult;
 import org.triplea.http.client.ServiceResponse;
 import org.triplea.http.client.error.report.create.ErrorReportResponse;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
-import org.triplea.server.reporting.error.ErrorReportResponseAdapter;
 
 class ErrorReportResponseAdapterTest {
 


### PR DESCRIPTION
Redundant imports are removed when running Organize Imports, so enforcing this up front will be one less type of change we see when running Clean Up, Spotless, etc.