### PR TITLE
Re-enable buttons correctly

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -200,8 +200,6 @@ public class ClientModel implements IMessengerErrorListener {
     // load in the saved name!
     final ClientProps props = getProps(this.ui);
     if (props == null) {
-      gameSelectorModel.setCanSelect(true);
-      cancel();
       return false;
     }
     final String name = props.getName();
@@ -268,18 +266,17 @@ public class ClientModel implements IMessengerErrorListener {
    * Resets stats and nulls out references, keeps chat alive.
    */
   public void cancel() {
-    if (messenger == null) {
-      return;
-    }
-    objectStreamFactory.setData(null);
-    messenger.shutDown();
-    chatPanel.setChat(null);
     gameSelectorModel.setGameData(gameDataOnStartup);
     gameSelectorModel.setCanSelect(true);
-    hostIsHeadlessBot = false;
-    gameSelectorModel.setIsHostHeadlessBot(false);
-    gameSelectorModel.setClientModelForHostBots(null);
-    messenger.removeErrorListener(this);
+    if (messenger != null) {
+      messenger.shutDown();
+      messenger.removeErrorListener(this);
+      objectStreamFactory.setData(null);
+      chatPanel.setChat(null);
+      hostIsHeadlessBot = false;
+      gameSelectorModel.setIsHostHeadlessBot(false);
+      gameSelectorModel.setClientModelForHostBots(null);
+    }
   }
 
   private void startGame(final byte[] gameData, final Map<String, INode> players, final CountDownLatch onDone,


### PR DESCRIPTION
## Overview
This fixes a small bug I discovered when testing #4570
When you click on "Connect to networked game", try to connect and an exception occurs (because the server doesn't exist for example) the "select map" and "select game" buttons don't get re-enabled correctly. Simply clicking cancel did work though.

## Functional Changes
Bug fix 🤷‍♂️ 

## Manual Testing Performed
Verified the bug no longer occurs.