### PR TITLE
Battle calc fixes and improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -171,7 +171,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   public List<PlayerId> getPlayersByUnitCount() {
     final IntegerMap<PlayerId> map = getPlayerUnitCounts();
     final List<PlayerId> players = new ArrayList<>(map.keySet());
-    players.sort(Comparator.<PlayerId>comparingInt(p -> map.getInt(p)).reversed());
+    players.sort(Comparator.comparingInt(map::getInt).reversed());
     return players;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -3,6 +3,7 @@ package games.strategy.engine.data;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -165,6 +166,13 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
     final IntegerMap<PlayerId> count = new IntegerMap<>();
     units.forEach(unit -> count.add(unit.getOwner(), 1));
     return count;
+  }
+
+  public List<PlayerId> getPlayersByUnitCount() {
+    final IntegerMap<PlayerId> map = getPlayerUnitCounts();
+    final List<PlayerId> players = new ArrayList<>(map.keySet());
+    players.sort(Comparator.<PlayerId>comparingInt(p -> map.getInt(p)).reversed());
+    return players;
   }
 
   public boolean hasUnitsFromMultiplePlayers() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -97,7 +97,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     List<Unit> unitsThatCanFight =
-        CollectionUtils.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
+        CollectionUtils.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, true));
     if (Properties.getTransportCasualtiesRestricted(data)) {
       unitsThatCanFight =
           CollectionUtils.getMatches(unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().negate());
@@ -112,7 +112,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     final List<Unit> unitsThatCanFight =
-        CollectionUtils.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
+        CollectionUtils.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, true));
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     sortedUnitsList.sort(new UnitBattleComparator(!attacking, ProData.unitValueMap,
         TerritoryEffectHelper.getEffects(t), data, false, false));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -148,10 +148,10 @@ public class ProOddsCalculator {
     final double winPercentage = results.getAttackerWinPercent() * 100;
     final List<Unit> averageAttackersRemaining = results.getAverageAttackingUnitsRemaining();
     final List<Unit> averageDefendersRemaining = results.getAverageDefendingUnitsRemaining();
-    final List<Unit> mainCombatAttackers =
-        CollectionUtils.getMatches(attackingUnits, Matches.unitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
+    final List<Unit> mainCombatAttackers = CollectionUtils.getMatches(attackingUnits,
+        Matches.unitCanBeInBattle(true, !t.isWater(), 1, true));
     final List<Unit> mainCombatDefenders = CollectionUtils.getMatches(defendingUnits,
-        Matches.unitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
+        Matches.unitCanBeInBattle(false, !t.isWater(), 1, true));
     double tuvSwing = results.getAverageTuvSwing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
     if (Matches.territoryIsNeutralButNotWater().test(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = TuvUtils.getTuv(mainCombatAttackers, ProData.unitValueMap);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleResults.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameDataComponent;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.IBattle.WhoWon;
-import games.strategy.util.CollectionUtils;
 
 /**
  * The results of an in-progress or complete battle.
@@ -56,14 +55,6 @@ public class BattleResults extends GameDataComponent {
     return remainingDefendingUnits;
   }
 
-  public int getAttackingCombatUnitsLeft() {
-    return CollectionUtils.countMatches(remainingAttackingUnits, Matches.unitIsNotInfrastructure());
-  }
-
-  public int getDefendingCombatUnitsLeft() {
-    return CollectionUtils.countMatches(remainingDefendingUnits, Matches.unitIsNotInfrastructure());
-  }
-
   public int getBattleRoundsFought() {
     return battleRoundsFought;
   }
@@ -81,6 +72,6 @@ public class BattleResults extends GameDataComponent {
 
   public boolean draw() {
     return (whoWon != WhoWon.ATTACKER && whoWon != WhoWon.DEFENDER)
-        || (getAttackingCombatUnitsLeft() == 0 && getDefendingCombatUnitsLeft() == 0);
+        || (getRemainingAttackingUnits().isEmpty() && getRemainingDefendingUnits().isEmpty());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1166,7 +1166,7 @@ public class BattleTracker implements Serializable {
   private static List<Unit> getSortedDefendingUnits(final IDelegateBridge bridge, final GameData gameData,
       final Territory territory, final List<Unit> defenders) {
     final List<Unit> sortedUnitsList = new ArrayList<>(CollectionUtils.getMatches(defenders,
-        Matches.unitCanBeInBattle(false, !territory.isWater(), 1, false, true, true)));
+        Matches.unitCanBeInBattle(false, !territory.isWater(), 1, true)));
     sortedUnitsList.sort(new UnitBattleComparator(true, TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
         TerritoryEffectHelper.getEffects(territory), gameData, false, false));
     Collections.reverse(sortedUnitsList);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2116,20 +2116,25 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanBeInBattle(final boolean attack, final boolean isLandBattle,
+      final int battleRound, final boolean doNotIncludeBombardingSeaUnits) {
+    return unitCanBeInBattle(attack, isLandBattle, battleRound, true, doNotIncludeBombardingSeaUnits);
+  }
+
+  public static Predicate<Unit> unitCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeBombardingSeaUnits) {
     return unit -> unitTypeCanBeInBattle(attack, isLandBattle, unit.getOwner(), battleRound,
-        includeAttackersThatCanNotMove, doNotIncludeAa, doNotIncludeBombardingSeaUnits).test(unit.getType());
+        includeAttackersThatCanNotMove, doNotIncludeBombardingSeaUnits).test(unit.getType());
   }
 
   public static Predicate<UnitType> unitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final PlayerId player, final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeBombardingSeaUnits) {
 
     // Filter out anything like factories, or units that have no combat ability AND cannot be taken casualty
     final PredicateBuilder<UnitType> canBeInBattleBuilder = PredicateBuilder.of(unitTypeIsInfrastructure().negate())
         .or(unitTypeIsSupporterOrHasCombatAbility(attack, player))
-        .orIf(!doNotIncludeAa, unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)));
+        .or(unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)));
 
     if (attack) {
       if (!includeAttackersThatCanNotMove) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -45,8 +45,8 @@ public class AggregateResults {
   private Optional<BattleResults> getBattleResultsClosestToAverage() {
     return results.stream()
         .min(Comparator.comparingDouble(
-            result -> Math.abs(result.getAttackingCombatUnitsLeft() - getAverageAttackingUnitsLeft())
-                + Math.abs(result.getDefendingCombatUnitsLeft() - getAverageDefendingUnitsLeft())));
+            result -> Math.abs(result.getRemainingAttackingUnits().size() - getAverageAttackingUnitsLeft())
+                + Math.abs(result.getRemainingDefendingUnits().size() - getAverageDefendingUnitsLeft())));
   }
 
   public List<Unit> getAverageAttackingUnitsRemaining() {
@@ -66,7 +66,7 @@ public class AggregateResults {
       return 0.0;
     }
     return results.stream()
-        .mapToDouble(BattleResults::getAttackingCombatUnitsLeft)
+        .mapToDouble(result -> result.getRemainingAttackingUnits().size())
         .sum() / results.size();
   }
 
@@ -119,7 +119,7 @@ public class AggregateResults {
     double total = 0;
     for (final BattleResults result : results) {
       if (result.attackerWon()) {
-        count += result.getAttackingCombatUnitsLeft();
+        count += result.getRemainingAttackingUnits().size();
         total += 1;
       }
     }
@@ -134,7 +134,7 @@ public class AggregateResults {
       return 0.0;
     }
     return results.stream()
-        .mapToDouble(BattleResults::getDefendingCombatUnitsLeft)
+        .mapToDouble(result -> result.getRemainingDefendingUnits().size())
         .sum() / results.size();
   }
 
@@ -146,7 +146,7 @@ public class AggregateResults {
     double total = 0;
     for (final BattleResults result : results) {
       if (result.defenderWon()) {
-        count += result.getDefendingCombatUnitsLeft();
+        count += result.getRemainingDefendingUnits().size();
         total += 1;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -66,7 +66,8 @@ public class AggregateResults {
       return 0.0;
     }
     return results.stream()
-        .mapToDouble(result -> result.getRemainingAttackingUnits().size())
+        .map(BattleResults::getRemainingAttackingUnits)
+        .mapToDouble(Collection::size)
         .sum() / results.size();
   }
 
@@ -134,7 +135,8 @@ public class AggregateResults {
       return 0.0;
     }
     return results.stream()
-        .mapToDouble(result -> result.getRemainingDefendingUnits().size())
+        .map(BattleResults::getRemainingDefendingUnits)
+        .mapToDouble(Collection::size)
         .sum() / results.size();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -63,11 +63,11 @@ public class OddsCalculatorDialog extends JDialog {
     if (lastPosition == null) {
       dialog.setLocationRelativeTo(taFrame);
       if (dialog.getHeight() > MAX_HEIGHT) {
-        dialog.setSize(new Dimension(dialog.getWidth(), MAX_HEIGHT));
+        dialog.setPreferredSize(new Dimension(dialog.getWidth(), MAX_HEIGHT));
       }
     } else {
       dialog.setLocation(lastPosition);
-      dialog.setSize(lastShape);
+      dialog.setPreferredSize(lastShape);
     }
     dialog.setVisible(true);
     taFrame.getUiContext().addShutdownWindow(dialog);

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -3,6 +3,8 @@ package games.strategy.triplea.odds.calculator;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
@@ -25,9 +27,7 @@ import games.strategy.ui.SwingComponents;
  */
 public class OddsCalculatorDialog extends JDialog {
   private static final long serialVersionUID = -7625420355087851930L;
-  private static final int MAX_HEIGHT = 640;
   private static Point lastPosition;
-  private static Dimension lastShape;
   private static List<OddsCalculatorDialog> instances = new ArrayList<>();
   private final OddsCalculatorPanel panel;
 
@@ -54,6 +54,16 @@ public class OddsCalculatorDialog extends JDialog {
       }
     });
 
+    dialog.addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentResized(final ComponentEvent e) {
+        final Dimension size = dialog.getSize();
+        size.width = Math.min(size.width, taFrame.getWidth() - 50);
+        size.height = Math.min(size.height, taFrame.getHeight() - 50);
+        dialog.setSize(size);
+      }
+    });
+
     // close when hitting the escape key
     SwingComponents.addEscapeKeyListener(dialog, () -> {
       dialog.setVisible(false);
@@ -62,12 +72,8 @@ public class OddsCalculatorDialog extends JDialog {
     dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
     if (lastPosition == null) {
       dialog.setLocationRelativeTo(taFrame);
-      if (dialog.getHeight() > MAX_HEIGHT) {
-        dialog.setPreferredSize(new Dimension(dialog.getWidth(), MAX_HEIGHT));
-      }
     } else {
       dialog.setLocation(lastPosition);
-      dialog.setPreferredSize(lastShape);
     }
     dialog.setVisible(true);
     taFrame.getUiContext().addShutdownWindow(dialog);
@@ -85,9 +91,10 @@ public class OddsCalculatorDialog extends JDialog {
     if (instances.isEmpty()) {
       return;
     }
-    final OddsCalculatorPanel currentPanel = instances.get(instances.size() - 1).panel;
-    currentPanel
-        .addDefendingUnits(t.getUnits().getMatches(Matches.alliedUnit(currentPanel.getDefender(), t.getData())));
+    final OddsCalculatorDialog currentDialog = instances.get(instances.size() - 1);
+    currentDialog.panel
+        .addDefendingUnits(t.getUnits().getMatches(Matches.alliedUnit(currentDialog.panel.getDefender(), t.getData())));
+    currentDialog.pack();
   }
 
   OddsCalculatorDialog(final GameData data, final UiContext uiContext, final JFrame parent, final Territory location) {
@@ -102,7 +109,6 @@ public class OddsCalculatorDialog extends JDialog {
   public void dispose() {
     instances.remove(this);
     lastPosition = new Point(getLocation());
-    lastShape = new Dimension(getSize());
     panel.shutdown();
     super.dispose();
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -202,6 +203,8 @@ class OddsCalculatorPanel extends JPanel {
         GridBagConstraints.NONE, new Insets(0, gap, gap, 0), 0, 0));
     attackAndDefend.add(defenderCombo, new GridBagConstraints(3, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, 0, gap / 2, gap), 0, 0));
+    attackAndDefend.add(new JPanel(), new GridBagConstraints(4, row0, 1, 1, 1.0, 0, GridBagConstraints.EAST,
+        GridBagConstraints.NONE, new Insets(0, 0, gap / 2, gap), 0, 0));
     row0++;
     attackAndDefend.add(attackerUnitsTotalNumber, new GridBagConstraints(0, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, gap, 0, 0), 0, 0));
@@ -220,18 +223,26 @@ class OddsCalculatorPanel extends JPanel {
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, gap, gap / 2, 0), 0, 0));
     attackAndDefend.add(defenderUnitsTotalPower, new GridBagConstraints(3, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, gap / 2, gap / 2, gap * 2), 0, 0));
-    row0++;
+
+
+    final JPanel unitPanels = new JPanel();
+    unitPanels.setLayout(new GridBagLayout());
     final JScrollPane attackerScroll = new JScrollPane(attackingUnitsPanel);
     attackerScroll.setBorder(null);
     attackerScroll.getViewport().setBorder(null);
     final JScrollPane defenderScroll = new JScrollPane(defendingUnitsPanel);
     defenderScroll.setBorder(null);
     defenderScroll.getViewport().setBorder(null);
-    attackAndDefend.add(attackerScroll, new GridBagConstraints(0, row0, 2, 1, 1, 1, GridBagConstraints.NORTH,
+    unitPanels.add(attackerScroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
         GridBagConstraints.BOTH, new Insets(10, gap, gap, gap), 0, 0));
-    attackAndDefend.add(defenderScroll, new GridBagConstraints(2, row0, 2, 1, 1, 1, GridBagConstraints.NORTH,
+    unitPanels.add(defenderScroll, new GridBagConstraints(1, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
         GridBagConstraints.BOTH, new Insets(10, gap, gap, gap), 0, 0));
-    main.add(attackAndDefend, BorderLayout.CENTER);
+
+    final JPanel leftPanel = new JPanel();
+    leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
+    leftPanel.add(attackAndDefend);
+    leftPanel.add(unitPanels);
+    main.add(leftPanel, BorderLayout.CENTER);
 
     final JPanel resultsText = new JPanel();
     resultsText.setLayout(new GridBagLayout());
@@ -662,6 +673,12 @@ class OddsCalculatorPanel extends JPanel {
         CollectionUtils.getMatches(units,
             Matches.unitCanBeInBattle(true, isLand(), 1, hasMaxRounds(isLand(), data), false)),
         isLand());
+    invalidate();
+    validate();
+    revalidate();
+    if (getParent() != null) {
+      getParent().invalidate();
+    }
   }
 
   void addDefendingUnits(final List<Unit> unitsToAdd) {
@@ -677,6 +694,12 @@ class OddsCalculatorPanel extends JPanel {
         getDefender(),
         CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand(), 1, false)),
         isLand());
+    invalidate();
+    validate();
+    revalidate();
+    if (getParent() != null) {
+      getParent().invalidate();
+    }
   }
 
   private boolean isLand() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -350,7 +350,9 @@ class OddsCalculatorPanel extends JPanel {
       } finally {
         data.releaseReadLock();
       }
-      updateDefender(null);
+      setDefendingUnits(defendingUnitsPanel.getUnits().stream().anyMatch(Matches.unitIsOwnedBy(getDefender()))
+          ? defendingUnitsPanel.getUnits()
+          : null);
       setWidgetActivation();
     });
     attackerCombo.addActionListener(e -> {
@@ -362,15 +364,15 @@ class OddsCalculatorPanel extends JPanel {
       } finally {
         data.releaseReadLock();
       }
-      updateAttacker(null);
+      setAttackingUnits(null);
       setWidgetActivation();
     });
     amphibiousCheckBox.addActionListener(e -> setWidgetActivation());
     landBattleCheckBox.addActionListener(e -> {
       attackerOrderOfLosses = null;
       defenderOrderOfLosses = null;
-      updateDefender(null);
-      updateAttacker(null);
+      setDefendingUnits(null);
+      setAttackingUnits(null);
       setWidgetActivation();
     });
     calculateButton.addActionListener(e -> updateStats());
