### PR TITLE
Restore error handling call.

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -7,6 +7,7 @@ import java.awt.GraphicsEnvironment;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
@@ -29,10 +30,12 @@ import games.strategy.triplea.ui.MacOsIntegration;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.Interruptibles;
 import javafx.application.Application;
+import lombok.extern.java.Log;
 
 /**
  * Runs a headed game client.
  */
+@Log
 public final class HeadedGameRunner {
   private HeadedGameRunner() {}
 
@@ -44,6 +47,8 @@ public final class HeadedGameRunner {
     checkState(!GraphicsEnvironment.isHeadless(),
         "UI client launcher invoked from headless environment. This is currently prohibited by design to "
             + "avoid UI rendering errors in the headless environment.");
+    Thread.setDefaultUncaughtExceptionHandler((t, e) -> log.log(Level.SEVERE, e.getLocalizedMessage(), e));
+
     ClientSetting.initialize();
     if (!ClientSetting.useExperimentalJavaFxUi.getValueOrThrow()) {
       Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {


### PR DESCRIPTION
## Overview

e0f86865568aaf98c96ca487191123161aa1947f chomped a line of code that
sent unhandled exceptions to our error handler. This update restores
that line.


## Functional Changes
- error message window shows on exceptions (once again)

## Manual Testing Performed
- launched app to verify things were okay, launched app again with an exception injected at the end of `HeadedGameRunner` to verify the error message was shown

![screenshot from 2019-01-14 08-54-07](https://user-images.githubusercontent.com/12397753/51127284-fce94980-17d9-11e9-920b-1ea60a92f2c7.png)


## Additional Review Notes
- noticed this mistake of mine while testing error upload window
