### PR TITLE
Remove WaitDialog from AbstractLauncher

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -35,7 +35,7 @@ public abstract class AbstractLauncher implements ILauncher {
 
   @Override
   public void launch(final Component parent) {
-    if (!headless && !SwingUtilities.isEventDispatchThread()) {
+    if (headless == SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread");
     }
     if (!headless && gameLoadingWindow != null) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -2,12 +2,8 @@ package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
 
-import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
-import games.strategy.engine.framework.ui.background.WaitWindow;
 
 /**
  * Abstract class for launching a game.
@@ -29,29 +25,8 @@ public abstract class AbstractLauncher<T> implements ILauncher {
 
   @Override
   public void launch(final Component parent) {
-    if (headless == SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
-    final WaitWindow gameLoadingWindow = headless ? null : new WaitWindow();
-    if (!headless) {
-      gameLoadingWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(parent));
-      gameLoadingWindow.setVisible(true);
-      gameLoadingWindow.showWait();
-    }
-    if (parent != null) {
-      JOptionPane.getFrameForComponent(parent).setVisible(false);
-    }
-    new Thread(() -> {
-      final T result;
-      try {
-        result = loadGame(parent);
-      } finally {
-        if (!headless) {
-          gameLoadingWindow.doneWait();
-        }
-      }
-      launchInternal(parent, result);
-    }, "Triplea start thread").start();
+    final T result = loadGame(parent);
+    new Thread(() -> launchInternal(parent, result)).start();
   }
 
   abstract T loadGame(Component parent);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -4,6 +4,8 @@ import java.awt.Component;
 
 /**
  * Abstract class for launching a game.
+ * @param <T> The type of object that gets returned by {@link #loadGame(Component)}
+ *          and is required by {@link #launchInternal(Component, Object)}.
  */
 public abstract class AbstractLauncher<T> implements ILauncher {
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -4,8 +4,9 @@ import java.awt.Component;
 
 /**
  * Abstract class for launching a game.
+ *
  * @param <T> The type of object that gets returned by {@link #loadGame(Component)}
- *          and is required by {@link #launchInternal(Component, Object)}.
+ *        and is required by {@link #launchInternal(Component, Object)}.
  */
 public abstract class AbstractLauncher<T> implements ILauncher {
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -1,6 +1,9 @@
 package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 /**
  * Abstract class for launching a game.
@@ -11,11 +14,11 @@ import java.awt.Component;
 public abstract class AbstractLauncher<T> implements ILauncher {
   @Override
   public void launch(final Component parent) {
-    final T result = loadGame(parent);
-    new Thread(() -> launchInternal(parent, result)).start();
+    final Optional<T> result = loadGame(parent);
+    new Thread(() -> launchInternal(parent, result.orElse(null))).start();
   }
 
-  abstract T loadGame(Component parent);
+  abstract Optional<T> loadGame(Component parent);
 
-  abstract void launchInternal(Component parent, T data);
+  abstract void launchInternal(Component parent, @Nullable T data);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/AbstractLauncher.java
@@ -2,27 +2,10 @@ package games.strategy.engine.framework.startup.launcher;
 
 import java.awt.Component;
 
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.framework.startup.mc.GameSelectorModel;
-
 /**
  * Abstract class for launching a game.
  */
 public abstract class AbstractLauncher<T> implements ILauncher {
-  protected final GameData gameData;
-  protected final GameSelectorModel gameSelectorModel;
-  protected final boolean headless;
-
-  AbstractLauncher(final GameSelectorModel gameSelectorModel) {
-    this(gameSelectorModel, false);
-  }
-
-  AbstractLauncher(final GameSelectorModel gameSelectorModel, final boolean headless) {
-    this.headless = headless;
-    this.gameSelectorModel = gameSelectorModel;
-    gameData = gameSelectorModel.getGameData();
-  }
-
   @Override
   public void launch(final Component parent) {
     final T result = loadGame(parent);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -24,14 +25,17 @@ import lombok.extern.java.Log;
  */
 @Log
 public class LocalLauncher extends AbstractLauncher<Optional<ServerGame>> {
+  private final GameData gameData;
+  private final GameSelectorModel gameSelectorModel;
   private final IRandomSource randomSource;
   private final PlayerListing playerListing;
 
   public LocalLauncher(final GameSelectorModel gameSelectorModel, final IRandomSource randomSource,
       final PlayerListing playerListing) {
-    super(gameSelectorModel);
     this.randomSource = randomSource;
     this.playerListing = playerListing;
+    this.gameSelectorModel = gameSelectorModel;
+    this.gameData = gameSelectorModel.getGameData();
   }
 
   @Override
@@ -55,9 +59,9 @@ public class LocalLauncher extends AbstractLauncher<Optional<ServerGame>> {
       final Messengers messengers = new Messengers(new HeadlessServerMessenger());
       final Set<IGamePlayer> gamePlayers =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap());
-      final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers, headless);
+      final ServerGame game = new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers, false);
       game.setRandomSource(randomSource);
-      gameData.getGameLoader().startGame(game, gamePlayers, headless, null);
+      gameData.getGameLoader().startGame(game, gamePlayers, false, null);
       return Optional.of(game);
     } catch (final Exception ex) {
       log.log(Level.SEVERE, "Failed to start game", ex);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -23,7 +23,7 @@ import lombok.extern.java.Log;
  * Implementation of {@link ILauncher} for a headed local or network client game.
  */
 @Log
-public class LocalLauncher extends AbstractLauncher {
+public class LocalLauncher extends AbstractLauncher<Optional<ServerGame>> {
   private final IRandomSource randomSource;
   private final PlayerListing playerListing;
 
@@ -35,8 +35,7 @@ public class LocalLauncher extends AbstractLauncher {
   }
 
   @Override
-  protected void launchInNewThread(final Component parent) {
-    final Optional<ServerGame> game = loadGame();
+  protected void launchInternal(final Component parent, final Optional<ServerGame> game) {
     try {
       game.ifPresent(ServerGame::startGame);
     } finally {
@@ -49,7 +48,8 @@ public class LocalLauncher extends AbstractLauncher {
     }
   }
 
-  private Optional<ServerGame> loadGame() {
+  @Override
+  Optional<ServerGame> loadGame(final Component parent) {
     try {
       gameData.doPreGameStartDataModifications(playerListing);
       final Messengers messengers = new Messengers(new HeadlessServerMessenger());
@@ -62,8 +62,6 @@ public class LocalLauncher extends AbstractLauncher {
     } catch (final Exception ex) {
       log.log(Level.SEVERE, "Failed to start game", ex);
       return Optional.empty();
-    } finally {
-      gameLoadingWindow.doneWait();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
@@ -24,7 +25,7 @@ import lombok.extern.java.Log;
  * Implementation of {@link ILauncher} for a headed local or network client game.
  */
 @Log
-public class LocalLauncher extends AbstractLauncher<Optional<ServerGame>> {
+public class LocalLauncher extends AbstractLauncher<ServerGame> {
   private final GameData gameData;
   private final GameSelectorModel gameSelectorModel;
   private final IRandomSource randomSource;
@@ -39,9 +40,11 @@ public class LocalLauncher extends AbstractLauncher<Optional<ServerGame>> {
   }
 
   @Override
-  protected void launchInternal(final Component parent, final Optional<ServerGame> game) {
+  protected void launchInternal(final Component parent, @Nullable final ServerGame game) {
     try {
-      game.ifPresent(ServerGame::startGame);
+      if (game != null) {
+        game.startGame();
+      }
     } finally {
       // todo(kg), this does not occur on the swing thread, and this notifies setupPanel observers
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -111,9 +111,7 @@ public class ServerLauncher extends AbstractLauncher {
       }
       serverModel.allowRemoveConnections();
       ui = parent;
-      if (headless) {
-        HeadlessGameServer.log("Game Status: Launching");
-      }
+      log.info("Game Status: Launching");
       remoteMessenger.registerRemote(serverReady, ClientModel.CLIENT_READY_CHANNEL);
       gameData.doPreGameStartDataModifications(playerListing);
       abortLaunch = testShouldWeAbort();
@@ -149,9 +147,7 @@ public class ServerLauncher extends AbstractLauncher {
           gameLoadingWindow.doneWait();
         }
       }
-      if (headless) {
-        HeadlessGameServer.log("Game Successfully Loaded. " + (abortLaunch ? "Aborting Launch." : "Starting Game."));
-      }
+      log.info("Game Successfully Loaded. " + (abortLaunch ? "Aborting Launch." : "Starting Game."));
       if (abortLaunch) {
         serverReady.countDownAll();
       }
@@ -171,9 +167,7 @@ public class ServerLauncher extends AbstractLauncher {
             if (gameLoadingWindow != null) {
               gameLoadingWindow.doneWait();
             }
-            if (headless) {
-              HeadlessGameServer.log("Starting Game Delegates.");
-            }
+            log.info("Starting Game Delegates.");
             serverGame.startGame();
           } else {
             stopGame();
@@ -230,8 +224,8 @@ public class ServerLauncher extends AbstractLauncher {
         if (headless) {
           // tell headless server to wait for new connections:
           HeadlessGameServer.waitForUsersHeadlessInstance();
-          HeadlessGameServer.log("Game Status: Waiting For Players");
         }
+        log.info("Game Status: Waiting For Players");
       }, "Triplea, start server game").start();
     } finally {
       if (gameLoadingWindow != null) {
@@ -240,9 +234,7 @@ public class ServerLauncher extends AbstractLauncher {
       if (inGameLobbyWatcher != null) {
         inGameLobbyWatcher.setGameStatus(GameDescription.GameStatus.IN_PROGRESS, serverGame);
       }
-      if (headless) {
-        HeadlessGameServer.log("Game Status: In Progress");
-      }
+      log.info("Game Status: In Progress");
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -7,11 +7,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
@@ -47,7 +49,7 @@ import lombok.extern.java.Log;
  * Implementation of {@link ILauncher} for a headed or headless network server game.
  */
 @Log
-public class ServerLauncher extends AbstractLauncher<Boolean> {
+public class ServerLauncher extends AbstractLauncher<Void> {
   private final GameData gameData;
   private final GameSelectorModel gameSelectorModel;
   private final boolean headless;
@@ -107,7 +109,7 @@ public class ServerLauncher extends AbstractLauncher<Boolean> {
   }
 
   @Override
-  Boolean loadGame(final Component parent) {
+  Optional<Void> loadGame(final Component parent) {
     try {
       // the order of this stuff does matter
       serverModel.setServerLauncher(this);
@@ -158,22 +160,22 @@ public class ServerLauncher extends AbstractLauncher<Boolean> {
         abortLaunch = true;
       }
       remoteMessenger.unregisterRemote(ClientModel.CLIENT_READY_CHANNEL);
-      return useSecureRandomSource;
     } finally {
       if (inGameLobbyWatcher != null) {
         inGameLobbyWatcher.setGameStatus(GameDescription.GameStatus.IN_PROGRESS, serverGame);
       }
       log.info("Game Status: In Progress");
     }
+    return Optional.empty();
   }
 
   @Override
-  void launchInternal(final Component parent, final Boolean useSecureRandomSource) {
+  void launchInternal(final Component parent, @Nullable final Void none) {
     try {
       isLaunching = false;
       abortLaunch = testShouldWeAbort();
       if (!abortLaunch) {
-        if (useSecureRandomSource) {
+        if (!remotePlayers.isEmpty()) {
           warmUpCryptoRandomSource();
         }
         log.info("Starting Game Delegates.");

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -236,7 +236,7 @@ public class ServerLauncher extends AbstractLauncher<Boolean> {
         HeadlessGameServer.waitForUsersHeadlessInstance();
       }
       log.info("Game Status: Waiting For Players");
-    }, "Triplea, start server game").start();
+    }, "TripleA, start server game").start();
   }
 
   private void warmUpCryptoRandomSource() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -164,9 +164,6 @@ public class ServerLauncher extends AbstractLauncher {
             if (useSecureRandomSource) {
               warmUpCryptoRandomSource();
             }
-            if (gameLoadingWindow != null) {
-              gameLoadingWindow.doneWait();
-            }
             log.info("Starting Game Delegates.");
             serverGame.startGame();
           } else {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -17,6 +17,7 @@ import javax.swing.SwingUtilities;
 
 import org.triplea.game.server.HeadlessGameServer;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.framework.AutoSaveFileUtils;
 import games.strategy.engine.framework.ServerGame;
@@ -47,6 +48,9 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ServerLauncher extends AbstractLauncher<Boolean> {
+  private final GameData gameData;
+  private final GameSelectorModel gameSelectorModel;
+  private final boolean headless;
   private final int clientCount;
   private final IRemoteMessenger remoteMessenger;
   private final IChannelMessenger channelMessenger;
@@ -70,7 +74,8 @@ public class ServerLauncher extends AbstractLauncher<Boolean> {
       final IChannelMessenger channelMessenger, final IMessenger messenger, final GameSelectorModel gameSelectorModel,
       final PlayerListing playerListing, final Map<String, INode> remotePlayers, final ServerModel serverModel,
       final boolean headless) {
-    super(gameSelectorModel, headless);
+    this.gameSelectorModel = gameSelectorModel;
+    this.headless = headless;
     this.clientCount = clientCount;
     this.remoteMessenger = remoteMessenger;
     this.channelMessenger = channelMessenger;
@@ -78,6 +83,7 @@ public class ServerLauncher extends AbstractLauncher<Boolean> {
     this.playerListing = playerListing;
     this.remotePlayers = remotePlayers;
     this.serverModel = serverModel;
+    this.gameData = gameSelectorModel.getGameData();
   }
 
   public void setInGameLobbyWatcher(final InGameLobbyWatcherWrapper watcher) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -266,11 +266,6 @@ public class ClientSetupPanel extends SetupPanel {
   }
 
   @Override
-  public JComponent getDrawable() {
-    return this;
-  }
-
-  @Override
   public boolean isCancelButtonVisible() {
     return true;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -6,8 +6,6 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.Optional;
 
-import javax.swing.JComponent;
-
 import org.triplea.game.startup.SetupModel;
 
 import games.strategy.engine.framework.startup.launcher.ILauncher;
@@ -64,10 +62,5 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
   @Override
   public Optional<ILauncher> getLauncher() {
     return Optional.of(LauncherFactory.getLocalLaunchers(gameSelectorModel, playerTypes));
-  }
-
-  @Override
-  public JComponent getDrawable() {
-    return this;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -7,7 +7,6 @@ import java.awt.Insets;
 import java.util.Optional;
 
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JPanel;
 
 import games.strategy.debug.error.reporting.ReportWindowController;
@@ -151,11 +150,6 @@ public class MetaSetupPanel extends SetupPanel {
 
   @Override
   public void cancel() {}
-
-  @Override
-  public JComponent getDrawable() {
-    return this;
-  }
 
   @Override
   public Optional<ILauncher> getLauncher() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -15,7 +15,6 @@ import java.util.Observer;
 import java.util.Optional;
 
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -194,10 +193,5 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
         new PlayerListing(null, playersEnabled, playerTypes, gameSelectorModel.getGameData().getGameVersion(),
             gameSelectorModel.getGameName(), gameSelectorModel.getGameRound(), null, null);
     return Optional.of(new LocalLauncher(gameSelectorModel, randomSource, pl));
-  }
-
-  @Override
-  public JComponent getDrawable() {
-    return this;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import javax.swing.Action;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -443,11 +442,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
           launcher.setInGameLobbyWatcher(lobbyWatcher);
           return launcher;
         });
-  }
-
-  @Override
-  public JComponent getDrawable() {
-    return this;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -12,7 +12,6 @@ import java.util.Observer;
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
@@ -138,8 +137,6 @@ public abstract class SetupPanel extends JPanel implements SetupModel {
     panel.validate();
     panel.repaint();
   }
-
-  public abstract JComponent getDrawable();
 
   public abstract boolean isCancelButtonVisible();
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -131,7 +131,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
   public void accept(final SetupPanel panel) {
     gameSetupPanel = panel;
     gameSetupPanelHolder.removeAll();
-    gameSetupPanelHolder.add(panel.getDrawable(), BorderLayout.CENTER);
+    gameSetupPanelHolder.add(panel, BorderLayout.CENTER);
     panel.addObserver(this);
     setWidgetActivation();
     // add the cancel button if we are not choosing the type.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
@@ -2,11 +2,14 @@ package games.strategy.engine.framework.startup.ui.panels.main;
 
 import java.util.Optional;
 
+import javax.swing.JOptionPane;
+
 import org.triplea.game.startup.SetupModel;
 
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
+import games.strategy.engine.framework.ui.background.WaitWindow;
 
 /**
  * Can be used to create a {@link MainPanel} UI component class, which is a UI holder. The final contents are added to
@@ -28,7 +31,20 @@ public class MainPanelBuilder {
         gameSelectorPanel,
         uiPanel -> {
           setupPanelModel.getPanel().getLauncher()
-              .ifPresent(launcher -> launcher.launch(uiPanel));
+              .ifPresent(launcher -> {
+                final WaitWindow gameLoadingWindow = new WaitWindow();
+                gameLoadingWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(uiPanel));
+                gameLoadingWindow.setVisible(true);
+                gameLoadingWindow.showWait();
+                JOptionPane.getFrameForComponent(uiPanel).setVisible(false);
+                new Thread(() -> {
+                  try {
+                    launcher.launch(uiPanel);
+                  } finally {
+                    gameLoadingWindow.doneWait();
+                  }
+                }).start();
+              });
           setupPanelModel.getPanel().postStartGame();
         },
         () -> Optional.ofNullable(setupPanelModel.getPanel())

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -223,13 +223,6 @@ public class HeadlessGameServer {
     }
   }
 
-  public static synchronized void log(final String stdout) {
-    final HeadlessGameServer instance = getInstance();
-    if (instance != null) {
-      log.info(stdout);
-    }
-  }
-
   public String getSalt() {
     return BCrypt.gensalt();
   }

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -521,7 +521,7 @@ public class HeadlessGameServer {
 
         final boolean launched = setupPanelModel.getPanel().getLauncher()
             .map(launcher -> {
-              launcher.launch(null);
+              new Thread(() -> launcher.launch(null)).start();
               return true;
             }).orElse(false);
         setupPanelModel.getPanel().postStartGame();


### PR DESCRIPTION
## Overview
This moves the WaitDialog creation and removal to the launch caller, instead of making the Abstract Launcher check if there it should behave headed. Also some other minor refactoring changes along the way.

## Functional Changes
Game starting logs are now also being logged for headed environments, to remove an unecessary dependency to HeadlessGameServer. Also maybe the loading dialog is now displayed a couple of fractions of a second longer or shorter (probably not even noticeable by humans, if there's a difference at all)

## Manual Testing Performed
I verified that Games could be launched as usual and the loading dialog was displayed and hidden correctly (local and hosted game).
I didn't launch a headless client, because it uses the same code as host game except for one line which creates a new Thread.

## Side Note
I'll pause this decoupling project for a couple days. This "headless" or not question is wired deeply into the game, way deeper than I anticipated.
In order to resolve this I will probably re-introduce a isHeadless method to `ServerSetupModel` as a way to allow migrating classes one after each other. But I will run into a problem where the `ServerSetupModel` implementations will get way too big because they'll have to implement so many one-liners.
So if you have a suggestion on how to tackle this problem, please tell me.

Also sorry @ssoloff this doesn't contain the promised change regarding the headless boolean 😅 