### PR TITLE
Add Spotless to Gradle build

### DIFF
--- a/.eclipse/format/triplea.importorder
+++ b/.eclipse/format/triplea.importorder
@@ -1,5 +1,6 @@
 #Organize Import Order
-#Sun Mar 26 23:18:20 EDT 2017
+#Sat Jan 12 15:06:38 EST 2019
+4=
 3=com
 2=org
 1=javax

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
     id 'java'
+    id 'com.diffplug.gradle.spotless' version '3.17.0' apply false
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'io.franzbecker.gradle-lombok' version '1.14' apply false
     id 'net.ltgt.errorprone' version '0.6.1' apply false
@@ -38,12 +39,14 @@ subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'java'
+    apply plugin: 'com.diffplug.gradle.spotless'
     apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'io.franzbecker.gradle-lombok'
 
-    apply from: "${rootProject.projectDir}/gradle/scripts/release.gradle"
-    apply from: "${rootProject.projectDir}/gradle/scripts/remote-lib.gradle"
-    apply from: "${rootProject.projectDir}/gradle/scripts/version.gradle"
+    apply from: rootProject.file('gradle/scripts/release.gradle')
+    apply from: rootProject.file('gradle/scripts/remote-lib.gradle')
+    apply from: rootProject.file('gradle/scripts/spotless.gradle')
+    apply from: rootProject.file('gradle/scripts/version.gradle')
 
     group = 'triplea'
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -76,10 +79,10 @@ subprojects {
         testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.1.4'
         testImplementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+        testImplementation "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"
         testImplementation 'org.junit-pioneer:junit-pioneer:0.3.0'
         testImplementation "org.mockito:mockito-core:$mockitoVersion"
         testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
-        testImplementation "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"
 
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.3.2'
@@ -138,7 +141,7 @@ subprojects {
 
     checkstyle {
         toolVersion = "8.8"
-        configFile = file("${rootProject.projectDir}/config/checkstyle/checkstyle.xml")
+        configFile = rootProject.file('config/checkstyle/checkstyle.xml')
         configProperties = [samedir: configFile.parent]
     }
 
@@ -168,6 +171,16 @@ subprojects {
     lombok {
         version = '1.18.4'
         sha256 = '39f3922deb679b1852af519eb227157ef2dd0a21eec3542c8ce1b45f2df39742'
+    }
+
+    spotless {
+        java {
+            eclipse('4.9.0').configFile rootProject.file('.eclipse/format/triplea_java_eclipse_format_style.xml')
+            endWithNewline()
+            importOrder(*getEclipseImportOrder())
+            removeUnusedImports()
+            trimTrailingWhitespace()
+        }
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,19 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
+// TODO: Remove once Spotless 3.17.0 is published to Gradle plugin portal and replace with entry under plugins
+// see https://github.com/triplea-game/triplea/pull/4569#discussion_r247326720
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.17.0'
+    }
+}
+
 plugins {
     id 'java'
-    id 'com.diffplug.gradle.spotless' version '3.17.0' apply false
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'io.franzbecker.gradle-lombok' version '1.14' apply false
     id 'net.ltgt.errorprone' version '0.6.1' apply false

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -138,4 +138,3 @@ public class DummyDelegateBridge implements IDelegateBridge {
     this.battle = battle;
   }
 }
-

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyGameModifiedChannel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyGameModifiedChannel.java
@@ -25,4 +25,3 @@ class DummyGameModifiedChannel implements IGameModifiedChannel {
   public void stepChanged(final String stepName, final String delegateName, final PlayerId player, final int round,
       final String displayName, final boolean loadedFromSavedGame) {}
 }
-

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -258,4 +258,3 @@ class OrderOfLossesInputPanel extends JPanel {
     return defenderTextField.getText();
   }
 }
-

--- a/gradle/scripts/spotless.gradle
+++ b/gradle/scripts/spotless.gradle
@@ -1,0 +1,17 @@
+/*
+ * Returns a list containing the contents of the Eclipse import order configuration file in a format appropriate for
+ * Spotless.
+ *
+ * Each non-empty token will have a period appended in order to ensure Spotless groups the imports identically to
+ * Eclipse. Without this period, Spotless simply performs a substring match at the beginning of each import, which may
+ * result in unexpected groupings. For example, without the trailing period, the "java" and "javafx" packages will
+ * appear in the same group, but with the trailing period, "javafx" will appear in the uncategorized group.
+ */
+ext.getEclipseImportOrder = {
+    def props = new Properties()
+    def importOrderFile = rootProject.file('.eclipse/format/triplea.importorder')
+    importOrderFile.withInputStream { props.load(it) }
+    return props
+            .sort()
+            .collect { _, value -> value + (value ? '.' : '') }
+}

--- a/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageSizeThrottle.java
+++ b/http-client/src/main/java/org/triplea/http/client/throttle/size/MessageSizeThrottle.java
@@ -35,4 +35,3 @@ public class MessageSizeThrottle<T> implements Consumer<T> {
     }
   }
 }
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,21 @@
+// TODO: Remove once Spotless 3.17.0 is published to Gradle plugin portal
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        jcenter()
+    }
+
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == 'com.diffplug.gradle.spotless') {
+                useModule "com.diffplug.spotless:spotless-plugin-gradle:${requested.version}"
+            }
+        }
+    }
+}
+
 rootProject.name='triplea'
+
 include 'game-core'
 include 'game-headed'
 include 'game-headless'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 // TODO: Remove once Spotless 3.17.0 is published to Gradle plugin portal
+// see https://github.com/triplea-game/triplea/pull/4569#discussion_r247326720
 pluginManagement {
     repositories {
         gradlePluginPortal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,22 +1,4 @@
-// TODO: Remove once Spotless 3.17.0 is published to Gradle plugin portal
-// see https://github.com/triplea-game/triplea/pull/4569#discussion_r247326720
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        jcenter()
-    }
-
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == 'com.diffplug.gradle.spotless') {
-                useModule "com.diffplug.spotless:spotless-plugin-gradle:${requested.version}"
-            }
-        }
-    }
-}
-
 rootProject.name='triplea'
-
 include 'game-core'
 include 'game-headed'
 include 'game-headless'


### PR DESCRIPTION
Adds Spotless to the Gradle build as requested in https://github.com/triplea-game/triplea/issues/4560#issuecomment-453710966.  Note that, at this time, the Spotless tasks are not automatically run (i.e. they are not dependencies of the `check` task).  This change simply makes the `spotlessCheck` and `spotlessApply` tasks available to the build.

The first commit is the core change that adds Spotless to the build; it uses the current Eclipse formatter and import order configuration as the basis for the checks.  The second commit contains the changes made after running `spotlessApply`.