### PR TITLE
Upgrade Checkstyle to 8.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = "8.8"
+        toolVersion = '8.12'
         configFile = rootProject.file('config/checkstyle/checkstyle.xml')
         configProperties = [samedir: configFile.parent]
     }


### PR DESCRIPTION
## Overview

Upgrades Checkstyle to version 8.12, which is the version bundled with the latest Eclipse Checkstyle plugin (Checkstyle 8.16 is the latest version as I write this).

@DanVanAtta @RoiEXLab @ron-murhammer There are no changes to the Checkstyle configuration, so upgrading your IDE plugin is not required.  However, you may want to consider doing that to ensure parity with the Gradle build.

## Functional Changes

None.

## Manual Testing Performed

None.