@@ -389,13 +391,16 @@ class OddsCalculatorPanel extends JPanel {
     swapSidesButton.addActionListener(e -> {
       attackerOrderOfLosses = null;
       defenderOrderOfLosses = null;
-      final List<Unit> getDefenders = defendingUnitsPanel.getUnits();
-      final List<Unit> getAttackers = attackingUnitsPanel.getUnits();
+      final List<Unit> newAttackers =
+          CollectionUtils.getMatches(defendingUnitsPanel.getUnits(), Matches.unitIsOwnedBy(getDefender())
+              .and(Matches.unitCanBeInBattle(true, isLand(), 1, hasMaxRounds(isLand(), data), true)));
+      final List<Unit> newDefenders = CollectionUtils.getMatches(attackingUnitsPanel.getUnits(),
+          Matches.unitCanBeInBattle(true, isLand(), 1, true));
       swapSidesCombo.setSelectedItem(getAttacker());
       attackerCombo.setSelectedItem(getDefender());
       defenderCombo.setSelectedItem(getSwapSides());
-      attackingUnitsPanel.init(getAttacker(), getDefenders, isLand());
-      defendingUnitsPanel.init(getDefender(), getAttackers, isLand());
+      setAttackingUnits(newAttackers);
+      setDefendingUnits(newDefenders);
       setWidgetActivation();
     });
     orderOfLossesButton.addActionListener(e -> {
@@ -423,32 +428,57 @@ class OddsCalculatorPanel extends JPanel {
       data.acquireReadLock();
       try {
         landBattleCheckBox.setSelected(!location.isWater());
-        // default to the current player
-        if (data.getSequence().getStep().getPlayerId() != null
-            && !data.getSequence().getStep().getPlayerId().isNull()) {
-          attackerCombo.setSelectedItem(data.getSequence().getStep().getPlayerId());
+
+        // Default attacker to current player
+        final PlayerId currentPlayer = data.getSequence().getStep().getPlayerId();
+        if (currentPlayer != null && !currentPlayer.isNull()) {
+          attackerCombo.setSelectedItem(currentPlayer);
         }
+
+        // Get players with units sorted
+        final List<PlayerId> players = location.getUnits().getPlayersByUnitCount();
+        if (players.contains(currentPlayer)) {
+          players.remove(currentPlayer);
+          players.add(0, currentPlayer);
+        }
+
+        // Check location to determine optimal attacker and defender
         if (!location.isWater()) {
           defenderCombo.setSelectedItem(location.getOwner());
-        } else {
-          // we need to find out the defender for sea zones
-          for (final PlayerId player : location.getUnits().getPlayersWithUnits()) {
-            if (!player.equals(getAttacker()) && !data.getRelationshipTracker().isAllied(player, getAttacker())) {
-              defenderCombo.setSelectedItem(player);
+          for (final PlayerId player : players) {
+            if (Matches.isAtWar(getDefender(), data).test(player)) {
+              attackerCombo.setSelectedItem(player);
               break;
             }
           }
+        } else {
+          if (players.size() == 1) {
+            defenderCombo.setSelectedItem(players.get(0));
+          } else if (players.size() > 1) {
+            if (!data.getRelationshipTracker().isAtWarWithAnyOfThesePlayers(players.get(0), players)) {
+              defenderCombo.setSelectedItem(players.get(0));
+            } else {
+              attackerCombo.setSelectedItem(players.get(0));
+              for (final PlayerId player : players) {
+                if (Matches.isAtWar(getAttacker(), data).test(player)) {
+                  defenderCombo.setSelectedItem(player);
+                  break;
+                }
+              }
+            }
+          }
         }
-        updateDefender(location.getUnits().getMatches(Matches.alliedUnit(getDefender(), data)));
-        updateAttacker(location.getUnits().getMatches(Matches.alliedUnit(getAttacker(), data)));
+
+        setAttackingUnits(location.getUnits().getMatches(Matches.unitIsOwnedBy(getAttacker())));
+        setDefendingUnits(location.getUnits().getMatches(Matches.alliedUnit(getDefender(), data)));
       } finally {
         data.releaseReadLock();
       }
     } else {
       landBattleCheckBox.setSelected(true);
       defenderCombo.setSelectedItem(data.getPlayerList().getPlayers().iterator().next());
-      updateDefender(null);
-      updateAttacker(null);
+      setDefendingUnits(null);
+      setAttackingUnits(null);
     }
     calculator = new ConcurrentOddsCalculator("BtlCalc Panel", () -> SwingUtilities.invokeLater(() -> {
       calculateButton.setText("Calculate Odds");
@@ -470,12 +500,12 @@ class OddsCalculatorPanel extends JPanel {
     }
   }
 
-  private PlayerId getDefender() {
-    return (PlayerId) defenderCombo.getSelectedItem();
+  PlayerId getAttacker() {
+    return (PlayerId) attackerCombo.getSelectedItem();
   }
 
-  private PlayerId getAttacker() {
-    return (PlayerId) attackerCombo.getSelectedItem();
+  PlayerId getDefender() {
+    return (PlayerId) defenderCombo.getSelectedItem();
   }
 
   private PlayerId getSwapSides() {
@@ -585,10 +615,10 @@ class OddsCalculatorPanel extends JPanel {
       defenderWin.setText(formatPercentage(results.get().getDefenderWinPercent()));
       draw.setText(formatPercentage(results.get().getDrawPercent()));
       final boolean isLand = isLand();
-      final List<Unit> mainCombatAttackers =
-          CollectionUtils.getMatches(attackers.get(), Matches.unitCanBeInBattle(true, isLand, 1, false, true, true));
-      final List<Unit> mainCombatDefenders =
-          CollectionUtils.getMatches(defenders.get(), Matches.unitCanBeInBattle(false, isLand, 1, false, true, true));
+      final List<Unit> mainCombatAttackers = CollectionUtils.getMatches(attackers.get(),
+          Matches.unitCanBeInBattle(true, isLand, 1, true));
+      final List<Unit> mainCombatDefenders = CollectionUtils.getMatches(defenders.get(),
+          Matches.unitCanBeInBattle(false, isLand, 1, true));
       final int attackersTotal = mainCombatAttackers.size();
       final int defendersTotal = mainCombatDefenders.size();
       defenderLeft.setText(formatValue(results.get().getAverageDefendingUnitsLeft()) + " / " + defendersTotal);
@@ -618,22 +648,35 @@ class OddsCalculatorPanel extends JPanel {
     return new DecimalFormat("#0.##").format(value);
   }
 
-  private void updateDefender(final List<Unit> initialUnits) {
-    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
-    final boolean isLand = isLand();
-    defendingUnitsPanel.init(
-        getDefender(),
-        CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand, 1, false, false, false)),
-        isLand);
+  void addAttackingUnits(final List<Unit> unitsToAdd) {
+    final List<Unit> units = attackingUnitsPanel.getUnits();
+    units.addAll(unitsToAdd);
+    setAttackingUnits(units);
+    setWidgetActivation();
   }
 
-  private void updateAttacker(final List<Unit> initialUnits) {
+  private void setAttackingUnits(final List<Unit> initialUnits) {
     final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
-    final boolean isLand = isLand();
     attackingUnitsPanel.init(
         getAttacker(),
-        CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(true, isLand, 1, false, false, false)),
-        isLand);
+        CollectionUtils.getMatches(units,
+            Matches.unitCanBeInBattle(true, isLand(), 1, hasMaxRounds(isLand(), data), false)),
+        isLand());
+  }
+
+  void addDefendingUnits(final List<Unit> unitsToAdd) {
+    final List<Unit> units = defendingUnitsPanel.getUnits();
+    units.addAll(unitsToAdd);
+    setDefendingUnits(units);
+    setWidgetActivation();
+  }
+
+  private void setDefendingUnits(final List<Unit> initialUnits) {
+    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
+    defendingUnitsPanel.init(
+        getDefender(),
+        CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand(), 1, false)),
+        isLand());
   }
 
   private boolean isLand() {
@@ -676,11 +719,10 @@ class OddsCalculatorPanel extends JPanel {
     final boolean isLand = isLand();
     try {
       data.acquireReadLock();
-      // do not include bombardment and aa guns in our "total" labels
       final List<Unit> attackers = CollectionUtils.getMatches(attackingUnitsPanel.getUnits(),
-          Matches.unitCanBeInBattle(true, isLand, 1, false, true, true));
+          Matches.unitCanBeInBattle(true, isLand, 1, true));
       final List<Unit> defenders = CollectionUtils.getMatches(defendingUnitsPanel.getUnits(),
-          Matches.unitCanBeInBattle(false, isLand, 1, false, true, true));
+          Matches.unitCanBeInBattle(false, isLand, 1, true));
       attackerUnitsTotalNumber.setText("Units: " + attackers.size());
       defenderUnitsTotalNumber.setText("Units: " + defenders.size());
       attackerUnitsTotalTuv.setText("TUV: " + TuvUtils.getTuv(attackers, getAttacker(),
@@ -741,4 +783,14 @@ class OddsCalculatorPanel extends JPanel {
     }
     return false;
   }
+
+  static boolean hasMaxRounds(final boolean isLand, final GameData data) {
+    data.acquireReadLock();
+    try {
+      return isLand ? Properties.getLandBattleRounds(data) > 0 : Properties.getSeaBattleRounds(data) > 0;
+    } finally {
+      data.releaseReadLock();
+    }
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -224,7 +224,6 @@ class OddsCalculatorPanel extends JPanel {
     attackAndDefend.add(defenderUnitsTotalPower, new GridBagConstraints(3, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, gap / 2, gap / 2, gap * 2), 0, 0));
 
-
     final JPanel unitPanels = new JPanel();
     unitPanels.setLayout(new GridBagLayout());
     final JScrollPane attackerScroll = new JScrollPane(attackingUnitsPanel);
@@ -673,12 +672,6 @@ class OddsCalculatorPanel extends JPanel {
         CollectionUtils.getMatches(units,
             Matches.unitCanBeInBattle(true, isLand(), 1, hasMaxRounds(isLand(), data), false)),
         isLand());
-    invalidate();
-    validate();
-    revalidate();
-    if (getParent() != null) {
-      getParent().invalidate();
-    }
   }
 
   void addDefendingUnits(final List<Unit> unitsToAdd) {
@@ -694,12 +687,6 @@ class OddsCalculatorPanel extends JPanel {
         getDefender(),
         CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand(), 1, false)),
         isLand());
-    invalidate();
-    validate();
-    revalidate();
-    if (getParent() != null) {
-      getParent().invalidate();
-    }
   }
 
   private boolean isLand() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -32,6 +32,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
+import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.GameData;
@@ -184,12 +185,12 @@ class OddsCalculatorPanel extends JPanel {
         + "include Bombarding sea units for land battles.");
     defenderUnitsTotalNumber.setToolTipText("Totals do not include AA guns and other infrastructure, and does not "
         + "include Bombarding sea units for land battles.");
-    setLayout(new BorderLayout());
 
+    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     final JPanel main = new JPanel();
     main.setBorder(BorderFactory.createEmptyBorder(10, 0, 10, 0));
-    add(main, BorderLayout.CENTER);
     main.setLayout(new BorderLayout());
+    add(main);
 
     final JPanel attackAndDefend = new JPanel();
     attackAndDefend.setLayout(new GridBagLayout());
@@ -202,8 +203,6 @@ class OddsCalculatorPanel extends JPanel {
     attackAndDefend.add(new JLabel("Defender: "), new GridBagConstraints(2, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, gap, gap, 0), 0, 0));
     attackAndDefend.add(defenderCombo, new GridBagConstraints(3, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
-        GridBagConstraints.NONE, new Insets(0, 0, gap / 2, gap), 0, 0));
-    attackAndDefend.add(new JPanel(), new GridBagConstraints(4, row0, 1, 1, 1.0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, 0, gap / 2, gap), 0, 0));
     row0++;
     attackAndDefend.add(attackerUnitsTotalNumber, new GridBagConstraints(0, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
@@ -223,24 +222,27 @@ class OddsCalculatorPanel extends JPanel {
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, gap, gap / 2, 0), 0, 0));
     attackAndDefend.add(defenderUnitsTotalPower, new GridBagConstraints(3, row0, 1, 1, 0, 0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(0, gap / 2, gap / 2, gap * 2), 0, 0));
+    final JPanel attackAndDefendAlignLeft = new JPanel();
+    attackAndDefendAlignLeft.setLayout(new BorderLayout());
+    attackAndDefendAlignLeft.add(attackAndDefend, BorderLayout.WEST);
 
     final JPanel unitPanels = new JPanel();
-    unitPanels.setLayout(new GridBagLayout());
+    unitPanels.setLayout(new BoxLayout(unitPanels, BoxLayout.X_AXIS));
     final JScrollPane attackerScroll = new JScrollPane(attackingUnitsPanel);
     attackerScroll.setBorder(null);
     attackerScroll.getViewport().setBorder(null);
+    attackerScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
     final JScrollPane defenderScroll = new JScrollPane(defendingUnitsPanel);
     defenderScroll.setBorder(null);
     defenderScroll.getViewport().setBorder(null);
-    unitPanels.add(attackerScroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-        GridBagConstraints.BOTH, new Insets(10, gap, gap, gap), 0, 0));
-    unitPanels.add(defenderScroll, new GridBagConstraints(1, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-        GridBagConstraints.BOTH, new Insets(10, gap, gap, gap), 0, 0));
+    defenderScroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+    unitPanels.add(attackerScroll);
+    unitPanels.add(defenderScroll);
 
     final JPanel leftPanel = new JPanel();
-    leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
-    leftPanel.add(attackAndDefend);
-    leftPanel.add(unitPanels);
+    leftPanel.setLayout(new BorderLayout());
+    leftPanel.add(attackAndDefendAlignLeft, BorderLayout.NORTH);
+    leftPanel.add(unitPanels, BorderLayout.CENTER);
     main.add(leftPanel, BorderLayout.CENTER);
 
     final JPanel resultsText = new JPanel();
@@ -342,14 +344,11 @@ class OddsCalculatorPanel extends JPanel {
     resultsScroll.setPreferredSize(resultsScrollDimensions);
     main.add(resultsScroll, BorderLayout.EAST);
 
-    final JPanel south = new JPanel();
-    south.setLayout(new BorderLayout());
     final JPanel buttons = new JPanel();
     buttons.setLayout(new FlowLayout(FlowLayout.CENTER));
     final JButton closeButton = new JButton("Close");
     buttons.add(closeButton);
-    south.add(buttons, BorderLayout.SOUTH);
-    add(south, BorderLayout.SOUTH);
+    add(buttons);
 
     defenderCombo.addActionListener(e -> {
       data.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -184,7 +184,8 @@ public class PlayerUnitsPanel extends JPanel {
 
     // Filter out anything like factories, or units that have no combat ability AND cannot be taken casualty
     unitTypes = CollectionUtils.getMatches(unitTypes,
-        Matches.unitTypeCanBeInBattle(!defender, isLand, player, 1, false, false, false));
+        Matches.unitTypeCanBeInBattle(!defender, isLand, player, 1, OddsCalculatorPanel.hasMaxRounds(isLand, data),
+            false));
 
     return unitTypes;
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -47,6 +47,7 @@ public class PlayerUnitsPanel extends JPanel {
     this.uiContext = uiContext;
     this.defender = defender;
     setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+    setBorder(BorderFactory.createEmptyBorder(0, 20, 0, 20));
   }
 
   public void clear() {
@@ -139,6 +140,9 @@ public class PlayerUnitsPanel extends JPanel {
         final UnitPanel upanel = new UnitPanel(uiContext, category, costs);
         upanel.addChangeListener(this::notifyListeners);
         panel.add(upanel);
+        panel.invalidate();
+        panel.validate();
+        panel.revalidate();
         unitPanels.add(upanel);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -140,9 +140,6 @@ public class PlayerUnitsPanel extends JPanel {
         final UnitPanel upanel = new UnitPanel(uiContext, category, costs);
         upanel.addChangeListener(this::notifyListeners);
         panel.add(upanel);
-        panel.invalidate();
-        panel.validate();
-        panel.revalidate();
         unitPanels.add(upanel);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -1,14 +1,14 @@
 package games.strategy.triplea.odds.calculator;
 
-import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 
@@ -40,28 +40,21 @@ public class PlayerUnitsPanel extends JPanel {
   private boolean isLand = true;
   private List<UnitCategory> categories = null;
   private final List<Runnable> listeners = new ArrayList<>();
+  private final List<UnitPanel> unitPanels = new ArrayList<>();
 
   public PlayerUnitsPanel(final GameData data, final UiContext uiContext, final boolean defender) {
     this.data = data;
     this.uiContext = uiContext;
     this.defender = defender;
-    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+    setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
   }
 
   public void clear() {
-    for (final Component c : getComponents()) {
-      final UnitPanel panel = (UnitPanel) c;
-      panel.setCount(0);
-    }
+    unitPanels.forEach(p -> p.setCount(0));
   }
 
   public List<Unit> getUnits() {
-    final List<Unit> allUnits = new ArrayList<>();
-    for (final Component c : getComponents()) {
-      final UnitPanel panel = (UnitPanel) c;
-      allUnits.addAll(panel.getUnits());
-    }
-    return allUnits;
+    return unitPanels.stream().map(UnitPanel::getUnits).flatMap(Collection::stream).collect(Collectors.toList());
   }
 
   public List<UnitCategory> getCategories() {
@@ -73,8 +66,21 @@ public class PlayerUnitsPanel extends JPanel {
    */
   public void init(final PlayerId id, final List<Unit> units, final boolean land) {
     isLand = land;
+    unitPanels.clear();
     categories = new ArrayList<>(categorize(id, units));
-    categories.sort(Comparator.comparing(UnitCategory::getType, (ut1, ut2) -> {
+
+    categories.sort((c1, c2) -> {
+      if (!c1.getOwner().equals(c2.getOwner())) {
+        if (c1.getOwner().equals(id)) {
+          return -1;
+        } else if (c2.getOwner().equals(id)) {
+          return 1;
+        } else {
+          return c1.getOwner().getName().compareTo(c2.getOwner().getName());
+        }
+      }
+      final UnitType ut1 = c1.getType();
+      final UnitType ut2 = c2.getType();
       final UnitAttachment u1 = UnitAttachment.get(ut1);
       final UnitAttachment u2 = UnitAttachment.get(ut2);
       // For land battles, sort by land, air, can't combat move (AA), bombarding
@@ -98,7 +104,8 @@ public class PlayerUnitsPanel extends JPanel {
         }
       }
       return u1.getName().compareTo(u2.getName());
-    }));
+    });
+
     removeAll();
     final Predicate<UnitType> predicate;
     if (land) {
@@ -117,13 +124,25 @@ public class PlayerUnitsPanel extends JPanel {
     } finally {
       data.releaseReadLock();
     }
+
+    PlayerId previousPlayer = null;
+    JPanel panel = null;
     for (final UnitCategory category : categories) {
       if (predicate.test(category.getType())) {
+        if (!category.getOwner().equals(previousPlayer)) {
+          panel = new JPanel();
+          panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+          panel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
+          add(panel);
+          previousPlayer = category.getOwner();
+        }
         final UnitPanel upanel = new UnitPanel(uiContext, category, costs);
         upanel.addChangeListener(this::notifyListeners);
-        add(upanel);
+        panel.add(upanel);
+        unitPanels.add(upanel);
       }
     }
+
     // TODO: probably do not need to do this much revalidation.
     invalidate();
     validate();
@@ -137,11 +156,20 @@ public class PlayerUnitsPanel extends JPanel {
    */
   private Set<UnitCategory> categorize(final PlayerId id, final List<Unit> units) {
 
-    // Get all unit types from production frontier and player unit types on the map
+    // Get player unit types from production frontier and unit types on the map
     final Set<UnitCategory> categories = new LinkedHashSet<>();
     for (final UnitType t : getUnitTypes(id)) {
       final UnitCategory category = new UnitCategory(t, id);
       categories.add(category);
+    }
+
+    // Get unit owner unit types from production frontier and unit types on the map
+    for (final PlayerId player : units.stream().map(Unit::getOwner).filter(p -> !p.equals(id))
+        .collect(Collectors.toSet())) {
+      for (final UnitType t : getUnitTypes(player)) {
+        final UnitCategory category = new UnitCategory(t, player);
+        categories.add(category);
+      }
     }
 
     // Populate units into each category then add any remaining categories (damaged units, etc)

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -30,6 +30,8 @@ class TerritoryDetailPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 1377022163587438988L;
   private final UiContext uiContext;
   private final JButton showOdds = new JButton("Battle Calculator (Ctrl-B)");
+  private final JButton addAttackers = new JButton("Add Attackers (Ctrl-A)");
+  private final JButton addDefenders = new JButton("Add Defenders (Ctrl-D)");
   private final JButton findTerritoryButton;
   private @Nullable Territory currentTerritory;
   private final TripleAFrame frame;
@@ -59,6 +61,14 @@ class TerritoryDetailPanel extends AbstractStatPanel {
     showOdds.addActionListener(e -> OddsCalculatorDialog.show(frame, currentTerritory));
     SwingComponents.addKeyListenerWithMetaAndCtrlMasks(
         frame, 'B', () -> OddsCalculatorDialog.show(frame, currentTerritory));
+
+    addAttackers.addActionListener(e -> OddsCalculatorDialog.addAttackers(currentTerritory));
+    SwingComponents.addKeyListenerWithMetaAndCtrlMasks(
+        frame, 'A', () -> OddsCalculatorDialog.addAttackers(currentTerritory));
+
+    addDefenders.addActionListener(e -> OddsCalculatorDialog.addDefenders(currentTerritory));
+    SwingComponents.addKeyListenerWithMetaAndCtrlMasks(
+        frame, 'D', () -> OddsCalculatorDialog.addDefenders(currentTerritory));
   }
 
   public void setGameData(final GameData data) {
@@ -74,6 +84,8 @@ class TerritoryDetailPanel extends AbstractStatPanel {
       return;
     }
     add(showOdds);
+    add(addAttackers);
+    add(addDefenders);
     add(findTerritoryButton);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final String labelText;

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -386,7 +386,7 @@ public final class TripleAFrame extends JFrame {
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(movePanel.getCustomKeyListeners()));
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getFlagToggleKeyListener(this)));
 
-    addTab("Actions", actionButtons, 'A');
+    addTab("Actions", actionButtons, 'C');
     actionButtons.setBorder(null);
     statsPanel = new StatPanel(data, uiContext);
     addTab("Players", statsPanel, 'P');
@@ -1976,7 +1976,7 @@ public final class TripleAFrame extends JFrame {
         tabsPanel.removeAll();
       }
       setWidgetActivation();
-      addTab("Actions", actionButtons, 'A');
+      addTab("Actions", actionButtons, 'C');
       addTab("Players", statsPanel, 'P');
       addTab("Resources", economyPanel, 'R');
       if (objectivePanel != null && !objectivePanel.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -119,7 +119,7 @@ public final class HelpMenu extends JMenu {
           + "To list specific units from a territory in the Territory panel, drag and drop from the territory on the "
           + "map to the territory panel.<br>"
           + "Press CTRL+(key) to select a specific tab panel "
-          + "(A-Actions, P-Players, R-Resources, O-Objectives, N-Notes, T-Territory).<br>"
+          + "(C-Actions, P-Players, R-Resources, O-Objectives, N-Notes, T-Territory).<br>"
           + "Press CTRL+E to toggle edit mode.<br>"
           + "Press CTRL+H and CTRL+G to show history or game modes.<br>"
           + "Press CTRL+W to show politics panel.<br>"


### PR DESCRIPTION
## Overview
- Addresses BC improvements discussed here: https://forums.triplea-game.org/topic/369/battle-calculator-question-feature
- Fixes a few issues around the BC not handling isInfra and 0 move units properly

## Functional Changes
- Added ability to use CTRL+A and CTRL+D to add attackers and defenders to last active battle calc window
- Improved default player selection for attacker and defender when opening a new battle calc
- Allow changing defending player in BC and if any of the current units are owned by the new defending player then units no longer reset
- When switching players in BC, it only moves over the units of the new attacking player (not any allied units which can't actually attack)
- BC considers isInfra units in unit counts and TUV (otherwise you could add combat isInfra units and it would appear they would always improve your TUV chance even if they were pretty much always being lost)
- Can have 0 move and can't combat move units in BC attackers for maps which have limited combat rounds (this is because battles can last more than 1 round so these units can become attackers)
- Changed action tab hotkey to 'C' and updated help menu
- Defending units now create separate columns for each player
- Scales appropriately based on unit list and number of defending players but also has a max window size slightly smaller than TripleA window

## Manual Testing Performed
- Did testing on revised, global, TWW, dragon war, house of hapsburg, civil war

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![image](https://user-images.githubusercontent.com/1427689/51287504-64132380-19bd-11e9-8dbf-e132cc66e89a.png)


### After
![image](https://user-images.githubusercontent.com/1427689/51287106-99b70d00-19bb-11e9-9560-9b6bdef7f5ae.png)



## Additional Review Notes
- There was also a considerable amount of refactoring that I'll try to point out to avoid confusion with the actual changes
