### PR TITLE
Define static imports using originating type rather than descendant type

### DIFF
--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -2,7 +2,7 @@ package games.strategy.debug.error.reporting;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Organize Imports wants to replace static imports from a subclass with a static import from the class where the imported entity is originally defined.  For example, `Mockito` inherits from `ArgumentMatchers`, so static methods defined on `ArgumentMatchers` should be imported via that type rather than the subtype `Mockito`.